### PR TITLE
Provide specialization of hash for the edge_descriptor we provide for OpenMesh

### DIFF
--- a/STL_Extension/include/CGAL/hash_openmesh.h
+++ b/STL_Extension/include/CGAL/hash_openmesh.h
@@ -73,7 +73,7 @@ inline std::size_t hash_value(const CGAL::internal::OMesh_edge<OpenMesh::Halfedg
 
 } // namespace OpenMesh
 
-#ifndef OM_HAS_HASH
+
 
 #include <functional>
 
@@ -86,6 +86,8 @@ namespace std {
 #endif
 
 #ifndef CGAL_CFG_NO_STD_HASH
+
+#ifndef OM_HAS_HASH
 
 template <>
 struct hash<OpenMesh::BaseHandle >
@@ -131,16 +133,6 @@ struct hash<OpenMesh::EdgeHandle >
   }
 };
 
-template <>
-struct hash<CGAL::internal::OMesh_edge<OpenMesh::HalfedgeHandle> >
-  : public CGAL::cpp98::unary_function<OpenMesh::HalfedgeHandle, std::size_t>
-{
-
-  std::size_t operator()(const CGAL::internal::OMesh_edge<OpenMesh::HalfedgeHandle>& h) const
-  {
-    return h.idx();
-  }
-};
 
 template <>
 struct hash<OpenMesh::FaceHandle >
@@ -153,6 +145,20 @@ struct hash<OpenMesh::FaceHandle >
   }
 };
 
+#endif  // OM_HAS_HASH
+
+template <typename H>
+struct hash<CGAL::internal::OMesh_edge<H> >
+  : public CGAL::cpp98::unary_function<CGAL::internal::OMesh_edge<H>, std::size_t>
+{
+
+  std::size_t operator()(const CGAL::internal::OMesh_edge<H>& h) const
+  {
+    return h.idx();
+  }
+};
+
+
 #endif // CGAL_CFG_NO_STD_HASH
 
 #if defined(BOOST_MSVC)
@@ -162,6 +168,6 @@ struct hash<OpenMesh::FaceHandle >
 } // namespace std
 
 
-#endif  // OM_HAS_HASH
+
 
 #endif // CGAL_HASH_OPENMESH_H

--- a/STL_Extension/test/STL_Extension/CMakeLists.txt
+++ b/STL_Extension/test/STL_Extension/CMakeLists.txt
@@ -9,6 +9,16 @@ find_package(CGAL REQUIRED)
 find_package( TBB QUIET )
 include(CGAL_TBB_support)
 
+find_package(OpenMesh QUIET)
+
+if(OpenMesh_FOUND)
+  include(UseOpenMesh)
+  add_definitions(-DCGAL_USE_OPENMESH)
+else()
+  message(STATUS "Tests that use OpenMesh will not be compiled.")
+endif()
+
+
 create_single_source_cgal_program( "test_Boolean_tag.cpp" )
 create_single_source_cgal_program( "test_Cache.cpp" )
 create_single_source_cgal_program( "test_Compact_container.cpp" )
@@ -48,4 +58,9 @@ create_single_source_cgal_program( "test_join_iterators.cpp" )
 create_single_source_cgal_program( "test_for_each.cpp" )
 if(TARGET CGAL::TBB_support)
   target_link_libraries(test_for_each PUBLIC CGAL::TBB_support)
+endif()
+
+if(OpenMesh_FOUND)
+  create_single_source_cgal_program("test_hash_OpenMesh.cpp")
+  target_link_libraries(test_hash_OpenMesh PRIVATE ${OPENMESH_LIBRARIES})
 endif()

--- a/STL_Extension/test/STL_Extension/test_hash_OpenMesh.cpp
+++ b/STL_Extension/test/STL_Extension/test_hash_OpenMesh.cpp
@@ -1,0 +1,36 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+
+#include <OpenMesh/Core/IO/MeshIO.hh>
+#include <OpenMesh/Core/Mesh/TriMesh_ArrayKernelT.hh>
+#include <CGAL/boost/graph/graph_traits_TriMesh_ArrayKernelT.h>
+
+#include <unordered_map>
+#include <boost/unordered_map.hpp>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
+
+typedef OpenMesh::TriMesh_ArrayKernelT</* MyTraits*/> Mesh;
+
+
+typedef boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
+typedef boost::graph_traits<Mesh>::face_descriptor face_descriptor;
+typedef boost::graph_traits<Mesh>::halfedge_descriptor halfedge_descriptor;
+typedef boost::graph_traits<Mesh>::edge_descriptor edge_descriptor;
+
+int main()
+{
+  {
+    std::unordered_map<vertex_descriptor, int> vmap;
+    std::unordered_map<halfedge_descriptor, int> hmap;
+    std::unordered_map<edge_descriptor, int> emap;
+    std::unordered_map<face_descriptor, int> fmap;
+  }
+  {
+    boost::unordered_map<vertex_descriptor, int> vmap;
+    boost::unordered_map<halfedge_descriptor, int> hmap;
+    boost::unordered_map<edge_descriptor, int> emap;
+    boost::unordered_map<face_descriptor, int> fmap;
+  }
+  return 0;
+}


### PR DESCRIPTION
## Summary of Changes

As the `boost::graph_traits<OpenMesh>::edge_descriptor` is a CGAL type and not the edge handle of OpenMesh, we have to provide the specialiasation of `hash` even if we have a version  of OpenMesh that has implemented the `hash` for its handle types.

## Release Management

* Affected package(s):  STL Extensions
* Issue(s) solved (if any): fix #5493
* License and copyright ownership:  unchanged

