### PR TITLE
PSP: Fix conversion warnings in clustering

### DIFF
--- a/Point_set_processing_3/include/CGAL/cluster_point_set.h
+++ b/Point_set_processing_3/include/CGAL/cluster_point_set.h
@@ -139,6 +139,7 @@ std::size_t cluster_point_set (PointRange& points,
   // basic geometric types
   typedef typename PointRange::iterator iterator;
   typedef typename iterator::value_type value_type;
+  typedef typename boost::property_traits<ClusterMap>::value_type Cluster_index_t;
   typedef typename CGAL::GetPointMap<PointRange, NamedParameters>::type PointMap;
   typedef typename Point_set_processing_3::GetK<PointRange, NamedParameters>::Kernel Kernel;
   typedef typename Point_set_processing_3::GetAdjacencies<PointRange, NamedParameters>::type Adjacencies;
@@ -175,7 +176,7 @@ std::size_t cluster_point_set (PointRange& points,
 
   // Init cluster map with -1
   for (const value_type& p : points)
-    put (cluster_map, p, -1);
+    put (cluster_map, p, Cluster_index_t(-1));
 
   Neighbor_query neighbor_query (points, point_map);
 
@@ -190,7 +191,7 @@ std::size_t cluster_point_set (PointRange& points,
   {
     const value_type& p = *it;
 
-    if (int(get (cluster_map, p)) != -1)
+    if (get (cluster_map, p) != Cluster_index_t(-1))
       continue;
 
     todo.push (it);
@@ -200,10 +201,10 @@ std::size_t cluster_point_set (PointRange& points,
       iterator current = todo.front();
       todo.pop();
 
-      if (int(get (cluster_map, *current)) != -1)
+      if (get (cluster_map, *current) != Cluster_index_t(-1))
         continue;
 
-      put (cluster_map, *current, nb_clusters);
+      put (cluster_map, *current, Cluster_index_t(nb_clusters));
       ++ done;
 
       if (callback && !callback (callback_factor * (done + 1) / double(size)))
@@ -230,7 +231,7 @@ std::size_t cluster_point_set (PointRange& points,
     done = 0;
     for (const value_type& p : points)
     {
-      std::size_t c0 = get (cluster_map, p);
+      std::size_t c0 = std::size_t(get (cluster_map, p));
 
       neighbors.clear();
       neighbor_query.get_iterators (get (point_map, p), 0, neighbor_radius,
@@ -238,7 +239,7 @@ std::size_t cluster_point_set (PointRange& points,
 
       for (const iterator& it : neighbors)
       {
-        std::size_t c1 = get (cluster_map, *it);
+        std::size_t c1 = std::size_t(get (cluster_map, *it));
         if (c0 < c1)
           adj.push_back (std::make_pair (c0, c1));
         else if (c0 > c1)


### PR DESCRIPTION
## Summary of Changes

Fix for the following warning: https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.3-I-107/Point_set_processing_3_Examples/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Release-64bits.gz

(The map is documented as having a value type `std::size_t`, but in practice it's more practical if it accepts any integer type without complaining.)

## Release Management

* Affected package(s): PSP
* Issue(s) solved (if any): fix #0000, fix #000