### PR TITLE
Polyhedron_demo: Animate plugin

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Animate_mesh_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Animate_mesh_plugin.cpp
@@ -116,7 +116,7 @@ public Q_SLOTS:
 
       for(auto pp : cur_frame)
       {
-        SMesh::Vertex_index vh(pp.first);
+        SMesh::Vertex_index vh(static_cast<SMesh::size_type>(pp.first));
         VPmap vpm = get(CGAL::vertex_point, *sm_item->face_graph());
         Point_3 np = pp.second;
         put(vpm, vh, Point_3(np.x()-offset.x,

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Animate_mesh_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Animate_mesh_plugin.cpp
@@ -110,17 +110,22 @@ public Q_SLOTS:
     void read_prev_frame()
     {
       typedef boost::property_map<SMesh,CGAL::vertex_point_t>::type VPmap;
+      const CGAL::qglviewer::Vec offset = Three::mainViewer()->offset();
       Frame cur_frame = old_frames.back();
       old_frames.pop_back();
-      sm_item->redraw();
 
       for(auto pp : cur_frame)
       {
         SMesh::Vertex_index vh(pp.first);
         VPmap vpm = get(CGAL::vertex_point, *sm_item->face_graph());
-        put(vpm, vh, pp.second);
+        Point_3 np = pp.second;
+        put(vpm, vh, Point_3(np.x()-offset.x,
+                             np.y()-offset.y,
+                             np.z()-offset.z));
+
         sm_item->updateVertex(vh);
       }
+      sm_item->redraw();
     }
 
   void read_next_frame()


### PR DESCRIPTION
## Summary of Changes

Change behavior when reading the previous frame, so that it restores the previous state, and does not simply read the previous frame, which might not do anything if the impacted points are not the same in both frames.
## Release Management

* Affected package(s):Polyhedron demo