### PR TITLE
Dependency inversion in Iterative_radon of segment_tree.h

### DIFF
--- a/Box_intersection_d/include/CGAL/Box_intersection_d/segment_tree.h
+++ b/Box_intersection_d/include/CGAL/Box_intersection_d/segment_tree.h
@@ -207,24 +207,19 @@ median_of_three( RandomAccessIter a, RandomAccessIter b, RandomAccessIter c,
 }
 
 
-template< class RandomAccessIter, class Predicate_traits >
+template< class RandomAccessIter, class Predicate_traits, class Generator>
 class Iterative_radon {
 
   RandomAccessIter begin;
-  std::ptrdiff_t size;
   Predicate_traits traits;
   int dim;
-
-  boost::rand48 rng;
-  boost::uniform_int<std::ptrdiff_t> dist;
-  boost::variate_generator<boost::rand48&, boost::uniform_int<std::ptrdiff_t> > generator;
+  Generator& generator;
 
 public:
 
-Iterative_radon( RandomAccessIter begin, RandomAccessIter end,
-                 Predicate_traits traits, int dim, int /*num_levels*/ )
-  : begin(begin), size(end-begin), traits(traits), dim(dim),
-    rng(), dist(0,size-1), generator(rng,dist)
+  Iterative_radon( const RandomAccessIter& begin_, const Predicate_traits& traits_,
+                   int dim_, Generator& generator_)
+  : begin(begin_), traits(traits_), dim(dim_), generator(generator_)
   {}
 
   RandomAccessIter
@@ -247,7 +242,10 @@ RandomAccessIter
 iterative_radon( RandomAccessIter begin, RandomAccessIter end,
                  Predicate_traits traits, int dim, int num_levels )
 {
-  Iterative_radon<RandomAccessIter, Predicate_traits> IR(begin,end,traits,dim,num_levels);
+  typedef typename boost::variate_generator<boost::rand48&, boost::uniform_int<std::ptrdiff_t> > Generator;
+  boost::rand48 rng;
+  Generator generator(rng, boost::uniform_int<std::ptrdiff_t>(0, (end-begin)-1));
+  Iterative_radon<RandomAccessIter, Predicate_traits, Generator> IR(begin, traits, dim, generator);
   return IR(num_levels);
 }
 


### PR DESCRIPTION
## Summary of Changes

The motivation for this PR was initially to suppress a static analysis warning. The error reported was that in the constructor initializer list that `this` is not initialized when reading `dist` since it depends on the member variable  `size` which in turn depends on `end` and `begin` However the initialization order is correct so it's not a problem. I did feel however that the approach here wasn't very conventional, what might be called a code smell, rather than an issue. 

Instead, this PR really is just a tidy up of the `Iterative_radon` class, by moving the dependencies of the generator out of the class it potentially allows different generators to be plugged in if dependency injection is desired, for example in unit tests and so on. It just happens to also suppress a false positive static analysis error.

## Release Management

* Affected package(s):  Box_intersection_d
* Issue(s) solved (if any): static analysis error. 
* Feature/Small Feature (if any): bugfix/cleaning
* License and copyright ownership: Returned to CGAL authors.

