### PR TITLE
Kd_tree using vector constructor instead of insert

### DIFF
--- a/Spatial_searching/include/CGAL/Kd_tree.h
+++ b/Spatial_searching/include/CGAL/Kd_tree.h
@@ -281,10 +281,8 @@ public:
   template <class InputIterator>
   Kd_tree(InputIterator first, InputIterator beyond,
           Splitter s = Splitter(),const SearchTraits traits=SearchTraits())
-    : traits_(traits),split(s), built_(false), removed_(false)
-  {
-    pts.insert(pts.end(), first, beyond);
-  }
+    : traits_(traits), split(s), pts(first, beyond), built_(false), removed_(false)
+  { }
 
   bool empty() const {
     return pts.empty();


### PR DESCRIPTION
This PR fixes issue #5482 by changing the constructor of `Kd_tree`. The internal vector with points is now created at the initialization step using the vector constructor instead of the `insert` method. This is more efficient and clean as well. This should also fix the macOS-related test suite errors.

## Release Management

* Affected package(s): `Spatial_searching`
* Issue(s) solved (if any): fix #5482
* Feature/Small Feature (if any): bug fix
* License and copyright ownership: no change

