### PR TITLE
Testsuite: Fixes for windows runs

### DIFF
--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -107,7 +107,7 @@ function(cgal_add_compilation_test exe_name)
       add_custom_target(compilation_of__CGAL_Qt5_moc_and_resources)
       add_dependencies( compilation_of__CGAL_Qt5_moc_and_resources CGAL_Qt5_moc_and_resources )
       add_test(NAME "compilation_of__CGAL_Qt5_moc_and_resources"
-        COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target "compilation_of__CGAL_Qt5_moc_and_resources" --config "$<CONFIG>")
+        COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target "CGAL_Qt5_moc_and_resources" --config "$<CONFIG>")
       set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
         APPEND PROPERTY LABELS "CGAL_build_system")
       set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"

--- a/Scripts/developer_scripts/run_testsuite_with_ctest
+++ b/Scripts/developer_scripts/run_testsuite_with_ctest
@@ -256,15 +256,13 @@ run_test_on_platform()
     NUMBER_OF_PROCESSORS=1
   fi
   CGAL_BINARY_DIR=${CGAL_BINARY_DIR_BASE}/${PLATFORM}
-  echo "CGAL_BINARY_DIR=${CGAL_BINARY_DIR}"
   cd "${CGAL_BINARY_DIR}"
-  
   log "${ACTUAL_LOGFILE}.test.${PLATFORM}" "Testing on host ${HOST} and platform ${PLATFORM}"
   
   if [ -f "${REFERENCE_PLATFORMS_DIR}/${PLATFORM}/setup" ]; then
     source "${REFERENCE_PLATFORMS_DIR}/${PLATFORM}/setup"
   else
-    INIT_FILE="${REFERENCE_PLATFORMS_DIR}/${PLATFORM}.cmake"
+    INIT_FILE="${CGAL_HOME}/${REFERENCE_PLATFORMS_DIR}/${PLATFORM}.cmake"
   fi
   if [ ! -f "${INIT_FILE}" ]; then
     echo "error NEED A INIT FILE !"
@@ -278,7 +276,6 @@ run_test_on_platform()
   if [ -z "${SHOW_PROGRESS}" ]; then
     cmake ${INIT_FILE:+"-C${INIT_FILE}"} -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR  >package_installation.log 2>&1 
   else
-    echo "cmake ${INIT_FILE:+\"-C${INIT_FILE}\"} -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR"
     cmake ${INIT_FILE:+"-C${INIT_FILE}"} -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR 2>&1 |tee package_installation.log
   fi
   LIST_TEST_FILE="${CGAL_HOME}/list_test_packages"
@@ -299,12 +296,11 @@ run_test_on_platform()
   echo "SET(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE 1000000000)" >> CTestCustom.cmake
   CTEST_OPTS="-T Start -T Test --timeout 1200 -j${NUMBER_OF_PROCESSORS} ${DO_NOT_TEST:+-E execution___of__} "
   if uname | grep -q "CYGWIN"; then
-    CTEST_OPTS="-C Release ${CTEST_OPTS} -V"
+    CTEST_OPTS="-C ${CONFIG_TYPE} ${CTEST_OPTS} -V"
   fi
   if [ -z "${SHOW_PROGRESS}" ]; then
     ctest ${TO_TEST:+-L ${TO_TEST} } ${CTEST_OPTS} ${KEEP_TESTS:+-FC .}> tmp.txt
   else
-    echo "ctest ${CTEST_OPTS} ${TO_TEST:+-L ${TO_TEST}} ${KEEP_TESTS:+-FC .} "
     ctest ${TO_TEST:+-L ${TO_TEST} } ${CTEST_OPTS} ${KEEP_TESTS:+-FC .} |tee tmp.txt
   fi
   #####################

--- a/Scripts/developer_scripts/run_testsuite_with_ctest
+++ b/Scripts/developer_scripts/run_testsuite_with_ctest
@@ -271,13 +271,14 @@ run_test_on_platform()
   fi
   cmake ${INIT_FILE:+"-C${INIT_FILE}"} -DBUILD_TESTING=ON -DWITH_tests=ON -DCGAL_TEST_SUITE=ON $CGAL_DIR>installation.log 2>&1
   rm CMakeCache.txt
-  CMAKE_OPTS="-DCGAL_TEST_SUITE=ON -DCMAKE_VERBOSE_MAKEFILE=ON"
+  CMAKE_OPTS="-DCGAL_TEST_SUITE=ON -DCMAKE_VERBOSE_MAKEFILE=ON -DWITH_tests=ON"
   if [ -n "${SCRIPTS_DIR}" ]; then
     CMAKE_OPTS="${CMAKE_OPTS} -DWITH_examples=ON -DWITH_demos=ON"
   fi
   if [ -z "${SHOW_PROGRESS}" ]; then
     cmake ${INIT_FILE:+"-C${INIT_FILE}"} -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR  >package_installation.log 2>&1 
   else
+    echo "cmake ${INIT_FILE:+\"-C${INIT_FILE}\"} -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR"
     cmake ${INIT_FILE:+"-C${INIT_FILE}"} -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR 2>&1 |tee package_installation.log
   fi
   LIST_TEST_FILE="${CGAL_HOME}/list_test_packages"
@@ -298,13 +299,13 @@ run_test_on_platform()
   echo "SET(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE 1000000000)" >> CTestCustom.cmake
   CTEST_OPTS="-T Start -T Test --timeout 1200 -j${NUMBER_OF_PROCESSORS} ${DO_NOT_TEST:+-E execution___of__} "
   if uname | grep -q "CYGWIN"; then
-    CTEST_OPTS="-C Release ${CTEST_OPTS}"
+    CTEST_OPTS="-C Release ${CTEST_OPTS} -V"
   fi
   if [ -z "${SHOW_PROGRESS}" ]; then
-    ctest ${TO_TEST:+-L ${TO_TEST} } ${CTEST_OPTS} ${KEEP_TESTS:+-FC ${CGAL_BINARY_DIR}}> tmp.txt
+    ctest ${TO_TEST:+-L ${TO_TEST} } ${CTEST_OPTS} ${KEEP_TESTS:+-FC .}> tmp.txt
   else
-    echo "ctest ${CTEST_OPTS} ${TO_TEST:+-L ${TO_TEST}} ${KEEP_TESTS:+-FC ${CGAL_BINARY_DIR}} "
-    ctest ${CTEST_OPTS} ${TO_TEST:+-L ${TO_TEST}} ${KEEP_TESTS:+-FC ${CGAL_BINARY_DIR}}|tee tmp.txt
+    echo "ctest ${CTEST_OPTS} ${TO_TEST:+-L ${TO_TEST}} ${KEEP_TESTS:+-FC .} "
+    ctest ${TO_TEST:+-L ${TO_TEST} } ${CTEST_OPTS} ${KEEP_TESTS:+-FC .} |tee tmp.txt
   fi
   #####################
   ##   GET RESULTS   ##

--- a/Scripts/developer_scripts/run_testsuite_with_ctest
+++ b/Scripts/developer_scripts/run_testsuite_with_ctest
@@ -256,22 +256,29 @@ run_test_on_platform()
     NUMBER_OF_PROCESSORS=1
   fi
   CGAL_BINARY_DIR=${CGAL_BINARY_DIR_BASE}/${PLATFORM}
+  echo "CGAL_BINARY_DIR=${CGAL_BINARY_DIR}"
   cd "${CGAL_BINARY_DIR}"
+  
   log "${ACTUAL_LOGFILE}.test.${PLATFORM}" "Testing on host ${HOST} and platform ${PLATFORM}"
-  INIT_FILE="${CGAL_HOME}/${REFERENCE_PLATFORMS_DIR}/${PLATFORM}.cmake"
+  
+  if [ -f "${REFERENCE_PLATFORMS_DIR}/${PLATFORM}/setup" ]; then
+    source "${REFERENCE_PLATFORMS_DIR}/${PLATFORM}/setup"
+  else
+    INIT_FILE="${REFERENCE_PLATFORMS_DIR}/${PLATFORM}.cmake"
+  fi
   if [ ! -f "${INIT_FILE}" ]; then
     echo "error NEED A INIT FILE !"
   fi
-  cmake ${INIT_FILE:+"-C${INIT_FILE}"} '${CMAKE_GENERATOR}' -DBUILD_TESTING=ON -DWITH_tests=ON -DCGAL_TEST_SUITE=ON $CGAL_DIR>installation.log 2>&1
+  cmake ${INIT_FILE:+"-C${INIT_FILE}"} -DBUILD_TESTING=ON -DWITH_tests=ON -DCGAL_TEST_SUITE=ON $CGAL_DIR>installation.log 2>&1
   rm CMakeCache.txt
   CMAKE_OPTS="-DCGAL_TEST_SUITE=ON -DCMAKE_VERBOSE_MAKEFILE=ON"
   if [ -n "${SCRIPTS_DIR}" ]; then
     CMAKE_OPTS="${CMAKE_OPTS} -DWITH_examples=ON -DWITH_demos=ON"
   fi
   if [ -z "${SHOW_PROGRESS}" ]; then
-    cmake ${INIT_FILE:+"-C${INIT_FILE}"} '${CMAKE_GENERATOR}' -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR  >package_installation.log 2>&1
+    cmake ${INIT_FILE:+"-C${INIT_FILE}"} -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR  >package_installation.log 2>&1 
   else
-    cmake ${INIT_FILE:+"-C${INIT_FILE}"} '${CMAKE_GENERATOR}'  -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR 2>&1 |tee package_installation.log
+    cmake ${INIT_FILE:+"-C${INIT_FILE}"} -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR 2>&1 |tee package_installation.log
   fi
   LIST_TEST_FILE="${CGAL_HOME}/list_test_packages"
   if [ -f ${LIST_TEST_FILE} ]; then
@@ -290,10 +297,14 @@ run_test_on_platform()
   echo "SET(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 1000000000)" > CTestCustom.cmake
   echo "SET(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE 1000000000)" >> CTestCustom.cmake
   CTEST_OPTS="-T Start -T Test --timeout 1200 -j${NUMBER_OF_PROCESSORS} ${DO_NOT_TEST:+-E execution___of__} "
+  if uname | grep -q "CYGWIN"; then
+    CTEST_OPTS="-C Release ${CTEST_OPTS}"
+  fi
   if [ -z "${SHOW_PROGRESS}" ]; then
-    ctest ${TO_TEST:+-L ${TO_TEST} } ${CTEST_OPTS} ${KEEP_TESTS:+-FC .}> tmp.txt
+    ctest ${TO_TEST:+-L ${TO_TEST} } ${CTEST_OPTS} ${KEEP_TESTS:+-FC ${CGAL_BINARY_DIR}}> tmp.txt
   else
-    ctest ${CTEST_OPTS} ${TO_TEST:+-L ${TO_TEST}} ${KEEP_TESTS:+-FC .}|tee tmp.txt
+    echo "ctest ${CTEST_OPTS} ${TO_TEST:+-L ${TO_TEST}} ${KEEP_TESTS:+-FC ${CGAL_BINARY_DIR}} "
+    ctest ${CTEST_OPTS} ${TO_TEST:+-L ${TO_TEST}} ${KEEP_TESTS:+-FC ${CGAL_BINARY_DIR}}|tee tmp.txt
   fi
   #####################
   ##   GET RESULTS   ##
@@ -365,21 +376,7 @@ run_test_on_host()
 setup_dirs
 
 
-# Setup cmake
-if uname | grep -q "CYGWIN"; then
-  JOM="`which jom`"
-  if [ -e "$JOM" ]; then
-    CMAKE_GENERATOR='-GNMake Makefiles JOM'
-    MAKE_CMD='jom'
-  else
-    CMAKE_GENERATOR='-GNMake Makefiles'
-    MAKE_CMD='nmake'
-  fi
-  IS_CYGWIN='y'
-else
-  MAKE_CMD='make'
-fi
-
+# Setup cmake 
 log "${ACTUAL_LOGFILE}" "running the testsuites"
 if [ -n "${CONSOLE_OUTPUT}" ]; then
     printf "\n-------------------------------------------------------\n"


### PR DESCRIPTION
## Summary of Changes
Adapts a little the ctest scripts for being able to run them on a windows platform.
Also fix a bug in the add_text maccro.
## Release Management

* Affected package(s):Scripts, Installation
