### PR TITLE
Polyhedron demo - improve PMP::isotropic_remeshing dialog box

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_dialog.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_dialog.ui
@@ -245,12 +245,12 @@
  </customwidgets>
  <tabstops>
   <tabstop>splitEdgesOnly_checkbox</tabstop>
+  <tabstop>edgeLength_dspinbox</tabstop>
   <tabstop>nbIterations_spinbox</tabstop>
   <tabstop>nbSmoothing_spinbox</tabstop>
   <tabstop>protect_checkbox</tabstop>
   <tabstop>smooth1D_checkbox</tabstop>
   <tabstop>preserveDuplicates_checkbox</tabstop>
-  <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -954,9 +954,11 @@ private:
             ui.nbIterations_spinbox, SLOT(setDisabled(bool)));
     connect(ui.splitEdgesOnly_checkbox, SIGNAL(toggled(bool)),
             ui.protect_checkbox, SLOT(setDisabled(bool)));
-    connect(ui.protect_checkbox, SIGNAL(toggled(bool)),
+    connect(ui.splitEdgesOnly_checkbox, SIGNAL(toggled(bool)),
             ui.smooth1D_checkbox, SLOT(setDisabled(bool)));
     connect(ui.splitEdgesOnly_checkbox, SIGNAL(toggled(bool)),
+            ui.nbSmoothing_spinbox, SLOT(setDisabled(bool)));
+    connect(ui.protect_checkbox, SIGNAL(toggled(bool)),
             ui.smooth1D_checkbox, SLOT(setDisabled(bool)));
     connect(ui.preserveDuplicates_checkbox, SIGNAL(toggled(bool)),
             ui.protect_checkbox, SLOT(setChecked(bool)));


### PR DESCRIPTION
## Summary of Changes

This PR improves the behavior of the `isotropic_remeshing_plugin` dialog box, by :
- disabling the spinbox for the number of smoothing iterations when "edges only" is selected
- changing the go-through-by-pushing-tab order to make it go from top to bottom of the UI

## Release Management

* Affected package(s): Polyhedron demo
* License and copyright ownership: unchanged

