### PR TITLE
Fix approximate_sqrt return types

### DIFF
--- a/Algebraic_foundations/include/CGAL/number_utils.h
+++ b/Algebraic_foundations/include/CGAL/number_utils.h
@@ -302,19 +302,21 @@ to_interval( const Real_embeddable& x) {
 }
 
 template <typename NT>
-NT approximate_sqrt(const NT& nt, CGAL::Null_functor)
+typename Coercion_traits<double, NT>::Type
+approximate_sqrt(const NT& x, CGAL::Null_functor)
 {
-  return NT(sqrt(CGAL::to_double(nt)));
+  return sqrt(CGAL::to_double(x));
 }
 
 template <typename NT, typename Sqrt>
-NT approximate_sqrt(const NT& nt, Sqrt sqrt)
+typename Sqrt::result_type
+approximate_sqrt(const NT& nt, Sqrt sqrt)
 {
   return sqrt(nt);
 }
 
 template <typename NT>
-NT approximate_sqrt(const NT& nt)
+decltype(auto) approximate_sqrt(const NT& nt)
 {
   // the initial version of this function was using Algebraic_category
   // for the dispatch but some ring type (like Gmpz) provides a Sqrt

--- a/Number_types/include/CGAL/mpq_class.h
+++ b/Number_types/include/CGAL/mpq_class.h
@@ -40,7 +40,6 @@
 
 namespace CGAL {
 
-
 // AST for mpq_class
 template<>
 class Algebraic_structure_traits< mpq_class  >

--- a/Number_types/test/Number_types/Gmpzf_new.cpp
+++ b/Number_types/test/Number_types/Gmpzf_new.cpp
@@ -31,7 +31,7 @@ int main() {
         CGAL::test_algebraic_structure<NT,Tag, Is_exact>();
         CGAL::test_real_embeddable<NT>();
 
-        // assert(CGAL::approximate_sqrt(NT(4)) == NT(2));
+        assert(CGAL::approximate_sqrt(NT(4)) == NT(2));
 
     }
  return 0;

--- a/Number_types/test/Number_types/include/CGAL/_test_utilities.h
+++ b/Number_types/test/Number_types/include/CGAL/_test_utilities.h
@@ -368,7 +368,7 @@ test_utilities(const NT& x)
 
   // approximate_sqrt
   std::cout << "  approximate_sqrt()" << std::endl;
-  if(CGAL::approximate_sqrt(zero + one) != one) return false;
+  if(CGAL::approximate_sqrt(one) != one) return false;
 
   return true;
 }

--- a/Number_types/test/Number_types/include/CGAL/_test_utilities.h
+++ b/Number_types/test/Number_types/include/CGAL/_test_utilities.h
@@ -368,7 +368,7 @@ test_utilities(const NT& x)
 
   // approximate_sqrt
   std::cout << "  approximate_sqrt()" << std::endl;
-  if(CGAL::approximate_sqrt(one) != one) return false;
+  if(NT(CGAL::approximate_sqrt(one)) != one) return false;
 
   return true;
 }

--- a/Number_types/test/Number_types/include/CGAL/_test_utilities.h
+++ b/Number_types/test/Number_types/include/CGAL/_test_utilities.h
@@ -366,6 +366,10 @@ test_utilities(const NT& x)
   if (!test_gcd(x,typename AST::Algebraic_category())) return false;
   if (!test_sqrt(x,typename AST::Sqrt())) return false;
 
+  // approximate_sqrt
+  std::cout << "  approximate_sqrt()" << std::endl;
+  if(CGAL::approximate_sqrt(zero + one) != one) return false;
+
   return true;
 }
 

--- a/Number_types/test/Number_types/utilities.cpp
+++ b/Number_types/test/Number_types/utilities.cpp
@@ -124,7 +124,7 @@ int main()
        // TEST Sqrt_extension
 #ifdef CGAL_USE_GMP
       typedef CGAL::Sqrt_extension<int,int> Ext_int;
-      TESTIT(Ext_int     , "CGAL::Sqrt_extension<CGAL::Gmpz,CGAL::Gmpz>");
+      TESTIT(Ext_int     , "CGAL::Sqrt_extension<int,int>");
       typedef CGAL::Sqrt_extension<CGAL::Gmpz,CGAL::Gmpz> Ext_int_int;
       TESTIT(Ext_int_int , "CGAL::Sqrt_extension<CGAL::Gmpz,CGAL::Gmpz>");
       typedef CGAL::Sqrt_extension<CGAL::Gmpq,CGAL::Gmpz> Ext_rat_int;

--- a/Number_types/test/Number_types/utilities.cpp
+++ b/Number_types/test/Number_types/utilities.cpp
@@ -1,10 +1,5 @@
 #include <CGAL/config.h>
 
-// TODO: solve conflict of CORE with GMPXX
-#ifdef CGAL_USE_CORE
-#undef CGAL_USE_GMPXX
-#endif
-
 #include <CGAL/Quotient.h>
 #include <CGAL/MP_Float.h>
 #include <CGAL/Lazy_exact_nt.h>

--- a/Number_types/test/Number_types/utilities.cpp
+++ b/Number_types/test/Number_types/utilities.cpp
@@ -72,7 +72,7 @@ int main()
   TESTIT(long double, "long double")
 
   // CGAL number types
-  //TESTIT(CGAL::MP_Float, "MP_Float")
+  //TESTIT(CGAL::MP_Float, "MP_Float") // CGAL::div(MP_Float, MP_Float) does not implement _integer_ division
   TESTIT(CGAL::Quotient<int>, "Quotient<int>")
   TESTIT(QMPF, "Quotient<MP_Float>")
   TESTIT(CGAL::Lazy_exact_nt<QMPF>, "Lazy_exact_nt<Quotient<MP_Float> >")

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_distance.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_distance.cpp
@@ -1,11 +1,11 @@
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
 #include <CGAL/Real_timer.h>
 #include <CGAL/IO/OFF_reader.h>
-
-
 #include <CGAL/boost/graph/property_maps.h>
-
+#include <CGAL/number_utils.h>
+#include <CGAL/Coercion_traits.h>
 
 #include <fstream>
 #include <ostream>
@@ -194,6 +194,14 @@ struct Custom_traits_Hausdorff
 };
 
 namespace CGAL{
+
+CGAL_DEFINE_COERCION_TRAITS_FOR_SELF(Custom_traits_Hausdorff::FT)
+CGAL_DEFINE_COERCION_TRAITS_FROM_TO(short, Custom_traits_Hausdorff::FT)
+CGAL_DEFINE_COERCION_TRAITS_FROM_TO(int, Custom_traits_Hausdorff::FT)
+CGAL_DEFINE_COERCION_TRAITS_FROM_TO(long, Custom_traits_Hausdorff::FT)
+CGAL_DEFINE_COERCION_TRAITS_FROM_TO(float, Custom_traits_Hausdorff::FT)
+CGAL_DEFINE_COERCION_TRAITS_FROM_TO(double, Custom_traits_Hausdorff::FT)
+
 template<>struct Kernel_traits<Custom_traits_Hausdorff::Point_3>
 {
   typedef Custom_traits_Hausdorff Kernel;


### PR DESCRIPTION
## Summary of Changes

The default `CGAL::approximate_sqrt()` is implemented as:
```
template <typename NT>
NT approximate_sqrt(const NT& nt)
{
  return NT(sqrt(CGAL::to_double(nt)));
}
```
Since `__gmp_expr` uses template to keep a stack of operations, this will fail to compile if `NT` is not trivial as there will not be a constructor from `double` available.

<s>This PR adds an overload for `__gmp_expr` and uses `Coercion_traits` to find the base type.</s>
This PR changes the return types of `CGAL::approximate_sqrt()` to use `Coercion_traits` and `result_type` to use the correct return types.

**Remarks:**

- I am not sure if that would work for everything or just stuff for which we have overloaded `Coercion_traits`.

- With regard to `mpz_class`: I'm a bit confused why this class has a `Sqrt` in `mpz_class.h`:
  * this simply calls `::sqrt()`, so it is not exact (and its algebraic category rightfully does not advertise sqrt): `sqrt(mpz_class(3))` is `1`. As such, it is misleading.
  * `CGAL::approximate_sqrt(mpz_class)` is also broken is a somewhat similar way: `CGAL::approximate_sqrt()` will think a `Sqrt` operator is available: it is defined and not `Null_functor`. But it will fail to compile for something like: `K::FT l = CGAL::approximate_sqrt(mpz_class(0) + mpz_class(9)/mpz_class(3));` since it is not possible to build a complex `__gmp_expr` as output from the `::sqrt(x)` (which is just a `double`).
Should this sqrt be completely removed to just rely on the approximate sqrt properly introduced by this PR? 

## Release Management

* Affected package(s): `Number_types`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

