### PR TITLE
Bbox size helpers

### DIFF
--- a/Kernel_23/include/CGAL/Bbox_2.h
+++ b/Kernel_23/include/CGAL/Bbox_2.h
@@ -61,6 +61,8 @@ public:
   inline double     ymin() const;
   inline double     xmax() const;
   inline double     ymax() const;
+  inline double x_span() const;
+  inline double y_span() const;
 
   inline double     max BOOST_PREVENT_MACRO_SUBSTITUTION (int i) const;
   inline double     min BOOST_PREVENT_MACRO_SUBSTITUTION (int i) const;
@@ -90,6 +92,14 @@ inline
 double
 Bbox_2::ymax() const
 { return rep[3]; }
+
+inline double Bbox_2::x_span() const {
+  return xmax() - xmin();
+}
+
+inline double Bbox_2::y_span() const {
+  return ymax() - ymin();
+}
 
 inline
 bool

--- a/Kernel_23/include/CGAL/Bbox_3.h
+++ b/Kernel_23/include/CGAL/Bbox_3.h
@@ -58,12 +58,15 @@ public:
   inline bool operator!=(const Bbox_3 &b) const;
 
   inline int dimension() const;
-  double  xmin() const;
-  double  ymin() const;
-  double  zmin() const;
-  double  xmax() const;
-  double  ymax() const;
-  double  zmax() const;
+  double xmin() const;
+  double ymin() const;
+  double zmin() const;
+  double xmax() const;
+  double ymax() const;
+  double zmax() const;
+  double x_span() const;
+  double y_span() const;
+  double z_span() const;
 
   inline double min BOOST_PREVENT_MACRO_SUBSTITUTION (int i) const;
   inline double max BOOST_PREVENT_MACRO_SUBSTITUTION (int i) const;
@@ -106,6 +109,18 @@ inline
 double
 Bbox_3::zmax() const
 { return rep[5]; }
+
+inline double Bbox_3::x_span() const {
+  return xmax() - xmin();
+}
+
+inline double Bbox_3::y_span() const {
+  return ymax() - ymin();
+}
+
+inline double Bbox_3::z_span() const {
+  return zmax() - zmin();
+}
 
 inline
 bool

--- a/Kernel_23/test/Kernel_23/test_bbox.cpp
+++ b/Kernel_23/test/Kernel_23/test_bbox.cpp
@@ -39,6 +39,9 @@ int main()
                              -3000000000000001.,
                              5000000.0000000019,
                              7.0000000000000026e+20) );
+  CGAL::Bbox_2 span{1,2,5,8};
+  assert( span.x_span() == 4);
+  assert( span.y_span() == 6);
   }
 
   {
@@ -70,5 +73,9 @@ int main()
                              5000000.000000014,
                              7.0000000000000197e+20,
                              15.000000000000027) );
+  CGAL::Bbox_3 span{1,2,3,5,8,11};
+  assert( span.x_span() == 4);
+  assert( span.y_span() == 6);
+  assert( span.z_span() == 8);
   }
 }


### PR DESCRIPTION
## Summary of Changes

Adds some helpers to calculate the size of a Bbox in each dimension.

## Release Management

* Affected package(s): Kernel_23
* Issue(s) solved (if any): N/A
* Feature/Small Feature (if any): N/A
* License and copyright ownership: CLA signed

