### PR TITLE
Classification: Add missing include

### DIFF
--- a/Classification/include/CGAL/Classification/Label_set.h
+++ b/Classification/include/CGAL/Classification/Label_set.h
@@ -19,6 +19,7 @@
 #include <CGAL/Random.h>
 
 #include <vector>
+#include <unordered_map>
 
 namespace CGAL {
 


### PR DESCRIPTION
## Summary of Changes

add missing <unordered_map> include
## Release Management

* Affected package(s):Classification

*Not based on 5.1 because the `unordered_map` call only appeared in 5.2
