### PR TITLE
Tetrahedral remeshing - fix indices for very small inputs

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
@@ -382,8 +382,10 @@ private:
             minMax[3 + j] = PN[6 * i + j];
         }
       for (std::size_t i = 0; i < 3; i++) {
-        minMax[i] *= 0.99;
-        minMax[3 + i] *= 1.01;
+        minMax[i] = (minMax[i] > 0.)
+                  ? (0.99 * minMax[i]) : (1.01 * minMax[i]);
+        minMax[3 + i] = (minMax[3+i] > 0.)
+                  ? (1.01 * minMax[3+i]) : (0.99 * minMax[3+i]);
       }
 
       for (std::size_t i = 0; i < 3; i++)

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
@@ -389,7 +389,7 @@ private:
       for (std::size_t i = 0; i < 3; i++)
       {
         res[i] = (std::size_t)ceil((minMax[3 + i] - minMax[i]) / cellSize);
-        if(res[1] == 0)
+        if(res[i] == 0)
           res[i] = 1;
       }
 


### PR DESCRIPTION
## Summary of Changes

This PR completes #5478 to deal with very small size meshes, and fixes a crash in this case

## Release Management

* Affected package(s): Tetrahedral remeshing
* License and copyright ownership: unchanged
