### PR TITLE
PCA: do not compile examples/tests without Eigen

### DIFF
--- a/Principal_component_analysis/examples/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/examples/Principal_component_analysis/CMakeLists.txt
@@ -9,6 +9,10 @@ find_package(CGAL REQUIRED)
 # Use Eigen
 find_package(Eigen3 3.1.0) #(requires 3.1.0 or greater)
 include(CGAL_Eigen3_support)
+if(NOT TARGET CGAL::Eigen3_support)
+  message(STATUS  "NOTICE: This project requires Eigen 3.1 (or greater) and will not be compiled.")
+  return()
+endif()
 
 # create a target per cppfile
 file(
@@ -17,8 +21,6 @@ file(
   ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 foreach(cppfile ${cppfiles})
   create_single_source_cgal_program("${cppfile}")
-  if(TARGET CGAL::Eigen3_support)
-    get_filename_component(target ${cppfile} NAME_WE)
-    target_link_libraries(${target} PUBLIC CGAL::Eigen3_support)
-  endif()
+  get_filename_component(target ${cppfile} NAME_WE)
+  target_link_libraries(${target} PUBLIC CGAL::Eigen3_support)
 endforeach()

--- a/Principal_component_analysis/test/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/test/Principal_component_analysis/CMakeLists.txt
@@ -9,6 +9,10 @@ find_package(CGAL REQUIRED)
 # Use Eigen
 find_package(Eigen3 3.1.0) #(requires 3.1.0 or greater)
 include(CGAL_Eigen3_support)
+if(NOT TARGET CGAL::Eigen3_support)
+  message(STATUS  "NOTICE: This project requires Eigen 3.1 (or greater) and will not be compiled.")
+  return()
+endif()
 
 # create a target per cppfile
 file(
@@ -17,8 +21,6 @@ file(
   ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
 foreach(cppfile ${cppfiles})
   create_single_source_cgal_program("${cppfile}")
-  if(TARGET CGAL::Eigen3_support)
-    get_filename_component(target ${cppfile} NAME_WE)
-    target_link_libraries(${target} PUBLIC CGAL::Eigen3_support)
-  endif()
+  get_filename_component(target ${cppfile} NAME_WE)
+  target_link_libraries(${target} PUBLIC CGAL::Eigen3_support)
 endforeach()


### PR DESCRIPTION
## Summary of Changes

PCA depends on Eigen, but the CMakeLists still try to compile the examples and tests without it (leading to [warnings](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.3-Ic-88/Principal_component_analysis_Examples/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz) as without Eigen, the package fallbacks on an internal implementation that is deprecated). This PR fixes that.

## Release Management

* Affected package(s): PCA
* Based on 5.2 to avoid conflicts as the CMakeLists changed since 5.1
