### PR TITLE
Allow to use CGAL as a submodule of a bigger CMake project

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,14 @@ set(CGAL_BRANCH_BUILD
     ON
     CACHE INTERNAL "Create CGAL from a Git branch" FORCE)
 
-include(${CMAKE_SOURCE_DIR}/CGALConfigVersion.cmake)
-include(${CMAKE_SOURCE_DIR}/Installation/cmake/modules/CGAL_SCM.cmake)
-cgal_detect_git(${CMAKE_SOURCE_DIR})
+include(${CMAKE_CURRENT_SOURCE_DIR}/CGALConfigVersion.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/Installation/cmake/modules/CGAL_SCM.cmake)
+cgal_detect_git(${CMAKE_CURRENT_SOURCE_DIR})
 
 function(CGAL_error_if_detect_in_source_build)
   # If in a Git repository, forbid in-source builds
-  get_filename_component(srcdir "${CMAKE_SOURCE_DIR}" REALPATH)
-  get_filename_component(bindir "${CMAKE_BINARY_DIR}" REALPATH)
+  get_filename_component(srcdir "${CMAKE_CURRENT_SOURCE_DIR}" REALPATH)
+  get_filename_component(bindir "${CMAKE_CURRENT_BINARY_DIR}" REALPATH)
   if("${srcdir}" STREQUAL "${bindir}")
     message(
       FATAL_ERROR

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -1,8 +1,8 @@
 # Top level CMakeLists.txt for CGAL
 # The name of our project is "CGAL".  CMakeLists files in this project can
-# refer to the root source directory of the project as ${CMAKE_SOURCE_DIR} or
-# ${CMAKE_SOURCE_DIR} and to the root binary directory of the project as
-# ${CMAKE_BINARY_DIR} or ${CMAKE_BINARY_DIR}.
+# refer to the root source directory of the project as ${CGAL_SOURCE_DIR} or
+# ${CGAL_SOURCE_DIR} and to the root binary directory of the project as
+# ${CGAL_BINARY_DIR} or ${CGAL_BINARY_DIR}.
 if(NOT PROJECT_NAME)
   cmake_minimum_required(VERSION 3.12...3.18)
   project(CGAL CXX C)
@@ -32,24 +32,24 @@ if(CGAL_BRANCH_BUILD)
   # list packages
   file(
     GLOB CGAL_CONFIGURED_PACKAGES
-    RELATIVE ${CMAKE_SOURCE_DIR}
-    "${CMAKE_SOURCE_DIR}/*")
+    RELATIVE ${CGAL_SOURCE_DIR}
+    "${CGAL_SOURCE_DIR}/*")
   list(SORT CGAL_CONFIGURED_PACKAGES)
   list(REMOVE_ITEM CGAL_CONFIGURED_PACKAGES copyright CMakeLists.txt .svn .git)
 
   # detect and remove not existing package-directories
   foreach(package ${CGAL_CONFIGURED_PACKAGES})
-    if(NOT IS_DIRECTORY "${CMAKE_SOURCE_DIR}/${package}")
+    if(NOT IS_DIRECTORY "${CGAL_SOURCE_DIR}/${package}")
       list(APPEND CGAL_WRONG_PACKAGES ${package})
     elseif(NOT EXISTS
-           "${CMAKE_SOURCE_DIR}/${package}/package_info/${package}/maintainer")
+           "${CGAL_SOURCE_DIR}/${package}/package_info/${package}/maintainer")
       list(APPEND CGAL_WRONG_PACKAGES ${package})
     endif()
   endforeach()
 
   find_program(
     CGAL_CREATE_CMAKE_SCRIPT cgal_create_cmake_script HINT
-    ${CMAKE_SOURCE_DIR}/Scripts/scripts
+    ${CGAL_SOURCE_DIR}/Scripts/scripts
     DOC "Script cgal_create_cmake_script, that creates CMakeLists.txt files"
     NO_DEFAULT_PATH NO_CMAKE_ENVIRONMENT_PATH)
 
@@ -61,20 +61,20 @@ if(CGAL_BRANCH_BUILD)
   set(CGAL_CONFIGURED_PACKAGES_NAMES ${CGAL_CONFIGURED_PACKAGES})
   set(CGAL_CONFIGURED_PACKAGES)
   foreach(package ${CGAL_CONFIGURED_PACKAGES_NAMES})
-    list(APPEND CGAL_CONFIGURED_PACKAGES "${CMAKE_SOURCE_DIR}/${package}")
+    list(APPEND CGAL_CONFIGURED_PACKAGES "${CGAL_SOURCE_DIR}/${package}")
   endforeach()
 
   set(CGAL_INSTALLATION_PACKAGE_DIR
-      "${CMAKE_SOURCE_DIR}/Installation"
+      "${CGAL_SOURCE_DIR}/Installation"
       CACHE INTERNAL "Directory containing the Installation package")
   set(CGAL_MAINTENANCE_PACKAGE_DIR
-      "${CMAKE_SOURCE_DIR}/Maintenance"
+      "${CGAL_SOURCE_DIR}/Maintenance"
       CACHE INTERNAL "Directory containing the Maintenance package")
   set(CGAL_CORE_PACKAGE_DIR
-      "${CMAKE_SOURCE_DIR}/Core"
+      "${CGAL_SOURCE_DIR}/Core"
       CACHE INTERNAL "Directory containing the Core package")
   set(CGAL_GRAPHICSVIEW_PACKAGE_DIR
-      "${CMAKE_SOURCE_DIR}/GraphicsView"
+      "${CGAL_SOURCE_DIR}/GraphicsView"
       CACHE INTERNAL "Directory containing the GraphicsView package")
 
   message(
@@ -86,7 +86,7 @@ if(CGAL_BRANCH_BUILD)
 else(CGAL_BRANCH_BUILD)
 
   # get release name
-  file(TO_CMAKE_PATH ${CMAKE_SOURCE_DIR} CMAKE_SOURCE_CDIR)
+  file(TO_CMAKE_PATH ${CGAL_SOURCE_DIR} CMAKE_SOURCE_CDIR)
   string(REGEX REPLACE "^/" "" CMAKE_SOURCE_DDIR ${CMAKE_SOURCE_CDIR})
   string(REPLACE "/" ";" CMAKE_SOURCE_PDIR ${CMAKE_SOURCE_DDIR})
   list(GET CMAKE_SOURCE_PDIR -1 CGAL_RELEASE_NAME)
@@ -95,19 +95,19 @@ else(CGAL_BRANCH_BUILD)
   set(CGAL_CONFIGURED_PACKAGES_NAMES ${CGAL_RELEASE_NAME})
 
   # list packages
-  set(CGAL_CONFIGURED_PACKAGES "${CMAKE_SOURCE_DIR}")
+  set(CGAL_CONFIGURED_PACKAGES "${CGAL_SOURCE_DIR}")
 
   set(CGAL_INSTALLATION_PACKAGE_DIR
-      "${CMAKE_SOURCE_DIR}"
+      "${CGAL_SOURCE_DIR}"
       CACHE INTERNAL "Directory containing the Installation package")
   set(CGAL_MAINTENANCE_PACKAGE_DIR
-      "${CMAKE_SOURCE_DIR}"
+      "${CGAL_SOURCE_DIR}"
       CACHE INTERNAL "Directory containing the Maintenance package")
   set(CGAL_CORE_PACKAGE_DIR
-      "${CMAKE_SOURCE_DIR}"
+      "${CGAL_SOURCE_DIR}"
       CACHE INTERNAL "Directory containing the Core package")
   set(CGAL_GRAPHICSVIEW_PACKAGE_DIR
-      "${CMAKE_SOURCE_DIR}"
+      "${CGAL_SOURCE_DIR}"
       CACHE INTERNAL "Directory containing the GraphicsView package")
 
   # Enable testing with BUILD_TESTING
@@ -120,7 +120,7 @@ endif(CGAL_BRANCH_BUILD)
 #message(STATUS "Packages found: ${CGAL_CONFIGURED_PACKAGES}")
 
 list(SORT CGAL_CONFIGURED_PACKAGES_NAMES)
-if(IS_DIRECTORY "${CMAKE_SOURCE_DIR}/Documentation")
+if(IS_DIRECTORY "${CGAL_SOURCE_DIR}/Documentation")
   # Rescope CGAL_CONFIGURED_PACKAGES_NAMES
   # We need this variable in the Doxygen configuration process. Reset it
   # and change the scope to the parent scope.
@@ -141,7 +141,7 @@ if(CGAL_BRANCH_BUILD)
   # Create version files
   #
 
-  file(REMOVE ${CMAKE_BINARY_DIR}/VERSION)
+  file(REMOVE ${CGAL_BINARY_DIR}/VERSION)
   if(CGAL_BUGFIX_VERSION AND CGAL_BUGFIX_VERSION GREATER 0)
     set(CGAL_CREATED_VERSION_NUM
         "${CGAL_MAJOR_VERSION}.${CGAL_MINOR_VERSION}.${CGAL_BUGFIX_VERSION}")
@@ -160,7 +160,7 @@ if(CGAL_BRANCH_BUILD)
       "${CGAL_CREATED_VERSION_NUM}-I-${CGAL_BUILD_VERSION}")
   set(CGAL_VERSION "${CGAL_CREATED_VERSION_NUM}-I-${CGAL_BUILD_VERSION}")
 
-  file(WRITE "${CMAKE_BINARY_DIR}/VERSION" "${CGAL_CREATED_VERSION_NUM}")
+  file(WRITE "${CGAL_BINARY_DIR}/VERSION" "${CGAL_CREATED_VERSION_NUM}")
 
   message(STATUS "CGAL_VERSION is ${CGAL_CREATED_VERSION}")
   set(CGAL_FULL_VERSION
@@ -196,11 +196,11 @@ if(CGAL_BRANCH_BUILD)
   message(
     STATUS "CGAL_CREATED_SVN_REVISION is ${CGAL_CREATED_SVN_REVISION} (dummy)")
 
-  file(REMOVE ${CMAKE_BINARY_DIR}/include/CGAL/version.h)
+  file(REMOVE ${CGAL_BINARY_DIR}/include/CGAL/version.h)
   string(TIMESTAMP CGAL_CREATED_RELEASE_DATE "%Y%m%d")
   configure_file(
     ${CGAL_INSTALLATION_PACKAGE_DIR}/cmake/modules/config/version.h.in
-    ${CMAKE_BINARY_DIR}/include/CGAL/version.h @ONLY)
+    ${CGAL_BINARY_DIR}/include/CGAL/version.h @ONLY)
 
   #
   # Duplicate files
@@ -265,8 +265,8 @@ if(CGAL_BRANCH_BUILD)
 
 else()
 
-  if(NOT EXISTS "${CMAKE_SOURCE_DIR}/VERSION"
-     OR NOT EXISTS "${CMAKE_SOURCE_DIR}/include/CGAL/version.h")
+  if(NOT EXISTS "${CGAL_SOURCE_DIR}/VERSION"
+     OR NOT EXISTS "${CGAL_SOURCE_DIR}/include/CGAL/version.h")
     message(
       FATAL_ERROR
         "File VERSION or include/CGAL/version.h are missing, required by release-build."
@@ -277,7 +277,7 @@ else()
   # Read and parse CGAL version number from VERSION file
   #
 
-  file(READ "${CMAKE_SOURCE_DIR}/VERSION" CGAL_VERSION)
+  file(READ "${CGAL_SOURCE_DIR}/VERSION" CGAL_VERSION)
   # Comment from Laurent Rineau, 2012/06/28:
   #   file(READ ..) should be replace by file(STRINGS ..), and then we take
   #   the first line. That would avoid parsing errors when the VERSION file
@@ -595,7 +595,7 @@ if(CGAL_DISABLE_GMP)
   unset(CGAL_USE_GMP)
   unset(CGAL_USE_GMP CACHE)
   # Nasty trick to make sure <gmp.h> is not used when CGAL_DISABLE_GMP is TRUE
-  file(WRITE "${CMAKE_BINARY_DIR}/include/gmp.h"
+  file(WRITE "${CGAL_BINARY_DIR}/include/gmp.h"
        "#error GMP is disabled by the CMake option CGAL_DISABLE_GMP")
 else()
   list(APPEND CGAL_ESSENTIAL_3RD_PARTY_LIBRARIES GMP MPFR)
@@ -603,7 +603,7 @@ else()
   # When CMake is run several times, to avoid duplicates
   list(REMOVE_DUPLICATES CGAL_ESSENTIAL_3RD_PARTY_LIBRARIES)
 
-  file(REMOVE "${CMAKE_BINARY_DIR}/include/gmp.h")
+  file(REMOVE "${CGAL_BINARY_DIR}/include/gmp.h")
 endif()
 hide_variable(CGAL_ESSENTIAL_3RD_PARTY_LIBRARIES)
 
@@ -698,7 +698,7 @@ set(CGAL_INSTALL_MAN_DIR
 
 message("== Generating build files ==")
 
-set(CGAL_INCLUDE_DIRS ${CMAKE_BINARY_DIR}/include)
+set(CGAL_INCLUDE_DIRS ${CGAL_BINARY_DIR}/include)
 
 foreach(package ${CGAL_CONFIGURED_PACKAGES})
   if(EXISTS ${package}/include)
@@ -775,9 +775,9 @@ if(CGAL_BRANCH_BUILD AND CGAL_REPORT_DUPLICATE_FILES)
 endif()
 
 configure_file("${CGAL_MODULES_DIR}/CGALConfig_binary_header_only.cmake.in"
-  "${CMAKE_BINARY_DIR}/CGALConfig.cmake"  @ONLY)
+  "${CGAL_BINARY_DIR}/CGALConfig.cmake"  @ONLY)
 configure_file("${CGAL_MODULES_DIR}/CGALConfigVersion_binary_header_only.cmake.in"
-  "${CMAKE_BINARY_DIR}/CGALConfigVersion.cmake"  @ONLY)
+  "${CGAL_BINARY_DIR}/CGALConfigVersion.cmake"  @ONLY)
 
 #--------------------------------------------------------------------------------------------------
 #
@@ -803,9 +803,9 @@ foreach(dir ${CGAL_CONFIGURED_PACKAGES})
       PATTERN "Qt" EXCLUDE)
   endif()
 endforeach()
-if(EXISTS ${CMAKE_BINARY_DIR}/include/CGAL)
+if(EXISTS ${CGAL_BINARY_DIR}/include/CGAL)
   install(
-    DIRECTORY ${CMAKE_BINARY_DIR}/include/CGAL
+    DIRECTORY ${CGAL_BINARY_DIR}/include/CGAL
     DESTINATION ${CGAL_INSTALL_INC_DIR}
     PATTERN ".svn" EXCLUDE
     PATTERN "Qt" EXCLUDE)
@@ -840,9 +840,9 @@ install(FILES
   DESTINATION ${CGAL_INSTALL_CMAKE_DIR})
 if(NOT CGAL_INSTALL_CMAKE_DIR STREQUAL "${CGAL_INSTALL_LIB_DIR}/cmake/CGAL")
   configure_file(${CMAKE_CURRENT_LIST_DIR}/lib/cmake/CGAL/CGALConfig-installation-dirs.cmake.in
-    ${CMAKE_BINARY_DIR}/config/CGALConfig-installation-dirs.cmake)
+    ${CGAL_BINARY_DIR}/config/CGALConfig-installation-dirs.cmake)
   install(FILES
-    ${CMAKE_BINARY_DIR}/config/CGALConfig-installation-dirs.cmake
+    ${CGAL_BINARY_DIR}/config/CGALConfig-installation-dirs.cmake
     DESTINATION ${CGAL_INSTALL_CMAKE_DIR})
 endif()
 
@@ -900,7 +900,7 @@ macro(add_programs subdir target ON_OFF)
 endmacro()
 
 # This allows programs to locate CGALConfig.cmake
-set(CGAL_DIR ${CMAKE_BINARY_DIR})
+set(CGAL_DIR ${CGAL_BINARY_DIR})
 
 if(NOT RUNNING_CGAL_AUTO_TEST)
 
@@ -1107,13 +1107,13 @@ You must disable CGAL_ENABLE_CHECK_HEADERS.")
     include_directories(SYSTEM ${CGAL_3RD_PARTY_INCLUDE_DIRS})
 
     # Build the doc
-    set(DOC_DIR "${CMAKE_BINARY_DIR}/build_doc")
+    set(DOC_DIR "${CGAL_BINARY_DIR}/build_doc")
     file(MAKE_DIRECTORY "${DOC_DIR}")
     execute_process(
       COMMAND
         "${CMAKE_COMMAND}" -DCGAL_BUILD_THREE_DOC=TRUE
         -DDOXYGEN_EXECUTABLE=${DOXYGEN_EXECUTABLE}
-        "${CMAKE_SOURCE_DIR}/Documentation/doc"
+        "${CGAL_SOURCE_DIR}/Documentation/doc"
       WORKING_DIRECTORY "${DOC_DIR}")
     execute_process(
       COMMAND
@@ -1122,7 +1122,7 @@ You must disable CGAL_ENABLE_CHECK_HEADERS.")
 
   #Get the list of the documented headers
   file(GLOB html_files RELATIVE "${DOC_DIR}/doc_output/" "${DOC_DIR}/doc_output/*/*.html")
-  file(GLOB example_files RELATIVE "${CMAKE_SOURCE_DIR}/" "${CMAKE_SOURCE_DIR}/*/examples/*/*.cpp")
+  file(GLOB example_files RELATIVE "${CGAL_SOURCE_DIR}/" "${CGAL_SOURCE_DIR}/*/examples/*/*.cpp")
   list(SORT example_files)
 
   find_program(AWK awk)
@@ -1139,7 +1139,7 @@ You must disable CGAL_ENABLE_CHECK_HEADERS.")
 
   message("listing headers from examples files")
   foreach(f ${example_files})
-    execute_process(COMMAND "${AWK}" "${awk_arguments}" "${CMAKE_SOURCE_DIR}/${f}"
+    execute_process(COMMAND "${AWK}" "${awk_arguments}" "${CGAL_SOURCE_DIR}/${f}"
       OUTPUT_VARIABLE tmp_list)
     if (NOT "${tmp_list}" STREQUAL "")
       string(REPLACE "\n" ";" tmp_list ${tmp_list})
@@ -1160,7 +1160,7 @@ You must disable CGAL_ENABLE_CHECK_HEADERS.")
     ## Loop on package and headers
     set(check_pkg_target_list)
     #get build dir for removal from deps
-    get_filename_component(BUILD_DIR ${CMAKE_BINARY_DIR} NAME)
+    get_filename_component(BUILD_DIR ${CGAL_BINARY_DIR} NAME)
     foreach(package ${CGAL_CONFIGURED_PACKAGES_NAMES})
       if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/../${package}/include)
         set(check_pkg_headers_depends "")


### PR DESCRIPTION
## Summary of Changes

Allow to use CGAL as a submodule of a bigger CMake project.

The trick is to use
  - `CGAL_SOURCE_DIR` instead of `CMAKE_SOURCE_DIR`, and
  - `CGAL_BINARY_DIR` instead of `CMAKE_BINARY_DIR`.

See
  - https://cmake.org/cmake/help/latest/variable/PROJECT-NAME_SOURCE_DIR.html
  - https://cmake.org/cmake/help/latest/variable/PROJECT-NAME_BINARY_DIR.html
> This can be useful when add_subdirectory() is used to connect several projects.


## Release Management

* Affected package(s): Installation
* License and copyright ownership: maintenance by GeometryFactory

