### PR TITLE
Remove code duplication in Reflex_vertex_searcher.h

### DIFF
--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Reflex_vertex_searcher.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Reflex_vertex_searcher.h
@@ -109,42 +109,25 @@ class Reflex_vertex_searcher : public Modifier_base<typename Nef_::SNC_structure
   int is_reflex_vertex(Vertex_handle vi) {
     int result = 0;
     SM_point_locator PL(&*vi);
-    Object_handle op(PL.locate(dir));
-    Object_handle on(PL.locate(dir.antipode()));
+    Object_handle o[2] = {PL.locate(dir), PL.locate(dir.antipode())};
 
-    bool markedsf[2];
-    SFace_handle sfp, sfn;
-    markedsf[0] = assign(sfp, op) && sfp->mark();
-    markedsf[1] = assign(sfn, on) && sfn->mark();
+    for(int i=0; i<2; ++i) {
+      SFace_handle sf;
+      bool markedsf = assign(sf, o[i]) && sf->mark();
 
-    CGAL_NEF_TRACEN("markedsf " << markedsf[0] << " " << markedsf[1]);
-    CGAL_NEF_TRACEN("sf " << &*sfp << "==" << &*sfn);
+      CGAL_NEF_TRACEN("markedsf " << markedsf);
+      CGAL_NEF_TRACEN("sf " << &*sf);
 
-    if(markedsf[0]) {
-      SFace_cycle_iterator sfci(sfp->sface_cycles_begin());
-      for(; sfci != sfp->sface_cycles_end(); ++sfci) {
-        SHalfedge_around_sface_circulator
-          sfc(sfci), send(sfc);
-        CGAL_For_all(sfc, send) {
-          int isrse = is_reflex_sedge<SNC_structure>(sfc, dir, false);
-          if(isrse==0) continue;
-          //          if(!markedsf[1] || sfp!=sfn)
-          isrse&=1;
-          result |= isrse;
-        }
-      }
-    }
-
-    if(/*sfp!=sfn &&*/ markedsf[1]) {
-      SFace_cycle_iterator sfci(sfn->sface_cycles_begin());
-      for(; sfci != sfn->sface_cycles_end(); ++sfci) {
-        SHalfedge_around_sface_circulator
-          sfc(sfci), send(sfc);
-        CGAL_For_all(sfc, send) {
-          int isrse = is_reflex_sedge<SNC_structure>(sfc, dir, false);
-          if(isrse==0) continue;
-          isrse&=2;
-          result |= isrse;
+      if(markedsf) {
+        SFace_cycle_iterator sfci(sf->sface_cycles_begin());
+        for(; sfci != sf->sface_cycles_end(); ++sfci) {
+          SHalfedge_around_sface_circulator sfc(sfci), send(sfc);
+          CGAL_For_all(sfc, send) {
+            int isrse = is_reflex_sedge<SNC_structure>(sfc, dir, false);
+            if(isrse == 0) continue;
+            isrse &= (i + 1);
+            result |= isrse;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary of Changes

This simplifies the code in Reflex_vertex_searcher.h by utilising the right variables as an array (Object_handle instead of markedsf) so that a loop can be used instead of repeating the same code twice. There is a slightly different trace output format but I don't think that matters.

I don't think the existing code was a deliberate manual loop unrolling, and it should be up to the compiler to unroll loops for performance.

This also fixes a static analysis false positive where the analysis gets confused about the check against markedsf and thinks there is a dereference after null.

## Release Management

* Affected package(s): Convex_decomposition_3
* Issue(s) solved (if any): bugfix / cleaning
* License and copyright ownership: Returned to CGAL authors.

