### PR TITLE
Fix division by zero in subdivision_masks_3.h

### DIFF
--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
@@ -331,7 +331,7 @@ public:
   void vertex_node(vertex_descriptor vertex, Point& pt) {
     Halfedge_around_vertex_circulator vcir(vertex, *(this->pmesh));
     size_t n = circulator_size(vcir);
-    CGAL_assertion(n > 0);
+    CGAL_assume(n > 0);
 
     FT R[] = {0.0, 0.0, 0.0};
     Point_ref S = get(this->vpmap,vertex);

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
@@ -331,6 +331,7 @@ public:
   void vertex_node(vertex_descriptor vertex, Point& pt) {
     Halfedge_around_vertex_circulator vcir(vertex, *(this->pmesh));
     size_t n = circulator_size(vcir);
+    CGAL_assertion(n > 0);
 
     FT R[] = {0.0, 0.0, 0.0};
     Point_ref S = get(this->vpmap,vertex);


### PR DESCRIPTION
## Summary of Changes

This adds an assertion to subdivision_masks_3.h which prevents a static analysis wanting about dividing by zero.

## Release Management

* Affected package(s): Subdivision methods
* Issue(s) solved (if any): bugfix / static analysis
* License and copyright ownership: Returned to CGAL authors.

