### PR TITLE
Linear_cell_complex_incremental_builder include

### DIFF
--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_incremental_builder.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_incremental_builder.h
@@ -14,6 +14,7 @@
 
 #include <vector>
 #include <cstddef>
+#include <CGAL/Linear_cell_complex_base.h>
 
 namespace CGAL {
   template<class LCC, class Combinatorial_data_structure=


### PR DESCRIPTION
## Summary of Changes

Adds a missing include. This file uses `Generalized_map_tag` on line 50, which is defined in `Linear_cell_complex_base.h`.

## Release Management

* Affected package(s): Linear cell complex
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: Signed CLA

