### PR TITLE
Shape Detection: Disable expensive tests by default

### DIFF
--- a/Shape_detection/test/Shape_detection/test_validity_sampled_data.cpp
+++ b/Shape_detection/test/Shape_detection/test_validity_sampled_data.cpp
@@ -20,6 +20,9 @@
 
 #include <boost/iterator/function_output_iterator.hpp>
 
+// Uncomment this line to run expensive test
+// #define CGAL_SHAPE_DETECTION_RUN_EXPENSIVE_TESTS
+
 namespace SD = CGAL::Shape_detection;
 
 using Kernel = CGAL::Simple_cartesian<double>;
@@ -64,7 +67,7 @@ int main (int argc, char** argv)
   test_copied_point_cloud (points, 2);
   test_copied_point_cloud (points, 5);
   test_copied_point_cloud (points, 10);
-#ifndef CGAL_TEST_SUITE // Disable tests too large for testsuite
+#ifdef CGAL_SHAPE_DETECTION_RUN_EXPENSIVE_TESTS
   test_copied_point_cloud (points, 20);
   test_copied_point_cloud (points, 50);
 #endif


### PR DESCRIPTION
## Summary of Changes

Shape detection runs tests that can take a while in debug mode, so it's better to disable them completely unless users want to try them.

## Release Management

* Affected package(s): Shape Detection
* Issue(s) solved (if any): fix https://github.com/CGAL/cgal/issues/5479
* (Based on 5.2 as guilty test was introduced by https://github.com/CGAL/cgal/pull/5234 integrated in 5.2)
