### PR TITLE
Fix uncaught exceptions cleanup

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
@@ -389,7 +389,7 @@ namespace CGAL {
     {}
 
     /// Destructor.
-    ~CMap_non_basic_iterator() noexcept(!CGAL_assertions)
+    ~CMap_non_basic_iterator() noexcept(!CGAL_ASSERTIONS_ENABLED)
     {
       CGAL_destructor_assertion( this->mmark_number!=Map::INVALID_MARK );
       if (this->mmap->get_number_of_times_mark_reserved

--- a/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_iterators_base.h
@@ -389,7 +389,7 @@ namespace CGAL {
     {}
 
     /// Destructor.
-    ~CMap_non_basic_iterator() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+    ~CMap_non_basic_iterator() noexcept(!CGAL_assertions)
     {
       CGAL_destructor_assertion( this->mmark_number!=Map::INVALID_MARK );
       if (this->mmap->get_number_of_times_mark_reserved

--- a/Documentation/doc/Documentation/Developer_manual/Chapter_checks.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_checks.txt
@@ -243,7 +243,7 @@ and \cgalCite{cgal:a-esgc-98} (also available at
 <A HREF="https://www.boost.org/community/exception_safety.html"><TT>https://www.boost.org/community/exception_safety.html</TT></A>).
 Any destructor which might throw an exception, including a destructor which
 uses the `CGAL_destructor_assertion` macro, should be marked with the
-`noexcept(!CGAL_assertions)`.
+`noexcept(!CGAL_ASSERTIONS_ENABLED)`.
 
 \section secchecks_req_and_rec Requirements and recommendations
 

--- a/Documentation/doc/Documentation/Developer_manual/Chapter_checks.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_checks.txt
@@ -243,8 +243,7 @@ and \cgalCite{cgal:a-esgc-98} (also available at
 <A HREF="https://www.boost.org/community/exception_safety.html"><TT>https://www.boost.org/community/exception_safety.html</TT></A>).
 Any destructor which might throw an exception, including a destructor which
 uses the `CGAL_destructor_assertion` macro, should be marked with the
-`CGAL_NOEXCEPT(false)` macro. This macro provides future compatibility with
-C++11 and above, which provides the `noexcept` keyword.
+`noexcept(!CGAL_assertions)`.
 
 \section secchecks_req_and_rec Requirements and recommendations
 

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -655,12 +655,6 @@ typedef const void * Nullptr_t;   // Anticipate C++0x's std::nullptr_t
 
 } //namespace CGAL
 
-//Support for c++11 noexcept
-#if BOOST_VERSION > 104600 && !defined(BOOST_NO_CXX11_NOEXCEPT) && !defined(BOOST_NO_NOEXCEPT)
-#define CGAL_NOEXCEPT(x) noexcept(x)
-#else
-#define CGAL_NOEXCEPT(x)
-#endif
 
 // The fallthrough attribute
 // See for clang:
@@ -682,12 +676,6 @@ typedef const void * Nullptr_t;   // Anticipate C++0x's std::nullptr_t
 // https://svn.boost.org/trac/boost/ticket/2839
 #if defined(BOOST_MSVC) && BOOST_VERSION < 105600
 #define CGAL_CFG_BOOST_VARIANT_SWAP_BUG 1
-#endif
-
-#ifndef CGAL_NO_ASSERTIONS
-#  define CGAL_NO_ASSERTIONS_BOOL false
-#else
-#  define CGAL_NO_ASSERTIONS_BOOL true
 #endif
 
 #if defined( __INTEL_COMPILER)

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -445,7 +445,7 @@ friend std::ostream& operator<<
 }
 
     /*
-~Node() noexcept(!CGAL_assertions)
+~Node() noexcept(!CGAL_ASSERTIONS_ENABLED)
 {
   CGAL_NEF_TRACEN("~Node: deleting node...");
   CGAL_destructor_assertion_catch(
@@ -1119,7 +1119,7 @@ bool update( Node_handle node,
   return (left_updated || right_updated);
 }
   /*
-~K3_tree() noexcept(!CGAL_assertions)
+~K3_tree() noexcept(!CGAL_ASSERTIONS_ENABLED)
 {
   CGAL_NEF_TRACEN("~K3_tree: deleting root...");
   CGAL_destructor_assertion_catch(

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -445,7 +445,7 @@ friend std::ostream& operator<<
 }
 
     /*
-~Node() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+~Node() noexcept(!CGAL_assertions)
 {
   CGAL_NEF_TRACEN("~Node: deleting node...");
   CGAL_destructor_assertion_catch(
@@ -1119,7 +1119,7 @@ bool update( Node_handle node,
   return (left_updated || right_updated);
 }
   /*
-~K3_tree() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+~K3_tree() noexcept(!CGAL_assertions)
 {
   CGAL_NEF_TRACEN("~K3_tree: deleting root...");
   CGAL_destructor_assertion_catch(

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -126,7 +126,7 @@ public:
 
   virtual void add_vertex(Vertex_handle) {}
 
-  virtual ~SNC_point_locator() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+  virtual ~SNC_point_locator() noexcept(!CGAL_assertions)
   {
     CGAL_NEF_CLOG("");
     CGAL_NEF_CLOG("construction_time:  "<<ct_t.time());
@@ -423,7 +423,7 @@ public:
     return updated;
   }
 
-  virtual ~SNC_point_locator_by_spatial_subdivision() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+  virtual ~SNC_point_locator_by_spatial_subdivision() noexcept(!CGAL_assertions)
   {
     CGAL_destructor_warning(initialized ||
                  candidate_provider == 0); // required?

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -126,7 +126,7 @@ public:
 
   virtual void add_vertex(Vertex_handle) {}
 
-  virtual ~SNC_point_locator() noexcept(!CGAL_assertions)
+  virtual ~SNC_point_locator() noexcept(!CGAL_ASSERTIONS_ENABLED)
   {
     CGAL_NEF_CLOG("");
     CGAL_NEF_CLOG("construction_time:  "<<ct_t.time());
@@ -423,7 +423,7 @@ public:
     return updated;
   }
 
-  virtual ~SNC_point_locator_by_spatial_subdivision() noexcept(!CGAL_assertions)
+  virtual ~SNC_point_locator_by_spatial_subdivision() noexcept(!CGAL_ASSERTIONS_ENABLED)
   {
     CGAL_destructor_warning(initialized ||
                  candidate_provider == 0); // required?

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
@@ -229,7 +229,7 @@ public:
   Sphere_map(bool = false) : boundary_item_(boost::none),
     svertices_(), sedges_(), sfaces_(), shalfloop_() {}
 
-  ~Sphere_map() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+  ~Sphere_map() noexcept(!CGAL_assertions)
   {
     CGAL_destructor_assertion_catch(
       clear();

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
@@ -229,7 +229,7 @@ public:
   Sphere_map(bool = false) : boundary_item_(boost::none),
     svertices_(), sedges_(), sfaces_(), shalfloop_() {}
 
-  ~Sphere_map() noexcept(!CGAL_assertions)
+  ~Sphere_map() noexcept(!CGAL_ASSERTIONS_ENABLED)
   {
     CGAL_destructor_assertion_catch(
       clear();

--- a/Nef_S2/include/CGAL/Nef_polyhedron_S2.h
+++ b/Nef_S2/include/CGAL/Nef_polyhedron_S2.h
@@ -73,7 +73,7 @@ class Nef_polyhedron_S2_rep {
 public:
   Nef_polyhedron_S2_rep() : sm_() {}
   Nef_polyhedron_S2_rep(const Self&) : sm_() {}
-  ~Nef_polyhedron_S2_rep() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+  ~Nef_polyhedron_S2_rep() noexcept(!CGAL_assertions)
   {
     CGAL_destructor_assertion_catch(
       sm_.clear();

--- a/Nef_S2/include/CGAL/Nef_polyhedron_S2.h
+++ b/Nef_S2/include/CGAL/Nef_polyhedron_S2.h
@@ -73,7 +73,7 @@ class Nef_polyhedron_S2_rep {
 public:
   Nef_polyhedron_S2_rep() : sm_() {}
   Nef_polyhedron_S2_rep(const Self&) : sm_() {}
-  ~Nef_polyhedron_S2_rep() noexcept(!CGAL_assertions)
+  ~Nef_polyhedron_S2_rep() noexcept(!CGAL_ASSERTIONS_ENABLED)
   {
     CGAL_destructor_assertion_catch(
       sm_.clear();

--- a/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
+++ b/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
@@ -191,7 +191,7 @@ public:
         CGAL_assertion_code(check_protocoll = 0;)
     }
 
-    ~Polyhedron_incremental_builder_3() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+    ~Polyhedron_incremental_builder_3() noexcept(!CGAL_assertions)
     {
         CGAL_destructor_assertion( check_protocoll == 0);
     }

--- a/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
+++ b/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
@@ -191,7 +191,7 @@ public:
         CGAL_assertion_code(check_protocoll = 0;)
     }
 
-    ~Polyhedron_incremental_builder_3() noexcept(!CGAL_assertions)
+    ~Polyhedron_incremental_builder_3() noexcept(!CGAL_ASSERTIONS_ENABLED)
     {
         CGAL_destructor_assertion( check_protocoll == 0);
     }

--- a/Polynomial/include/CGAL/Exponent_vector.h
+++ b/Polynomial/include/CGAL/Exponent_vector.h
@@ -161,7 +161,7 @@ inline std::ostream& operator << (std::ostream& os, const Exponent_vector& ev) {
 namespace std{
 template <> inline
 void swap(CGAL::Exponent_vector& ev1, CGAL::Exponent_vector& ev2)
-  CGAL_NOEXCEPT(std::is_nothrow_move_constructible<CGAL::Exponent_vector>::value
+  noexcept(std::is_nothrow_move_constructible<CGAL::Exponent_vector>::value
                 && std::is_nothrow_move_assignable<CGAL::Exponent_vector>::value)
 {
   ev1.swap(ev2);

--- a/STL_Extension/include/CGAL/Handle.h
+++ b/STL_Extension/include/CGAL/Handle.h
@@ -46,8 +46,7 @@ class Handle
     Handle() noexcept
         : PTR(static_cast<Rep*>(0)) {}
 
-    // FIXME: if the precondition throws in a noexcept function, the program terminates
-    Handle(const Handle& x) noexcept
+    Handle(const Handle& x) noexcept(!(CGAL_preconditions || CGAL_assertions))
     {
       CGAL_precondition( x.PTR != static_cast<Rep*>(0) );
       PTR = x.PTR;
@@ -68,7 +67,7 @@ class Handle
     }
 
     Handle&
-    operator=(const Handle& x) noexcept
+    operator=(const Handle& x) noexcept(!CGAL_preconditions)
     {
       CGAL_precondition( x.PTR != static_cast<Rep*>(0) );
       x.PTR->count++;

--- a/STL_Extension/include/CGAL/Handle.h
+++ b/STL_Extension/include/CGAL/Handle.h
@@ -46,7 +46,7 @@ class Handle
     Handle() noexcept
         : PTR(static_cast<Rep*>(0)) {}
 
-    Handle(const Handle& x) noexcept(!(CGAL_preconditions || CGAL_assertions))
+    Handle(const Handle& x) noexcept(!(CGAL_PRECONDITIONS_ENABLED || CGAL_ASSERTIONS_ENABLED))
     {
       CGAL_precondition( x.PTR != static_cast<Rep*>(0) );
       PTR = x.PTR;
@@ -67,7 +67,7 @@ class Handle
     }
 
     Handle&
-    operator=(const Handle& x) noexcept(!CGAL_preconditions)
+    operator=(const Handle& x) noexcept(!CGAL_PRECONDITIONS_ENABLED)
     {
       CGAL_precondition( x.PTR != static_cast<Rep*>(0) );
       x.PTR->count++;

--- a/STL_Extension/include/CGAL/Handle_for.h
+++ b/STL_Extension/include/CGAL/Handle_for.h
@@ -102,7 +102,7 @@ public:
         ptr_ = p;
     }
 
-    Handle_for(const Handle_for& h) noexcept(!CGAL_assertions)
+    Handle_for(const Handle_for& h) noexcept(!CGAL_ASSERTIONS_ENABLED)
       : ptr_(h.ptr_)
     {
         CGAL_assume (ptr_->count > 0);
@@ -110,7 +110,7 @@ public:
     }
 
     Handle_for&
-    operator=(const Handle_for& h) noexcept(!CGAL_assertions)
+    operator=(const Handle_for& h) noexcept(!CGAL_ASSERTIONS_ENABLED)
     {
         Handle_for tmp = h;
         swap(tmp);

--- a/STL_Extension/include/CGAL/Handle_for.h
+++ b/STL_Extension/include/CGAL/Handle_for.h
@@ -102,7 +102,7 @@ public:
         ptr_ = p;
     }
 
-    Handle_for(const Handle_for& h) noexcept
+    Handle_for(const Handle_for& h) noexcept(!CGAL_assertions)
       : ptr_(h.ptr_)
     {
         CGAL_assume (ptr_->count > 0);
@@ -110,7 +110,7 @@ public:
     }
 
     Handle_for&
-    operator=(const Handle_for& h) noexcept
+    operator=(const Handle_for& h) noexcept(!CGAL_assertions)
     {
         Handle_for tmp = h;
         swap(tmp);
@@ -149,9 +149,9 @@ public:
         return *this;
     }
 
-    ~Handle_for() noexcept
+    ~Handle_for()
     {
-      try{
+      try {
         if (--(ptr_->count) == 0) {
           Allocator_traits::destroy(allocator, ptr_);
           allocator.deallocate( ptr_, 1);

--- a/STL_Extension/include/CGAL/Multiset.h
+++ b/STL_Extension/include/CGAL/Multiset.h
@@ -590,7 +590,7 @@ public:
   /*!
    * Destructor. [takes O(n) operations]
    */
-  virtual ~Multiset () noexcept(!CGAL_assertions);
+  virtual ~Multiset () noexcept(!CGAL_ASSERTIONS_ENABLED);
 
   /*!
    * Assignment operator. [takes O(n) operations]
@@ -1565,7 +1565,7 @@ Multiset<Type, Compare, Allocator, UseCompactContainer>::Multiset (const Self& t
 // Destructor.
 //
 template <class Type, class Compare, typename Allocator, typename UseCompactContainer>
-Multiset<Type, Compare, Allocator, UseCompactContainer>::~Multiset () noexcept(!CGAL_assertions)
+Multiset<Type, Compare, Allocator, UseCompactContainer>::~Multiset () noexcept(!CGAL_ASSERTIONS_ENABLED)
 {
   if (UseCompactContainer::value)
     return;

--- a/STL_Extension/include/CGAL/Multiset.h
+++ b/STL_Extension/include/CGAL/Multiset.h
@@ -590,7 +590,7 @@ public:
   /*!
    * Destructor. [takes O(n) operations]
    */
-  virtual ~Multiset ();
+  virtual ~Multiset () noexcept(!CGAL_assertions);
 
   /*!
    * Assignment operator. [takes O(n) operations]
@@ -1565,14 +1565,16 @@ Multiset<Type, Compare, Allocator, UseCompactContainer>::Multiset (const Self& t
 // Destructor.
 //
 template <class Type, class Compare, typename Allocator, typename UseCompactContainer>
-Multiset<Type, Compare, Allocator, UseCompactContainer>::~Multiset ()
+Multiset<Type, Compare, Allocator, UseCompactContainer>::~Multiset () noexcept(!CGAL_assertions)
 {
   if (UseCompactContainer::value)
     return;
 
   // Delete the entire tree recursively.
-  if (rootP != nullptr)
-    _destroy (rootP);
+  CGAL_destructor_assertion_catch(
+    if (rootP != nullptr)
+      _destroy (rootP);
+  );
 
   rootP = nullptr;
   beginNode.parentP = nullptr;

--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -77,6 +77,7 @@ inline bool possibly(Uncertain<bool> c);
 // ----------
 
 #if defined(CGAL_NO_ASSERTIONS)
+#  define CGAL_assertions false
 #  define CGAL_assertion(EX) (static_cast<void>(0))
 #  define CGAL_destructor_assertion(EX) (static_cast<void>(0))
 #  define CGAL_destructor_assertion_catch(CODE) CODE
@@ -90,6 +91,7 @@ inline bool possibly(Uncertain<bool> c);
 #    define CGAL_assume_code(CODE) CGAL_assertion_code(CODE)
 #  endif // not def CGAL_ASSUME
 #else // no CGAL_NO_ASSERTIONS
+#  define CGAL_assertions true
 #  define CGAL_assertion(EX) \
    (CGAL::possibly(EX)?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__))
 #  if __cpp_lib_uncaught_exceptions || ( _MSVC_LANG >= 201703L )  // C++17

--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -77,7 +77,7 @@ inline bool possibly(Uncertain<bool> c);
 // ----------
 
 #if defined(CGAL_NO_ASSERTIONS)
-#  define CGAL_assertions false
+#  define CGAL_ASSERTIONS_ENABLED false
 #  define CGAL_assertion(EX) (static_cast<void>(0))
 #  define CGAL_destructor_assertion(EX) (static_cast<void>(0))
 #  define CGAL_destructor_assertion_catch(CODE) CODE
@@ -91,7 +91,7 @@ inline bool possibly(Uncertain<bool> c);
 #    define CGAL_assume_code(CODE) CGAL_assertion_code(CODE)
 #  endif // not def CGAL_ASSUME
 #else // no CGAL_NO_ASSERTIONS
-#  define CGAL_assertions true
+#  define CGAL_ASSERTIONS_ENABLED true
 #  define CGAL_assertion(EX) \
    (CGAL::possibly(EX)?(static_cast<void>(0)): ::CGAL::assertion_fail( # EX , __FILE__, __LINE__))
 #  if __cpp_lib_uncaught_exceptions || ( _MSVC_LANG >= 201703L )  // C++17
@@ -193,12 +193,12 @@ inline bool possibly(Uncertain<bool> c);
 // -------------
 
 #if defined(CGAL_NO_PRECONDITIONS)
-#  define CGAL_preconditions false
+#  define CGAL_PRECONDITIONS_ENABLED false
 #  define CGAL_precondition(EX) (static_cast<void>(0))
 #  define CGAL_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_precondition_code(CODE)
 #else
-#  define CGAL_preconditions true
+#  define CGAL_PRECONDITIONS_ENABLED true
 #  define CGAL_precondition(EX) \
    (CGAL::possibly(EX)?(static_cast<void>(0)): ::CGAL::precondition_fail( # EX , __FILE__, __LINE__))
 #  define CGAL_precondition_msg(EX,MSG) \

--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -193,10 +193,12 @@ inline bool possibly(Uncertain<bool> c);
 // -------------
 
 #if defined(CGAL_NO_PRECONDITIONS)
+#  define CGAL_preconditions false
 #  define CGAL_precondition(EX) (static_cast<void>(0))
 #  define CGAL_precondition_msg(EX,MSG) (static_cast<void>(0))
 #  define CGAL_precondition_code(CODE)
 #else
+#  define CGAL_preconditions true
 #  define CGAL_precondition(EX) \
    (CGAL::possibly(EX)?(static_cast<void>(0)): ::CGAL::precondition_fail( # EX , __FILE__, __LINE__))
 #  define CGAL_precondition_msg(EX,MSG) \

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_aux.h
@@ -164,7 +164,7 @@ private:
   Ref_counted_base& operator=( Ref_counted_base const &);
 protected:
   Ref_counted_base(): mCount(0) {}
-  virtual ~Ref_counted_base() noexcept(!CGAL_assertions) {}
+  virtual ~Ref_counted_base() noexcept(!CGAL_ASSERTIONS_ENABLED) {}
 public:
     void AddRef() const { ++mCount; }
     void Release() const

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_aux.h
@@ -164,7 +164,7 @@ private:
   Ref_counted_base& operator=( Ref_counted_base const &);
 protected:
   Ref_counted_base(): mCount(0) {}
-  virtual ~Ref_counted_base() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL) {}
+  virtual ~Ref_counted_base() noexcept(!CGAL_assertions) {}
 public:
     void AddRef() const { ++mCount; }
     void Release() const

--- a/Stream_support/include/CGAL/IO/VRML/VRML_2_ostream.h
+++ b/Stream_support/include/CGAL/IO/VRML/VRML_2_ostream.h
@@ -30,7 +30,7 @@ class VRML_2_ostream
 public:
   VRML_2_ostream() : m_os(nullptr) {}
   VRML_2_ostream(std::ostream& o) : m_os(&o) { header(); }
-  ~VRML_2_ostream() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+  ~VRML_2_ostream() noexcept(!CGAL_assertions)
   {
     CGAL_destructor_assertion_catch(
       close();

--- a/Stream_support/include/CGAL/IO/VRML/VRML_2_ostream.h
+++ b/Stream_support/include/CGAL/IO/VRML/VRML_2_ostream.h
@@ -30,7 +30,7 @@ class VRML_2_ostream
 public:
   VRML_2_ostream() : m_os(nullptr) {}
   VRML_2_ostream(std::ostream& o) : m_os(&o) { header(); }
-  ~VRML_2_ostream() noexcept(!CGAL_assertions)
+  ~VRML_2_ostream() noexcept(!CGAL_ASSERTIONS_ENABLED)
   {
     CGAL_destructor_assertion_catch(
       close();

--- a/Surface_mesher/archive/include/CGAL/builder.h
+++ b/Surface_mesher/archive/include/CGAL/builder.h
@@ -175,7 +175,7 @@ public:
         CGAL_assertion_code(check_protocoll = 0;)
     }
 
-    ~Enriched_polyhedron_incremental_builder_3() noexcept(!CGAL_assertions)
+    ~Enriched_polyhedron_incremental_builder_3() noexcept(!CGAL_ASSERTIONS_ENABLED)
     {
         CGAL_destructor_assertion( check_protocoll == 0);
     }

--- a/Surface_mesher/archive/include/CGAL/builder.h
+++ b/Surface_mesher/archive/include/CGAL/builder.h
@@ -175,7 +175,7 @@ public:
         CGAL_assertion_code(check_protocoll = 0;)
     }
 
-    ~Enriched_polyhedron_incremental_builder_3() CGAL_NOEXCEPT(CGAL_NO_ASSERTIONS_BOOL)
+    ~Enriched_polyhedron_incremental_builder_3() noexcept(!CGAL_assertions)
     {
         CGAL_destructor_assertion( check_protocoll == 0);
     }


### PR DESCRIPTION
## Summary of Changes

This continues the previous changes done under #5233 and addresses further uncaught exceptions found in by static analysis since upgrading from CGAL version 5.0.3

* Make the changes less ugly
* Use the language features correctly (now that C++11 is minimum)
* Fix uncaught exceptions warnings in Handle.h Handle_for.h and Multiset.h

## Release Management

* Affected package(s): STL_extention
* Issue(s) solved (if any): static analysis/bugfix/cleaning
* License and copyright ownership: Returned to CGAL authors

