### PR TITLE
Polyhedron_demo : Fix a warning

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_group_item.cpp
@@ -10,18 +10,19 @@ Scene_group_item::Scene_group_item(QString name)
     expanded = true;
     already_drawn = false;
     scene = Three::scene();
+    children = new QList<Scene_interface::Item_id>();
 }
 
 bool Scene_group_item::isFinite() const
 {
-  Q_FOREACH(Scene_interface::Item_id id, children)
+  for(Scene_interface::Item_id id : *children)
     if(!getChild(id)->isFinite()){      return false;
     }
   return true;
 }
 
 bool Scene_group_item::isEmpty() const {
-  Q_FOREACH(Scene_interface::Item_id id, children)
+  for(Scene_interface::Item_id id : *children)
     if(!getChild(id)->isEmpty()){
       return false;
     }
@@ -31,7 +32,7 @@ bool Scene_group_item::isEmpty() const {
 Scene_group_item::Bbox Scene_group_item::bbox() const
 {
  Scene_item* first_non_empty = nullptr;
- Q_FOREACH(Scene_interface::Item_id id, children)
+ for(Scene_interface::Item_id id : *children)
    if(!getChild(id)->isEmpty())
    {
      first_non_empty = getChild(id);
@@ -40,7 +41,7 @@ Scene_group_item::Bbox Scene_group_item::bbox() const
  if(first_non_empty)
  {
    Bbox b =first_non_empty->bbox();
-   Q_FOREACH(Scene_interface::Item_id id, children)
+   for(Scene_interface::Item_id id : *children)
      b+=getChild(id)->bbox();
    return b;
  }
@@ -50,7 +51,7 @@ Scene_group_item::Bbox Scene_group_item::bbox() const
 
 bool Scene_group_item::supportsRenderingMode(RenderingMode m) const {
 
-  Q_FOREACH(Scene_interface::Item_id id, children)
+  for(Scene_interface::Item_id id : *children)
     if(!getChild(id)->supportsRenderingMode(m))
       return false;
   return true;
@@ -59,16 +60,16 @@ bool Scene_group_item::supportsRenderingMode(RenderingMode m) const {
 
 QString Scene_group_item::toolTip() const {
     QString str =
-            QObject::tr( "<p>Number of children: %1<br />").arg(children.size());
+            QObject::tr( "<p>Number of children: %1<br />").arg(children->size());
     str+="</p>";
     return str;
 }
 
 void Scene_group_item::addChild(Scene_item* new_item)
 {
-    if(!children.contains(scene->item_id(new_item)))
+    if(!children->contains(scene->item_id(new_item)))
     {
-        children.append(scene->item_id(new_item));
+        children->append(scene->item_id(new_item));
         update_group_number(new_item, has_group+1);
     }
 
@@ -76,9 +77,9 @@ void Scene_group_item::addChild(Scene_item* new_item)
 
 void Scene_group_item::addChild(Scene_interface::Item_id new_id)
 {
-  if(!children.contains(new_id))
+  if(!children->contains(new_id))
   {
-    children.append(new_id);
+    children->append(new_id);
     update_group_number(getChild(new_id), has_group+1);
   }
 }
@@ -98,7 +99,7 @@ void Scene_group_item::update_group_number(Scene_item * new_item, int n)
 void Scene_group_item::setColor(QColor c)
 {
   Scene_item::setColor(c);
-  Q_FOREACH(Scene_interface::Item_id id, children)
+  for(Scene_interface::Item_id id : *children)
   {
     getChild(id)->setColor(c);
   }
@@ -107,7 +108,7 @@ void Scene_group_item::setColor(QColor c)
 void Scene_group_item::setRenderingMode(RenderingMode m)
 {
   Scene_item::setRenderingMode(m);
-  Q_FOREACH(Scene_interface::Item_id id, children)
+  for(Scene_interface::Item_id id : *children)
   {
     Scene_item* child = getChild(id);
     if(child->supportsRenderingMode(m))
@@ -118,7 +119,7 @@ void Scene_group_item::setRenderingMode(RenderingMode m)
 void Scene_group_item::setVisible(bool b)
 {
   Scene_item::setVisible(b);
-  Q_FOREACH(Scene_interface::Item_id id, children)
+  for(Scene_interface::Item_id id : *children)
   {
     Scene_item* child = getChild(id);
     child->setVisible(b);
@@ -139,12 +140,12 @@ void Scene_group_item::setExpanded(bool b)
 
 void Scene_group_item::moveDown(int i)
 {
-    children.move(i, i+1);
+    children->move(i, i+1);
 }
 
 void Scene_group_item::moveUp(int i)
 {
-    children.move(i, i-1);
+    children->move(i, i-1);
 }
 
 void Scene_group_item::draw(CGAL::Three::Viewer_interface* ) const  {
@@ -167,7 +168,7 @@ void Scene_group_item::renderChildren(Viewer_interface *viewer,
                             bool with_names)
 {
 
-  Q_FOREACH(Scene_interface::Item_id id, children){
+  for(Scene_interface::Item_id id : *children){
     if(with_names) {
       viewer->glClearDepthf(1.0f);
       viewer->glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -229,14 +230,14 @@ void Scene_group_item::lockChild(Scene_item *child)
 
 void Scene_group_item::lockChild(Scene_interface::Item_id id)
 {
-  if(!children.contains(id))
+  if(!children->contains(id))
     return;
   getChild(id)->setProperty("lock", true);
 }
 
 void Scene_group_item::unlockChild(Scene_interface::Item_id id)
 {
-  if(!children.contains(id))
+  if(!children->contains(id))
        return;
   getChild(id)->setProperty("lock", false);
 }
@@ -246,7 +247,7 @@ void Scene_group_item::unlockChild(Scene_item *child)
 }
 bool Scene_group_item::isChildLocked(Scene_interface::Item_id id)
 {
-  if(!children.contains(id)
+  if(!children->contains(id)
      || (!getChild(id)->property("lock").toBool()) )
      return false;
    return true;
@@ -259,7 +260,7 @@ bool Scene_group_item::isChildLocked(Scene_item *child)
 void Scene_group_item::setAlpha(int )
 {
 
-  Q_FOREACH(Scene_interface::Item_id id, children)
+  for(Scene_interface::Item_id id : *children)
   {
     scene->item(id)->setAlpha(static_cast<int>(alpha()*255));
   }

--- a/Three/include/CGAL/Three/Scene_group_item.h
+++ b/Three/include/CGAL/Three/Scene_group_item.h
@@ -39,7 +39,7 @@ class DEMO_FRAMEWORK_EXPORT Scene_group_item : public Scene_item_rendering_helpe
     Q_OBJECT
 public :
     Scene_group_item(QString name = QString("New group"));
-    ~Scene_group_item() {}
+    ~Scene_group_item() { delete children;}
     //!Returns false to avoid disturbing the BBox of the scene.
     bool isFinite() const Q_DECL_OVERRIDE;
     //!Returns true to avoid disturbing the BBox of the scene.
@@ -196,7 +196,7 @@ public :
     //!
     //! Only returns children that have this item as a parent.
     //! Children of these children are not returned.
-    QList<Scene_interface::Item_id> getChildren() const {return children;}
+    QList<Scene_interface::Item_id> getChildren() const {return *children;}
 
     //! \brief getChildrenForSelection returns the list of
     //! children to select along with the group.
@@ -205,7 +205,7 @@ public :
     //! this function defines which of its children will be added too.
     //! Typically overriden to allow applying an operation from the
     //! Operation menu only to the parent item and not to its children.
-    virtual QList<Scene_interface::Item_id> getChildrenForSelection() const {return children;}
+    virtual QList<Scene_interface::Item_id> getChildrenForSelection() const {return *children;}
     //!Removes a Scene_item from the list of children.
     //!@see getChildren() @see addChild()
     void removeChild( Scene_item* item)
@@ -214,7 +214,7 @@ public :
       return;
      update_group_number(item,0);
      item->moveToGroup(0);
-     children.removeOne(scene->item_id(item));
+     children->removeOne(scene->item_id(item));
     }
     //!Removes a Scene_item from the list of children using its index.
     //!@see getChildren() @see addChild()
@@ -243,13 +243,13 @@ public Q_SLOTS:
     //!
     void adjustIds(Scene_interface::Item_id removed_id)
     {
-      for(int i = 0; i < children.size(); ++i)
+      for(int i = 0; i < children->size(); ++i)
       {
-        if(children[i] > removed_id)
-          --children[i];
-        else if(children[i] == removed_id)//child has been removed from the scene, it doesn't exist anymore.
+        if((*children)[i] > removed_id)
+          --(*children)[i];
+        else if((*children)[i] == removed_id)//child has been removed from the scene, it doesn't exist anymore.
         {
-          children.removeAll(removed_id);
+          children->removeAll(removed_id);
         }
       }
     }
@@ -260,7 +260,7 @@ private:
 protected:
     Scene_interface *scene;
     //!Contains a reference to all the children of this group.
-    QList<Scene_interface::Item_id> children;
+    QList<Scene_interface::Item_id>* children;
 
 }; //end of class Scene_group_item
 

--- a/Three/include/CGAL/Three/Scene_item_with_properties.h
+++ b/Three/include/CGAL/Three/Scene_item_with_properties.h
@@ -14,6 +14,12 @@
 
 #include <CGAL/license/Three.h>
 
+#ifdef demo_framework_EXPORTS
+#  define DEMO_FRAMEWORK_EXPORT Q_DECL_EXPORT
+#else
+#  define DEMO_FRAMEWORK_EXPORT Q_DECL_IMPORT
+#endif
+
 namespace CGAL
 {
 namespace Three {
@@ -22,7 +28,7 @@ namespace Three {
 //! Base class to allow an item to copy properties from another.
 //! Properties reprensent the current state of an item : its color,
 //! the position of its manipulated frame, ...
-class Scene_item_with_properties {
+class DEMO_FRAMEWORK_EXPORT Scene_item_with_properties {
 public:
   virtual ~Scene_item_with_properties(){}
  //!\brief Copies properties from another Scene_item.


### PR DESCRIPTION
## Summary of Changes
Replace a member of type QList<> with a pointer to silent a warning about QList<> not being a dll-interface and add a missing macro to an interface class.
## Release Management

* Affected package(s):Polyhedron_Demo, Three
