### PR TITLE
Polyhedron Demo: Fix edit bbox

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
@@ -772,6 +772,7 @@ bool Scene_edit_box_item::eventFilter(QObject *obj, QEvent *event)
       int type, picked;
       d->picked_pixel = e->pos();
       d->picking(type, picked, viewer);
+      viewer->makeCurrent();
       if(type !=-1)
       {
         bool found = false;


### PR DESCRIPTION
## Summary of Changes

A missing call to viewer->makeCUrrent() was responsible for the bbox being teleported after each picking.
