### PR TITLE
Fix uninitialized member in Ray_2_Segment_2.h

### DIFF
--- a/Intersections_2/include/CGAL/Intersections_2/Ray_2_Segment_2.h
+++ b/Intersections_2/include/CGAL/Intersections_2/Ray_2_Segment_2.h
@@ -37,10 +37,10 @@ namespace internal {
 template <class K>
 class Ray_2_Segment_2_pair {
 public:
-    enum Intersection_results {NO_INTERSECTION, POINT, SEGMENT};
+    enum Intersection_results {NOT_COMPUTED_YET, NO_INTERSECTION, POINT, SEGMENT};
     Ray_2_Segment_2_pair(typename K::Ray_2 const *ray,
                          typename K::Segment_2 const *seg)
-            : _ray(ray), _seg(seg), _known(false) {}
+            : _ray(ray), _seg(seg), _known(false), _result(NOT_COMPUTED_YET) {}
 
     Intersection_results intersection_type() const;
 


### PR DESCRIPTION
## Summary of Changes

Added NOT_COMPUTED_YET to enum (similar enum member is present in Line_2_Line_2.h, and #5194)

Fix uninitialized member (_result) in Ray_2_Segment_2.h

## Release Management

* Affected package(s): Intersections_2
* Issue(s) solved (if any): fix #5181
* Feature/Small Feature (if any): bugfix/static analysis
* License and copyright ownership: Returned to CGAL authors

