### PR TITLE
Fix uninitalized scalar in Cartesian_converter.h

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian_converter.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian_converter.h
@@ -137,12 +137,13 @@ public:
       typedef typename
         Type_mapper< boost::optional< boost::variant< BOOST_VARIANT_ENUM_PARAMS(U) > >,
                      K1, K2 >::type result_type;
-      result_type res;
+
       if(!o) {
         // empty converts to empty
-        return res;
+        return boost::none;
       }
 
+      result_type res;
       internal::Converting_visitor<Self, result_type>
         conv_visitor = internal::Converting_visitor<Self, result_type>(*this, res);
       boost::apply_visitor(conv_visitor, *o);


### PR DESCRIPTION
## Summary of Changes

A function in Cartesian_converter.h returns an uninitialised scalar variable. This shows as a new high impact error in coverity static analysis.

The proposed change is just to return boost::none



## Release Management

* Affected package(s): Cartesian_kernel
* Issue(s) solved (if any): bugfix/security
* License and copyright ownership: Returned to CGAL authors.

