### PR TITLE
Lipschitz sizing field macOS warning fixed

### DIFF
--- a/GraphicsView/demo/Triangulation_2/include/CGAL/Lipschitz_sizing_field_criteria_2.h
+++ b/GraphicsView/demo/Triangulation_2/include/CGAL/Lipschitz_sizing_field_criteria_2.h
@@ -38,7 +38,8 @@ public:
     : Base(aspect_bound), sizing_field(sf), traits(traits)
   {}
 
-  Lipschitz_sizing_field_criteria_2& operator =(const Lipschitz_sizing_field_criteria_2<CDT,SF>& c)
+  Lipschitz_sizing_field_criteria_2(const Lipschitz_sizing_field_criteria_2<CDT,SF>&) = default;
+  Lipschitz_sizing_field_criteria_2& operator=(const Lipschitz_sizing_field_criteria_2<CDT,SF>& c)
   {
     if(&c == this) return *this;
     this->sizing_field = c.sizing_field;


### PR DESCRIPTION
This little PR fixes the C++11 warning on the macOS produced by the missing `= default` tag in the Lipschitz sizing field class in the Triangulation 2 demo. The warning is revealed in the recent test suite.

## Release Management

* Affected package(s): `GraphicsView`
* Issue(s) solved (if any): warnings
* Feature/Small Feature (if any): bug fix
* License and copyright ownership: no changes

