### PR TITLE
PMP::isotropic_remeshing - keep corners incident to isolated constrained edges

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -77,7 +77,8 @@ namespace internal {
     PATCH,       //h and hopp belong to the patch to be remeshed
     PATCH_BORDER,//h belongs to the patch, hopp is MESH
     MESH,        //h and hopp belong to the mesh, not the patch
-    MESH_BORDER  //h belongs to the mesh, face(hopp, pmesh) == null_face()
+    MESH_BORDER, //h belongs to the mesh, face(hopp, pmesh) == null_face()
+    ISOLATED_CONSTRAINT //h is constrained, and incident to faces that do not belong to a patch
   };
 
   // A property map
@@ -1472,7 +1473,8 @@ private:
       {
         halfedge_descriptor hopp = opposite(h, mesh_);
         if ( is_on_border(h) || is_on_patch_border(h)
-          || is_on_border(hopp) || is_on_patch_border(hopp))
+          || is_on_border(hopp) || is_on_patch_border(hopp)
+          || is_an_isolated_constraint(h))
           ++nb_incident_features;
         if (nb_incident_features > 2)
           return true;
@@ -1538,19 +1540,43 @@ private:
           {
             //deal with h and hopp for borders that are sharp edges to be preserved
             halfedge_descriptor h = halfedge(e, mesh_);
-            if (status(h) == PATCH){
+            Halfedge_status hs = status(h);
+            if (hs == PATCH) {
               set_status(h, PATCH_BORDER);
+              hs = PATCH_BORDER;
               has_border_ = true;
             }
 
             halfedge_descriptor hopp = opposite(h, mesh_);
-            if (status(hopp) == PATCH){
+            Halfedge_status hsopp = status(hopp);
+            if (hsopp == PATCH) {
               set_status(hopp, PATCH_BORDER);
+              hsopp = PATCH_BORDER;
               has_border_ = true;
+            }
+
+            if (hs != PATCH_BORDER && hsopp != PATCH_BORDER)
+            {
+              set_status(h, ISOLATED_CONSTRAINT);
+              set_status(hopp, ISOLATED_CONSTRAINT);
             }
           }
         }
       }
+
+      std::ofstream ofs("dump_isolated.polylines.txt");
+      for (edge_descriptor e : edges(mesh_))
+      {
+        halfedge_descriptor h = halfedge(e, mesh_);
+        if (status(h) == ISOLATED_CONSTRAINT)
+        {
+          CGAL_assertion(status(opposite(h, mesh_)) == ISOLATED_CONSTRAINT);
+          ofs << "2 " << get(vpmap_, target(h, mesh_))
+            << " " << get(vpmap_, source(h, mesh_)) << std::endl;
+        }
+      }
+      ofs.close();
+
     }
 
     Halfedge_status status(const halfedge_descriptor& h) const
@@ -1819,6 +1845,13 @@ public:
     bool is_on_mesh(const halfedge_descriptor& h) const
     {
       return status(h) == MESH;
+    }
+
+    bool is_an_isolated_constraint(const halfedge_descriptor& h) const
+    {
+      bool res = (status(h) == ISOLATED_CONSTRAINT);
+      CGAL_assertion(!res || status(opposite(h, mesh_)) == ISOLATED_CONSTRAINT);
+      return res;
     }
 
 private:


### PR DESCRIPTION
## Summary of Changes

This PR introduces a new type of "halfedge status" of edges that are part of the input constrained edges property map, and are incident to a face to be remeshed only by a vertex.
These edges contribute to creating corner vertices (incident to >= 3 constrained edges), but should still not be considered as patch borders.

Without dealing with these "isolated constraints", the corner vertices that were incident to 2 patch borders and 1 of these edges were not considered as corners but as simple patch border vertices, hence they could be moved/deleted by a collapse or relaxation steps.

## Release Management

* Affected package(s): PMP
* License and copyright ownership: unchanged

