### PR TITLE
Polyhedron_3 and TDS_3 compare handle nullptr

### DIFF
--- a/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
+++ b/Polyhedron/include/CGAL/Polyhedron_incremental_builder_3.h
@@ -402,7 +402,7 @@ protected:
         CGAL_assertion( ! last_vertex);
         HalfedgeDS_items_decorator<HDS> decorator;
         Halfedge_handle e = get_vertex_to_edge_map( w);
-        if ( e != Halfedge_handle()) {
+        if ( e != nullptr) {
             CGAL_assertion( e->vertex() == index_to_vertex_map[w]);
             // check that the facet has no self intersections
             if ( current_face != Face_handle()
@@ -491,7 +491,7 @@ protected:
         // Halfedge e points to a vertex w. Walk around w to find a hole
         // in the facet structure. Report an error if none exist. Return
         // the halfedge at this hole that points to the vertex w.
-        CGAL_assertion( e != Halfedge_handle());
+        CGAL_assertion( e != nullptr);
         HalfedgeDS_items_decorator<HDS> decorator;
         Halfedge_handle start_edge( e);
         do {
@@ -649,7 +649,7 @@ add_vertex_to_facet( std::size_t v2) {
             Halfedge_handle hole = lookup_hole( v1);
             if ( m_error)
                 return;
-            CGAL_assertion( hole != Halfedge_handle());
+            CGAL_assertion( hole != nullptr);
             h2->opposite()->HBase::set_next( hole->next());
             decorator.set_prev( hole->next(), h2->opposite());
             hole->HBase::set_next( h1->opposite());
@@ -689,7 +689,7 @@ add_vertex_to_facet( std::size_t v2) {
                 } while ( e->next() != prev && e != h1);
                 if ( e == h1) {
                     // disconnected facet complexes
-                    if ( hole != Halfedge_handle()) {
+                    if ( hole != nullptr) {
                         // The complex can be connected with
                         // the hole at hprime.
                         hprime->HBase::set_next( hole->next());
@@ -763,8 +763,8 @@ test_facet_indices( std::vector< std::size_t> indices) {
         // check if halfedge is already in the HDS and is not border halfedge
         Halfedge_handle v = get_vertex_to_edge_map(indices[i]);
         Vertex_handle   w = index_to_vertex_map[indices[i+1]];
-        if ( v != Halfedge_handle()
-             && get_vertex_to_edge_map(indices[i+1]) != Halfedge_handle()) {
+        if ( v != nullptr
+             && get_vertex_to_edge_map(indices[i+1]) != nullptr) {
             // cycle through halfedge-loop and find edge to indices[i+1]
             Halfedge_handle vstart = v;
             do {
@@ -780,7 +780,7 @@ test_facet_indices( std::vector< std::size_t> indices) {
         // tested for non-manifold halfedges already, we just need to check
         // if the vertex indices[i] is not a closed manifold yet.
         Halfedge_handle v = get_vertex_to_edge_map(indices[i]);
-        if ( v != Halfedge_handle()) {
+        if ( v != nullptr) {
             Halfedge_handle vstart = v;
             do {
                 v = v->next()->opposite();

--- a/STL_Extension/include/CGAL/In_place_list.h
+++ b/STL_Extension/include/CGAL/In_place_list.h
@@ -86,6 +86,8 @@ namespace internal {
 
     bool  operator==( const Self& x) const { return node == x.node; }
     bool  operator!=( const Self& x) const { return node != x.node; }
+    bool  operator==( std::nullptr_t) const { return node == nullptr; }
+    bool  operator!=( std::nullptr_t) const { return node != nullptr; }
     bool  operator< ( const Self& x) const { return node< x.node;   }
     bool  operator<=( const Self& x) const { return node<= x.node;  }
     bool  operator> ( const Self& x) const { return node> x.node;   }
@@ -139,6 +141,8 @@ namespace internal {
 
     bool     operator==( const Self& x) const { return node == x.node; }
     bool     operator!=( const Self& x) const { return node != x.node; }
+    bool     operator==( std::nullptr_t) const { return node == nullptr; }
+    bool     operator!=( std::nullptr_t) const { return node != nullptr; }
     bool     operator< ( const Self& x) const { return node< x.node;   }
     bool     operator<=( const Self& x) const { return node<= x.node;  }
     bool     operator> ( const Self& x) const { return node> x.node;   }

--- a/STL_Extension/include/CGAL/vector.h
+++ b/STL_Extension/include/CGAL/vector.h
@@ -109,6 +109,8 @@ public:
         tmp += n;
         return tmp.operator*();
     }
+    bool operator==( std::nullptr_t) const { return ptr == nullptr; }
+    bool operator!=( std::nullptr_t) const { return ptr != nullptr; }
     bool operator< ( const Self& i) const { return ( ptr < i.ptr); }
     bool operator> ( const Self& i) const { return i < *this;    }
     bool operator<=( const Self& i) const { return !(i < *this); }

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -1924,7 +1924,7 @@ create_star_2(Vertex_handle v, Cell_handle c, int li )
     // pnew is null at the first iteration
     v1->set_cell(cnew);
     //pnew->set_neighbor( cw(pnew->index(v1)), cnew );
-    if (pnew != Cell_handle()) { pnew->set_neighbor( 1, cnew );}
+    if (pnew != nullptr) { pnew->set_neighbor( 1, cnew );}
 
     bound = cur;
     i1 = ccw(i1);


### PR DESCRIPTION
## Summary of Changes

This uses the nullptr comparison operators of Compact_container to check for an empty handle instead of using an instance of an empty handle.  I think this is clearer semantically, and possibly slightly more performant.

The same operators are then added to In_place_list, and vector_iterator. Comparisons to nullptr utilised in the same way.

The change also suppresses some static analysis warnings about usage after explicit null.

## Release Management

* Affected package(s): Polyhedron_3 and TDS_3
* Issue(s) solved (if any): cleaning
* License and copyright ownership: Returned to CGAL authors.

