### PR TITLE
Fix inconsistency in normal computation in robust projection code

### DIFF
--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -2752,24 +2752,18 @@ namespace CommonKernelFunctors {
     bool
     is_inside_triangle_3(const typename K::Point_3& p,
                          const typename K::Triangle_3& t,
+                         const typename K::Vector_3& w,
                          typename K::Point_3& result,
                          const K& k)
     {
       typedef typename K::Point_3 Point_3;
-      typedef typename K::Vector_3 Vector_3;
 
-      typename K::Construct_vector_3 vector =
-        k.construct_vector_3_object();
       typename K::Construct_vertex_3 vertex_on =
         k.construct_vertex_3_object();
-      typename K::Construct_cross_product_vector_3 cross_product =
-        k.construct_cross_product_vector_3_object();
 
       const Point_3& t0 = vertex_on(t,0);
       const Point_3& t1 = vertex_on(t,1);
       const Point_3& t2 = vertex_on(t,2);
-
-      Vector_3 w = cross_product(vector(t0,t1), vector(t1,t2));
 
       bool outside = false;
       if (   is_inside_triangle_3_aux(w, t0, t1, p, result, outside, k)
@@ -2846,6 +2840,8 @@ namespace CommonKernelFunctors {
       typename K::Construct_projected_point_3 projection =
         k.construct_projected_point_3_object();
       typename K::Is_degenerate_3 is_degenerate = k.is_degenerate_3_object();
+      typename K::Construct_orthogonal_vector_3 normal =
+        k.construct_orthogonal_vector_3_object();
 
       const typename K::Plane_3 plane = supporting_plane(triangle);
       if(is_degenerate(plane)) {
@@ -2892,9 +2888,8 @@ namespace CommonKernelFunctors {
       // Project origin on triangle supporting plane
       const Point_3 proj = projection(plane, origin);
 
-
       Point_3 moved_point;
-      bool inside = is_inside_triangle_3(proj,triangle,moved_point,k);
+      bool inside = is_inside_triangle_3(proj,triangle,normal(plane),moved_point,k);
 
       // If proj is inside triangle, return it
       if ( inside )


### PR DESCRIPTION
## Summary of Changes

Somewhat follow-up of https://github.com/CGAL/cgal/pull/1741.

If the triangle/plane is degenerate, the case is already handled separately.
But if we know the plane is not degenerate, the normal should not be recomputed in a different manner, as it might lead to a null normal and some issues down the line.

## Release Management

* Affected package(s): `Kernel_23`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

