### PR TITLE
Cleanup index adder in polygon_mesh_to_nef_3

### DIFF
--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Ray_hit_generator.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Ray_hit_generator.h
@@ -107,8 +107,7 @@ class Ray_hit_generator : public Modifier_base<typename Nef_::SNC_and_PL> {
         e->twin() = svb;
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
         svb->set_index(e->get_index());
-        svf->set_index();
-        svf->twin()->set_index(svf->get_index());
+        svf->twin()->set_index(svf->new_index());
 #endif
       } else {
         svf->twin() = e;
@@ -117,8 +116,7 @@ class Ray_hit_generator : public Modifier_base<typename Nef_::SNC_and_PL> {
         e->twin() = svf;
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
         svf->set_index(e->get_index());
-        svb->set_index();
-        svb->twin()->set_index(svb->get_index());
+        svb->twin()->set_index(svb->new_index());
 #endif
       }
 
@@ -165,8 +163,7 @@ class Ray_hit_generator : public Modifier_base<typename Nef_::SNC_and_PL> {
         SM_walls smw(&*v_new);
         sv2 = smw.add_ray_svertex(Sphere_point(-dir));
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
-      sv1->set_index();
-      sv2->set_index(sv1->get_index());
+      sv2->set_index(sv1->new_index());
 #endif
       }
     }

--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Ray_hit_generator2.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Ray_hit_generator2.h
@@ -112,8 +112,7 @@ class Ray_hit_generator2 : public Modifier_base<typename Nef_::SNC_and_PL> {
         e->twin() = svb;
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
         svb->set_index(e->get_index());
-        svf->set_index();
-        svf->twin()->set_index(svf->get_index());
+        svf->twin()->set_index(svf->new_index());
 #endif
       } else {
         svf->twin() = e;
@@ -122,8 +121,7 @@ class Ray_hit_generator2 : public Modifier_base<typename Nef_::SNC_and_PL> {
         e->twin() = svf;
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
         svf->set_index(e->get_index());
-        svb->set_index();
-        svb->twin()->set_index(svb->get_index());
+        svb->twin()->set_index(svb->new_index());
 #endif
       }
 
@@ -182,8 +180,7 @@ class Ray_hit_generator2 : public Modifier_base<typename Nef_::SNC_and_PL> {
       sv1->twin() = sv2; // TODO: why is this necessary?
       sv2->twin() = sv1; // these edges should not go into the Edge_sorter
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
-      sv1->set_index();
-      sv2->set_index(sv1->get_index());
+      sv2->set_index(sv1->new_index());
 #endif
     }
   }

--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/SM_walls.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/SM_walls.h
@@ -529,10 +529,8 @@ class SM_walls : SM_decorator<SMap> {
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
     CGAL_assertion(index1==0 || index1!=index2);
     if(index1==0) {
-      se_new->set_index();
-      se_new->twin()->set_index();
-      index1 = se_new->get_index();
-      index2 = se_new->twin()->get_index();
+      index1 = se_new->new_index();
+      index2 = se_new->twin()->new_index();
     } else {
       se_new->set_index(index1);
       se_new->twin()->set_index(index2);

--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Single_wall_creator.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Single_wall_creator.h
@@ -204,8 +204,7 @@ class Single_wall_creator : public Modifier_base<typename Nef_::SNC_and_PL> {
       opp->twin() = lateral_svertex;
       lateral_svertex->twin() = opp;
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
-      opp->set_index();
-      lateral_svertex->set_index(opp->get_index());
+      lateral_svertex->set_index(opp->new_index());
 #endif
       pl->add_edge(lateral_svertex);
 
@@ -237,8 +236,7 @@ class Single_wall_creator : public Modifier_base<typename Nef_::SNC_and_PL> {
     lateral_svertex->twin() = opp;
 
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
-      opp->set_index();
-      lateral_svertex->set_index(opp->get_index());
+      lateral_svertex->set_index(opp->new_index());
 #endif
     pl->add_edge(lateral_svertex);
 
@@ -275,8 +273,7 @@ class Single_wall_creator : public Modifier_base<typename Nef_::SNC_and_PL> {
       opp->twin() = lateral_svertex;
       lateral_svertex->twin() = opp;
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
-      opp->set_index();
-      lateral_svertex->set_index(opp->get_index());
+      lateral_svertex->set_index(opp->new_index());
 #endif
       pl->add_edge(lateral_svertex);
 
@@ -308,8 +305,7 @@ class Single_wall_creator : public Modifier_base<typename Nef_::SNC_and_PL> {
     opp->twin() = lateral_svertex;
     lateral_svertex->twin() = opp;
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
-      opp->set_index();
-      lateral_svertex->set_index(opp->get_index());
+      lateral_svertex->set_index(opp->new_index());
 #endif
     pl->add_edge(lateral_svertex);
 

--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Single_wall_creator2.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Single_wall_creator2.h
@@ -163,8 +163,7 @@ class Single_wall_creator2 : public Modifier_base<typename Nef_::SNC_and_PL> {
         lateral_sv_tgt[0]->twin() = lateral_sv_tgt[1];
         lateral_sv_tgt[1]->twin() = lateral_sv_tgt[0];
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
-        lateral_sv_tgt[0]->set_index();
-        lateral_sv_tgt[1]->set_index(lateral_sv_tgt[0]->get_index());
+        lateral_sv_tgt[1]->set_index(lateral_sv_tgt[0]->new_index());
 #endif
         return;
       }
@@ -174,8 +173,7 @@ class Single_wall_creator2 : public Modifier_base<typename Nef_::SNC_and_PL> {
         opp->twin() = lateral_sv_tgt[0];
         lateral_sv_tgt[0]->twin() = opp;
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
-        opp->set_index();
-        lateral_sv_tgt[0]->set_index(opp->get_index());
+        lateral_sv_tgt[0]->set_index(opp->new_index());
 #endif
         lateral_sv_tgt[0] =
           SMW_tgt.add_lateral_svertex(Sphere_segment(lateral_sv_tgt[0]->point().antipode(),

--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Single_wall_creator3.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Single_wall_creator3.h
@@ -169,8 +169,7 @@ class Single_wall_creator3 : public Modifier_base<typename Nef_::SNC_and_PL> {
         lateral_sv_tgt[0]->twin() = lateral_sv_tgt[1];
         lateral_sv_tgt[1]->twin() = lateral_sv_tgt[0];
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
-        lateral_sv_tgt[0]->set_index();
-        lateral_sv_tgt[1]->set_index(lateral_sv_tgt[0]->get_index());
+        lateral_sv_tgt[1]->set_index(lateral_sv_tgt[0]->new_index());
 #endif
         pl->add_edge(lateral_sv_tgt[0]);
         return;
@@ -182,8 +181,7 @@ class Single_wall_creator3 : public Modifier_base<typename Nef_::SNC_and_PL> {
       lateral_sv_tgt[0]->twin() = opp;
       pl->add_edge(opp);
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
-      opp->set_index();
-      lateral_sv_tgt[0]->set_index(opp->get_index());
+      lateral_sv_tgt[0]->set_index(opp->new_index());
 #endif
       lateral_sv_tgt[0] =
         SMW_tgt.add_lateral_svertex(Sphere_segment(lateral_sv_tgt[0]->point().antipode(),

--- a/Nef_3/include/CGAL/Nef_3/ID_support_handler.h
+++ b/Nef_3/include/CGAL/Nef_3/ID_support_handler.h
@@ -78,8 +78,7 @@ class ID_support_handler<SNC_indexed_items, Decorator> {
                     << " "  << f2->plane() << &f2);
 
     if(f2m[f1][f2]==0) {
-      sv->set_index();
-      f2m[f1][f2] = sv->get_index();
+      f2m[f1][f2] = sv->new_index();
       CGAL_NEF_TRACEN("insert " << sv->point() << &*sv
                       << ": " << f2m[f1][f2]);
       CGAL_NEF_TRACEN("not defined, yet");

--- a/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
@@ -2129,16 +2129,14 @@ class SNC_constructor<SNC_indexed_items, SNC_structure_>
 
     Halfedge_iterator e;
     CGAL_forall_edges(e, *this->sncp()) {
-      e->set_index();
-      e->twin()->set_index(e->get_index());
+      e->twin()->set_index(e->new_index());
     }
 
     Halffacet_iterator f;
     CGAL_forall_halffacets(f, *this->sncp()) {
       Halffacet_cycle_iterator fci(f->facet_cycles_begin());
       SHalfedge_handle se(fci);
-      se->set_index();
-      int index(se->get_index());
+      int index(se->new_index());
       for(; fci != f->facet_cycles_end(); ++fci) {
         if(fci.is_shalfedge()) {
           SHalfedge_around_facet_circulator c1(fci), c2(c1);

--- a/Nef_3/include/CGAL/Nef_3/SNC_indexed_items.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_indexed_items.h
@@ -118,7 +118,7 @@ class SNC_indexed_items {
     }
     int new_index()
     { index = Index_generator::get_unique_index(); return index; }
-    void set_index(int idx = Index_generator::get_unique_index())
+    void set_index(int idx)
     { index = idx; }
     int get_index() const { return index; }
     Halffacet_const_handle get_index_facet() const {
@@ -154,7 +154,7 @@ class SNC_indexed_items {
     }
     int new_index()
     { index = index2 = Index_generator::get_unique_index(); return index; }
-    void set_index(int idx = Index_generator::get_unique_index())
+    void set_index(int idx)
     { index = index2 = idx; }
     int get_index() const {
       return index;
@@ -190,7 +190,7 @@ class SNC_indexed_items {
     }
     int new_index()
     { index = Index_generator::get_unique_index(); return index; }
-    void set_index(int idx = Index_generator::get_unique_index())
+    void set_index(int idx)
     { index = idx; }
     int get_index() const { return index; }
   };

--- a/Nef_3/include/CGAL/Nef_3/SNC_indexed_items.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_indexed_items.h
@@ -116,7 +116,8 @@ class SNC_indexed_items {
       init_ifacet = sl.init_ifacet;
       return *this;
     }
-
+    int new_index()
+    { index = Index_generator::get_unique_index(); return index; }
     void set_index(int idx = Index_generator::get_unique_index())
     { index = idx; }
     int get_index() const { return index; }
@@ -151,7 +152,8 @@ class SNC_indexed_items {
       init_ifacet = se.init_ifacet;
       return *this;
     }
-
+    int new_index()
+    { index = index2 = Index_generator::get_unique_index(); return index; }
     void set_index(int idx = Index_generator::get_unique_index())
     { index = index2 = idx; }
     int get_index() const {
@@ -186,7 +188,8 @@ class SNC_indexed_items {
       index = sv.index;
       return *this;
     }
-
+    int new_index()
+    { index = Index_generator::get_unique_index(); return index; }
     void set_index(int idx = Index_generator::get_unique_index())
     { index = idx; }
     int get_index() const { return index; }

--- a/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
@@ -126,11 +126,11 @@ class Face_graph_index_adder<CGAL::SNC_indexed_items, PolygonMesh, SNC_structure
 
   typedef Halfedge_around_face_circulator<PolygonMesh>
     Halfedge_around_facet_const_circulator;
-    typedef std::vector<SHalfedge_handle> SHalfedge_list;
+  typedef std::vector<SHalfedge_handle> SHalfedges;
 
   PolygonMesh& P;
   HalfedgeIndexMap him;
-  SHalfedge_list shalfedges;
+  SHalfedges shalfedges;
 
 public:
   Face_graph_index_adder(PolygonMesh& P_, HalfedgeIndexMap him) : P(P_), him(him)

--- a/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
@@ -126,21 +126,21 @@ class Face_graph_index_adder<CGAL::SNC_indexed_items, PolygonMesh, SNC_structure
 
   typedef Halfedge_around_face_circulator<PolygonMesh>
     Halfedge_around_facet_const_circulator;
-    typedef std::vector<SHalfedge_handle> Hash;
+    typedef std::vector<SHalfedge_handle> SHalfedge_list;
 
   PolygonMesh& P;
   HalfedgeIndexMap him;
-  Hash hash;
+  SHalfedge_list shalfedges;
 
 public:
   Face_graph_index_adder(PolygonMesh& P_, HalfedgeIndexMap him) : P(P_), him(him)
   {
-    hash.resize(num_halfedges(P));
+    shalfedges.resize(num_halfedges(P));
   }
 
-  void set_hash(halfedge_descriptor evc,
+  void set_edge(halfedge_descriptor evc,
                 SHalfedge_handle se) {
-    hash[get(him,evc)] = se;
+    shalfedges[get(him,evc)] = se;
   }
 
   void resolve_indexes()
@@ -148,14 +148,14 @@ public:
     for(face_descriptor fi : faces(P)) {
       Halfedge_around_facet_const_circulator
         fc(halfedge(fi,P),P), end(fc);
-      SHalfedge_handle s = hash[get(him,*fc)];
+      SHalfedge_handle s = shalfedges[get(him,*fc)];
       int se  = s->new_index();
       int set = s->twin()->new_index();
       int sv  = s->twin()->source()->new_index();
 
       ++fc;
       CGAL_For_all(fc, end) {
-        SHalfedge_handle n = hash[get(him,*fc)];
+        SHalfedge_handle n = shalfedges[get(him,*fc)];
         n->set_index(se);
         n->twin()->set_index(set);
         n->source()->set_index(sv);
@@ -256,7 +256,7 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
         e->twin()->circle() = ss_circle.opposite();
         e->mark() = e->twin()->mark() = true;
 
-        index_adder.set_hash(pe_prev, e);
+        index_adder.set_edge(pe_prev, e);
       }
 
       sv_prev = sv;
@@ -288,7 +288,7 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
       e->twin()->circle() = ss_circle.opposite();
       e->mark() = e->twin()->mark() = true;
 
-      index_adder.set_hash(pe_prev, e);
+      index_adder.set_edge(pe_prev, e);
     }
 
     // create faces

--- a/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
@@ -148,26 +148,22 @@ public:
     for(face_descriptor fi : faces(P)) {
       Halfedge_around_facet_const_circulator
         fc(halfedge(fi,P),P), end(fc);
-      typename boost::property_traits<HalfedgeIndexMap>::value_type
-        index = get(him,*fc);
-      hash[index]->set_index();
-      hash[index]->twin()->set_index();
-      hash[index]->twin()->source()->set_index();
-      int se  = hash[index]->get_index();
-      int set = hash[index]->twin()->get_index();
-      int sv  = hash[index]->twin()->source()->get_index();
+      SHalfedge_handle s = hash[get(him,*fc)];
+      int se  = s->new_index();
+      int set = s->twin()->new_index();
+      int sv  = s->twin()->source()->new_index();
 
       ++fc;
       CGAL_For_all(fc, end) {
-        index = get(him,*fc);
-        hash[index]->set_index(se);
-        hash[index]->twin()->set_index(set);
-        hash[index]->source()->set_index(sv);
-        hash[index]->twin()->source()->set_index();
-        sv = hash[index]->twin()->source()->get_index();
+        SHalfedge_handle n = hash[get(him,*fc)];
+        n->set_index(se);
+        n->twin()->set_index(set);
+        n->source()->set_index(sv);
+        sv = n->twin()->source()->new_index();
       }
-      hash[get(him,*fc)]->source()->set_index(sv);
+      s->source()->set_index(sv);
     }
+
   }
 };
 

--- a/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
@@ -112,7 +112,7 @@ class Face_graph_index_adder {
   typedef typename boost::graph_traits<Polyhedron>::halfedge_descriptor halfedge_descriptor;
  public:
   Face_graph_index_adder(Polyhedron&, HalfedgeIndexMap ) {}
-  void set_hash(halfedge_descriptor,
+  void set_edge(halfedge_descriptor,
                 SHalfedge_handle) {}
   void resolve_indexes() {}
 };

--- a/Nef_3/include/CGAL/Nef_3/vertex_cycle_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/vertex_cycle_to_nef_3.h
@@ -35,37 +35,6 @@
 
 namespace CGAL {
 
-/*
-template<typename Items>
-class Index_assigner {
-  Index_assigner() {}
-  template<typename Handle>
-    void assign_index(Handle& ) const {}
-  template<typename Handle>
-    void assign_first_index() const {}
-  template<typename Handle>
-    void assign_new_index() {}
-};
-
-template<> class Index_assigner<CGAL::SNC_indexed_items> {
-  int first;
-  int index;
- public:
- Index_assigner() :
-  first(Index_generator::get_unique_index()), index(first) {}
-
-  template<typename Handle>
-    void assign_index(Handle& h) const
-    { h->set_index(index); }
-  template<typename Handle>
-    void assign_first_index(Handle& h) const
-    { h->set_index(first); }
-  template<typename Handle>
-    void assign_new_index(Handle& h)
-    { h->set_index(); index = h->get_index(); }
-};
-*/
-
 //template<typename Items> class Index_matcher;
 
 template<typename Vertex>
@@ -121,11 +90,10 @@ template<typename Edge, typename CompareEdges>
       h->set_index(ei->second);
       if(plusTwin) h->twin()->set_index(h->get_index()+1);
     } else {
-      int new_index = Index_generator::get_unique_index();
+      int new_index = h->new_index();
       edge2int.insert(std::make_pair(e,new_index));
-      h->set_index(new_index);
       if(plusTwin)
-        h->twin()->set_index();
+        h->twin()->new_index();
     }
   }
 };

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -490,8 +490,7 @@ protected:
        SFace_handle sf(v->new_sface());
        SM.link_as_isolated_vertex(sv,sf);
        if(first) {
-         sv->set_index();
-         index = sv->get_index();
+         index = sv->new_index();
          first = false;
        } else
          sv->set_index(index);
@@ -512,8 +511,7 @@ protected:
        SM.link_as_isolated_vertex(sv1,sf);
        SM.link_as_isolated_vertex(sv2,sf);
        sv1->set_index(index);
-       sv2->set_index();
-       index = sv2->get_index();
+       index = sv2->new_index();
      }
  };
 


### PR DESCRIPTION
## Summary of Changes

This is mostly just cleaning the code in `Face_graph_index_adder` which is part of the code in polygon_mesh_to_nef_3.h

* Remove multiple vector lookups using index.
* Remove an additional property hash lookup.
* Add methods for explicitly creating a new index, and return it instead of set_index()/get_index()
* Rename variable member variable to `shalfedges` instead of `hash`. 

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): cleaning
* Feature/Small Feature (if any): cleaning
* License and copyright ownership: Returned to CGAL authors.

