### PR TITLE
PSP: Fix pointmatcher example

### DIFF
--- a/Point_set_processing_3/examples/Point_set_processing_3/registration_with_pointmatcher.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/registration_with_pointmatcher.cpp
@@ -114,32 +114,35 @@ int main(int argc, const char** argv)
                                           * */
      );
 
-  // OR call the ICP registration method from pointmatcher and apply the transformation to pwn2
-  bool converged =
-  CGAL::pointmatcher::register_point_sets
-    (pwns1, pwns2,
-     params::point_map(Point_map()).normal_map(Normal_map())
-     .point_set_filters(point_set_1_filters)
-     .matcher(matcher)
-     .outlier_filters(outlier_filters)
-     .error_minimizer(error_minimizer)
-     .transformation_checkers(transformation_checkers)
-     .inspector(inspector)
-     .logger(logger),
-     params::point_map(Point_map()).normal_map(Normal_map())
-     .point_set_filters(point_set_2_filters)
-     .transformation(res.first) /* pass the above computed transformation as initial transformation.
-                                * as a result, the registration will require less iterations to converge.
-                                * */
-     );
-
-  if (converged)
-    std::cerr << "Success" << std::endl;
-  else
+  bool converged = false;
+  do
   {
-    std::cerr << "Failure" << std::endl;
-    return EXIT_FAILURE;
+    // OR call the ICP registration method from pointmatcher and apply the transformation to pwn2
+    converged =
+      CGAL::pointmatcher::register_point_sets
+      (pwns1, pwns2,
+       params::point_map(Point_map()).normal_map(Normal_map())
+       .point_set_filters(point_set_1_filters)
+       .matcher(matcher)
+       .outlier_filters(outlier_filters)
+       .error_minimizer(error_minimizer)
+       .transformation_checkers(transformation_checkers)
+       .inspector(inspector)
+       .logger(logger),
+       params::point_map(Point_map()).normal_map(Normal_map())
+       .point_set_filters(point_set_2_filters)
+       .transformation(res.first) /* pass the above computed transformation as initial transformation.
+                                   * as a result, the registration will require less iterations to converge.
+                                   * */
+        );
+
+    // Algorithm may randomly not converge, repeat until it does
+    if (converged)
+      std::cerr << "Success" << std::endl;
+    else
+      std::cerr << "Did not converge, try again" << std::endl;
   }
+  while (!converged);
 
   std::ofstream out("pwns2_aligned.ply");
   if (!out ||


### PR DESCRIPTION
## Summary of Changes

Pointmatcher might randomly not converge, which leads to [errors](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.3-I-97/Point_set_processing_3_Examples/TestReport_lrineau_Ubuntu-Latest.gz) in the testsuite. In my experiments, it happens only 6% of the time. I added a loop to run it again until convergence and it fixes the problem.

## Release Management

* Affected package(s): PSP
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): NA
* License and copyright ownership: no change

