### PR TITLE
Tutorial_GIS.txt: fandom rorest -> random forest

### DIFF
--- a/Documentation/doc/Documentation/Tutorials/Tutorial_GIS.txt
+++ b/Documentation/doc/Documentation/Tutorials/Tutorial_GIS.txt
@@ -276,7 +276,7 @@ classifier currently available in \cgal is the %random forest from
 ETHZ. As it is a supervised classifier, a training set is needed.
 
 The following snippet shows how to use some manually selected training
-set to train a %fandom rorest classifier and compute a classification
+set to train a %random forest classifier and compute a classification
 regularized by a graph cut algorithm:
 
 \snippet Classification/gis_tutorial_example.cpp Classification


### PR DESCRIPTION
fandom rorest -> random forest
## Summary of Changes
fix tutorial typo
## Release Management
* Link to compiled documentation
 https://doc.cgal.org/latest/Manual/tuto_gis.html#title12
* License and copyright ownership:
 none
