### PR TITLE
Replace boost::shared_ptr used in public API

### DIFF
--- a/CGAL_ipelets/demo/CGAL_ipelets/skeleton.cpp
+++ b/CGAL_ipelets/demo/CGAL_ipelets/skeleton.cpp
@@ -11,7 +11,7 @@
 // Author(s)     : Sebastien Loriot, Sylvain Pion
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include<boost/shared_ptr.hpp>
+#include<memory>
 #include <CGAL/CGAL_Ipelet_base.h>
 #include<CGAL/create_offset_polygons_2.h>
 #include <boost/format.hpp>
@@ -38,10 +38,10 @@ const std::string Hmsg[] = {
 class SkeletonIpelet
   : public CGAL::Ipelet_base<Kernel,7>{
 
-  typedef boost::shared_ptr<Polygon_2>        PolygonPtr ;
+  typedef std::shared_ptr<Polygon_2>        PolygonPtr ;
   typedef std::vector<PolygonPtr>             PolygonPtrVector ;
   typedef CGAL::Straight_skeleton_2<Kernel>   Skeleton ;
-  typedef boost::shared_ptr<Skeleton>         SkeletonPtr ;
+  typedef std::shared_ptr<Skeleton>         SkeletonPtr ;
 
   void draw_straight_skeleton(const Skeleton& skeleton,double);
 

--- a/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/common-libraries.hpp
+++ b/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/common-libraries.hpp
@@ -45,8 +45,7 @@
 #include <boost/serialization/vector.hpp>
 #endif
 #include <boost/scoped_ptr.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
+#include <memory>
 #include <boost/unordered_set.hpp>
 #include <iostream>
 #include <cstdio>

--- a/Classification/include/CGAL/Classification/Feature/Gradient_of_feature.h
+++ b/Classification/include/CGAL/Classification/Feature/Gradient_of_feature.h
@@ -37,7 +37,7 @@ class Gradient_of_feature : public Feature_base
   const InputRange& m_input;
   ItemMap m_map;
   Feature_handle m_feature;
-  boost::shared_ptr<NeighborQuery> m_query;
+  std::shared_ptr<NeighborQuery> m_query;
 
 public:
   /*!

--- a/GraphicsView/demo/Polygon/Polygon_2.cpp
+++ b/GraphicsView/demo/Polygon/Polygon_2.cpp
@@ -1,5 +1,5 @@
 #include <fstream>
-#include<boost/shared_ptr.hpp>
+#include<memory>
 // CGAL headers
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polygon_2.h>
@@ -44,9 +44,9 @@ typedef CGAL::Polygon_with_holes_2<K,std::list< Point_2 > > Polygon_with_holes_2
 
 typedef CGAL::Straight_skeleton_2<K> Ss ;
 
-typedef boost::shared_ptr<Ss> SsPtr ;
+typedef std::shared_ptr<Ss> SsPtr ;
 
-typedef boost::shared_ptr<Polygon2> PolygonPtr ;
+typedef std::shared_ptr<Polygon2> PolygonPtr ;
 
 typedef std::vector<PolygonPtr> PolygonPtr_vector ;
 

--- a/Point_set_3/examples/Point_set_3/point_set_algo.cpp
+++ b/Point_set_3/examples/Point_set_3/point_set_algo.cpp
@@ -68,7 +68,7 @@ int main (int, char**)
   parameters.normal_threshold = 0.9;
   ransac.detect(parameters);
 
-  for(boost::shared_ptr<Efficient_ransac::Shape> shape : ransac.shapes())
+  for(std::shared_ptr<Efficient_ransac::Shape> shape : ransac.shapes())
     if (Sphere* sphere = dynamic_cast<Sphere*>(shape.get()))
       std::cerr << "Detected sphere of center " << sphere->center() // Center should be approx 0, 0, 0
                 << " and of radius " << sphere->radius() << std::endl; // Radius should be approx 1

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/Cluster_classification.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/Cluster_classification.h
@@ -98,7 +98,7 @@ class Cluster_classification : public Item_classification_base
 
   void add_cluster_features ()
   {
-    m_eigen = boost::make_shared<Local_eigen_analysis>
+    m_eigen = std::make_shared<Local_eigen_analysis>
       (Local_eigen_analysis::create_from_point_clusters(m_clusters,
                                                         Concurrency_tag()));
 
@@ -388,7 +388,7 @@ class Cluster_classification : public Item_classification_base
 
   int m_index_color;
 
-  boost::shared_ptr<Local_eigen_analysis> m_eigen;
+  std::shared_ptr<Local_eigen_analysis> m_eigen;
 
   bool m_input_is_las;
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_average_spacing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_average_spacing_plugin.cpp
@@ -27,7 +27,7 @@ struct Compute_average_spacing_functor
 {
   Point_set* points;
   const int nb_neighbors;
-  boost::shared_ptr<double> result;
+  std::shared_ptr<double> result;
 
   Compute_average_spacing_functor (Point_set* points, const int nb_neighbors)
     : points (points), nb_neighbors (nb_neighbors), result (new double(0)) { }

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_bilateral_smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_bilateral_smoothing_plugin.cpp
@@ -29,7 +29,7 @@ struct Bilateral_smoothing_functor
   Point_set* points;
   unsigned int neighborhood_size;
   unsigned int sharpness_angle;
-  boost::shared_ptr<double> result;
+  std::shared_ptr<double> result;
 
   Bilateral_smoothing_functor  (Point_set* points,
                                 unsigned int neighborhood_size,

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_clustering_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_clustering_plugin.cpp
@@ -29,7 +29,7 @@ struct Clustering_functor
   Point_set* points;
   Point_set::Property_map<std::size_t> cluster_map;
   const double neighbor_radius;
-  boost::shared_ptr<std::size_t> result;
+  std::shared_ptr<std::size_t> result;
 
   Clustering_functor (Point_set* points,
                       const double neighbor_radius,

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_outliers_removal_plugin.cpp
@@ -26,7 +26,7 @@ struct Outlier_removal_functor
   int nb_neighbors;
   double removed_percentage;
   double distance_threshold;
-  boost::shared_ptr<Point_set::iterator> result;
+  std::shared_ptr<Point_set::iterator> result;
 
   Outlier_removal_functor  (Point_set* points,
                             int nb_neighbors,

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_selection_plugin.cpp
@@ -37,7 +37,7 @@
 
 #include <map>
 #include <fstream>
-#include <boost/make_shared.hpp>
+#include <memory>
 #include "Selection_visualizer.h"
 
 //#undef  CGAL_LINKED_WITH_TBB
@@ -332,7 +332,7 @@ class Neighborhood
   typedef CGAL::Fuzzy_sphere<Search_traits> Sphere;
 
   Scene_points_with_normal_item* points_item;
-  boost::shared_ptr<Tree> tree;
+  std::shared_ptr<Tree> tree;
 
 public:
 
@@ -351,7 +351,7 @@ public:
     {
       this->points_item = points_item;
 
-      tree = boost::make_shared<Tree> (points_item->point_set()->begin(),
+      tree = std::make_shared<Tree> (points_item->point_set()->begin(),
                                        points_item->point_set()->end(),
                                        Tree::Splitter(),
                                        Search_traits (points_item->point_set()->point_map()));

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_shape_detection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_shape_detection_plugin.cpp
@@ -460,7 +460,7 @@ private:
         sm_item = new Scene_surface_mesh_item;
 
         using Plane = CGAL::Shape_detection::RG::Plane<Kernel>;
-        boost::shared_ptr<Plane> rg_plane(new Plane(*points, points->point_map(), regions[index], plane));
+        std::shared_ptr<Plane> rg_plane(new Plane(*points, points->point_map(), regions[index], plane));
         build_alpha_shape(
           *(point_item->point_set()), rg_plane,
           sm_item, search_sphere_radius);
@@ -668,7 +668,7 @@ private:
     std::map<Kernel::Point_3, QColor> color_map;
 
     int index = 0;
-    for(boost::shared_ptr<typename Ransac::Shape> shape : ransac.shapes())
+    for(std::shared_ptr<typename Ransac::Shape> shape : ransac.shapes())
     {
       CGAL::Shape_detection::Cylinder<Traits> *cyl;
       cyl = dynamic_cast<CGAL::Shape_detection::Cylinder<Traits> *>(shape.get());
@@ -743,8 +743,8 @@ private:
         {
           ss << item->name().toStdString() << "_plane_";
 
-          boost::shared_ptr<CGAL::Shape_detection::Plane<Traits> > pshape
-            = boost::dynamic_pointer_cast<CGAL::Shape_detection::Plane<Traits> > (shape);
+          std::shared_ptr<CGAL::Shape_detection::Plane<Traits> > pshape
+            = std::dynamic_pointer_cast<CGAL::Shape_detection::Plane<Traits> > (shape);
 
           Kernel::Point_3 ref = CGAL::ORIGIN + pshape->plane_normal ();
 
@@ -913,7 +913,7 @@ private:
   }
 
     template<typename Plane>
-    void build_alpha_shape (Point_set& points, boost::shared_ptr<Plane> plane,
+    void build_alpha_shape (Point_set& points, std::shared_ptr<Plane> plane,
                           Scene_surface_mesh_item* sm_item, double epsilon);
 
 }; // end Polyhedron_demo_point_set_shape_detection_plugin
@@ -1011,7 +1011,7 @@ void Polyhedron_demo_point_set_shape_detection_plugin::on_actionDetect_triggered
 
 template<typename Plane>
 void Polyhedron_demo_point_set_shape_detection_plugin::build_alpha_shape
-(Point_set& points,  boost::shared_ptr<Plane> plane, Scene_surface_mesh_item* sm_item, double epsilon)
+(Point_set& points,  std::shared_ptr<Plane> plane, Scene_surface_mesh_item* sm_item, double epsilon)
 {
   typedef Kernel::Point_2  Point_2;
   typedef CGAL::Alpha_shape_vertex_base_2<Kernel> Vb;

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_simplification_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_simplification_plugin.cpp
@@ -29,7 +29,7 @@ struct Compute_average_spacing_functor
 {
   Point_set* points;
   const int nb_neighbors;
-  boost::shared_ptr<double> result;
+  std::shared_ptr<double> result;
 
   Compute_average_spacing_functor (Point_set* points, const int nb_neighbors)
     : points (points), nb_neighbors (nb_neighbors), result (new double(0)) { }
@@ -49,7 +49,7 @@ struct Grid_simplify_functor
 {
   Point_set* points;
   double grid_size;
-  boost::shared_ptr<Point_set::iterator> result;
+  std::shared_ptr<Point_set::iterator> result;
 
   Grid_simplify_functor (Point_set* points, double grid_size)
     : points (points), grid_size (grid_size), result (new Point_set::iterator) { }
@@ -69,7 +69,7 @@ struct Hierarchy_simplify_functor
   Point_set* points;
   unsigned int max_cluster_size;
   double max_surface_variation;
-  boost::shared_ptr<Point_set::iterator> result;
+  std::shared_ptr<Point_set::iterator> result;
 
   Hierarchy_simplify_functor (Point_set* points,
                               double max_cluster_size,

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_wlop_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_wlop_plugin.cpp
@@ -27,7 +27,7 @@ struct Compute_average_spacing_functor
 {
   Point_set* points;
   const int nb_neighbors;
-  boost::shared_ptr<double> result;
+  std::shared_ptr<double> result;
 
   Compute_average_spacing_functor (Point_set* points, const int nb_neighbors)
     : points (points), nb_neighbors (nb_neighbors), result (new double(0)) { }

--- a/Polyhedron/demo/Polyhedron/include/run_with_qprogressdialog.h
+++ b/Polyhedron/demo/Polyhedron/include/run_with_qprogressdialog.h
@@ -19,9 +19,9 @@ private:
   mutable std::size_t nb;
 
 public:
-  boost::shared_ptr<double> latest_adv;
-  boost::shared_ptr<bool> state;
-  boost::shared_ptr<Callback_signaler> signaler;
+  std::shared_ptr<double> latest_adv;
+  std::shared_ptr<bool> state;
+  std::shared_ptr<Callback_signaler> signaler;
 
   Signal_callback(bool)
     : latest_adv (new double(0))
@@ -70,7 +70,7 @@ public:
 class Functor_with_signal_callback
 {
 protected:
-  boost::shared_ptr<Signal_callback> m_callback;
+  std::shared_ptr<Signal_callback> m_callback;
 public:
 
   Signal_callback* callback() { return m_callback.get(); }

--- a/Shape_detection/examples/Shape_detection/efficient_RANSAC_with_point_access.cpp
+++ b/Shape_detection/examples/Shape_detection/efficient_RANSAC_with_point_access.cpp
@@ -99,7 +99,7 @@ int main(int argc, char** argv) {
   Efficient_ransac::Shape_range::iterator it = shapes.begin();
   while (it != shapes.end()) {
 
-    boost::shared_ptr<Efficient_ransac::Shape> shape = *it;
+    std::shared_ptr<Efficient_ransac::Shape> shape = *it;
 
     // Use Shape_base::info() to print the parameters of the detected shape.
     std::cout << (*it)->info();

--- a/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
@@ -37,9 +37,9 @@
 
 // boost --------------
 #include <CGAL/boost/iterator/counting_iterator.hpp>
-#include <boost/shared_ptr.hpp>
-#include <boost/make_shared.hpp>
 //---------------------
+
+#include <memory>
 
 namespace CGAL {
 namespace Shape_detection {
@@ -104,36 +104,36 @@ public:
 
 #ifdef DOXYGEN_RUNNING
   typedef unspecified_type Shape_range;
-  ///< `Iterator_range` with a bidirectional constant iterator type with value type `boost::shared_ptr<Shape>`.
+  ///< `Iterator_range` with a bidirectional constant iterator type with value type `std::shared_ptr<Shape>`.
   typedef unspecified_type Plane_range;
-  ///< `Iterator_range` with a bidirectional constant iterator type with value type `boost::shared_ptr<Plane_shape>`.
+  ///< `Iterator_range` with a bidirectional constant iterator type with value type `std::shared_ptr<Plane_shape>`.
 #else
 
   struct Shape_range : public Iterator_range<
-          typename std::vector<boost::shared_ptr<Shape> >::const_iterator> {
+          typename std::vector<std::shared_ptr<Shape> >::const_iterator> {
     typedef Iterator_range<
-            typename std::vector<boost::shared_ptr<Shape> >::const_iterator> Base;
+            typename std::vector<std::shared_ptr<Shape> >::const_iterator> Base;
 
-    Shape_range(boost::shared_ptr<std::vector<boost::shared_ptr<Shape> > >
+    Shape_range(std::shared_ptr<std::vector<std::shared_ptr<Shape> > >
                 extracted_shapes) : Base(make_range(extracted_shapes->begin(),
                                                     extracted_shapes->end())), m_extracted_shapes(extracted_shapes) {}
 
   private:
-    boost::shared_ptr<std::vector<boost::shared_ptr<Shape> > >
+    std::shared_ptr<std::vector<std::shared_ptr<Shape> > >
             m_extracted_shapes; // keeps a reference to the shape vector
   };
 
   struct Plane_range : public Iterator_range<
-          typename std::vector<boost::shared_ptr<Plane_shape> >::const_iterator> {
+          typename std::vector<std::shared_ptr<Plane_shape> >::const_iterator> {
     typedef Iterator_range<
-            typename std::vector<boost::shared_ptr<Plane_shape> >::const_iterator> Base;
+            typename std::vector<std::shared_ptr<Plane_shape> >::const_iterator> Base;
 
-    Plane_range(boost::shared_ptr<std::vector<boost::shared_ptr<Plane_shape> > >
+    Plane_range(std::shared_ptr<std::vector<std::shared_ptr<Plane_shape> > >
                 extracted_shapes) : Base(make_range(extracted_shapes->begin(),
                                                     extracted_shapes->end())), m_extracted_shapes(extracted_shapes) {}
 
   private:
-    boost::shared_ptr<std::vector<boost::shared_ptr<Plane_shape> > >
+    std::shared_ptr<std::vector<std::shared_ptr<Plane_shape> > >
             m_extracted_shapes; // keeps a reference to the shape vector
   };
 
@@ -291,7 +291,7 @@ public:
     clear();
 
     m_extracted_shapes =
-            boost::make_shared<std::vector<boost::shared_ptr<Shape> > >();
+            std::make_shared<std::vector<std::shared_ptr<Shape> > >();
 
     m_num_available_points = m_num_total_points = std::distance(
             m_input_iterator_first, m_input_iterator_beyond);
@@ -435,7 +435,7 @@ public:
     std::vector<int>().swap(m_shape_index);
 
     m_extracted_shapes =
-            boost::make_shared<std::vector<boost::shared_ptr<Shape> > >();
+            std::make_shared<std::vector<std::shared_ptr<Shape> > >();
 
     m_num_available_points = m_num_total_points;
 
@@ -485,7 +485,7 @@ public:
 
     // Reset data structures possibly used by former search
     m_extracted_shapes =
-            boost::make_shared<std::vector<boost::shared_ptr<Shape> > >();
+            std::make_shared<std::vector<std::shared_ptr<Shape> > >();
     m_num_available_points = m_num_total_points;
 
     for (std::size_t i = 0; i < m_num_subsets; i++) {
@@ -740,7 +740,7 @@ public:
 
         //1. add best candidate to final result.
         m_extracted_shapes->push_back(
-                boost::shared_ptr<Shape>(best_candidate));
+                std::shared_ptr<Shape>(best_candidate));
 
         if (callback && !callback(num_invalid / double(m_num_total_points)))
           return false;
@@ -857,7 +857,7 @@ public:
   /// @{
   /*!
     Returns an `Iterator_range` with a bidirectional iterator with value type
-    `boost::shared_ptr<Shape>` over the detected shapes in the order of detection.
+    `std::shared_ptr<Shape>` over the detected shapes in the order of detection.
     Depending on the chosen probability
     for the detection, the shapes are ordered with decreasing size.
   */
@@ -867,21 +867,21 @@ public:
 
   /*!
     Returns an `Iterator_range` with a bidirectional iterator with
-    value type `boost::shared_ptr<Plane_shape>` over only the
+    value type `std::shared_ptr<Plane_shape>` over only the
     detected planes in the order of detection.  Depending on the
     chosen probability for the detection, the planes are ordered
     with decreasing size.
   */
   Plane_range planes() const {
-    boost::shared_ptr<std::vector<boost::shared_ptr<Plane_shape> > > planes
-            = boost::make_shared<std::vector<boost::shared_ptr<Plane_shape> > >();
+    std::shared_ptr<std::vector<std::shared_ptr<Plane_shape> > > planes
+            = std::make_shared<std::vector<std::shared_ptr<Plane_shape> > >();
 
     for (std::size_t i = 0; i < m_extracted_shapes->size(); ++i) {
-      boost::shared_ptr<Plane_shape> pshape
-              = boost::dynamic_pointer_cast<Plane_shape>((*m_extracted_shapes)[i]);
+      std::shared_ptr<Plane_shape> pshape
+              = std::dynamic_pointer_cast<Plane_shape>((*m_extracted_shapes)[i]);
 
       // Ignore all shapes other than plane
-      if (pshape != boost::shared_ptr<Plane_shape>())
+      if (pshape != std::shared_ptr<Plane_shape>())
         planes->push_back(pshape);
     }
     return Plane_range(planes);
@@ -1183,7 +1183,7 @@ private:
   //give the index of the subset of point i
   std::vector<int> m_index_subsets;
 
-  boost::shared_ptr<std::vector<boost::shared_ptr<Shape> > > m_extracted_shapes;
+  std::shared_ptr<std::vector<std::shared_ptr<Shape> > > m_extracted_shapes;
 
   std::vector<Shape *(*)()> m_shape_factories;
 

--- a/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/property_map.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/property_map.h
@@ -31,7 +31,7 @@ namespace Shape_detection {
   class Point_to_shape_index_map
   {
     typedef CGAL::Shape_detection::Shape_base<Traits> Shape;
-    boost::shared_ptr<std::vector<int> > m_indices;
+    std::shared_ptr<std::vector<int> > m_indices;
 
   public:
     typedef std::size_t key_type; ///< %Index of the point in the random access point range.
@@ -50,7 +50,7 @@ namespace Shape_detection {
 
       \tparam ShapeRange must be an `Iterator_range` with a bidirectional
       constant iterator type with value type
-      `boost::shared_ptr<CGAL::Shape_detection::Shape_base<Traits> >`.
+      `std::shared_ptr<CGAL::Shape_detection::Shape_base<Traits> >`.
      */
     template <typename PointRange, typename ShapeRange>
     Point_to_shape_index_map (const PointRange& points,
@@ -85,7 +85,7 @@ namespace Shape_detection {
   {
   public:
     typedef CGAL::Shape_detection::Plane<Traits> Plane_shape;
-    typedef boost::shared_ptr<Plane_shape> key_type;
+    typedef std::shared_ptr<Plane_shape> key_type;
     typedef typename Traits::Plane_3 value_type;
     typedef value_type reference;
     typedef boost::read_write_property_map_tag category;

--- a/Shape_detection/include/CGAL/Shape_detection/deprecated/Region_growing.h
+++ b/Shape_detection/include/CGAL/Shape_detection/deprecated/Region_growing.h
@@ -34,8 +34,10 @@
 #include <CGAL/boost/iterator/transform_iterator.hpp>
 
 // Boost includes.
-#include <boost/make_shared.hpp>
 #include <boost/iterator/filter_iterator.hpp>
+
+
+#include <memory>
 
 // Deprecated -->
 #define CGAL_DEPRECATED_HEADER "<CGAL/Shape_detection/deprecated/Region_growing.h>"
@@ -98,39 +100,39 @@ namespace Shape_detection {
   #ifdef DOXYGEN_RUNNING
 
     typedef unspecified_type Shape_range;
-    ///< An `Iterator_range` with a bidirectional constant iterator type with value type `boost::shared_ptr<Shape>`.
+    ///< An `Iterator_range` with a bidirectional constant iterator type with value type `std::shared_ptr<Shape>`.
 
     typedef unspecified_type Plane_range;
-    ///< An `Iterator_range` with a bidirectional constant iterator type with value type `boost::shared_ptr<Plane_shape>`.
+    ///< An `Iterator_range` with a bidirectional constant iterator type with value type `std::shared_ptr<Plane_shape>`.
 
   #else
 
     struct Shape_range : public Iterator_range<
-      typename std::vector<boost::shared_ptr<Shape> >::const_iterator> {
+      typename std::vector<std::shared_ptr<Shape> >::const_iterator> {
       typedef Iterator_range<
-        typename std::vector<boost::shared_ptr<Shape> >::const_iterator> Base;
+        typename std::vector<std::shared_ptr<Shape> >::const_iterator> Base;
 
-      Shape_range(boost::shared_ptr<std::vector<boost::shared_ptr<Shape> > >
+      Shape_range(std::shared_ptr<std::vector<std::shared_ptr<Shape> > >
       extracted_shapes) :
       Base(make_range(extracted_shapes->begin(),
       extracted_shapes->end())), m_extracted_shapes(extracted_shapes) { }
 
     private:
-      boost::shared_ptr<std::vector<boost::shared_ptr<Shape> > >
+      std::shared_ptr<std::vector<std::shared_ptr<Shape> > >
       m_extracted_shapes; // keeps a reference to the shape vector
     };
 
     struct Plane_range : public Iterator_range<
-      typename std::vector<boost::shared_ptr<Plane_shape> >::const_iterator> {
+      typename std::vector<std::shared_ptr<Plane_shape> >::const_iterator> {
       typedef Iterator_range<
-        typename std::vector<boost::shared_ptr<Plane_shape> >::const_iterator> Base;
+        typename std::vector<std::shared_ptr<Plane_shape> >::const_iterator> Base;
 
-      Plane_range(boost::shared_ptr<std::vector<boost::shared_ptr<Plane_shape> > >
+      Plane_range(std::shared_ptr<std::vector<std::shared_ptr<Plane_shape> > >
         extracted_shapes) : Base(make_range(extracted_shapes->begin(),
         extracted_shapes->end())), m_extracted_shapes(extracted_shapes) { }
 
     private:
-      boost::shared_ptr<std::vector<boost::shared_ptr<Plane_shape> > >
+      std::shared_ptr<std::vector<std::shared_ptr<Plane_shape> > >
         m_extracted_shapes; // keeps a reference to the shape vector
     };
 
@@ -233,8 +235,8 @@ namespace Shape_detection {
       My_point_map m_index_map;
       Tree& m_tree;
       FT m_cluster_epsilon;
-      mutable boost::shared_ptr<std::vector<std::size_t> > nb_points;
-      mutable boost::shared_ptr<std::vector<FT> > score;
+      mutable std::shared_ptr<std::vector<std::size_t> > nb_points;
+      mutable std::shared_ptr<std::vector<FT> > score;
 
     public:
       Sort_by_planarity (Input_iterator first,
@@ -302,7 +304,7 @@ namespace Shape_detection {
     // Give the index of the subset of point i.
     std::vector<int> m_index_subsets;
 
-    boost::shared_ptr<std::vector<boost::shared_ptr<Shape> > > m_extracted_shapes;
+    std::shared_ptr<std::vector<std::shared_ptr<Shape> > > m_extracted_shapes;
 
     std::vector<Shape *(*)()> m_shape_factories;
 
@@ -390,7 +392,7 @@ namespace Shape_detection {
         clear();
 
         m_extracted_shapes =
-          boost::make_shared<std::vector<boost::shared_ptr<Shape> > >();
+          std::make_shared<std::vector<std::shared_ptr<Shape> > >();
 
         m_num_available_points = m_num_total_points = std::distance(
           m_input_iterator_first, m_input_iterator_beyond);
@@ -466,7 +468,7 @@ namespace Shape_detection {
       std::vector<int>().swap(m_shape_index);
 
       m_extracted_shapes =
-        boost::make_shared<std::vector<boost::shared_ptr<Shape> > >();
+        std::make_shared<std::vector<std::shared_ptr<Shape> > >();
 
       m_num_available_points = m_num_total_points;
     }
@@ -506,7 +508,7 @@ namespace Shape_detection {
 
       // Reset data structures possibly used by former search.
       m_extracted_shapes =
-        boost::make_shared<std::vector<boost::shared_ptr<Shape> > >();
+        std::make_shared<std::vector<std::shared_ptr<Shape> > >();
       m_num_available_points = m_num_total_points;
 
       m_options = options;
@@ -692,7 +694,7 @@ namespace Shape_detection {
           Plane_shape* ps = dynamic_cast<Plane_shape*>(p);
           CGAL_assume (ps != nullptr);
           ps->update (optimal_plane);
-          m_extracted_shapes->push_back (boost::shared_ptr<Shape>(p));
+          m_extracted_shapes->push_back (std::shared_ptr<Shape>(p));
         }
         else
         {
@@ -712,7 +714,7 @@ namespace Shape_detection {
     /// @{
     /*!
       Returns an `Iterator_range` with a bidirectional iterator with value type
-      `boost::shared_ptr<Shape>` over the detected shapes in the order of detection.
+      `std::shared_ptr<Shape>` over the detected shapes in the order of detection.
 
       \note So far, region growing algorithm only supports plane
       detection, so this method is equivalent to `planes()` except
@@ -724,20 +726,20 @@ namespace Shape_detection {
 
     /*!
       Returns an `Iterator_range` with a bidirectional iterator with
-      value type `boost::shared_ptr<Plane_shape>` over only the
+      value type `std::shared_ptr<Plane_shape>` over only the
       detected planes in the order of detection.
     */
     Plane_range planes() const {
-      boost::shared_ptr<std::vector<boost::shared_ptr<Plane_shape> > > planes
-        = boost::make_shared<std::vector<boost::shared_ptr<Plane_shape> > >();
+      std::shared_ptr<std::vector<std::shared_ptr<Plane_shape> > > planes
+        = std::make_shared<std::vector<std::shared_ptr<Plane_shape> > >();
 
       for (std::size_t i = 0; i < m_extracted_shapes->size(); ++ i)
       {
-        boost::shared_ptr<Plane_shape> pshape
-          = boost::dynamic_pointer_cast<Plane_shape>((*m_extracted_shapes)[i]);
+        std::shared_ptr<Plane_shape> pshape
+          = std::dynamic_pointer_cast<Plane_shape>((*m_extracted_shapes)[i]);
 
         // Ignore all shapes other than plane.
-        if (pshape != boost::shared_ptr<Plane_shape>())
+        if (pshape != std::shared_ptr<Plane_shape>())
           planes->push_back (pshape);
       }
       return Plane_range(planes);

--- a/Shape_detection/test/Shape_detection/test_efficient_RANSAC_cone_parameters.cpp
+++ b/Shape_detection/test/Shape_detection/test_efficient_RANSAC_cone_parameters.cpp
@@ -74,7 +74,7 @@ bool test_cone_parameters() {
     if (shapes.size() != 1)
       continue;
 
-    boost::shared_ptr<Cone> cone = boost::dynamic_pointer_cast<Cone>((*shapes.first));
+    std::shared_ptr<Cone> cone = std::dynamic_pointer_cast<Cone>((*shapes.first));
 
     // Check: shape detected is a cone.
     if (!cone)

--- a/Shape_detection/test/Shape_detection/test_efficient_RANSAC_cylinder_parameters.cpp
+++ b/Shape_detection/test/Shape_detection/test_efficient_RANSAC_cylinder_parameters.cpp
@@ -73,7 +73,7 @@ bool test_cylinder_parameters() {
     if (shapes.size() != 1)
       continue;
 
-    boost::shared_ptr<Cylinder> cyl = boost::dynamic_pointer_cast<Cylinder>((*shapes.first));
+    std::shared_ptr<Cylinder> cyl = std::dynamic_pointer_cast<Cylinder>((*shapes.first));
 
     // Check: shape detected is a cylinder.
     if (!cyl)

--- a/Shape_detection/test/Shape_detection/test_efficient_RANSAC_plane_parameters.cpp
+++ b/Shape_detection/test/Shape_detection/test_efficient_RANSAC_plane_parameters.cpp
@@ -67,7 +67,7 @@ bool test_plane_parameters() {
     if (shapes.size() != 1)
       continue;
 
-    boost::shared_ptr<Plane> pl = boost::dynamic_pointer_cast<Plane>((*shapes.first));
+    std::shared_ptr<Plane> pl = std::dynamic_pointer_cast<Plane>((*shapes.first));
 
     if (!pl)
       continue;

--- a/Shape_detection/test/Shape_detection/test_efficient_RANSAC_scene.cpp
+++ b/Shape_detection/test/Shape_detection/test_efficient_RANSAC_scene.cpp
@@ -75,7 +75,7 @@ bool test_scene(int argc, char** argv) {
 
   // Iterate through all shapes and access each point.
   while (it != shapes.end()) {
-    boost::shared_ptr<typename Efficient_ransac::Shape> shape = *it;
+    std::shared_ptr<typename Efficient_ransac::Shape> shape = *it;
 
     // Sum distances of points to detected shapes.
     FT sum_distances = 0;

--- a/Shape_detection/test/Shape_detection/test_efficient_RANSAC_sphere_parameters.cpp
+++ b/Shape_detection/test/Shape_detection/test_efficient_RANSAC_sphere_parameters.cpp
@@ -70,7 +70,7 @@ bool test_sphere_parameters() {
     if (shapes.size() != 1)
       continue;
 
-    boost::shared_ptr<Sphere> sphere = boost::dynamic_pointer_cast<Sphere>((*shapes.first));
+    std::shared_ptr<Sphere> sphere = std::dynamic_pointer_cast<Sphere>((*shapes.first));
 
     // Check: shape detected is a cylinder.
     if (!sphere)

--- a/Shape_detection/test/Shape_detection/test_efficient_RANSAC_torus_parameters.cpp
+++ b/Shape_detection/test/Shape_detection/test_efficient_RANSAC_torus_parameters.cpp
@@ -72,8 +72,8 @@ bool test_torus_parameters() {
     if (shapes.size() != 1)
       continue;
 
-    boost::shared_ptr<Torus> torus =
-      boost::dynamic_pointer_cast<Torus>((*shapes.first));
+    std::shared_ptr<Torus> torus =
+      std::dynamic_pointer_cast<Torus>((*shapes.first));
 
     // Check: shape detected is a torus.
     if (!torus)

--- a/Straight_skeleton_2/benchmark/Straight_skeleton_2/compare_kernels_simple_polygon_skeleton.cpp
+++ b/Straight_skeleton_2/benchmark/Straight_skeleton_2/compare_kernels_simple_polygon_skeleton.cpp
@@ -10,7 +10,7 @@
 #include <CGAL/Straight_skeleton_2.h>
 #include <CGAL/Straight_skeleton_builder_traits_2.h>
 #include <CGAL/Straight_skeleton_builder_2.h>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <CGAL/gmp.h>
 #include <CGAL/Timer.h>
 
@@ -97,7 +97,7 @@ void build_skeleton(const char* fname)
   time.start();
   SsBuilder ssb;
   ssb.enter_contour(pgn.vertices_begin(), pgn.vertices_end());
-  boost::shared_ptr<Ss> straight_ske = ssb.construct_skeleton();
+  std::shared_ptr<Ss> straight_ske = ssb.construct_skeleton();
   time.stop();
 
   std::cout << "Time spent to build skeleton " << time.time() << "\n";

--- a/Straight_skeleton_2/benchmark/Straight_skeleton_2/create_exterior_skeleton.cpp
+++ b/Straight_skeleton_2/benchmark/Straight_skeleton_2/create_exterior_skeleton.cpp
@@ -1,6 +1,6 @@
 #include<vector>
 
-#include<boost/shared_ptr.hpp>
+#include<memory>
 
 #include<CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include<CGAL/Polygon_2.h>
@@ -13,8 +13,8 @@ typedef K::Point_2                   Point ;
 typedef CGAL::Polygon_2<K>           Polygon_2 ;
 typedef CGAL::Straight_skeleton_2<K> Ss ;
 
-typedef boost::shared_ptr<Polygon_2> PolygonPtr ;
-typedef boost::shared_ptr<Ss> SsPtr ;
+typedef std::shared_ptr<Polygon_2> PolygonPtr ;
+typedef std::shared_ptr<Ss> SsPtr ;
 
 typedef std::vector<PolygonPtr> PolygonPtrVector ;
 

--- a/Straight_skeleton_2/benchmark/Straight_skeleton_2/create_exterior_skeleton_tweaking_skeleton.cpp
+++ b/Straight_skeleton_2/benchmark/Straight_skeleton_2/create_exterior_skeleton_tweaking_skeleton.cpp
@@ -1,6 +1,6 @@
 #include<vector>
 
-#include<boost/shared_ptr.hpp>
+#include<memory>
 
 #include<CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include<CGAL/Polygon_2.h>
@@ -13,8 +13,8 @@ typedef CGAL::Polygon_2<K>           Polygon_2 ;
 typedef CGAL::Straight_skeleton_2<K> Ss ;
 typedef Ss::Halfedge_const_iterator Halfedge_const_iterator ;
 
-typedef boost::shared_ptr<Polygon_2> PolygonPtr ;
-typedef boost::shared_ptr<Ss> SsPtr ;
+typedef std::shared_ptr<Polygon_2> PolygonPtr ;
+typedef std::shared_ptr<Ss> SsPtr ;
 
 typedef std::vector<PolygonPtr> PolygonPtrVector ;
 

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/Polygon_offset_builder_2.h
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/Polygon_offset_builder_2.h
@@ -91,12 +91,12 @@ or external angle approaches `0`, numerical overflow may prevent some of the pol
 If that happens, the failed contour just won't be added into the resulting sequence.
 
 \tparam OutputIterator must be a model of the <I>OutputIterator</I> category whose `value_type`
-                       is a `boost::shared_ptr` holding the dynamically allocated instances of type `Container`.
+                       is a `std::shared_ptr` holding the dynamically allocated instances of type `Container`.
 
 \param t the offset value
 \param out an output iterator. For each resulting offset contour, a default constructed instance
            of `Container` type, is dynamically allocated and each offset vertex is added to it.
-           A `boost::shared_ptr` holding onto the dynamically allocated container is inserted
+           A `std::shared_ptr` holding onto the dynamically allocated container is inserted
            into the output sequence via the OutputIterator `out`.
 
 \returns an `OutputIterator` past-the-end of the resulting sequence, which contains each offset contour generated.

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/Straight_skeleton_builder_2.h
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/Straight_skeleton_builder_2.h
@@ -195,7 +195,7 @@ must be entered before calling `construct_skeleton()`.
 After `construct_skeleton()` completes, you cannot enter more contours and/or call `construct_skeleton()` again.
 If you need another straight skeleton for another polygon you must instantiate and use another builder.
 
-The result is a dynamically allocated instance of the `Ss` class, wrapped in a `boost::shared_ptr`.
+The result is a dynamically allocated instance of the `Ss` class, wrapped in a `std::shared_ptr`.
 
 If the construction process fails for whatever reason (such as a nearly-degenerate vertex whose internal
 or external angle is almost zero), the return value will be <I>null</I>, represented
@@ -204,7 +204,7 @@ by a default constructed `shared_ptr`.
 The algorithm automatically checks the consistency of the result, thus, if it is not <I>nullptr</I>,
 it is guaranteed to be valid.
 */
-boost::shared_ptr<Ss> construct_skeleton();
+std::shared_ptr<Ss> construct_skeleton();
 
 /// @}
 

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/Straight_skeleton_converter_2.h
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/Straight_skeleton_converter_2.h
@@ -14,7 +14,7 @@ using the items converter `ic` to convert the geometric embedding to the types o
 \sa `CGAL::Straight_skeleton_converter_2<SrcSs,TgtSs,ItemsCV>`
 */
 template <class Target_skeleton, class Source_skeleton, class Items_converter>
-boost::shared_ptr<Target_skeleton>
+std::shared_ptr<Target_skeleton>
 convert_straight_skeleton_2( Source_skeleton const& s,
                              Items_converted const& ic = Items_converter() );
 
@@ -77,7 +77,7 @@ Straight_skeleton_converter_2( const Items_converter& c = Items_converter() );
 /*!
 returns a new straight skeleton data structure with the same combinatorial and geometric data as `s` using the items converter to convert the geometric embeeding to the types of the target traits.
 */
-boost::shared_ptr<Target_skeleton> operator()( const Source_skeleton& s) const;
+std::shared_ptr<Target_skeleton> operator()( const Source_skeleton& s) const;
 
 /// @}
 

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/arrange_offset_polygons_2.h
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/arrange_offset_polygons_2.h
@@ -8,16 +8,16 @@ by `create_offset_polygons_2()` into 2D polygons with holes by determining geome
 relationships using a simple algorithm based on the particular characteristics of offset polygons.
 
 The function determines parent-hole relationships among the polygons given by `[begin,end]` creating
-`boost::shared_ptr< GeneralPolygonWithHoles_2 >` objects added to the output sequence given `out`.
+`std::shared_ptr< GeneralPolygonWithHoles_2 >` objects added to the output sequence given `out`.
 A `CLOCKWISE` oriented polygon `H` is a hole of a `COUNTERCLOCKWISE` polygon `P`, iff at least one vertex of `H` is `ON_BOUNDED_SIDE` of `P`.
 
 This function should not be used to arrange arbitrary polygons into polygons with holes unless they meet the requirements specified below.
 
 \tparam K must be a model of `Kernel`.
 \tparam InputPolygonPtrIterator must be a model of `InputIterator` whose `value_type` is a smart pointer
-(such as `boost::shared_ptr`) whose `element_type` is a model of `SequenceContainer` with value type `K::Point_2`.
+(such as `std::shared_ptr`) whose `element_type` is a model of `SequenceContainer` with value type `K::Point_2`.
 \tparam OutputPolygonWithHolesPtrIterator must be a model of `OutputIterator` whose `value_type` is a smart pointer
-(such as `boost::shared_ptr`) whose `element_type` is a model of `GeneralPolygonWithHoles_2`.
+(such as `std::shared_ptr`) whose `element_type` is a model of `GeneralPolygonWithHoles_2`.
 
 \pre The input polygons must be simple.
 \pre The set of input polygons are unique and interior disjoint. That is, given distinct polygons

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/create_offset_polygons_2.h
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/create_offset_polygons_2.h
@@ -25,7 +25,7 @@ of a polygon with holes, the offset polygons will be generated in its exterior.
 \sa `Polygon_offset_builder_2<Ss,Traits,Container>`
 */
 template<class OfKPolygon, class FT, class StraightSkeleton, class OfK>
-std::vector< boost::shared_ptr<OfKPolygon> >
+std::vector< std::shared_ptr<OfKPolygon> >
 create_offset_polygons_2 ( FT offset,
                            const StraightSkeleton& s,
                            OfK k = Exact_predicates_inexact_constructions_kernel ) ;
@@ -63,7 +63,7 @@ polygons to be constructed.
 \sa `Polygon_offset_builder_2<Ss,Traits,Container>`
 */
 template<class OfKPolygon, class FT, class InKPolygon, class OfK, class SsK>
-std::vector< boost::shared_ptr<OfKPolygon> >
+std::vector< std::shared_ptr<OfKPolygon> >
 create_exterior_skeleton_and_offset_polygons_2( FT offset,
                                                 const InKPolygon& poly,
                                                 OfK ofk = Exact_predicates_inexact_constructions_kernel,
@@ -100,7 +100,7 @@ and `create_offset_polygons_2()` instead.
 \sa `Polygon_offset_builder_2<Ss,Traits,Container>`
 */
 template<class OfKPolygon, class FT, class InKPolygon, class HoleIterator, class OfK, class SsK>
-std::vector< boost::shared_ptr<OfKPolygon> >
+std::vector< std::shared_ptr<OfKPolygon> >
 create_interior_skeleton_and_offset_polygons_2 ( FT offset,
                                                  const InKPolygon& outer_boundary,
                                                  HoleIterator holes_begin,
@@ -135,7 +135,7 @@ and `create_offset_polygons_2()` instead.
 \sa `Polygon_offset_builder_2<Ss,Traits,Container>`
 */
 template<class OfKPolygon, class FT, class InKPolygon, class OfK, class SsK>
-std::vector< boost::shared_ptr<OfKPolygon> >
+std::vector< std::shared_ptr<OfKPolygon> >
 create_interior_skeleton_and_offset_polygons_2 ( FT offset,
                                                  const InKPolygon& poly,
                                                  OfK ofk = CGAL::Exact_predicates_inexact_constructions_kernel,

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/create_offset_polygons_from_polygon_with_holes_2.h
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/create_offset_polygons_from_polygon_with_holes_2.h
@@ -25,7 +25,7 @@ This is equivalent to `arrange_offset_polygons_2(create_interior_skeleton_and_of
 \sa `Polygon_offset_builder_2<Ss,Traits,Container>`
 */
 template<class OfKPolygon, class FT, class InKPolygon, class OfK, class SsK>
-std::vector< boost::shared_ptr< OfKPolygon > >
+std::vector< std::shared_ptr< OfKPolygon > >
 create_interior_skeleton_and_offset_polygons_with_holes_2(FT offset,
                                                           const InKPolygon& poly_with_holes,
                                                           OfK ofk = CGAL::Exact_predicates_inexact_constructions_kernel,
@@ -59,7 +59,7 @@ This is equivalent to `arrange_offset_polygons_2(create_exterior_skeleton_and_of
 \sa `Polygon_offset_builder_2<Ss,Traits,Container>`
 */
 template<class OfKPolygon, class FT, class InKPolygon, class OfK, class SsK>
-std::vector<boost::shared_ptr<OfKPolygon> >
+std::vector<std::shared_ptr<OfKPolygon> >
 create_exterior_skeleton_and_offset_polygons_with_holes_2(FT offset,
                                                           const InKPolygon& poly_with_holes,
                                                           OfK ofk = Exact_predicates_inexact_constructions_kernel,

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/create_straight_skeleton_2.h
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/create_straight_skeleton_2.h
@@ -26,7 +26,7 @@ from this exterior skeleton, as computed by the function `compute_outer_frame_ma
 \sa `CGAL::Straight_skeleton_builder_2<Traits,Ss,Visitor>`
 */
 template<class FT, class PointIterator, class SsK>
-boost::shared_ptr< Straight_skeleton_2<SsK> >
+std::shared_ptr< Straight_skeleton_2<SsK> >
 create_exterior_straight_skeleton_2( FT max_offset,
                                      PointIterator vertices_begin,
                                      PointIterator vertices_end,
@@ -56,7 +56,7 @@ from this exterior skeleton, as computed by the function `compute_outer_frame_ma
 \sa `CGAL::Straight_skeleton_builder_2<Traits,Ss,Visitor>`
 */
 template<class FT, class Polygon, class SsK>
-boost::shared_ptr< Straight_skeleton_2<SsK> >
+std::shared_ptr< Straight_skeleton_2<SsK> >
 create_exterior_straight_skeleton_2 ( FT max_offset,
                                       const Polygon& P,
                                       SsK k = CGAL::Exact_predicates_inexact_constructions_kernel ) ;
@@ -82,7 +82,7 @@ holes given by `[holes_begin,holes_end]`.
 \sa `CGAL::Straight_skeleton_builder_2<Traits,Ss,Visitor>`
 */
 template<class PointIterator, class HoleIterator, class SsK>
-boost::shared_ptr< Straight_skeleton_2<SsK> >
+std::shared_ptr< Straight_skeleton_2<SsK> >
 create_interior_straight_skeleton_2 ( PointIterator outer_contour_vertices_begin,
                                       PointIterator outer_contour_vertices_end,
                                       HoleIterator holes_begin,
@@ -105,7 +105,7 @@ polygon whose outer boundary is given by the point sequence
 \sa `CGAL::Straight_skeleton_builder_2<Traits,Ss,Visitor>`
 */
 template<class PointIterator, class SsK>
-boost::shared_ptr< Straight_skeleton_2<SsK> >
+std::shared_ptr< Straight_skeleton_2<SsK> >
 create_interior_straight_skeleton_2 ( PointIterator outer_contour_vertices_begin,
                                       PointIterator outer_contour_vertices_end,
                                       SsK k = CGAL::Exact_predicates_inexact_constructions_kernel ) ;
@@ -127,7 +127,7 @@ polygon `outer_contour`.
 \sa `CGAL::Straight_skeleton_builder_2<Traits,Ss,Visitor>`
 */
 template<class Polygon, class SsK>
-boost::shared_ptr< Straight_skeleton_2<SsK> >
+std::shared_ptr< Straight_skeleton_2<SsK> >
 create_interior_straight_skeleton_2 ( const Polygon& outer_contour,
                                       SsK k = CGAL::Exact_predicates_inexact_constructions_kernel ) ;
 

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/Straight_skeleton_2.txt
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/Straight_skeleton_2.txt
@@ -368,11 +368,11 @@ To construct a set of inward offset contours the user must:
 
 (3) Call `Polygon_offset_builder_2::construct_offset_contours()` passing the desired offset
 distance and an output iterator that can store a
-`boost::shared_ptr` of `Container` instances
+`std::shared_ptr` of `Container` instances
 into a resulting sequence (typically, a back insertion iterator)
 
 Each element in the resulting sequence is an <I>offset contour</I>, given by
-a `boost::shared_ptr` holding a dynamically allocated instance
+a `std::shared_ptr` holding a dynamically allocated instance
 of the Container type. Such a container can be any model of the
 `SequenceContainer` concept, for example, a `CGAL::Polygon_2`,
 or just a `std::vector` of 2D points.

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/Create_offset_polygons_2.cpp
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/Create_offset_polygons_2.cpp
@@ -4,7 +4,7 @@
 #include <CGAL/create_offset_polygons_2.h>
 #include "print.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <vector>
 #include <cassert>
@@ -15,8 +15,8 @@ typedef K::Point_2                   Point ;
 typedef CGAL::Polygon_2<K>           Polygon_2 ;
 typedef CGAL::Straight_skeleton_2<K> Ss ;
 
-typedef boost::shared_ptr<Polygon_2> PolygonPtr ;
-typedef boost::shared_ptr<Ss> SsPtr ;
+typedef std::shared_ptr<Polygon_2> PolygonPtr ;
+typedef std::shared_ptr<Ss> SsPtr ;
 
 typedef std::vector<PolygonPtr> PolygonPtrVector ;
 

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/Create_saop_from_polygon_with_holes_2.cpp
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/Create_saop_from_polygon_with_holes_2.cpp
@@ -4,7 +4,7 @@
 #include <CGAL/create_offset_polygons_from_polygon_with_holes_2.h>
 #include "print.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <cassert>
 #include <vector>
@@ -16,8 +16,8 @@ typedef CGAL::Polygon_2<K>            Polygon_2 ;
 typedef CGAL::Polygon_with_holes_2<K> Polygon_with_holes ;
 typedef CGAL::Straight_skeleton_2<K>  Ss ;
 
-typedef boost::shared_ptr<Polygon_2> PolygonPtr ;
-typedef boost::shared_ptr<Ss> SsPtr ;
+typedef std::shared_ptr<Polygon_2> PolygonPtr ;
+typedef std::shared_ptr<Ss> SsPtr ;
 
 typedef std::vector<PolygonPtr> PolygonPtrVector ;
 

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/Create_skeleton_and_offset_polygons_2.cpp
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/Create_skeleton_and_offset_polygons_2.cpp
@@ -4,7 +4,7 @@
 #include <CGAL/create_offset_polygons_2.h>
 #include "print.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <cassert>
 #include <vector>
@@ -16,8 +16,8 @@ typedef K::Point_2                   Point ;
 typedef CGAL::Polygon_2<K>           Polygon_2 ;
 typedef CGAL::Straight_skeleton_2<K> Ss ;
 
-typedef boost::shared_ptr<Polygon_2> PolygonPtr ;
-typedef boost::shared_ptr<Ss> SsPtr ;
+typedef std::shared_ptr<Polygon_2> PolygonPtr ;
+typedef std::shared_ptr<Ss> SsPtr ;
 
 typedef std::vector<PolygonPtr> PolygonPtrVector ;
 

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/Create_skeleton_and_offset_polygons_with_holes_2.cpp
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/Create_skeleton_and_offset_polygons_with_holes_2.cpp
@@ -4,7 +4,7 @@
 #include <CGAL/create_offset_polygons_from_polygon_with_holes_2.h>
 #include "print.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <vector>
 #include <cassert>
@@ -15,7 +15,7 @@ typedef K::Point_2                    Point ;
 typedef CGAL::Polygon_2<K>            Polygon_2 ;
 typedef CGAL::Polygon_with_holes_2<K> PolygonWithHoles ;
 
-typedef boost::shared_ptr<PolygonWithHoles> PolygonWithHolesPtr ;
+typedef std::shared_ptr<PolygonWithHoles> PolygonWithHolesPtr ;
 
 typedef std::vector<PolygonWithHolesPtr> PolygonWithHolesPtrVector;
 

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/Create_straight_skeleton_2.cpp
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/Create_straight_skeleton_2.cpp
@@ -4,7 +4,7 @@
 #include<CGAL/create_straight_skeleton_2.h>
 #include "print.h"
 
-#include<boost/shared_ptr.hpp>
+#include<memory>
 
 #include <cassert>
 
@@ -14,7 +14,7 @@ typedef K::Point_2                   Point ;
 typedef CGAL::Polygon_2<K>           Polygon_2 ;
 typedef CGAL::Straight_skeleton_2<K> Ss ;
 
-typedef boost::shared_ptr<Ss> SsPtr ;
+typedef std::shared_ptr<Ss> SsPtr ;
 
 int main()
 {

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/Create_straight_skeleton_from_polygon_with_holes_2.cpp
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/Create_straight_skeleton_from_polygon_with_holes_2.cpp
@@ -4,7 +4,7 @@
 #include <CGAL/create_straight_skeleton_from_polygon_with_holes_2.h>
 #include "print.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <cassert>
 
@@ -15,7 +15,7 @@ typedef CGAL::Polygon_2<K>            Polygon_2 ;
 typedef CGAL::Polygon_with_holes_2<K> Polygon_with_holes ;
 typedef CGAL::Straight_skeleton_2<K>  Ss ;
 
-typedef boost::shared_ptr<Ss> SsPtr ;
+typedef std::shared_ptr<Ss> SsPtr ;
 
 int main()
 {

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/Low_level_API.cpp
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/Low_level_API.cpp
@@ -7,7 +7,7 @@
 #include <CGAL/compute_outer_frame_margin.h>
 #include "print.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <vector>
 #include <cassert>
@@ -22,7 +22,7 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 
 typedef Kernel::Point_2 Point_2;
 typedef CGAL::Polygon_2<Kernel>    Contour;
-typedef boost::shared_ptr<Contour> ContourPtr;
+typedef std::shared_ptr<Contour> ContourPtr;
 typedef std::vector<ContourPtr>    ContourSequence ;
 
 typedef CGAL::Straight_skeleton_2<Kernel> Ss;
@@ -97,7 +97,7 @@ int main()
     ssb.enter_contour(star.rbegin(),star.rend());
 
     // Construct the skeleton
-    boost::shared_ptr<Ss> ss = ssb.construct_skeleton();
+    std::shared_ptr<Ss> ss = ssb.construct_skeleton();
 
     // Proceed only if the skeleton was correctly constructed.
     if ( ss )

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/Show_offset_polygon.cpp
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/Show_offset_polygon.cpp
@@ -4,7 +4,7 @@
 #include <CGAL/create_offset_polygons_from_polygon_with_holes_2.h>
 #include "dump_to_eps.h"
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <cassert>
 #include <fstream>
@@ -16,7 +16,7 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel K ;
 
 typedef CGAL::Polygon_with_holes_2<K> Polygon_with_holes ;
 
-typedef boost::shared_ptr<Polygon_with_holes> Polygon_with_holes_ptr ;
+typedef std::shared_ptr<Polygon_with_holes> Polygon_with_holes_ptr ;
 
 typedef std::vector<Polygon_with_holes_ptr> Polygon_with_holes_ptr_vector ;
 

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/Show_straight_skeleton.cpp
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/Show_straight_skeleton.cpp
@@ -6,7 +6,7 @@
 #include <fstream>
 #include <cassert>
 
-#include<boost/shared_ptr.hpp>
+#include<memory>
 
 #include<CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include<CGAL/Polygon_with_holes_2.h>
@@ -21,7 +21,7 @@ typedef CGAL::Polygon_2<K>            Polygon_2 ;
 typedef CGAL::Polygon_with_holes_2<K> Polygon_with_holes ;
 typedef CGAL::Straight_skeleton_2<K>  Straight_skeleton ;
 
-typedef boost::shared_ptr<Straight_skeleton> Straight_skeleton_ptr ;
+typedef std::shared_ptr<Straight_skeleton> Straight_skeleton_ptr ;
 
 int main( int argc, char* argv[] )
 {

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/draw_straight_skeleton_2.cpp
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/draw_straight_skeleton_2.cpp
@@ -4,7 +4,7 @@
 #include <CGAL/create_straight_skeleton_2.h>
 #include <CGAL/draw_straight_skeleton_2.h>
 
-#include<boost/shared_ptr.hpp>
+#include<memory>
 
 #include <cassert>
 
@@ -14,7 +14,7 @@ typedef K::Point_2                   Point ;
 typedef CGAL::Polygon_2<K>           Polygon_2 ;
 typedef CGAL::Straight_skeleton_2<K> Ss ;
 
-typedef boost::shared_ptr<Ss> SsPtr ;
+typedef std::shared_ptr<Ss> SsPtr ;
 
 int main()
 {

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/dump_to_eps.h
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/dump_to_eps.h
@@ -84,11 +84,11 @@ void dump_to_eps( CGAL::Straight_skeleton_2<K> const& aSkeleton, char const* aTy
 
 template<class K, class C>
 void dump_to_eps ( CGAL::Polygon_with_holes_2<K,C> const&                                     aInput
-                 , std::vector< boost::shared_ptr< CGAL::Polygon_with_holes_2<K,C> > > const& aOutput
+                 , std::vector< std::shared_ptr< CGAL::Polygon_with_holes_2<K,C> > > const& aOutput
                  , std::ostream&                                                            rOut
                  )
 {
-  typedef std::vector< boost::shared_ptr< CGAL::Polygon_with_holes_2<K,C> > > PolyWH_vector ;
+  typedef std::vector< std::shared_ptr< CGAL::Polygon_with_holes_2<K,C> > > PolyWH_vector ;
 
   CGAL::Bbox_2 lBbox = CGAL::bbox_2(aInput);
 

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/print.h
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/print.h
@@ -21,9 +21,9 @@ void print_polygon ( CGAL::Polygon_2<K,C> const& poly )
 }
 
 template<class K, class C>
-void print_polygons ( std::vector< boost::shared_ptr< CGAL::Polygon_2<K,C> > > const& polies )
+void print_polygons ( std::vector< std::shared_ptr< CGAL::Polygon_2<K,C> > > const& polies )
 {
-  typedef std::vector< boost::shared_ptr< CGAL::Polygon_2<K,C> > > PolygonVector ;
+  typedef std::vector< std::shared_ptr< CGAL::Polygon_2<K,C> > > PolygonVector ;
 
   std::cout << "Polygon list with " << polies.size() << " polygons" << std::endl ;
 
@@ -45,10 +45,10 @@ void print_polygon_with_holes ( CGAL::Polygon_with_holes_2<K,C> const& polywh )
 }
 
 template<class K, class C>
-void print_polygons_with_holes ( std::vector< boost::shared_ptr< CGAL::Polygon_with_holes_2<K,C> > > const& polies )
+void print_polygons_with_holes ( std::vector< std::shared_ptr< CGAL::Polygon_with_holes_2<K,C> > > const& polies )
 {
 
-  typedef std::vector< boost::shared_ptr< CGAL::Polygon_with_holes_2<K,C> > > PolygonWithHolesVector ;
+  typedef std::vector< std::shared_ptr< CGAL::Polygon_with_holes_2<K,C> > > PolygonWithHolesVector ;
 
   std::cout << "Polygon_with_holes list with " << polies.size() << " element" << std::endl ;
 

--- a/Straight_skeleton_2/include/CGAL/Polygon_offset_builder_2.h
+++ b/Straight_skeleton_2/include/CGAL/Polygon_offset_builder_2.h
@@ -17,7 +17,7 @@
 #include <CGAL/Polygon_offset_builder_traits_2.h>
 
 #include <boost/optional/optional.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <vector>
 
@@ -71,7 +71,7 @@ public :
 
   typedef boost::optional<Point_2> OptionalPoint_2 ;
 
-  typedef boost::shared_ptr<Container> ContainerPtr ;
+  typedef std::shared_ptr<Container> ContainerPtr ;
 
   Polygon_offset_builder_2( Ss const& aSs, Traits const& aTraits = Traits(), Visitor const& aVisitor = Visitor() )  ;
 

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Polygon_iterators.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Polygon_iterators.h
@@ -15,7 +15,7 @@
 
 #include <CGAL/Polygon_with_holes_2.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 namespace CGAL {
 namespace CGAL_SS_i {
@@ -33,11 +33,11 @@ inline typename Poly::const_iterator vertices_end ( Poly const& aPoly )
 { return aPoly.end() ; }
 
 template<class Poly>
-inline typename Poly::const_iterator vertices_begin ( boost::shared_ptr<Poly> const& aPoly )
+inline typename Poly::const_iterator vertices_begin ( std::shared_ptr<Poly> const& aPoly )
 { return aPoly->begin() ; }
 
 template<class Poly>
-inline typename Poly::const_iterator vertices_end ( boost::shared_ptr<Poly> const& aPoly )
+inline typename Poly::const_iterator vertices_end ( std::shared_ptr<Poly> const& aPoly )
 { return aPoly->end() ; }
 
 // Polygon_2
@@ -52,11 +52,11 @@ vertices_end( Polygon_2<K,C> const& aPoly )
 { return aPoly.vertices_end() ; }
 
 template<class K, class C>
-inline typename Polygon_2<K,C>::Vertex_const_iterator vertices_begin ( boost::shared_ptr<Polygon_2<K,C> > const& aPoly )
+inline typename Polygon_2<K,C>::Vertex_const_iterator vertices_begin ( std::shared_ptr<Polygon_2<K,C> > const& aPoly )
 { return aPoly->vertices_begin() ; }
 
 template<class K, class C>
-inline typename Polygon_2<K,C>::Vertex_const_iterator vertices_end( boost::shared_ptr<Polygon_2<K,C> > const& aPoly )
+inline typename Polygon_2<K,C>::Vertex_const_iterator vertices_end( std::shared_ptr<Polygon_2<K,C> > const& aPoly )
 { return aPoly->vertices_end() ; }
 
 // Polygon_with_holes_2
@@ -72,12 +72,12 @@ vertices_end( Polygon_with_holes_2<K,C> const& aPoly )
 
 template<class K, class C>
 inline typename Polygon_with_holes_2<K,C>::Polygon_2::Vertex_const_iterator
-vertices_begin ( boost::shared_ptr<Polygon_with_holes_2<K,C> > const& aPoly )
+vertices_begin ( std::shared_ptr<Polygon_with_holes_2<K,C> > const& aPoly )
 { return aPoly->outer_boundary().vertices_begin() ; }
 
 template<class K, class C>
 inline typename Polygon_with_holes_2<K,C>::Polygon_2::Vertex_const_iterator
-vertices_end( boost::shared_ptr<Polygon_with_holes_2<K,C> > const& aPoly )
+vertices_end( std::shared_ptr<Polygon_with_holes_2<K,C> > const& aPoly )
 { return aPoly->outer_boundary().vertices_end() ; }
 
 } // namespace CGAL_SS_i

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_builder_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_builder_2.h
@@ -24,7 +24,7 @@
 
 #include <boost/tuple/tuple.hpp>
 #include <boost/intrusive_ptr.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <boost/scoped_ptr.hpp>
 #include <boost/mpl/bool.hpp>
 
@@ -111,7 +111,7 @@ public:
   typedef SSkel_   SSkel ;
   typedef Visitor_ Visitor ;
 
-  typedef boost::shared_ptr<SSkel> SSkelPtr ;
+  typedef std::shared_ptr<SSkel> SSkelPtr ;
 
 private :
 

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_converter_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_converter_2.h
@@ -18,7 +18,7 @@
 #include <CGAL/assertions.h>
 #include <CGAL/Cartesian_converter.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <vector>
 
@@ -88,7 +88,7 @@ struct Straight_skeleton_converter_2
   typedef typename Source_skeleton::Traits Source_traits ;
   typedef typename Target_skeleton::Traits Target_traits ;
 
-  typedef boost::shared_ptr<Target_skeleton> Target_skeleton_ptr ;
+  typedef std::shared_ptr<Target_skeleton> Target_skeleton_ptr ;
 
   typedef typename Source_skeleton::Vertex_const_iterator   Source_vertex_const_iterator ;
   typedef typename Source_skeleton::Halfedge_const_iterator Source_halfedge_const_iterator ;
@@ -270,7 +270,7 @@ private :
 } ;
 
 template<class Target_skeleton, class Source_skeleton, class Items_converter>
-boost::shared_ptr<Target_skeleton>
+std::shared_ptr<Target_skeleton>
 convert_straight_skeleton_2 ( Source_skeleton const& aSrc, Items_converter const& ic )
 {
   typedef Straight_skeleton_converter_2<Source_skeleton,Target_skeleton,Items_converter> Skeleton_converter ;
@@ -282,7 +282,7 @@ convert_straight_skeleton_2 ( Source_skeleton const& aSrc, Items_converter const
 }
 
 template<class Target_skeleton, class Source_skeleton>
-boost::shared_ptr<Target_skeleton>
+std::shared_ptr<Target_skeleton>
 convert_straight_skeleton_2 ( Source_skeleton const& aSrc )
 {
   typedef Straight_skeleton_items_converter_2<Source_skeleton,Target_skeleton> Items_converter ;

--- a/Straight_skeleton_2/include/CGAL/arrange_offset_polygons_2.h
+++ b/Straight_skeleton_2/include/CGAL/arrange_offset_polygons_2.h
@@ -20,7 +20,7 @@
 #include <CGAL/Polygon_with_holes_2.h>
 
 #include <boost/range/value_type.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <algorithm>
 #include <iostream>
@@ -52,7 +52,7 @@ bool arrange_offset_polygons_2 ( InputPolygonPtrIterator           aBegin
   typedef typename std::iterator_traits<InputPolygonPtrIterator>::difference_type difference_type ;
   typedef typename std::iterator_traits<InputPolygonPtrIterator>::value_type PolygonPtr ;
 
-  typedef boost::shared_ptr<PolygonWithHoles> PolygonWithHolesPtr ;
+  typedef std::shared_ptr<PolygonWithHoles> PolygonWithHolesPtr ;
 
   difference_type lSize = std::distance(aBegin,aEnd);
 
@@ -112,18 +112,18 @@ bool arrange_offset_polygons_2 ( InputPolygonPtrIterator           aBegin
 }
 
 template<class PolygonWithHoles, class Polygon>
-std::vector< boost::shared_ptr<PolygonWithHoles> >
+std::vector< std::shared_ptr<PolygonWithHoles> >
 inline
-arrange_offset_polygons_2 ( std::vector<boost::shared_ptr<Polygon> > const& aPolygons,
+arrange_offset_polygons_2 ( std::vector<std::shared_ptr<Polygon> > const& aPolygons,
                             bool& no_error)
 {
-  typedef std::vector< boost::shared_ptr<PolygonWithHoles> > result_type ;
+  typedef std::vector< std::shared_ptr<PolygonWithHoles> > result_type ;
   typedef std::back_insert_iterator<result_type> Back_inserter;
 
   typedef typename PolygonWithHoles::General_polygon_2 Polygon_2 ;
   typedef typename Kernel_traits<typename boost::range_value<Polygon_2>::type>::Kernel K ;
 
-  typedef typename std::vector<boost::shared_ptr<Polygon> >::const_iterator PolygonIterator ;
+  typedef typename std::vector<std::shared_ptr<Polygon> >::const_iterator PolygonIterator ;
 
   result_type rResult ;
   no_error = arrange_offset_polygons_2<K, PolygonIterator, Back_inserter, PolygonWithHoles>(
@@ -133,9 +133,9 @@ arrange_offset_polygons_2 ( std::vector<boost::shared_ptr<Polygon> > const& aPol
 }
 
 template<class PolygonWithHoles, class Polygon>
-std::vector< boost::shared_ptr<PolygonWithHoles> >
+std::vector< std::shared_ptr<PolygonWithHoles> >
 inline
-arrange_offset_polygons_2 ( std::vector<boost::shared_ptr<Polygon> > const& aPolygons)
+arrange_offset_polygons_2 ( std::vector<std::shared_ptr<Polygon> > const& aPolygons)
 {
   bool no_error;
   return arrange_offset_polygons_2<PolygonWithHoles>(aPolygons, no_error);

--- a/Straight_skeleton_2/include/CGAL/create_offset_polygons_2.h
+++ b/Straight_skeleton_2/include/CGAL/create_offset_polygons_2.h
@@ -30,7 +30,7 @@
 
 #include <boost/optional/optional.hpp>
 #include <boost/range/value_type.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <algorithm>
 #include <iostream>
@@ -103,7 +103,7 @@ struct Default_return_polygon_with_holes_type<Polygon, OfK, false> // Polygon ty
 };
 
 template<class FT, class PointIterator, class HoleIterator, class K>
-boost::shared_ptr< Straight_skeleton_2<K> >
+std::shared_ptr< Straight_skeleton_2<K> >
 create_partial_interior_straight_skeleton_2 ( FT const&     aMaxTime
                                             , PointIterator aOuterContour_VerticesBegin
                                             , PointIterator aOuterContour_VerticesEnd
@@ -139,7 +139,7 @@ create_partial_interior_straight_skeleton_2 ( FT const&     aMaxTime
 }
 
 template<class FT, class PointIterator, class K>
-boost::shared_ptr< Straight_skeleton_2<K> >
+std::shared_ptr< Straight_skeleton_2<K> >
 create_partial_exterior_straight_skeleton_2 ( FT const&      aMaxOffset
                                             , PointIterator  aVerticesBegin
                                             , PointIterator  aVerticesEnd
@@ -152,7 +152,7 @@ create_partial_exterior_straight_skeleton_2 ( FT const&      aMaxOffset
   typedef typename Kernel_traits<Point_2>::Kernel                    IK;
   typedef typename IK::FT                                            IFT;
 
-  boost::shared_ptr<Straight_skeleton_2<K> > rSkeleton;
+  std::shared_ptr<Straight_skeleton_2<K> > rSkeleton;
 
   // That's because we might not have FT == IK::FT (e.g. `double` and `Core`)
   // Note that we can also have IK != K (e.g. `Simple_cartesian<Core>` and `EPICK`)
@@ -199,10 +199,10 @@ create_partial_exterior_straight_skeleton_2 ( FT const&      aMaxOffset
 // Kernel != Skeleton::kernel. The skeleton is converted to Straight_skeleton_2<Kernel>
 //
 template<class OutPolygon, class FT, class Skeleton, class K>
-std::vector< boost::shared_ptr<OutPolygon> >
+std::vector< std::shared_ptr<OutPolygon> >
 create_offset_polygons_2 ( FT const& aOffset, Skeleton const& aSs, K const& , Tag_false )
 {
-  typedef boost::shared_ptr<OutPolygon> OutPolygonPtr ;
+  typedef std::shared_ptr<OutPolygon> OutPolygonPtr ;
   typedef std::vector<OutPolygonPtr>    OutPolygonPtrVector ;
 
   typedef Straight_skeleton_2<K> OfSkeleton ;
@@ -212,7 +212,7 @@ create_offset_polygons_2 ( FT const& aOffset, Skeleton const& aSs, K const& , Ta
 
   OutPolygonPtrVector rR ;
 
-  boost::shared_ptr<OfSkeleton> lConvertedSs = convert_straight_skeleton_2<OfSkeleton>(aSs);
+  std::shared_ptr<OfSkeleton> lConvertedSs = convert_straight_skeleton_2<OfSkeleton>(aSs);
   OffsetBuilder ob( *lConvertedSs );
   ob.construct_offset_contours(aOffset, std::back_inserter(rR) ) ;
 
@@ -223,10 +223,10 @@ create_offset_polygons_2 ( FT const& aOffset, Skeleton const& aSs, K const& , Ta
 // Kernel == Skeleton::kernel, no conversion
 //
 template<class OutPolygon, class FT, class Skeleton, class K>
-std::vector< boost::shared_ptr<OutPolygon> >
+std::vector< std::shared_ptr<OutPolygon> >
 create_offset_polygons_2 ( FT const& aOffset, Skeleton const& aSs, K const& /*k*/, Tag_true )
 {
-  typedef boost::shared_ptr<OutPolygon> OutPolygonPtr ;
+  typedef std::shared_ptr<OutPolygon> OutPolygonPtr ;
   typedef std::vector<OutPolygonPtr>    OutPolygonPtrVector ;
 
   typedef Polygon_offset_builder_traits_2<K>                                OffsetBuilderTraits;
@@ -242,7 +242,7 @@ create_offset_polygons_2 ( FT const& aOffset, Skeleton const& aSs, K const& /*k*
 
 // Allow failure due to invalid straight skeletons to go through the users
 template<class Skeleton>
-Skeleton const& dereference ( boost::shared_ptr<Skeleton> const& ss )
+Skeleton const& dereference ( std::shared_ptr<Skeleton> const& ss )
 {
   CGAL_precondition(ss.get() != 0);
   return *ss;
@@ -251,7 +251,7 @@ Skeleton const& dereference ( boost::shared_ptr<Skeleton> const& ss )
 } // namespace CGAL_SS_i
 
 template<class OutPolygon, class FT, class Skeleton, class K>
-std::vector< boost::shared_ptr<OutPolygon> >
+std::vector< std::shared_ptr<OutPolygon> >
 inline
 create_offset_polygons_2(const FT& aOffset,
                          const Skeleton& aSs,
@@ -263,7 +263,7 @@ create_offset_polygons_2(const FT& aOffset,
 
 template<class Polygon = Polygon_2<Exact_predicates_inexact_constructions_kernel>,
          class FT, class Skeleton>
-std::vector< boost::shared_ptr<Polygon> >
+std::vector< std::shared_ptr<Polygon> >
 inline
 create_offset_polygons_2(const FT& aOffset,
                          const Skeleton& aSs)
@@ -278,7 +278,7 @@ create_offset_polygons_2(const FT& aOffset,
 
 template<class FT, class APolygon, class HoleIterator, class OfK, class SsK,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<APolygon, OfK>::type>
-std::vector< boost::shared_ptr<OutPolygon> >
+std::vector< std::shared_ptr<OutPolygon> >
 inline
 create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                const APolygon& aOuterBoundary,
@@ -302,7 +302,7 @@ create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
 
 template<class FT, class APolygon, class HoleIterator, class OfK,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<APolygon, OfK>::type>
-std::vector< boost::shared_ptr<OutPolygon> >
+std::vector< std::shared_ptr<OutPolygon> >
 inline
 create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                const APolygon& aOuterBoundary,
@@ -319,7 +319,7 @@ create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
 // Overload where Polygon actually is a simple polygon (no holes)
 template<class FT, class APolygon, class OfK, class SsK,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<APolygon, OfK>::type>
-std::vector< boost::shared_ptr<OutPolygon> >
+std::vector< std::shared_ptr<OutPolygon> >
 inline
 create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                const APolygon& aPoly,
@@ -337,7 +337,7 @@ create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
 // Overloads common to both polygons with and without holes, a simple polygon is returned in any case
 template<class FT, class APolygon, class OfK,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<APolygon, OfK>::type>
-std::vector<boost::shared_ptr<OutPolygon> >
+std::vector<std::shared_ptr<OutPolygon> >
 inline
 create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                const APolygon& aPoly,
@@ -350,7 +350,7 @@ create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
 template<class FT, class APolygon,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<
                               APolygon, Exact_predicates_inexact_constructions_kernel>::type>
-std::vector<boost::shared_ptr<OutPolygon> >
+std::vector<std::shared_ptr<OutPolygon> >
 inline
 create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                const APolygon& aPoly)
@@ -369,7 +369,7 @@ create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
 // Overload where Polygon actually is a simple polygon (no holes)
 template<class FT, class APolygon, class OfK, class SsK,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<APolygon, OfK>::type>
-std::vector< boost::shared_ptr<OutPolygon> >
+std::vector< std::shared_ptr<OutPolygon> >
 inline
 create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                const APolygon& aPoly,
@@ -392,7 +392,7 @@ create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
 // Overloads common to both polygons with and without holes, a simple polygon is returned in any case
 template<class FT, class APolygon, class OfK,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<APolygon, OfK>::type>
-std::vector< boost::shared_ptr<OutPolygon> >
+std::vector< std::shared_ptr<OutPolygon> >
 inline
 create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                const APolygon& aPoly,
@@ -405,7 +405,7 @@ create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
 template<class FT, class APolygon,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<
                               APolygon, Exact_predicates_inexact_constructions_kernel>::type>
-std::vector< boost::shared_ptr<OutPolygon> >
+std::vector< std::shared_ptr<OutPolygon> >
 inline
 create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                const APolygon& aPoly)

--- a/Straight_skeleton_2/include/CGAL/create_offset_polygons_from_polygon_with_holes_2.h
+++ b/Straight_skeleton_2/include/CGAL/create_offset_polygons_from_polygon_with_holes_2.h
@@ -21,7 +21,7 @@
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <type_traits>
 #include <vector>
@@ -38,7 +38,7 @@ namespace CGAL {
 // overload where PolygonWithHoles actually is a type of Polygon that supports holes
 template<class FT, class PolygonWithHoles, class OfK, class SsK,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<PolygonWithHoles, OfK>::type> // Hole-less polygon type
-std::vector<boost::shared_ptr<OutPolygon> >
+std::vector<std::shared_ptr<OutPolygon> >
 inline
 create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                const PolygonWithHoles& aPoly,
@@ -57,7 +57,7 @@ create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
 // Polygon might be a Polygon with holes or not, but it returns a Polygon with holes
 template<class FT, class Polygon, class OfK, class SsK,
          class OutPolygonWithHoles = typename CGAL_SS_i::Default_return_polygon_with_holes_type<Polygon, OfK>::type>
-std::vector<boost::shared_ptr<OutPolygonWithHoles> >
+std::vector<std::shared_ptr<OutPolygonWithHoles> >
 inline
 create_interior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
                                                           const Polygon& aPoly,
@@ -70,7 +70,7 @@ create_interior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
 
 template<class FT, class Polygon, class OfK,
          class OutPolygonWithHoles = typename CGAL_SS_i::Default_return_polygon_with_holes_type<Polygon, OfK>::type>
-std::vector<boost::shared_ptr<OutPolygonWithHoles> >
+std::vector<std::shared_ptr<OutPolygonWithHoles> >
 inline
 create_interior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
                                                           const Polygon& aPoly,
@@ -83,7 +83,7 @@ create_interior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
 template<class FT, class Polygon,
          class OutPolygonWithHoles = typename CGAL_SS_i::Default_return_polygon_with_holes_type<
                                        Polygon, Exact_predicates_inexact_constructions_kernel>::type>
-std::vector<boost::shared_ptr<OutPolygonWithHoles> >
+std::vector<std::shared_ptr<OutPolygonWithHoles> >
 inline
 create_interior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
                                                           const Polygon& aPoly)
@@ -102,7 +102,7 @@ create_interior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
 // overload where PolygonWithHoles actually is a type of Polygon that supports holes
 template<class FT, class PolygonWithHoles, class OfK, class SsK,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<PolygonWithHoles, OfK>::type>
-std::vector<boost::shared_ptr<OutPolygon> >
+std::vector<std::shared_ptr<OutPolygon> >
 inline
 create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                const PolygonWithHoles& aPoly,
@@ -119,7 +119,7 @@ create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
 // Polygon might be a Polygon with holes or not, but it returns a Polygon with holes
 template<class FT, class Polygon, class OfK, class SsK,
          class OutPolygonWithHoles = typename CGAL_SS_i::Default_return_polygon_with_holes_type<Polygon, OfK>::type>
-std::vector<boost::shared_ptr<OutPolygonWithHoles> >
+std::vector<std::shared_ptr<OutPolygonWithHoles> >
 inline
 create_exterior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
                                                           const Polygon& aPoly,
@@ -132,7 +132,7 @@ create_exterior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
 
 template<class FT, class Polygon, class OfK,
          class OutPolygonWithHoles = typename CGAL_SS_i::Default_return_polygon_with_holes_type<Polygon, OfK>::type>
-std::vector<boost::shared_ptr<OutPolygonWithHoles> >
+std::vector<std::shared_ptr<OutPolygonWithHoles> >
 inline
 create_exterior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
                                                           const Polygon& aPoly,
@@ -145,7 +145,7 @@ create_exterior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
 template<class FT, class Polygon,
          class OutPolygonWithHoles = typename CGAL_SS_i::Default_return_polygon_with_holes_type<
                                     Polygon, Exact_predicates_inexact_constructions_kernel>::type>
-std::vector<boost::shared_ptr<OutPolygonWithHoles> >
+std::vector<std::shared_ptr<OutPolygonWithHoles> >
 inline
 create_exterior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
                                                           const Polygon& aPoly)

--- a/Straight_skeleton_2/include/CGAL/create_straight_skeleton_2.h
+++ b/Straight_skeleton_2/include/CGAL/create_straight_skeleton_2.h
@@ -22,7 +22,7 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <boost/optional/optional.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <algorithm>
 #include <iterator>
@@ -31,7 +31,7 @@
 namespace CGAL {
 
 template<class PointIterator, class HoleIterator, class K>
-boost::shared_ptr< Straight_skeleton_2<K> >
+std::shared_ptr< Straight_skeleton_2<K> >
 create_interior_straight_skeleton_2 ( PointIterator aOuterContour_VerticesBegin
                                     , PointIterator aOuterContour_VerticesEnd
                                     , HoleIterator  aHolesBegin
@@ -61,7 +61,7 @@ create_interior_straight_skeleton_2 ( PointIterator aOuterContour_VerticesBegin
 }
 
 template<class PointIterator, class HoleIterator>
-boost::shared_ptr< Straight_skeleton_2< Exact_predicates_inexact_constructions_kernel > >
+std::shared_ptr< Straight_skeleton_2< Exact_predicates_inexact_constructions_kernel > >
 inline
 create_interior_straight_skeleton_2 ( PointIterator aOuterContour_VerticesBegin
                                     , PointIterator aOuterContour_VerticesEnd
@@ -78,7 +78,7 @@ create_interior_straight_skeleton_2 ( PointIterator aOuterContour_VerticesBegin
 }
 
 template<class PointIterator, class K>
-boost::shared_ptr< Straight_skeleton_2<K> >
+std::shared_ptr< Straight_skeleton_2<K> >
 inline
 create_interior_straight_skeleton_2 ( PointIterator aOuterContour_VerticesBegin
                                     , PointIterator aOuterContour_VerticesEnd
@@ -98,7 +98,7 @@ create_interior_straight_skeleton_2 ( PointIterator aOuterContour_VerticesBegin
 }
 
 template<class PointIterator>
-boost::shared_ptr< Straight_skeleton_2<Exact_predicates_inexact_constructions_kernel> >
+std::shared_ptr< Straight_skeleton_2<Exact_predicates_inexact_constructions_kernel> >
 inline
 create_interior_straight_skeleton_2 ( PointIterator aOuterContour_VerticesBegin
                                     , PointIterator aOuterContour_VerticesEnd
@@ -111,7 +111,7 @@ create_interior_straight_skeleton_2 ( PointIterator aOuterContour_VerticesBegin
 }
 
 template<class Polygon, class K>
-boost::shared_ptr< Straight_skeleton_2<K> >
+std::shared_ptr< Straight_skeleton_2<K> >
 inline
 create_interior_straight_skeleton_2 ( Polygon const& aOutContour,
                                       K const& k,
@@ -125,7 +125,7 @@ create_interior_straight_skeleton_2 ( Polygon const& aOutContour,
 }
 
 template<class Polygon>
-boost::shared_ptr< Straight_skeleton_2< Exact_predicates_inexact_constructions_kernel > >
+std::shared_ptr< Straight_skeleton_2< Exact_predicates_inexact_constructions_kernel > >
 inline
 create_interior_straight_skeleton_2 ( Polygon const& aOutContour )
 {
@@ -138,7 +138,7 @@ create_interior_straight_skeleton_2 ( Polygon const& aOutContour )
 /// EXTERIOR
 
 template<class FT, class PointIterator, class K>
-boost::shared_ptr< Straight_skeleton_2<K> >
+std::shared_ptr< Straight_skeleton_2<K> >
 create_exterior_straight_skeleton_2 ( FT const&      aMaxOffset
                                     , PointIterator  aVerticesBegin
                                     , PointIterator  aVerticesEnd
@@ -151,7 +151,7 @@ create_exterior_straight_skeleton_2 ( FT const&      aMaxOffset
   typedef typename Kernel_traits<Point_2>::Kernel                    IK;
   typedef typename IK::FT                                            IFT;
 
-  boost::shared_ptr<Straight_skeleton_2<K> > rSkeleton;
+  std::shared_ptr<Straight_skeleton_2<K> > rSkeleton;
 
   // That's because we might not have FT == IK::FT (e.g. `double` and `Core`)
   // Note that we can also have IK != K (e.g. `Simple_cartesian<Core>` and `EPICK`)
@@ -195,7 +195,7 @@ create_exterior_straight_skeleton_2 ( FT const&      aMaxOffset
 }
 
 template<class FT, class PointIterator>
-boost::shared_ptr< Straight_skeleton_2<Exact_predicates_inexact_constructions_kernel> >
+std::shared_ptr< Straight_skeleton_2<Exact_predicates_inexact_constructions_kernel> >
 inline
 create_exterior_straight_skeleton_2 ( FT const&      aMaxOffset
                                     , PointIterator  aVerticesBegin
@@ -210,7 +210,7 @@ create_exterior_straight_skeleton_2 ( FT const&      aMaxOffset
 }
 
 template<class FT, class Polygon, class K>
-boost::shared_ptr< Straight_skeleton_2<K> >
+std::shared_ptr< Straight_skeleton_2<K> >
 inline
 create_exterior_straight_skeleton_2 ( FT const& aMaxOffset, Polygon const& aPoly, K const& k )
 {
@@ -222,7 +222,7 @@ create_exterior_straight_skeleton_2 ( FT const& aMaxOffset, Polygon const& aPoly
 }
 
 template<class FT, class Polygon>
-boost::shared_ptr< Straight_skeleton_2<Exact_predicates_inexact_constructions_kernel> >
+std::shared_ptr< Straight_skeleton_2<Exact_predicates_inexact_constructions_kernel> >
 inline
 create_exterior_straight_skeleton_2 ( FT const& aMaxOffset, Polygon const& aPoly )
 {

--- a/Straight_skeleton_2/include/CGAL/create_straight_skeleton_from_polygon_with_holes_2.h
+++ b/Straight_skeleton_2/include/CGAL/create_straight_skeleton_from_polygon_with_holes_2.h
@@ -20,14 +20,14 @@
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <type_traits>
 
 namespace CGAL {
 
 template<class K, class Polygon>
-boost::shared_ptr< Straight_skeleton_2<K> >
+std::shared_ptr< Straight_skeleton_2<K> >
 inline
 create_interior_straight_skeleton_2 ( Polygon const& aPolyWithHoles,
                                       K const& k,

--- a/Straight_skeleton_2/test/Straight_skeleton_2/include/CGAL/test_offset_builder_types.h
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/include/CGAL/test_offset_builder_types.h
@@ -21,7 +21,7 @@
 #include <CGAL/compute_outer_frame_margin.h>
 #include <CGAL/HalfedgeDS_const_decorator.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <vector>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
@@ -29,10 +29,10 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef K::Point_2                    Point;
 typedef CGAL::Aff_transformation_2<K> Transformation;
 typedef std::vector<Point>            Polygon_2;
-typedef boost::shared_ptr<Polygon_2>  PolygonPtr;
+typedef std::shared_ptr<Polygon_2>  PolygonPtr;
 typedef CGAL::Segment_2<K>            Segment;
 typedef std::vector<PolygonPtr>       Region ;
-typedef boost::shared_ptr<Region>     RegionPtr ;
+typedef std::shared_ptr<Region>     RegionPtr ;
 typedef std::vector<RegionPtr>        Regions ;
 typedef std::vector<double>           Doubles ;
 
@@ -51,7 +51,7 @@ typedef Sls::Vertex_const_handle   Vertex_const_handle ;
 
 typedef CGAL::HalfedgeDS_const_decorator<Sls> Sls_const_decorator ;
 
-typedef boost::shared_ptr<Sls> SlsPtr ;
+typedef std::shared_ptr<Sls> SlsPtr ;
 
 #endif
 

--- a/Straight_skeleton_2/test/Straight_skeleton_2/include/CGAL/test_sls_builder_types.h
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/include/CGAL/test_sls_builder_types.h
@@ -20,7 +20,7 @@
 #include <CGAL/Polygon_offset_builder_2.h>
 #include <CGAL/HalfedgeDS_const_decorator.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <vector>
 
 //typedef CGAL::Simple_cartesian<double> K ;
@@ -30,10 +30,10 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef K::Point_2                    Point;
 typedef CGAL::Aff_transformation_2<K> Transformation;
 typedef std::vector<Point>            Polygon_2;
-typedef boost::shared_ptr<Polygon_2>  PolygonPtr;
+typedef std::shared_ptr<Polygon_2>  PolygonPtr;
 typedef CGAL::Segment_2<K>            Segment;
 typedef std::vector<PolygonPtr>       Region ;
-typedef boost::shared_ptr<Region>     RegionPtr ;
+typedef std::shared_ptr<Region>     RegionPtr ;
 typedef std::vector<RegionPtr>        Regions ;
 typedef std::vector<double>           Doubles ;
 
@@ -50,7 +50,7 @@ typedef Sls::Vertex_const_handle   Vertex_const_handle ;
 
 typedef CGAL::HalfedgeDS_const_decorator<Sls> Sls_const_decorator ;
 
-typedef boost::shared_ptr<Sls> SlsPtr ;
+typedef std::shared_ptr<Sls> SlsPtr ;
 
 #endif
 

--- a/Straight_skeleton_2/test/Straight_skeleton_2/include/CGAL/test_sls_types.h
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/include/CGAL/test_sls_types.h
@@ -24,7 +24,7 @@
 #include <CGAL/compute_outer_frame_margin.h>
 #include <CGAL/HalfedgeDS_const_decorator.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 #include <vector>
 
 #include <CGAL/Real_timer.h>
@@ -50,16 +50,16 @@ typedef std::vector<double>           Doubles ;
 
 typedef CGAL::Segment_2<IK>           ISegment;
 typedef std::vector<IPoint>           IPolygon;
-typedef boost::shared_ptr<IPolygon>   IPolygonPtr;
+typedef std::shared_ptr<IPolygon>   IPolygonPtr;
 typedef std::vector<IPolygonPtr>      IRegion ;
-typedef boost::shared_ptr<IRegion>    IRegionPtr ;
+typedef std::shared_ptr<IRegion>    IRegionPtr ;
 typedef std::vector<IRegionPtr>       IRegions ;
 
 typedef CGAL::Segment_2<OK>           OSegment;
 typedef std::vector<OPoint>           OPolygon;
-typedef boost::shared_ptr<OPolygon>   OPolygonPtr;
+typedef std::shared_ptr<OPolygon>   OPolygonPtr;
 typedef std::vector<OPolygonPtr>      ORegion ;
-typedef boost::shared_ptr<ORegion>    ORegionPtr ;
+typedef std::shared_ptr<ORegion>    ORegionPtr ;
 typedef std::vector<ORegionPtr>       ORegions ;
 
 typedef CGAL::Straight_skeleton_2<IK>                             ISls;
@@ -157,8 +157,8 @@ public:
 
 typedef CGAL::HalfedgeDS_const_decorator<ISls> Sls_const_decorator ;
 
-typedef boost::shared_ptr<ISls> ISlsPtr ;
-typedef boost::shared_ptr<OSls> OSlsPtr ;
+typedef std::shared_ptr<ISls> ISlsPtr ;
+typedef std::shared_ptr<OSls> OSlsPtr ;
 
 typedef CGAL::Straight_skeleton_items_converter_2<ISls,OSls> SlsItemsConverter ;
 

--- a/Straight_skeleton_2/test/Straight_skeleton_2/issue4533.cpp
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/issue4533.cpp
@@ -5,7 +5,7 @@
 #include "print.h"
 #include<CGAL/Polygon_2.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <cassert>
 
@@ -15,7 +15,7 @@ typedef K::Point_2                                                  Point;
 typedef CGAL::Polygon_2<K>                                          Polygon_2;
 typedef CGAL::Straight_skeleton_2<K>                                Ss;
 
-typedef boost::shared_ptr<Ss>                                       SsPtr;
+typedef std::shared_ptr<Ss>                                       SsPtr;
 
 int main()
 {

--- a/Straight_skeleton_2/test/Straight_skeleton_2/issue4684.cpp
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/issue4684.cpp
@@ -4,7 +4,7 @@
 #include<CGAL/create_offset_polygons_2.h>
 #include<CGAL/draw_straight_skeleton_2.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <iostream>
 #include <vector>
@@ -13,7 +13,7 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel     K;
 typedef K::Point_2                                              Point;
 
 typedef CGAL::Polygon_2<K>                                      Polygon_2;
-typedef boost::shared_ptr<Polygon_2>                            PolygonPtr;
+typedef std::shared_ptr<Polygon_2>                            PolygonPtr;
 
 void low_precision_run()
 {

--- a/Straight_skeleton_2/test/Straight_skeleton_2/print.h
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/print.h
@@ -24,9 +24,9 @@ void print_polygon ( CGAL::Polygon_2<K,C> const& poly )
 }
 
 template<class K, class C>
-void print_polygons ( std::vector< boost::shared_ptr< CGAL::Polygon_2<K,C> > > const& polies )
+void print_polygons ( std::vector< std::shared_ptr< CGAL::Polygon_2<K,C> > > const& polies )
 {
-  typedef std::vector< boost::shared_ptr< CGAL::Polygon_2<K,C> > > PolygonVector ;
+  typedef std::vector< std::shared_ptr< CGAL::Polygon_2<K,C> > > PolygonVector ;
 
   std::cout << "Polygon list with " << polies.size() << " polygons" << std::endl ;
 
@@ -48,10 +48,10 @@ void print_polygon_with_holes ( CGAL::Polygon_with_holes_2<K,C> const& polywh )
 }
 
 template<class K, class C>
-void print_polygons_with_holes ( std::vector< boost::shared_ptr< CGAL::Polygon_with_holes_2<K,C> > > const& polies )
+void print_polygons_with_holes ( std::vector< std::shared_ptr< CGAL::Polygon_with_holes_2<K,C> > > const& polies )
 {
 
-  typedef std::vector< boost::shared_ptr< CGAL::Polygon_with_holes_2<K,C> > > PolygonWithHolesVector ;
+  typedef std::vector< std::shared_ptr< CGAL::Polygon_with_holes_2<K,C> > > PolygonWithHolesVector ;
 
   std::cout << "Polygon_with_holes list with " << polies.size() << " element" << std::endl ;
 

--- a/Straight_skeleton_2/test/Straight_skeleton_2/test_sls_offset.cpp
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/test_sls_offset.cpp
@@ -36,7 +36,7 @@ void Straight_skeleton_traits_external_trace(std::string m)
 #include <CGAL/Polygon_2.h>
 #include <CGAL/draw_polygon_2.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <cassert>
 #include <iostream>
@@ -59,10 +59,10 @@ void test_API()
   Polygon_2 p;
   Polygon_with_holes_2 pwh;
 
-  std::vector< boost::shared_ptr<Polygon_2> > res;
-  std::vector< boost::shared_ptr<Polygon_2_EPICK> > res_EPICK;
-  std::vector< boost::shared_ptr<Polygon_with_holes_2> > res_w;
-  std::vector< boost::shared_ptr<Polygon_with_holes_2_EPICK> > res_w_EPICK;
+  std::vector< std::shared_ptr<Polygon_2> > res;
+  std::vector< std::shared_ptr<Polygon_2_EPICK> > res_EPICK;
+  std::vector< std::shared_ptr<Polygon_with_holes_2> > res_w;
+  std::vector< std::shared_ptr<Polygon_with_holes_2_EPICK> > res_w_EPICK;
 
   // First kernel is the offset construction (and thus output kernel), second kernel is the skeleton construction
 
@@ -134,7 +134,7 @@ void test_API()
 }
 
 template <typename K, typename StraightSkeleton>
-bool is_valid(const boost::shared_ptr<StraightSkeleton>& ss)
+bool is_valid(const std::shared_ptr<StraightSkeleton>& ss)
 {
   typedef typename StraightSkeleton::Traits::Point_2 Point;
 
@@ -175,7 +175,7 @@ void test_offset_square()
 
   typedef typename K::Point_2                                                  Point;
   typedef CGAL::Polygon_2<K>                                                   Polygon_2;
-  typedef boost::shared_ptr<Polygon_2>                                         Polygon_ptr;
+  typedef std::shared_ptr<Polygon_2>                                         Polygon_ptr;
   typedef std::vector<Polygon_ptr>                                             Polygon_ptr_container;
 
   typedef CGAL::Straight_skeleton_2<K>                                         Ss;
@@ -192,7 +192,7 @@ void test_offset_square()
   Skeleton_builder ssb;
   ssb.enter_contour(square.begin(), square.end());
 
-  boost::shared_ptr<Ss> ss = ssb.construct_skeleton();
+  std::shared_ptr<Ss> ss = ssb.construct_skeleton();
   assert(is_valid<K>(ss));
 
   Polygon_ptr_container offset_polys =
@@ -215,7 +215,7 @@ void test_offset_four_square_holes()
 
   typedef CGAL::Polygon_2<K>                                         Polygon_2;
   typedef CGAL::Polygon_with_holes_2<K>                              Polygon_with_holes_2;
-  typedef boost::shared_ptr<Polygon_with_holes_2>                    Polygon_with_holes_2_ptr;
+  typedef std::shared_ptr<Polygon_with_holes_2>                    Polygon_with_holes_2_ptr;
   typedef std::vector<Polygon_with_holes_2_ptr>                      Polygon_with_holes_2_ptr_container;
 
   Polygon_2 outer, hole1, hole2, hole3, hole4;
@@ -274,7 +274,7 @@ void test_offset_L()
 
   typedef typename K::Point_2                                                  Point;
   typedef CGAL::Polygon_2<K>                                                   Polygon_2;
-  typedef boost::shared_ptr<Polygon_2>                                         Polygon_ptr;
+  typedef std::shared_ptr<Polygon_2>                                         Polygon_ptr;
   typedef std::vector<Polygon_ptr>                                             Polygon_ptr_container;
 
   typedef CGAL::Straight_skeleton_2<K>                                         Ss;
@@ -295,7 +295,7 @@ void test_offset_L()
   Skeleton_builder ssb;
   ssb.enter_contour(L.begin(), L.end());
 
-  boost::shared_ptr<Ss> ss = ssb.construct_skeleton();
+  std::shared_ptr<Ss> ss = ssb.construct_skeleton();
   assert(is_valid<K>(ss));
 
   Polygon_ptr_container offset_polys =
@@ -319,7 +319,7 @@ void test_offset_polygon_with_hole()
 
   typedef CGAL::Polygon_2<K>                                         Polygon_2;
   typedef CGAL::Polygon_with_holes_2<K>                              Polygon_with_holes_2;
-  typedef boost::shared_ptr<Polygon_with_holes_2>                    Polygon_with_holes_2_ptr;
+  typedef std::shared_ptr<Polygon_with_holes_2>                    Polygon_with_holes_2_ptr;
   typedef std::vector<Polygon_with_holes_2_ptr>                      Polygon_with_holes_2_ptr_container;
 
   // Square with a non-centered square hole
@@ -408,7 +408,7 @@ void test_offset_pinched()
   typedef typename K::FT                                                       FT;
   typedef typename K::Point_2                                                  Point;
   typedef CGAL::Polygon_2<K>                                                   Polygon_2;
-  typedef boost::shared_ptr<Polygon_2>                                         Polygon_ptr;
+  typedef std::shared_ptr<Polygon_2>                                         Polygon_ptr;
   typedef std::vector<Polygon_ptr>                                             Polygon_ptrs;
 
   typedef CGAL::Straight_skeleton_2<K>                                         Ss;
@@ -446,7 +446,7 @@ void test_offset_pinched()
   Skeleton_builder ssb;
   ssb.enter_contour(input.begin(), input.end());
 
-  boost::shared_ptr<Ss> ss = ssb.construct_skeleton();
+  std::shared_ptr<Ss> ss = ssb.construct_skeleton();
   assert(is_valid<K>(ss));
 
   // The two splitting fronts meet in the middle, and at that time,
@@ -489,7 +489,7 @@ void test_offset_multiple_CCs()
   typedef typename K::FT                                                       FT;
   typedef typename K::Point_2                                                  Point_2;
   typedef CGAL::Polygon_2<K>                                                   Contour;
-  typedef boost::shared_ptr<Contour>                                           ContourPtr;
+  typedef std::shared_ptr<Contour>                                           ContourPtr;
   typedef std::vector<ContourPtr>                                              Contour_sequence;
 
   typedef CGAL::Straight_skeleton_2<K>                                         Ss;
@@ -541,7 +541,7 @@ void test_offset_multiple_CCs()
   ssb.enter_contour(frame, frame+4);
   ssb.enter_contour(input.rbegin(), input.rend());
 
-  boost::shared_ptr<Ss> ss = ssb.construct_skeleton();
+  std::shared_ptr<Ss> ss = ssb.construct_skeleton();
   assert(is_valid<K>(ss));
 
   Contour_sequence offset_contours;
@@ -563,7 +563,7 @@ void test_offset_non_manifold()
   typedef typename K::Point_2                                                  Point;
   typedef CGAL::Polygon_2<K>                                                   Polygon_2;
   typedef CGAL::Polygon_with_holes_2<K>                                        Polygon_with_holes_2;
-  typedef boost::shared_ptr<Polygon_with_holes_2>                              Polygon_with_holes_ptr;
+  typedef std::shared_ptr<Polygon_with_holes_2>                              Polygon_with_holes_ptr;
   typedef std::vector<Polygon_with_holes_ptr>                                  Polygon_with_holes_ptrs;
 
   typedef CGAL::Straight_skeleton_2<K>                                         Ss;
@@ -587,7 +587,7 @@ void test_offset_non_manifold()
   ssb.enter_contour(outer.begin(), outer.end());
   ssb.enter_contour(hole.begin(), hole.end());
 
-  boost::shared_ptr<Ss> ss = ssb.construct_skeleton();
+  std::shared_ptr<Ss> ss = ssb.construct_skeleton();
   assert(is_valid<K>(ss));
 
   // The two splitting fronts meet in the middle, and at that time,
@@ -646,7 +646,7 @@ void test_offset_non_manifold_2()
   typedef typename K::Point_2                                                  Point;
   typedef CGAL::Polygon_2<K>                                                   Polygon_2;
   typedef CGAL::Polygon_with_holes_2<K>                                        Polygon_with_holes_2;
-  typedef boost::shared_ptr<Polygon_with_holes_2>                              Polygon_with_holes_ptr;
+  typedef std::shared_ptr<Polygon_with_holes_2>                              Polygon_with_holes_ptr;
   typedef std::vector<Polygon_with_holes_ptr>                                  Polygon_with_holes_ptrs;
 
   typedef CGAL::Straight_skeleton_2<K>                                         Ss;
@@ -678,7 +678,7 @@ void test_offset_non_manifold_2()
   ssb.enter_contour(outer.begin(), outer.end());
   ssb.enter_contour(hole.begin(), hole.end());
 
-  boost::shared_ptr<Ss> ss = ssb.construct_skeleton();
+  std::shared_ptr<Ss> ss = ssb.construct_skeleton();
   assert(is_valid<K>(ss));
 
   // Similar to the previous function, a split event happens and at that particular time,
@@ -732,7 +732,7 @@ void test_offset_polygon_exterior()
 
   typedef CGAL::Polygon_2<K>                                         Polygon_2;
   typedef CGAL::Polygon_with_holes_2<K>                              Polygon_with_holes_2;
-  typedef boost::shared_ptr<Polygon_with_holes_2>                    Polygon_with_holes_2_ptr;
+  typedef std::shared_ptr<Polygon_with_holes_2>                    Polygon_with_holes_2_ptr;
   typedef std::vector<Polygon_with_holes_2_ptr>                      Polygon_with_holes_2_ptr_container;
 
   Polygon_2 poly;
@@ -819,7 +819,7 @@ void test_offset(const char* filename)
 
   typedef CGAL::Polygon_2<K>                                         Polygon_2;
   typedef CGAL::Polygon_with_holes_2<K>                              Polygon_with_holes_2;
-  typedef boost::shared_ptr<Polygon_with_holes_2>                    Polygon_with_holes_2_ptr;
+  typedef std::shared_ptr<Polygon_with_holes_2>                    Polygon_with_holes_2_ptr;
   typedef std::vector<Polygon_with_holes_2_ptr>                      Polygon_with_holes_2_ptr_container;
 
   typedef CGAL::Straight_skeleton_2<K>                               Ss;
@@ -884,7 +884,7 @@ void test_offset(const char* filename)
     ssb.enter_contour(polys[i+1].begin(), polys[i+1].end());
   }
 
-  boost::shared_ptr<Ss> ss = ssb.construct_skeleton();
+  std::shared_ptr<Ss> ss = ssb.construct_skeleton();
   assert(is_valid<K>(ss));
 
   std::set<FT> offset_times;

--- a/Straight_skeleton_2/test/Straight_skeleton_2/test_sls_simple.cpp
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/test_sls_simple.cpp
@@ -34,7 +34,7 @@ void Straight_skeleton_traits_external_trace(std::string m)
 #include <CGAL/Polygon_2.h>
 #include <CGAL/draw_polygon_2.h>
 
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 #include <cassert>
 #include <iostream>
@@ -53,10 +53,10 @@ void test_API()
   typedef CGAL::Polygon_with_holes_2<K>                              Polygon_with_holes_2;
 
   typedef CGAL::Straight_skeleton_2<EPICK>                           Straight_skeleton_EPICK;
-  typedef boost::shared_ptr<Straight_skeleton_EPICK>                 Straight_skeleton_Ptr_EPICK;
+  typedef std::shared_ptr<Straight_skeleton_EPICK>                 Straight_skeleton_Ptr_EPICK;
 
   typedef CGAL::Straight_skeleton_2<K>                               Straight_skeleton;
-  typedef boost::shared_ptr<Straight_skeleton>                       Straight_skeleton_Ptr;
+  typedef std::shared_ptr<Straight_skeleton>                       Straight_skeleton_Ptr;
 
   Polygon_2 p;
   Straight_skeleton_Ptr_EPICK ss0 = CGAL::create_interior_straight_skeleton_2(p);
@@ -72,7 +72,7 @@ void test_API()
 }
 
 template <typename K, typename StraightSkeleton>
-bool is_valid(const boost::shared_ptr<StraightSkeleton>& ss)
+bool is_valid(const std::shared_ptr<StraightSkeleton>& ss)
 {
   typedef typename StraightSkeleton::Traits::Point_2                 Point;
   typedef CGAL::Polygon_2<K>                                         Polygon_2;
@@ -136,7 +136,7 @@ void test_skeleton(const char* filename,
   typedef CGAL::Polygon_with_holes_2<K>                              Polygon_with_holes_2;
 
   typedef CGAL::Straight_skeleton_2<K>                               Straight_skeleton;
-  typedef boost::shared_ptr<Straight_skeleton>                       Straight_skeleton_Ptr;
+  typedef std::shared_ptr<Straight_skeleton>                       Straight_skeleton_Ptr;
 
   std::ifstream in(filename);
   assert(in);

--- a/Straight_skeleton_2/test/Straight_skeleton_2/test_straight_skeleton_copy.cpp
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/test_straight_skeleton_copy.cpp
@@ -1,6 +1,6 @@
 #include<vector>
 
-#include<boost/shared_ptr.hpp>
+#include<memory>
 
 #include<CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include<CGAL/Polygon_2.h>
@@ -12,8 +12,8 @@ typedef K::Point_2                   Point ;
 typedef CGAL::Polygon_2<K>           Polygon_2 ;
 typedef CGAL::Straight_skeleton_2<K> Ss ;
 
-typedef boost::shared_ptr<Polygon_2> PolygonPtr ;
-typedef boost::shared_ptr<Ss> SsPtr ;
+typedef std::shared_ptr<Polygon_2> PolygonPtr ;
+typedef std::shared_ptr<Ss> SsPtr ;
 
 typedef std::vector<PolygonPtr> PolygonPtrVector ;
 

--- a/Stream_support/include/CGAL/internal/Geometry_container.h
+++ b/Stream_support/include/CGAL/internal/Geometry_container.h
@@ -17,7 +17,7 @@
 #if BOOST_VERSION >= 105600 && (! defined(BOOST_GCC) || BOOST_GCC >= 40500)
 #include <boost/geometry/io/wkt/write.hpp>
 #include <boost/geometry/io/wkt/read.hpp>
-#include <boost/shared_ptr.hpp>
+#include <memory>
 
 struct Dummy_deleter{
   template<class T>
@@ -46,7 +46,7 @@ struct Geometry_container{
   typedef typename Range::const_reverse_iterator const_reverse_iterator;
   typedef typename Range::size_type size_type;
   typedef typename Range::value_type value_type;
-  boost::shared_ptr<Range>  range;
+  std::shared_ptr<Range>  range;
   bool must_delete;
   //
   // Default constructor.


### PR DESCRIPTION
Follow up of #5649 

Not sure how we should handle the deprecation of public API in that case so this PR