### PR TITLE
Classification: Sanitize addresses

### DIFF
--- a/Classification/examples/Classification/example_cluster_classification.cpp
+++ b/Classification/examples/Classification/example_cluster_classification.cpp
@@ -82,7 +82,12 @@ int main (int argc, char** argv)
 #endif
 
   generator.generate_point_based_features (pointwise_features);
-  generator.generate_normal_based_features (pointwise_features, pts.normal_map());
+
+  // Generator should only be used with variables defined at the scope
+  // of the generator object, thus we instantiate the normal map
+  // outside of the function
+  Vmap normal_map = pts.normal_map();
+  generator.generate_normal_based_features (pointwise_features, normal_map);
 
 #ifdef CGAL_LINKED_WITH_TBB
   pointwise_features.end_parallel_additions();
@@ -152,8 +157,8 @@ int main (int argc, char** argv)
 
   // First, compute means of features.
   features.begin_parallel_additions();
-  for (Feature_handle fh : pointwise_features)
-    features.add<Feature::Cluster_mean_of_feature> (clusters, fh);
+  for (std::size_t i = 0; i < pointwise_features.size(); ++ i)
+    features.add<Feature::Cluster_mean_of_feature> (clusters, pointwise_features[i]);
   features.end_parallel_additions();
 
   // Then, compute variances of features (and remaining cluster features).

--- a/Classification/include/CGAL/Classification/Feature_set.h
+++ b/Classification/include/CGAL/Classification/Feature_set.h
@@ -228,7 +228,7 @@ public:
   {
 #ifdef CGAL_LINKED_WITH_TBB
     m_tasks->wait();
-    m_tasks.release();
+    m_tasks.reset();
     m_adders.clear();
 #endif
   }


### PR DESCRIPTION
## Summary of Changes

The cluster example triggered [an error on _one_ platform](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.3-Ic-94/Classification_Examples/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Release-64bits.gz).

After running the address sanitizer (which did detect problems), I figured it came from the fact that I used a temporary variable when generating features. I made this variable defined at the right scope (as is already documented) and it fixed the problem. I'm surprised no more platforms actually crashed on this…

The address sanitizer also revealed a leak that I fixed (I used `std::unique_ptr<>::release()` instead of `std::unique_ptr<>::reset()`: _release_ does not free the memory but only gives the user the ownership of the pointer).

## Release Management

* Affected package(s): Classification
* Base on 5.2 to avoid conflicts in 5.1