### PR TITLE
Nef_3: Do not test has_on for a point where we know that it will be true

### DIFF
--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -49,26 +49,24 @@ namespace CommonKernelFunctors {
 
     int operator()(const Vector_3& vec) const
     {
-      int dir = -1;
       if(certainly_not(is_zero(vec.x()))){
-        dir = 0;
+        return 0;
       } else if(certainly_not(is_zero(vec.y()))){
-        dir = 1;
+        return 1;
       }else if(certainly_not(is_zero(vec.y()))){
-        dir = 2;
+        return 2;
       }
 
-      if(dir == -1){
-        if(! is_zero(vec.x())){
-          return 0;
-        } else if(! is_zero(vec.y())){
-          return 1;
-        } else if(! is_zero(vec.z())){
-          return 2;
-        }
+      if(! is_zero(vec.x())){
+        return 0;
+      } else if(! is_zero(vec.y())){
+        return 1;
+      } else if(! is_zero(vec.z())){
+        return 2;
       }
-      return dir;
-    }
+
+      return -1;
+  }
   };
 
 

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -37,6 +37,41 @@ namespace CGAL {
 
 namespace CommonKernelFunctors {
 
+
+
+  template <typename K>
+  class Non_zero_dimension_3
+  {
+    typedef typename K::Vector_3 Vector_3;
+
+  public:
+    typedef int result_type;
+
+    int operator()(const Vector_3& vec) const
+    {
+      int dir = -1;
+      if(certainly_not(is_zero(vec.x()))){
+        dir = 0;
+      } else if(certainly_not(is_zero(vec.y()))){
+        dir = 1;
+      }else if(certainly_not(is_zero(vec.y()))){
+        dir = 2;
+      }
+
+      if(dir == -1){
+        if(! is_zero(vec.x())){
+          return 0;
+        } else if(! is_zero(vec.y())){
+          return 1;
+        } else if(! is_zero(vec.z())){
+          return 2;
+        }
+      }
+      return dir;
+    }
+  };
+
+
   template <typename K>
   class Are_ordered_along_line_2
   {

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -47,7 +47,7 @@ namespace CommonKernelFunctors {
   public:
     typedef int result_type;
 
-    int operator()(const Vector_3& vec) const
+    result_type operator()(const Vector_3& vec) const
     {
       if(certainly_not(is_zero(vec.x()))){
         return 0;

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -582,6 +582,8 @@ CGAL_Kernel_pred(Less_y_3,
                  less_y_3_object)
 CGAL_Kernel_pred(Less_z_3,
                  less_z_3_object)
+CGAL_Kernel_pred(Non_zero_dimension_3,
+                 non_zero_dimension_3_object)
 CGAL_Kernel_pred_RT(Orientation_2,
                     orientation_2_object)
 CGAL_Kernel_pred_RT(Orientation_3,

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -849,7 +849,24 @@ public:
           _CGAL_NEF_TRACEN("found on facet...");
           return make_object(f);
         }
-        if( is.does_intersect_internally(s,f,ip)) {
+
+        // We next check if v is a vertex on the face to avoid a geometric test
+        bool v_vertex_of_f = false;
+        Halffacet_cycle_iterator fci;
+        for(fci=f->facet_cycles_begin(); fci!=f->facet_cycles_end(); ++fci) {
+          if(fci.is_shalfedge()) {
+            SHalfedge_around_facet_circulator sfc(fci), send(sfc);
+            CGAL_For_all(sfc,send) {
+              if(sfc->source()->center_vertex() ==  v){
+                v_vertex_of_f = true;
+                break;
+              }
+            }
+          }
+        }
+
+
+        if( (! v_vertex_of_f) &&  is.does_intersect_internally(s,f,ip) ) {
           s = Segment_3(p, normalized(ip));
           result = make_object(f);
         }

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -853,7 +853,7 @@ public:
         // We next check if v is a vertex on the face to avoid a geometric test
         bool v_vertex_of_f = false;
         Halffacet_cycle_iterator fci;
-        for(fci=f->facet_cycles_begin(); fci!=f->facet_cycles_end(); ++fci) {
+        for(fci=f->facet_cycles_begin(); (! v_vertex_of_f) && (fci!=f->facet_cycles_end()); ++fci) {
           if(fci.is_shalfedge()) {
             SHalfedge_around_facet_circulator sfc(fci), send(sfc);
             CGAL_For_all(sfc,send) {

--- a/Nef_3/include/CGAL/Nef_3/bounded_side_3.h
+++ b/Nef_3/include/CGAL/Nef_3/bounded_side_3.h
@@ -73,12 +73,12 @@ Bounded_side bounded_side_3(IteratorForward first,
   auto apv = approx(plane.orthogonal_vector());
 
   int dir = 0;
-  auto max = CGAL::abs(apv.x());
-  if(CGAL::abs(apv.y()) > max){
+  double max = CGAL::abs(apv.x().sup());
+  if(CGAL::abs(apv.y().sup()) > max){
     dir = 1;
-    max = CGAL::abs(apv.y());
+    max = CGAL::abs(apv.y().sup());
   }
-  if(CGAL::abs(apv.z()) > max){
+  if(CGAL::abs(apv.z().sup()) > max){
     dir = 2;
   }
 

--- a/Nef_3/include/CGAL/Nef_3/bounded_side_3.h
+++ b/Nef_3/include/CGAL/Nef_3/bounded_side_3.h
@@ -99,8 +99,9 @@ Bounded_side bounded_side_3(IteratorForward first,
        we don't need to care about the plane orientation */
   }
 
-
-
+  typename R::Non_zero_dimension_3 non_zero_dimension_3;
+  int dir = non_zero_dimension_3(plane.orthogonal_vector());
+#if 0
   auto apv = approx(plane.orthogonal_vector());
 
   int dir = 0;
@@ -112,7 +113,7 @@ Bounded_side bounded_side_3(IteratorForward first,
   if(CGAL::abs(apv.z().sup()) > max){
     dir = 2;
   }
-
+#endif
 
   CGAL_assertion(!plane.is_degenerate());
   Point_2 (*t)(const Point_3&);

--- a/Nef_3/include/CGAL/Nef_3/bounded_side_3.h
+++ b/Nef_3/include/CGAL/Nef_3/bounded_side_3.h
@@ -82,7 +82,6 @@ Bounded_side bounded_side_3(IteratorForward first,
                             typename R::Plane_3 plane = typename R::Plane_3(0,0,0,0)) {
   typedef typename R::Point_2 Point_2;
   typedef typename R::Point_3 Point_3;
-  typedef typename R::Vector_3 Vector_3;
   typedef typename R::Plane_3 Plane_3;
 
   if(plane == Plane_3(0,0,0,0)) {
@@ -101,19 +100,7 @@ Bounded_side bounded_side_3(IteratorForward first,
 
   typename R::Non_zero_dimension_3 non_zero_dimension_3;
   int dir = non_zero_dimension_3(plane.orthogonal_vector());
-#if 0
-  auto apv = approx(plane.orthogonal_vector());
 
-  int dir = 0;
-  double max = CGAL::abs(apv.x().sup());
-  if(CGAL::abs(apv.y().sup()) > max){
-    dir = 1;
-    max = CGAL::abs(apv.y().sup());
-  }
-  if(CGAL::abs(apv.z().sup()) > max){
-    dir = 2;
-  }
-#endif
 
   CGAL_assertion(!plane.is_degenerate());
   Point_2 (*t)(const Point_3&);
@@ -138,94 +125,5 @@ Bounded_side bounded_side_3(IteratorForward first,
 
 } //namespace CGAL
 
-#ifdef WRONG_IMPLEMENTATION
-/* The following code is wrong since Proyector_.. structures must not return
-   references to temporal objects */
-template < class Point_2, class Point_3>
-struct Project_XY {
-  typedef Point_3                  argument_type;
-  typedef Point_2                  result_type;
-  Point_2 operator()( Point_3& p) const {
-    return Point_2(p.hx(), p.hy(), p.hw());
-  }
-  const Point_2 operator()( const Point_3& p) const {
-    return Point_2(p.hx(), p.hy(), p.hw());
-  }
-};
-
-template < class Point_2, class Point_3>
-struct Project_YZ {
-  typedef Point_3                  argument_type;
-  typedef Point_2                  result_type;
-  Point_2 operator()( Point_3& p) const {
-    return Point_2(p.hy(), p.hz(), p.hw());
-  }
-  const Point_2 operator()( const Point_3& p) const {
-    return Point_2(p.hy(), p.hz(), p.hw());
-  }
-};
-
-template < class Point_2, class Point_3>
-struct Project_XZ {
-  typedef Point_3                  argument_type;
-  typedef Point_2                  result_type;
-  Point_2 operator()( Point_3& p) const {
-    return Point_2(p.hx(), p.hz(), p.hw());
-  }
-  const Point_2 operator()( const Point_3& p) const {
-    return Point_2(p.hx(), p.hz(), p.hw());
-  }
-};
-
-template <class IC, class R>
-Bounded_side bounded_side_3(IC first,
-                            IC last,
-                            const Point_3<R>& point,
-                            Plane_3<R> plane = Plane_3<R>(0,0,0,0)) {
-
-  typedef typename R::Point_2 Point_2;
-  typedef typename R::Point_3 Point_3;
-  typedef typename R::Vector_3 Vector_3;
-  typedef typename R::Plane_3 Plane_3;
-
-  CGAL_assertion( !CGAL::is_empty_range( first, last));
-
-  if(plane == Plane_3(0,0,0,0)) {
-    Vector_3 hv;
-    normal_vector_newell_3( first, last, hv);
-    plane = Plane_3( *first, Vector_3(hv));
-  }
-  CGAL_assertion(!plane.is_degenerate());
-  Vector_3 pd(plane.orthogonal_vector()), pyz(1,0,0), pxz(0,1,0);
-  if(pd == pyz || pd == -pyz) {
-    /* the plane is parallel to the YZ plane */
-    typedef Project_YZ< Point_2, Point_3>                  Project_YZ;
-    typedef Iterator_project< IC, Project_YZ> Iterator_YZ;
-    Project_YZ project;
-    Point_2 p = project(point);
-    Iterator_YZ pfirst(first), plast(last);
-    return bounded_side_2(pfirst, plast, p);
-  }
-  else if(pd == pxz || pd ==- pxz) {
-    /* the plane is parallel to the XZ plane */
-    typedef Project_XZ< Point_2, Point_3>                  Project_XZ;
-    typedef Iterator_project< IC, Project_XZ> Iterator_XZ;
-    Project_XZ project;
-    Point_2 p = project(point);
-    Iterator_XZ pfirst(first), plast(last);
-    return bounded_side_2(pfirst, plast, p);
-  }
-  else {
-    CGAL_assertion(cross_product(pd.vector(), Vector_3(0,0,1)) == NULL_VECTOR);
-    /* the plane is not perpendicular to the XY plane */
-    typedef Project_XY< Point_2, Point_3>                  Project_XY;
-    typedef Iterator_project< IC, Project_XY> Iterator_XY;
-    Project_XY project;
-    Point_2 p = project(point);
-    Iterator_XY pfirst(first), plast(last);
-    return bounded_side_2(pfirst, plast, p);
-  }
-}
-#endif // WRONG_IMPLEMENTATION
 
 #endif // CGAL_BOUNDED_SIDE_3_H

--- a/Nef_3/include/CGAL/Nef_3/bounded_side_3.h
+++ b/Nef_3/include/CGAL/Nef_3/bounded_side_3.h
@@ -30,17 +30,17 @@
 namespace CGAL {
 
 template <class Point_2, class Point_3>
-Point_2 point_3_get_x_y_point_2(Point_3 p) {
+Point_2 point_3_get_x_y_point_2(const Point_3& p) {
   return( Point_2(p.hx(), p.hy(), p.hw()) );
 }
 
 template <class Point_2, class Point_3>
-Point_2 point_3_get_y_z_point_2(Point_3 p) {
+Point_2 point_3_get_y_z_point_2(const Point_3& p) {
   return( Point_2(p.hy(), p.hz(), p.hw()) );
 }
 
 template <class Point_2, class Point_3>
-Point_2 point_3_get_z_x_point_2(Point_3 p) {
+Point_2 point_3_get_z_x_point_2(const Point_3& p) {
   return( Point_2(p.hz(), p.hx(), p.hw()) );
 }
 
@@ -70,21 +70,27 @@ Bounded_side bounded_side_3(IteratorForward first,
 
 
 
+  auto apv = approx(plane.orthogonal_vector());
+
+  int dir = 0;
+  auto max = CGAL::abs(apv.x());
+  if(CGAL::abs(apv.y()) > max){
+    dir = 1;
+    max = CGAL::abs(apv.y());
+  }
+  if(CGAL::abs(apv.z()) > max){
+    dir = 2;
+  }
+
+
   CGAL_assertion(!plane.is_degenerate());
-  Point_2 (*t)(Point_3);
-  Vector_3 pv(plane.orthogonal_vector()), pxy(0,0,1), pyz(1,0,0), pzx(0,1,0);
-  CGAL_NEF_TRACEN("pv*pxz: "<<pv*pzx);
-  CGAL_NEF_TRACEN("pv*pyz: "<<pv*pyz);
-  CGAL_NEF_TRACEN("pv*pxy: "<<pv*pxy);
-  if( !CGAL_NTS is_zero(pv*pzx) )
-    /* the plane is not perpendicular to the ZX plane */
-    t = &point_3_get_z_x_point_2< Point_2, Point_3>;
-  else if( !CGAL_NTS is_zero(pv*pyz) )
-    /* the plane is not perpendicular to the YZ plane */
+  Point_2 (*t)(const Point_3&);
+
+  if(dir == 0){
     t = &point_3_get_y_z_point_2< Point_2, Point_3>;
-  else {
-    CGAL_assertion( !CGAL_NTS is_zero(pv*pxy) );
-    /* the plane is not perpendicular to the XY plane */
+  }else if(dir == 1){
+    t = &point_3_get_z_x_point_2< Point_2, Point_3>;
+  }else{
     t = &point_3_get_x_y_point_2< Point_2, Point_3>;
   }
 
@@ -95,7 +101,6 @@ Bounded_side bounded_side_3(IteratorForward first,
     points.push_back( t(*first));
   }
   Bounded_side side = bounded_side_2( points.begin(), points.end(), t(point));
-  points.clear();
   return side;
 }
 

--- a/Nef_S2/include/CGAL/Nef_S2/SM_point_locator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_point_locator.h
@@ -257,7 +257,7 @@ public:
     Unique_hash_map<SHalfedge_handle,bool> visited(false);
     CGAL_forall_svertices(v,*this) {
       Sphere_point vp = v->point();
-      if ( s.has_on(vp) ) {
+      if ( (v == v_res) || s.has_on(vp) ) {
         CGAL_NEF_TRACEN(" location via vertex at "<<vp);
         s = Sphere_segment(p,vp,s.sphere_circle()); // we shrink the segment
         if ( is_isolated(v) ) {

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_segment.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_segment.h
@@ -210,7 +210,7 @@ bool has_on(const Sphere_point<R>& p) const;
 /*{\Mop return true iff |\Mvar| contains |p|.}*/
 bool has_on_after_intersection(const Sphere_point<R>& p) const;
 
-bool has_in_relative_interior(const Sphere_point<R>& p) const;
+  bool has_in_relative_interior(const Sphere_point<R>& p, bool check_has_on = true) const;
 /*{\Mop return true iff |\Mvar| contains |p| in
 its relative interior.}*/
 
@@ -315,8 +315,8 @@ has_on_after_intersection(const CGAL::Sphere_point<R>& p) const {
 
 template <typename R>
 bool Sphere_segment<R>::
-has_in_relative_interior(const CGAL::Sphere_point<R>& p) const
-{ if ( !sphere_circle().has_on(p) ) return false;
+has_in_relative_interior(const CGAL::Sphere_point<R>& p, bool check_has_on) const
+{ if (check_has_on &&( !sphere_circle().has_on(p) ) ) return false;
   if ( !is_long() ) {
     return orientation(Point_3(0,0,0),
                        CGAL::ORIGIN + sphere_circle().orthogonal_vector(),
@@ -360,11 +360,11 @@ bool do_intersect_internally(const Sphere_segment<R>& s1,
   if ( equal_as_sets(s1.sphere_circle(),s2.sphere_circle()) )
     return false;
   p = CGAL::intersection(s1.sphere_circle(),s2.sphere_circle());
-  if ( s1.has_in_relative_interior(p) &&
-       s2.has_in_relative_interior(p) ) return true;
+  if ( s1.has_in_relative_interior(p, false) &&
+       s2.has_in_relative_interior(p, false) ) return true;
   p = p.antipode();
-  if ( s1.has_in_relative_interior(p) &&
-       s2.has_in_relative_interior(p) ) return true;
+  if ( s1.has_in_relative_interior(p, false) &&
+       s2.has_in_relative_interior(p, false) ) return true;
   return false;
 }
 
@@ -377,9 +377,9 @@ bool do_intersect_internally(const Sphere_circle<R>& c1,
   if ( equal_as_sets(c1,s2.sphere_circle()) )
     return false;
   p = CGAL::intersection(c1,s2.sphere_circle());
-  if ( s2.has_in_relative_interior(p) ) return true;
+  if ( s2.has_in_relative_interior(p, false) ) return true;
   p = p.antipode();
-  if ( s2.has_in_relative_interior(p) ) return true;
+  if ( s2.has_in_relative_interior(p, false) ) return true;
   return false;
 }
 


### PR DESCRIPTION
## Summary of Changes

Given two segments of great circles we construct an intersection of the two great circles. In the test if the intersection point lies on the segments we first check if the point is on the great circle.  First we know that, and second this triggers an exact test.

## Release Management

* Affected package(s): Nef_S2, Nef_3
* License and copyright ownership: unchanged.

