### PR TITLE
Use TBB captured exception in PMP

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -47,6 +47,7 @@
 #include <exception>
 #include <sstream>
 #include <type_traits>
+#include <typeinfo>
 #include <vector>
 
 #ifdef DOXYGEN_RUNNING
@@ -508,9 +509,14 @@ bool does_self_intersect(const FaceRange& face_range,
     return true;
   }
   #if defined(CGAL_LINKED_WITH_TBB)
-  catch (tbb::captured_exception& e)
+  catch (const tbb::captured_exception& e)
   {
-    return true;
+    const char* ti1 = e.name();
+    const char* ti2 = typeid(const CGAL::internal::Throw_at_output_exception&).name();
+    const std::string tn1(ti1);
+    const std::string tn2(ti2);
+    if (tn1 == tn2) return true;
+    else throw;
   }
   #endif
   catch ( ... )

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -508,7 +508,7 @@ bool does_self_intersect(const FaceRange& face_range,
   {
     return true;
   }
-  #if defined(CGAL_LINKED_WITH_TBB) && defined(TBB_USE_CAPTURED_EXCEPTION)
+  #if defined(CGAL_LINKED_WITH_TBB) && TBB_USE_CAPTURED_EXCEPTION
   catch (const tbb::captured_exception& e)
   {
     const char* ti1 = e.name();

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -519,10 +519,6 @@ bool does_self_intersect(const FaceRange& face_range,
     else throw;
   }
   #endif
-  catch ( ... )
-  {
-    throw;
-  }
   return false;
 }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -508,7 +508,7 @@ bool does_self_intersect(const FaceRange& face_range,
   {
     return true;
   }
-  #if defined(CGAL_LINKED_WITH_TBB)
+  #if defined(CGAL_LINKED_WITH_TBB) && !TBB_USE_CAPTURED_EXCEPTION
   catch (const tbb::captured_exception& e)
   {
     const char* ti1 = e.name();

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -503,7 +503,11 @@ bool does_self_intersect(const FaceRange& face_range,
     CGAL::Emptyset_iterator unused_out;
     internal::self_intersections_impl<ConcurrencyTag>(face_range, tmesh, unused_out, true /*throw*/, np);
   }
+  #if defined(CGAL_LINKED_WITH_TBB)
+  catch(tbb::captured_exception&)
+  #else
   catch(CGAL::internal::Throw_at_output_exception&)
+  #endif
   {
     return true;
   }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -508,7 +508,7 @@ bool does_self_intersect(const FaceRange& face_range,
   {
     return true;
   }
-  #if defined(CGAL_LINKED_WITH_TBB) && !TBB_USE_CAPTURED_EXCEPTION
+  #if defined(CGAL_LINKED_WITH_TBB) && defined(TBB_USE_CAPTURED_EXCEPTION)
   catch (const tbb::captured_exception& e)
   {
     const char* ti1 = e.name();

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -498,11 +498,24 @@ bool does_self_intersect(const FaceRange& face_range,
 {
   CGAL_precondition(CGAL::is_triangle_mesh(tmesh));
 
-  try {
+  try
+  {
     CGAL::Emptyset_iterator unused_out;
     internal::self_intersections_impl<ConcurrencyTag>(face_range, tmesh, unused_out, true /*throw*/, np);
-  } catch(const std::exception&) {
+  }
+  catch (const CGAL::internal::Throw_at_output_exception&)
+  {
     return true;
+  }
+  #if defined(CGAL_LINKED_WITH_TBB)
+  catch (tbb::captured_exception& e)
+  {
+    return true;
+  }
+  #endif
+  catch ( ... )
+  {
+    throw;
   }
   return false;
 }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -498,20 +498,12 @@ bool does_self_intersect(const FaceRange& face_range,
 {
   CGAL_precondition(CGAL::is_triangle_mesh(tmesh));
 
-  try
-  {
+  try {
     CGAL::Emptyset_iterator unused_out;
     internal::self_intersections_impl<ConcurrencyTag>(face_range, tmesh, unused_out, true /*throw*/, np);
-  }
-  #if defined(CGAL_LINKED_WITH_TBB)
-  catch(tbb::captured_exception&)
-  #else
-  catch(CGAL::internal::Throw_at_output_exception&)
-  #endif
-  {
+  } catch(const std::exception&) {
     return true;
   }
-
   return false;
 }
 


### PR DESCRIPTION
In the macOS test suite, the `self_intersections_example` is using TBB. When the TBB support is on, this example is aborted due to an exception thrown by TBB, however, this exception is not caught. As far as I see, the problem is that the TBB version provided by brew (which is what I think most often used on macOS) is compiled without C++11 support, which is required to handle this exception according to the posts [here](https://software.intel.com/content/www/us/en/develop/blogs/exact-exception-propagation-in-the-intel-threading-building-blocks-library-and-c11.html) and [here](https://www.threadingbuildingblocks.org/docs/help/reference/environment/feature_macros.html). In fact, only one CGAL file seems to use this type of exception and this is the `self_intersections` from PMP.

This PR proposes a simple fix that allows catching the `tbb:captured_exception` when checking for self-intersections in case TBB is on. Please let me know if there is a better or more flexible fix.

The exact error is
```
TBB Warning: Exact exception propagation is requested by application but the linked library is built without support for it
libc++abi.dylib: terminating with uncaught exception of type tbb::captured_exception: std::exception
Abort trap: 6
```

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): no opened issues
* Feature/Small Feature (if any): bug fix
* License and copyright ownership: no changes

