### PR TITLE
Fix uninitialized scalar variable in Modifiable_priority_queue.h

### DIFF
--- a/STL_Extension/include/CGAL/Modifiable_priority_queue.h
+++ b/STL_Extension/include/CGAL/Modifiable_priority_queue.h
@@ -102,14 +102,12 @@ public:
 
   boost::optional<value_type> extract_top()
   {
-    boost::optional<value_type> r ;
-    if ( !empty() )
-    {
-      value_type v = top();
-      pop();
-      r = boost::optional<value_type>(v) ;
-    }
-    return r ;
+    if ( empty() )
+      return boost::none;
+
+    value_type v = top();
+    pop();
+    return boost::optional<value_type>(v) ;
   }
 
   static handle null_handle() { return handle(false); }


### PR DESCRIPTION
## Summary of Changes

A function in Modifiable_priority_queue.h returns an uninitialised scalar variable. This shows as a new high impact error in coverity static analysis.

The proposed change is just to return `boost::none`

## Release Management

* Affected package(s): STL_extension
* Issue(s) solved (if any): bugfix/security
* License and copyright ownership: Returned to CGAL authors.

