### PR TITLE
Fix uninitialized members in Edge_collapse.h

### DIFF
--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
@@ -425,7 +425,9 @@ EdgeCollapse(Triangle_mesh& tmesh,
     m_get_placement(get_placement),
     m_should_ignore(should_ignore),
     m_visitor(visitor),
-    m_has_border(!is_closed(tmesh))
+    m_has_border(!is_closed(tmesh)),
+    m_initial_edge_count(0),
+    m_current_edge_count(0)
 {
   m_max_dihedral_angle_squared_cos = CGAL::square(std::cos(1.0 * CGAL_PI / 180.0));
 


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized member (m_initial_edge_count, m_current_edge_count) in Edge_collapse.h

## Release Management

* Affected package(s): Surface Mesh Simplification
* Issue(s) solved (if any): fix #5181
* Feature/Small Feature (if any): bugfix / static analysis
* License and copyright ownership: Returned to CGAL authors.

