### PR TITLE
Number_types: Add Is_zero functor for Gmpq

### DIFF
--- a/Number_types/include/CGAL/GMP/Gmpq_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpq_type.h
@@ -228,12 +228,6 @@ public:
   double to_double() const noexcept;
   Sign sign() const noexcept;
 
-  bool is_zero() const
-  {
-    const __mpz_struct* zn = mpq_numref(mpq());
-    return mpn_zero_p(zn->_mp_d, zn->_mp_size);
-  }
-
   const mpq_t & mpq() const noexcept { return Ptr()->mpQ; }
   mpq_t & mpq() noexcept { return ptr()->mpQ; }
 

--- a/Number_types/include/CGAL/GMP/Gmpq_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpq_type.h
@@ -228,6 +228,12 @@ public:
   double to_double() const noexcept;
   Sign sign() const noexcept;
 
+  bool is_zero() const
+  {
+    const __mpz_struct* zn = mpq_numref(mpq());
+    return mpn_zero_p(zn->_mp_d, zn->_mp_size);
+  }
+
   const mpq_t & mpq() const noexcept { return Ptr()->mpQ; }
   mpq_t & mpq() noexcept { return ptr()->mpQ; }
 

--- a/Number_types/include/CGAL/Gmpq.h
+++ b/Number_types/include/CGAL/Gmpq.h
@@ -27,11 +27,10 @@ template <> class Algebraic_structure_traits< Gmpq >
     typedef Tag_false            Is_numerical_sensitive;
 
     class Is_zero
-      : public CGAL::cpp98::unary_function<Type&,
-                                bool > {
+      : public CGAL::cpp98::unary_function<Type&, bool > {
       public:
         bool operator()( const Type& x_) const {
-          return x_.is_zero();
+          return mpq_sgn(x_.mpq()) == 0;
         }
     };
 

--- a/Number_types/include/CGAL/Gmpq.h
+++ b/Number_types/include/CGAL/Gmpq.h
@@ -26,6 +26,16 @@ template <> class Algebraic_structure_traits< Gmpq >
     typedef Tag_true            Is_exact;
     typedef Tag_false            Is_numerical_sensitive;
 
+    class Is_zero
+      : public CGAL::cpp98::unary_function<Type&,
+                                bool > {
+      public:
+        bool operator()( const Type& x_) const {
+          return x_.is_zero();
+        }
+    };
+
+
     class Is_square
       : public CGAL::cpp98::binary_function< Type, Type&,
                                 bool > {

--- a/Number_types/include/CGAL/Gmpq.h
+++ b/Number_types/include/CGAL/Gmpq.h
@@ -27,7 +27,7 @@ template <> class Algebraic_structure_traits< Gmpq >
     typedef Tag_false            Is_numerical_sensitive;
 
     class Is_zero
-      : public CGAL::cpp98::unary_function<Type&, bool > {
+      : public CGAL::cpp98::unary_function< Type, bool > {
       public:
         bool operator()( const Type& x_) const {
           return mpq_sgn(x_.mpq()) == 0;
@@ -68,6 +68,22 @@ template <> class Algebraic_structure_traits< Gmpq >
 template <> class Real_embeddable_traits< Gmpq >
   : public INTERN_RET::Real_embeddable_traits_base< Gmpq , CGAL::Tag_true > {
   public:
+
+    class Is_positive
+      : public CGAL::cpp98::unary_function< Type, bool > {
+      public:
+        bool operator()( const Type& x_) const {
+          return mpq_sgn(x_.mpq()) > 0;
+        }
+    };
+
+    class Is_negative
+      : public CGAL::cpp98::unary_function< Type, bool > {
+      public:
+        bool operator()( const Type& x_) const {
+          return mpq_sgn(x_.mpq()) < 0;
+        }
+    };
 
     class Sgn
       : public CGAL::cpp98::unary_function< Type, ::CGAL::Sign > {


### PR DESCRIPTION
## Summary of Changes

Is this  faster than a comparison with zero?    And in case we change code where we currently compare with zero, we have to find out if it becomes slower when we apply `is_zero()` to a double.  And what  about `> 0`  ?

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

