### PR TITLE
Segment_2/Segment_3 midpoint()

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -2741,6 +2741,7 @@ namespace CartesianKernelFunctors {
   {
     typedef typename K::FT        FT;
     typedef typename K::Point_2   Point_2;
+    typedef typename K::Segment_2 Segment_2;
   public:
     typedef Point_2          result_type;
 
@@ -2752,6 +2753,17 @@ namespace CartesianKernelFunctors {
       midpointC2(p.x(), p.y(), q.x(), q.y(), x, y);
       return construct_point_2(x, y);
     }
+
+    Point_2
+    operator()(const Segment_2& s) const
+    {
+      typename K::Construct_point_2 construct_point_2;
+      FT x, y;
+      const Point_2& p = s.source();
+      const Point_2& q = s.target();
+      midpointC2(p.x(), p.y(), q.x(), q.y(), x, y);
+      return construct_point_2(x, y);
+    }
   };
 
   template <typename K>
@@ -2759,12 +2771,24 @@ namespace CartesianKernelFunctors {
   {
     typedef typename K::FT        FT;
     typedef typename K::Point_3   Point_3;
+    typedef typename K::Segment_3 Segment_3;
   public:
     typedef Point_3               result_type;
 
     Point_3
     operator()(const Point_3& p, const Point_3& q) const
     {
+      typename K::Construct_point_3 construct_point_3;
+      FT x, y, z;
+      midpointC3(p.x(), p.y(), p.z(), q.x(), q.y(), q.z(), x, y, z);
+      return construct_point_3(x, y, z);
+    }
+
+    Point_3
+    operator()(const Segment_3& s) const
+    {
+      const Point_3& p = s.source();
+      const Point_3& q = s.target();
       typename K::Construct_point_3 construct_point_3;
       FT x, y, z;
       midpointC3(p.x(), p.y(), p.z(), q.x(), q.y(), q.z(), x, y, z);

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
@@ -2950,6 +2950,7 @@ namespace HomogeneousKernelFunctors {
   {
     typedef typename K::FT        FT;
     typedef typename K::Point_2   Point_2;
+    typedef typename K::Segment_2 Segment_2;
   public:
     typedef Point_2          result_type;
 
@@ -2963,6 +2964,19 @@ namespace HomogeneousKernelFunctors {
                       p.hy()*qhw + q.hy()*phw,
                       phw * qhw * RT( 2));
     }
+
+    Point_2
+    operator()(const Segment_2& s) const
+    {
+      typedef typename K::RT RT;
+      const Point_2& p = s.source();
+      const Point_2& q = s.target();
+      const RT& phw = p.hw();
+      const RT& qhw = q.hw();
+      return Point_2( p.hx()*qhw + q.hx()*phw,
+                      p.hy()*qhw + q.hy()*phw,
+                      phw * qhw * RT( 2));
+    }
   };
 
   template <typename K>
@@ -2970,6 +2984,7 @@ namespace HomogeneousKernelFunctors {
   {
     typedef typename K::FT        FT;
     typedef typename K::Point_3   Point_3;
+    typedef typename K::Segment_3 Segment_3;
   public:
     typedef Point_3          result_type;
 
@@ -2977,6 +2992,20 @@ namespace HomogeneousKernelFunctors {
     operator()(const Point_3& p, const Point_3& q) const
     {
       typedef typename K::RT RT;
+      RT phw = p.hw();
+      RT qhw = q.hw();
+      return Point_3( p.hx()*qhw + q.hx()*phw,
+                      p.hy()*qhw + q.hy()*phw,
+                      p.hz()*qhw + q.hz()*phw,
+                      RT(2) * phw * qhw );
+    }
+
+    Point_3
+    operator()(const Segment_3& s) const
+    {
+      typedef typename K::RT RT;
+      const Point_3& p = s.source();
+      const Point_3& q = s.target();
       RT phw = p.hw();
       RT qhw = q.hw();
       return Point_3( p.hx()*qhw + q.hx()*phw,

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -2242,11 +2242,24 @@ template <typename Kernel>
 CGAL::Point_2<Kernel> midpoint( const CGAL::Point_2<Kernel>& p,
 const CGAL::Point_2<Kernel>& q );
 
+
+  /*!
+computes the midpoint of the segment `s`.
+*/
+template <typename Kernel>
+CGAL::Point_2<Kernel> midpoint( const CGAL::Segment_2<Kernel>& s);
+
 /*!
 computes the midpoint of the segment `pq`.
 */
 template <typename Kernel>
 CGAL::Point_3<Kernel> midpoint( const CGAL::Point_3<Kernel>& p, const CGAL::Point_3<Kernel>& q );
+
+/*!
+computes the midpoint of the segment `s`.
+*/
+template <typename Kernel>
+CGAL::Point_3<Kernel> midpoint( const CGAL::Segment_3<Kernel>& s );
 
 /// @}
 

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -4996,6 +4996,10 @@ public:
   */
   Kernel::Point_2 operator()(const Kernel::Point_2& p,
                              const Kernel::Point_2& q );
+  /*!
+    computes the midpoint of the segment `s`.
+  */
+  Kernel::Point_2 operator()(const Kernel::Segment_2& s);
 
   /// @}
 
@@ -5022,6 +5026,11 @@ public:
   */
   Kernel::Point_3 operator()(const Kernel::Point_3& p,
                              const Kernel::Point_3& q );
+
+  /*!
+    computes the midpoint of the segment `s`.
+  */
+  Kernel::Point_3 operator()(const Kernel::Segment_3& s);
 
 
   /// @}

--- a/Kernel_23/include/CGAL/Kernel/global_functions_2.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_2.h
@@ -757,7 +757,7 @@ midpoint(const Point_2<K> &p, const Point_2<K> &q)
 template < class K >
 inline typename K::Point_2 midpoint(const Segment_2<K> &s)
 {
-  return midpoint(s.source(), s.target());
+  return internal::midpoint(s, K());
 }
 
 template < class K >

--- a/Kernel_23/include/CGAL/Kernel/global_functions_2.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_2.h
@@ -755,6 +755,12 @@ midpoint(const Point_2<K> &p, const Point_2<K> &q)
 }
 
 template < class K >
+inline typename K::Point_2 midpoint(const Segment_2<K> &s)
+{
+  return midpoint(s.source(), s.target());
+}
+
+template < class K >
 inline
 typename K::Point_2
 max_vertex(const Iso_rectangle_2<K> &ir)

--- a/Kernel_23/include/CGAL/Kernel/global_functions_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_3.h
@@ -741,7 +741,7 @@ midpoint(const Point_3<K> &p, const Point_3<K> &q)
 template < class K >
 inline typename K::Point_3 midpoint(const Segment_3<K> &s)
 {
-  return midpoint(s.source(), s.target());
+  return internal::midpoint(s, K());
 }
 
 template < class K >

--- a/Kernel_23/include/CGAL/Kernel/global_functions_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_3.h
@@ -739,6 +739,12 @@ midpoint(const Point_3<K> &p, const Point_3<K> &q)
 }
 
 template < class K >
+inline typename K::Point_3 midpoint(const Segment_3<K> &s)
+{
+  return midpoint(s.source(), s.target());
+}
+
+template < class K >
 inline
 typename K::Point_3
 max_vertex(const Iso_cuboid_3<K> &ic)

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_2.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_2.h
@@ -791,6 +791,14 @@ midpoint(const typename K::Point_2 &p,
 template < class K >
 inline
 typename K::Point_2
+midpoint(const typename K::Segment_2 &s, const K &k)
+{
+  return k.construct_midpoint_2_object()(s);
+}
+
+template < class K >
+inline
+typename K::Point_2
 max_vertex(const typename K::Iso_rectangle_2 &ir, const K &k)
 {
   return k.construct_max_vertex_2_object()(ir);

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
@@ -832,6 +832,14 @@ midpoint(const typename K::Point_3 &p,
 template < class K >
 inline
 typename K::Point_3
+midpoint(const typename K::Segment_3 &s, const K &k)
+{
+  return k.construct_midpoint_3_object()(s);
+}
+
+template < class K >
+inline
+typename K::Point_3
 max_vertex(const typename K::Iso_cuboid_3 &ic, const K &k)
 {
   return k.construct_max_vertex_3_object()(ic);

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_constructions_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_constructions_2.h
@@ -24,6 +24,7 @@ _test_fct_constructions_2(const R&)
 {
   typedef typename R::RT              RT;
   typedef CGAL::Point_2<R>            Point;
+  typedef CGAL::Segment_2<R>          Segment;
   typedef CGAL::Weighted_point_2<R>   Weighted_Point;
   typedef CGAL::Triangle_2<R>         Triangle;
   typedef CGAL::Vector_2<R>           Vector;
@@ -52,6 +53,7 @@ _test_fct_constructions_2(const R&)
   // midpoint
   assert( CGAL::midpoint( pne, psw) == p);
   assert( CGAL::midpoint( pnw, pse) == p);
+  assert( CGAL::midpoint( Segment{pnw, pse}) == p);
 
   // circumcenter
   assert( CGAL::circumcenter( pne, pne ) == pne);

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_constructions_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_constructions_3.h
@@ -69,6 +69,7 @@ _test_fct_constructions_3(const R& r)
   assert( CGAL::midpoint( p110, p001) == p);
   assert( CGAL::midpoint( p010, p101) == p);
   assert( CGAL::midpoint( p100, p011) == p);
+  assert( CGAL::midpoint( Segment{p100, p011}) == p);
 
   // circumcenter
   assert( CGAL::circumcenter( p111, p001, p010, p000) == p);


### PR DESCRIPTION
## Summary of Changes

Adds a CGAL::midpoint() implementation for segments.

In the documentation:   [function ](https://cgal.github.io/5545/v0/Kernel_23/group__midpoint__grp.html) and [concept](https://cgal.github.io/5545/v0/Kernel_23/classKernel_1_1ConstructMidpoint__3.html)

## Release Management

* Affected package(s): Kernel_23
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): n/a
* License and copyright ownership: CLA signed

