### PR TITLE
Documentation: Fix `read_ply_points_with_properties` 

### DIFF
--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -92,7 +92,7 @@ namespace CGAL {
 #endif // DOXYGEN_RUNNING
 
 /**
-  \ingroup PkgPointSetProcessingIOPly
+  \ingroup PkgPointSetProcessing3IOPly
 
   Reads user-selected points properties from a .ply stream (ASCII or
   binary).


### PR DESCRIPTION
## Summary of Changes

There was a mistake in the group name of that function.
## Release Management

* Affected package(s):PSP
* Issue(s) solved (if any): fix #5531