### PR TITLE
Robustify internal side-of-triangle-mesh calls

### DIFF
--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -428,6 +428,11 @@ public:
   Closest_point closest_point_object() const {return Closest_point(*this);}
   Compare_distance compare_distance_object() const {return Compare_distance();}
 
+  typedef enum { CGAL_AXIS_X = 0,
+                 CGAL_AXIS_Y = 1,
+                 CGAL_AXIS_Z = 2} Axis;
+
+  static Axis longest_axis(const Bounding_box& bbox);
 
 private:
   /**
@@ -445,13 +450,6 @@ private:
   {
     return internal::Primitive_helper<AT>::get_datum(pr,*this).bbox();
   }
-
-
-  typedef enum { CGAL_AXIS_X = 0,
-                 CGAL_AXIS_Y = 1,
-                 CGAL_AXIS_Z = 2} Axis;
-
-  static Axis longest_axis(const Bounding_box& bbox);
 
   /// Comparison functions
   static bool less_x(const Primitive& pr1, const Primitive& pr2,const AABB_traits<GeomTraits,AABBPrimitive, BboxMap>& traits)

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -1110,13 +1110,17 @@ public:
                                 ? ON_UNBOUNDED_SIDE : ON_BOUNDED_SIDE;
 
       typedef typename Nodes_vector::Exact_kernel Exact_kernel;
-      typedef Side_of_vpm_helper<Node_id_map,
-                                 VertexPointMap2,
-                                 Nodes_vector, Kernel> VPM_helper;
-      typedef typename VPM_helper::type SOTM_vpm2;
+      typedef Side_of_helper<TriangleMesh,
+                             Node_id_map,
+                             VertexPointMap2,
+                             Nodes_vector, Kernel> VPM_helper;
+      typedef typename VPM_helper::VPM SOTM_vpm2;
+      typedef typename VPM_helper::Tree_type Tree_type;
 
       SOTM_vpm2 sotm_vpm2 = VPM_helper::get_vpm(vertex_to_node_id2, vpm2, nodes);
-      Side_of_triangle_mesh<TriangleMesh, Exact_kernel, SOTM_vpm2> inside_tm2(tm2, sotm_vpm2);
+      Tree_type tree;
+      VPM_helper::build_tree(tm2, tree, vertex_to_node_id2, fids2, vpm2, nodes);
+      Side_of_triangle_mesh<TriangleMesh, Exact_kernel, SOTM_vpm2, Tree_type> inside_tm2(tree);
 
       for(face_descriptor f : faces(tm1))
       {
@@ -1182,13 +1186,16 @@ public:
                                 ? ON_UNBOUNDED_SIDE : ON_BOUNDED_SIDE;
 
       typedef typename Nodes_vector::Exact_kernel Exact_kernel;
-      typedef Side_of_vpm_helper<Node_id_map,
-                                 VertexPointMap1,
-                                 Nodes_vector, Kernel> VPM_helper;
-      typedef typename VPM_helper::type SOTM_vpm1;
+      typedef Side_of_helper<TriangleMesh,
+                             Node_id_map,
+                             VertexPointMap1,
+                             Nodes_vector, Kernel> VPM_helper;
+      typedef typename VPM_helper::VPM SOTM_vpm1;
+      typedef typename VPM_helper::Tree_type Tree_type;
 
-      SOTM_vpm1 sotm_vpm1 = VPM_helper::get_vpm(vertex_to_node_id1, vpm1, nodes);
-      Side_of_triangle_mesh<TriangleMesh, Exact_kernel, SOTM_vpm1> inside_tm1(tm1, sotm_vpm1);
+      Tree_type tree;
+      VPM_helper::build_tree(tm1, tree, vertex_to_node_id1, fids1, vpm1, nodes);
+      Side_of_triangle_mesh<TriangleMesh, Exact_kernel, SOTM_vpm1, Tree_type> inside_tm1(tree);
 
       for(face_descriptor f : faces(tm2))
       {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -1117,7 +1117,6 @@ public:
       typedef typename VPM_helper::VPM SOTM_vpm2;
       typedef typename VPM_helper::Tree_type Tree_type;
 
-      SOTM_vpm2 sotm_vpm2 = VPM_helper::get_vpm(vertex_to_node_id2, vpm2, nodes);
       Tree_type tree;
       VPM_helper::build_tree(tm2, tree, vertex_to_node_id2, fids2, vpm2, nodes);
       Side_of_triangle_mesh<TriangleMesh, Exact_kernel, SOTM_vpm2, Tree_type> inside_tm2(tree);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -1147,7 +1147,7 @@ public:
 
           if (index_p1 != NID)
           {
-            if (tm1_coplanar_faces.test(f_id))  // TODO delay the building of the tree?
+            if (tm1_coplanar_faces.test(f_id))
             {
               coplanar_patches_of_tm1.set(patch_id);
               coplanar_patches_of_tm1_for_union_and_intersection.set(patch_id);
@@ -1221,7 +1221,7 @@ public:
           }
           if (index_p2 != NID)
           {
-            if (tm2_coplanar_faces.test(f_id))  // TODO delay the building of the tree?
+            if (tm2_coplanar_faces.test(f_id))
             {
               coplanar_patches_of_tm2.set(patch_id);
               coplanar_patches_of_tm2_for_union_and_intersection.set(patch_id);


### PR DESCRIPTION
Use an exact AABB-tree using exact node values.

Not backported to 5.1 on purpose.