### PR TITLE
Polyhedron Demo:  Trivial Warning

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -1099,11 +1099,13 @@ bool Scene::dropMimeData(const QMimeData * /*data*/,
       CGAL::Three::Scene_group_item* group =
           qobject_cast<CGAL::Three::Scene_group_item*>(item(i));
       if(group)
+      {
         Q_FOREACH(Item_id id, group->getChildren())
         {
           CGAL::Three::Scene_item* child = item(id);
           groups_children << item_id(child);
         }
+      }
     }
     // Insure that children of selected groups will not be added twice
     Q_FOREACH(int i, selected_items_list)

--- a/Polyhedron/demo/Polyhedron/TextRenderer.cpp
+++ b/Polyhedron/demo/Polyhedron/TextRenderer.cpp
@@ -16,7 +16,7 @@ void TextRenderer::draw(CGAL::Three::Viewer_interface *viewer, const QVector3D& 
       qobject_cast<CGAL::Three::Scene_print_item_interface*>(scene->item(scene->mainSelectionIndex()));
       if( item &&
           item->shouldDisplayIds(list->item())
-         )
+         ){
         Q_FOREACH(TextItem* item, list->textList())
         {
           CGAL::qglviewer::Vec src(item->position().x(), item->position().y(),item->position().z());
@@ -48,6 +48,7 @@ void TextRenderer::draw(CGAL::Three::Viewer_interface *viewer, const QVector3D& 
             painter->drawText(rect, item->text());
           }
         }
+      }
     }
 
     //Display the local TextItems

--- a/STL_Extension/include/CGAL/Object.h
+++ b/STL_Extension/include/CGAL/Object.h
@@ -24,6 +24,7 @@
 #include <CGAL/config.h>
 #include <CGAL/assertions.h>
 
+#include <iterator>
 #include <typeinfo>
 
 #include <boost/variant.hpp>

--- a/Stream_support/include/CGAL/IO/OFF/File_header_OFF_impl.h
+++ b/Stream_support/include/CGAL/IO/OFF/File_header_OFF_impl.h
@@ -208,9 +208,6 @@ operator+=( const File_header_OFF& header) {
 // Write header.
 CGAL_INLINE_FUNCTION
 std::ostream& operator<<( std::ostream& out, const File_header_OFF& h) {
-    if ( h.comments()) {
-        out << "# Output of a CGAL tool\n";
-    }
     if ( h.has_textures())
         out << "ST";
     if ( h.has_colors())
@@ -232,10 +229,6 @@ std::ostream& operator<<( std::ostream& out, const File_header_OFF& h) {
         out << h.size_of_vertices() << ' '<< h.size_of_facets();
         if ( h.off())
             out << " 0";
-        if ( h.comments()) {
-            out << "\n\n# " << h.size_of_vertices() << " vertices\n";
-            out << "# ------------------------------------------\n";
-        }
         out << std::endl;
     }
     return out;

--- a/Stream_support/include/CGAL/IO/OFF/File_writer_OFF.h
+++ b/Stream_support/include/CGAL/IO/OFF/File_writer_OFF.h
@@ -60,8 +60,6 @@ public:
 
   void write_footer()
   {
-    if(m_header.ascii() && m_header.comments())
-      out() << "\n\n# End of OFF #";
     out() << std::endl;
   }
 
@@ -124,17 +122,7 @@ public:
   {
     if(m_header.ascii())
     {
-      if(m_header.no_comments())
-      {
-        out() << '\n';
-      }
-      else
-      {
-        out() << "\n\n# " << m_header.size_of_facets()
-              << " facets\n";
-        out() << "# ------------------------------------------"
-                 "\n\n";
-      }
+      out() << '\n';
     }
   }
 


### PR DESCRIPTION
## Summary of Changes
Fix a trivial warning about braces in the scene
## Release Management
I did not find the issue in previous release so I only applied it in master.