### PR TITLE
Fixed Polyhedron demo warnings in the macOS test suite

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/VSA_wrapper.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/VSA_wrapper.h
@@ -66,7 +66,7 @@ class VSA_WRAPPER_EXPORT VSA_wrapper {
       // fitting center
       Vector_3 center = CGAL::NULL_VECTOR;
       FT area(0.0);
-      for(const face_descriptor f : faces) {
+      for(const face_descriptor& f : faces) {
         center = center + (get(center_pmap, f) - CGAL::ORIGIN) * get(area_pmap, f);
         area += get(area_pmap, f);
       }

--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -2410,7 +2410,7 @@ void Scene_surface_mesh_item::updateVertex(vertex_descriptor vh)
         getEdgeContainer(0)->getVbo(Ed::Vertices),
         new_point,id);
 
-  for(const auto & v_it : CGAL::vertices_around_target(vh, *face_graph()))
+  for(const auto v_it : CGAL::vertices_around_target(vh, *face_graph()))
   {
     EPICK::Vector_3 n = CGAL::Polygon_mesh_processing::compute_vertex_normal(v_it, *face_graph());
     cgal_gl_data new_n[3];
@@ -2430,7 +2430,7 @@ void Scene_surface_mesh_item::updateVertex(vertex_descriptor vh)
  }
 
 
-   for(const auto& f_it : CGAL::faces_around_target( halfedge(vh, *face_graph()), *face_graph()))
+   for(const auto f_it : CGAL::faces_around_target( halfedge(vh, *face_graph()), *face_graph()))
    {
      if (f_it == boost::graph_traits<SMesh>::null_face()) continue;
 

--- a/Polyhedron/demo/Polyhedron/Server_ws.cpp
+++ b/Polyhedron/demo/Polyhedron/Server_ws.cpp
@@ -88,7 +88,7 @@ int main(int argc, char *argv[])
   parser.addHelpOption();
   QCommandLineOption portOption(QStringList() << "p" << "port",
                                 QCoreApplication::translate("main", "Port for echoserver [default: 1234]."),
-                                QCoreApplication::translate("main", "port"), QLatin1Literal("1234"));
+                                QCoreApplication::translate("main", "port"), QLatin1String("1234"));
   parser.addOption(portOption);
   parser.process(a);
   int port = parser.value(portOption).toInt();

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -92,7 +92,7 @@ public:
   //!Set total number of depth peeling passes.
    void setTotalPass(int);
    void resetFov();
-   const QVector3D& scaler() const;
+   const QVector3D& scaler() const override;
 Q_SIGNALS:
   void sendMessage(QString);
   void doneInitGL(CGAL::Three::Viewer_interface*);


### PR DESCRIPTION
The macOS test suite reveals various little warnings when compiling the Polyhedron demo. This PR fixes these warnings.

## Release Management

* Affected package(s): Polyhedron
* Issue(s) solved (if any): warnings
* Feature/Small Feature (if any): bug fix
* License and copyright ownership: no changes

