### PR TITLE
Fix warning: std::pow(float, int) returns double instead of float in recent C++

### DIFF
--- a/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
+++ b/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
@@ -437,7 +437,7 @@ edge_aware_upsample_point_set(
   //
   FT cos_sigma = static_cast<FT>(std::cos(FT(CGAL::to_double(sharpness_angle))
                                           / FT(180) * FT(CGAL_PI)));
-  FT sharpness_bandwidth = std::pow((CGAL::max)((FT)1e-8, (FT)1.0 - cos_sigma), 2);
+  FT sharpness_bandwidth = static_cast<FT>(std::pow((CGAL::max)((FT)1e-8, (FT)1.0 - cos_sigma), 2));
 
   FT sum_density = 0.0;
   unsigned int count_density = 1;

--- a/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
@@ -1030,7 +1030,7 @@ namespace CGAL {
     }
 
     inline FT stop_probability(std::size_t largest_candidate, std::size_t num_pts, std::size_t num_candidates, std::size_t octree_depth) const {
-      return (std::min<FT>)(std::pow(FT(1) - FT(largest_candidate)
+      return (std::min<FT>)((FT)std::pow(FT(1) - FT(largest_candidate)
                                      / (FT(num_pts) * FT(octree_depth+1)
                                         * FT(1 << (m_required_samples - 1))),
                                      int(num_candidates)), FT(1));


### PR DESCRIPTION
## Summary of Changes

`std::pow(float,int)` used to return `float` but now returns `double`, which triggers warnings in our code when using `CGAL::Simple_cartesian<float>` where we assumed that the return type of `std::pow` was always the same as the argument type. This PR adds explicit casts where needed.

## Release Management

* Affected package(s): Shape Detection, PSP
* Based on 5.2 to avoid conflicts (incriminated lines have changed since 5.1)