### PR TITLE
Documentation: Fix doxygen comparison scripts

### DIFF
--- a/Documentation/doc/scripts/process_doc.sh
+++ b/Documentation/doc/scripts/process_doc.sh
@@ -18,39 +18,69 @@ PUBLISH_DIR="$3"
 DOXYGEN_1=$($PATH_TO_1_8_4 --version)
 DOXYGEN_2=$($PATH_TO_1_8_13 --version)
 
+DO_COMPARE=TRUE
+PATH_TO_SCRIPTS=${PWD}
 
 #######################################
 ## download and build doxygen_master ##
-#######################################
-echo "downloading and building master"
-git clone https://github.com/doxygen/doxygen.git doxygen_master  1> /dev/null
-cd doxygen_master
-git pull  https://github.com/lrineau/doxygen.git 1> /dev/null
-MASTER_DESCRIBE=$(git describe --tags)
-mkdir -p build
-cd build
-cmake ..  1> /dev/null
-make -j$NB_CORES 1> /dev/null
-cd ../.. #scripts
+ #######################################
+#echo "downloading and building master"
+#git clone https://github.com/doxygen/doxygen.git doxygen_master  1> /dev/null
+#if [ $? -ne 0 ]; then
+#  DO_COMPARE=FALSE
+#else
+#  cd doxygen_master
+#  git pull  https://github.com/lrineau/doxygen.git 1> /dev/null
+#fi
+#if [ "$DO_COMPARE" = "FALSE" ] || [ $? -ne 0 ]; then
+#  DO_COMPARE=FALSE
+#else
+#  MASTER_DESCRIBE=$(git describe --tags)
+#  mkdir -p build
+#  cd build
+#  cmake ..  1> /dev/null
+#fi
+#if [ "$DO_COMPARE" = "FALSE" ] || [ $? -ne 0 ]; then
+#  DO_COMPARE=FALSE
+#else
+#  make -j$NB_CORES 1> /dev/null
+#fi
+cd $PATH_TO_SCRIPTS #scripts
 PATH_TO_MASTER="$PWD/doxygen_master/build/bin/doxygen"
 echo "done."
-
+ 
 echo "comparing versions 1.8.4 and 1.8.13"
 bash -$- test_doxygen_versions.sh $PATH_TO_1_8_4 $PATH_TO_1_8_13 $PWD/doc_1_8_4 $PWD/doc_1_8_13 $PUBLISH_DIR
 mv diff.txt diff1.txt
 
 echo "comparing versions 1.8.4 and master"
-bash -$- test_doxygen_versions.sh $PATH_TO_1_8_4 $PATH_TO_MASTER $PWD/doc_1_8_4 $PWD/doc_master $PUBLISH_DIR
-mv diff.txt diff2.txt
-
+if [ "$DO_COMPARE" = "TRUE" ]; then
+  bash -$- test_doxygen_versions.sh $PATH_TO_1_8_4 $PATH_TO_MASTER $PWD/doc_1_8_4 $PWD/doc_master $PUBLISH_DIR
+fi
+if [ $? -ne 0 ]; then
+  DO_COMPARE=FALSE
+  mv build_doc build_master
+else
+  mv diff.txt diff2.txt
+fi
 #update overview
 CGAL_NAME=$(cat cgal_version)
-python ${PWD}/testsuite.py --output-dir1 $PWD/doc_1_8_4/doc_output/ --output-dir2 $PWD/doc_1_8_13/doc_output/ --doc-log-dir1 $PWD/doc_1_8_4/doc_log/ \
-  --doc-log-dir2 $PWD/doc_1_8_13/doc_log/ --doc-log-dir-master $PWD/doc_master/doc_log/ \
-  --publish $PUBLISH_DIR --diff1 $PWD/diff1.txt --diff2 $PWD/diff2.txt --master-dir $PWD/doc_master/doc_output/ \
-  --cgal-version "$CGAL_NAME" --do-copy-results --version-to-keep 10 --doxygen-version1 "$DOXYGEN_1" --doxygen-version2 "$DOXYGEN_2" --master-describe "$MASTER_DESCRIBE"
-
+if [ "$DO_COMPARE" = "TRUE" ]; then
+  python ${PWD}/testsuite.py --output-dir1 $PWD/doc_1_8_4/doc_output/ --output-dir2 $PWD/doc_1_8_13/doc_output/ --doc-log-dir1 $PWD/doc_1_8_4/doc_log/ \
+    --doc-log-dir2 $PWD/doc_1_8_13/doc_log/ --doc-log-dir-master $PWD/doc_master/doc_log/ \
+    --publish $PUBLISH_DIR --diff1 $PWD/diff1.txt --diff2 $PWD/diff2.txt --master-dir $PWD/doc_master/doc_output/ \
+    --cgal-version "$CGAL_NAME" --do-copy-results --version-to-keep 10 --doxygen-version1 "$DOXYGEN_1" --doxygen-version2 "$DOXYGEN_2" --master-describe "$MASTER_DESCRIBE" 
+else
+  echo "NO MASTER"
+  python ${PWD}/testsuite.py --output-dir1 $PWD/doc_1_8_4/doc_output/ --output-dir2 $PWD/doc_1_8_13/doc_output/ --doc-log-dir1 $PWD/doc_1_8_4/doc_log/ \
+    --doc-log-dir2 $PWD/doc_1_8_13/doc_log/ --doc-log-dir-master $PWD/doc_master/ \
+    --publish $PUBLISH_DIR --diff1 $PWD/diff1.txt \
+    --cgal-version "$CGAL_NAME" --do-copy-results --version-to-keep 10 --doxygen-version1 "$DOXYGEN_1" --doxygen-version2 "$DOXYGEN_2"
+fi
 #clean-up
-rm -rf ./doc_1_8_4 ./doc_1_8_13 ./doc_master ./doxygen_master
-rm ./diff1.txt ./diff2.txt ./cgal_version
+#rm -rf ./doc_1_8_4 ./doc_1_8_13 ./doc_master #./doxygen_master
+#rm ./diff1.txt ./cgal_version
+#if [ -f ./diff2.txt ]; then
+#  rm ./diff2.txt 
+#fi
 

--- a/Documentation/doc/scripts/test_doxygen_versions.sh
+++ b/Documentation/doc/scripts/test_doxygen_versions.sh
@@ -58,8 +58,8 @@ if [ "$HAS_REF" -ne "1" ]; then
   echo "Building reference documentation..."
   mkdir -p ./build_doc
   cd ./build_doc
-  cmake -DCGAL_DOC_MATHJAX_LOCATION:STRING=../../MathJax -DCGAL_DOC_RELEASE=ON -DCGAL_GENERATE_XML=ON -DDOXYGEN_EXECUTABLE="$PATH_TO_1" ../..  1> /dev/null
-  make -j$NB_CORES doc  &> /dev/null
+  cmake -DCGAL_DOC_MATHJAX_LOCATION:STRING=../../MathJax -DCGAL_DOC_RELEASE=ON -DCGAL_GENERATE_XML=ON -DDOXYGEN_EXECUTABLE="$PATH_TO_1" ../..  1>> ./build_logs
+  make -j$NB_CORES doc  &>> ./build_logs
   echo "done."
   cd ../ #scripts
   echo "Creating text files for diff...."
@@ -78,8 +78,8 @@ fi
 echo "Building second documentation..."
 mkdir -p build_doc
 cd ./build_doc
-cmake -DCGAL_DOC_MATHJAX_LOCATION:STRING=../../MathJax -DCGAL_DOC_RELEASE=ON -DCGAL_GENERATE_XML=ON -DDOXYGEN_EXECUTABLE="$PATH_TO_2" ../..  1> /dev/null
-make -j$NB_CORES doc  &> /dev/null
+cmake -DCGAL_DOC_MATHJAX_LOCATION:STRING=../../MathJax -DCGAL_DOC_RELEASE=ON -DCGAL_GENERATE_XML=ON -DDOXYGEN_EXECUTABLE="$PATH_TO_2" ../..  1>> ./build_logs
+make -j$NB_CORES doc  &>> ./build_logs
 echo "done."
 cd ../ #scripts
 DOXYGEN_1=$($PATH_TO_1 --version)
@@ -94,7 +94,7 @@ echo "done."
 #add post-processing
 cd ./build_doc
 echo "Adding postprocessing..."
-make -j$NB_CORES doc_with_postprocessing  &> /dev/null
+make -j$NB_CORES doc_with_postprocessing  &>> ./build_logs
 echo "done."
 cd .. #scripts
 mv ./build_doc/* $BUILD_DIR_2
@@ -108,16 +108,16 @@ if [ "$HAS_REF" -ne "1" ]; then
   #######################################################################################################################
   rm -rf ./doc_dir
   cd $BUILD_DIR_1
-  cmake -DCGAL_DOC_MATHJAX_LOCATION:STRING=../../MathJax -DCGAL_DOC_RELEASE=ON -DCGAL_DOC_CREATE_LOGS="true" -DDOXYGEN_EXECUTABLE="$PATH_TO_1" ../..  1> /dev/null
+  cmake -DCGAL_DOC_MATHJAX_LOCATION:STRING=../../MathJax -DCGAL_DOC_RELEASE=ON -DCGAL_DOC_CREATE_LOGS="true" -DDOXYGEN_EXECUTABLE="$PATH_TO_1" ../..  1>> ./build_logs
   echo "Building reference documentation with postprocessing..."
-  make -j$NB_CORES doc  &> /dev/null
-  make -j$NB_CORES doc  &> /dev/null
-  make -j$NB_CORES doc_with_postprocessing &> /dev/null
+  make -j$NB_CORES doc  &>> ./build_logs
+  make -j$NB_CORES doc  &>> ./build_logs
+  make -j$NB_CORES doc_with_postprocessing &>> ./build_logs
   echo "done."
   if [ $IS_RELEASE = 0 ]; then
     cd $ROOT
     mkdir -p ./build && cd ./build
-    cmake -DWITH_CGAL_Core=false -DWITH_CGAL_ImageIO=false -DWITH_CGAL_Qt5=false .. 1> /dev/null
+    cmake -DWITH_CGAL_Core=false -DWITH_CGAL_ImageIO=false -DWITH_CGAL_Qt5=false .. 1>> ./build_logs
     CGAL_NAME="$(cat $PWD/VERSION)"
     cd $ROOT
     rm -rf ./build
@@ -132,11 +132,11 @@ else
   rm -rf ./first_doc_ref
 fi
   cd $BUILD_DIR_2
-  cmake -DCGAL_DOC_MATHJAX_LOCATION:STRING=../../MathJax -DCGAL_DOC_RELEASE=ON -DCGAL_DOC_CREATE_LOGS="true" -DDOXYGEN_EXECUTABLE="$PATH_TO_2" ../..  1> /dev/null
+  cmake -DCGAL_DOC_MATHJAX_LOCATION:STRING=../../MathJax -DCGAL_DOC_RELEASE=ON -DCGAL_DOC_CREATE_LOGS="true" -DDOXYGEN_EXECUTABLE="$PATH_TO_2" ../..  1>> ./build_logs
   echo "Building reference documentation with postprocessing..."
-  make -j$NB_CORES doc  &> /dev/null
-  make -j$NB_CORES doc  &> /dev/null
-  make -j$NB_CORES doc_with_postprocessing &> /dev/null
+  make -j$NB_CORES doc  &>> ./build_logs
+  make -j$NB_CORES doc  &>> ./build_logs
+  make -j$NB_CORES doc_with_postprocessing &>> ./build_logs
   echo "done."
   cd .. #scripts
   #get VERSION's content

--- a/Documentation/doc/scripts/testsuite.py
+++ b/Documentation/doc/scripts/testsuite.py
@@ -98,7 +98,9 @@ body  {color: black; background-color: #C0C0D0; font-family: sans-serif;}
       suffix = ''
       if args.master_describe:
         suffix=args.master_describe
-      link_master="\n<br><a href=\"master/Manual/index.html\">Documentation built</a> with <a href=\"https://github.com/doxygen/doxygen\">the master version of Doxygen {_suffix}</a> (buggy), so that we see progress/regression of doxygen development as far as CGAL is concerned.\n".format(_suffix=suffix)
+        link_master="\n<br><a href=\"master/Manual/index.html\">Documentation built</a> with <a href=\"https://github.com/doxygen/doxygen\">the master version of Doxygen {_suffix}</a> (buggy), so that we see progress/regression of doxygen development as far as CGAL is concerned.\n".format(_suffix=suffix)
+      else:
+        link_master="\n<p style=\"color:red\"><br>/!\\ Documentation with the master version of Doxygen FAILED /!\\ </p>\n"
       d = pq(page_header+link1+"   "+link2+"   "+link_master+page_footer)
     else:
       d = pq(page_header+page_footer)
@@ -129,17 +131,22 @@ body  {color: black; background-color: #C0C0D0; font-family: sans-serif;}
         basename=os.path.basename(log)
         result = [(basename, pretty_name, res)]
         results2.extend(result)
+    if args.doc_log_dir_master:
+      os.chdir(args.doc_log_dir_master)
+      if(args.diff2):
+        logs=sorted(glob.glob('./*.log'))
 
-    os.chdir(args.doc_log_dir_master)
-    logs=sorted(glob.glob('./*.log'))
-
-    for log in logs:
-        res=count_errors_and_warnings(log)
-        err_war_sum_master=tuple(map(operator.add, err_war_sum_master, res))
-        basename=os.path.basename(log)
-        pretty_name=basename[0:-4]
-        result = [(basename, pretty_name, res)]
-        results_master.extend(result)
+        for log in logs:
+            res=count_errors_and_warnings(log)
+            err_war_sum_master=tuple(map(operator.add, err_war_sum_master, res))
+            basename=os.path.basename(log)
+            pretty_name=basename[0:-4]
+            result = [(basename, pretty_name, res)]
+            results_master.extend(result)
+    else:
+      results_master=[]
+      for index in range(0, len(results1)-1):
+        results_master.append('./build_logs')
 
     for index in range(0, len(results1)-1):
         status='class="package-good"'
@@ -276,14 +283,17 @@ body  {color: black; background-color: #C0C0D0; font-family: sans-serif;}
           diff1='<a href="{log_path}/diff1.txt">Diff between {test_version} and {master_version}.</a>'.format(
           log_path=version_string, test_version=args.doxygen_version1, master_version=args.doxygen_version2)
 
-        with open(diff_file2, 'r') as myfile:
-          diff2=myfile.read()
-        if not diff2:
-          diff2='none'
+        if args.diff2:
+          with open(diff_file2, 'r') as myfile:
+            diff2=myfile.read()
+          if not diff2:
+            diff2='none'
+          else:
+            diff2='<a href="{log_path}/diff2.txt">Diff between {test_version} and {master_version}.</a>'.format(
+            log_path=version_string, test_version=args.doxygen_version1, master_version=args.master_describe)
         else:
-          diff2='<a href="{log_path}/diff2.txt">Diff between {test_version} and {master_version}.</a>'.format(
-          log_path=version_string, test_version=args.doxygen_version1, master_version=args.master_describe)
-
+          diff2='<p style="color:red">Documentation with the master version of Doxygen FAILED</p>'
+          
         d=pq(filename=publish_dir + 'index.html',parser="html")
         revs=d('#revisions tr')
         new_row='''<tr><td><a href="{revision}/index.html">{revision}</a></td><td>{date}</td>
@@ -319,10 +329,12 @@ body  {color: black; background-color: #C0C0D0; font-family: sans-serif;}
           shutil.copytree(args.doc_log_dir1, log_target+'/logs1/')
           shutil.copyfile(args.doc_log_dir1+'/index.html', log_target+'/index.html')
           shutil.copytree(args.doc_log_dir2, log_target+'/logs2/')
-          shutil.copytree(args.doc_log_dir_master, log_target+'/logs_master/')
+          if args.doc_log_dir_master:
+            shutil.copytree(args.doc_log_dir_master, log_target+'/logs_master/')
           #copy diff
           shutil.copyfile(diff_file1, log_target+'/diff1.txt')
-          shutil.copyfile(diff_file2, log_target+'/diff2.txt')
+          if args.diff2:
+              shutil.copyfile(diff_file2, log_target+'/diff2.txt')
           try:
             #copy documentation
             if args.do_copy_results:

--- a/Documentation/doc/scripts/testsuite.py
+++ b/Documentation/doc/scripts/testsuite.py
@@ -7,11 +7,14 @@
 # $URL$
 # $Id$
 # SPDX-License-Identifier: GPL-3.0-or-later
-# 
-# 
+#
+#
 # Author(s)     : Philipp Moeller
 
-import argparse 
+#NOTE : if args.diff2 is not given, then it is considered that something went
+# wrong during the build of doxygen_master or the generation of the doc.
+
+import argparse
 import shutil
 import sys
 import subprocess
@@ -143,11 +146,10 @@ body  {color: black; background-color: #C0C0D0; font-family: sans-serif;}
             pretty_name=basename[0:-4]
             result = [(basename, pretty_name, res)]
             results_master.extend(result)
-    else:
-      results_master=[]
-      for index in range(0, len(results1)-1):
-        results_master.append('./build_logs')
-
+      else:
+        for index in range(0, len(results1)):
+          result = [('./build_logs', './build_logs', (0,1))]
+          results_master.extend(result)
     for index in range(0, len(results1)-1):
         status='class="package-good"'
         no_errors = True
@@ -293,7 +295,7 @@ body  {color: black; background-color: #C0C0D0; font-family: sans-serif;}
             log_path=version_string, test_version=args.doxygen_version1, master_version=args.master_describe)
         else:
           diff2='<p style="color:red">Documentation with the master version of Doxygen FAILED</p>'
-          
+
         d=pq(filename=publish_dir + 'index.html',parser="html")
         revs=d('#revisions tr')
         new_row='''<tr><td><a href="{revision}/index.html">{revision}</a></td><td>{date}</td>


### PR DESCRIPTION
## Summary of Changes

If the build of doxygen master fails, or if make fails to build the doc with it, the script will fail to upload the whole documentation testsuite. This PR modifies the scripts so that they can upload the testsuite and the log instead of nothing in such a situation.
## Release Management

* Affected package(s):Documentation
