### PR TITLE
PMP: Remove needles&caps fixes

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -79,12 +79,10 @@ is_badly_shaped(const typename boost::graph_traits<TriangleMesh>::face_descripto
       return make_array(res, null_h);
     }
   }
-  else // let's not make it possible to have a face be both a cap and a needle (for now)
-  {
-    res = PMP::is_cap_triangle_face(f, tmesh, cap_threshold, parameters::vertex_point_map(vpm).geom_traits(gt));
-    if(res != null_h && !get(ecm, edge(res, tmesh)))
-      return make_array(null_h, res);
-  }
+
+  res = PMP::is_cap_triangle_face(f, tmesh, cap_threshold, parameters::vertex_point_map(vpm).geom_traits(gt));
+  if(res != null_h && !get(ecm, edge(res, tmesh)))
+    return make_array(null_h, res);
 
   return make_array(null_h, null_h);
 }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -73,7 +73,7 @@ is_badly_shaped(const typename boost::graph_traits<TriangleMesh>::face_descripto
   if(res != null_h && !get(ecm, edge(res, tmesh)))
   {
     // don't want to collapse edges that are too large
-    if(collapse_length_threshold == 0  ||
+    if(collapse_length_threshold == 0 ||
        edge_length(res, tmesh, parameters::vertex_point_map(vpm).geom_traits(gt)) <= collapse_length_threshold)
     {
       return make_array(res, null_h);
@@ -87,7 +87,7 @@ is_badly_shaped(const typename boost::graph_traits<TriangleMesh>::face_descripto
   return make_array(null_h, null_h);
 }
 
-template <typename TriangleMesh, typename EdgeContainer,
+template <typename TriangleMesh, typename HalfedgeContainer,
           typename VPM, typename ECM, typename Traits>
 void collect_badly_shaped_triangles(const typename boost::graph_traits<TriangleMesh>::face_descriptor f,
                                     TriangleMesh& tmesh,
@@ -97,8 +97,8 @@ void collect_badly_shaped_triangles(const typename boost::graph_traits<TriangleM
                                     const double cap_threshold, // angle over this threshold (as a cosine) ==> cap
                                     const double needle_threshold, // longest edge / shortest edge over this ratio ==> needle
                                     const double collapse_length_threshold, // max length of edges allowed to be collapsed
-                                    EdgeContainer& edges_to_collapse,
-                                    EdgeContainer& edges_to_flip)
+                                    HalfedgeContainer& edges_to_collapse,
+                                    HalfedgeContainer& edges_to_flip)
 {
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor       halfedge_descriptor;
 
@@ -107,21 +107,23 @@ void collect_badly_shaped_triangles(const typename boost::graph_traits<TriangleM
 
   if(res[0] != boost::graph_traits<TriangleMesh>::null_halfedge())
   {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
     std::cout << "add new needle: " << edge(res[0], tmesh) << std::endl;
 #endif
-    CGAL_assertion( !get(ecm, edge(res[0], tmesh)) );
-    edges_to_collapse.insert(edge(res[0], tmesh));
+    CGAL_assertion(!is_border(res[0], tmesh));
+    CGAL_assertion(!get(ecm, edge(res[0], tmesh)));
+    edges_to_collapse.insert(res[0]);
   }
   else // let's not make it possible to have a face be both a cap and a needle (for now)
   {
     if(res[1] != boost::graph_traits<TriangleMesh>::null_halfedge())
     {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
       std::cout << "add new cap: " << edge(res[1],tmesh) << std::endl;
 #endif
-      CGAL_assertion( !get(ecm, edge(res[1], tmesh)) );
-      edges_to_flip.insert(edge(res[1], tmesh));
+      CGAL_assertion(!is_border(res[1], tmesh));
+      CGAL_assertion(!get(ecm, edge(res[1], tmesh)));
+      edges_to_flip.insert(res[1]);
     }
   }
 }
@@ -381,6 +383,9 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
   typedef typename boost::property_map<TriangleMesh, Vertex_property_tag>::type DVCM;
   DVCM vcm = get(Vertex_property_tag(), tmesh);
 
+  CGAL_precondition(is_valid_polygon_mesh(tmesh));
+  CGAL_precondition(is_triangle_mesh(tmesh));
+
   for(face_descriptor f : face_range)
   {
     if(f == boost::graph_traits<TriangleMesh>::null_face())
@@ -401,15 +406,22 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
   }
 
   // Start the process of removing bad elements
-  std::set<edge_descriptor> edges_to_collapse;
-  std::set<edge_descriptor> edges_to_flip;
+  std::set<halfedge_descriptor> edges_to_collapse;
+  std::set<halfedge_descriptor> edges_to_flip;
 
   // @todo could probably do something a bit better by looping edges, consider the incident faces
   // f1 / f2 and look at f1 if f1<f2, and the edge is smaller than the two other edges...
   for(face_descriptor f : face_range)
+  {
     internal::collect_badly_shaped_triangles(f, tmesh, vpm, ecm, gt,
                                              cap_threshold, needle_threshold, collapse_length_threshold,
                                              edges_to_collapse, edges_to_flip);
+  }
+
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
+  std::cout << edges_to_collapse.size() << " to collapse" << std::endl;
+  std::cout << edges_to_flip.size() << " to flip" << std::endl;
+#endif
 
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
   int iter = 0;
@@ -421,6 +433,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
     std::cout << edges_to_collapse.size() << " needles and " << edges_to_flip.size() << " caps" << std::endl;
+    std::cout << "Iter: " << iter << std::endl;
     std::ostringstream oss;
     oss << "degen_cleaning_iter_" << iter++ << ".off";
     std::ofstream out(oss.str().c_str());
@@ -433,120 +446,108 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
       return true;
 
     // @todo maybe using a priority queue handling the more almost degenerate elements should be used
-    std::set<edge_descriptor> next_edges_to_collapse;
-    std::set<edge_descriptor> next_edges_to_flip;
+    std::set<halfedge_descriptor> next_edges_to_collapse;
+    std::set<halfedge_descriptor> next_edges_to_flip;
 
-    // treat needles
+    // Treat needles ===============================================================================
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
     int kk=0;
     std::ofstream(std::string("tmp/n-00000.off")) << tmesh;
 #endif
     while(!edges_to_collapse.empty())
     {
-      edge_descriptor e = *edges_to_collapse.begin();
+      halfedge_descriptor h = *edges_to_collapse.begin();
       edges_to_collapse.erase(edges_to_collapse.begin());
 
-      CGAL_assertion(!get(ecm, e));
+      CGAL_assertion(!is_border(h, tmesh));
 
-      if(get(vcm, source(e, tmesh)) && get(vcm, target(e, tmesh)))
+      const edge_descriptor e = edge(h, tmesh);
+      CGAL_assertion(!get(ecm, edge(h, tmesh)));
+
+      if(get(vcm, source(h, tmesh)) && get(vcm, target(h, tmesh)))
         continue;
 
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
-      std::cout << "  treat needle: " << e << " (" << tmesh.point(source (e, tmesh))
-                                        << " --- " << tmesh.point(target(e, tmesh)) << ")" << std::endl;
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+      std::cout << "  treat needle: " << e
+                << " (" << source(e, tmesh) << " " << tmesh.point(source(h, tmesh))
+                << " --- " << source(e, tmesh) << " " << tmesh.point(target(h, tmesh)) << ")" << std::endl;
 #endif
       if(CGAL::Euler::does_satisfy_link_condition(e, tmesh))
       {
-        // the following edges are removed by the collapse
-        halfedge_descriptor h = halfedge(e, tmesh);
-        CGAL_assertion(!is_border(h, tmesh)); // because extracted from a face
-
-        std::array<halfedge_descriptor, 2> nc =
+        // Verify that the element is still badly shaped
+        const std::array<halfedge_descriptor, 2> nc =
           internal::is_badly_shaped(face(h, tmesh), tmesh, vpm, ecm, gt,
                                     cap_threshold, needle_threshold, collapse_length_threshold);
 
         if(nc[0] != h)
         {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
-          std::cerr << "Warning: Needle criteria no longer verified " << tmesh.point(source(e, tmesh)) << " "
-                                                                      << tmesh.point(target(e, tmesh)) << std::endl;
-#endif
-          // the opposite edge might also have been inserted in the set and might still be a needle
-          h = opposite(h, tmesh);
-          if(is_border(h, tmesh))
-            continue;
-
-          nc = internal::is_badly_shaped(face(h, tmesh), tmesh, vpm, ecm, gt,
-                                         cap_threshold, needle_threshold,
-                                         collapse_length_threshold);
-          if(nc[0] != h)
-            continue;
-        }
-
-        int nb_cst=0;
-        bool too_much_constrained = false;
-        for(int i=0; i<2; ++i)
-        {
-          if(!is_border(h, tmesh))
-          {
-            edge_descriptor pe = edge(prev(h, tmesh), tmesh);
-            if ( get(ecm, pe) )
-            {
-              ++nb_cst;
-              pe = edge(next(h, tmesh), tmesh);
-              if ( get(ecm, pe) )
-              {
-                too_much_constrained = true;
-                break;
-              }
-            }
-            CGAL_assertion( !get(ecm, pe) );
-            edges_to_flip.erase(pe);
-            next_edges_to_collapse.erase(pe);
-            edges_to_collapse.erase(pe);
-          }
-
-          h = opposite(h, tmesh);
-        }
-
-        if ( too_much_constrained )
-        {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
-            std::cerr << "Warning: cannot collapse: too much constrained! "
-                      << tmesh.point(source(e, tmesh)) << " "
-                      << tmesh.point(target(e, tmesh)) << std::endl;
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+          std::cout << "\t Needle criteria no longer verified" << std::endl;
 #endif
           continue;
         }
 
         // pick the orientation of edge to keep the vertex minimizing the volume variation
-        h = internal::get_best_edge_orientation(e, tmesh, vpm, vcm, gt);
-
-        if(h == boost::graph_traits<TriangleMesh>::null_halfedge())
+        const halfedge_descriptor best_h = internal::get_best_edge_orientation(e, tmesh, vpm, vcm, gt);
+        if(best_h == boost::graph_traits<TriangleMesh>::null_halfedge())
         {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
-            std::cerr << "Warning: geometrically invalid edge collapse! "
-                      << tmesh.point(source(e, tmesh)) << " "
-                      << tmesh.point(target(e, tmesh)) << std::endl;
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+            std::cout << "\t Geometrically invalid edge collapse!" << std::endl;
 #endif
-          next_edges_to_collapse.insert(e);
+          next_edges_to_collapse.insert(h);
           continue;
         }
 
-        edges_to_flip.erase(e);
-        next_edges_to_collapse.erase(e); // for edges added in faces incident to a vertex kept after a collapse
+        // Proceeding with the collapse, purge the sets from halfedges being removed
+        for(int i=0; i<2; ++i)
+        {
+          if(!is_border(h, tmesh))
+          {
+            edges_to_flip.erase(h);
+            edges_to_collapse.erase(h);
+            next_edges_to_collapse.erase(h);
+
+            halfedge_descriptor rm_h = prev(h, tmesh);
+            if(get(ecm, edge(rm_h, tmesh)))
+              rm_h = next(h, tmesh);
+
+            edges_to_flip.erase(rm_h);
+            edges_to_collapse.erase(rm_h);
+            next_edges_to_collapse.erase(rm_h);
+
+            halfedge_descriptor opp_rm_h = opposite(rm_h, tmesh);
+            edges_to_flip.erase(opp_rm_h);
+            edges_to_collapse.erase(opp_rm_h);
+            next_edges_to_collapse.erase(opp_rm_h);
+          }
+
+          h = opposite(h, tmesh);
+        }
+
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
-        std::cerr << "  " << kk << " -- Collapsing " << tmesh.point(source(h, tmesh)) << "  "
-                                                     << tmesh.point(target(h, tmesh)) << std::endl;
+        std::cout << "  " << kk << " -- Collapsing " << tmesh.point(source(best_h, tmesh)) << "  "
+                                                     << tmesh.point(target(best_h, tmesh)) << std::endl;
 #endif
+
+        CGAL_assertion(!get(vcm, source(best_h, tmesh)));
+
+        // The function get_best_edge_orientation() has ensured that get(vcm, source(h, tmesh))
+        // is not constrained, so get(ecm, e) is also not constrained for all e incident
+        // to source(h, tmesh).
+        //
+        // The function Euler::collapse_edge() removes edge(prev(h, tmesh)), but that edge
+        // might be constrained. In that case, next() must be removed instead.
+        vertex_descriptor v;
+        if(get(ecm, edge(prev(h, tmesh), tmesh)))
+          v = Euler::collapse_edge(edge(best_h, tmesh), tmesh, ecm);
+        else
+          v = Euler::collapse_edge(edge(best_h, tmesh), tmesh);
+
         // moving to the midpoint is not a good idea. On a circle for example you might endpoint with
         // a bad geometry because you iteratively move one point
         // auto mp = midpoint(tmesh.point(source(h, tmesh)), tmesh.point(target(h, tmesh)));
+        // tmesh.point(v) = mp;
 
-        vertex_descriptor v = nb_cst == 0 ? Euler::collapse_edge(edge(h, tmesh), tmesh)
-                                          : Euler::collapse_edge(edge(h, tmesh), tmesh, ecm);
-
-        //tmesh.point(v) = mp;
         // examine all faces incident to the vertex kept
         for(halfedge_descriptor hv : halfedges_around_target(v, tmesh))
         {
@@ -568,92 +569,87 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 #endif
         something_was_done = true;
       }
-      else
+      else // ! CGAL::Euler::does_satisfy_link_condition(e, tmesh)
       {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
-        std::cerr << "Warning: uncollapsable edge! " << tmesh.point(source(e, tmesh)) << " "
-                                                     << tmesh.point(target(e, tmesh)) << std::endl;
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+        std::cout << "\t Uncollapsable edge!" << std::endl;
 #endif
-        next_edges_to_collapse.insert(e);
+        next_edges_to_collapse.insert(h);
       }
     }
 
-    // treat caps
+    // Treat caps ==================================================================================
+    CGAL_assertion(next_edges_to_flip.empty());
+
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
     kk=0;
     std::ofstream(std::string("tmp/c-000.off")) << tmesh;
 #endif
     while(!edges_to_flip.empty())
     {
-      edge_descriptor e = *edges_to_flip.begin();
+      halfedge_descriptor h = *edges_to_flip.begin();
       edges_to_flip.erase(edges_to_flip.begin());
 
+      CGAL_assertion(!is_border(h, tmesh));
+
+      const edge_descriptor e = edge(h, tmesh);
       CGAL_assertion(!get(ecm, e));
 
       if(get(vcm, source(e, tmesh)) && get(vcm, target(e, tmesh)))
         continue;
 
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
-      std::cout << "treat cap: " << e << " (" << tmesh.point(source(e, tmesh))
-                                   << " --- " << tmesh.point(target(e, tmesh)) << ")" << std::endl;
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+      std::cout << "  treat cap: " << e
+                << " (" << source(e, tmesh) << " " << tmesh.point(source(h, tmesh))
+                << " --- " << target(e, tmesh) << " " << tmesh.point(target(h, tmesh)) << ")" << std::endl;
 #endif
 
-      halfedge_descriptor h = halfedge(e, tmesh);
       std::array<halfedge_descriptor,2> nc = internal::is_badly_shaped(face(h, tmesh), tmesh, vpm, ecm, gt,
                                                                        cap_threshold, needle_threshold,
                                                                        collapse_length_threshold);
-      // First check the triangle is still a cap
+      // Check the triangle is still a cap
       if(nc[1] != h)
       {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
-        std::cerr << "Warning: Cap criteria no longer verified " << tmesh.point(source(e, tmesh)) << " --- "
-                                                                 << tmesh.point(target(e, tmesh)) << std::endl;
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+        std::cout << "\t Cap criteria no longer verified" << std::endl;
 #endif
-        // the opposite edge might also have been inserted in the set and might still be a cap
-        h = opposite(h, tmesh);
-        if(is_border(h, tmesh))
-          continue;
-
-        nc = internal::is_badly_shaped(face(h, tmesh), tmesh, vpm, ecm, gt,
-                                       cap_threshold, needle_threshold, collapse_length_threshold);
-        if(nc[1] != h)
-          continue;
+        continue;
       }
 
-      // special case on the border
+      // special case of `edge(h, tmesh)` being a border edge --> remove the face
       if(is_border(opposite(h, tmesh), tmesh))
       {
-        // remove the triangle
-        edges_to_flip.erase(edge(prev(h, tmesh), tmesh));
-        edges_to_flip.erase(edge(next(h, tmesh), tmesh));
-        next_edges_to_collapse.erase(edge(prev(h, tmesh), tmesh));
-        next_edges_to_collapse.erase(edge(next(h, tmesh), tmesh));
+        for(halfedge_descriptor hh : CGAL::halfedges_around_face(h, tmesh))
+        {
+          // Remove from even 'next_edges_to_flip' because it might have been re-added from a flip
+          edges_to_flip.erase(hh);
+          next_edges_to_flip.erase(hh);
+          next_edges_to_collapse.erase(hh);
+        }
+
         Euler::remove_face(h, tmesh);
+
         something_was_done = true;
         continue;
       }
+
+      CGAL_assertion(!is_border(e, tmesh));
 
       // condition for the flip to be valid (the edge to be created does not already exist)
       if(!halfedge(target(next(h, tmesh), tmesh),
                    target(next(opposite(h, tmesh), tmesh), tmesh), tmesh).second)
       {
-
         if(!internal::should_flip(e, tmesh, vpm, gt))
         {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
-          std::cout << "Flipping prevented: not the best diagonal" << std::endl;
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+          std::cout << "\t Flipping prevented: not the best diagonal" << std::endl;
 #endif
-          next_edges_to_flip.insert(e);
+          next_edges_to_flip.insert(h);
           continue;
         }
 
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
-        std::cout << "Flipping" << std::endl;
-#endif
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
-        std::cerr << "step " << kk << "\n";
-        std::cerr << "  Flipping " << tmesh.point(source(h, tmesh)) << "  "
-                                                   << tmesh.point(target(h, tmesh)) << std::endl;
+        std::cout << "\t step " << kk << " -- Flipping" << std::endl;
 #endif
         Euler::flip_edge(h, tmesh);
         CGAL_assertion(edge(h, tmesh) == e);
@@ -666,30 +662,25 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
             internal::is_badly_shaped(face(h, tmesh), tmesh, vpm, ecm, gt,
                                       cap_threshold, needle_threshold, collapse_length_threshold);
 
-          if(nc[1] != boost::graph_traits<TriangleMesh>::null_halfedge())
-          {
-            if(edge(nc[1], tmesh) != e)
-              next_edges_to_flip.insert(edge(nc[1], tmesh));
-          }
-          else
-          {
-            if(nc[0] != boost::graph_traits<TriangleMesh>::null_halfedge())
-            {
-              next_edges_to_collapse.insert(edge(nc[0], tmesh));
-            }
-          }
+          if(nc[1] != boost::graph_traits<TriangleMesh>::null_halfedge() && nc[1] != h)
+            next_edges_to_flip.insert(nc[1]);
+          else if(nc[0] != boost::graph_traits<TriangleMesh>::null_halfedge())
+            next_edges_to_collapse.insert(nc[0]);
+
           h = opposite(h, tmesh);
         }
+
         something_was_done = true;
       }
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
-      else
+      else // flipped edge already exists in the mesh
       {
-        std::cerr << "Warning: unflippable edge! " << tmesh.point(source(h, tmesh)) << " --- "
-                                                   << tmesh.point(target(h, tmesh)) << std::endl;
-        next_edges_to_flip.insert(e);
-      }
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+        std::cout << "\t Unflippable edge!" << std::endl;
 #endif
+        CGAL_assertion(!is_border(h, tmesh));
+        next_edges_to_flip.insert(h);
+      }
+
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
       std::string nb = std::to_string(++kk);
       if(kk<10) nb = std::string("0")+nb;
@@ -700,11 +691,11 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 #endif
     }
 
-    std::swap(edges_to_collapse, next_edges_to_collapse);
-    std::swap(edges_to_flip, next_edges_to_flip);
-
     if(!something_was_done)
       return false;
+
+    std::swap(edges_to_collapse, next_edges_to_collapse);
+    std::swap(edges_to_flip, next_edges_to_flip);
   }
 
   return false;
@@ -1522,7 +1513,7 @@ bool remove_degenerate_edges(const EdgeRange& edge_range,
             face_set.insert(face(hd, tmesh));
         }
 
-        CGAL_assertion(is_valid_polygon_mesh(tmesh));
+        CGAL_expensive_assertion(is_valid_polygon_mesh(tmesh));
       }
     }
   }
@@ -1609,6 +1600,7 @@ bool remove_degenerate_faces(const FaceRange& face_range,
                              const NamedParameters& np)
 {
   CGAL_assertion(CGAL::is_triangle_mesh(tmesh));
+  CGAL_assertion(CGAL::is_valid_polygon_mesh(tmesh));
 
   using parameters::get_parameter;
   using parameters::choose_parameter;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/shape_predicates.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/shape_predicates.h
@@ -358,6 +358,8 @@ is_needle_triangle_face(typename boost::graph_traits<TriangleMesh>::face_descrip
                         const NamedParameters& np)
 {
   CGAL_precondition(threshold >= 1.);
+  CGAL_precondition(f != boost::graph_traits<TriangleMesh>::null_face());
+  CGAL_precondition(CGAL::is_triangle(halfedge(f, tm), tm));
 
   using parameters::get_parameter;
   using parameters::choose_parameter;
@@ -462,7 +464,8 @@ is_cap_triangle_face(typename boost::graph_traits<TriangleMesh>::face_descriptor
                      const double threshold,
                      const NamedParameters& np)
 {
-  CGAL_precondition(CGAL::is_triangle_mesh(tm));
+  CGAL_precondition(f != boost::graph_traits<TriangleMesh>::null_face());
+  CGAL_precondition(CGAL::is_triangle(halfedge(f, tm), tm));
   CGAL_precondition(threshold >= -1.);
   CGAL_precondition(threshold <= 0.);
 


### PR DESCRIPTION
## Summary of Changes

Fix a number of issues with `PMP::remove_almost_degenerate_faces()`:

- `Edge::collapse_edge` ignored the `ecm`
- A needle ignored due to having a too long collapsable edge was not considered as a cap
- Fix not purging the edge being currently considered from future sets (might have been inserted from an adjacency)
- Fix over-purging sets when using `remove_face()` in the case of a cap on the border
- Don't purge sets if `get_best_oriented()` is going to reject the collapse anyway (everything should still be in the future sets)
- Don't swap if we're going to return anyway

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): -
* License and copyright ownership: no change