### PR TITLE
Fixed unassigned variable in the tests of Arrangement_on_surface_2

### DIFF
--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/IO_base_test.h
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/IO_base_test.h
@@ -1687,7 +1687,7 @@ bool IO_base_test<Base_geom_traits>::read_xcurve(InputStream_& is,
   read_point(is, p2);
   CGAL_assertion(p1 != p2);
 
-  unsigned int flag;
+  unsigned int flag = static_cast<unsigned int>(-1);
   is >> flag;
   if (flag == 1) {
     X_monotone_curve_2::Direction_3 normal;


### PR DESCRIPTION
In the recent test suit on the mac mini arm architecture, we have several run-time errors in the `Arrangement_on_surface_2` package. It turns out that they are caused by the unassigned variable that is then used to call the constructor that further leads to errors in the code.

This little PR fixes this problem. The change is tested locally on `x86_64` and `arm` platforms.

## Release Management

* Affected package(s): `Arrangement_on_surface_2`
* Issue(s) solved (if any): run-time errors
* Feature/Small Feature (if any): bug fix
* License and copyright ownership: no changes

