### PR TITLE
Doc link issue workaround

### DIFF
--- a/Documentation/doc/Documentation/Doxyfile.in
+++ b/Documentation/doc/Documentation/Doxyfile.in
@@ -1,6 +1,6 @@
 # this package is a little peculiar and different from the other packages
 @INCLUDE = ${CGAL_DOC_PACKAGE_DEFAULTS}
-PROJECT_NAME = "CGAL ${CGAL_DOC_VERSION} - Manual"
+PROJECT_NAME = "C&zwj;GAL ${CGAL_DOC_VERSION} - Manual"
 PROJECT_BRIEF       =
 OUTPUT_DIRECTORY    = ${CGAL_DOC_OUTPUT_DIR}/Manual
 

--- a/Documentation/doc/Documentation/Doxyfile.in
+++ b/Documentation/doc/Documentation/Doxyfile.in
@@ -1,6 +1,6 @@
 # this package is a little peculiar and different from the other packages
 @INCLUDE = ${CGAL_DOC_PACKAGE_DEFAULTS}
-PROJECT_NAME = "C&zwj;GAL ${CGAL_DOC_VERSION} - Manual"
+PROJECT_NAME = "%CGAL ${CGAL_DOC_VERSION} - Manual"
 PROJECT_BRIEF       =
 OUTPUT_DIRECTORY    = ${CGAL_DOC_OUTPUT_DIR}/Manual
 

--- a/Documentation/doc/scripts/html_output_post_processing.py
+++ b/Documentation/doc/scripts/html_output_post_processing.py
@@ -350,6 +350,9 @@ removes some unneeded files, and performs minor repair on some glitches.''')
 
     # remove %CGAL in navtree: this should be a fix in doxygen but for now it does not worth it
     re_replace_first_in_file('%CGAL','CGAL',glob.glob('./Manual/navtree.js')[0])
+    manual_pages=glob.glob('./Manual/*.html')
+    for fn in manual_pages:
+      re_replace_in_file('%CGAL','CGAL',fn)
     clean_doc()
 
     #remove links to CGAL in the bibliography


### PR DESCRIPTION
Fixes project name linking to CGAL namespace reported in #5600 