### PR TITLE
Fix dereference after null check in K3_tree.h

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -970,11 +970,11 @@ typename Object_list::difference_type n_vertices = std::distance(objects.begin()
 
   template <typename Visitor>
   void visit_k3tree(const Node* current, Visitor& V) const {
+    if(!current) return;
+
     V.pre_visit(current);
-    if(current->left() != 0) {
-      visit_k3tree(current->left(), V);
-      visit_k3tree(current->right(), V);
-    }
+    visit_k3tree(current->left(), V);
+    visit_k3tree(current->right(), V);
     V.post_visit(current);
   }
 


### PR DESCRIPTION
## Summary of Changes

Check for null in `visit_k3tree`

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): fix #5613 
* Feature/Small Feature (if any): bugfix
* License and copyright ownership: Returned to CGAL authors.

