### PR TITLE
Migration to faster hash maps - Handle_hash_map

### DIFF
--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Reflex_vertex_searcher.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Reflex_vertex_searcher.h
@@ -16,6 +16,7 @@
 
 
 #include<CGAL/Nef_3/SNC_decorator.h>
+#include<CGAL/Unique_hash_map.h>
 #include<CGAL/Convex_decomposition_3/is_reflex_sedge.h>
 #undef CGAL_NEF_DEBUG
 #define CGAL_NEF_DEBUG 229

--- a/Hash_map/include/CGAL/Handle_hash_map.h
+++ b/Hash_map/include/CGAL/Handle_hash_map.h
@@ -76,6 +76,11 @@ public:
         insert(key_begin,key_end,values_begin);
     }
 
+    void reserve(size_type n)
+    {
+        Base::reserve(n);
+    }
+
     void clear()
     {
         Base::clear();

--- a/Hash_map/include/CGAL/Handle_hash_map.h
+++ b/Hash_map/include/CGAL/Handle_hash_map.h
@@ -1,0 +1,122 @@
+// Copyright (c) 2021  GeometryFactory Sarl (France).
+// All rights reserved.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Giles Bathgate <giles.bathgate@gmail.com>
+
+#ifndef CGAL_HANDLE_HASH_MAP
+#define CGAL_HANDLE_HASH_MAP
+
+#include <CGAL/config.h>
+#include <CGAL/Handle_hash_function.h>
+#include <CGAL/Tools/robin_hood.h>
+#include <cstddef>
+#include <functional>
+
+namespace CGAL
+{
+namespace internal
+{
+
+template <class Key,
+          class T,
+          class Hash = Handle_hash_function,
+          class KeyEqual = std::equal_to<Key>,
+          class Allocator = void>
+class Handle_hash_map
+  : private robin_hood::unordered_node_map<Key,T,Hash,KeyEqual>
+{
+    typedef robin_hood::unordered_node_map<Key,T,Hash,KeyEqual> Base;
+
+public:
+    // STL compliance
+    typedef Key                           key_type;
+    typedef T                             mapped_type;
+    typedef std::size_t                   size_type;
+    typedef Hash                          hasher;
+    typedef KeyEqual                      key_equal;
+    typedef typename Base::const_iterator const_iterator;
+
+    // Backwards compatibility
+    typedef mapped_type  Data;
+
+private:
+    mapped_type _default;
+
+public:
+    Handle_hash_map()
+        : _default(mapped_type())
+    {
+    }
+
+    Handle_hash_map(const mapped_type& def)
+        : _default(def)
+    {
+    }
+
+    Handle_hash_map(const mapped_type& def,size_type table_size)
+        : _default(def)
+    {
+        Base::reserve(table_size);
+    }
+
+    Handle_hash_map(key_type key_begin,key_type key_end,mapped_type values_begin,
+                    const mapped_type& def,size_type table_size)
+        : _default(def)
+    {
+        Base::reserve(table_size);
+        insert(key_begin,key_end,values_begin);
+    }
+
+    void clear()
+    {
+        Base::clear();
+    }
+
+    void clear(const mapped_type& def)
+    {
+        clear();
+        _default = def;
+    }
+
+    bool is_defined(const key_type& key) const
+    {
+        return Base::contains(key);
+    }
+
+    const mapped_type& operator[](const key_type& key) const
+    {
+        const_iterator f = Base::find(key);
+        if(f != Base::end())
+            return f->second;
+        return _default;
+    }
+
+    mapped_type& operator[](const key_type& key)
+    {
+        return Base::try_emplace(key,_default).first->second;
+    }
+
+    mapped_type insert(key_type key_begin,key_type key_end,
+                       mapped_type values_begin)
+    {
+        for(; key_begin != key_end; (++key_begin,++values_begin)) {
+            Base::insert_or_assign(key_begin,values_begin);
+        }
+        return values_begin;
+    }
+};
+
+}
+}
+
+#endif // CGAL_HANDLE_HASH_MAP
+

--- a/Hash_map/include/CGAL/Tools/robin_hood.h
+++ b/Hash_map/include/CGAL/Tools/robin_hood.h
@@ -1,0 +1,2529 @@
+//                 ______  _____                 ______                _________
+//  ______________ ___  /_ ___(_)_______         ___  /_ ______ ______ ______  /
+//  __  ___/_  __ \__  __ \__  / __  __ \        __  __ \_  __ \_  __ \_  __  /
+//  _  /    / /_/ /_  /_/ /_  /  _  / / /        _  / / // /_/ // /_/ // /_/ /
+//  /_/     \____/ /_.___/ /_/   /_/ /_/ ________/_/ /_/ \____/ \____/ \__,_/
+//                                      _/_____/
+//
+// Fast & memory efficient hashtable based on robin hood hashing for C++11/14/17/20
+// https://github.com/martinus/robin-hood-hashing
+//
+// Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2018-2021 Martin Ankerl <http://martin.ankerl.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef ROBIN_HOOD_H_INCLUDED
+#define ROBIN_HOOD_H_INCLUDED
+
+// see https://semver.org/
+#define ROBIN_HOOD_VERSION_MAJOR 3  // for incompatible API changes
+#define ROBIN_HOOD_VERSION_MINOR 11 // for adding functionality in a backwards-compatible manner
+#define ROBIN_HOOD_VERSION_PATCH 1  // for backwards-compatible bug fixes
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <functional>
+#include <memory> // only to support hash of smart pointers
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+#include <utility>
+#if __cplusplus >= 201703L
+#    include <string_view>
+#endif
+
+// #define ROBIN_HOOD_LOG_ENABLED
+#ifdef ROBIN_HOOD_LOG_ENABLED
+#    include <iostream>
+#    define ROBIN_HOOD_LOG(...) \
+        std::cout << __FUNCTION__ << "@" << __LINE__ << ": " << __VA_ARGS__ << std::endl;
+#else
+#    define ROBIN_HOOD_LOG(x)
+#endif
+
+// #define ROBIN_HOOD_TRACE_ENABLED
+#ifdef ROBIN_HOOD_TRACE_ENABLED
+#    include <iostream>
+#    define ROBIN_HOOD_TRACE(...) \
+        std::cout << __FUNCTION__ << "@" << __LINE__ << ": " << __VA_ARGS__ << std::endl;
+#else
+#    define ROBIN_HOOD_TRACE(x)
+#endif
+
+// #define ROBIN_HOOD_COUNT_ENABLED
+#ifdef ROBIN_HOOD_COUNT_ENABLED
+#    include <iostream>
+#    define ROBIN_HOOD_COUNT(x) ++counts().x;
+namespace robin_hood {
+struct Counts {
+    uint64_t shiftUp{};
+    uint64_t shiftDown{};
+};
+inline std::ostream& operator<<(std::ostream& os, Counts const& c) {
+    return os << c.shiftUp << " shiftUp" << std::endl << c.shiftDown << " shiftDown" << std::endl;
+}
+
+static Counts& counts() {
+    static Counts counts{};
+    return counts;
+}
+} // namespace robin_hood
+#else
+#    define ROBIN_HOOD_COUNT(x)
+#endif
+
+// all non-argument macros should use this facility. See
+// https://www.fluentcpp.com/2019/05/28/better-macros-better-flags/
+#define ROBIN_HOOD(x) ROBIN_HOOD_PRIVATE_DEFINITION_##x()
+
+// mark unused members with this macro
+#define ROBIN_HOOD_UNUSED(identifier)
+
+// bitness
+#if SIZE_MAX == UINT32_MAX
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_BITNESS() 32
+#elif SIZE_MAX == UINT64_MAX
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_BITNESS() 64
+#else
+#    error Unsupported bitness
+#endif
+
+// endianess
+#ifdef _MSC_VER
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_LITTLE_ENDIAN() 1
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_BIG_ENDIAN() 0
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_LITTLE_ENDIAN() \
+        (__BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__)
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_BIG_ENDIAN() (__BYTE_ORDER__ == __ORDER_BIG_ENDIAN__)
+#endif
+
+// inline
+#ifdef _MSC_VER
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_NOINLINE() __declspec(noinline)
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_NOINLINE() __attribute__((noinline))
+#endif
+
+// exceptions
+#if !defined(__cpp_exceptions) && !defined(__EXCEPTIONS) && !defined(_CPPUNWIND)
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_EXCEPTIONS() 0
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_EXCEPTIONS() 1
+#endif
+
+// count leading/trailing bits
+#if !defined(ROBIN_HOOD_DISABLE_INTRINSICS)
+#    ifdef _MSC_VER
+#        if ROBIN_HOOD(BITNESS) == 32
+#            define ROBIN_HOOD_PRIVATE_DEFINITION_BITSCANFORWARD() _BitScanForward
+#        else
+#            define ROBIN_HOOD_PRIVATE_DEFINITION_BITSCANFORWARD() _BitScanForward64
+#        endif
+#        include <intrin.h>
+#        pragma intrinsic(ROBIN_HOOD(BITSCANFORWARD))
+#        define ROBIN_HOOD_COUNT_TRAILING_ZEROES(x)                                       \
+            [](size_t mask) noexcept -> int {                                             \
+                unsigned long index;                                                      \
+                return ROBIN_HOOD(BITSCANFORWARD)(&index, mask) ? static_cast<int>(index) \
+                                                                : ROBIN_HOOD(BITNESS);    \
+            }(x)
+#    else
+#        if ROBIN_HOOD(BITNESS) == 32
+#            define ROBIN_HOOD_PRIVATE_DEFINITION_CTZ() __builtin_ctzl
+#            define ROBIN_HOOD_PRIVATE_DEFINITION_CLZ() __builtin_clzl
+#        else
+#            define ROBIN_HOOD_PRIVATE_DEFINITION_CTZ() __builtin_ctzll
+#            define ROBIN_HOOD_PRIVATE_DEFINITION_CLZ() __builtin_clzll
+#        endif
+#        define ROBIN_HOOD_COUNT_LEADING_ZEROES(x) ((x) ? ROBIN_HOOD(CLZ)(x) : ROBIN_HOOD(BITNESS))
+#        define ROBIN_HOOD_COUNT_TRAILING_ZEROES(x) ((x) ? ROBIN_HOOD(CTZ)(x) : ROBIN_HOOD(BITNESS))
+#    endif
+#endif
+
+// fallthrough
+#ifndef __has_cpp_attribute // For backwards compatibility
+#    define __has_cpp_attribute(x) 0
+#endif
+#if __has_cpp_attribute(clang::fallthrough)
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_FALLTHROUGH() [[clang::fallthrough]]
+#elif __has_cpp_attribute(gnu::fallthrough)
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_FALLTHROUGH() [[gnu::fallthrough]]
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_FALLTHROUGH()
+#endif
+
+// likely/unlikely
+#ifdef _MSC_VER
+#    define ROBIN_HOOD_LIKELY(condition) condition
+#    define ROBIN_HOOD_UNLIKELY(condition) condition
+#else
+#    define ROBIN_HOOD_LIKELY(condition) __builtin_expect(condition, 1)
+#    define ROBIN_HOOD_UNLIKELY(condition) __builtin_expect(condition, 0)
+#endif
+
+// detect if native wchar_t type is availiable in MSVC
+#ifdef _MSC_VER
+#    ifdef _NATIVE_WCHAR_T_DEFINED
+#        define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_NATIVE_WCHART() 1
+#    else
+#        define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_NATIVE_WCHART() 0
+#    endif
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_HAS_NATIVE_WCHART() 1
+#endif
+
+// detect if MSVC supports the pair(std::piecewise_construct_t,...) consructor being constexpr
+#ifdef _MSC_VER
+#    if _MSC_VER <= 1900
+#        define ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR() 1
+#    else
+#        define ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR() 0
+#    endif
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_BROKEN_CONSTEXPR() 0
+#endif
+
+// workaround missing "is_trivially_copyable" in g++ < 5.0
+// See https://stackoverflow.com/a/31798726/48181
+#if defined(__GNUC__) && __GNUC__ < 5
+#    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) __has_trivial_copy(__VA_ARGS__)
+#else
+#    define ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(...) std::is_trivially_copyable<__VA_ARGS__>::value
+#endif
+
+// helpers for C++ versions, see https://gcc.gnu.org/onlinedocs/cpp/Standard-Predefined-Macros.html
+#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX() __cplusplus
+#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX98() 199711L
+#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX11() 201103L
+#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX14() 201402L
+#define ROBIN_HOOD_PRIVATE_DEFINITION_CXX17() 201703L
+
+#if ROBIN_HOOD(CXX) >= ROBIN_HOOD(CXX17)
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_NODISCARD() [[nodiscard]]
+#else
+#    define ROBIN_HOOD_PRIVATE_DEFINITION_NODISCARD()
+#endif
+
+namespace robin_hood {
+
+#if ROBIN_HOOD(CXX) >= ROBIN_HOOD(CXX14)
+#    define ROBIN_HOOD_STD std
+#else
+
+// c++11 compatibility layer
+namespace ROBIN_HOOD_STD {
+template <class T>
+struct alignment_of
+    : std::integral_constant<std::size_t, alignof(typename std::remove_all_extents<T>::type)> {};
+
+template <class T, T... Ints>
+class integer_sequence {
+public:
+    using value_type = T;
+    static_assert(std::is_integral<value_type>::value, "not integral type");
+    static constexpr std::size_t size() noexcept {
+        return sizeof...(Ints);
+    }
+};
+template <std::size_t... Inds>
+using index_sequence = integer_sequence<std::size_t, Inds...>;
+
+namespace detail_ {
+template <class T, T Begin, T End, bool>
+struct IntSeqImpl {
+    using TValue = T;
+    static_assert(std::is_integral<TValue>::value, "not integral type");
+    static_assert(Begin >= 0 && Begin < End, "unexpected argument (Begin<0 || Begin<=End)");
+
+    template <class, class>
+    struct IntSeqCombiner;
+
+    template <TValue... Inds0, TValue... Inds1>
+    struct IntSeqCombiner<integer_sequence<TValue, Inds0...>, integer_sequence<TValue, Inds1...>> {
+        using TResult = integer_sequence<TValue, Inds0..., Inds1...>;
+    };
+
+    using TResult =
+        typename IntSeqCombiner<typename IntSeqImpl<TValue, Begin, Begin + (End - Begin) / 2,
+                                                    (End - Begin) / 2 == 1>::TResult,
+                                typename IntSeqImpl<TValue, Begin + (End - Begin) / 2, End,
+                                                    (End - Begin + 1) / 2 == 1>::TResult>::TResult;
+};
+
+template <class T, T Begin>
+struct IntSeqImpl<T, Begin, Begin, false> {
+    using TValue = T;
+    static_assert(std::is_integral<TValue>::value, "not integral type");
+    static_assert(Begin >= 0, "unexpected argument (Begin<0)");
+    using TResult = integer_sequence<TValue>;
+};
+
+template <class T, T Begin, T End>
+struct IntSeqImpl<T, Begin, End, true> {
+    using TValue = T;
+    static_assert(std::is_integral<TValue>::value, "not integral type");
+    static_assert(Begin >= 0, "unexpected argument (Begin<0)");
+    using TResult = integer_sequence<TValue, Begin>;
+};
+} // namespace detail_
+
+template <class T, T N>
+using make_integer_sequence = typename detail_::IntSeqImpl<T, 0, N, (N - 0) == 1>::TResult;
+
+template <std::size_t N>
+using make_index_sequence = make_integer_sequence<std::size_t, N>;
+
+template <class... T>
+using index_sequence_for = make_index_sequence<sizeof...(T)>;
+
+} // namespace ROBIN_HOOD_STD
+
+#endif
+
+namespace detail {
+
+// make sure we static_cast to the correct type for hash_int
+#if ROBIN_HOOD(BITNESS) == 64
+using SizeT = uint64_t;
+#else
+using SizeT = uint32_t;
+#endif
+
+template <typename T>
+T rotr(T x, unsigned k) {
+    return (x >> k) | (x << (8U * sizeof(T) - k));
+}
+
+// This cast gets rid of warnings like "cast from 'uint8_t*' {aka 'unsigned char*'} to
+// 'uint64_t*' {aka 'long unsigned int*'} increases required alignment of target type". Use with
+// care!
+template <typename T>
+inline T reinterpret_cast_no_cast_align_warning(void* ptr) noexcept {
+    return reinterpret_cast<T>(ptr);
+}
+
+template <typename T>
+inline T reinterpret_cast_no_cast_align_warning(void const* ptr) noexcept {
+    return reinterpret_cast<T>(ptr);
+}
+
+// make sure this is not inlined as it is slow and dramatically enlarges code, thus making other
+// inlinings more difficult. Throws are also generally the slow path.
+template <typename E, typename... Args>
+[[noreturn]] ROBIN_HOOD(NOINLINE)
+#if ROBIN_HOOD(HAS_EXCEPTIONS)
+    void doThrow(Args&&... args) {
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-array-to-pointer-decay)
+    throw E(std::forward<Args>(args)...);
+}
+#else
+    void doThrow(Args&&... ROBIN_HOOD_UNUSED(args) /*unused*/) {
+    abort();
+}
+#endif
+
+template <typename E, typename T, typename... Args>
+T* assertNotNull(T* t, Args&&... args) {
+    if (ROBIN_HOOD_UNLIKELY(nullptr == t)) {
+        doThrow<E>(std::forward<Args>(args)...);
+    }
+    return t;
+}
+
+template <typename T>
+inline T unaligned_load(void const* ptr) noexcept {
+    // using memcpy so we don't get into unaligned load problems.
+    // compiler should optimize this very well anyways.
+    T t;
+    std::memcpy(&t, ptr, sizeof(T));
+    return t;
+}
+
+// Allocates bulks of memory for objects of type T. This deallocates the memory in the destructor,
+// and keeps a linked list of the allocated memory around. Overhead per allocation is the size of a
+// pointer.
+template <typename T, size_t MinNumAllocs = 4, size_t MaxNumAllocs = 256>
+class BulkPoolAllocator {
+public:
+    BulkPoolAllocator() noexcept = default;
+
+    // does not copy anything, just creates a new allocator.
+    BulkPoolAllocator(const BulkPoolAllocator& ROBIN_HOOD_UNUSED(o) /*unused*/) noexcept
+        : mHead(nullptr)
+        , mListForFree(nullptr) {}
+
+    BulkPoolAllocator(BulkPoolAllocator&& o) noexcept
+        : mHead(o.mHead)
+        , mListForFree(o.mListForFree) {
+        o.mListForFree = nullptr;
+        o.mHead = nullptr;
+    }
+
+    BulkPoolAllocator& operator=(BulkPoolAllocator&& o) noexcept {
+        reset();
+        mHead = o.mHead;
+        mListForFree = o.mListForFree;
+        o.mListForFree = nullptr;
+        o.mHead = nullptr;
+        return *this;
+    }
+
+    BulkPoolAllocator&
+    // NOLINTNEXTLINE(bugprone-unhandled-self-assignment,cert-oop54-cpp)
+    operator=(const BulkPoolAllocator& ROBIN_HOOD_UNUSED(o) /*unused*/) noexcept {
+        // does not do anything
+        return *this;
+    }
+
+    ~BulkPoolAllocator() noexcept {
+        reset();
+    }
+
+    // Deallocates all allocated memory.
+    void reset() noexcept {
+        while (mListForFree) {
+            T* tmp = *mListForFree;
+            ROBIN_HOOD_LOG("std::free")
+            std::free(mListForFree);
+            mListForFree = reinterpret_cast_no_cast_align_warning<T**>(tmp);
+        }
+        mHead = nullptr;
+    }
+
+    // allocates, but does NOT initialize. Use in-place new constructor, e.g.
+    //   T* obj = pool.allocate();
+    //   ::new (static_cast<void*>(obj)) T();
+    T* allocate() {
+        T* tmp = mHead;
+        if (!tmp) {
+            tmp = performAllocation();
+        }
+
+        mHead = *reinterpret_cast_no_cast_align_warning<T**>(tmp);
+        return tmp;
+    }
+
+    // does not actually deallocate but puts it in store.
+    // make sure you have already called the destructor! e.g. with
+    //  obj->~T();
+    //  pool.deallocate(obj);
+    void deallocate(T* obj) noexcept {
+        *reinterpret_cast_no_cast_align_warning<T**>(obj) = mHead;
+        mHead = obj;
+    }
+
+    // Adds an already allocated block of memory to the allocator. This allocator is from now on
+    // responsible for freeing the data (with free()). If the provided data is not large enough to
+    // make use of, it is immediately freed. Otherwise it is reused and freed in the destructor.
+    void addOrFree(void* ptr, const size_t numBytes) noexcept {
+        // calculate number of available elements in ptr
+        if (numBytes < ALIGNMENT + ALIGNED_SIZE) {
+            // not enough data for at least one element. Free and return.
+            ROBIN_HOOD_LOG("std::free")
+            std::free(ptr);
+        } else {
+            ROBIN_HOOD_LOG("add to buffer")
+            add(ptr, numBytes);
+        }
+    }
+
+    void swap(BulkPoolAllocator<T, MinNumAllocs, MaxNumAllocs>& other) noexcept {
+        using std::swap;
+        swap(mHead, other.mHead);
+        swap(mListForFree, other.mListForFree);
+    }
+
+private:
+    // iterates the list of allocated memory to calculate how many to alloc next.
+    // Recalculating this each time saves us a size_t member.
+    // This ignores the fact that memory blocks might have been added manually with addOrFree. In
+    // practice, this should not matter much.
+    ROBIN_HOOD(NODISCARD) size_t calcNumElementsToAlloc() const noexcept {
+        auto tmp = mListForFree;
+        size_t numAllocs = MinNumAllocs;
+
+        while (numAllocs * 2 <= MaxNumAllocs && tmp) {
+            auto x = reinterpret_cast<T***>(tmp);
+            tmp = *x;
+            numAllocs *= 2;
+        }
+
+        return numAllocs;
+    }
+
+    // WARNING: Underflow if numBytes < ALIGNMENT! This is guarded in addOrFree().
+    void add(void* ptr, const size_t numBytes) noexcept {
+        const size_t numElements = (numBytes - ALIGNMENT) / ALIGNED_SIZE;
+
+        auto data = reinterpret_cast<T**>(ptr);
+
+        // link free list
+        auto x = reinterpret_cast<T***>(data);
+        *x = mListForFree;
+        mListForFree = data;
+
+        // create linked list for newly allocated data
+        auto* const headT =
+            reinterpret_cast_no_cast_align_warning<T*>(reinterpret_cast<char*>(ptr) + ALIGNMENT);
+
+        auto* const head = reinterpret_cast<char*>(headT);
+
+        // Visual Studio compiler automatically unrolls this loop, which is pretty cool
+        for (size_t i = 0; i < numElements; ++i) {
+            *reinterpret_cast_no_cast_align_warning<char**>(head + i * ALIGNED_SIZE) =
+                head + (i + 1) * ALIGNED_SIZE;
+        }
+
+        // last one points to 0
+        *reinterpret_cast_no_cast_align_warning<T**>(head + (numElements - 1) * ALIGNED_SIZE) =
+            mHead;
+        mHead = headT;
+    }
+
+    // Called when no memory is available (mHead == 0).
+    // Don't inline this slow path.
+    ROBIN_HOOD(NOINLINE) T* performAllocation() {
+        size_t const numElementsToAlloc = calcNumElementsToAlloc();
+
+        // alloc new memory: [prev |T, T, ... T]
+        size_t const bytes = ALIGNMENT + ALIGNED_SIZE * numElementsToAlloc;
+        ROBIN_HOOD_LOG("std::malloc " << bytes << " = " << ALIGNMENT << " + " << ALIGNED_SIZE
+                                      << " * " << numElementsToAlloc)
+        add(assertNotNull<std::bad_alloc>(std::malloc(bytes)), bytes);
+        return mHead;
+    }
+
+    // enforce byte alignment of the T's
+#if ROBIN_HOOD(CXX) >= ROBIN_HOOD(CXX14)
+    static constexpr size_t ALIGNMENT =
+        (std::max)(std::alignment_of<T>::value, std::alignment_of<T*>::value);
+#else
+    static const size_t ALIGNMENT =
+        (ROBIN_HOOD_STD::alignment_of<T>::value > ROBIN_HOOD_STD::alignment_of<T*>::value)
+            ? ROBIN_HOOD_STD::alignment_of<T>::value
+            : +ROBIN_HOOD_STD::alignment_of<T*>::value; // the + is for walkarround
+#endif
+
+    static constexpr size_t ALIGNED_SIZE = ((sizeof(T) - 1) / ALIGNMENT + 1) * ALIGNMENT;
+
+    static_assert(MinNumAllocs >= 1, "MinNumAllocs");
+    static_assert(MaxNumAllocs >= MinNumAllocs, "MaxNumAllocs");
+    static_assert(ALIGNED_SIZE >= sizeof(T*), "ALIGNED_SIZE");
+    static_assert(0 == (ALIGNED_SIZE % sizeof(T*)), "ALIGNED_SIZE mod");
+    static_assert(ALIGNMENT >= sizeof(T*), "ALIGNMENT");
+
+    T* mHead{nullptr};
+    T** mListForFree{nullptr};
+};
+
+template <typename T, size_t MinSize, size_t MaxSize, bool IsFlat>
+struct NodeAllocator;
+
+// dummy allocator that does nothing
+template <typename T, size_t MinSize, size_t MaxSize>
+struct NodeAllocator<T, MinSize, MaxSize, true> {
+
+    // we are not using the data, so just free it.
+    void addOrFree(void* ptr, size_t ROBIN_HOOD_UNUSED(numBytes) /*unused*/) noexcept {
+        ROBIN_HOOD_LOG("std::free")
+        std::free(ptr);
+    }
+};
+
+template <typename T, size_t MinSize, size_t MaxSize>
+struct NodeAllocator<T, MinSize, MaxSize, false> : public BulkPoolAllocator<T, MinSize, MaxSize> {};
+
+// c++14 doesn't have is_nothrow_swappable, and clang++ 6.0.1 doesn't like it either, so I'm making
+// my own here.
+namespace swappable {
+#if ROBIN_HOOD(CXX) < ROBIN_HOOD(CXX17)
+using std::swap;
+template <typename T>
+struct nothrow {
+    static const bool value = noexcept(swap(std::declval<T&>(), std::declval<T&>()));
+};
+#else
+template <typename T>
+struct nothrow {
+    static const bool value = std::is_nothrow_swappable<T>::value;
+};
+#endif
+} // namespace swappable
+
+} // namespace detail
+
+struct is_transparent_tag {};
+
+// A custom pair implementation is used in the map because std::pair is not is_trivially_copyable,
+// which means it would  not be allowed to be used in std::memcpy. This struct is copyable, which is
+// also tested.
+template <typename T1, typename T2>
+struct pair {
+    using first_type = T1;
+    using second_type = T2;
+
+    template <typename U1 = T1, typename U2 = T2,
+              typename = typename std::enable_if<std::is_default_constructible<U1>::value &&
+                                                 std::is_default_constructible<U2>::value>::type>
+    constexpr pair() noexcept(noexcept(U1()) && noexcept(U2()))
+        : first()
+        , second() {}
+
+    // pair constructors are explicit so we don't accidentally call this ctor when we don't have to.
+    explicit constexpr pair(std::pair<T1, T2> const& o) noexcept(
+        noexcept(T1(std::declval<T1 const&>())) && noexcept(T2(std::declval<T2 const&>())))
+        : first(o.first)
+        , second(o.second) {}
+
+    // pair constructors are explicit so we don't accidentally call this ctor when we don't have to.
+    explicit constexpr pair(std::pair<T1, T2>&& o) noexcept(noexcept(
+        T1(std::move(std::declval<T1&&>()))) && noexcept(T2(std::move(std::declval<T2&&>()))))
+        : first(std::move(o.first))
+        , second(std::move(o.second)) {}
+
+    constexpr pair(T1&& a, T2&& b) noexcept(noexcept(
+        T1(std::move(std::declval<T1&&>()))) && noexcept(T2(std::move(std::declval<T2&&>()))))
+        : first(std::move(a))
+        , second(std::move(b)) {}
+
+    template <typename U1, typename U2>
+    constexpr pair(U1&& a, U2&& b) noexcept(noexcept(T1(std::forward<U1>(
+        std::declval<U1&&>()))) && noexcept(T2(std::forward<U2>(std::declval<U2&&>()))))
+        : first(std::forward<U1>(a))
+        , second(std::forward<U2>(b)) {}
+
+    template <typename... U1, typename... U2>
+    // MSVC 2015 produces error "C2476: ‘constexpr’ constructor does not initialize all members"
+    // if this constructor is constexpr
+#if !ROBIN_HOOD(BROKEN_CONSTEXPR)
+    constexpr
+#endif
+        pair(std::piecewise_construct_t /*unused*/, std::tuple<U1...> a,
+             std::tuple<U2...>
+                 b) noexcept(noexcept(pair(std::declval<std::tuple<U1...>&>(),
+                                           std::declval<std::tuple<U2...>&>(),
+                                           ROBIN_HOOD_STD::index_sequence_for<U1...>(),
+                                           ROBIN_HOOD_STD::index_sequence_for<U2...>())))
+        : pair(a, b, ROBIN_HOOD_STD::index_sequence_for<U1...>(),
+               ROBIN_HOOD_STD::index_sequence_for<U2...>()) {
+    }
+
+    // constructor called from the std::piecewise_construct_t ctor
+    template <typename... U1, size_t... I1, typename... U2, size_t... I2>
+    pair(std::tuple<U1...>& a, std::tuple<U2...>& b, ROBIN_HOOD_STD::index_sequence<I1...> /*unused*/, ROBIN_HOOD_STD::index_sequence<I2...> /*unused*/) noexcept(
+        noexcept(T1(std::forward<U1>(std::get<I1>(
+            std::declval<std::tuple<
+                U1...>&>()))...)) && noexcept(T2(std::
+                                                     forward<U2>(std::get<I2>(
+                                                         std::declval<std::tuple<U2...>&>()))...)))
+        : first(std::forward<U1>(std::get<I1>(a))...)
+        , second(std::forward<U2>(std::get<I2>(b))...) {
+        // make visual studio compiler happy about warning about unused a & b.
+        // Visual studio's pair implementation disables warning 4100.
+        (void)a;
+        (void)b;
+    }
+
+    void swap(pair<T1, T2>& o) noexcept((detail::swappable::nothrow<T1>::value) &&
+                                        (detail::swappable::nothrow<T2>::value)) {
+        using std::swap;
+        swap(first, o.first);
+        swap(second, o.second);
+    }
+
+    T1 first;  // NOLINT(misc-non-private-member-variables-in-classes)
+    T2 second; // NOLINT(misc-non-private-member-variables-in-classes)
+};
+
+template <typename A, typename B>
+inline void swap(pair<A, B>& a, pair<A, B>& b) noexcept(
+    noexcept(std::declval<pair<A, B>&>().swap(std::declval<pair<A, B>&>()))) {
+    a.swap(b);
+}
+
+template <typename A, typename B>
+inline constexpr bool operator==(pair<A, B> const& x, pair<A, B> const& y) {
+    return (x.first == y.first) && (x.second == y.second);
+}
+template <typename A, typename B>
+inline constexpr bool operator!=(pair<A, B> const& x, pair<A, B> const& y) {
+    return !(x == y);
+}
+template <typename A, typename B>
+inline constexpr bool operator<(pair<A, B> const& x, pair<A, B> const& y) noexcept(noexcept(
+    std::declval<A const&>() < std::declval<A const&>()) && noexcept(std::declval<B const&>() <
+                                                                     std::declval<B const&>())) {
+    return x.first < y.first || (!(y.first < x.first) && x.second < y.second);
+}
+template <typename A, typename B>
+inline constexpr bool operator>(pair<A, B> const& x, pair<A, B> const& y) {
+    return y < x;
+}
+template <typename A, typename B>
+inline constexpr bool operator<=(pair<A, B> const& x, pair<A, B> const& y) {
+    return !(x > y);
+}
+template <typename A, typename B>
+inline constexpr bool operator>=(pair<A, B> const& x, pair<A, B> const& y) {
+    return !(x < y);
+}
+
+inline size_t hash_bytes(void const* ptr, size_t len) noexcept {
+    static constexpr uint64_t m = UINT64_C(0xc6a4a7935bd1e995);
+    static constexpr uint64_t seed = UINT64_C(0xe17a1465);
+    static constexpr unsigned int r = 47;
+
+    auto const* const data64 = static_cast<uint64_t const*>(ptr);
+    uint64_t h = seed ^ (len * m);
+
+    size_t const n_blocks = len / 8;
+    for (size_t i = 0; i < n_blocks; ++i) {
+        auto k = detail::unaligned_load<uint64_t>(data64 + i);
+
+        k *= m;
+        k ^= k >> r;
+        k *= m;
+
+        h ^= k;
+        h *= m;
+    }
+
+    auto const* const data8 = reinterpret_cast<uint8_t const*>(data64 + n_blocks);
+    switch (len & 7U) {
+    case 7:
+        h ^= static_cast<uint64_t>(data8[6]) << 48U;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    case 6:
+        h ^= static_cast<uint64_t>(data8[5]) << 40U;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    case 5:
+        h ^= static_cast<uint64_t>(data8[4]) << 32U;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    case 4:
+        h ^= static_cast<uint64_t>(data8[3]) << 24U;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    case 3:
+        h ^= static_cast<uint64_t>(data8[2]) << 16U;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    case 2:
+        h ^= static_cast<uint64_t>(data8[1]) << 8U;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    case 1:
+        h ^= static_cast<uint64_t>(data8[0]);
+        h *= m;
+        ROBIN_HOOD(FALLTHROUGH); // FALLTHROUGH
+    default:
+        break;
+    }
+
+    h ^= h >> r;
+
+    // not doing the final step here, because this will be done by keyToIdx anyways
+    // h *= m;
+    // h ^= h >> r;
+    return static_cast<size_t>(h);
+}
+
+inline size_t hash_int(uint64_t x) noexcept {
+    // tried lots of different hashes, let's stick with murmurhash3. It's simple, fast, well tested,
+    // and doesn't need any special 128bit operations.
+    x ^= x >> 33U;
+    x *= UINT64_C(0xff51afd7ed558ccd);
+    x ^= x >> 33U;
+
+    // not doing the final step here, because this will be done by keyToIdx anyways
+    // x *= UINT64_C(0xc4ceb9fe1a85ec53);
+    // x ^= x >> 33U;
+    return static_cast<size_t>(x);
+}
+
+// A thin wrapper around std::hash, performing an additional simple mixing step of the result.
+template <typename T, typename Enable = void>
+struct hash : public std::hash<T> {
+    size_t operator()(T const& obj) const
+        noexcept(noexcept(std::declval<std::hash<T>>().operator()(std::declval<T const&>()))) {
+        // call base hash
+        auto result = std::hash<T>::operator()(obj);
+        // return mixed of that, to be save against identity has
+        return hash_int(static_cast<detail::SizeT>(result));
+    }
+};
+
+template <typename CharT>
+struct hash<std::basic_string<CharT>> {
+    size_t operator()(std::basic_string<CharT> const& str) const noexcept {
+        return hash_bytes(str.data(), sizeof(CharT) * str.size());
+    }
+};
+
+#if ROBIN_HOOD(CXX) >= ROBIN_HOOD(CXX17)
+template <typename CharT>
+struct hash<std::basic_string_view<CharT>> {
+    size_t operator()(std::basic_string_view<CharT> const& sv) const noexcept {
+        return hash_bytes(sv.data(), sizeof(CharT) * sv.size());
+    }
+};
+#endif
+
+template <class T>
+struct hash<T*> {
+    size_t operator()(T* ptr) const noexcept {
+        return hash_int(reinterpret_cast<detail::SizeT>(ptr));
+    }
+};
+
+template <class T>
+struct hash<std::unique_ptr<T>> {
+    size_t operator()(std::unique_ptr<T> const& ptr) const noexcept {
+        return hash_int(reinterpret_cast<detail::SizeT>(ptr.get()));
+    }
+};
+
+template <class T>
+struct hash<std::shared_ptr<T>> {
+    size_t operator()(std::shared_ptr<T> const& ptr) const noexcept {
+        return hash_int(reinterpret_cast<detail::SizeT>(ptr.get()));
+    }
+};
+
+template <typename Enum>
+struct hash<Enum, typename std::enable_if<std::is_enum<Enum>::value>::type> {
+    size_t operator()(Enum e) const noexcept {
+        using Underlying = typename std::underlying_type<Enum>::type;
+        return hash<Underlying>{}(static_cast<Underlying>(e));
+    }
+};
+
+#define ROBIN_HOOD_HASH_INT(T)                           \
+    template <>                                          \
+    struct hash<T> {                                     \
+        size_t operator()(T const& obj) const noexcept { \
+            return hash_int(static_cast<uint64_t>(obj)); \
+        }                                                \
+    }
+
+#if defined(__GNUC__) && !defined(__clang__)
+#    pragma GCC diagnostic push
+#    pragma GCC diagnostic ignored "-Wuseless-cast"
+#endif
+// see https://en.cppreference.com/w/cpp/utility/hash
+ROBIN_HOOD_HASH_INT(bool);
+ROBIN_HOOD_HASH_INT(char);
+ROBIN_HOOD_HASH_INT(signed char);
+ROBIN_HOOD_HASH_INT(unsigned char);
+ROBIN_HOOD_HASH_INT(char16_t);
+ROBIN_HOOD_HASH_INT(char32_t);
+#if ROBIN_HOOD(HAS_NATIVE_WCHART)
+ROBIN_HOOD_HASH_INT(wchar_t);
+#endif
+ROBIN_HOOD_HASH_INT(short);
+ROBIN_HOOD_HASH_INT(unsigned short);
+ROBIN_HOOD_HASH_INT(int);
+ROBIN_HOOD_HASH_INT(unsigned int);
+ROBIN_HOOD_HASH_INT(long);
+ROBIN_HOOD_HASH_INT(long long);
+ROBIN_HOOD_HASH_INT(unsigned long);
+ROBIN_HOOD_HASH_INT(unsigned long long);
+#if defined(__GNUC__) && !defined(__clang__)
+#    pragma GCC diagnostic pop
+#endif
+namespace detail {
+
+template <typename T>
+struct void_type {
+    using type = void;
+};
+
+template <typename T, typename = void>
+struct has_is_transparent : public std::false_type {};
+
+template <typename T>
+struct has_is_transparent<T, typename void_type<typename T::is_transparent>::type>
+    : public std::true_type {};
+
+// using wrapper classes for hash and key_equal prevents the diamond problem when the same type
+// is used. see https://stackoverflow.com/a/28771920/48181
+template <typename T>
+struct WrapHash : public T {
+    WrapHash() = default;
+    explicit WrapHash(T const& o) noexcept(noexcept(T(std::declval<T const&>())))
+        : T(o) {}
+};
+
+template <typename T>
+struct WrapKeyEqual : public T {
+    WrapKeyEqual() = default;
+    explicit WrapKeyEqual(T const& o) noexcept(noexcept(T(std::declval<T const&>())))
+        : T(o) {}
+};
+
+// A highly optimized hashmap implementation, using the Robin Hood algorithm.
+//
+// In most cases, this map should be usable as a drop-in replacement for std::unordered_map, but
+// be about 2x faster in most cases and require much less allocations.
+//
+// This implementation uses the following memory layout:
+//
+// [Node, Node, ... Node | info, info, ... infoSentinel ]
+//
+// * Node: either a DataNode that directly has the std::pair<key, val> as member,
+//   or a DataNode with a pointer to std::pair<key,val>. Which DataNode representation to use
+//   depends on how fast the swap() operation is. Heuristically, this is automatically choosen
+//   based on sizeof(). there are always 2^n Nodes.
+//
+// * info: Each Node in the map has a corresponding info byte, so there are 2^n info bytes.
+//   Each byte is initialized to 0, meaning the corresponding Node is empty. Set to 1 means the
+//   corresponding node contains data. Set to 2 means the corresponding Node is filled, but it
+//   actually belongs to the previous position and was pushed out because that place is already
+//   taken.
+//
+// * infoSentinel: Sentinel byte set to 1, so that iterator's ++ can stop at end() without the
+//   need for a idx variable.
+//
+// According to STL, order of templates has effect on throughput. That's why I've moved the
+// boolean to the front.
+// https://www.reddit.com/r/cpp/comments/ahp6iu/compile_time_binary_size_reductions_and_cs_future/eeguck4/
+template <bool IsFlat, size_t MaxLoadFactor100, typename Key, typename T, typename Hash,
+          typename KeyEqual>
+class Table
+    : public WrapHash<Hash>,
+      public WrapKeyEqual<KeyEqual>,
+      detail::NodeAllocator<
+          typename std::conditional<
+              std::is_void<T>::value, Key,
+              robin_hood::pair<typename std::conditional<IsFlat, Key, Key const>::type, T>>::type,
+          4, 16384, IsFlat> {
+public:
+    static constexpr bool is_flat = IsFlat;
+    static constexpr bool is_map = !std::is_void<T>::value;
+    static constexpr bool is_set = !is_map;
+    static constexpr bool is_transparent =
+        has_is_transparent<Hash>::value && has_is_transparent<KeyEqual>::value;
+
+    using key_type = Key;
+    using mapped_type = T;
+    using value_type = typename std::conditional<
+        is_set, Key,
+        robin_hood::pair<typename std::conditional<is_flat, Key, Key const>::type, T>>::type;
+    using size_type = size_t;
+    using hasher = Hash;
+    using key_equal = KeyEqual;
+    using Self = Table<IsFlat, MaxLoadFactor100, key_type, mapped_type, hasher, key_equal>;
+
+private:
+    static_assert(MaxLoadFactor100 > 10 && MaxLoadFactor100 < 100,
+                  "MaxLoadFactor100 needs to be >10 && < 100");
+
+    using WHash = WrapHash<Hash>;
+    using WKeyEqual = WrapKeyEqual<KeyEqual>;
+
+    // configuration defaults
+
+    // make sure we have 8 elements, needed to quickly rehash mInfo
+    static constexpr size_t InitialNumElements = sizeof(uint64_t);
+    static constexpr uint32_t InitialInfoNumBits = 5;
+    static constexpr uint8_t InitialInfoInc = 1U << InitialInfoNumBits;
+    static constexpr size_t InfoMask = InitialInfoInc - 1U;
+    static constexpr uint8_t InitialInfoHashShift = 0;
+    using DataPool = detail::NodeAllocator<value_type, 4, 16384, IsFlat>;
+
+    // type needs to be wider than uint8_t.
+    using InfoType = uint32_t;
+
+    // DataNode ////////////////////////////////////////////////////////
+
+    // Primary template for the data node. We have special implementations for small and big
+    // objects. For large objects it is assumed that swap() is fairly slow, so we allocate these
+    // on the heap so swap merely swaps a pointer.
+    template <typename M, bool>
+    class DataNode {};
+
+    // Small: just allocate on the stack.
+    template <typename M>
+    class DataNode<M, true> final {
+    public:
+        template <typename... Args>
+        explicit DataNode(M& ROBIN_HOOD_UNUSED(map) /*unused*/, Args&&... args) noexcept(
+            noexcept(value_type(std::forward<Args>(args)...)))
+            : mData(std::forward<Args>(args)...) {}
+
+        DataNode(M& ROBIN_HOOD_UNUSED(map) /*unused*/, DataNode<M, true>&& n) noexcept(
+            std::is_nothrow_move_constructible<value_type>::value)
+            : mData(std::move(n.mData)) {}
+
+        // doesn't do anything
+        void destroy(M& ROBIN_HOOD_UNUSED(map) /*unused*/) noexcept {}
+        void destroyDoNotDeallocate() noexcept {}
+
+        value_type const* operator->() const noexcept {
+            return &mData;
+        }
+        value_type* operator->() noexcept {
+            return &mData;
+        }
+
+        const value_type& operator*() const noexcept {
+            return mData;
+        }
+
+        value_type& operator*() noexcept {
+            return mData;
+        }
+
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, typename VT::first_type&>::type getFirst() noexcept {
+            return mData.first;
+        }
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_set, VT&>::type getFirst() noexcept {
+            return mData;
+        }
+
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, typename VT::first_type const&>::type
+            getFirst() const noexcept {
+            return mData.first;
+        }
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_set, VT const&>::type getFirst() const noexcept {
+            return mData;
+        }
+
+        template <typename MT = mapped_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, MT&>::type getSecond() noexcept {
+            return mData.second;
+        }
+
+        template <typename MT = mapped_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_set, MT const&>::type getSecond() const noexcept {
+            return mData.second;
+        }
+
+        void swap(DataNode<M, true>& o) noexcept(
+            noexcept(std::declval<value_type>().swap(std::declval<value_type>()))) {
+            mData.swap(o.mData);
+        }
+
+    private:
+        value_type mData;
+    };
+
+    // big object: allocate on heap.
+    template <typename M>
+    class DataNode<M, false> {
+    public:
+        template <typename... Args>
+        explicit DataNode(M& map, Args&&... args)
+            : mData(map.allocate()) {
+            ::new (static_cast<void*>(mData)) value_type(std::forward<Args>(args)...);
+        }
+
+        DataNode(M& ROBIN_HOOD_UNUSED(map) /*unused*/, DataNode<M, false>&& n) noexcept
+            : mData(std::move(n.mData)) {}
+
+        void destroy(M& map) noexcept {
+            // don't deallocate, just put it into list of datapool.
+            mData->~value_type();
+            map.deallocate(mData);
+        }
+
+        void destroyDoNotDeallocate() noexcept {
+            mData->~value_type();
+        }
+
+        value_type const* operator->() const noexcept {
+            return mData;
+        }
+
+        value_type* operator->() noexcept {
+            return mData;
+        }
+
+        const value_type& operator*() const {
+            return *mData;
+        }
+
+        value_type& operator*() {
+            return *mData;
+        }
+
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, typename VT::first_type&>::type getFirst() noexcept {
+            return mData->first;
+        }
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_set, VT&>::type getFirst() noexcept {
+            return *mData;
+        }
+
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, typename VT::first_type const&>::type
+            getFirst() const noexcept {
+            return mData->first;
+        }
+        template <typename VT = value_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_set, VT const&>::type getFirst() const noexcept {
+            return *mData;
+        }
+
+        template <typename MT = mapped_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, MT&>::type getSecond() noexcept {
+            return mData->second;
+        }
+
+        template <typename MT = mapped_type>
+        ROBIN_HOOD(NODISCARD)
+        typename std::enable_if<is_map, MT const&>::type getSecond() const noexcept {
+            return mData->second;
+        }
+
+        void swap(DataNode<M, false>& o) noexcept {
+            using std::swap;
+            swap(mData, o.mData);
+        }
+
+    private:
+        value_type* mData;
+    };
+
+    using Node = DataNode<Self, IsFlat>;
+
+    // helpers for insertKeyPrepareEmptySpot: extract first entry (only const required)
+    ROBIN_HOOD(NODISCARD) key_type const& getFirstConst(Node const& n) const noexcept {
+        return n.getFirst();
+    }
+
+    // in case we have void mapped_type, we are not using a pair, thus we just route k through.
+    // No need to disable this because it's just not used if not applicable.
+    ROBIN_HOOD(NODISCARD) key_type const& getFirstConst(key_type const& k) const noexcept {
+        return k;
+    }
+
+    // in case we have non-void mapped_type, we have a standard robin_hood::pair
+    template <typename Q = mapped_type>
+    ROBIN_HOOD(NODISCARD)
+    typename std::enable_if<!std::is_void<Q>::value, key_type const&>::type
+        getFirstConst(value_type const& vt) const noexcept {
+        return vt.first;
+    }
+
+    // Cloner //////////////////////////////////////////////////////////
+
+    template <typename M, bool UseMemcpy>
+    struct Cloner;
+
+    // fast path: Just copy data, without allocating anything.
+    template <typename M>
+    struct Cloner<M, true> {
+        void operator()(M const& source, M& target) const {
+            auto const* const src = reinterpret_cast<char const*>(source.mKeyVals);
+            auto* tgt = reinterpret_cast<char*>(target.mKeyVals);
+            auto const numElementsWithBuffer = target.calcNumElementsWithBuffer(target.mMask + 1);
+            std::copy(src, src + target.calcNumBytesTotal(numElementsWithBuffer), tgt);
+        }
+    };
+
+    template <typename M>
+    struct Cloner<M, false> {
+        void operator()(M const& s, M& t) const {
+            auto const numElementsWithBuffer = t.calcNumElementsWithBuffer(t.mMask + 1);
+            std::copy(s.mInfo, s.mInfo + t.calcNumBytesInfo(numElementsWithBuffer), t.mInfo);
+
+            for (size_t i = 0; i < numElementsWithBuffer; ++i) {
+                if (t.mInfo[i]) {
+                    ::new (static_cast<void*>(t.mKeyVals + i)) Node(t, *s.mKeyVals[i]);
+                }
+            }
+        }
+    };
+
+    // Destroyer ///////////////////////////////////////////////////////
+
+    template <typename M, bool IsFlatAndTrivial>
+    struct Destroyer {};
+
+    template <typename M>
+    struct Destroyer<M, true> {
+        void nodes(M& m) const noexcept {
+            m.mNumElements = 0;
+        }
+
+        void nodesDoNotDeallocate(M& m) const noexcept {
+            m.mNumElements = 0;
+        }
+    };
+
+    template <typename M>
+    struct Destroyer<M, false> {
+        void nodes(M& m) const noexcept {
+            m.mNumElements = 0;
+            // clear also resets mInfo to 0, that's sometimes not necessary.
+            auto const numElementsWithBuffer = m.calcNumElementsWithBuffer(m.mMask + 1);
+
+            for (size_t idx = 0; idx < numElementsWithBuffer; ++idx) {
+                if (0 != m.mInfo[idx]) {
+                    Node& n = m.mKeyVals[idx];
+                    n.destroy(m);
+                    n.~Node();
+                }
+            }
+        }
+
+        void nodesDoNotDeallocate(M& m) const noexcept {
+            m.mNumElements = 0;
+            // clear also resets mInfo to 0, that's sometimes not necessary.
+            auto const numElementsWithBuffer = m.calcNumElementsWithBuffer(m.mMask + 1);
+            for (size_t idx = 0; idx < numElementsWithBuffer; ++idx) {
+                if (0 != m.mInfo[idx]) {
+                    Node& n = m.mKeyVals[idx];
+                    n.destroyDoNotDeallocate();
+                    n.~Node();
+                }
+            }
+        }
+    };
+
+    // Iter ////////////////////////////////////////////////////////////
+
+    struct fast_forward_tag {};
+
+    // generic iterator for both const_iterator and iterator.
+    template <bool IsConst>
+    // NOLINTNEXTLINE(hicpp-special-member-functions,cppcoreguidelines-special-member-functions)
+    class Iter {
+    private:
+        using NodePtr = typename std::conditional<IsConst, Node const*, Node*>::type;
+
+    public:
+        using difference_type = std::ptrdiff_t;
+        using value_type = typename Self::value_type;
+        using reference = typename std::conditional<IsConst, value_type const&, value_type&>::type;
+        using pointer = typename std::conditional<IsConst, value_type const*, value_type*>::type;
+        using iterator_category = std::forward_iterator_tag;
+
+        // default constructed iterator can be compared to itself, but WON'T return true when
+        // compared to end().
+        Iter() = default;
+
+        // Rule of zero: nothing specified. The conversion constructor is only enabled for
+        // iterator to const_iterator, so it doesn't accidentally work as a copy ctor.
+
+        // Conversion constructor from iterator to const_iterator.
+        template <bool OtherIsConst,
+                  typename = typename std::enable_if<IsConst && !OtherIsConst>::type>
+        // NOLINTNEXTLINE(hicpp-explicit-conversions)
+        Iter(Iter<OtherIsConst> const& other) noexcept
+            : mKeyVals(other.mKeyVals)
+            , mInfo(other.mInfo) {}
+
+        Iter(NodePtr valPtr, uint8_t const* infoPtr) noexcept
+            : mKeyVals(valPtr)
+            , mInfo(infoPtr) {}
+
+        Iter(NodePtr valPtr, uint8_t const* infoPtr,
+             fast_forward_tag ROBIN_HOOD_UNUSED(tag) /*unused*/) noexcept
+            : mKeyVals(valPtr)
+            , mInfo(infoPtr) {
+            fastForward();
+        }
+
+        template <bool OtherIsConst,
+                  typename = typename std::enable_if<IsConst && !OtherIsConst>::type>
+        Iter& operator=(Iter<OtherIsConst> const& other) noexcept {
+            mKeyVals = other.mKeyVals;
+            mInfo = other.mInfo;
+            return *this;
+        }
+
+        // prefix increment. Undefined behavior if we are at end()!
+        Iter& operator++() noexcept {
+            mInfo++;
+            mKeyVals++;
+            fastForward();
+            return *this;
+        }
+
+        Iter operator++(int) noexcept {
+            Iter tmp = *this;
+            ++(*this);
+            return tmp;
+        }
+
+        reference operator*() const {
+            return **mKeyVals;
+        }
+
+        pointer operator->() const {
+            return &**mKeyVals;
+        }
+
+        template <bool O>
+        bool operator==(Iter<O> const& o) const noexcept {
+            return mKeyVals == o.mKeyVals;
+        }
+
+        template <bool O>
+        bool operator!=(Iter<O> const& o) const noexcept {
+            return mKeyVals != o.mKeyVals;
+        }
+
+    private:
+        // fast forward to the next non-free info byte
+        // I've tried a few variants that don't depend on intrinsics, but unfortunately they are
+        // quite a bit slower than this one. So I've reverted that change again. See map_benchmark.
+        void fastForward() noexcept {
+            size_t n = 0;
+            while (0U == (n = detail::unaligned_load<size_t>(mInfo))) {
+                mInfo += sizeof(size_t);
+                mKeyVals += sizeof(size_t);
+            }
+#if defined(ROBIN_HOOD_DISABLE_INTRINSICS)
+            // we know for certain that within the next 8 bytes we'll find a non-zero one.
+            if (ROBIN_HOOD_UNLIKELY(0U == detail::unaligned_load<uint32_t>(mInfo))) {
+                mInfo += 4;
+                mKeyVals += 4;
+            }
+            if (ROBIN_HOOD_UNLIKELY(0U == detail::unaligned_load<uint16_t>(mInfo))) {
+                mInfo += 2;
+                mKeyVals += 2;
+            }
+            if (ROBIN_HOOD_UNLIKELY(0U == *mInfo)) {
+                mInfo += 1;
+                mKeyVals += 1;
+            }
+#else
+#    if ROBIN_HOOD(LITTLE_ENDIAN)
+            auto inc = ROBIN_HOOD_COUNT_TRAILING_ZEROES(n) / 8;
+#    else
+            auto inc = ROBIN_HOOD_COUNT_LEADING_ZEROES(n) / 8;
+#    endif
+            mInfo += inc;
+            mKeyVals += inc;
+#endif
+        }
+
+        friend class Table<IsFlat, MaxLoadFactor100, key_type, mapped_type, hasher, key_equal>;
+        NodePtr mKeyVals{nullptr};
+        uint8_t const* mInfo{nullptr};
+    };
+
+    ////////////////////////////////////////////////////////////////////
+
+    // highly performance relevant code.
+    // Lower bits are used for indexing into the array (2^n size)
+    // The upper 1-5 bits need to be a reasonable good hash, to save comparisons.
+    template <typename HashKey>
+    void keyToIdx(HashKey&& key, size_t* idx, InfoType* info) const {
+        // In addition to whatever hash is used, add another mul & shift so we get better hashing.
+        // This serves as a bad hash prevention, if the given data is
+        // badly mixed.
+        auto h = static_cast<uint64_t>(WHash::operator()(key));
+
+        h *= mHashMultiplier;
+        h ^= h >> 33U;
+
+        // the lower InitialInfoNumBits are reserved for info.
+        *info = mInfoInc + static_cast<InfoType>((h & InfoMask) >> mInfoHashShift);
+        *idx = (static_cast<size_t>(h) >> InitialInfoNumBits) & mMask;
+    }
+
+    // forwards the index by one, wrapping around at the end
+    void next(InfoType* info, size_t* idx) const noexcept {
+        *idx = *idx + 1;
+        *info += mInfoInc;
+    }
+
+    void nextWhileLess(InfoType* info, size_t* idx) const noexcept {
+        // unrolling this by hand did not bring any speedups.
+        while (*info < mInfo[*idx]) {
+            next(info, idx);
+        }
+    }
+
+    // Shift everything up by one element. Tries to move stuff around.
+    void
+    shiftUp(size_t startIdx,
+            size_t const insertion_idx) noexcept(std::is_nothrow_move_assignable<Node>::value) {
+        auto idx = startIdx;
+        ::new (static_cast<void*>(mKeyVals + idx)) Node(std::move(mKeyVals[idx - 1]));
+        while (--idx != insertion_idx) {
+            mKeyVals[idx] = std::move(mKeyVals[idx - 1]);
+        }
+
+        idx = startIdx;
+        while (idx != insertion_idx) {
+            ROBIN_HOOD_COUNT(shiftUp)
+            mInfo[idx] = static_cast<uint8_t>(mInfo[idx - 1] + mInfoInc);
+            if (ROBIN_HOOD_UNLIKELY(mInfo[idx] + mInfoInc > 0xFF)) {
+                mMaxNumElementsAllowed = 0;
+            }
+            --idx;
+        }
+    }
+
+    void shiftDown(size_t idx) noexcept(std::is_nothrow_move_assignable<Node>::value) {
+        // until we find one that is either empty or has zero offset.
+        // TODO(martinus) we don't need to move everything, just the last one for the same
+        // bucket.
+        mKeyVals[idx].destroy(*this);
+
+        // until we find one that is either empty or has zero offset.
+        while (mInfo[idx + 1] >= 2 * mInfoInc) {
+            ROBIN_HOOD_COUNT(shiftDown)
+            mInfo[idx] = static_cast<uint8_t>(mInfo[idx + 1] - mInfoInc);
+            mKeyVals[idx] = std::move(mKeyVals[idx + 1]);
+            ++idx;
+        }
+
+        mInfo[idx] = 0;
+        // don't destroy, we've moved it
+        // mKeyVals[idx].destroy(*this);
+        mKeyVals[idx].~Node();
+    }
+
+    // copy of find(), except that it returns iterator instead of const_iterator.
+    template <typename Other>
+    ROBIN_HOOD(NODISCARD)
+    size_t findIdx(Other const& key) const {
+        size_t idx{};
+        InfoType info{};
+        keyToIdx(key, &idx, &info);
+
+        do {
+            // unrolling this twice gives a bit of a speedup. More unrolling did not help.
+            if (info == mInfo[idx] &&
+                ROBIN_HOOD_LIKELY(WKeyEqual::operator()(key, mKeyVals[idx].getFirst()))) {
+                return idx;
+            }
+            next(&info, &idx);
+            if (info == mInfo[idx] &&
+                ROBIN_HOOD_LIKELY(WKeyEqual::operator()(key, mKeyVals[idx].getFirst()))) {
+                return idx;
+            }
+            next(&info, &idx);
+        } while (info <= mInfo[idx]);
+
+        // nothing found!
+        return mMask == 0 ? 0
+                          : static_cast<size_t>(std::distance(
+                                mKeyVals, reinterpret_cast_no_cast_align_warning<Node*>(mInfo)));
+    }
+
+    void cloneData(const Table& o) {
+        Cloner<Table, IsFlat && ROBIN_HOOD_IS_TRIVIALLY_COPYABLE(Node)>()(o, *this);
+    }
+
+    // inserts a keyval that is guaranteed to be new, e.g. when the hashmap is resized.
+    // @return True on success, false if something went wrong
+    void insert_move(Node&& keyval) {
+        // we don't retry, fail if overflowing
+        // don't need to check max num elements
+        if (0 == mMaxNumElementsAllowed && !try_increase_info()) {
+            throwOverflowError();
+        }
+
+        size_t idx{};
+        InfoType info{};
+        keyToIdx(keyval.getFirst(), &idx, &info);
+
+        // skip forward. Use <= because we are certain that the element is not there.
+        while (info <= mInfo[idx]) {
+            idx = idx + 1;
+            info += mInfoInc;
+        }
+
+        // key not found, so we are now exactly where we want to insert it.
+        auto const insertion_idx = idx;
+        auto const insertion_info = static_cast<uint8_t>(info);
+        if (ROBIN_HOOD_UNLIKELY(insertion_info + mInfoInc > 0xFF)) {
+            mMaxNumElementsAllowed = 0;
+        }
+
+        // find an empty spot
+        while (0 != mInfo[idx]) {
+            next(&info, &idx);
+        }
+
+        auto& l = mKeyVals[insertion_idx];
+        if (idx == insertion_idx) {
+            ::new (static_cast<void*>(&l)) Node(std::move(keyval));
+        } else {
+            shiftUp(idx, insertion_idx);
+            l = std::move(keyval);
+        }
+
+        // put at empty spot
+        mInfo[insertion_idx] = insertion_info;
+
+        ++mNumElements;
+    }
+
+public:
+    using iterator = Iter<false>;
+    using const_iterator = Iter<true>;
+
+    Table() noexcept(noexcept(Hash()) && noexcept(KeyEqual()))
+        : WHash()
+        , WKeyEqual() {
+        ROBIN_HOOD_TRACE(this)
+    }
+
+    // Creates an empty hash map. Nothing is allocated yet, this happens at the first insert.
+    // This tremendously speeds up ctor & dtor of a map that never receives an element. The
+    // penalty is payed at the first insert, and not before. Lookup of this empty map works
+    // because everybody points to DummyInfoByte::b. parameter bucket_count is dictated by the
+    // standard, but we can ignore it.
+    explicit Table(
+        size_t ROBIN_HOOD_UNUSED(bucket_count) /*unused*/, const Hash& h = Hash{},
+        const KeyEqual& equal = KeyEqual{}) noexcept(noexcept(Hash(h)) && noexcept(KeyEqual(equal)))
+        : WHash(h)
+        , WKeyEqual(equal) {
+        ROBIN_HOOD_TRACE(this)
+    }
+
+    template <typename Iter>
+    Table(Iter first, Iter last, size_t ROBIN_HOOD_UNUSED(bucket_count) /*unused*/ = 0,
+          const Hash& h = Hash{}, const KeyEqual& equal = KeyEqual{})
+        : WHash(h)
+        , WKeyEqual(equal) {
+        ROBIN_HOOD_TRACE(this)
+        insert(first, last);
+    }
+
+    Table(std::initializer_list<value_type> initlist,
+          size_t ROBIN_HOOD_UNUSED(bucket_count) /*unused*/ = 0, const Hash& h = Hash{},
+          const KeyEqual& equal = KeyEqual{})
+        : WHash(h)
+        , WKeyEqual(equal) {
+        ROBIN_HOOD_TRACE(this)
+        insert(initlist.begin(), initlist.end());
+    }
+
+    Table(Table&& o) noexcept
+        : WHash(std::move(static_cast<WHash&>(o)))
+        , WKeyEqual(std::move(static_cast<WKeyEqual&>(o)))
+        , DataPool(std::move(static_cast<DataPool&>(o))) {
+        ROBIN_HOOD_TRACE(this)
+        if (o.mMask) {
+            mHashMultiplier = std::move(o.mHashMultiplier);
+            mKeyVals = std::move(o.mKeyVals);
+            mInfo = std::move(o.mInfo);
+            mNumElements = std::move(o.mNumElements);
+            mMask = std::move(o.mMask);
+            mMaxNumElementsAllowed = std::move(o.mMaxNumElementsAllowed);
+            mInfoInc = std::move(o.mInfoInc);
+            mInfoHashShift = std::move(o.mInfoHashShift);
+            // set other's mask to 0 so its destructor won't do anything
+            o.init();
+        }
+    }
+
+    Table& operator=(Table&& o) noexcept {
+        ROBIN_HOOD_TRACE(this)
+        if (&o != this) {
+            if (o.mMask) {
+                // only move stuff if the other map actually has some data
+                destroy();
+                mHashMultiplier = std::move(o.mHashMultiplier);
+                mKeyVals = std::move(o.mKeyVals);
+                mInfo = std::move(o.mInfo);
+                mNumElements = std::move(o.mNumElements);
+                mMask = std::move(o.mMask);
+                mMaxNumElementsAllowed = std::move(o.mMaxNumElementsAllowed);
+                mInfoInc = std::move(o.mInfoInc);
+                mInfoHashShift = std::move(o.mInfoHashShift);
+                WHash::operator=(std::move(static_cast<WHash&>(o)));
+                WKeyEqual::operator=(std::move(static_cast<WKeyEqual&>(o)));
+                DataPool::operator=(std::move(static_cast<DataPool&>(o)));
+
+                o.init();
+
+            } else {
+                // nothing in the other map => just clear us.
+                clear();
+            }
+        }
+        return *this;
+    }
+
+    Table(const Table& o)
+        : WHash(static_cast<const WHash&>(o))
+        , WKeyEqual(static_cast<const WKeyEqual&>(o))
+        , DataPool(static_cast<const DataPool&>(o)) {
+        ROBIN_HOOD_TRACE(this)
+        if (!o.empty()) {
+            // not empty: create an exact copy. it is also possible to just iterate through all
+            // elements and insert them, but copying is probably faster.
+
+            auto const numElementsWithBuffer = calcNumElementsWithBuffer(o.mMask + 1);
+            auto const numBytesTotal = calcNumBytesTotal(numElementsWithBuffer);
+
+            ROBIN_HOOD_LOG("std::malloc " << numBytesTotal << " = calcNumBytesTotal("
+                                          << numElementsWithBuffer << ")")
+            mHashMultiplier = o.mHashMultiplier;
+            mKeyVals = static_cast<Node*>(
+                detail::assertNotNull<std::bad_alloc>(std::malloc(numBytesTotal)));
+            // no need for calloc because clonData does memcpy
+            mInfo = reinterpret_cast<uint8_t*>(mKeyVals + numElementsWithBuffer);
+            mNumElements = o.mNumElements;
+            mMask = o.mMask;
+            mMaxNumElementsAllowed = o.mMaxNumElementsAllowed;
+            mInfoInc = o.mInfoInc;
+            mInfoHashShift = o.mInfoHashShift;
+            cloneData(o);
+        }
+    }
+
+    // Creates a copy of the given map. Copy constructor of each entry is used.
+    // Not sure why clang-tidy thinks this doesn't handle self assignment, it does
+    // NOLINTNEXTLINE(bugprone-unhandled-self-assignment,cert-oop54-cpp)
+    Table& operator=(Table const& o) {
+        ROBIN_HOOD_TRACE(this)
+        if (&o == this) {
+            // prevent assigning of itself
+            return *this;
+        }
+
+        // we keep using the old allocator and not assign the new one, because we want to keep
+        // the memory available. when it is the same size.
+        if (o.empty()) {
+            if (0 == mMask) {
+                // nothing to do, we are empty too
+                return *this;
+            }
+
+            // not empty: destroy what we have there
+            // clear also resets mInfo to 0, that's sometimes not necessary.
+            destroy();
+            init();
+            WHash::operator=(static_cast<const WHash&>(o));
+            WKeyEqual::operator=(static_cast<const WKeyEqual&>(o));
+            DataPool::operator=(static_cast<DataPool const&>(o));
+
+            return *this;
+        }
+
+        // clean up old stuff
+        Destroyer<Self, IsFlat && std::is_trivially_destructible<Node>::value>{}.nodes(*this);
+
+        if (mMask != o.mMask) {
+            // no luck: we don't have the same array size allocated, so we need to realloc.
+            if (0 != mMask) {
+                // only deallocate if we actually have data!
+                ROBIN_HOOD_LOG("std::free")
+                std::free(mKeyVals);
+            }
+
+            auto const numElementsWithBuffer = calcNumElementsWithBuffer(o.mMask + 1);
+            auto const numBytesTotal = calcNumBytesTotal(numElementsWithBuffer);
+            ROBIN_HOOD_LOG("std::malloc " << numBytesTotal << " = calcNumBytesTotal("
+                                          << numElementsWithBuffer << ")")
+            mKeyVals = static_cast<Node*>(
+                detail::assertNotNull<std::bad_alloc>(std::malloc(numBytesTotal)));
+
+            // no need for calloc here because cloneData performs a memcpy.
+            mInfo = reinterpret_cast<uint8_t*>(mKeyVals + numElementsWithBuffer);
+            // sentinel is set in cloneData
+        }
+        WHash::operator=(static_cast<const WHash&>(o));
+        WKeyEqual::operator=(static_cast<const WKeyEqual&>(o));
+        DataPool::operator=(static_cast<DataPool const&>(o));
+        mHashMultiplier = o.mHashMultiplier;
+        mNumElements = o.mNumElements;
+        mMask = o.mMask;
+        mMaxNumElementsAllowed = o.mMaxNumElementsAllowed;
+        mInfoInc = o.mInfoInc;
+        mInfoHashShift = o.mInfoHashShift;
+        cloneData(o);
+
+        return *this;
+    }
+
+    // Swaps everything between the two maps.
+    void swap(Table& o) {
+        ROBIN_HOOD_TRACE(this)
+        using std::swap;
+        swap(o, *this);
+    }
+
+    // Clears all data, without resizing.
+    void clear() {
+        ROBIN_HOOD_TRACE(this)
+        if (empty()) {
+            // don't do anything! also important because we don't want to write to
+            // DummyInfoByte::b, even though we would just write 0 to it.
+            return;
+        }
+
+        Destroyer<Self, IsFlat && std::is_trivially_destructible<Node>::value>{}.nodes(*this);
+
+        auto const numElementsWithBuffer = calcNumElementsWithBuffer(mMask + 1);
+        // clear everything, then set the sentinel again
+        uint8_t const z = 0;
+        std::fill(mInfo, mInfo + calcNumBytesInfo(numElementsWithBuffer), z);
+        mInfo[numElementsWithBuffer] = 1;
+
+        mInfoInc = InitialInfoInc;
+        mInfoHashShift = InitialInfoHashShift;
+    }
+
+    // Destroys the map and all it's contents.
+    ~Table() {
+        ROBIN_HOOD_TRACE(this)
+        destroy();
+    }
+
+    // Checks if both tables contain the same entries. Order is irrelevant.
+    bool operator==(const Table& other) const {
+        ROBIN_HOOD_TRACE(this)
+        if (other.size() != size()) {
+            return false;
+        }
+        for (auto const& otherEntry : other) {
+            if (!has(otherEntry)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    bool operator!=(const Table& other) const {
+        ROBIN_HOOD_TRACE(this)
+        return !operator==(other);
+    }
+
+    template <typename Q = mapped_type>
+    typename std::enable_if<!std::is_void<Q>::value, Q&>::type operator[](const key_type& key) {
+        ROBIN_HOOD_TRACE(this)
+        auto idxAndState = insertKeyPrepareEmptySpot(key);
+        switch (idxAndState.second) {
+        case InsertionState::key_found:
+            break;
+
+        case InsertionState::new_node:
+            ::new (static_cast<void*>(&mKeyVals[idxAndState.first]))
+                Node(*this, std::piecewise_construct, std::forward_as_tuple(key),
+                     std::forward_as_tuple());
+            break;
+
+        case InsertionState::overwrite_node:
+            mKeyVals[idxAndState.first] = Node(*this, std::piecewise_construct,
+                                               std::forward_as_tuple(key), std::forward_as_tuple());
+            break;
+
+        case InsertionState::overflow_error:
+            throwOverflowError();
+        }
+
+        return mKeyVals[idxAndState.first].getSecond();
+    }
+
+    template <typename Q = mapped_type>
+    typename std::enable_if<!std::is_void<Q>::value, Q&>::type operator[](key_type&& key) {
+        ROBIN_HOOD_TRACE(this)
+        auto idxAndState = insertKeyPrepareEmptySpot(key);
+        switch (idxAndState.second) {
+        case InsertionState::key_found:
+            break;
+
+        case InsertionState::new_node:
+            ::new (static_cast<void*>(&mKeyVals[idxAndState.first]))
+                Node(*this, std::piecewise_construct, std::forward_as_tuple(std::move(key)),
+                     std::forward_as_tuple());
+            break;
+
+        case InsertionState::overwrite_node:
+            mKeyVals[idxAndState.first] =
+                Node(*this, std::piecewise_construct, std::forward_as_tuple(std::move(key)),
+                     std::forward_as_tuple());
+            break;
+
+        case InsertionState::overflow_error:
+            throwOverflowError();
+        }
+
+        return mKeyVals[idxAndState.first].getSecond();
+    }
+
+    template <typename Iter>
+    void insert(Iter first, Iter last) {
+        for (; first != last; ++first) {
+            // value_type ctor needed because this might be called with std::pair's
+            insert(value_type(*first));
+        }
+    }
+
+    void insert(std::initializer_list<value_type> ilist) {
+        for (auto&& vt : ilist) {
+            insert(std::move(vt));
+        }
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> emplace(Args&&... args) {
+        ROBIN_HOOD_TRACE(this)
+        Node n{*this, std::forward<Args>(args)...};
+        auto idxAndState = insertKeyPrepareEmptySpot(getFirstConst(n));
+        switch (idxAndState.second) {
+        case InsertionState::key_found:
+            n.destroy(*this);
+            break;
+
+        case InsertionState::new_node:
+            ::new (static_cast<void*>(&mKeyVals[idxAndState.first])) Node(*this, std::move(n));
+            break;
+
+        case InsertionState::overwrite_node:
+            mKeyVals[idxAndState.first] = std::move(n);
+            break;
+
+        case InsertionState::overflow_error:
+            n.destroy(*this);
+            throwOverflowError();
+            break;
+        }
+
+        return std::make_pair(iterator(mKeyVals + idxAndState.first, mInfo + idxAndState.first),
+                              InsertionState::key_found != idxAndState.second);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const key_type& key, Args&&... args) {
+        return try_emplace_impl(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(key_type&& key, Args&&... args) {
+        return try_emplace_impl(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const_iterator hint, const key_type& key,
+                                          Args&&... args) {
+        (void)hint;
+        return try_emplace_impl(key, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    std::pair<iterator, bool> try_emplace(const_iterator hint, key_type&& key, Args&&... args) {
+        (void)hint;
+        return try_emplace_impl(std::move(key), std::forward<Args>(args)...);
+    }
+
+    template <typename Mapped>
+    std::pair<iterator, bool> insert_or_assign(const key_type& key, Mapped&& obj) {
+        return insertOrAssignImpl(key, std::forward<Mapped>(obj));
+    }
+
+    template <typename Mapped>
+    std::pair<iterator, bool> insert_or_assign(key_type&& key, Mapped&& obj) {
+        return insertOrAssignImpl(std::move(key), std::forward<Mapped>(obj));
+    }
+
+    template <typename Mapped>
+    std::pair<iterator, bool> insert_or_assign(const_iterator hint, const key_type& key,
+                                               Mapped&& obj) {
+        (void)hint;
+        return insertOrAssignImpl(key, std::forward<Mapped>(obj));
+    }
+
+    template <typename Mapped>
+    std::pair<iterator, bool> insert_or_assign(const_iterator hint, key_type&& key, Mapped&& obj) {
+        (void)hint;
+        return insertOrAssignImpl(std::move(key), std::forward<Mapped>(obj));
+    }
+
+    std::pair<iterator, bool> insert(const value_type& keyval) {
+        ROBIN_HOOD_TRACE(this)
+        return emplace(keyval);
+    }
+
+    std::pair<iterator, bool> insert(value_type&& keyval) {
+        return emplace(std::move(keyval));
+    }
+
+    // Returns 1 if key is found, 0 otherwise.
+    size_t count(const key_type& key) const { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        auto kv = mKeyVals + findIdx(key);
+        if (kv != reinterpret_cast_no_cast_align_warning<Node*>(mInfo)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    template <typename OtherKey, typename Self_ = Self>
+    // NOLINTNEXTLINE(modernize-use-nodiscard)
+    typename std::enable_if<Self_::is_transparent, size_t>::type count(const OtherKey& key) const {
+        ROBIN_HOOD_TRACE(this)
+        auto kv = mKeyVals + findIdx(key);
+        if (kv != reinterpret_cast_no_cast_align_warning<Node*>(mInfo)) {
+            return 1;
+        }
+        return 0;
+    }
+
+    bool contains(const key_type& key) const { // NOLINT(modernize-use-nodiscard)
+        return 1U == count(key);
+    }
+
+    template <typename OtherKey, typename Self_ = Self>
+    // NOLINTNEXTLINE(modernize-use-nodiscard)
+    typename std::enable_if<Self_::is_transparent, bool>::type contains(const OtherKey& key) const {
+        return 1U == count(key);
+    }
+
+    // Returns a reference to the value found for key.
+    // Throws std::out_of_range if element cannot be found
+    template <typename Q = mapped_type>
+    // NOLINTNEXTLINE(modernize-use-nodiscard)
+    typename std::enable_if<!std::is_void<Q>::value, Q&>::type at(key_type const& key) {
+        ROBIN_HOOD_TRACE(this)
+        auto kv = mKeyVals + findIdx(key);
+        if (kv == reinterpret_cast_no_cast_align_warning<Node*>(mInfo)) {
+            doThrow<std::out_of_range>("key not found");
+        }
+        return kv->getSecond();
+    }
+
+    // Returns a reference to the value found for key.
+    // Throws std::out_of_range if element cannot be found
+    template <typename Q = mapped_type>
+    // NOLINTNEXTLINE(modernize-use-nodiscard)
+    typename std::enable_if<!std::is_void<Q>::value, Q const&>::type at(key_type const& key) const {
+        ROBIN_HOOD_TRACE(this)
+        auto kv = mKeyVals + findIdx(key);
+        if (kv == reinterpret_cast_no_cast_align_warning<Node*>(mInfo)) {
+            doThrow<std::out_of_range>("key not found");
+        }
+        return kv->getSecond();
+    }
+
+    const_iterator find(const key_type& key) const { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        const size_t idx = findIdx(key);
+        return const_iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    template <typename OtherKey>
+    const_iterator find(const OtherKey& key, is_transparent_tag /*unused*/) const {
+        ROBIN_HOOD_TRACE(this)
+        const size_t idx = findIdx(key);
+        return const_iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    template <typename OtherKey, typename Self_ = Self>
+    typename std::enable_if<Self_::is_transparent, // NOLINT(modernize-use-nodiscard)
+                            const_iterator>::type  // NOLINT(modernize-use-nodiscard)
+    find(const OtherKey& key) const {              // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        const size_t idx = findIdx(key);
+        return const_iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    iterator find(const key_type& key) {
+        ROBIN_HOOD_TRACE(this)
+        const size_t idx = findIdx(key);
+        return iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    template <typename OtherKey>
+    iterator find(const OtherKey& key, is_transparent_tag /*unused*/) {
+        ROBIN_HOOD_TRACE(this)
+        const size_t idx = findIdx(key);
+        return iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    template <typename OtherKey, typename Self_ = Self>
+    typename std::enable_if<Self_::is_transparent, iterator>::type find(const OtherKey& key) {
+        ROBIN_HOOD_TRACE(this)
+        const size_t idx = findIdx(key);
+        return iterator{mKeyVals + idx, mInfo + idx};
+    }
+
+    iterator begin() {
+        ROBIN_HOOD_TRACE(this)
+        if (empty()) {
+            return end();
+        }
+        return iterator(mKeyVals, mInfo, fast_forward_tag{});
+    }
+    const_iterator begin() const { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return cbegin();
+    }
+    const_iterator cbegin() const { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        if (empty()) {
+            return cend();
+        }
+        return const_iterator(mKeyVals, mInfo, fast_forward_tag{});
+    }
+
+    iterator end() {
+        ROBIN_HOOD_TRACE(this)
+        // no need to supply valid info pointer: end() must not be dereferenced, and only node
+        // pointer is compared.
+        return iterator{reinterpret_cast_no_cast_align_warning<Node*>(mInfo), nullptr};
+    }
+    const_iterator end() const { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return cend();
+    }
+    const_iterator cend() const { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return const_iterator{reinterpret_cast_no_cast_align_warning<Node*>(mInfo), nullptr};
+    }
+
+    iterator erase(const_iterator pos) {
+        ROBIN_HOOD_TRACE(this)
+        // its safe to perform const cast here
+        // NOLINTNEXTLINE(cppcoreguidelines-pro-type-const-cast)
+        return erase(iterator{const_cast<Node*>(pos.mKeyVals), const_cast<uint8_t*>(pos.mInfo)});
+    }
+
+    // Erases element at pos, returns iterator to the next element.
+    iterator erase(iterator pos) {
+        ROBIN_HOOD_TRACE(this)
+        // we assume that pos always points to a valid entry, and not end().
+        auto const idx = static_cast<size_t>(pos.mKeyVals - mKeyVals);
+
+        shiftDown(idx);
+        --mNumElements;
+
+        if (*pos.mInfo) {
+            // we've backward shifted, return this again
+            return pos;
+        }
+
+        // no backward shift, return next element
+        return ++pos;
+    }
+
+    size_t erase(const key_type& key) {
+        ROBIN_HOOD_TRACE(this)
+        size_t idx{};
+        InfoType info{};
+        keyToIdx(key, &idx, &info);
+
+        // check while info matches with the source idx
+        do {
+            if (info == mInfo[idx] && WKeyEqual::operator()(key, mKeyVals[idx].getFirst())) {
+                shiftDown(idx);
+                --mNumElements;
+                return 1;
+            }
+            next(&info, &idx);
+        } while (info <= mInfo[idx]);
+
+        // nothing found to delete
+        return 0;
+    }
+
+    // reserves space for the specified number of elements. Makes sure the old data fits.
+    // exactly the same as reserve(c).
+    void rehash(size_t c) {
+        // forces a reserve
+        reserve(c, true);
+    }
+
+    // reserves space for the specified number of elements. Makes sure the old data fits.
+    // Exactly the same as rehash(c). Use rehash(0) to shrink to fit.
+    void reserve(size_t c) {
+        // reserve, but don't force rehash
+        reserve(c, false);
+    }
+
+    // If possible reallocates the map to a smaller one. This frees the underlying table.
+    // Does not do anything if load_factor is too large for decreasing the table's size.
+    void compact() {
+        ROBIN_HOOD_TRACE(this)
+        auto newSize = InitialNumElements;
+        while (calcMaxNumElementsAllowed(newSize) < mNumElements && newSize != 0) {
+            newSize *= 2;
+        }
+        if (ROBIN_HOOD_UNLIKELY(newSize == 0)) {
+            throwOverflowError();
+        }
+
+        ROBIN_HOOD_LOG("newSize > mMask + 1: " << newSize << " > " << mMask << " + 1")
+
+        // only actually do anything when the new size is bigger than the old one. This prevents to
+        // continuously allocate for each reserve() call.
+        if (newSize < mMask + 1) {
+            rehashPowerOfTwo(newSize, true);
+        }
+    }
+
+    size_type size() const noexcept { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return mNumElements;
+    }
+
+    size_type max_size() const noexcept { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return static_cast<size_type>(-1);
+    }
+
+    ROBIN_HOOD(NODISCARD) bool empty() const noexcept {
+        ROBIN_HOOD_TRACE(this)
+        return 0 == mNumElements;
+    }
+
+    float max_load_factor() const noexcept { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return MaxLoadFactor100 / 100.0F;
+    }
+
+    // Average number of elements per bucket. Since we allow only 1 per bucket
+    float load_factor() const noexcept { // NOLINT(modernize-use-nodiscard)
+        ROBIN_HOOD_TRACE(this)
+        return static_cast<float>(size()) / static_cast<float>(mMask + 1);
+    }
+
+    ROBIN_HOOD(NODISCARD) size_t mask() const noexcept {
+        ROBIN_HOOD_TRACE(this)
+        return mMask;
+    }
+
+    ROBIN_HOOD(NODISCARD) size_t calcMaxNumElementsAllowed(size_t maxElements) const noexcept {
+        if (ROBIN_HOOD_LIKELY(maxElements <= (std::numeric_limits<size_t>::max)() / 100)) {
+            return maxElements * MaxLoadFactor100 / 100;
+        }
+
+        // we might be a bit inprecise, but since maxElements is quite large that doesn't matter
+        return (maxElements / 100) * MaxLoadFactor100;
+    }
+
+    ROBIN_HOOD(NODISCARD) size_t calcNumBytesInfo(size_t numElements) const noexcept {
+        // we add a uint64_t, which houses the sentinel (first byte) and padding so we can load
+        // 64bit types.
+        return numElements + sizeof(uint64_t);
+    }
+
+    ROBIN_HOOD(NODISCARD)
+    size_t calcNumElementsWithBuffer(size_t numElements) const noexcept {
+        auto maxNumElementsAllowed = calcMaxNumElementsAllowed(numElements);
+        return numElements + (std::min)(maxNumElementsAllowed, (static_cast<size_t>(0xFF)));
+    }
+
+    // calculation only allowed for 2^n values
+    ROBIN_HOOD(NODISCARD) size_t calcNumBytesTotal(size_t numElements) const {
+#if ROBIN_HOOD(BITNESS) == 64
+        return numElements * sizeof(Node) + calcNumBytesInfo(numElements);
+#else
+        // make sure we're doing 64bit operations, so we are at least safe against 32bit overflows.
+        auto const ne = static_cast<uint64_t>(numElements);
+        auto const s = static_cast<uint64_t>(sizeof(Node));
+        auto const infos = static_cast<uint64_t>(calcNumBytesInfo(numElements));
+
+        auto const total64 = ne * s + infos;
+        auto const total = static_cast<size_t>(total64);
+
+        if (ROBIN_HOOD_UNLIKELY(static_cast<uint64_t>(total) != total64)) {
+            throwOverflowError();
+        }
+        return total;
+#endif
+    }
+
+private:
+    template <typename Q = mapped_type>
+    ROBIN_HOOD(NODISCARD)
+    typename std::enable_if<!std::is_void<Q>::value, bool>::type has(const value_type& e) const {
+        ROBIN_HOOD_TRACE(this)
+        auto it = find(e.first);
+        return it != end() && it->second == e.second;
+    }
+
+    template <typename Q = mapped_type>
+    ROBIN_HOOD(NODISCARD)
+    typename std::enable_if<std::is_void<Q>::value, bool>::type has(const value_type& e) const {
+        ROBIN_HOOD_TRACE(this)
+        return find(e) != end();
+    }
+
+    void reserve(size_t c, bool forceRehash) {
+        ROBIN_HOOD_TRACE(this)
+        auto const minElementsAllowed = (std::max)(c, mNumElements);
+        auto newSize = InitialNumElements;
+        while (calcMaxNumElementsAllowed(newSize) < minElementsAllowed && newSize != 0) {
+            newSize *= 2;
+        }
+        if (ROBIN_HOOD_UNLIKELY(newSize == 0)) {
+            throwOverflowError();
+        }
+
+        ROBIN_HOOD_LOG("newSize > mMask + 1: " << newSize << " > " << mMask << " + 1")
+
+        // only actually do anything when the new size is bigger than the old one. This prevents to
+        // continuously allocate for each reserve() call.
+        if (forceRehash || newSize > mMask + 1) {
+            rehashPowerOfTwo(newSize, false);
+        }
+    }
+
+    // reserves space for at least the specified number of elements.
+    // only works if numBuckets if power of two
+    // True on success, false otherwise
+    void rehashPowerOfTwo(size_t numBuckets, bool forceFree) {
+        ROBIN_HOOD_TRACE(this)
+
+        Node* const oldKeyVals = mKeyVals;
+        uint8_t const* const oldInfo = mInfo;
+
+        const size_t oldMaxElementsWithBuffer = calcNumElementsWithBuffer(mMask + 1);
+
+        // resize operation: move stuff
+        initData(numBuckets);
+        if (oldMaxElementsWithBuffer > 1) {
+            for (size_t i = 0; i < oldMaxElementsWithBuffer; ++i) {
+                if (oldInfo[i] != 0) {
+                    // might throw an exception, which is really bad since we are in the middle of
+                    // moving stuff.
+                    insert_move(std::move(oldKeyVals[i]));
+                    // destroy the node but DON'T destroy the data.
+                    oldKeyVals[i].~Node();
+                }
+            }
+
+            // this check is not necessary as it's guarded by the previous if, but it helps
+            // silence g++'s overeager "attempt to free a non-heap object 'map'
+            // [-Werror=free-nonheap-object]" warning.
+            if (oldKeyVals != reinterpret_cast_no_cast_align_warning<Node*>(&mMask)) {
+                // don't destroy old data: put it into the pool instead
+                if (forceFree) {
+                    std::free(oldKeyVals);
+                } else {
+                    DataPool::addOrFree(oldKeyVals, calcNumBytesTotal(oldMaxElementsWithBuffer));
+                }
+            }
+        }
+    }
+
+    ROBIN_HOOD(NOINLINE) void throwOverflowError() const {
+#if ROBIN_HOOD(HAS_EXCEPTIONS)
+        throw std::overflow_error("robin_hood::map overflow");
+#else
+        abort();
+#endif
+    }
+
+    template <typename OtherKey, typename... Args>
+    std::pair<iterator, bool> try_emplace_impl(OtherKey&& key, Args&&... args) {
+        ROBIN_HOOD_TRACE(this)
+        auto idxAndState = insertKeyPrepareEmptySpot(key);
+        switch (idxAndState.second) {
+        case InsertionState::key_found:
+            break;
+
+        case InsertionState::new_node:
+            ::new (static_cast<void*>(&mKeyVals[idxAndState.first])) Node(
+                *this, std::piecewise_construct, std::forward_as_tuple(std::forward<OtherKey>(key)),
+                std::forward_as_tuple(std::forward<Args>(args)...));
+            break;
+
+        case InsertionState::overwrite_node:
+            mKeyVals[idxAndState.first] = Node(*this, std::piecewise_construct,
+                                               std::forward_as_tuple(std::forward<OtherKey>(key)),
+                                               std::forward_as_tuple(std::forward<Args>(args)...));
+            break;
+
+        case InsertionState::overflow_error:
+            throwOverflowError();
+            break;
+        }
+
+        return std::make_pair(iterator(mKeyVals + idxAndState.first, mInfo + idxAndState.first),
+                              InsertionState::key_found != idxAndState.second);
+    }
+
+    template <typename OtherKey, typename Mapped>
+    std::pair<iterator, bool> insertOrAssignImpl(OtherKey&& key, Mapped&& obj) {
+        ROBIN_HOOD_TRACE(this)
+        auto idxAndState = insertKeyPrepareEmptySpot(key);
+        switch (idxAndState.second) {
+        case InsertionState::key_found:
+            mKeyVals[idxAndState.first].getSecond() = std::forward<Mapped>(obj);
+            break;
+
+        case InsertionState::new_node:
+            ::new (static_cast<void*>(&mKeyVals[idxAndState.first])) Node(
+                *this, std::piecewise_construct, std::forward_as_tuple(std::forward<OtherKey>(key)),
+                std::forward_as_tuple(std::forward<Mapped>(obj)));
+            break;
+
+        case InsertionState::overwrite_node:
+            mKeyVals[idxAndState.first] = Node(*this, std::piecewise_construct,
+                                               std::forward_as_tuple(std::forward<OtherKey>(key)),
+                                               std::forward_as_tuple(std::forward<Mapped>(obj)));
+            break;
+
+        case InsertionState::overflow_error:
+            throwOverflowError();
+            break;
+        }
+
+        return std::make_pair(iterator(mKeyVals + idxAndState.first, mInfo + idxAndState.first),
+                              InsertionState::key_found != idxAndState.second);
+    }
+
+    void initData(size_t max_elements) {
+        mNumElements = 0;
+        mMask = max_elements - 1;
+        mMaxNumElementsAllowed = calcMaxNumElementsAllowed(max_elements);
+
+        auto const numElementsWithBuffer = calcNumElementsWithBuffer(max_elements);
+
+        // calloc also zeroes everything
+        auto const numBytesTotal = calcNumBytesTotal(numElementsWithBuffer);
+        ROBIN_HOOD_LOG("std::calloc " << numBytesTotal << " = calcNumBytesTotal("
+                                      << numElementsWithBuffer << ")")
+        mKeyVals = reinterpret_cast<Node*>(
+            detail::assertNotNull<std::bad_alloc>(std::calloc(1, numBytesTotal)));
+        mInfo = reinterpret_cast<uint8_t*>(mKeyVals + numElementsWithBuffer);
+
+        // set sentinel
+        mInfo[numElementsWithBuffer] = 1;
+
+        mInfoInc = InitialInfoInc;
+        mInfoHashShift = InitialInfoHashShift;
+    }
+
+    enum class InsertionState { overflow_error, key_found, new_node, overwrite_node };
+
+    // Finds key, and if not already present prepares a spot where to pot the key & value.
+    // This potentially shifts nodes out of the way, updates mInfo and number of inserted
+    // elements, so the only operation left to do is create/assign a new node at that spot.
+    template <typename OtherKey>
+    std::pair<size_t, InsertionState> insertKeyPrepareEmptySpot(OtherKey&& key) {
+        for (int i = 0; i < 256; ++i) {
+            size_t idx{};
+            InfoType info{};
+            keyToIdx(key, &idx, &info);
+            nextWhileLess(&info, &idx);
+
+            // while we potentially have a match
+            while (info == mInfo[idx]) {
+                if (WKeyEqual::operator()(key, mKeyVals[idx].getFirst())) {
+                    // key already exists, do NOT insert.
+                    // see http://en.cppreference.com/w/cpp/container/unordered_map/insert
+                    return std::make_pair(idx, InsertionState::key_found);
+                }
+                next(&info, &idx);
+            }
+
+            // unlikely that this evaluates to true
+            if (ROBIN_HOOD_UNLIKELY(mNumElements >= mMaxNumElementsAllowed)) {
+                if (!increase_size()) {
+                    return std::make_pair(size_t(0), InsertionState::overflow_error);
+                }
+                continue;
+            }
+
+            // key not found, so we are now exactly where we want to insert it.
+            auto const insertion_idx = idx;
+            auto const insertion_info = info;
+            if (ROBIN_HOOD_UNLIKELY(insertion_info + mInfoInc > 0xFF)) {
+                mMaxNumElementsAllowed = 0;
+            }
+
+            // find an empty spot
+            while (0 != mInfo[idx]) {
+                next(&info, &idx);
+            }
+
+            if (idx != insertion_idx) {
+                shiftUp(idx, insertion_idx);
+            }
+            // put at empty spot
+            mInfo[insertion_idx] = static_cast<uint8_t>(insertion_info);
+            ++mNumElements;
+            return std::make_pair(insertion_idx, idx == insertion_idx
+                                                     ? InsertionState::new_node
+                                                     : InsertionState::overwrite_node);
+        }
+
+        // enough attempts failed, so finally give up.
+        return std::make_pair(size_t(0), InsertionState::overflow_error);
+    }
+
+    bool try_increase_info() {
+        ROBIN_HOOD_LOG("mInfoInc=" << mInfoInc << ", numElements=" << mNumElements
+                                   << ", maxNumElementsAllowed="
+                                   << calcMaxNumElementsAllowed(mMask + 1))
+        if (mInfoInc <= 2) {
+            // need to be > 2 so that shift works (otherwise undefined behavior!)
+            return false;
+        }
+        // we got space left, try to make info smaller
+        mInfoInc = static_cast<uint8_t>(mInfoInc >> 1U);
+
+        // remove one bit of the hash, leaving more space for the distance info.
+        // This is extremely fast because we can operate on 8 bytes at once.
+        ++mInfoHashShift;
+        auto const numElementsWithBuffer = calcNumElementsWithBuffer(mMask + 1);
+
+        for (size_t i = 0; i < numElementsWithBuffer; i += 8) {
+            auto val = unaligned_load<uint64_t>(mInfo + i);
+            val = (val >> 1U) & UINT64_C(0x7f7f7f7f7f7f7f7f);
+            std::memcpy(mInfo + i, &val, sizeof(val));
+        }
+        // update sentinel, which might have been cleared out!
+        mInfo[numElementsWithBuffer] = 1;
+
+        mMaxNumElementsAllowed = calcMaxNumElementsAllowed(mMask + 1);
+        return true;
+    }
+
+    // True if resize was possible, false otherwise
+    bool increase_size() {
+        // nothing allocated yet? just allocate InitialNumElements
+        if (0 == mMask) {
+            initData(InitialNumElements);
+            return true;
+        }
+
+        auto const maxNumElementsAllowed = calcMaxNumElementsAllowed(mMask + 1);
+        if (mNumElements < maxNumElementsAllowed && try_increase_info()) {
+            return true;
+        }
+
+        ROBIN_HOOD_LOG("mNumElements=" << mNumElements << ", maxNumElementsAllowed="
+                                       << maxNumElementsAllowed << ", load="
+                                       << (static_cast<double>(mNumElements) * 100.0 /
+                                           (static_cast<double>(mMask) + 1)))
+
+        nextHashMultiplier();
+        if (mNumElements * 2 < calcMaxNumElementsAllowed(mMask + 1)) {
+            // we have to resize, even though there would still be plenty of space left!
+            // Try to rehash instead. Delete freed memory so we don't steadyily increase mem in case
+            // we have to rehash a few times
+            rehashPowerOfTwo(mMask + 1, true);
+        } else {
+            // Each resize use a different hash so we don't so easily overflow.
+            // Make sure we only have odd numbers, so that the multiplication is reversible!
+            rehashPowerOfTwo((mMask + 1) * 2, false);
+        }
+        return true;
+    }
+
+    void nextHashMultiplier() {
+        // adding an *even* number, so that the multiplier will always stay odd. This is necessary
+        // so that the hash stays a mixing function (and thus doesn't have any information loss).
+        mHashMultiplier += UINT64_C(0xc4ceb9fe1a85ec54);
+    }
+
+    void destroy() {
+        if (0 == mMask) {
+            // don't deallocate!
+            return;
+        }
+
+        Destroyer<Self, IsFlat && std::is_trivially_destructible<Node>::value>{}
+            .nodesDoNotDeallocate(*this);
+
+        // This protection against not deleting mMask shouldn't be needed as it's sufficiently
+        // protected with the 0==mMask check, but I have this anyways because g++ 7 otherwise
+        // reports a compile error: attempt to free a non-heap object 'fm'
+        // [-Werror=free-nonheap-object]
+        if (mKeyVals != reinterpret_cast_no_cast_align_warning<Node*>(&mMask)) {
+            ROBIN_HOOD_LOG("std::free")
+            std::free(mKeyVals);
+        }
+    }
+
+    void init() noexcept {
+        mKeyVals = reinterpret_cast_no_cast_align_warning<Node*>(&mMask);
+        mInfo = reinterpret_cast<uint8_t*>(&mMask);
+        mNumElements = 0;
+        mMask = 0;
+        mMaxNumElementsAllowed = 0;
+        mInfoInc = InitialInfoInc;
+        mInfoHashShift = InitialInfoHashShift;
+    }
+
+    // members are sorted so no padding occurs
+    uint64_t mHashMultiplier = UINT64_C(0xc4ceb9fe1a85ec53);                // 8 byte  8
+    Node* mKeyVals = reinterpret_cast_no_cast_align_warning<Node*>(&mMask); // 8 byte 16
+    uint8_t* mInfo = reinterpret_cast<uint8_t*>(&mMask);                    // 8 byte 24
+    size_t mNumElements = 0;                                                // 8 byte 32
+    size_t mMask = 0;                                                       // 8 byte 40
+    size_t mMaxNumElementsAllowed = 0;                                      // 8 byte 48
+    InfoType mInfoInc = InitialInfoInc;                                     // 4 byte 52
+    InfoType mInfoHashShift = InitialInfoHashShift;                         // 4 byte 56
+                                                    // 16 byte 56 if NodeAllocator
+};
+
+} // namespace detail
+
+// map
+
+template <typename Key, typename T, typename Hash = hash<Key>,
+          typename KeyEqual = std::equal_to<Key>, size_t MaxLoadFactor100 = 80>
+using unordered_flat_map = detail::Table<true, MaxLoadFactor100, Key, T, Hash, KeyEqual>;
+
+template <typename Key, typename T, typename Hash = hash<Key>,
+          typename KeyEqual = std::equal_to<Key>, size_t MaxLoadFactor100 = 80>
+using unordered_node_map = detail::Table<false, MaxLoadFactor100, Key, T, Hash, KeyEqual>;
+
+template <typename Key, typename T, typename Hash = hash<Key>,
+          typename KeyEqual = std::equal_to<Key>, size_t MaxLoadFactor100 = 80>
+using unordered_map =
+    detail::Table<sizeof(robin_hood::pair<Key, T>) <= sizeof(size_t) * 6 &&
+                      std::is_nothrow_move_constructible<robin_hood::pair<Key, T>>::value &&
+                      std::is_nothrow_move_assignable<robin_hood::pair<Key, T>>::value,
+                  MaxLoadFactor100, Key, T, Hash, KeyEqual>;
+
+// set
+
+template <typename Key, typename Hash = hash<Key>, typename KeyEqual = std::equal_to<Key>,
+          size_t MaxLoadFactor100 = 80>
+using unordered_flat_set = detail::Table<true, MaxLoadFactor100, Key, void, Hash, KeyEqual>;
+
+template <typename Key, typename Hash = hash<Key>, typename KeyEqual = std::equal_to<Key>,
+          size_t MaxLoadFactor100 = 80>
+using unordered_node_set = detail::Table<false, MaxLoadFactor100, Key, void, Hash, KeyEqual>;
+
+template <typename Key, typename Hash = hash<Key>, typename KeyEqual = std::equal_to<Key>,
+          size_t MaxLoadFactor100 = 80>
+using unordered_set = detail::Table<sizeof(Key) <= sizeof(size_t) * 6 &&
+                                        std::is_nothrow_move_constructible<Key>::value &&
+                                        std::is_nothrow_move_assignable<Key>::value,
+                                    MaxLoadFactor100, Key, void, Hash, KeyEqual>;
+
+} // namespace robin_hood
+
+#endif

--- a/Hash_map/include/CGAL/Tools/robin_hood.h
+++ b/Hash_map/include/CGAL/Tools/robin_hood.h
@@ -9,26 +9,11 @@
 // https://github.com/martinus/robin-hood-hashing
 //
 // Licensed under the MIT License <http://opensource.org/licenses/MIT>.
+// $URL$
+// $Id$
 // SPDX-License-Identifier: MIT
 // Copyright (c) 2018-2021 Martin Ankerl <http://martin.ankerl.com>
 //
-// Permission is hereby granted, free of charge, to any person obtaining a copy
-// of this software and associated documentation files (the "Software"), to deal
-// in the Software without restriction, including without limitation the rights
-// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-// copies of the Software, and to permit persons to whom the Software is
-// furnished to do so, subject to the following conditions:
-//
-// The above copyright notice and this permission notice shall be included in all
-// copies or substantial portions of the Software.
-//
-// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-// SOFTWARE.
 
 #ifndef ROBIN_HOOD_H_INCLUDED
 #define ROBIN_HOOD_H_INCLUDED

--- a/Hash_map/package_info/Hash_map/license.txt
+++ b/Hash_map/package_info/Hash_map/license.txt
@@ -1,1 +1,2 @@
 LGPL (v3 or later)
+MIT/X11 (BSD like)

--- a/Nef_2/include/CGAL/Nef_2/Constrained_triang_traits.h
+++ b/Nef_2/include/CGAL/Nef_2/Constrained_triang_traits.h
@@ -16,7 +16,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/generic_sweep.h>
 #include <CGAL/Nef_2/PM_checker.h>
 #include <cstdlib>
@@ -150,7 +150,7 @@ public:
     Vertex_handle           event;
     Point                   p_sweep;
     Sweep_status_structure  SL;
-    CGAL::Unique_hash_map<Halfedge_handle,ss_iterator> SLItem;
+    CGAL::internal::Handle_hash_map<Halfedge_handle,ss_iterator> SLItem;
     const NEWEDGE&          Treat_new_edge;
     Halfedge_handle         e_low,e_high; // framing edges !
     Halfedge_handle         e_search;

--- a/Nef_2/include/CGAL/Nef_2/Object_index.h
+++ b/Nef_2/include/CGAL/Nef_2/Object_index.h
@@ -17,7 +17,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <string>
 #include <sstream>
 
@@ -26,7 +26,7 @@ namespace CGAL {
 template <typename I>
 class Object_index {
   char _prefix;
-  CGAL::Unique_hash_map<I,int> _index;
+  CGAL::internal::Handle_hash_map<I,int> _index;
 public:
   Object_index() : _prefix('\0'), _index(-1) {}
   Object_index(I first, I beyond, char c=' ') : _prefix(c), _index(-1)

--- a/Nef_2/include/CGAL/Nef_2/PM_checker.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_checker.h
@@ -17,7 +17,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Nef_2/PM_const_decorator.h>
 
 namespace CGAL {
@@ -248,7 +248,7 @@ check_is_triangulation() const
   check_order_preserving_embedding();
   eb = check_boundary_is_clockwise_weakly_polygon();
 
-  CGAL::Unique_hash_map< Halfedge_const_iterator, bool> on_boundary(false);
+  CGAL::internal::Handle_hash_map< Halfedge_const_iterator, bool> on_boundary(false);
   Halfedge_around_face_const_circulator hit(eb), hend(hit);
   std::ostringstream error_status;
   CGAL::set_pretty_mode ( error_status );

--- a/Nef_2/include/CGAL/Nef_2/PM_const_decorator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_const_decorator.h
@@ -17,7 +17,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <string>
 #include <list>
 #include <sstream>
@@ -505,7 +505,7 @@ PM_const_decorator<HDS>::
 number_of_face_cycles() const
 {
   Size_type fc_num=0;
-  CGAL::Unique_hash_map<Halfedge_const_handle,bool> visited;
+  CGAL::internal::Handle_hash_map<Halfedge_const_handle,bool> visited;
     // init with bool() == false
   Halfedge_const_iterator eit =  phds->halfedges_begin();
   Halfedge_const_iterator eend = phds->halfedges_end();
@@ -525,7 +525,7 @@ number_of_connected_components() const
   typedef Vertex_const_iterator vc_handle;
   typedef Halfedge_around_vertex_const_circulator hvc_circulator;
   int comp_num=0;
-  CGAL::Unique_hash_map< vc_handle, bool> handled(false);
+  CGAL::internal::Handle_hash_map< vc_handle, bool> handled(false);
   vc_handle vit = vertices_begin(), vend = vertices_end();
   for ( ; vit != vend; ++vit) {
     if (handled[vit]) continue;
@@ -567,8 +567,8 @@ void print_as_leda_graph(std::ostream& os, const PMCDEC& D,
   typedef typename PMCDEC::Halfedge_const_iterator
   Halfedge_const_iterator;
   int vn(1), en(1);
-  CGAL::Unique_hash_map<Vertex_const_iterator,int>   v_num;
-  CGAL::Unique_hash_map<Halfedge_const_iterator,int> e_num;
+  CGAL::internal::Handle_hash_map<Vertex_const_iterator,int>   v_num;
+  CGAL::internal::Handle_hash_map<Halfedge_const_iterator,int> e_num;
   os << "LEDA.GRAPH\n" << "point\n" << "int\n";
   os << D.number_of_vertices() << std::endl;
   Vertex_const_iterator vit;

--- a/Nef_2/include/CGAL/Nef_2/PM_decorator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_decorator.h
@@ -21,7 +21,7 @@
 #else
 #include <boost/any.hpp>
 #endif
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <vector>
 
 namespace CGAL {
@@ -796,9 +796,9 @@ void PM_decorator<HDS>::clone(const HDS& H) const
 
   PM_const_decorator<HDS> DC(H);
   CGAL_assertion((DC.check_integrity_and_topological_planarity(),1));
-  CGAL::Unique_hash_map<Vertex_const_iterator,Vertex_handle>     Vnew;
-  CGAL::Unique_hash_map<Halfedge_const_iterator,Halfedge_handle> Hnew;
-  CGAL::Unique_hash_map<Face_const_iterator,Face_handle>         Fnew;
+  CGAL::internal::Handle_hash_map<Vertex_const_iterator,Vertex_handle>     Vnew;
+  CGAL::internal::Handle_hash_map<Halfedge_const_iterator,Halfedge_handle> Hnew;
+  CGAL::internal::Handle_hash_map<Face_const_iterator,Face_handle>         Fnew;
 
   /* First clone all objects and store correspondance in three maps.*/
   Vertex_const_iterator vit, vend = H.vertices_end();
@@ -864,8 +864,8 @@ clone_skeleton(const HDS& H, const LINKDA& L) const
 
   PM_const_decorator<HDS> DC(H);
   CGAL_assertion((DC.check_integrity_and_topological_planarity(),1));
-  CGAL::Unique_hash_map<Vertex_const_iterator,Vertex_handle>     Vnew;
-  CGAL::Unique_hash_map<Halfedge_const_iterator,Halfedge_handle> Hnew;
+  CGAL::internal::Handle_hash_map<Vertex_const_iterator,Vertex_handle>     Vnew;
+  CGAL::internal::Handle_hash_map<Halfedge_const_iterator,Halfedge_handle> Hnew;
 
   /* First clone all objects and store correspondance in the two maps.*/
   Vertex_const_iterator vit, vend = H.vertices_end();

--- a/Nef_2/include/CGAL/Nef_2/PM_overlayer.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_overlayer.h
@@ -17,7 +17,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Union_find.h>
 #include <CGAL/Nef_2/Segment_overlay_traits.h>
 #ifdef CGAL_I_DO_WANT_TO_USE_GENINFO
@@ -132,11 +132,11 @@ struct PMO_from_pm {
 
   const Decorator& G;
   const Const_decorator* pGI[2];
-  CGAL::Unique_hash_map<IT,INFO>& M;
+  CGAL::internal::Handle_hash_map<IT,INFO>& M;
   PMO_from_pm(const Decorator& Gi,
               const Const_decorator* pG0,
               const Const_decorator* pG1,
-              CGAL::Unique_hash_map<IT,INFO>& Mi) : G(Gi),M(Mi)
+              CGAL::internal::Handle_hash_map<IT,INFO>& Mi) : G(Gi),M(Mi)
  { pGI[0]=pG0; pGI[1]=pG1; }
 
  Vertex_handle new_vertex(const Point& p) const
@@ -431,7 +431,7 @@ and |\Mvar.mark(v,1) = D1.mark(f1)|.}*/
   Const_decorator PI[2];
   PI[0] = Const_decorator(P0); PI[1] = Const_decorator(P1);
   Seg_list Segments; int i;
-  CGAL::Unique_hash_map<Seg_iterator,Seg_info> From;
+  CGAL::internal::Handle_hash_map<Seg_iterator,Seg_info> From;
   for (i=0; i<2; ++i) {
     Vertex_const_iterator v;
     for(v = PI[i].vertices_begin(); v != PI[i].vertices_end(); ++v)
@@ -567,7 +567,7 @@ avoid the simplification for edge pairs referenced by |e|.}*/
 {
   CGAL_NEF_TRACEN("simplifying");
   typedef typename CGAL::Union_find<Face_handle>::handle Union_find_handle;
-  CGAL::Unique_hash_map< Face_iterator, Union_find_handle> Pitem;
+  CGAL::internal::Handle_hash_map< Face_iterator, Union_find_handle> Pitem;
   CGAL::Union_find<Face_handle> unify_faces;
 
   Face_iterator f, fend = this->faces_end();
@@ -596,7 +596,7 @@ avoid the simplification for edge pairs referenced by |e|.}*/
     }
   }
 
-  CGAL::Unique_hash_map<Halfedge_handle,bool> linked(false);
+  CGAL::internal::Handle_hash_map<Halfedge_handle,bool> linked(false);
   for (e = this->halfedges_begin(); e != eend; ++e) {
     if ( linked[e] ) continue;
     Halfedge_around_face_circulator hfc(e),hend(hfc);
@@ -816,7 +816,7 @@ template <typename Below_info>
 void create_face_objects(const Below_info& D) const
 {
   CGAL_NEF_TRACEN("create_face_objects()");
-  CGAL::Unique_hash_map<Halfedge_handle,int> FaceCycle(-1);
+  CGAL::internal::Handle_hash_map<Halfedge_handle,int> FaceCycle(-1);
   std::vector<Halfedge_handle>  MinimalHalfedge;
   int i=0;
   Halfedge_iterator e, eend = this->halfedges_end();
@@ -877,7 +877,7 @@ template <typename Below_info>
 void create_face_objects_pl(const Below_info& D) const
 {
   CGAL_NEF_TRACEN("create_face_objects_pl()");
-  CGAL::Unique_hash_map<Halfedge_handle,int> FaceCycle(-1);
+  CGAL::internal::Handle_hash_map<Halfedge_handle,int> FaceCycle(-1);
   std::vector<Halfedge_handle>  MinimalHalfedge;
   int i=0;
   Halfedge_iterator e, eend = this->halfedges_end();
@@ -927,7 +927,7 @@ void create_face_objects_pl(const Below_info& D) const
 template <typename Below_info>
 Face_handle determine_face(Halfedge_handle e,
   const std::vector<Halfedge_handle>& MinimalHalfedge,
-  const CGAL::Unique_hash_map<Halfedge_handle,int>& FaceCycle,
+  const CGAL::internal::Handle_hash_map<Halfedge_handle,int>& FaceCycle,
   const Below_info& D) const
 { CGAL_NEF_TRACEN("determine_face "<<PE(e));
   Halfedge_handle e_min = MinimalHalfedge[FaceCycle[e]];

--- a/Nef_2/include/CGAL/Nef_2/PM_point_locator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_point_locator.h
@@ -16,7 +16,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Nef_2/Constrained_triang_traits.h>
 #include <CGAL/Nef_2/Object_handle.h>
 #include <CGAL/Circulator_project.h>
@@ -233,7 +233,7 @@ public:
     Halfedge_const_handle e_res;
     Segment ss = s; // we shorten the segment iteratively
     Direction dso = K.construct_direction(K.target(s),p), d_res;
-    CGAL::Unique_hash_map<Halfedge_const_handle,bool> visited(false);
+    CGAL::internal::Handle_hash_map<Halfedge_const_handle,bool> visited(false);
     for(vit = this->vertices_begin(); vit != this->vertices_end(); ++vit) {
       Point p_res, vp = point(vit);
       if ( K.contains(ss,vp) ) {

--- a/Nef_2/include/CGAL/Nef_2/Segment_overlay_traits.h
+++ b/Nef_2/include/CGAL/Nef_2/Segment_overlay_traits.h
@@ -433,7 +433,7 @@ public:
 #include <sstream>
 #include <map>
 #include <CGAL/Multiset.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 
 namespace CGAL {
 
@@ -557,15 +557,15 @@ public:
   typedef std::list<ITERATOR>                            IsoList;
   typedef CGAL::Multiset<Point_2, compare_pnts_xy>       EventQueue;
   typedef typename EventQueue::iterator                  event_iterator;
-  typedef Unique_hash_map<Point_2*, IsoList*>            X2iso;
+  typedef CGAL::internal::Handle_hash_map<Point_2*, IsoList*>            X2iso;
 
   typedef CGAL::Multiset<ISegment, compare_segs_at_sweepline>  SweepStatus;
   typedef typename SweepStatus::iterator                       ss_iterator;
   typedef typename SweepStatus::const_iterator                 ss_const_iterator;
-  typedef CGAL::Unique_hash_map<ISegment, event_iterator>      Y2X;
-  typedef CGAL::Unique_hash_map<ISegment, ISegment>            Y2Y;
-  typedef CGAL::Unique_hash_map<Point_2*, ss_iterator>         X2Y;
-  typedef CGAL::Unique_hash_map<ISegment, Halfedge_handle>     AssocEdgeMap;
+  typedef CGAL::internal::Handle_hash_map<ISegment, event_iterator>      Y2X;
+  typedef CGAL::internal::Handle_hash_map<ISegment, ISegment>            Y2Y;
+  typedef CGAL::internal::Handle_hash_map<Point_2*, ss_iterator>         X2Y;
+  typedef CGAL::internal::Handle_hash_map<ISegment, Halfedge_handle>     AssocEdgeMap;
 
   typedef std::pair<ISegment,ISegment>                   is_pair;
 

--- a/Nef_2/include/CGAL/Nef_polyhedron_2.h
+++ b/Nef_2/include/CGAL/Nef_polyhedron_2.h
@@ -295,9 +295,9 @@ protected:
   template<typename IT>
   struct From_intersecting_polygons {
 
-    Unique_hash_map<Halfedge_handle,IT>& halfedge2iterator;
+    CGAL::internal::Handle_hash_map<Halfedge_handle,IT>& halfedge2iterator;
 
-    From_intersecting_polygons(Unique_hash_map<Halfedge_handle,IT>& e2i)
+    From_intersecting_polygons(CGAL::internal::Handle_hash_map<Halfedge_handle,IT>& e2i)
       : halfedge2iterator(e2i) {}
 
     void supporting_segment(Halfedge_handle e, IT it)
@@ -476,7 +476,7 @@ public:
     }
 
     Overlayer D(pm());
-    Unique_hash_map<Halfedge_handle,ES_iterator> e2i;
+    CGAL::internal::Handle_hash_map<Halfedge_handle,ES_iterator> e2i;
     From_intersecting_polygons<ES_iterator> fip(e2i);
     D.create(L.begin(),L.end(),fip);
 

--- a/Nef_3/include/CGAL/Nef_3/Binary_operation.h
+++ b/Nef_3/include/CGAL/Nef_3/Binary_operation.h
@@ -21,7 +21,7 @@
 
 #include <CGAL/basic.h>
 #include <CGAL/Nef_S2/Normalizing.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Nef_3/SNC_decorator.h>
 #include <CGAL/Nef_S2/SM_decorator.h>
 #include <CGAL/Nef_S2/SM_point_locator.h>
@@ -307,7 +307,7 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
       number_of_intersection_candidates=0;
 #endif
 
-    Unique_hash_map<Vertex_const_handle, bool> ignore(false);
+    CGAL::internal::Handle_hash_map<Vertex_const_handle, bool> ignore(false);
     Vertex_const_iterator v0;
 
     //    CGAL_NEF_SETDTHREAD(19*43*131);

--- a/Nef_3/include/CGAL/Nef_3/Combine_with_halfspace.h
+++ b/Nef_3/include/CGAL/Nef_3/Combine_with_halfspace.h
@@ -19,7 +19,7 @@
 
 
 #include <CGAL/Nef_S2/Normalizing.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Nef_3/SNC_const_decorator.h>
 #include <CGAL/Nef_S2/SM_decorator.h>
 #include <CGAL/Nef_3/SNC_SM_overlayer.h>

--- a/Nef_3/include/CGAL/Nef_3/ID_support_handler.h
+++ b/Nef_3/include/CGAL/Nef_3/ID_support_handler.h
@@ -18,8 +18,7 @@
 
 #include <CGAL/Nef_S2/ID_support_handler.h>
 #include <CGAL/Nef_3/SNC_indexed_items.h>
-#include <boost/functional/hash.hpp>
-#include <unordered_map>
+#include <CGAL/Handle_hash_map.h>
 #include <map>
 
 #undef CGAL_NEF_DEBUG
@@ -55,7 +54,7 @@ class ID_support_handler<SNC_indexed_items, Decorator> {
       return hash;
     }
   };
-  std::unordered_map<Halffacet_pair, int, Handle_pair_hash_function> f2m;
+  CGAL::internal::Handle_hash_map<Halffacet_pair, int, Handle_pair_hash_function> f2m;
   std::map<int, int> hash;
 
  public:

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -18,7 +18,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Nef_3/quotient_coordinates_to_homogeneous_point.h>
 #include <CGAL/Lazy_kernel.h>
 #include <CGAL/Cartesian.h>
@@ -179,7 +179,7 @@ private:
                                     SHalfedge_around_facet_circulator;
 
     CT ct;
-    CGAL::Unique_hash_map<Face_handle, bool> visited;
+    CGAL::internal::Handle_hash_map<Face_handle, bool> visited;
     Finite_face_iterator fi;
 
   public:
@@ -885,9 +885,9 @@ typename Object_list::difference_type n_vertices = std::distance(objects.begin()
     Object_list O;
 
     Objects_around_segment objects( *this, s);
-    Unique_hash_map< Vertex_handle, bool> v_mark(false);
-    Unique_hash_map< Halfedge_handle, bool> e_mark(false);
-    Unique_hash_map< Halffacet_handle, bool> f_mark(false);
+    CGAL::internal::Handle_hash_map< Vertex_handle, bool> v_mark(false);
+    CGAL::internal::Handle_hash_map< Halfedge_handle, bool> e_mark(false);
+    CGAL::internal::Handle_hash_map< Halffacet_handle, bool> f_mark(false);
     std::map< Triangle_3, bool, Compare_triangle_3<Triangle_3> > t_mark;
     for( typename Objects_around_segment::Iterator oar = objects.begin();
          oar != objects.end(); ++oar) {
@@ -1067,16 +1067,16 @@ std::string dump_object_list( const Object_list& O, int level = 0) {
   return os.str();
  }
 
-bool update( Unique_hash_map<Vertex_handle, bool>& V,
-             Unique_hash_map<Halfedge_handle, bool>& E,
-             Unique_hash_map<Halffacet_handle, bool>& F) {
+bool update( CGAL::internal::Handle_hash_map<Vertex_handle, bool>& V,
+             CGAL::internal::Handle_hash_map<Halfedge_handle, bool>& E,
+             CGAL::internal::Handle_hash_map<Halffacet_handle, bool>& F) {
   return update( root, V, E, F);
 }
 
 bool update( Node_handle node,
-             Unique_hash_map<Vertex_handle, bool>& V,
-             Unique_hash_map<Halfedge_handle, bool>& E,
-             Unique_hash_map<Halffacet_handle, bool>& F) {
+             CGAL::internal::Handle_hash_map<Vertex_handle, bool>& V,
+             CGAL::internal::Handle_hash_map<Halfedge_handle, bool>& E,
+             CGAL::internal::Handle_hash_map<Halffacet_handle, bool>& F) {
   CGAL_assertion( node != nullptr);
   if( node->is_leaf()) {
     bool updated = false;

--- a/Nef_3/include/CGAL/Nef_3/SM_visualizor.h
+++ b/Nef_3/include/CGAL/Nef_3/SM_visualizor.h
@@ -168,7 +168,7 @@ void draw_map() const
 
 
   SM_Halfedge_const_iterator h;
-  Unique_hash_map<SM_Halfedge_const_iterator,bool> Done(false);
+  CGAL::internal::Handle_hash_map<SM_Halfedge_const_iterator,bool> Done(false);
   CGAL_forall_shalfedges(h,T_) {
     if ( Done[h] ) continue;
     SM_Halfedge_const_iterator hn(T_.next(h)),hnn(T_.next(hn));
@@ -207,7 +207,7 @@ void draw_triangulation() const
   CGAL_forall_svertices(v,T_)
     S_.push_back(T_.point(v),CO_.color(vd,T_.mark(v)));
 
-  Unique_hash_map<SM_Halfedge_const_iterator,bool> Done(false);
+  CGAL::internal::Handle_hash_map<SM_Halfedge_const_iterator,bool> Done(false);
   CGAL_forall_shalfedges(e,T_) {
     if ( Done[e] ) continue;
     SM_Halfedge_const_iterator en(T_.next(e)),enn(T_.next(en));

--- a/Nef_3/include/CGAL/Nef_3/SNC_FM_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_FM_decorator.h
@@ -110,14 +110,14 @@ struct Sort_sedges2 {
 template <typename P, typename V, typename E, typename I>
 struct Halffacet_output {
 
-Halffacet_output(CGAL::Unique_hash_map<I,E>& F, std::vector<E>& S)
+Halffacet_output(CGAL::internal::Handle_hash_map<I,E>& F, std::vector<E>& S)
   : From(F), Support(S) { edge_number=0; Support[0]=E(); }
 
 typedef P         Point;
 typedef V         Vertex_handle;
 typedef unsigned  Halfedge_handle;
 
-CGAL::Unique_hash_map<I,E>& From;
+CGAL::internal::Handle_hash_map<I,E>& From;
 std::vector<E>& Support;
 unsigned edge_number;
 
@@ -404,7 +404,7 @@ protected:
 
   Halffacet_handle determine_facet(SHalfedge_handle e,
     const std::vector<SHalfedge_handle>& MinimalEdge,
-    const CGAL::Unique_hash_map<SHalfedge_handle,int>& FacetCycle,
+    const CGAL::internal::Handle_hash_map<SHalfedge_handle,int>& FacetCycle,
     const std::vector<SHalfedge_handle>& Edge_of) const
   { CGAL_NEF_TRACEN("  determine_facet "<<debug(e));
     int fc = FacetCycle[e];
@@ -467,12 +467,12 @@ create_facet_objects(const Plane_3& plane_supporting_facet,
   Object_list_iterator start, Object_list_iterator end) const
 { CGAL_NEF_TRACEN(">>>>>create_facet_objects "
                   << normalized(plane_supporting_facet));
-  CGAL::Unique_hash_map<SHalfedge_handle,int> FacetCycle(-1);
+  CGAL::internal::Handle_hash_map<SHalfedge_handle,int> FacetCycle(-1);
   std::vector<SHalfedge_handle> MinimalEdge;
   std::list<SHalfedge_handle> SHalfedges;
   std::list<SHalfloop_handle> SHalfloops;
 
-  CGAL::Unique_hash_map<Segment_iterator,SHalfedge_handle>  From;
+  CGAL::internal::Handle_hash_map<Segment_iterator,SHalfedge_handle>  From;
 
   Segment_list Segments;
   SHalfedge_handle e; SHalfloop_handle l;

--- a/Nef_3/include/CGAL/Nef_3/SNC_SM_overlayer.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_SM_overlayer.h
@@ -91,8 +91,8 @@ public:
     CGAL_NEF_TRACEN("simplifying");
 
     typedef typename CGAL::Union_find<SFace_handle>::handle Union_find_handle;
-    CGAL::Unique_hash_map< SFace_handle, Union_find_handle> Pitem(nullptr);
-    CGAL::Unique_hash_map< SVertex_handle, Union_find_handle> Vitem(nullptr);
+    CGAL::internal::Handle_hash_map< SFace_handle, Union_find_handle> Pitem(nullptr);
+    CGAL::internal::Handle_hash_map< SVertex_handle, Union_find_handle> Vitem(nullptr);
     CGAL::Union_find< SFace_handle> UF;
 
     SFace_iterator f;
@@ -142,7 +142,7 @@ public:
       }
     }
 
-    CGAL::Unique_hash_map<SHalfedge_handle,bool> linked(false);
+    CGAL::internal::Handle_hash_map<SHalfedge_handle,bool> linked(false);
     for (e = this->shalfedges_begin(); e != this->shalfedges_end(); ++e) {
       if ( linked[e] ) continue;
       SHalfedge_around_sface_circulator hfc(e),hend(hfc);
@@ -358,8 +358,8 @@ class SNC_SM_overlayer<SNC_indexed_items, SM_decorator_>
     CGAL_NEF_TRACEN("simplifying");
 
     typedef typename CGAL::Union_find<SFace_handle>::handle Union_find_handle;
-    CGAL::Unique_hash_map< SFace_handle, Union_find_handle> Pitem(nullptr);
-    CGAL::Unique_hash_map< SVertex_handle, Union_find_handle> Vitem(nullptr);
+    CGAL::internal::Handle_hash_map< SFace_handle, Union_find_handle> Pitem(nullptr);
+    CGAL::internal::Handle_hash_map< SVertex_handle, Union_find_handle> Vitem(nullptr);
     CGAL::Union_find< SFace_handle> UF;
 
     SFace_iterator f;
@@ -409,7 +409,7 @@ class SNC_SM_overlayer<SNC_indexed_items, SM_decorator_>
       }
     }
 
-    CGAL::Unique_hash_map<SHalfedge_handle,bool> linked(false);
+    CGAL::internal::Handle_hash_map<SHalfedge_handle,bool> linked(false);
     for (e = this->shalfedges_begin(); e != this->shalfedges_end(); ++e) {
       if ( linked[e] ) continue;
       SHalfedge_around_sface_circulator hfc(e),hend(hfc);

--- a/Nef_3/include/CGAL/Nef_3/SNC_SM_visualizor.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_SM_visualizor.h
@@ -146,7 +146,7 @@ void draw_map() const
 
 
   SM_Halfedge_const_iterator h;
-  Unique_hash_map<SM_Halfedge_const_iterator,bool> Done(false);
+  CGAL::internal::Handle_hash_map<SM_Halfedge_const_iterator,bool> Done(false);
   CGAL_nef3_forall_halfedges(h,T_) {
     if ( Done[h] ) continue;
     SM_Halfedge_const_iterator hn(T_.next(h)),hnn(T_.next(hn));
@@ -185,7 +185,7 @@ void draw_triangulation() const
   CGAL_nef3_forall_vertices(v,T_)
     S_.push_back(T_.point(v),CO_.color(vd,T_.mark(v)));
 
-  Unique_hash_map<SM_Halfedge_const_iterator,bool> Done(false);
+  CGAL::internal::Handle_hash_map<SM_Halfedge_const_iterator,bool> Done(false);
   CGAL_nef3_forall_halfedges(e,T_) {
     if ( Done[e] ) continue;
     SM_Halfedge_const_iterator en(T_.next(e)),enn(T_.next(en));

--- a/Nef_3/include/CGAL/Nef_3/SNC_const_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_const_decorator.h
@@ -21,7 +21,7 @@
 
 #include <CGAL/basic.h>
 #include <CGAL/Nef_S2/Normalizing.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Nef_3/SNC_iteration.h>
 #include <CGAL/Nef_3/SNC_decorator_traits.h>
 #include <CGAL/Nef_S2/SM_point_locator.h>
@@ -562,10 +562,10 @@ visit_shell_objects(SFace_const_handle f, Visitor& V) const
 {
   std::list<SFace_const_handle> SFaceCandidates;
   std::list<Halffacet_const_handle> FacetCandidates;
-  CGAL::Unique_hash_map<SFace_const_handle,bool> DoneSF(false);
-  CGAL::Unique_hash_map<Vertex_const_handle,bool> DoneV(false);
-  CGAL::Unique_hash_map<SVertex_const_handle,bool> DoneSV(false);
-  CGAL::Unique_hash_map<Halffacet_const_handle,bool> DoneF(false);
+  CGAL::internal::Handle_hash_map<SFace_const_handle,bool> DoneSF(false);
+  CGAL::internal::Handle_hash_map<Vertex_const_handle,bool> DoneV(false);
+  CGAL::internal::Handle_hash_map<SVertex_const_handle,bool> DoneSV(false);
+  CGAL::internal::Handle_hash_map<Halffacet_const_handle,bool> DoneF(false);
   SFaceCandidates.push_back(f);  DoneSF[f] = true;
   while ( true ) {
     if ( SFaceCandidates.empty() && FacetCandidates.empty() ) break;

--- a/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
@@ -435,7 +435,7 @@ public:
 
   Vertex_handle create_for_infibox_overlay(Vertex_const_handle vin) const {
 
-    Unique_hash_map<SHalfedge_handle, Mark> mark_of_right_sface;
+    CGAL::internal::Handle_hash_map<SHalfedge_handle, Mark> mark_of_right_sface;
 
     Vertex_handle v = this->sncp()->new_vertex(vin->point(), vin->mark());
     SM_decorator D(&*v);
@@ -689,10 +689,10 @@ public:
     ++number_of_clones;
 #endif
 
-    CGAL::Unique_hash_map<SVertex_const_handle, SVertex_handle>         VM;
-    CGAL::Unique_hash_map<SHalfedge_const_handle, SHalfedge_handle>     EM;
-    CGAL::Unique_hash_map<SHalfloop_const_handle, SHalfloop_handle>     LM;
-    CGAL::Unique_hash_map<SFace_const_handle, SFace_handle>             FM;
+    CGAL::internal::Handle_hash_map<SVertex_const_handle, SVertex_handle>         VM;
+    CGAL::internal::Handle_hash_map<SHalfedge_const_handle, SHalfedge_handle>     EM;
+    CGAL::internal::Handle_hash_map<SHalfloop_const_handle, SHalfloop_handle>     LM;
+    CGAL::internal::Handle_hash_map<SFace_const_handle, SFace_handle>             FM;
 
     SM_const_decorator E(&*vin);
     Vertex_handle vout = this->sncp()->new_vertex(vin->point(), vin->mark());
@@ -769,7 +769,7 @@ public:
 
     CGAL_NEF_TRACEN("edge facet overlay " << p);
 
-    Unique_hash_map<SHalfedge_handle, Mark> mark_of_right_sface;
+    CGAL::internal::Handle_hash_map<SHalfedge_handle, Mark> mark_of_right_sface;
 
     SM_decorator D(&*this->sncp()->new_vertex(p, BOP(e->mark(), f->mark())));
     SM_const_decorator E(&*e->source());
@@ -966,7 +966,7 @@ public:
       typedef std::map< Pluecker_line_3, Halfedge_list, Pluecker_line_lt>
         Pluecker_line_map;
 
-      Unique_hash_map<Vertex_handle, bool> erase_vertex(false);
+      CGAL::internal::Handle_hash_map<Vertex_handle, bool> erase_vertex(false);
       std::list<Point_3> recreate;
 
       SNC_decorator D(*this);
@@ -1910,10 +1910,10 @@ class SNC_constructor<SNC_indexed_items, SNC_structure_>
     ++number_of_clones;
 #endif
 
-    CGAL::Unique_hash_map<SVertex_const_handle, SVertex_handle>         VM;
-    CGAL::Unique_hash_map<SHalfedge_const_handle, SHalfedge_handle>     EM;
-    CGAL::Unique_hash_map<SHalfloop_const_handle, SHalfloop_handle>     LM;
-    CGAL::Unique_hash_map<SFace_const_handle, SFace_handle>             FM;
+    CGAL::internal::Handle_hash_map<SVertex_const_handle, SVertex_handle>         VM;
+    CGAL::internal::Handle_hash_map<SHalfedge_const_handle, SHalfedge_handle>     EM;
+    CGAL::internal::Handle_hash_map<SHalfloop_const_handle, SHalfloop_handle>     LM;
+    CGAL::internal::Handle_hash_map<SFace_const_handle, SFace_handle>             FM;
 
     SM_const_decorator E(&*vin);
     Vertex_handle vout = this->sncp()->new_vertex(vin->point(), vin->mark());
@@ -1995,7 +1995,7 @@ class SNC_constructor<SNC_indexed_items, SNC_structure_>
 
     CGAL_NEF_TRACEN("edge facet overlay " << p);
 
-    Unique_hash_map<SHalfedge_handle, Mark> mark_of_right_sface;
+    CGAL::internal::Handle_hash_map<SHalfedge_handle, Mark> mark_of_right_sface;
 
     SM_decorator D(&*this->sncp()->new_vertex(p, BOP(e->mark(), f->mark())));
     SM_const_decorator E(&*e->source());

--- a/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
@@ -21,7 +21,7 @@
 
 #include <CGAL/basic.h>
 #include <CGAL/Nef_S2/Normalizing.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Nef_3/SNC_iteration.h>
 #include <CGAL/Nef_3/SNC_const_decorator.h>
 #include <CGAL/Nef_S2/SM_decorator.h>
@@ -276,7 +276,7 @@ class SNC_decorator : public SNC_const_decorator<Map> {
   struct Shell_volume_setter {
     const SNCD_ D;
     Volume_handle c;
-    typedef Unique_hash_map< SFace_handle, bool> SFace_map;
+    typedef CGAL::internal::Handle_hash_map< SFace_handle, bool> SFace_map;
     SFace_map linked;
     Shell_volume_setter(const SNCD_& Di)
       : D(Di), linked(false) {}
@@ -657,9 +657,9 @@ class SNC_decorator : public SNC_const_decorator<Map> {
       valid = valid && vi->is_valid(verb, level);
 
       SM_decorator SD(&*vi);
-      Unique_hash_map<SVertex_handle, bool> SVvisited(false);
-      Unique_hash_map<SHalfedge_handle, bool> SEvisited(false);
-      Unique_hash_map<SFace_handle, bool> SFvisited(false);
+      CGAL::internal::Handle_hash_map<SVertex_handle, bool> SVvisited(false);
+      CGAL::internal::Handle_hash_map<SHalfedge_handle, bool> SEvisited(false);
+      CGAL::internal::Handle_hash_map<SFace_handle, bool> SFvisited(false);
 
       valid = valid && SD.is_valid(SVvisited,SEvisited,SFvisited, verb, level);
 
@@ -720,7 +720,7 @@ class SNC_decorator : public SNC_const_decorator<Map> {
     verr << "CGAL::SNC_decorator<...>::is_valid(): structure is "
          << ( valid ? "valid." : "NOT VALID.") << std::endl;
 
-    Unique_hash_map<SHalfedge_handle, bool> SEinUniqueFC(false);
+    CGAL::internal::Handle_hash_map<SHalfedge_handle, bool> SEinUniqueFC(false);
     Halffacet_iterator hfi;
     CGAL_forall_halffacets(hfi,*this) {
       valid = valid && hfi->is_valid(verb, level);

--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -247,12 +247,12 @@ public:
 
   SNC_point_locator* pl;
 
-  typedef CGAL::Unique_hash_map<SFace_const_handle,unsigned int>
+  typedef CGAL::internal::Handle_hash_map<SFace_const_handle,unsigned int>
                                                          Sface_shell_hash;
-  typedef CGAL::Unique_hash_map<Halffacet_const_handle,unsigned int>
+  typedef CGAL::internal::Handle_hash_map<Halffacet_const_handle,unsigned int>
                                                          Face_shell_hash;
-  typedef CGAL::Unique_hash_map<SFace_const_handle,bool> SFace_visited_hash;
-  typedef CGAL::Unique_hash_map<SFace_const_handle,bool> Shell_closed_hash;
+  typedef CGAL::internal::Handle_hash_map<SFace_const_handle,bool> SFace_visited_hash;
+  typedef CGAL::internal::Handle_hash_map<SFace_const_handle,bool> Shell_closed_hash;
 
   using SNC_decorator::visit_shell_objects;
   using SNC_decorator::link_as_inner_shell;
@@ -734,7 +734,7 @@ public:
       M[normalized(h)].push_back(make_object(e->twin()));
       CGAL_NEF_TRACEN(" normalized as " << normalized(h));
       /*
-        Unique_hash_map<SHalfedge_handle, bool> Done(false);
+        CGAL::internal::Handle_hash_map<SHalfedge_handle, bool> Done(false);
         SHalfedge_iterator ei;
         CGAL_forall_sedges(ei,*this->sncp()) {
         if(Done[ei]) continue;
@@ -1304,7 +1304,7 @@ public:
     link_shalfedges_to_facet_cycles();
 
     std::map<int, int> hash;
-    CGAL::Unique_hash_map<SHalfedge_handle, bool> done(false);
+    CGAL::internal::Handle_hash_map<SHalfedge_handle, bool> done(false);
 
     SHalfedge_iterator sei;
     CGAL_forall_shalfedges(sei, *this->sncp()) {
@@ -1382,7 +1382,7 @@ public:
     simp.vertex_simplificationI();
 
     //    std::map<int, int> hash;
-    CGAL::Unique_hash_map<SHalfedge_handle, bool>
+    CGAL::internal::Handle_hash_map<SHalfedge_handle, bool>
       done(false);
 
     /*

--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -796,9 +796,13 @@ public:
     //    CGAL_NEF_SETDTHREAD(37*43*503*509);
 
     CGAL_NEF_TRACEN(">>>>>create_volumes");
+    auto sface_count = this->sncp()->number_of_sfaces();
     Sface_shell_hash     ShellSf(0);
+    ShellSf.reserve(sface_count);
     Face_shell_hash      ShellF(0);
+    ShellF.reserve(this->sncp()->number_of_halffacets());
     SFace_visited_hash Done(false);
+    Done.reserve(sface_count);
     Shell_explorer V(*this,ShellSf,ShellF,Done);
     std::vector<SFace_handle> MinimalSFace;
     std::vector<SFace_handle> EntrySFace;
@@ -828,11 +832,14 @@ public:
       Closed.push_back(false);
 
     Halffacet_iterator hf;
-    CGAL_forall_facets(hf,*this)
-      if(ShellF[hf] != ShellF[hf->twin()]) {
-        Closed[ShellF[hf]] = true;
-        Closed[ShellF[hf->twin()]] = true;
+    CGAL_forall_facets(hf,*this) {
+      unsigned int shf = ShellF[hf];
+      unsigned int shf_twin = ShellF[hf->twin()];
+      if(shf != shf_twin) {
+        Closed[shf] = true;
+        Closed[shf_twin] = true;
       }
+    }
 
     CGAL_assertion( pl != nullptr);
 
@@ -1305,6 +1312,7 @@ public:
 
     std::map<int, int> hash;
     CGAL::internal::Handle_hash_map<SHalfedge_handle, bool> done(false);
+    done.reserve(this->sncp()->number_of_shalfedges());
 
     SHalfedge_iterator sei;
     CGAL_forall_shalfedges(sei, *this->sncp()) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_io_parser.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_io_parser.h
@@ -20,7 +20,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Nef_S2/SM_decorator.h>
 #include <CGAL/Nef_3/SNC_structure.h>
 #include <CGAL/Nef_3/SNC_decorator.h>
@@ -635,7 +635,7 @@ struct find_minimal_sface_of_shell : public SNC_const_decorator<T> {
   typedef typename T::SFace_handle        SFace_handle;
   typedef typename T::SHalfedge_handle    SHalfedge_handle;
   typedef typename T::SHalfloop_handle    SHalfloop_handle;
-  typedef CGAL::Unique_hash_map<SFace_handle,bool> SFace_visited_hash;
+  typedef CGAL::internal::Handle_hash_map<SFace_handle,bool> SFace_visited_hash;
 
   SFace_visited_hash& Done;
   SFace_handle sf_min;
@@ -1275,7 +1275,7 @@ SNC_io_parser<EW>::SNC_io_parser(std::ostream& os, SNC_structure& W,
     SFI[*sfl] = i++;
 
   Volume_iterator ci;
-  CGAL::Unique_hash_map<SFace_handle,bool> Done(false);
+  CGAL::internal::Handle_hash_map<SFace_handle,bool> Done(false);
   find_minimal_sface_of_shell<SNC_structure> findMinSF(*this->sncp(),Done);
   CGAL_forall_volumes(ci, *this->sncp()) {
     if(sorted) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
@@ -160,8 +160,8 @@ public:
   bool reference_counted;
 #endif
   SNC_decorator D;
-  Unique_hash_map<Vertex_handle, Oriented_side> OnSideMap;
-  Unique_hash_map<const RT*, Oriented_side> OnSideMapRC;
+  CGAL::internal::Handle_hash_map<Vertex_handle, Oriented_side> OnSideMap;
+  CGAL::internal::Handle_hash_map<const RT*, Oriented_side> OnSideMapRC;
 };
 
 template <class SNC_decorator>

--- a/Nef_3/include/CGAL/Nef_3/SNC_list.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_list.h
@@ -17,7 +17,7 @@
 
 
 #include <CGAL/Nef_S2/SM_list.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 
 namespace CGAL {
 
@@ -649,13 +649,13 @@ template <typename Kernel, typename Items>
 void SNC_list<Kernel,Items>::
 pointer_update(const SNC_list<Kernel,Items>& D)
 {
-  CGAL::Unique_hash_map<Vertex_const_handle,Vertex_handle>       VM;
-  CGAL::Unique_hash_map<Halfedge_const_handle,Halfedge_handle>   EM;
-  CGAL::Unique_hash_map<Halffacet_const_handle,Halffacet_handle> FM;
-  CGAL::Unique_hash_map<Volume_const_handle,Volume_handle>       CM;
-  CGAL::Unique_hash_map<SHalfedge_const_handle,SHalfedge_handle> SEM;
-  CGAL::Unique_hash_map<SHalfloop_const_handle,SHalfloop_handle> SLM;
-  CGAL::Unique_hash_map<SFace_const_handle,SFace_handle>         SFM;
+  CGAL::internal::Handle_hash_map<Vertex_const_handle,Vertex_handle>       VM;
+  CGAL::internal::Handle_hash_map<Halfedge_const_handle,Halfedge_handle>   EM;
+  CGAL::internal::Handle_hash_map<Halffacet_const_handle,Halffacet_handle> FM;
+  CGAL::internal::Handle_hash_map<Volume_const_handle,Volume_handle>       CM;
+  CGAL::internal::Handle_hash_map<SHalfedge_const_handle,SHalfedge_handle> SEM;
+  CGAL::internal::Handle_hash_map<SHalfloop_const_handle,SHalfloop_handle> SLM;
+  CGAL::internal::Handle_hash_map<SFace_const_handle,SFace_handle>         SFM;
   Vertex_const_iterator vc = D.vertices_begin();
   Vertex_iterator v = vertices_begin();
   for ( ; vc != D.vertices_end(); ++vc,++v) VM[vc] = v;

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -20,7 +20,7 @@
 #include <CGAL/Nef_3/SNC_intersection.h>
 #include <CGAL/Nef_3/SNC_k3_tree_traits.h>
 #include <CGAL/Nef_3/K3_tree.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Timer.h>
 #include <string>
 
@@ -116,9 +116,9 @@ public:
 
   virtual void transform(const Aff_transformation_3& t) = 0;
 
-  //virtual bool update( Unique_hash_map<Vertex_handle, bool>& V,
-  //                   Unique_hash_map<Halfedge_handle, bool>& E,
-  //                   Unique_hash_map<Halffacet_handle, bool>& F) = 0;
+  //virtual bool update( CGAL::internal::Handle_hash_map<Vertex_handle, bool>& V,
+  //                   CGAL::internal::Handle_hash_map<Halfedge_handle, bool>& E,
+  //                   CGAL::internal::Handle_hash_map<Halffacet_handle, bool>& F) = 0;
 
   virtual void add_facet(Halffacet_handle) {}
 
@@ -224,7 +224,7 @@ public:
     typedef typename CT::Edge                  Edge;
 
     CT ct;
-    CGAL::Unique_hash_map<Face_handle, bool> visited;
+    CGAL::internal::Handle_hash_map<Face_handle, bool> visited;
     Finite_face_iterator fi;
 
   public:
@@ -413,9 +413,9 @@ public:
     candidate_provider->transform(t);
   }
 
-  virtual bool update( Unique_hash_map<Vertex_handle, bool>& V,
-                       Unique_hash_map<Halfedge_handle, bool>& E,
-                       Unique_hash_map<Halffacet_handle, bool>& F) {
+  virtual bool update( CGAL::internal::Handle_hash_map<Vertex_handle, bool>& V,
+                       CGAL::internal::Handle_hash_map<Halfedge_handle, bool>& E,
+                       CGAL::internal::Handle_hash_map<Halffacet_handle, bool>& F) {
     CGAL_NEF_TIMER(ct_t.start());
     CGAL_assertion( initialized);
     bool updated = candidate_provider->update( V, E, F);
@@ -997,7 +997,7 @@ public:
                                                          e0->twin()->source()->point()));
 
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
-    Unique_hash_map< Halffacet_triangle_handle, bool> f_mark(false);
+    CGAL::internal::Handle_hash_map< Halffacet_triangle_handle, bool> f_mark(false);
 #endif // CGAL_NEF3_TRIANGULATE_FACETS
 
     Segment_3 s(Segment_3(e0->source()->point(),e0->twin()->source()->point()));
@@ -1134,7 +1134,7 @@ public:
     _CGAL_NEF_TRACEN( "intersecting edge: "<< Segment_3(e0->source()->point(),
                                                e0->twin()->source()->point()));
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
-    Unique_hash_map< Halffacet_triangle_handle, bool> f_mark(false);
+    CGAL::internal::Handle_hash_map< Halffacet_triangle_handle, bool> f_mark(false);
 #endif // CGAL_NEF3_TRIANGULATE_FACETS
     Segment_3 s(Segment_3(e0->source()->point(),e0->twin()->source()->point()));
     Vertex_handle v;
@@ -1297,9 +1297,9 @@ public:
     return new Self;
   }
 
-  virtual bool update( Unique_hash_map<Vertex_handle, bool>& V,
-                       Unique_hash_map<Halfedge_handle, bool>& E,
-                       Unique_hash_map<Halffacet_handle, bool>& F) {
+  virtual bool update( CGAL::internal::Handle_hash_map<Vertex_handle, bool>& V,
+                       CGAL::internal::Handle_hash_map<Halfedge_handle, bool>& E,
+                       CGAL::internal::Handle_hash_map<Halffacet_handle, bool>& F) {
     CGAL_NEF_TIMER(ct_t.start());
     CGAL_assertion( initialized);
     CGAL_NEF_TIMER(ct_t.stop());

--- a/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
@@ -330,11 +330,13 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
 
     this->sncp()->clear_boundary();
 
+    hash_volume.reserve(this->sncp()->number_of_volumes());
     Volume_iterator c;
     CGAL_forall_volumes( c, *this->sncp()) {
       hash_volume[c] = uf_volume.make_set(c);
       this->sncp()->reset_object_list(c->shell_entry_objects());
     }
+    hash_sface.reserve(this->sncp()->number_of_sfaces());
     SFace_iterator sf;
     CGAL_forall_sfaces( sf, *this->sncp()) {
       hash_sface[sf] = uf_sface.make_set(sf);
@@ -371,6 +373,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
       f = f_next;
     }
 
+    hash_facet.reserve(this->sncp()->number_of_halffacets());
     CGAL_forall_halffacets( f, *this->sncp()) {
       hash_facet[f] = uf_facet.make_set(f);
       this->sncp()->reset_object_list(f->boundary_entry_objects());
@@ -545,6 +548,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
       CGAL::internal::Handle_hash_map< SFace_handle, UFH_sface>& hash,
       Union_find< SFace_handle>& uf ) {
     CGAL::internal::Handle_hash_map< SHalfedge_handle, bool> linked(false);
+    linked.reserve(this->sncp()->number_of_shalfedges());
     SNC_decorator D(*this->sncp());
     SHalfedge_iterator e;
     CGAL_forall_shalfedges(e, *this->sncp()) {
@@ -598,6 +602,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
       CGAL::internal::Handle_hash_map< Halffacet_handle, UFH_facet>& hash,
       Union_find< Halffacet_handle>& uf) {
     CGAL::internal::Handle_hash_map< SHalfedge_handle, bool> linked(false);
+    linked.reserve(this->sncp()->number_of_shalfedges());
     SNC_decorator D(*this->sncp());
     SHalfedge_iterator u;
     CGAL_forall_shalfedges(u, *this->sncp()) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
@@ -84,7 +84,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
 
   void remove_f_including_all_edge_uses_in_its_boundary_cycles
     ( Halffacet_handle f,
-      Unique_hash_map< SFace_handle, UFH_sface>& hash,
+      CGAL::internal::Handle_hash_map< SFace_handle, UFH_sface>& hash,
       Union_find< SFace_handle>& uf )
     /* removes f and its boundary cycles, and merges up the sphere facets
        incident to them. */ {
@@ -316,9 +316,9 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
     CGAL_NEF_TRACEN(">>> simplifying");
     SNC_decorator D(*this->sncp());
 
-    Unique_hash_map< Volume_handle, UFH_volume> hash_volume;
-    Unique_hash_map< Halffacet_handle, UFH_facet> hash_facet;
-    Unique_hash_map< SFace_handle, UFH_sface> hash_sface;
+    CGAL::internal::Handle_hash_map< Volume_handle, UFH_volume> hash_volume;
+    CGAL::internal::Handle_hash_map< Halffacet_handle, UFH_facet> hash_facet;
+    CGAL::internal::Handle_hash_map< SFace_handle, UFH_sface> hash_sface;
     Union_find< Volume_handle> uf_volume;
     Union_find< Halffacet_handle> uf_facet;
     Union_find< SFace_handle> uf_sface;
@@ -490,9 +490,9 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
    }
 
    void purge_no_find_objects(
-      Unique_hash_map< Volume_handle, UFH_volume>& hash_volume,
-      Unique_hash_map< Halffacet_handle, UFH_facet>& hash_facet,
-      Unique_hash_map< SFace_handle, UFH_sface>& hash_sface,
+      CGAL::internal::Handle_hash_map< Volume_handle, UFH_volume>& hash_volume,
+      CGAL::internal::Handle_hash_map< Halffacet_handle, UFH_facet>& hash_facet,
+      CGAL::internal::Handle_hash_map< SFace_handle, UFH_sface>& hash_sface,
       Union_find< Volume_handle>& uf_volume,
       Union_find< Halffacet_handle>& uf_facet,
       Union_find< SFace_handle>& uf_sface ) {
@@ -542,9 +542,9 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
    }
 
   void create_boundary_links_forall_sfaces(
-      Unique_hash_map< SFace_handle, UFH_sface>& hash,
+      CGAL::internal::Handle_hash_map< SFace_handle, UFH_sface>& hash,
       Union_find< SFace_handle>& uf ) {
-    Unique_hash_map< SHalfedge_handle, bool> linked(false);
+    CGAL::internal::Handle_hash_map< SHalfedge_handle, bool> linked(false);
     SNC_decorator D(*this->sncp());
     SHalfedge_iterator e;
     CGAL_forall_shalfedges(e, *this->sncp()) {
@@ -595,9 +595,9 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
   }
 
   void create_boundary_links_forall_facets(
-      Unique_hash_map< Halffacet_handle, UFH_facet>& hash,
+      CGAL::internal::Handle_hash_map< Halffacet_handle, UFH_facet>& hash,
       Union_find< Halffacet_handle>& uf) {
-    Unique_hash_map< SHalfedge_handle, bool> linked(false);
+    CGAL::internal::Handle_hash_map< SHalfedge_handle, bool> linked(false);
     SNC_decorator D(*this->sncp());
     SHalfedge_iterator u;
     CGAL_forall_shalfedges(u, *this->sncp()) {
@@ -643,10 +643,10 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
   }
 
   void create_boundary_links_forall_volumes(
-      Unique_hash_map< Volume_handle, UFH_volume>& hash,
+      CGAL::internal::Handle_hash_map< Volume_handle, UFH_volume>& hash,
       Union_find< Volume_handle>& uf) {
     typedef typename SNC_decorator::template Shell_volume_setter<SNC_decorator> Volume_setter;
-    //   typedef Unique_hash_map< SFace_handle, bool> SFace_map;
+    //   typedef CGAL::internal::Handle_hash_map< SFace_handle, bool> SFace_map;
     //  SFace_map linked(false);
 
     SNC_decorator D(*this->sncp());

--- a/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
@@ -18,7 +18,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Nef_2/Object_handle.h>
 #include <CGAL/Nef_S2/SM_iteration.h>
 #include <CGAL/Nef_S2/Generic_handle_map.h>

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -19,7 +19,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/In_place_list.h>
 #include <CGAL/Nef_3/SNC_list.h>
 #include <CGAL/Nef_S2/Generic_handle_map.h>
@@ -1352,13 +1352,13 @@ template <typename Kernel, typename Items, typename Mark>
 void SNC_structure<Kernel,Items,Mark>::
 pointer_update(const SNC_structure<Kernel,Items,Mark>& D)
 {
-  CGAL::Unique_hash_map<Vertex_const_handle,Vertex_handle>       VM;
-  CGAL::Unique_hash_map<Halfedge_const_handle,Halfedge_handle>   EM;
-  CGAL::Unique_hash_map<Halffacet_const_handle,Halffacet_handle> FM;
-  CGAL::Unique_hash_map<Volume_const_handle,Volume_handle>       CM;
-  CGAL::Unique_hash_map<SHalfedge_const_handle,SHalfedge_handle> SEM;
-  CGAL::Unique_hash_map<SHalfloop_const_handle,SHalfloop_handle> SLM;
-  CGAL::Unique_hash_map<SFace_const_handle,SFace_handle>         SFM;
+  CGAL::internal::Handle_hash_map<Vertex_const_handle,Vertex_handle>       VM;
+  CGAL::internal::Handle_hash_map<Halfedge_const_handle,Halfedge_handle>   EM;
+  CGAL::internal::Handle_hash_map<Halffacet_const_handle,Halffacet_handle> FM;
+  CGAL::internal::Handle_hash_map<Volume_const_handle,Volume_handle>       CM;
+  CGAL::internal::Handle_hash_map<SHalfedge_const_handle,SHalfedge_handle> SEM;
+  CGAL::internal::Handle_hash_map<SHalfloop_const_handle,SHalfloop_handle> SLM;
+  CGAL::internal::Handle_hash_map<SFace_const_handle,SFace_handle>         SFM;
   Vertex_const_iterator vc = D.vertices_begin();
   Vertex_iterator v = vertices_begin();
   for ( ; vc != D.vertices_end(); ++vc,++v) VM[vc] = v;

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -681,8 +681,8 @@ protected:
     typedef typename CT::Edge                  Edge;
 
     CT ct;
-    CGAL::Unique_hash_map<Face_handle, bool> visited;
-    CGAL::Unique_hash_map<CTVertex_handle, Vertex_const_handle> ctv2v;
+    CGAL::internal::Handle_hash_map<Face_handle, bool> visited;
+    CGAL::internal::Handle_hash_map<CTVertex_handle, Vertex_const_handle> ctv2v;
     Finite_face_iterator fi;
     Plane_3 supporting_plane;
 
@@ -912,11 +912,11 @@ protected:
 
     class Find_holes {
 
-      Unique_hash_map<Vertex_const_handle, bool>& omit_vertex;
+      CGAL::internal::Handle_hash_map<Vertex_const_handle, bool>& omit_vertex;
       int nov, nof;
 
     public:
-      Find_holes(Unique_hash_map<Vertex_const_handle, bool>& omit_vertex_)
+      Find_holes(CGAL::internal::Handle_hash_map<Vertex_const_handle, bool>& omit_vertex_)
         : omit_vertex(omit_vertex_), nov(0), nof(0) {}
 
       void visit(Halffacet_const_handle f) {
@@ -958,13 +958,13 @@ protected:
     class Add_vertices {
 
       Polyhedron_incremental_builder_3<HDS>& B;
-      Unique_hash_map<Vertex_const_handle, bool>& omit_vertex;
+      CGAL::internal::Handle_hash_map<Vertex_const_handle, bool>& omit_vertex;
       Object_index<Vertex_const_iterator>& VI;
       int vertex_index;
 
     public:
       Add_vertices(Polyhedron_incremental_builder_3<HDS>& B_,
-                   Unique_hash_map<Vertex_const_handle, bool>& omit_vertex_,
+                   CGAL::internal::Handle_hash_map<Vertex_const_handle, bool>& omit_vertex_,
                    Object_index<Vertex_const_iterator>& VI_)
         : B(B_), omit_vertex(omit_vertex_), VI(VI_), vertex_index(0) {}
 
@@ -986,12 +986,12 @@ protected:
 
       const Object_index<Vertex_const_iterator>& VI;
       Polyhedron_incremental_builder_3<HDS>& B;
-      const Unique_hash_map<Vertex_const_handle, bool>& omit_vertex;
+      const CGAL::internal::Handle_hash_map<Vertex_const_handle, bool>& omit_vertex;
       SNC_const_decorator& D;
 
     public:
       Visitor(Polyhedron_incremental_builder_3<HDS>& BB,
-              const Unique_hash_map<Vertex_const_handle, bool>& omit_vertex_,
+              const CGAL::internal::Handle_hash_map<Vertex_const_handle, bool>& omit_vertex_,
               SNC_const_decorator& sd,
               Object_index<Vertex_const_iterator>& vi)
         : VI(vi), B(BB), omit_vertex(omit_vertex_), D(sd){}
@@ -1033,7 +1033,7 @@ protected:
     SFace_const_handle sf;
     SNC_const_decorator& scd;
     Object_index<Vertex_const_iterator> VI;
-    Unique_hash_map<Vertex_const_handle, bool> omit_vertex;
+    CGAL::internal::Handle_hash_map<Vertex_const_handle, bool> omit_vertex;
 
     Build_polyhedron2(SFace_const_handle sf_, SNC_const_decorator& s) :
       sf(sf_), scd(s), VI(s.vertices_begin(),s.vertices_end(),'V'),
@@ -1322,11 +1322,11 @@ protected:
     if( simplified) {
 #ifdef CGAL_NEF3_UPDATE_K3TREE_AFTER_SIMPLIFICATION
       /*debug*/ snc().print_statistics();
-      Unique_hash_map<Vertex_handle, bool>
+      CGAL::internal::Handle_hash_map<Vertex_handle, bool>
         V(false, snc().number_of_vertices());
-      Unique_hash_map<Halfedge_handle, bool>
+      CGAL::internal::Handle_hash_map<Halfedge_handle, bool>
         E(false, snc().number_of_halfedges());
-      Unique_hash_map<Halffacet_handle, bool>
+      CGAL::internal::Handle_hash_map<Halffacet_handle, bool>
         F(false, snc().number_of_halffacets());
       Vertex_iterator v;
       Halfedge_iterator e;

--- a/Nef_3/test/Nef_3/include/CGAL/test_Nef_3.h
+++ b/Nef_3/test/Nef_3/include/CGAL/test_Nef_3.h
@@ -92,7 +92,7 @@ public:
 
 private:
 
-  typedef CGAL::Unique_hash_map<SFace_const_handle,bool> SFace_visited_hash;
+  typedef CGAL::internal::Handle_hash_map<SFace_const_handle,bool> SFace_visited_hash;
 
   struct Shell_explorer {
     bool first;

--- a/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
@@ -16,7 +16,7 @@
 #include <CGAL/license/Nef_S2.h>
 
 
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 
 namespace CGAL {
 
@@ -29,8 +29,8 @@ struct Void_handle_hash_function {
 
 template <class I>
 class Generic_handle_map : public
-  Unique_hash_map<void*,I,Void_handle_hash_function>
-{ typedef Unique_hash_map<void*,I,Void_handle_hash_function> Base;
+  CGAL::internal::Handle_hash_map<void*,I,Void_handle_hash_function>
+{ typedef CGAL::internal::Handle_hash_map<void*,I,Void_handle_hash_function> Base;
 public:
   Generic_handle_map() : Base() {}
   Generic_handle_map(I i) : Base(i) {}

--- a/Nef_S2/include/CGAL/Nef_S2/ID_support_handler.h
+++ b/Nef_S2/include/CGAL/Nef_S2/ID_support_handler.h
@@ -16,7 +16,7 @@
 #include <CGAL/license/Nef_S2.h>
 
 
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <map>
 
 #undef CGAL_NEF_DEBUG

--- a/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
@@ -21,7 +21,7 @@
 
 #include <CGAL/basic.h>
 #include <CGAL/circulator.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Nef_2/Object_index.h>
 #include <CGAL/Nef_S2/SM_iteration.h>
 #include <CGAL/Nef_S2/SM_decorator_traits.h>
@@ -379,7 +379,7 @@ SM_const_decorator<SM_>::
 number_of_sface_cycles() const
 {
   unsigned int fc_num=0;
-  CGAL::Unique_hash_map<SHalfedge_const_handle,bool> visited;
+  CGAL::internal::Handle_hash_map<SHalfedge_const_handle,bool> visited;
   SHalfedge_const_iterator e;
   CGAL_forall_shalfedges(e,*this) {
     if (visited[e]) continue;
@@ -397,7 +397,7 @@ SM_const_decorator<SM_>::
 number_of_connected_components() const
 {
   int comp_num=0;
-  CGAL::Unique_hash_map<SVertex_const_iterator,bool> visited(false);
+  CGAL::internal::Handle_hash_map<SVertex_const_iterator,bool> visited(false);
   SVertex_const_iterator v;
   CGAL_forall_svertices(v,*this) {
     if (visited[v]) continue;

--- a/Nef_S2/include/CGAL/Nef_S2/SM_constrained_triang_traits.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_constrained_triang_traits.h
@@ -16,7 +16,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/generic_sweep.h>
 //#include <CGAL/Nef_S2/SM_checker.h>
 #include <string>
@@ -133,7 +133,7 @@ public:
   SVertex_handle           event;
   Point                   p_sweep;
   Sweep_status_structure  SL;
-  CGAL::Unique_hash_map<SHalfedge_handle,ss_iterator> SLItem;
+  CGAL::internal::Handle_hash_map<SHalfedge_handle,ss_iterator> SLItem;
   SHalfedge_handle         e_low,e_high; // framing edges !
   SHalfedge_handle         e_search;
   SVertex_iterator         v_first, v_beyond;

--- a/Nef_S2/include/CGAL/Nef_S2/SM_decorator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_decorator.h
@@ -28,7 +28,7 @@
 #include <CGAL/Nef_S2/SM_decorator_traits.h>
 #include <CGAL/Nef_S2/Sphere_map.h>
 #include <CGAL/Nef_S2/Normalizing.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/IO/Verbose_ostream.h>
 #ifndef CGAL_I_DO_WANT_TO_USE_GENINFO
 #include <boost/any.hpp>
@@ -821,9 +821,9 @@ void extract_boundary() {
   CGAL_forall_sfaces(sf,*this) sf->mark() = false;
 }
 
-bool is_valid( Unique_hash_map<SVertex_handle,bool>& sv_hash,
-               Unique_hash_map<SHalfedge_handle,bool>& se_hash,
-               Unique_hash_map<SFace_handle,bool>& sf_hash,
+bool is_valid( CGAL::internal::Handle_hash_map<SVertex_handle,bool>& sv_hash,
+               CGAL::internal::Handle_hash_map<SHalfedge_handle,bool>& se_hash,
+               CGAL::internal::Handle_hash_map<SFace_handle,bool>& sf_hash,
                bool verb = false, int level = 0) {
 
   Verbose_ostream verr(verb);

--- a/Nef_S2/include/CGAL/Nef_S2/SM_io_parser.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_io_parser.h
@@ -507,7 +507,7 @@ void SM_io_parser<Decorator_>::print_faces() const
   out << "SHalfedges: " << this->number_of_shalfedges() << "\n";
   out << "Loop:      " << this->number_of_shalfloops() << "\n";
   SHalfedge_iterator e;
-  Unique_hash_map<SHalfedge_iterator,bool> Done(false);
+  CGAL::internal::Handle_hash_map<SHalfedge_iterator,bool> Done(false);
   CGAL_forall_shalfedges(e,*this) {
     if ( Done[e] ) continue;
     typename Base::SHalfedge_around_sface_circulator c(e), ce = c;

--- a/Nef_S2/include/CGAL/Nef_S2/SM_overlayer.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_overlayer.h
@@ -52,7 +52,7 @@ struct SMO_from_segs {
   typedef typename SM_decorator::SHalfedge_handle   Halfedge_handle;
   typedef typename SM_decorator::Sphere_point       Point;
   typedef typename SM_decorator::Sphere_segment     Segment;
-  typedef CGAL::Unique_hash_map<I,bool>             Iterator_map;
+  typedef CGAL::internal::Handle_hash_map<I,bool>             Iterator_map;
   SM_decorator G;
   const Iterator_map& M;
   SMO_from_segs(SM_decorator Gi, const Iterator_map& Mi) : G(Gi),M(Mi) {}
@@ -159,10 +159,10 @@ struct SMO_from_sm {
   typedef typename SM_overlayer::Sphere_segment          Segment;
 
   SM_overlayer G;
-  CGAL::Unique_hash_map<IT,INFO>& M;
+  CGAL::internal::Handle_hash_map<IT,INFO>& M;
   SMO_from_sm(SM_overlayer Gi,
               SM_const_decorator* /* pGIi */,
-              CGAL::Unique_hash_map<IT,INFO>& Mi) :
+              CGAL::internal::Handle_hash_map<IT,INFO>& Mi) :
     G(Gi), M(Mi) {}
 
 Vertex_handle new_vertex(const Point& p)
@@ -532,7 +532,7 @@ public:
   typedef typename Seg_list::iterator          Seg_iterator;
   typedef std::pair<Seg_iterator,Seg_iterator> Seg_it_pair;
   typedef std::pair<Sphere_segment,Sphere_segment> Seg_pair;
-  typedef CGAL::Unique_hash_map<Seg_iterator,Seg_info> Seg_map;
+  typedef CGAL::internal::Handle_hash_map<Seg_iterator,Seg_info> Seg_map;
 
   // ---------------------------------------------------------------
 
@@ -693,7 +693,7 @@ public:
   template <typename Below_accessor>
   SFace_handle determine_face(SHalfedge_handle e,
     const std::vector<SHalfedge_handle>& MinimalSHalfedge,
-    const CGAL::Unique_hash_map<SHalfedge_handle,int>& SFaceCycle,
+    const CGAL::internal::Handle_hash_map<SHalfedge_handle,int>& SFaceCycle,
     const Below_accessor& D)
   { CGAL_NEF_TRACEN("determine_face "<<PH(e));
     int fc = SFaceCycle[e];
@@ -803,7 +803,7 @@ public:
   void subdivide_segments(Iterator start, Iterator end) const;
   template <typename Iterator, typename T>
   void partition_to_halfsphere(Iterator start, Iterator end,
-    Seg_list& L, CGAL::Unique_hash_map<Iterator,T>& M,
+    Seg_list& L, CGAL::internal::Handle_hash_map<Iterator,T>& M,
     Sphere_circle xycircle, Sphere_circle yzcircle, bool include_equator) const;
 
   template <typename Mark_accessor>
@@ -842,7 +842,7 @@ create_from_segments(Forward_iterator start, Forward_iterator end)
 {
   CGAL_NEF_TRACEN("creating from segment iterator range");
   Seg_list L(start,end);
-  Unique_hash_map<Seg_iterator,bool> From_input(false);
+  CGAL::internal::Handle_hash_map<Seg_iterator,bool> From_input(false);
   Seg_iterator it;
   CGAL_forall_iterators(it,L) From_input[it]=true;
   Seg_list L_pos,L_neg;
@@ -910,7 +910,7 @@ create_from_circles(Forward_iterator start, Forward_iterator end)
 {
   CGAL_NEF_TRACEN("creating from circle iterator range");
   Seg_list L;
-  Unique_hash_map<Seg_iterator,bool> From_input(false);
+  CGAL::internal::Handle_hash_map<Seg_iterator,bool> From_input(false);
   for ( ; start != end; ++start ) {
     std::pair<Sphere_segment,Sphere_segment> spair =
       start->split_at_xy_plane();
@@ -1942,7 +1942,7 @@ template <typename Map>
 template <typename Iterator, typename T>
 void SM_overlayer<Map>::
 partition_to_halfsphere(Iterator start, Iterator beyond, Seg_list& L,
-                        CGAL::Unique_hash_map<Iterator,T>& M,
+                        CGAL::internal::Handle_hash_map<Iterator,T>& M,
                         Sphere_circle xycircle, Sphere_circle yzcircle,
                         bool include_equator) const
 { CGAL_NEF_TRACEN("partition_to_halfsphere ");
@@ -2048,7 +2048,7 @@ create_face_objects(SHalfedge_iterator e_start, SHalfedge_iterator e_end,
 {
   CGAL_NEF_TRACEN("create_face_objects()");
   if(e_start != e_end) {
-    CGAL::Unique_hash_map<SHalfedge_handle,int> SFaceCycle(-1);
+    CGAL::internal::Handle_hash_map<SHalfedge_handle,int> SFaceCycle(-1);
     std::vector<SHalfedge_handle>  MinimalSHalfedge;
     SHalfedge_around_sface_circulator hfc(last_out_edge(v_start)),hend(hfc);
     CGAL_NEF_TRACEN("equator cycle "<<PH(hfc));
@@ -2311,8 +2311,8 @@ void SM_overlayer<Map>::simplify()
   CGAL_NEF_TRACEN("simplifying");
 
   typedef typename CGAL::Union_find<SFace_handle>::handle Union_find_handle;
-  CGAL::Unique_hash_map< SFace_handle, Union_find_handle> Pitem(nullptr);
-  CGAL::Unique_hash_map< SVertex_handle, Union_find_handle> Vitem(nullptr);
+  CGAL::internal::Handle_hash_map< SFace_handle, Union_find_handle> Pitem(nullptr);
+  CGAL::internal::Handle_hash_map< SVertex_handle, Union_find_handle> Vitem(nullptr);
   CGAL::Union_find< SFace_handle> UF;
 
   SFace_iterator f;
@@ -2360,7 +2360,7 @@ void SM_overlayer<Map>::simplify()
     }
   }
 
-  CGAL::Unique_hash_map<SHalfedge_handle,bool> linked(false);
+  CGAL::internal::Handle_hash_map<SHalfedge_handle,bool> linked(false);
   for (e = this->shalfedges_begin(); e != this->shalfedges_end(); ++e) {
     if ( linked[e] ) continue;
     SHalfedge_around_sface_circulator hfc(e),hend(hfc);

--- a/Nef_S2/include/CGAL/Nef_S2/SM_point_locator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_point_locator.h
@@ -17,7 +17,7 @@
 
 #include <vector>
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #ifdef CGAL_I_DO_WANT_TO_USE_GENINFO
 #include <CGAL/Nef_2/geninfo.h>
 #else
@@ -254,7 +254,7 @@ public:
     // s now initialized
 
     Sphere_direction dso(s.sphere_circle().opposite());
-    Unique_hash_map<SHalfedge_handle,bool> visited(false);
+    CGAL::internal::Handle_hash_map<SHalfedge_handle,bool> visited(false);
     CGAL_forall_svertices(v,*this) {
       Sphere_point vp = v->point();
       if ( (v == v_res) || s.has_on(vp) ) {
@@ -378,7 +378,7 @@ public:
       }
     } // all vertices
 
-    CGAL::Unique_hash_map<SHalfedge_handle,bool> visited(false);
+    CGAL::internal::Handle_hash_map<SHalfedge_handle,bool> visited(false);
     SHalfedge_iterator e_res;
     CGAL_forall_sedges(e,*this) {
       Sphere_segment se = segment(e);

--- a/Nef_S2/include/CGAL/Nef_S2/SM_triangulator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_triangulator.h
@@ -17,7 +17,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Nef_2/Segment_overlay_traits.h>
 #ifdef CGAL_I_DO_WANT_TO_USE_GENINFO
 #include <CGAL/Nef_2/geninfo.h>
@@ -48,12 +48,12 @@ struct SM_subdivision {
   typedef typename Decorator_::Sphere_point   Point;
   typedef typename Decorator_::Sphere_segment Segment;
   Triangulator T;
-  CGAL::Unique_hash_map<IT,INFO>& M;
+  CGAL::internal::Handle_hash_map<IT,INFO>& M;
   /* M stores the object that supports the segment that
      is input object of the sweep */
 
   SM_subdivision(Triangulator Ti,
-                 CGAL::Unique_hash_map<IT,INFO>& Mi) : T(Ti), M(Mi) {}
+                 CGAL::internal::Handle_hash_map<IT,INFO>& Mi) : T(Ti), M(Mi) {}
 
 Vertex_handle new_vertex(const Point& p)
 { Vertex_handle v = T.new_svertex(p); T.assoc_info(v);
@@ -172,7 +172,7 @@ public:
   typedef typename Seg_list::iterator          Seg_iterator;
   typedef std::pair<Seg_iterator,Seg_iterator> Seg_it_pair;
   typedef std::pair<Sphere_segment,Sphere_segment> Seg_pair;
-  typedef CGAL::Unique_hash_map<Seg_iterator,Object_handle> Seg_map;
+  typedef CGAL::internal::Handle_hash_map<Seg_iterator,Object_handle> Seg_map;
 
   using Base::info;
   using Base::set_first_out_edge;
@@ -338,7 +338,7 @@ public:
 
   template <typename Iterator, typename T>
   void partition_to_halfsphere(Iterator start, Iterator end,
-    Seg_list& L, CGAL::Unique_hash_map<Iterator,T>& M, int pos) const;
+    Seg_list& L, CGAL::internal::Handle_hash_map<Iterator,T>& M, int pos) const;
 
   void merge_halfsphere_maps(SVertex_handle v1, SVertex_handle v2);
   void merge_nodes(SHalfedge_handle e1, SHalfedge_handle e2);
@@ -534,7 +534,7 @@ template <typename Decorator_>
 template <typename Iterator, typename T>
 void SM_triangulator<Decorator_>::
 partition_to_halfsphere(Iterator start, Iterator beyond, Seg_list& L,
-  CGAL::Unique_hash_map<Iterator,T>& M, int pos) const
+  CGAL::internal::Handle_hash_map<Iterator,T>& M, int pos) const
 { CGAL_NEF_TRACEN("partition_to_halfsphere ");
   CGAL_assertion(pos!=0);
   bool add_cross = true;

--- a/Nef_S2/include/CGAL/Nef_S2/SM_visualizor.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_visualizor.h
@@ -129,7 +129,7 @@ void draw_map() const
   CGAL_forall_svertices(v,*E_)
     S_.push_back(E_->point(v),CO_.color(v,E_->mark(v)));
 
-  Unique_hash_map<SHalfedge_const_iterator,bool> Done(false);
+  CGAL::internal::Handle_hash_map<SHalfedge_const_iterator,bool> Done(false);
   CGAL_forall_shalfedges(e,*this) {
     if ( Done[e] ) continue;
     SHalfedge_const_handle en(next(e)),enn(next(en));
@@ -172,7 +172,7 @@ void draw_triangulation() const
   CGAL_forall_svertices(v,*this)
     S_.push_back(point(v),CO_.color(v,mark(v)));
 
-  Unique_hash_map<SHalfedge_const_iterator,bool> Done(false);
+  CGAL::internal::Handle_hash_map<SHalfedge_const_iterator,bool> Done(false);
   CGAL_forall_shalfedges(e,*this) {
     if ( Done[e] ) continue;
     SHalfedge_const_handle en(next(e)),enn(next(en));

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_geometry_OGL.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_geometry_OGL.h
@@ -773,7 +773,7 @@ class NefS2_to_UnitSphere
     CGAL_forall_svertices(v,E_)
       S_.push_back(v->point(),CO_.color(v,v->mark()));
 
-    Unique_hash_map<SHalfedge_const_iterator,bool> Done(false);
+    CGAL::internal::Handle_hash_map<SHalfedge_const_iterator,bool> Done(false);
     CGAL_forall_shalfedges(e,T_) {
       if ( Done[e] ) continue;
       SHalfedge_const_handle en(e->snext()),enn(en->snext());

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
@@ -18,7 +18,7 @@
 
 
 #include <CGAL/basic.h>
-#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Handle_hash_map.h>
 #include <CGAL/Nef_2/Object_handle.h>
 #include <CGAL/Nef_S2/SM_items.h>
 #include <CGAL/Nef_S2/SM_list.h>
@@ -495,10 +495,10 @@ template <typename K, typename I, typename M>
 void Sphere_map<K, I, M>::
 pointer_update(const Sphere_map<K, I, M>& D)
 {
-  CGAL::Unique_hash_map<SVertex_const_handle,SVertex_handle>     VM;
-  CGAL::Unique_hash_map<SHalfedge_const_handle,SHalfedge_handle> EM;
-  CGAL::Unique_hash_map<SHalfloop_const_handle,SHalfloop_handle> LM;
-  CGAL::Unique_hash_map<SFace_const_handle,SFace_handle>         FM;
+  CGAL::internal::Handle_hash_map<SVertex_const_handle,SVertex_handle>     VM;
+  CGAL::internal::Handle_hash_map<SHalfedge_const_handle,SHalfedge_handle> EM;
+  CGAL::internal::Handle_hash_map<SHalfloop_const_handle,SHalfloop_handle> LM;
+  CGAL::internal::Handle_hash_map<SFace_const_handle,SFace_handle>         FM;
 
   SVertex_const_iterator vc = D.svertices_begin();
   SVertex_iterator v = svertices_begin();

--- a/Scripts/developer_scripts/licensecheck
+++ b/Scripts/developer_scripts/licensecheck
@@ -604,6 +604,10 @@ sub parselicense {
         $license = "BSL 1.0";
       }
 
+      if ($licensetext =~ /SPDX-License-Identifier MIT/i) {
+        $license = "MIT/X11 (BSD like)";
+      }
+
       if ($licensetext =~ /SPDX-License-Identifier LicenseRef-RFL/i) {
         $license = "MIT/X11 (BSD like)";
       }


### PR DESCRIPTION
# Summary of Changes

This pull request adds a new `internal::Handle_hash_map` class that provides a drop-in replacement for `Unique_hash_map` but is backed by the single header `robin_hood::unordered_node_map`  This provides an easy means to migrate via an adaptor/wrapper which has then been applied to the Nef_2/Nef_S2 and Nef_3 packages.

Benchmarks for the Handle_hash_map are provided here: https://github.com/GilesBathgate/hashmap-benchmarks 
The main benefit is construction speed since Unique_hash_map suffers from a hard-coded minimum size of 512 buckets, which impacts the creation of small hashmaps. However there are measurable performance improvements on insert and update operations too, and being a robin hood hashing scheme it does not have the requirement for unique keys.

Some of the benefits were also discussed in #4049 . Other backends were discussed and this wrapper provides an easy way to migrate to another choice too. 

## Release Management

* Affected package(s): Nef_2/Nef_S2/Nef_3
* Issue(s) solved (if any): fix #5379 
* Feature/Small Feature (if any): performance/speed
* Link to compiled documentation: Undocumented internal use only.
* License and copyright ownership: 
    MIT license for additional code from https://github.com/martinus/robin-hood-hashing Copyright (c) 2018-2020 Martin Ankerl <http://martin.ankerl.com> 
   The adaptor/wrapper is authored by me but I return the copyright to CGAL.
   