### PR TITLE
Tetrahedral_remeshing - fix bad_alloc for very small input mesh

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
@@ -388,11 +388,12 @@ private:
 
       for (std::size_t i = 0; i < 3; i++)
       {
-        if(minMax[3 + i] == minMax[i])
+        res[i] = (std::size_t)ceil((minMax[3 + i] - minMax[i]) / cellSize);
+        if(res[1] == 0)
           res[i] = 1;
-        else
-          res[i] = (std::size_t)ceil((minMax[3 + i] - minMax[i]) / cellSize);
+        CGAL_assertion(res[i] > 0);
       }
+
       std::size_t LUTSize = res[0] * res[1] * res[2];
       LUT.resize(LUTSize);
       LUT.assign(LUTSize, 0);

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
@@ -391,7 +391,6 @@ private:
         res[i] = (std::size_t)ceil((minMax[3 + i] - minMax[i]) / cellSize);
         if(res[1] == 0)
           res[i] = 1;
-        CGAL_assertion(res[i] > 0);
       }
 
       std::size_t LUTSize = res[0] * res[1] * res[2];

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
@@ -469,7 +469,7 @@ private:
       {
         if (vp[j] < 0)
           p[j] = 0;
-        if (vp[j] >= res[j])
+        else if (vp[j] >= res[j])
           p[j] = res[j] - 1;
         else
           p[j] = static_cast<std::size_t>(std::floor(vp[j]));

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
@@ -382,11 +382,17 @@ private:
             minMax[3 + j] = PN[6 * i + j];
         }
       for (std::size_t i = 0; i < 3; i++) {
-        minMax[i] -= 0.001f;
-        minMax[3 + i] += 0.001f;
+        minMax[i] *= 0.99;
+        minMax[3 + i] *= 1.01;
       }
+
       for (std::size_t i = 0; i < 3; i++)
-        res[i] = (std::size_t)ceil((minMax[3 + i] - minMax[i]) / cellSize);
+      {
+        if(minMax[3 + i] == minMax[i])
+          res[i] = 1;
+        else
+          res[i] = (std::size_t)ceil((minMax[3 + i] - minMax[i]) / cellSize);
+      }
       std::size_t LUTSize = res[0] * res[1] * res[2];
       LUT.resize(LUTSize);
       LUT.assign(LUTSize, 0);


### PR DESCRIPTION
## Summary of Changes

This PR prevents a "bad_alloc" error that could happen when the size of the input object (in terms of size of the bbox) was very small and edge lengths even smaller, e.g. `cellSize = 1e-9`.
Thresholding the bbox size with `1e-3` was not consistent with the size of the object, leading to using `resize(n)` on a `std::vector` with `n` larger than `vector.max_size()`.

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged

