### PR TITLE
Kernel_23: Add a version of Do_intersect_3 where we can use a RT

### DIFF
--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -3002,7 +3002,7 @@ namespace CommonKernelFunctors {
   public:
     typedef typename K::Boolean     result_type;
 
-    // There are x combinaisons, so I use a template.
+    // There are x combinations, so I use a template.
     template <class T1, class T2>
     result_type
     operator()(const T1& t1, const T2& t2) const
@@ -3011,6 +3011,27 @@ namespace CommonKernelFunctors {
     result_type
     operator()(const typename K::Plane_3& pl1, const typename K::Plane_3& pl2, const typename K::Plane_3& pl3) const
     { return Intersections::internal::do_intersect(pl1, pl2, pl3, K() ); }
+
+  };
+
+
+  template <typename K>
+  class Do_intersect_RT_3
+  {
+  public:
+    typedef typename K::Boolean     result_type;
+
+    result_type
+    operator()(const typename K::Triangle_3& t1, const typename K::Triangle_3& t2) const
+    {
+      return Intersections::internal::do_intersect(t1, t2, K());
+    }
+
+    result_type
+    operator()(const typename K::Triangle_3& t, const typename K::Segment_3& s) const
+    {
+      return Intersections::internal::do_intersect(t, s, K());
+    }
 
   };
 

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -498,6 +498,8 @@ CGAL_Kernel_pred(Do_intersect_2,
                  do_intersect_2_object)
 CGAL_Kernel_pred(Do_intersect_3,
                  do_intersect_3_object)
+CGAL_Kernel_pred_RT(Do_intersect_RT_3,
+                 do_intersect_RT_3_object)
 CGAL_Kernel_pred(Equal_xy_3,
                  equal_xy_3_object)
 CGAL_Kernel_pred(Equal_x_2,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -67,7 +67,7 @@ bool do_faces_intersect(typename boost::graph_traits<TM>::halfedge_descriptor h,
                         const VPM vpmap,
                         const typename GT::Construct_segment_3& construct_segment,
                         const typename GT::Construct_triangle_3& construct_triangle,
-                        const typename GT::Do_intersect_3& do_intersect)
+                        const typename GT::Do_intersect_RT_3& do_intersect)
 {
   typedef typename boost::graph_traits<TM>::vertex_descriptor                 vertex_descriptor;
   typedef typename boost::graph_traits<TM>::halfedge_descriptor               halfedge_descriptor;
@@ -174,7 +174,7 @@ struct Strict_intersect_faces // "strict" as in "not sharing a subface"
   const VPM m_vpmap;
   typename GT::Construct_segment_3 m_construct_segment;
   typename GT::Construct_triangle_3 m_construct_triangle;
-  typename GT::Do_intersect_3 m_do_intersect;
+  typename GT::Do_intersect_RT_3 m_do_intersect;
 
   Strict_intersect_faces(const TM& tmesh, VPM vpmap, const GT& gt, OutputIterator it)
     :
@@ -183,7 +183,7 @@ struct Strict_intersect_faces // "strict" as in "not sharing a subface"
       m_vpmap(vpmap),
       m_construct_segment(gt.construct_segment_3_object()),
       m_construct_triangle(gt.construct_triangle_3_object()),
-      m_do_intersect(gt.do_intersect_3_object())
+      m_do_intersect(gt.do_intersect_RT_3_object())
   {}
 
   void operator()(const Box* b, const Box* c) const


### PR DESCRIPTION
## Summary of Changes

Doing a self intersection test of a data set with many neighboring coplanar triangles the intersection test is done with an exact number type.   As some `do_intersect()` functions perform divisions we cannot simply use the interface macro `Kernel_pred_RT`.  We have to get rid of the divisions first.  This PR is basically a work around and the functor added is an implementation detail and not  meant to be documented.  This faster test is only used in  `PMP::does_self_intersect()`.

## Release Management

* Affected package(s): Kernel_23, Intersections_3, PMP
* Issue(s) solved (if any): fix #0000, fix #0000,...
* License and copyright ownership: maintenance by GF

