### PR TITLE
Linear Cell Complex: Check if stream is valid

### DIFF
--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
@@ -249,6 +249,9 @@ namespace CGAL {
       {
         std::size_t index;
         scanner.scan_facet_vertex_index(index, j+1, i);
+        if(! in){
+          return false;
+        }
         B.add_vertex_to_facet(index);
       }
       B.end_facet();

--- a/Surface_mesh_topology/include/CGAL/Path_on_surface.h
+++ b/Surface_mesh_topology/include/CGAL/Path_on_surface.h
@@ -1129,7 +1129,7 @@ public:
     CGAL_assertion(pp1.length() % primitiveSize == 0);
     pp1.cut(primitiveSize);
     CGAL_assertion(pp1.is_closed());
-    return std::make_pair(pp1, originalLength / primitiveSize);
+    return std::make_pair(pp1, int(originalLength / primitiveSize));
   }
 
   /// @return the turn between dart number i and dart number i+1.


### PR DESCRIPTION
## Summary of Changes

Implement what @gdamiand suggested in Issue #5576, that is to check if the stream is still valid, in order to avoid a justified warning.

## Release Management

* Affected package(s): Linear cell complex
* Issue(s) solved (if any): fix #5576
* License and copyright ownership: unchanged

