### PR TITLE
CGAL ImageIO: Add an example and restore VTK support

### DIFF
--- a/CGAL_ImageIO/archive/demo/CGALimageIO/CMakeLists.txt
+++ b/CGAL_ImageIO/archive/demo/CGALimageIO/CMakeLists.txt
@@ -30,8 +30,8 @@ if(VTK_FOUND)
   if(TARGET vtkRenderingQt AND TARGET vtkFiltersModeling)
     find_package(VTK COMPONENTS vtkRenderingQt vtkFiltersModeling NO_MODULE)
     include(${VTK_USE_FILE})
-    find_package(Qt${VTK_QT_VERSION} COMPONENTS QtGui)
-    if(NOT TARGET Qt${VTK_QT_VERSION}::QtGui)
+    find_package(Qt${VTK_QT_VERSION} COMPONENTS Gui)
+    if(NOT TARGET Qt${VTK_QT_VERSION}::Gui)
       message(
         STATUS
           "NOTICE: vtkRenderingQt needs Qt${VTK_QT_VERSION}, and will not be compiled."
@@ -44,7 +44,7 @@ if(VTK_FOUND)
 
     target_link_libraries(
       image_to_vtk_viewer ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES}
-      ${VTK_LIBRARIES} Qt${VTK_QT_VERSION}::QtGui)
+      ${VTK_LIBRARIES} Qt${VTK_QT_VERSION}::Gui)
   else()
     message(
       STATUS

--- a/CGAL_ImageIO/examples/CGALimageIO/CMakeLists.txt
+++ b/CGAL_ImageIO/examples/CGALimageIO/CMakeLists.txt
@@ -16,6 +16,7 @@ if(CGAL_ImageIO_FOUND)
   create_single_source_cgal_program("convert_raw_image_to_inr.cpp")
   create_single_source_cgal_program("test_imageio.cpp")
   create_single_source_cgal_program("extract_a_sub_image.cpp")
+  create_single_source_cgal_program("slice_image.cpp")
 else()
   message(
     STATUS

--- a/CGAL_ImageIO/examples/CGALimageIO/extract_a_sub_image.cpp
+++ b/CGAL_ImageIO/examples/CGALimageIO/extract_a_sub_image.cpp
@@ -33,7 +33,7 @@ int main(int argc, char **argv) {
   for (auto k = zmin; k < zmax; ++k)
     for (auto j = ymin; j <= ymax; ++j)
       for (auto i = xmin; i <= xmax; ++i) {
-        auto pos = data + image->wdim * (i + image->xdim * (j + image->zdim * k));
+        auto pos = data + image->wdim * (i + image->xdim * (j + image->ydim * k));
         std::copy(pos, pos + image->wdim, new_data);
         new_data += image->wdim;
       }

--- a/CGAL_ImageIO/examples/CGALimageIO/slice_image.cpp
+++ b/CGAL_ImageIO/examples/CGALimageIO/slice_image.cpp
@@ -3,6 +3,10 @@
 #include <string>
 
 int main(int argc, char **argv) {
+  if (argc != 3) {
+    std::cerr << "Usage: slice_size <input> <output>\n";
+    return argc != 1;
+  }
   _image *image = ::_readImage(argv[1]);
   if (!image)
     return 2;

--- a/CGAL_ImageIO/examples/CGALimageIO/slice_image.cpp
+++ b/CGAL_ImageIO/examples/CGALimageIO/slice_image.cpp
@@ -1,0 +1,23 @@
+#include <CGAL/ImageIO.h>
+#include <iostream>
+#include <string>
+
+int main(int argc, char **argv) {
+  _image *image = ::_readImage(argv[1]);
+  if (!image)
+    return 2;
+  auto *new_image = ::_createImage(image->xdim, image->ydim, image->zdim / 2 + 1, 1,
+                                   image->vx, image->vy, image->vz*2, image->wdim,
+                                   image->wordKind, image->sign);
+  const auto* const data = static_cast<char*>(image->data);
+  auto* new_data = static_cast<char*>(new_image->data);
+  const auto slice_size = image->wdim * image->xdim * image->ydim;
+  for (auto k = 0ul; k < image->zdim; k+=2) {
+    auto pos = data + slice_size * k;
+    new_data = std::copy(pos, pos + slice_size, new_data);
+  }
+  auto r = ::_writeImage(new_image, argv[2]);
+  if(r != ImageIO_NO_ERROR) return 3;
+  ::_freeImage(image);
+  ::_freeImage(new_image);
+}

--- a/CGAL_ImageIO/include/CGAL/Image_3_vtk_interface.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3_vtk_interface.h
@@ -110,6 +110,9 @@ struct VTK_type_generator<boost::uint32_t> {
   vtk_image->SetSpacing(image.vx(),
                         image.vy(),
                         image.vz());
+  vtk_image->SetOrigin(image.tx(),
+                       image.ty(),
+                       image.tz());
   vtk_image->AllocateScalars(type, 1);
   vtk_image->GetPointData()->SetScalars(data_array);
   return vtk_image;


### PR DESCRIPTION
## Summary of Changes

This PR is a maintenance PR:
  - it adds a new example for CGAL_ImageIO: slicing an image in the z direction. Well, I am not sure "slicing" it the right word.
  - it fixes `CGAL_ImageIO/archive/demo/CGALimageIO/CMakeLists.txt` to that one can compile `image_to_vtk_viewer.cpp`.

## Release Management

* Affected package(s): CGAL_ImageIO
* License and copyright ownership: maintenance by GeometryFactory

