### PR TITLE
Fix uninitialized scalar variable in Lazy.h

### DIFF
--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -1664,14 +1664,14 @@ struct Lazy_construction_variant {
 
       // the approximate result requires the trait with types from the AK
       AT approx_v = lazy.approx();
-      // the result we build
-      result_type res;
 
       if(!approx_v) {
         // empty
-        return res;
+        return result_type();
       }
 
+      // the result we build
+      result_type res;
       // the static visitor fills the result_type with the correct unwrapped type
       internal::Fill_lazy_variant_visitor_2< result_type, AK, LK, EK, Lazy<AT, ET, E2A> > visitor(res, lazy);
       boost::apply_visitor(visitor, *approx_v);
@@ -1682,12 +1682,12 @@ struct Lazy_construction_variant {
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);
 
       ET exact_v = EC()(CGAL::exact(l1), CGAL::exact(l2));
-      result_type res;
 
       if(!exact_v) {
-        return res;
+        return result_type();
       }
 
+      result_type res;
       internal::Fill_lazy_variant_visitor_0<result_type, AK, LK, EK> visitor(res);
       boost::apply_visitor(visitor, *exact_v);
       return res;
@@ -1717,14 +1717,14 @@ struct Lazy_construction_variant {
 
       // the approximate result requires the trait with types from the AK
       AT approx_v = lazy.approx();
-      // the result we build
-      result_type res;
 
       if(!approx_v) {
         // empty
-        return res;
+        return result_type();
       }
 
+      // the result we build
+      result_type res;
       // the static visitor fills the result_type with the correct unwrapped type
       internal::Fill_lazy_variant_visitor_2< result_type, AK, LK, EK, Lazy<AT, ET, E2A> > visitor(res, lazy);
       boost::apply_visitor(visitor, *approx_v);
@@ -1735,12 +1735,12 @@ struct Lazy_construction_variant {
       Protect_FPU_rounding<!Protection> P2(CGAL_FE_TONEAREST);
 
       ET exact_v = EC()(CGAL::exact(l1), CGAL::exact(l2), CGAL::exact(l3));
-      result_type res;
 
       if(!exact_v) {
-        return res;
+        return result_type();
       }
 
+      result_type res;
       internal::Fill_lazy_variant_visitor_0< result_type, AK, LK, EK> visitor(res);
       boost::apply_visitor(visitor, *exact_v);
       return res;


### PR DESCRIPTION
## Summary of Changes

Several places in Lazy.h return an uninitialised scalar variable. These show as new high impact errors in coverity static analysis. 

My speculation is that they were possibly introduced in 4248a8a9f79887ebc4ccaba95f035e6313e9160f where result_type was changed from `cpp11::result_of` which might have been auto initalised differently.

The proposed change is just to return initialised scalar variables, where needed, which seems more semantically correct.

## Release Management

* Affected package(s): Filtered_kernel
* Issue(s) solved (if any): bugfix/security
* License and copyright ownership: Returned to CGAL authors.

