### PR TITLE
Make `ToS2` compatible with `Voronoi_diagram_2`

### DIFF
--- a/Triangulation_on_sphere_2/include/CGAL/Delaunay_triangulation_on_sphere_2.h
+++ b/Triangulation_on_sphere_2/include/CGAL/Delaunay_triangulation_on_sphere_2.h
@@ -1051,7 +1051,7 @@ Delaunay_triangulation_on_sphere_2<Gt, Tds>::
 circumcenter_on_sphere(const Face_handle f) const
 {
   CGAL_precondition(dimension() == 2);
-  CGAL_precondition(!is_ghost(f));
+//  CGAL_precondition(!is_ghost(f));
 
   return circumcenter_on_sphere(point(f, 0), point(f, 1), point(f, 2));
 }
@@ -1062,7 +1062,7 @@ Delaunay_triangulation_on_sphere_2<Gt, Tds>::
 dual_on_sphere(const Face_handle f) const
 {
   CGAL_precondition(dimension() == 2);
-  CGAL_precondition(!is_ghost(f));
+//  CGAL_precondition(!is_ghost(f));
 
   return circumcenter_on_sphere(f);
 }
@@ -1073,7 +1073,7 @@ Delaunay_triangulation_on_sphere_2<Gt, Tds>::
 dual_on_sphere(const Edge& e) const
 {
   CGAL_precondition(dimension() == 2);
-  CGAL_precondition(!is_ghost(e));
+//  CGAL_precondition(!is_ghost(e));
 
   return geom_traits().construct_arc_on_sphere_2_object()(dual_on_sphere(e.first),
                                                           dual_on_sphere(e.first->neighbor(e.second)));

--- a/Triangulation_on_sphere_2/include/CGAL/Delaunay_triangulation_on_sphere_traits_2.h
+++ b/Triangulation_on_sphere_2/include/CGAL/Delaunay_triangulation_on_sphere_traits_2.h
@@ -305,6 +305,17 @@ public:
     initialize_bounds();
   }
 
+  friend void swap(Self& l, Self& r)
+  {
+    using std::swap;
+    swap(static_cast<LK&>(l), static_cast<LK&>(r));
+    swap(static_cast<SK&>(l), static_cast<SK&>(r));
+    swap(l._center, r._center);
+    swap(l._radius, r._radius);
+    l.initialize_bounds();
+    r.initialize_bounds();
+  }
+
 public:
   const LK& lk() const { return static_cast<const LK&>(*this); }
   const SK& sk() const { return static_cast<const SK&>(*this); }

--- a/Triangulation_on_sphere_2/include/CGAL/Triangulation_on_sphere_2.h
+++ b/Triangulation_on_sphere_2/include/CGAL/Triangulation_on_sphere_2.h
@@ -491,8 +491,9 @@ void
 Triangulation_on_sphere_2<Gt, Tds>::
 swap(Triangulation_on_sphere_2& tr)
 {
+  using std::swap;
   _tds.swap(tr._tds);
-  std::swap(tr.geom_traits(), geom_traits());
+  swap(_gt, tr._gt);
 }
 
 template <typename Gt, typename Tds>

--- a/Triangulation_on_sphere_2/include/CGAL/Triangulation_on_sphere_2.h
+++ b/Triangulation_on_sphere_2/include/CGAL/Triangulation_on_sphere_2.h
@@ -200,11 +200,22 @@ public:
     return is_contour(e.first, e.second);
   }
 
+  template<class T>
+  bool is_infinite(const T&, int = 0) const
+  {
+    return false;
+  }
+
   //-----------------------TRAVERSING : ITERATORS AND CIRCULATORS-----------------------------------
 
   typedef typename Tds::Vertex_iterator           Vertices_iterator;
+  typedef typename Tds::Vertex_iterator           All_vertices_iterator;
   typedef typename Tds::Edge_iterator             All_edges_iterator;
   typedef typename Tds::Face_iterator             All_faces_iterator;
+
+  typedef typename Tds::Vertex_iterator           Finite_vertices_iterator;
+  typedef typename Tds::Edge_iterator             Finite_edges_iterator;
+  typedef typename Tds::Face_iterator             Finite_faces_iterator;
 
   typedef typename Tds::Vertex_circulator         Vertex_circulator;
   typedef typename Tds::Edge_circulator           Edge_circulator;
@@ -267,14 +278,18 @@ public:
   typedef boost::transform_iterator<Pt_proj, Vertices_iterator>      Point_iterator;
   typedef Iterator_range<Point_iterator>                             Points;
 
+  // -- faces
   All_faces_iterator all_faces_begin() const { return _tds.faces_begin(); }
   All_faces_iterator all_faces_end() const { return _tds.faces_end(); }
+  Finite_faces_iterator finite_faces_begin() const { return _tds.faces_begin(); }
+  Finite_faces_iterator finite_faces_end() const { return _tds.faces_end(); }
 
   All_face_handles all_face_handles() const
   {
     return make_prevent_deref_range(all_faces_begin(), all_faces_end());
   }
 
+  // -- edges
   Contour_edges_iterator contour_edges_begin() const
   {
     if(dimension() < 1)
@@ -326,10 +341,19 @@ public:
 
   All_edges_iterator all_edges_begin() const { return _tds.edges_begin(); }
   All_edges_iterator all_edges_end() const { return _tds.edges_end(); }
+  Finite_edges_iterator finite_edges_begin() const { return _tds.edges_begin(); }
+  Finite_edges_iterator finite_edges_end() const { return _tds.edges_end(); }
+
   All_edges all_edges() const { return _tds.edges(); }
 
+  // -- vertices
   Vertices_iterator vertices_begin() const { return _tds.vertices_begin(); }
   Vertices_iterator vertices_end() const { return _tds.vertices_end(); }
+  All_vertices_iterator all_vertices_begin() const { return _tds.vertices_begin(); }
+  All_vertices_iterator all_vertices_end() const { return _tds.vertices_end(); }
+  Finite_vertices_iterator finite_vertices_begin() const { return _tds.vertices_begin(); }
+  Finite_vertices_iterator finite_vertices_end() const { return _tds.vertices_end(); }
+
   Vertex_handles vertex_handles() const
   {
     return make_prevent_deref_range(vertices_begin(), vertices_end());

--- a/Triangulation_on_sphere_2/include/CGAL/Triangulation_on_sphere_2/internal/arc_on_sphere_2_subsampling.h
+++ b/Triangulation_on_sphere_2/include/CGAL/Triangulation_on_sphere_2/internal/arc_on_sphere_2_subsampling.h
@@ -40,7 +40,7 @@ double get_theta( typename Kernel::Point_3& pt,
   typedef Eigen::Matrix<FT, 3, 3, Eigen::DontAlign>                  Matrix;
   typedef Eigen::Matrix<FT, 3, 1>                                    Col;
 #else
-  CGAL_static_assertion(false, "Eigen is required to perform arc subsampling!");
+  CGAL_static_assertion_msg(false, "Eigen is required to perform arc subsampling!");
 #endif
 
   auto V1c = V1.cartesian_begin(), V2c = V2.cartesian_begin(), V3c = V3.cartesian_begin();

--- a/Triangulation_on_sphere_2/include/CGAL/Triangulation_on_sphere_2/internal/arc_on_sphere_2_subsampling.h
+++ b/Triangulation_on_sphere_2/include/CGAL/Triangulation_on_sphere_2/internal/arc_on_sphere_2_subsampling.h
@@ -15,9 +15,11 @@
 
 #include <CGAL/license/Triangulation_on_sphere_2.h>
 
-#ifdef CGAL_EIGEN3_ENABLED
+#include <CGAL/triangulation_assertions.h>
 
+#ifdef CGAL_EIGEN3_ENABLED
 #include <CGAL/Eigen_solver_traits.h>
+#endif
 
 #include <cmath>
 #include <list>
@@ -34,8 +36,12 @@ double get_theta( typename Kernel::Point_3& pt,
 {
   typedef typename Kernel::FT                                        FT;
 
+#ifdef CGAL_EIGEN3_ENABLED
   typedef Eigen::Matrix<FT, 3, 3, Eigen::DontAlign>                  Matrix;
   typedef Eigen::Matrix<FT, 3, 1>                                    Col;
+#else
+  CGAL_static_assertion(false, "Eigen is required to perform arc subsampling!");
+#endif
 
   auto V1c = V1.cartesian_begin(), V2c = V2.cartesian_begin(), V3c = V3.cartesian_begin();
 
@@ -153,7 +159,5 @@ void subsample_arc_on_sphere_2(const ArcOnSphere& arc,
 } // namespace internal
 } // namespace Triangulations_on_sphere_2
 } // namespace CGAL
-
-#endif // CGAL_EIGEN3_ENABLED
 
 #endif // CGAL_TOS2_INTERNAL_ARC_ON_SPHERE_SUBSAMPLING_H

--- a/Triangulation_on_sphere_2/include/CGAL/Triangulation_on_sphere_2/internal/arc_on_sphere_2_subsampling.h
+++ b/Triangulation_on_sphere_2/include/CGAL/Triangulation_on_sphere_2/internal/arc_on_sphere_2_subsampling.h
@@ -16,6 +16,7 @@
 #include <CGAL/license/Triangulation_on_sphere_2.h>
 
 #include <CGAL/triangulation_assertions.h>
+#include <CGAL/Default.h>
 
 #ifdef CGAL_EIGEN3_ENABLED
 #include <CGAL/Eigen_solver_traits.h>
@@ -28,20 +29,35 @@ namespace CGAL {
 namespace Triangulations_on_sphere_2 {
 namespace internal {
 
-template <class Kernel>
-double get_theta( typename Kernel::Point_3& pt,
-                  typename Kernel::Vector_3& V1,
-                  typename Kernel::Vector_3& V2,
-                  typename Kernel::Vector_3& V3)
+template <class Kernel,
+          class Matrix_ = Default,
+          class Col_ = Default,
+          class EigenlessDefault = void>
+double get_theta(typename Kernel::Point_3& pt,
+                 typename Kernel::Vector_3& V1,
+                 typename Kernel::Vector_3& V2,
+                 typename Kernel::Vector_3& V3)
 {
   typedef typename Kernel::FT                                        FT;
 
+  typedef typename Default::Get<Matrix_,
 #ifdef CGAL_EIGEN3_ENABLED
-  typedef Eigen::Matrix<FT, 3, 3, Eigen::DontAlign>                  Matrix;
-  typedef Eigen::Matrix<FT, 3, 1>                                    Col;
+                                Eigen::Matrix<FT, 3, 3, Eigen::DontAlign>
 #else
-  CGAL_static_assertion_msg(false, "Eigen is required to perform arc subsampling!");
+                                EigenlessDefault
 #endif
+                                >::type                              Matrix;
+
+  typedef typename Default::Get<Col_,
+#ifdef CGAL_EIGEN3_ENABLED
+                                Eigen::Matrix<FT, 3, 1>
+#else
+                                EigenlessDefault
+#endif
+                                >::type                              Col;
+
+  CGAL_static_assertion_msg(!(std::is_same<Matrix, EigenlessDefault>::value),
+                            "Eigen is required to perform arc subsampling!");
 
   auto V1c = V1.cartesian_begin(), V2c = V2.cartesian_begin(), V3c = V3.cartesian_begin();
 

--- a/Voronoi_diagram_2/include/CGAL/Delaunay_triangulation_on_sphere_adaptation_traits_2.h
+++ b/Voronoi_diagram_2/include/CGAL/Delaunay_triangulation_on_sphere_adaptation_traits_2.h
@@ -1,0 +1,62 @@
+// Copyright (c) 2021 GeometryFactory
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+//
+//
+// Author(s)     : Mael Rouxel-Labbé
+
+#ifndef CGAL_DELAUNAY_TRIANGULATION_ADAPTATION_TRAITS_2_H
+#define CGAL_DELAUNAY_TRIANGULATION_ADAPTATION_TRAITS_2_H 1
+
+#include <CGAL/license/Voronoi_diagram_2.h>
+
+#include <CGAL/Voronoi_diagram_2/basic.h>
+#include <CGAL/Voronoi_diagram_2/Adaptation_traits_functors.h>
+#include <CGAL/Voronoi_diagram_2/Construct_dual_points.h>
+#include <CGAL/Voronoi_diagram_2/Site_accessors.h>
+
+namespace CGAL {
+
+template <typename DTOS>
+struct Delaunay_triangulation_on_sphere_adaptation_traits_2
+{
+public:
+  typedef DTOS                                                       Delaunay_graph;
+  typedef typename Delaunay_graph::Geom_traits                       Geom_traits;
+
+  typedef CGAL_VORONOI_DIAGRAM_2_INS::DToS2_Point_accessor<DTOS>     Access_site_2;
+  typedef CGAL_VORONOI_DIAGRAM_2_INS::DToS2_Voronoi_point_2<DTOS>    Construct_Voronoi_point_2;
+
+  typedef typename Delaunay_graph::Vertex_handle                     Delaunay_vertex_handle;
+  typedef typename Delaunay_graph::Edge                              Delaunay_edge;
+  typedef typename Delaunay_graph::Face_handle                       Delaunay_face_handle;
+
+  typedef CGAL::Tag_false                                            Has_nearest_site_2;
+  typedef CGAL_VORONOI_DIAGRAM_2_INS::Null_functor                   Nearest_site_2;
+
+  Delaunay_triangulation_on_sphere_adaptation_traits_2(const DTOS& dtos) : dtos(dtos) { }
+
+  Access_site_2 access_site_2_object() const
+  { return Access_site_2(dtos); }
+
+  Construct_Voronoi_point_2 construct_Voronoi_point_2_object() const
+  { return Construct_Voronoi_point_2(dtos); }
+
+  Nearest_site_2 nearest_site_2_object() const
+  { return Nearest_site_2(); }
+
+  typedef typename Geom_traits::Point_on_sphere_2                    Point_2;
+  typedef Point_2                                                    Site_2;
+
+private:
+  const DTOS& dtos;
+};
+
+} //namespace CGAL
+
+#endif // CGAL_DELAUNAY_TRIANGULATION_ADAPTATION_TRAITS_2_H

--- a/Voronoi_diagram_2/include/CGAL/Delaunay_triangulation_on_sphere_adaptation_traits_2.h
+++ b/Voronoi_diagram_2/include/CGAL/Delaunay_triangulation_on_sphere_adaptation_traits_2.h
@@ -22,15 +22,17 @@
 
 namespace CGAL {
 
-template <typename DTOS>
+template <typename DToS2>
 struct Delaunay_triangulation_on_sphere_adaptation_traits_2
 {
 public:
-  typedef DTOS                                                       Delaunay_graph;
-  typedef typename Delaunay_graph::Geom_traits                       Geom_traits;
+  typedef DToS2                                                      Delaunay_graph;
+  typedef typename DToS2::Geom_traits                                Geom_traits;
+  typedef typename Geom_traits::Point_on_sphere_2                    Point_2;
+  typedef Point_2                                                    Site_2;
 
-  typedef CGAL_VORONOI_DIAGRAM_2_INS::DToS2_Point_accessor<DTOS>     Access_site_2;
-  typedef CGAL_VORONOI_DIAGRAM_2_INS::DToS2_Voronoi_point_2<DTOS>    Construct_Voronoi_point_2;
+  typedef CGAL_VORONOI_DIAGRAM_2_INS::Point_accessor<Point_2,DToS2,Tag_true> Access_site_2;
+  typedef CGAL_VORONOI_DIAGRAM_2_INS::DToS2_Voronoi_point_2<DToS2>   Construct_Voronoi_point_2;
 
   typedef typename Delaunay_graph::Vertex_handle                     Delaunay_vertex_handle;
   typedef typename Delaunay_graph::Edge                              Delaunay_edge;
@@ -39,22 +41,19 @@ public:
   typedef CGAL::Tag_false                                            Has_nearest_site_2;
   typedef CGAL_VORONOI_DIAGRAM_2_INS::Null_functor                   Nearest_site_2;
 
-  Delaunay_triangulation_on_sphere_adaptation_traits_2(const DTOS& dtos) : dtos(dtos) { }
+  Delaunay_triangulation_on_sphere_adaptation_traits_2(const Geom_traits& gt) : gt(gt) { }
 
   Access_site_2 access_site_2_object() const
-  { return Access_site_2(dtos); }
+  { return Access_site_2(gt); }
 
   Construct_Voronoi_point_2 construct_Voronoi_point_2_object() const
-  { return Construct_Voronoi_point_2(dtos); }
+  { return Construct_Voronoi_point_2(gt); }
 
   Nearest_site_2 nearest_site_2_object() const
   { return Nearest_site_2(); }
 
-  typedef typename Geom_traits::Point_on_sphere_2                    Point_2;
-  typedef Point_2                                                    Site_2;
-
 private:
-  const DTOS& dtos;
+  const Geom_traits gt; // intentional copy
 };
 
 } //namespace CGAL

--- a/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Construct_dual_points.h
+++ b/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Construct_dual_points.h
@@ -77,6 +77,31 @@ public:
 
 //=========================================================================
 
+template<class DTOS>
+struct DToS2_Voronoi_point_2
+{
+private:
+  typedef typename DTOS::Geom_traits                       Geom_traits;
+  typedef typename Geom_traits::Point_on_sphere_2          Point_on_sphere_2;
+
+public:
+  typedef Point_on_sphere_2                                result_type;
+  typedef typename DTOS::Face_handle                       Face_handle;
+
+  DToS2_Voronoi_point_2(const DTOS& dtos) : dtos(dtos) { }
+
+  result_type operator()(const Face_handle f) const
+  {
+    return dtos.geom_traits().construct_circumcenter_on_sphere_2_object()(
+             dtos.point(f, 0), dtos.point(f, 1), dtos.point(f, 2));
+  }
+
+private:
+  const DTOS& dtos;
+};
+
+//=========================================================================
+
 template<class SVD2>
 class Segment_Voronoi_diagram_Voronoi_point_2
 {

--- a/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Construct_dual_points.h
+++ b/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Construct_dual_points.h
@@ -77,27 +77,27 @@ public:
 
 //=========================================================================
 
-template<class DTOS>
+template<class DToS2>
 struct DToS2_Voronoi_point_2
 {
 private:
-  typedef typename DTOS::Geom_traits                       Geom_traits;
+  typedef typename DToS2::Geom_traits                      Geom_traits;
   typedef typename Geom_traits::Point_on_sphere_2          Point_on_sphere_2;
 
 public:
+  typedef typename DToS2::Face_handle                      Face_handle;
   typedef Point_on_sphere_2                                result_type;
-  typedef typename DTOS::Face_handle                       Face_handle;
 
-  DToS2_Voronoi_point_2(const DTOS& dtos) : dtos(dtos) { }
+  DToS2_Voronoi_point_2(const Geom_traits& gt) : gt(gt) { }
 
   result_type operator()(const Face_handle f) const
   {
-    return dtos.geom_traits().construct_circumcenter_on_sphere_2_object()(
-             dtos.point(f, 0), dtos.point(f, 1), dtos.point(f, 2));
+    return gt.construct_circumcenter_on_sphere_2_object()(
+             f->vertex(0)->point(), f->vertex(1)->point(), f->vertex(2)->point());
   }
 
 private:
-  const DTOS& dtos;
+  const Geom_traits& gt;
 };
 
 //=========================================================================

--- a/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Identity_rejectors.h
+++ b/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Identity_rejectors.h
@@ -53,22 +53,12 @@ struct Identity_edge_rejector
     return false;
   }
 
-  bool operator()(const Delaunay_graph& , const Edge& ) const {
-    return false;
-  }
+  // handles Edge, All_edges_iterator, Finite_edges_iterator, Edge_circulator...
+  // use a single template in case some of these types (typically All_edges_iterator
+  // and Finite_edges_iterator) are equal
 
-  bool operator()(const Delaunay_graph& ,
-                  const All_edges_iterator& ) const {
-    return false;
-  }
-
-  bool operator()(const Delaunay_graph& ,
-                  const Finite_edges_iterator& ) const {
-    return false;
-  }
-
-  bool operator()(const Delaunay_graph& ,
-                  const Edge_circulator& ) const {
+  template <typename E>
+  bool operator()(const Delaunay_graph& , const E& ) const {
     return false;
   }
 };

--- a/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Site_accessors.h
+++ b/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Site_accessors.h
@@ -71,29 +71,6 @@ struct Point_accessor
 
 //=========================================================================
 
-template <typename DTOS>
-struct DToS2_Point_accessor
-{
-private:
-  typedef typename DTOS::Geom_traits::Point_on_sphere_2      Point_on_sphere_2;
-
-public:
-  typedef const Point_on_sphere_2&                           result_type;
-  typedef typename DTOS::Vertex_handle                       Vertex_handle;
-
-  DToS2_Point_accessor(const DTOS& dtos) : dtos(dtos) { }
-
-  result_type operator()(const Vertex_handle v) const
-  {
-    return dtos.point(v);
-  }
-
-private:
-  const DTOS& dtos;
-};
-
-//=========================================================================
-
 } // namespace Internal
 } // namespace VoronoiDiagram_2
 } // namespace CGAL

--- a/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Site_accessors.h
+++ b/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Site_accessors.h
@@ -15,12 +15,11 @@
 
 #include <CGAL/license/Voronoi_diagram_2.h>
 
-
 #include <CGAL/Voronoi_diagram_2/basic.h>
 
 namespace CGAL {
-
-namespace VoronoiDiagram_2 { namespace Internal {
+namespace VoronoiDiagram_2 {
+namespace Internal {
 
 //=========================================================================
 //=========================================================================
@@ -71,10 +70,32 @@ struct Point_accessor
 };
 
 //=========================================================================
+
+template <typename DTOS>
+struct DToS2_Point_accessor
+{
+private:
+  typedef typename DTOS::Geom_traits::Point_on_sphere_2      Point_on_sphere_2;
+
+public:
+  typedef const Point_on_sphere_2&                           result_type;
+  typedef typename DTOS::Vertex_handle                       Vertex_handle;
+
+  DToS2_Point_accessor(const DTOS& dtos) : dtos(dtos) { }
+
+  result_type operator()(const Vertex_handle v) const
+  {
+    return dtos.point(v);
+  }
+
+private:
+  const DTOS& dtos;
+};
+
 //=========================================================================
 
-} } //namespace VoronoiDiagram_2::Internal
-
-} //namespace CGAL
+} // namespace Internal
+} // namespace VoronoiDiagram_2
+} // namespace CGAL
 
 #endif // CGAL_VORONOI_DIAGRAM_2_SITE_ACCESSORS_H


### PR DESCRIPTION
## Summary of Changes

Add the additional types / functions / adapters required for `CGAL::Delaunay_triangulation_on_sphere_2` to be compatible with `CGAL::Voronoi_diagram_2`.

Example of usage: https://gist.github.com/MaelRL/f5671a48dccb9ec874c41c47ba13bab4.

TODO:
- [x] Move the adapter classes from the gist into the `Voronoi_diagram_2` package (+ add policies?)
- [x] Check pyramid case

## Release Management

Into CGAL `5.3.1` due to the minor swap bug.

* Affected package(s): `Triangulation_on_sphere_2`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

