### PR TITLE
[cleanup][surface_mesh] Remove unused and duplicate includes

### DIFF
--- a/Surface_mesh/examples/Surface_mesh/sm_do_intersect.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_do_intersect.cpp
@@ -8,14 +8,6 @@
 #include <CGAL/box_intersection_d.h>
 #include <CGAL/Timer.h>
 
-#include <boost/bind.hpp>
-#include <boost/functional/value_factory.hpp>
-#include <boost/range/algorithm/transform.hpp>
-
-#include <algorithm>
-#include <vector>
-#include <fstream>
-
 typedef CGAL::Exact_predicates_exact_constructions_kernel K;
 
 typedef K::Triangle_3 Triangle_3;

--- a/Surface_mesh/examples/Surface_mesh/sm_do_intersect.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_do_intersect.cpp
@@ -1,12 +1,12 @@
-#include <algorithm>
-#include <vector>
-#include <fstream>
-
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
 
 #include <CGAL/box_intersection_d.h>
 #include <CGAL/Timer.h>
+
+#include <algorithm>
+#include <vector>
+#include <fstream>
 
 typedef CGAL::Exact_predicates_exact_constructions_kernel K;
 


### PR DESCRIPTION
## Summary of Changes

Removes unused boost includes and some duplicate STL includes.
The includes became unnecessary after a735e84.

## Release Management

* Affected package(s): Surface_mesh
