### PR TITLE
Polyhedron_demo: Move LAS code from item to plugin

### DIFF
--- a/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
+++ b/GraphicsView/include/CGAL/Qt/Basic_viewer_qt.h
@@ -184,16 +184,16 @@ public:
     // Add custom mouse description
     setMouseBindingDescription(::Qt::Key_C, ::Qt::ControlModifier, ::Qt::LeftButton, "Rotate the clipping plane when enabled");
     setMouseBindingDescription(::Qt::Key_C, ::Qt::ControlModifier, ::Qt::RightButton, "Translate the clipping plane when enabled");
-    setMouseBindingDescription(::Qt::Key_C, ::Qt::ControlModifier, ::Qt::MidButton, "Control the clipping plane transparency when enabled");
+    setMouseBindingDescription(::Qt::Key_C, ::Qt::ControlModifier, ::Qt::MiddleButton, "Control the clipping plane transparency when enabled");
 
     setMouseBinding(::Qt::ControlModifier, ::Qt::LeftButton, qglviewer::FRAME, qglviewer::NO_MOUSE_ACTION);
     setMouseBinding(::Qt::ControlModifier, ::Qt::RightButton, qglviewer::FRAME, qglviewer::NO_MOUSE_ACTION);
-    setMouseBinding(::Qt::ControlModifier, ::Qt::MidButton, qglviewer::FRAME, qglviewer::NO_MOUSE_ACTION);
+    setMouseBinding(::Qt::ControlModifier, ::Qt::MiddleButton, qglviewer::FRAME, qglviewer::NO_MOUSE_ACTION);
     setWheelBinding(::Qt::ControlModifier, qglviewer::FRAME, qglviewer::NO_MOUSE_ACTION);
 
     setMouseBinding(::Qt::Key_C, ::Qt::ControlModifier, ::Qt::LeftButton, qglviewer::FRAME, qglviewer::ROTATE);
     setMouseBinding(::Qt::Key_C, ::Qt::ControlModifier, ::Qt::RightButton, qglviewer::FRAME, qglviewer::TRANSLATE);
-    setMouseBinding(::Qt::Key_C, ::Qt::ControlModifier, ::Qt::MidButton, qglviewer::FRAME, qglviewer::ZOOM);
+    setMouseBinding(::Qt::Key_C, ::Qt::ControlModifier, ::Qt::MiddleButton, qglviewer::FRAME, qglviewer::ZOOM);
     setWheelBinding(::Qt::Key_C, ::Qt::ControlModifier, qglviewer::FRAME, qglviewer::ZOOM);
 
     if (title[0]==0)

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -338,23 +338,6 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
                           PUBLIC CGAL::Eigen3_support)
   endif()
 
-  find_package(LASLIB)
-  set_package_properties(
-    LASLIB PROPERTIES
-    DESCRIPTION "A library for some I/O."
-    PURPOSE "Requiered for reading or writing LAS files.")
-
-  include(CGAL_LASLIB_support)
-  if(TARGET CGAL::LASLIB_support)
-    target_link_libraries(scene_points_with_normal_item
-                          PUBLIC CGAL::LASLIB_support)
-    if(MSVC)
-      target_compile_definitions(
-        scene_points_with_normal_item
-        PUBLIC "-D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS")
-    endif()
-  endif()
-
   if(TBB_FOUND)
     target_link_libraries(scene_points_with_normal_item
                           PUBLIC CGAL::TBB_support)

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
@@ -1,5 +1,13 @@
 include(polyhedron_demo_macros)
 
+find_package(LASLIB)
+set_package_properties(
+  LASLIB PROPERTIES
+  DESCRIPTION "A library for some I/O."
+  PURPOSE "Requiered for reading or writing LAS files.")
+
+include(CGAL_LASLIB_support)
+
 polyhedron_demo_plugin(gocad_plugin GOCAD_io_plugin KEYWORDS Viewer)
 target_link_libraries(gocad_plugin PUBLIC scene_surface_mesh_item)
 
@@ -96,6 +104,11 @@ else()
     polyhedron_demo_plugin(las_plugin LAS_io_plugin KEYWORDS Viewer PointSetProcessing Classification)
     target_link_libraries(las_plugin PUBLIC scene_points_with_normal_item CGAL::LASLIB_support)
     target_compile_features(las_plugin PRIVATE ${needed_cxx_features})
+    if(MSVC)
+      target_compile_definitions(
+        las_plugin
+        PUBLIC "-D_CRT_SECURE_NO_DEPRECATE -D_CRT_SECURE_NO_WARNINGS")
+    endif()
   else()
     message(
       STATUS

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/LAS_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/LAS_io_plugin.cpp
@@ -2,6 +2,7 @@
 #include <CGAL/Three/Polyhedron_demo_io_plugin_interface.h>
 #include <CGAL/Three/Three.h>
 #include <CGAL/Three/Scene_item.h>
+#include <CGAL/Point_set_3/IO.h>
 #include <fstream>
 using namespace CGAL::Three;
 class Polyhedron_demo_las_plugin :
@@ -35,12 +36,32 @@ load(QFileInfo fileinfo, bool& ok, bool add_to_scene) {
 
   Scene_points_with_normal_item* item;
   item = new Scene_points_with_normal_item();
-  if(!item->read_las_point_set(in))
+  Q_ASSERT(item->point_set() != nullptr);
+
+  item->point_set()->clear();
+
+  ok = CGAL::read_LAS (in, *(item->point_set())) && !item->isEmpty();
+  if(ok)
+  {
+    std::cerr << item->point_set()->info();
+
+    if (!item->point_set()->has_normal_map())
     {
-      delete item;
-      ok = false;
-      return QList<Scene_item*>();
+      item->setRenderingMode(Points);
     }
+    else{
+      item->setRenderingMode(CGAL::Three::Three::defaultPointSetRenderingMode());
+    }
+    if (item->point_set()->check_colors())
+      std::cerr << "-> Point set has colors" << std::endl;
+
+    item->invalidateOpenGLBuffers();
+  }
+  if(!ok)
+  {
+    delete item;
+    return QList<Scene_item*>();
+  }
 
   item->setName(fileinfo.completeBaseName());
   ok = true;
@@ -63,14 +84,18 @@ bool Polyhedron_demo_las_plugin::save(QFileInfo fileinfo,QList<CGAL::Three::Scen
     return false;
 
   // This plugin supports point sets
-  const Scene_points_with_normal_item* point_set_item =
-    qobject_cast<const Scene_points_with_normal_item*>(item);
+  Scene_points_with_normal_item* point_set_item =
+    qobject_cast<Scene_points_with_normal_item*>(item);
   if(!point_set_item)
     return false;
 
   std::ofstream out(fileinfo.filePath().toUtf8().data());
   items.pop_front();
-  return point_set_item->write_las_point_set(out);
+  Q_ASSERT(point_set_item->point_set() != nullptr);
+
+  point_set_item->point_set()->reset_indices();
+
+  return CGAL::write_LAS(out, *(point_set_item->point_set()));
 }
 
 

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.cpp
@@ -547,43 +547,6 @@ void Scene_points_with_normal_item::selectDuplicates()
   Q_EMIT itemChanged();
 }
 
-#ifdef CGAL_LINKED_WITH_LASLIB
-// Loads point set from .LAS file
-bool Scene_points_with_normal_item::read_las_point_set(std::istream& stream)
-{
-  Q_ASSERT(d->m_points != NULL);
-
-  d->m_points->clear();
-
-  bool ok = CGAL::read_LAS (stream, *(d->m_points)) && !isEmpty();
-
-  std::cerr << d->m_points->info();
-
-  if (!d->m_points->has_normal_map())
-  {
-    setRenderingMode(Points);
-  }
-  else{
-    setRenderingMode(CGAL::Three::Three::defaultPointSetRenderingMode());
-  }
-  if (d->m_points->check_colors())
-    std::cerr << "-> Point set has colors" << std::endl;
-
-  invalidateOpenGLBuffers();
-  return ok;
-}
-
-// Write point set to .LAS file
-bool Scene_points_with_normal_item::write_las_point_set(std::ostream& stream) const
-{
-  Q_ASSERT(d->m_points != NULL);
-
-  d->m_points->reset_indices();
-
-  return CGAL::write_LAS(stream, *(d->m_points));
-}
-
-#endif // LAS
 
 // Loads point set from .PLY file
 bool Scene_points_with_normal_item::read_ply_point_set(std::istream& stream)

--- a/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_points_with_normal_item.h
@@ -50,10 +50,6 @@ public:
   QMenu* contextMenu() Q_DECL_OVERRIDE;
 
   // IO
-#ifdef CGAL_LINKED_WITH_LASLIB
-  bool read_las_point_set(std::istream& in);
-  bool write_las_point_set(std::ostream& out) const;
-#endif // LAS
   bool read_ply_point_set(std::istream& in);
   bool write_ply_point_set(std::ostream& out, bool binary) const;
   bool read_off_point_set(std::istream& in);


### PR DESCRIPTION
## Summary of Changes

 - There is a BOOL declaration in both lib3mf and LASTools, that conflict in 3mf_plugin. To prevent it, I moved the LAS code from the item to the LAS_plugin.
 - Some Qt::MidButton were added in Basic_viewer_qt in 5.3, change them in middlebutton to fix a warning

## Release Management
This is based on master because the CGAL_IO and the CMake modernization makes it really hard to have a single coherent fix base don an old release, and I don't think anyone uses lib3mf except me, but if asked I can do 2 other PRs for 5.1 and 5.2