### PR TITLE
Tetrahedral Remeshing - fix link error

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -68,7 +68,7 @@ const int indices_table[4][3] = { { 3, 1, 2 },
                                   { 3, 0, 1 },
                                   { 2, 1, 0 } };
 
-int indices(const int& i, const int& j)
+inline int indices(const int& i, const int& j)
 {
   CGAL_assertion(i < 4 && j < 3);
   if(i < 4 && j < 3)


### PR DESCRIPTION
## Summary of Changes

This PR fixes a "double definition" link error.
We `inline` the `indices(int, int)` function, which is was not template, nor inline and causing the error when compiling two cpp targets together.

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged

