### PR TITLE
Kernel_23: Fix warnings in Circle_3

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Circle_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Circle_3.h
@@ -17,6 +17,7 @@
 #define CGAL_CARTESIAN_CIRCLEC3_H
 
 #include <CGAL/Interval_nt.h>
+#include "boost/tuple/tuple.hpp"
 
 namespace CGAL {
 
@@ -29,13 +30,8 @@ class CircleC3 {
   typedef typename R_::Direction_3              Direction_3;
   typedef typename R_::FT                       FT;
 
-  struct Rep
-  {
-    Sphere_3 first;
-    Plane_3 second;
-    Rep () : first(), second() { }
-    Rep (const Sphere_3& s, const Plane_3& p) : first(s), second(p) { }
-  };
+  typedef boost::tuple<Sphere_3, Plane_3> Rep;
+
 
   typedef typename R_::template Handle<Rep>::type  Base;
   Base base;
@@ -125,7 +121,7 @@ public:
 
   const Plane_3& supporting_plane() const
   {
-    return get_pointee_or_identity(base).second;
+    return boost::get<1>(get_pointee_or_identity(base));
   }
 
   const Sphere_3& supporting_sphere() const
@@ -145,7 +141,7 @@ public:
 
   const Sphere_3& diametral_sphere() const
   {
-    return get_pointee_or_identity(base).first;
+    return boost::get<0>(get_pointee_or_identity(base));
   }
 
   double approximate_area() const

--- a/Cartesian_kernel/include/CGAL/Cartesian/Circle_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Circle_3.h
@@ -30,6 +30,7 @@ class CircleC3 {
   typedef typename R_::Direction_3              Direction_3;
   typedef typename R_::FT                       FT;
 
+  //using a boost::tuple because std::pair and tuple cannot work with incomplete types.
   typedef boost::tuple<Sphere_3, Plane_3> Rep;
 
 


### PR DESCRIPTION
## Summary of Changes

Replace the Rep type by a boost::tuple to silence a warning.
## Release Management

* Affected package(s):Kernel_23
* Issue(s) solved (if any): fix #5506