### PR TITLE
Distance_3: Avoid needless orientation checks / distance computations

### DIFF
--- a/Distance_3/include/CGAL/squared_distance_3_2.h
+++ b/Distance_3/include/CGAL/squared_distance_3_2.h
@@ -234,31 +234,37 @@ squared_distance_to_triangle(
   const Vector_3 oe3 = vector(t0, t2);
   const Vector_3 normal = wcross(e1, oe3, k);
 
-  if(normal != NULL_VECTOR
-     && on_left_of_triangle_edge(pt, normal, t0, t1, k)
-     && on_left_of_triangle_edge(pt, normal, t1, t2, k)
-     && on_left_of_triangle_edge(pt, normal, t2, t0, k))
-      {
-        // the projection of pt is inside the triangle
-        inside = true;
-        return squared_distance_to_plane(normal, vector(t0, pt), k);
-      }
-      else {
-        // The case normal==NULL_VECTOR covers the case when the triangle
-        // is colinear, or even more degenerate. In that case, we can
-        // simply take also the distance to the three segments.
-        typename K::FT d1 = squared_distance(pt,
-                                             typename K::Segment_3(t2, t0),
-                                             k);
-        typename K::FT d2 = squared_distance(pt,
-                                             typename K::Segment_3(t1, t2),
-                                             k);
-        typename K::FT d3 = squared_distance(pt,
-                                             typename K::Segment_3(t0, t1),
-                                             k);
+  if(normal == NULL_VECTOR) {
+    // The case normal==NULL_VECTOR covers the case when the triangle
+    // is colinear, or even more degenerate. In that case, we can
+    // simply take also the distance to the three segments.
+    typename K::FT d1 = squared_distance(pt, typename K::Segment_3(t2, t0), k);
+    typename K::FT d2 = squared_distance(pt, typename K::Segment_3(t1, t2), k);
 
-        return (std::min)( (std::min)(d1, d2), d3);
-      }
+    // should not be needed since at most 2 edges cover the full triangle in the degenerate case
+    typename K::FT d3 = squared_distance(pt, typename K::Segment_3(t0, t1), k);
+
+    return (std::min)( (std::min)(d1, d2), d3);
+  }
+
+  const bool b01 = on_left_of_triangle_edge(pt, normal, t0, t1, k);
+  if(!b01) {
+    return internal::squared_distance(pt, typename K::Segment_3(t0, t1), k);
+  }
+
+  const bool b12 = on_left_of_triangle_edge(pt, normal, t1, t2, k);
+  if(!b12) {
+    return internal::squared_distance(pt, typename K::Segment_3(t1, t2), k);
+  }
+
+  const bool b20 = on_left_of_triangle_edge(pt, normal, t2, t0, k);
+  if(!b20) {
+    return internal::squared_distance(pt, typename K::Segment_3(t2, t0), k);
+  }
+
+  // The projection of pt is inside the triangle
+  inside = true;
+  return squared_distance_to_plane(normal, vector(t0, pt), k);
 }
 
 template <class K>


### PR DESCRIPTION
## Summary of Changes

Accelerate `squared_distance_to_triangle()` by exiting early: if the orientation check says the projection is right of the edge, then we can just take the distance to the edge's segment. In addition, the old version caused a lot of filter failures in the `std::min(d1, d2, d3)` call as about half of the points in 3D space realize the min distance at a vertex of the triangle, resulting in that distance computation being expensive in e.g. nurbs meshing.

Use distance to the segment directly rather than checking if the query is right of two edges (and then the min would be at the common vertex) because the call to `on_left_of_triangle_edge()` is on average more expensive than a call to `squared_distance(Point_3, Segment_3)`.

## Release Management

Separate from #5227 and for 5.3 by request from @afabri.

There will be a conflict with [`b95c60f` (#5527)](https://github.com/CGAL/cgal/pull/5527/commits/b95c60fc9fe671eb42a6811e137ab48167657db2). Use #5527's version.

* Affected package(s): `Distance_3`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

