### PR TITLE
Fix uninitialized member in Generic_facegraph_printer.h

### DIFF
--- a/BGL/include/CGAL/boost/graph/IO/Generic_facegraph_printer.h
+++ b/BGL/include/CGAL/boost/graph/IO/Generic_facegraph_printer.h
@@ -85,7 +85,7 @@ class Generic_facegraph_printer
   typedef typename boost::graph_traits<Graph>::face_descriptor                     face_descriptor;
 
 public:
-  Generic_facegraph_printer(Stream& os) : m_os(os) { }
+  Generic_facegraph_printer(Stream& os) : m_os(os), m_writer{} { }
   Generic_facegraph_printer(Stream& os, FileWriter writer) : m_os(os), m_writer(writer) { }
 
   template <typename NamedParameters>


### PR DESCRIPTION
## Summary of Changes

Fix uninitialized member (m_writer) in Generic_facegraph_printer.h

## Release Management

* Affected package(s): BGL
* Issue(s) solved (if any): partial fix of #5181
* Feature/Small Feature (if any): bugfix / static analysis
* License and copyright ownership: Returned to CGAL authors. 

