### PR TITLE
AOS: Compare with nullptr to avoid warning

### DIFF
--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/algebraic_segments.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/algebraic_segments.cpp
@@ -61,7 +61,7 @@ int main()
   // but not for this instance
   for(size_t i = 0; i < pre_segs.size(); ++i) {
     auto* curr_p = boost::get<X_monotone_curve_2>(&pre_segs[i]);;
-    CGAL_assertion(curr_p);
+    CGAL_assertion(curr_p != nullptr);
     segs.push_back(*curr_p);
   }
   // Construct an ellipse with equation 2*x^2+5*y^2-7=0


### PR DESCRIPTION
## Summary of Changes

Avoid warning `forcing value to bool 'true' or 'false' (performance warning)` in  a VC++ [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.3-Ic-71/Arrangement_on_surface_2_Examples/TestReport_afabri_x64_Cygwin-Windows10_MSVC2015-Debug-64bits.gz)

## Release Management

* Affected package(s): Arrangement on Surface


