### PR TITLE
Replace internal use of boost shared_ptr

### DIFF
--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
@@ -49,7 +49,7 @@
 
 #include <CGAL/tss.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 
 namespace CGAL {
@@ -393,8 +393,8 @@ public:
     Algebraic_curve_kernel_2()
       : _m_gcd_cache_2(new Gcd_cache_2())
     {
-      _m_curve_cache_2 = boost::shared_ptr<Curve_cache_2>(new Curve_cache_2(this));
-      _m_curve_pair_cache_2 =  boost::shared_ptr<Curve_pair_cache_2> (new Curve_pair_cache_2(this));
+      _m_curve_cache_2 = std::shared_ptr<Curve_cache_2>(new Curve_cache_2(this));
+      _m_curve_pair_cache_2 =  std::shared_ptr<Curve_pair_cache_2> (new Curve_pair_cache_2(this));
       // std::cout << "CONSTRUCTION  Algebraic_curve_kernel_2 " << std::endl;
     }
 
@@ -2766,9 +2766,9 @@ public:
 
 protected:
 
-mutable boost::shared_ptr<Curve_cache_2> _m_curve_cache_2;
-mutable boost::shared_ptr<Curve_pair_cache_2> _m_curve_pair_cache_2;
-mutable boost::shared_ptr<Gcd_cache_2> _m_gcd_cache_2;
+mutable std::shared_ptr<Curve_cache_2> _m_curve_cache_2;
+mutable std::shared_ptr<Curve_pair_cache_2> _m_curve_pair_cache_2;
+mutable std::shared_ptr<Gcd_cache_2> _m_gcd_cache_2;
 
 
 }; // class Algebraic_curve_kernel_2

--- a/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
+++ b/Alpha_shapes_3/include/CGAL/internal/Lazy_alpha_nt_3.h
@@ -20,7 +20,7 @@
 #include <CGAL/internal/Exact_type_selector.h>
 #include <CGAL/Has_conversion.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/type_traits.hpp>
 #include <boost/optional.hpp>
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_X_trapezoid.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_X_trapezoid.h
@@ -23,7 +23,7 @@
 
 #include <CGAL/Arr_point_location/Trapezoidal_decomposition_2.h>
 #include <boost/variant.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 
 #ifdef CGAL_TD_DEBUG
@@ -95,7 +95,7 @@ public:
   typedef Td_ninetuple<boost::variant<Vertex_const_handle,Point>,
                        boost::variant<Vertex_const_handle,unsigned char>,
                        boost::variant<Halfedge_const_handle,
-                                      boost::shared_ptr<X_monotone_curve_2> >,
+                                      std::shared_ptr<X_monotone_curve_2> >,
                        Halfedge_const_handle,
                        unsigned char,
                        Self*, Self*,
@@ -230,7 +230,7 @@ public:
 
     if (type() == TD_EDGE)
     {
-      //ptr()->e2 = (boost::shared_ptr<X_monotone_curve_2>)(new X_monotone_curve_2(top()->curve()));
+      //ptr()->e2 = (std::shared_ptr<X_monotone_curve_2>)(new X_monotone_curve_2(top()->curve()));
       set_curve_for_rem_he(top()->curve());
       return;
     }
@@ -238,8 +238,8 @@ public:
     //else if (type() == TD_VERTEX)
 
     Curve_end v_ce(left()->curve_end());
-    ptr()->e2 = (boost::shared_ptr<X_monotone_curve_2>)(new X_monotone_curve_2(v_ce.cv()));
-    //CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2>>( &(ptr()->e2)) != nullptr);
+    ptr()->e2 = (std::shared_ptr<X_monotone_curve_2>)(new X_monotone_curve_2(v_ce.cv()));
+    //CGAL_assertion(boost::get<std::shared_ptr<X_monotone_curve_2>>( &(ptr()->e2)) != nullptr);
 
     ptr()->e1 = (v_ce.ce() == ARR_MIN_END ) ? CGAL_TD_CV_MIN_END : CGAL_TD_CV_MAX_END;
 
@@ -255,7 +255,7 @@ public:
   {
     CGAL_precondition (type() == TD_EDGE);
 
-    ptr()->e2 = (boost::shared_ptr<X_monotone_curve_2>)(new X_monotone_curve_2(cv));
+    ptr()->e2 = (std::shared_ptr<X_monotone_curve_2>)(new X_monotone_curve_2(cv));
   }
 
   /*! Set the trapezoid's type flag (Trapezoid/Edge/Vertex). */
@@ -537,8 +537,8 @@ public:
     CGAL_precondition(is_on_boundaries());
 
     CGAL_assertion(boost::get<unsigned char>( &(ptr()->e1)) != nullptr);
-    CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
-    X_monotone_curve_2* cv_ptr = (boost::get<boost::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
+    CGAL_assertion(boost::get<std::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
+    X_monotone_curve_2* cv_ptr = (boost::get<std::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
     CGAL_assertion(cv_ptr != nullptr);
 
     Arr_curve_end ce =
@@ -555,8 +555,8 @@ public:
     CGAL_precondition(is_on_boundaries());
 
     CGAL_assertion(boost::get<unsigned char>( &(ptr()->e1)) != nullptr);
-    CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
-    X_monotone_curve_2* cv_ptr = (boost::get<boost::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
+    CGAL_assertion(boost::get<std::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
+    X_monotone_curve_2* cv_ptr = (boost::get<std::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
     CGAL_assertion(cv_ptr != nullptr);
 
     Arr_curve_end ce =
@@ -572,8 +572,8 @@ public:
     CGAL_precondition(type() == TD_VERTEX);
 
     CGAL_assertion(boost::get<unsigned char>( &(ptr()->e1)) != nullptr);
-    CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
-    X_monotone_curve_2* cv_ptr = (boost::get<boost::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
+    CGAL_assertion(boost::get<std::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
+    X_monotone_curve_2* cv_ptr = (boost::get<std::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
     CGAL_assertion(cv_ptr != nullptr);
 
     Arr_curve_end ce =
@@ -587,8 +587,8 @@ public:
   {
     CGAL_precondition(!is_active() && type() == TD_EDGE);
 
-    CGAL_assertion(boost::get<boost::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
-    X_monotone_curve_2* cv_ptr = (boost::get<boost::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
+    CGAL_assertion(boost::get<std::shared_ptr<X_monotone_curve_2> >(&(ptr()->e2)) != nullptr);
+    X_monotone_curve_2* cv_ptr = (boost::get<std::shared_ptr<X_monotone_curve_2> >(ptr()->e2)).get();
     CGAL_assertion(cv_ptr != nullptr);
     return *cv_ptr;
   }

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_edge.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_edge.h
@@ -22,7 +22,7 @@
 
 #include <CGAL/Arr_point_location/Trapezoidal_decomposition_2.h>
 #include <boost/variant.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 
 #ifdef CGAL_TD_DEBUG

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_fictitious_vertex.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_fictitious_vertex.h
@@ -22,7 +22,7 @@
 
 #include <CGAL/Arr_point_location/Trapezoidal_decomposition_2.h>
 #include <boost/variant.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #ifdef CGAL_TD_DEBUG
 #define CGAL_TD_INLINE

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_vertex.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_active_vertex.h
@@ -22,7 +22,7 @@
 
 #include <CGAL/Arr_point_location/Trapezoidal_decomposition_2.h>
 #include <boost/variant.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 
 #ifdef CGAL_TD_DEBUG

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_edge.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Td_inactive_edge.h
@@ -22,7 +22,7 @@
 
 #include <CGAL/Arr_point_location/Trapezoidal_decomposition_2.h>
 #include <boost/variant.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 
 #ifdef CGAL_TD_DEBUG
@@ -115,14 +115,14 @@ public:
 
   public:
     //c'tors
-    Data (boost::shared_ptr<X_monotone_curve_2>& _cv, Dag_node* _p_node)
+    Data (std::shared_ptr<X_monotone_curve_2>& _cv, Dag_node* _p_node)
        : cv(_cv), p_node(_p_node) //, lb(_lb),lt(_lt),rb(_rb),rt(_rt)
     { }
 
     ~Data() { }
 
   protected:
-    boost::shared_ptr<X_monotone_curve_2> cv;
+    std::shared_ptr<X_monotone_curve_2> cv;
     Dag_node* p_node;
   };
 
@@ -148,7 +148,7 @@ public:
   }
 
   /*! Set the x_monotone_curve_2 for removed edge degenerate trapezoid. */
-  CGAL_TD_INLINE void set_curve(boost::shared_ptr<X_monotone_curve_2>& cv)
+  CGAL_TD_INLINE void set_curve(std::shared_ptr<X_monotone_curve_2>& cv)
   {
     ptr()->cv = cv;
   }
@@ -159,7 +159,7 @@ public:
   //@{
 
   /*! Constructor given Vertex & Halfedge handles. */
-  Td_inactive_edge (boost::shared_ptr<X_monotone_curve_2>& cv, Dag_node* node = nullptr)
+  Td_inactive_edge (std::shared_ptr<X_monotone_curve_2>& cv, Dag_node* node = nullptr)
   {
     PTR = new Data(cv,node);
   }

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Trapezoidal_decomposition_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Trapezoidal_decomposition_2.h
@@ -27,7 +27,7 @@
 
 #include <boost/optional.hpp>
 #include <boost/variant.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <cstdlib>
 #include <cstring>
@@ -1206,7 +1206,7 @@ protected:
 
   void deactivate_vertex (Dag_node& vtx_node) const;
 
-  void deactivate_edge (boost::shared_ptr<X_monotone_curve_2>& cv, Dag_node& edge_node) const;
+  void deactivate_edge (std::shared_ptr<X_monotone_curve_2>& cv, Dag_node& edge_node) const;
 
   //-----------------------------------------------------------------------------
   // Description:

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Trapezoidal_decomposition_2_impl.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Trapezoidal_decomposition_2_impl.h
@@ -244,7 +244,7 @@ deactivate_vertex(Dag_node& vtx_node) const
 
 template <typename Td_traits>
 void Trapezoidal_decomposition_2<Td_traits>::
-deactivate_edge(boost::shared_ptr<X_monotone_curve_2>& cv,
+deactivate_edge(std::shared_ptr<X_monotone_curve_2>& cv,
                 Dag_node& edge_node) const
 {
   CGAL_precondition(traits->is_active(edge_node.get_data()));
@@ -1870,7 +1870,7 @@ void Trapezoidal_decomposition_2<Td_traits>::remove(Halfedge_const_handle he)
 
   //-----------------------------------
   //3. remove the trapezoids that represent the removed halfedge
-  boost::shared_ptr<X_monotone_curve_2>
+  std::shared_ptr<X_monotone_curve_2>
     removed_cv_ptr(new X_monotone_curve_2(he->curve()));
   Base_map_item_iterator last_edge_fragment_it = mid_it;
   //Base_trapezoid_iterator last_mid = mid_it;

--- a/Boolean_set_operations_2/archive/demo/Boolean_set_operations_2_GraphicsView/boolean_operations_2.cpp
+++ b/Boolean_set_operations_2/archive/demo/Boolean_set_operations_2_GraphicsView/boolean_operations_2.cpp
@@ -31,7 +31,7 @@ void trace( std::string s )
   out << s ;
 }
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <QtGui>
 #include <QString>
@@ -306,7 +306,7 @@ public:
 
 class Curve_set
 {
-  typedef boost::shared_ptr<Rep_base> Rep_ptr ;
+  typedef std::shared_ptr<Rep_base> Rep_ptr ;
 
 public:
 
@@ -417,7 +417,7 @@ private:
 
   QPen                        mPen ;
   QBrush                      mBrush ;
-  boost::shared_ptr<Rep_base> mRep ;
+  std::shared_ptr<Rep_base> mRep ;
 
 } ;
 

--- a/CGAL_ImageIO/include/CGAL/Image_3.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3.h
@@ -19,7 +19,7 @@
 #include <CGAL/basic.h>
 #include <CGAL/array.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/format.hpp>
 #include <boost/unordered_set.hpp>
 #include <CGAL/ImageIO.h>
@@ -81,7 +81,7 @@ class CGAL_IMAGEIO_EXPORT Image_3
 public:
   enum Own { OWN_THE_DATA, DO_NOT_OWN_THE_DATA };
 
-  typedef boost::shared_ptr<_image> Image_shared_ptr;
+  typedef std::shared_ptr<_image> Image_shared_ptr;
   typedef Image_shared_ptr Pointer;
 
 protected:

--- a/Mesh_3/archive/applications/mesher_tester.h
+++ b/Mesh_3/archive/applications/mesher_tester.h
@@ -15,7 +15,7 @@
 #include <sstream>
 #include <stdlib.h>
 #include <algorithm>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include "thread_queue.h"
 
@@ -51,7 +51,7 @@ template <class C3T3, class Domain> struct Optimizer;
 template <class C3T3, class MeshCriteria, class Domain>
 struct Mesher
 {
-  Mesher(const boost::shared_ptr<Domain_builder<Domain> >& pdomain_builder,
+  Mesher(const std::shared_ptr<Domain_builder<Domain> >& pdomain_builder,
          const int mesh_nb,
          const std::string& filename,
          const std::string& output,
@@ -95,7 +95,7 @@ struct Mesher
     timer.start();
 
     // we keep c3t3 between lines
-    boost::shared_ptr<C3T3> pc3t3_save (new C3T3());
+    std::shared_ptr<C3T3> pc3t3_save (new C3T3());
 
     // Generate Mesh
     file_out << "Generate mesh...";
@@ -183,7 +183,7 @@ private:
   }
 
 private:
-  boost::shared_ptr<Domain_builder<Domain> > pdomain_builder_;
+  std::shared_ptr<Domain_builder<Domain> > pdomain_builder_;
   int mesh_nb_;
   std::string filename_;
   std::string output_prefix_;
@@ -196,8 +196,8 @@ private:
 template <class C3T3, class Domain>
 struct Optimizer
 {
-  Optimizer(const boost::shared_ptr<C3T3>& pc3t3,
-            const boost::shared_ptr<Domain_builder<Domain> >& pdomain_builder,
+  Optimizer(const std::shared_ptr<C3T3>& pc3t3,
+            const std::shared_ptr<Domain_builder<Domain> >& pdomain_builder,
             const int mesh_nb,
             const std::string& output,
             const std::string& command_line)
@@ -339,8 +339,8 @@ private:
 
 
 private:
-  boost::shared_ptr<C3T3> pc3t3_;
-  boost::shared_ptr<Domain_builder<Domain> > pdomain_builder_;
+  std::shared_ptr<C3T3> pc3t3_;
+  std::shared_ptr<Domain_builder<Domain> > pdomain_builder_;
   std::string mesh_nb_;
   std::string output_prefix_;
   std::string command_line_;
@@ -571,7 +571,7 @@ void mesh(const std::string& data, const std::string& output_dir, const int nb_t
     //Load the domain
     std::stringstream cout_loc;
     cout_loc << "+ [" << filename << "] Create domain...";
-    boost::shared_ptr<Domain_builder<Domain> > pdomain_builder(new Domain_builder<Domain>(it->path().string()));
+    std::shared_ptr<Domain_builder<Domain> > pdomain_builder(new Domain_builder<Domain>(it->path().string()));
     cout_loc << "done (" << timer.time() << "s)\n";
     std::cout << cout_loc.str();
 

--- a/Mesh_3/benchmark/Mesh_3/StdAfx.h
+++ b/Mesh_3/benchmark/Mesh_3/StdAfx.h
@@ -131,7 +131,7 @@
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/uniform_smallint.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/thread/tss.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits.hpp>

--- a/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
@@ -27,7 +27,7 @@
 #include <CGAL/Bbox_3.h>
 #include <CGAL/point_generators_3.h>
 #include <CGAL/boost/parameter.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <CGAL/tuple.h>
 #include <CGAL/Origin.h>
 
@@ -148,7 +148,7 @@ protected:
   typedef typename Geom_traits::Sphere_3 Sphere_3;
   typedef typename Geom_traits::Iso_cuboid_3 Iso_cuboid_3;
   typedef typename Geom_traits::FT FT;
-  typedef boost::shared_ptr<CGAL::Random> CGAL_Random_share_ptr_t;
+  typedef std::shared_ptr<CGAL::Random> CGAL_Random_share_ptr_t;
   /// Returns squared error bound from \c bbox and \c error
   FT squared_error_bound(const Iso_cuboid_3& bbox, const FT& error) const
   {

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Lipschitz_sizing_experimental.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Lipschitz_sizing_experimental.h
@@ -29,7 +29,7 @@
 #include <CGAL/array.h>
 #include <CGAL/Bbox_3.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <list>
 #include <sstream>
@@ -93,7 +93,7 @@ private:
 private:
   //only one of these aabb_trees is needed
   const Tree* m_ptree;
-  boost::shared_ptr<Tree> m_own_ptree;
+  std::shared_ptr<Tree> m_own_ptree;
 
   const MeshDomain& m_domain;
   Parameters m_params;
@@ -104,7 +104,7 @@ private:
 
 #ifdef CGAL_MESH_3_EXPERIMENTAL_USE_PATCHES_IDS
   //help to accelerate aabb_tree queries in m_ptree
-  boost::shared_ptr<Kd_tree> m_kd_tree;
+  std::shared_ptr<Kd_tree> m_kd_tree;
 
   Facet_patch_id_map m_facet_patch_id_map;
   const Patches_ids_map& patches_ids_map;

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Lipschitz_sizing_polyhedron.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Lipschitz_sizing_polyhedron.h
@@ -26,7 +26,7 @@
 #include <CGAL/array.h>
 #include <CGAL/Bbox_3.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <list>
 #include <sstream>
@@ -66,7 +66,7 @@ public:
 
 private:
   const Tree* m_ptree;
-  boost::shared_ptr<Tree> m_own_ptree;
+  std::shared_ptr<Tree> m_own_ptree;
 
   const MeshDomain& m_domain;
   Parameters m_params;

--- a/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -40,8 +40,7 @@
 #include <boost/variant.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/utility/enable_if.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
+#include <memory>
 
 namespace CGAL {
 
@@ -859,7 +858,7 @@ public:
   typedef CGAL::AABB_tree<AABB_curves_traits> Curves_AABB_tree;
 
 private:
-  mutable boost::shared_ptr<Curves_AABB_tree> curves_aabb_tree_ptr_;
+  mutable std::shared_ptr<Curves_AABB_tree> curves_aabb_tree_ptr_;
   mutable bool curves_aabb_tree_is_built;
 
 public:
@@ -884,7 +883,7 @@ public:
     if(curves_aabb_tree_ptr_) {
       curves_aabb_tree_ptr_->clear();
     } else {
-      curves_aabb_tree_ptr_ = boost::make_shared<Curves_AABB_tree>();
+      curves_aabb_tree_ptr_ = std::make_shared<Curves_AABB_tree>();
     }
     for(typename Edges::const_iterator
           edges_it = edges_.begin(),

--- a/Poisson_surface_reconstruction_3/include/CGAL/Poisson_reconstruction_function.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/Poisson_reconstruction_function.h
@@ -43,7 +43,7 @@
 #include <CGAL/compute_average_spacing.h>
 #include <CGAL/Timer.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/array.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <boost/utility/enable_if.hpp>
@@ -274,7 +274,7 @@ private:
 
   // operator() is pre-computed on vertices of *m_tr by solving
   // the Poisson equation Laplacian(f) = divergent(normals field).
-  boost::shared_ptr<Triangulation> m_tr;
+  std::shared_ptr<Triangulation> m_tr;
   mutable std::shared_ptr<std::vector<Cached_bary_coord> > m_bary;
   mutable std::vector<Point> Dual;
   mutable std::vector<Vector> Normal;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
@@ -21,7 +21,7 @@
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
 
 #include <boost/graph/graph_traits.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <set>
 
 namespace CGAL {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -42,7 +42,7 @@
 #include <boost/range/join.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/unordered_set.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/container/flat_set.hpp>
 #include <boost/optional.hpp>
 
@@ -92,7 +92,7 @@ namespace internal {
     typedef typename boost::graph_traits<PM>::edge_descriptor edge_descriptor;
     typedef FaceIndexMap FIMap;
 
-    boost::shared_ptr< std::set<edge_descriptor> > border_edges_ptr;
+    std::shared_ptr< std::set<edge_descriptor> > border_edges_ptr;
     const PM* pmesh_ptr_;
 
   public:

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_autorefinement.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_autorefinement.cpp
@@ -22,7 +22,7 @@ struct My_visitor :
     : i (new int(0) )
   {}
 
-  boost::shared_ptr<int> i;
+  std::shared_ptr<int> i;
 };
 
 void test(const char* fname, std::size_t nb_polylines, std::size_t total_nb_points,

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefine.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefine.cpp
@@ -20,7 +20,7 @@ struct My_visitor :
     : i (new int(0) )
   {}
 
-  boost::shared_ptr<int> i;
+  std::shared_ptr<int> i;
 };
 
 void test(const char* f1, const char* f2)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Offset_meshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Offset_meshing_plugin.cpp
@@ -76,8 +76,8 @@ public:
   }
 
 private:
-  boost::shared_ptr<Tree> m_tree_ptr;
-  boost::shared_ptr<Side_of> m_side_of_ptr;
+  std::shared_ptr<Tree> m_tree_ptr;
+  std::shared_ptr<Side_of> m_side_of_ptr;
   double m_offset_distance;
   bool m_is_closed;
 

--- a/Polyhedron/include/CGAL/boost/graph/properties_Polyhedron_3.h
+++ b/Polyhedron/include/CGAL/boost/graph/properties_Polyhedron_3.h
@@ -17,7 +17,7 @@
 #include <CGAL/Unique_hash_map.h>
 #include <CGAL/squared_distance_2_1.h>
 #include <CGAL/number_utils.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <CGAL/boost/graph/internal/Has_member_id.h>
 
 #define CGAL_HDS_PARAM_ template < class Traits, class Items, class Alloc> class HDS
@@ -46,7 +46,7 @@ public:
 
   reference operator[](const key_type& k) const { return (*map_)[k]; }
 private:
-   boost::shared_ptr<Map> map_;
+   std::shared_ptr<Map> map_;
 };
 
 // Special case for edges.
@@ -75,7 +75,7 @@ public:
 
   reference operator[](const key_type& k) const { return (*map_)[k]; }
 private:
-  boost::shared_ptr<Map> map_;
+  std::shared_ptr<Map> map_;
 };
 
   template<typename Handle, typename FT>

--- a/Property_map/include/CGAL/Dynamic_property_map.h
+++ b/Property_map/include/CGAL/Dynamic_property_map.h
@@ -18,7 +18,7 @@
 #include <CGAL/boost/graph/properties.h>
 #include <CGAL/property_map.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/unordered_map.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/mpl/if.hpp>
@@ -70,7 +70,7 @@ struct Dynamic_property_map {
 
 
   typedef boost::unordered_map<K,V> Map;
-  boost::shared_ptr<Map> map_;
+  std::shared_ptr<Map> map_;
   V default_value_;
 };
 
@@ -119,7 +119,7 @@ struct Dynamic {
     put(*(m.map_), k, v);
   }
 
-  boost::shared_ptr<PM> map_;
+  std::shared_ptr<PM> map_;
 };
 
 template <typename Key, typename Value>
@@ -152,7 +152,7 @@ struct Dynamic_with_index
     (*m.m_values)[k.idx()]=v;
   }
 
-  boost::shared_ptr<std::vector<value_type> > m_values;
+  std::shared_ptr<std::vector<value_type> > m_values;
 };
 
 } // namespace internal

--- a/Property_map/include/CGAL/Index_property_map.h
+++ b/Property_map/include/CGAL/Index_property_map.h
@@ -13,7 +13,7 @@
 #define CGAL_INDEX_PROPERTY_MAP_H
 
 #include <CGAL/property_map.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <iterator>
 #include <map>
@@ -97,7 +97,7 @@ public:
 
 private:
   // Property maps must be lightweight classes => share std::map
-  boost::shared_ptr<Index_map> m_index_map;
+  std::shared_ptr<Index_map> m_index_map;
 };
 
 /// @cond SKIP_IN_MANUAL

--- a/QP_solver/test/QP_solver/master_mps_to_derivatives.cpp
+++ b/QP_solver/test/QP_solver/master_mps_to_derivatives.cpp
@@ -18,7 +18,7 @@
 
 #include <CGAL/boost/iterator/transform_iterator.hpp>
 #include <boost/iterator/zip_iterator.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <CGAL/Exact_rational.h>
 #include <CGAL/MP_Float.h>
@@ -200,7 +200,7 @@ void write_MPS(std::ostream& out,
   CGAL::print_quadratic_program(out, qp, problem_name);
 }
 
-boost::shared_ptr<std::ofstream>
+std::shared_ptr<std::ofstream>
 create_output_file(const char *filename, // Note: "Bernd3" and not
                                          // "Bernd3.mps".
                    const char *directory,
@@ -210,7 +210,7 @@ create_output_file(const char *filename, // Note: "Bernd3" and not
   std::string new_name = std::string(directory) +
     std::string("/") + std::string(filename) + std::string("_") +
     std::string(suffix) + std::string(".mps");
-  return boost::shared_ptr<std::ofstream>(new std::ofstream(new_name.c_str(),
+  return std::shared_ptr<std::ofstream>(new std::ofstream(new_name.c_str(),
                                                             std::ios_base::trunc |
                                                             std::ios_base::out));
 }
@@ -275,7 +275,7 @@ void create_shifted_instance(const CGAL::Quadratic_program_from_mps <IT>& qp,
   // output:
   using boost::make_transform_iterator;
   using boost::make_zip_iterator;
-  boost::shared_ptr<std::ofstream> out = create_output_file(file, dir, "shifted");
+  std::shared_ptr<std::ofstream> out = create_output_file(file, dir, "shifted");
 
   write_MPS(*out,
                   "", // deduce number-type
@@ -359,7 +359,7 @@ void create_free_instance(CGAL::Quadratic_program_from_mps<IT>& qp,
     qp.set_u(i, false);                         // variable becomes free
   }
   // output:
-  boost::shared_ptr<std::ofstream> out = create_output_file(file, dir, "free");
+  std::shared_ptr<std::ofstream> out = create_output_file(file, dir, "free");
   write_MPS(*out,
                   "", // deduce number-type
                   "Freed instance of original file",

--- a/Ridges_3/include/CGAL/Umbilics.h
+++ b/Ridges_3/include/CGAL/Umbilics.h
@@ -19,7 +19,7 @@
 #include <CGAL/PolyhedralSurf_neighbors.h>
 #include <CGAL/Kernel/global_functions_3.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <list>
 #include <vector>
@@ -133,7 +133,7 @@ class Umbilic_approximation
   const TriangleMesh& P;
 
   typedef T_PolyhedralSurf_neighbors<TriangleMesh> Poly_neighbors;
-  boost::shared_ptr<Poly_neighbors> poly_neighbors;
+  std::shared_ptr<Poly_neighbors> poly_neighbors;
 
   CGAL::Abs<FT> cgal_abs;
   CGAL::To_double<FT> To_double;
@@ -165,7 +165,7 @@ Umbilic_approximation(const TriangleMesh& p,
 {
   CGAL_precondition(is_triangle_mesh(P));
 
-  poly_neighbors = boost::shared_ptr<Poly_neighbors>(new Poly_neighbors(P));
+  poly_neighbors = std::shared_ptr<Poly_neighbors>(new Poly_neighbors(P));
 }
 
 

--- a/STL_Extension/include/CGAL/Object.h
+++ b/STL_Extension/include/CGAL/Object.h
@@ -30,13 +30,13 @@
 #include <boost/variant.hpp>
 #include <boost/optional.hpp>
 #include <boost/any.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace CGAL {
 
 class Object
 {
-    boost::shared_ptr<boost::any> obj;
+    std::shared_ptr<boost::any> obj;
 
     // returns an any pointer from a variant
     struct Any_from_variant : public boost::static_visitor<boost::any*> {

--- a/Skin_surface_3/include/CGAL/Skin_surface_base_3.h
+++ b/Skin_surface_3/include/CGAL/Skin_surface_base_3.h
@@ -24,7 +24,7 @@
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/uniform_smallint.hpp>
 #include <boost/random/variate_generator.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 // Used for the triangulated mixed complex / Voronoi diagram
 #include <CGAL/Triangulation_vertex_base_with_info_3.h>
@@ -93,7 +93,7 @@ private:
 
 public:
   typedef Anchor_point                                               Vertex_info;
-  typedef std::pair<Simplex, boost::shared_ptr<Quadratic_surface> >  Cell_info;
+  typedef std::pair<Simplex, std::shared_ptr<Quadratic_surface> >  Cell_info;
 
 private:
   // Triangulated_mixed_complex:

--- a/Skin_surface_3/include/CGAL/Triangulated_mixed_complex_observer_3.h
+++ b/Skin_surface_3/include/CGAL/Triangulated_mixed_complex_observer_3.h
@@ -18,7 +18,7 @@
 #include <CGAL/Skin_surface_quadratic_surface_3.h>
 #include <CGAL/Triangulation_simplex_3.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace CGAL {
 
@@ -163,7 +163,7 @@ public:
 
   FT shrink;
   Rt_Simplex prev_s;
-  boost::shared_ptr<Quadratic_surface> surf;
+  std::shared_ptr<Quadratic_surface> surf;
 
   // c is the center of the orthogonal sphere
   // w is the weight of the orthogonal sphere
@@ -179,14 +179,14 @@ public:
       Q[1] = Q[3] = Q[4] = 0;
       Q[0] = Q[2] = Q[5] = orient;
 
-      surf = boost::shared_ptr<Quadratic_surface>(new Quadratic_surface(Q, c, s*w, (orient==1? 0 : 3)));
+      surf = std::shared_ptr<Quadratic_surface>(new Quadratic_surface(Q, c, s*w, (orient==1? 0 : 3)));
     } else {
       // Multiply with 1-s to make the function defining the
       // skin surface implicitly continuous
       Q[1] = Q[3] = Q[4] = 0;
       Q[0] = Q[2] = Q[5] = orient*(1-s);
 
-      surf = boost::shared_ptr<Quadratic_surface>(new Quadratic_surface(Q, c, s*(1-s)*w, (orient==1? 0 : 3)));
+      surf = std::shared_ptr<Quadratic_surface>(new Quadratic_surface(Q, c, s*(1-s)*w, (orient==1? 0 : 3)));
     }
   }
 
@@ -207,7 +207,7 @@ public:
     Q[4] = orient*(-2*t.z()*t.y()/den);
     Q[5] = orient*(-  t.z()*t.z()/den + (1-s));
 
-    surf = boost::shared_ptr<Quadratic_surface>(new Quadratic_surface(Q, c, s*(1-s)*w, (orient==1? 1 : 2)));
+    surf = std::shared_ptr<Quadratic_surface>(new Quadratic_surface(Q, c, s*(1-s)*w, (orient==1? 1 : 2)));
   }
 
   Surface_RT Q[6];

--- a/Solver_interface/include/CGAL/Eigen_solver_traits.h
+++ b/Solver_interface/include/CGAL/Eigen_solver_traits.h
@@ -29,7 +29,7 @@
 
 #include <CGAL/Eigen_matrix.h>
 #include <CGAL/Eigen_vector.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace CGAL {
 namespace internal {
@@ -226,7 +226,7 @@ public:
 
 protected:
   const typename Matrix::EigenType* m_mat;
-  boost::shared_ptr<EigenSolverT> m_solver_sptr;
+  std::shared_ptr<EigenSolverT> m_solver_sptr;
 };
 
 // Specialization of the solver for BiCGSTAB as for surface parameterization,
@@ -275,7 +275,7 @@ public:
   }
 
 protected:
-  boost::shared_ptr<EigenSolverT> m_solver_sptr;
+  std::shared_ptr<EigenSolverT> m_solver_sptr;
 };
 
 } // namespace CGAL

--- a/Spatial_searching/include/CGAL/Search_traits_adapter.h
+++ b/Spatial_searching/include/CGAL/Search_traits_adapter.h
@@ -142,7 +142,7 @@ public:
     typedef typename boost::property_traits<PointPropertyMap>::value_type
     Point;
 
-    boost::shared_ptr<Point> point;
+    std::shared_ptr<Point> point;
     std::size_t idx;
 
   public:
@@ -157,18 +157,18 @@ public:
     void increment()
     {
       ++idx;
-      CGAL_assertion(point != boost::shared_ptr<Point>());
+      CGAL_assertion(point != std::shared_ptr<Point>());
     }
     void decrement()
     {
       --idx;
-      CGAL_assertion(point != boost::shared_ptr<Point>());
+      CGAL_assertion(point != std::shared_ptr<Point>());
     }
 
     void advance(std::ptrdiff_t n)
     {
       idx += n;
-      CGAL_assertion(point != boost::shared_ptr<Point>());
+      CGAL_assertion(point != std::shared_ptr<Point>());
     }
 
     std::ptrdiff_t distance_to(const No_lvalue_iterator& other) const

--- a/Stream_lines_2/include/CGAL/Regular_grid_2.h
+++ b/Stream_lines_2/include/CGAL/Regular_grid_2.h
@@ -19,7 +19,7 @@
 #include <CGAL/basic.h>
 #include <CGAL/streamlines_assertions.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <vector>
 
@@ -39,7 +39,7 @@ public:
   typedef typename StreamLinesTraits_2::Point_2 Point_2;
   typedef typename StreamLinesTraits_2::Vector_2 Vector_2;
 protected:
-  boost::shared_ptr< std::vector<FT> > vector_field;
+  std::shared_ptr< std::vector<FT> > vector_field;
   inline int get_index(int i,int j) const;
   int number_of_samples_x;
   int number_of_samples_y;
@@ -118,7 +118,7 @@ Regular_grid_2<StreamLinesTraits_2>::Regular_grid_2(int m,
   number_of_samples_y = n;
   domain_size_x = x;
   domain_size_y = y;
-  vector_field = boost::shared_ptr<std::vector<FT> >(new std::vector<FT>(number_of_samples_x*number_of_samples_y* 2));
+  vector_field = std::shared_ptr<std::vector<FT> >(new std::vector<FT>(number_of_samples_x*number_of_samples_y* 2));
 }
 
 

--- a/Stream_lines_2/include/CGAL/Stream_lines_2.h
+++ b/Stream_lines_2/include/CGAL/Stream_lines_2.h
@@ -32,7 +32,7 @@
 #include <boost/random/uniform_real.hpp> // undocumented class
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/uniform_smallint.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace CGAL {
 
@@ -96,8 +96,8 @@ protected:
   Point_2                                                        seed_point;
   int                                                            samp_step;
   unsigned int _number_of_lines;
-  boost::shared_ptr<Vector_field_2> vf_2;
-  boost::shared_ptr<Integrator_2> int_2;
+  std::shared_ptr<Vector_field_2> vf_2;
+  std::shared_ptr<Integrator_2> int_2;
 public:
   void set_separating_distance(FT new_value){separating_distance = new_value;}
   void set_saturation_ratio(FT new_value){ saturation_ratio = new_value;}
@@ -241,8 +241,8 @@ vector_field_2, const Integrator_2 & m_integrator, const FT & m_separating_dista
       m_DT.insert(pPoint);
     }
   _number_of_lines = 0;
-  vf_2 = boost::shared_ptr<Vector_field_2>(new Vector_field_2(vector_field_2));
-  int_2 = boost::shared_ptr<Integrator_2>(new Integrator_2(m_integrator));
+  vf_2 = std::shared_ptr<Vector_field_2>(new Vector_field_2(vector_field_2));
+  int_2 = std::shared_ptr<Integrator_2>(new Integrator_2(m_integrator));
   samp_step = sampling_step;
   stl_container.clear();
   place_stream_lines(vector_field_2, m_integrator,

--- a/Surface_mesh_simplification/test/Surface_mesh_simplification/test_edge_collapse_Polyhedron_3.cpp
+++ b/Surface_mesh_simplification/test/Surface_mesh_simplification/test_edge_collapse_Polyhedron_3.cpp
@@ -17,7 +17,7 @@
 #include "basics.h"
 #include "test_self_intersection.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 //#define TEST_TEST_TRACE_ENABLED
 
@@ -48,7 +48,7 @@ namespace SMS = CGAL::Surface_mesh_simplification;
 
 typedef SMS::Edge_profile<Surface> Profile;
 
-typedef boost::shared_ptr<Surface> SurfaceSP;
+typedef std::shared_ptr<Surface> SurfaceSP;
 
 // Constructs a flat polyhedron containing just the link of an edge or vertex.
 class Link_builder : public CGAL::Modifier_base<Surface::HalfedgeDS>

--- a/Surface_mesher/archive/include/CGAL/Polyhedral_surface_3.h
+++ b/Surface_mesher/archive/include/CGAL/Polyhedral_surface_3.h
@@ -31,7 +31,7 @@
 #include <CGAL/circulator.h>
 #include <CGAL/iterator.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/tuple/tuple.hpp>
 
 #include <CGAL/make_surface_mesh.h>
@@ -274,8 +274,8 @@ public:
   typedef Intersection_data_structure_3<Normalized_geom_traits,
                                         Segment_3> Subsegments_tree;
 #endif
-  typedef boost::shared_ptr<Subfacets_tree> Subfacets_tree_ptr;
-  typedef boost::shared_ptr<Subsegments_tree> Subsegments_tree_ptr;
+  typedef std::shared_ptr<Subfacets_tree> Subfacets_tree_ptr;
+  typedef std::shared_ptr<Subsegments_tree> Subsegments_tree_ptr;
 //   typedef typename Subsegments_tree::Point_with_index
 //   Intersection_point;
 
@@ -1252,13 +1252,13 @@ public:
   Subfacets_tree_ptr subfacets_tree_ptr;
   Subsegments_tree_ptr subsegments_tree_ptr;
   typedef std::set<Vertex_handle, Compare_vertex_iterators> Input_vertices;
-  boost::shared_ptr<Input_vertices> input_vertices_ptr;
+  std::shared_ptr<Input_vertices> input_vertices_ptr;
   typedef std::vector<Vertex_handle> Corner_vertices;
-  boost::shared_ptr<Corner_vertices> corner_vertices_ptr;
+  std::shared_ptr<Corner_vertices> corner_vertices_ptr;
   typedef std::vector<Vertex_handle> Edges_vertices;
-  boost::shared_ptr<Edges_vertices> edges_vertices_ptr;
+  std::shared_ptr<Edges_vertices> edges_vertices_ptr;
 #ifdef CGAL_SURFACE_MESHER_POLYHEDRAL_SURFACE_USE_PINPOLYHEDRON
-  typedef boost::shared_ptr<PointInPolyhedron> PointInPolyhedron_ptr;
+  typedef std::shared_ptr<PointInPolyhedron> PointInPolyhedron_ptr;
   PointInPolyhedron_ptr pinpolyhedron_ptr;
 #endif
 

--- a/Surface_mesher/include/CGAL/AABB_polyhedral_oracle.h
+++ b/Surface_mesher/include/CGAL/AABB_polyhedral_oracle.h
@@ -25,7 +25,7 @@
 #include <CGAL/AABB_traits.h>
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace CGAL {
 
@@ -50,7 +50,7 @@ namespace CGAL {
     typedef AABB_tree<AABB_traits> Tree;
     typedef typename AABB_traits::Bounding_box Bounding_box;
 
-    typedef boost::shared_ptr<Tree> Tree_shared_ptr;
+    typedef std::shared_ptr<Tree> Tree_shared_ptr;
     Tree_shared_ptr m_pTree;
 
   public:

--- a/Surface_mesher/include/CGAL/Gray_level_image_3.h
+++ b/Surface_mesher/include/CGAL/Gray_level_image_3.h
@@ -19,7 +19,7 @@
 
 #include <CGAL/auto_link/ImageIO.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #ifdef CGAL_SURFACE_MESHER_DEBUG_GRAY_LEVEL_IMAGE_3_CONSTRUCTOR
 #include <boost/format.hpp>

--- a/Visibility_2/include/CGAL/Triangular_expansion_visibility_2.h
+++ b/Visibility_2/include/CGAL/Triangular_expansion_visibility_2.h
@@ -18,7 +18,7 @@
 
 
 #include <CGAL/Arrangement_2.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <CGAL/boost/iterator/transform_iterator.hpp>
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>
 #include <CGAL/Arr_observer.h>
@@ -151,7 +151,7 @@ private:
 
   // May change during visibility computation
   mutable Observer observer;
-  mutable boost::shared_ptr<CDT> p_cdt;
+  mutable std::shared_ptr<CDT> p_cdt;
   mutable std::vector<Segment_2> needles;
 
   // Copy constructor and assignment not supported
@@ -696,7 +696,7 @@ private:
                                               Make_constraint());
 
     //std::cout << "init_cdt new CDT" << std::endl;
-    p_cdt = boost::shared_ptr<CDT>(new CDT(begin, end));
+    p_cdt = std::shared_ptr<CDT>(new CDT(begin, end));
     observer.has_changed = false;
     //std::cout << "init_cdt done" << std::endl;
     //std::cout << std::endl;


### PR DESCRIPTION
Triggered by some deprecation warnings from boost:

```
In file included from /usr/include/boost/smart_ptr/detail/sp_thread_sleep.hpp:22,
                 from /usr/include/boost/smart_ptr/detail/yield_k.hpp:23,
                 from /usr/include/boost/smart_ptr/detail/spinlock_gcc_atomic.hpp:14,
                 from /usr/include/boost/smart_ptr/detail/spinlock.hpp:42,
                 from /usr/include/boost/smart_ptr/detail/spinlock_pool.hpp:25,
                 from /usr/include/boost/smart_ptr/shared_ptr.hpp:29,
                 from /usr/include/boost/shared_ptr.hpp:17,
                 from /mnt/testsuite/include/CGAL/Object.h:33,
                 from /mnt/testsuite/include/CGAL/kernel_basic.h:25,
                 from /mnt/testsuite/include/CGAL/basic.h:30,
                 from /mnt/testsuite/include/CGAL/Cartesian/Cartesian_base.h:20,
                 from /mnt/testsuite/include/CGAL/Simple_cartesian.h:20,
                 from /home/cgal_tester/build/src/cmake/platforms/ArchLinux-CXX17-Release/test/Classification_Examples/example_classification.cpp:6:
/usr/include/boost/detail/iterator.hpp:13:1: note: ‘#pragma message: This header is deprecated. Use <iterator> instead.’
   13 | BOOST_HEADER_DEPRECATED("<iterator>")
      | ^~~~~~~~~~~~~~~~~~~~~~~
```
for example [here](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.3-I-112/Classification_Examples/TestReport_lrineau_ArchLinux-CXX17-Release.gz)

It might be that only the first commit is needed to fix it but then it might be triggered by next include directives.

I also have the change for shared_ptr used in public API that I'll put in a separate draft PR as I don't know how to handle it. 
