### PR TITLE
Nef_3 performance chained map

### DIFF
--- a/Hash_map/include/CGAL/Tools/chained_map.h
+++ b/Hash_map/include/CGAL/Tools/chained_map.h
@@ -125,7 +125,7 @@ public:
     return (it == &stop) ? nullptr : it;
   }
 
-  size_type number_of_entries()
+  size_type number_of_entries() const
   {
     size_type n = 0;
     if (!table.begin)

--- a/Hash_map/include/CGAL/Tools/chained_map.h
+++ b/Hash_map/include/CGAL/Tools/chained_map.h
@@ -53,12 +53,16 @@ public:
     size_type n = number_of_entries();
     if (reserved_size < n)
       std::cout << "reserved: " << reserved_size << " entries: " << n << std::endl;
+
+    if(rehash_count>0)
+      std::cout << "rehash_count: " << rehash_count << std::endl;
 #endif
     destroy(table);
   }
 
   void reserve(size_type n)
   {
+    CGAL_assertion(!table.begin);
     reserved_size = n;
   }
 
@@ -200,6 +204,9 @@ private:
 
   void rehash()
   {
+#ifdef CHAINED_MAP_DEBUG
+    ++rehash_count;
+#endif
     table_type old_table = table;
 
     item old_table_mid = table.begin + table.size;
@@ -304,6 +311,9 @@ private:
   size_type reserved_size;
   key_type old_key;
   allocator_type alloc;
+#ifdef CHAINED_MAP_DEBUG
+  size_type rehash_count=0;
+#endif
 };
 
 } // namespace internal

--- a/Hash_map/include/CGAL/Unique_hash_map.h
+++ b/Hash_map/include/CGAL/Unique_hash_map.h
@@ -57,7 +57,7 @@ public:
 
     Unique_hash_map() { m_map.xdef() = Data(); }
 
-    Unique_hash_map( const Data& deflt, std::size_t table_size = 1)
+    Unique_hash_map( const Data& deflt, std::size_t table_size = Map::min_size)
         : m_map( table_size) { m_map.xdef() = deflt; }
 
     Unique_hash_map( const Data& deflt,
@@ -71,12 +71,15 @@ public:
     }
     Unique_hash_map( Key first1, Key beyond1, Data first2,
                      const Data& deflt,
-                     std::size_t table_size   = 1,
+                     std::size_t table_size   = Map::min_size,
                      const Hash_function& fct = Hash_function())
     : m_hash_function(fct), m_map( table_size) {
         m_map.xdef() = deflt;
         insert( first1, beyond1, first2);
     }
+
+    void reserve(std::size_t n)
+    { m_map.reserve(n); }
 
     Data default_value() const { return m_map.cxdef(); }
 

--- a/Nef_3/include/CGAL/Nef_3/Binary_operation.h
+++ b/Nef_3/include/CGAL/Nef_3/Binary_operation.h
@@ -330,6 +330,7 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
     CGAL_forall_shalfloops(sli, snc2)
       A.initialize_hash(sli);
 
+    ignore.reserve(snc1.number_of_vertices());
     CGAL_forall_vertices( v0, snc1) {
       CGAL_assertion(!ignore[v0]);
       Point_3 p0(v0->point());

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -606,6 +606,7 @@ Node_handle build_kdtree(Vertex_list& V, Halfedge_list& E, Halffacet_list& F,
 #else
   Side_of_plane sop(point_on_plane, coord);
 #endif
+  sop.reserve(V.size());
 
   Vertex_list V1,V2;
   classify_objects(V, sop, V1, V2);

--- a/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
@@ -280,6 +280,7 @@ class SNC_decorator : public SNC_const_decorator<Map> {
     SFace_map linked;
     Shell_volume_setter(const SNCD_& Di)
       : D(Di), linked(false) {}
+    void reserve(Size_type n) { linked.reserve(n); }
     void visit(SFace_handle h) {
       CGAL_NEF_TRACEN(h->center_vertex()->point());
       D.set_volume(h, c);

--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -796,9 +796,13 @@ public:
     //    CGAL_NEF_SETDTHREAD(37*43*503*509);
 
     CGAL_NEF_TRACEN(">>>>>create_volumes");
+    auto sface_count = this->sncp()->number_of_sfaces();
     Sface_shell_hash     ShellSf(0);
+    ShellSf.reserve(sface_count);
     Face_shell_hash      ShellF(0);
+    ShellF.reserve(this->sncp()->number_of_halffacets());
     SFace_visited_hash Done(false);
+    Done.reserve(sface_count);
     Shell_explorer V(*this,ShellSf,ShellF,Done);
     std::vector<SFace_handle> MinimalSFace;
     std::vector<SFace_handle> EntrySFace;
@@ -828,11 +832,14 @@ public:
       Closed.push_back(false);
 
     Halffacet_iterator hf;
-    CGAL_forall_facets(hf,*this)
-      if(ShellF[hf] != ShellF[hf->twin()]) {
-        Closed[ShellF[hf]] = true;
-        Closed[ShellF[hf->twin()]] = true;
+    CGAL_forall_facets(hf,*this) {
+      unsigned int shf = ShellF[hf];
+      unsigned int shf_twin = ShellF[hf->twin()];
+      if(shf != shf_twin) {
+        Closed[shf] = true;
+        Closed[shf_twin] = true;
       }
+    }
 
     CGAL_assertion( pl != nullptr);
 
@@ -1305,6 +1312,7 @@ public:
 
     std::map<int, int> hash;
     CGAL::Unique_hash_map<SHalfedge_handle, bool> done(false);
+    done.reserve(this->sncp()->number_of_shalfedges());
 
     SHalfedge_iterator sei;
     CGAL_forall_shalfedges(sei, *this->sncp()) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
@@ -85,7 +85,7 @@ public:
 #else
   Side_of_plane(const Point_3& p, int c) : OnSideMap(unknown_side), coord(c), pop(p) {}
 #endif
-
+  void reserve(std::size_t n) { OnSideMap.reserve(n); }
   Oriented_side operator()(Vertex_handle v);
   Oriented_side operator()(Halfedge_handle e);
   Oriented_side operator()(Halffacet_handle f);

--- a/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
@@ -330,11 +330,13 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
 
     this->sncp()->clear_boundary();
 
+    hash_volume.reserve(this->sncp()->number_of_volumes());
     Volume_iterator c;
     CGAL_forall_volumes( c, *this->sncp()) {
       hash_volume[c] = uf_volume.make_set(c);
       this->sncp()->reset_object_list(c->shell_entry_objects());
     }
+    hash_sface.reserve(this->sncp()->number_of_sfaces());
     SFace_iterator sf;
     CGAL_forall_sfaces( sf, *this->sncp()) {
       hash_sface[sf] = uf_sface.make_set(sf);
@@ -371,6 +373,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
       f = f_next;
     }
 
+    hash_facet.reserve(this->sncp()->number_of_halffacets());
     CGAL_forall_halffacets( f, *this->sncp()) {
       hash_facet[f] = uf_facet.make_set(f);
       this->sncp()->reset_object_list(f->boundary_entry_objects());
@@ -545,6 +548,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
       Unique_hash_map< SFace_handle, UFH_sface>& hash,
       Union_find< SFace_handle>& uf ) {
     Unique_hash_map< SHalfedge_handle, bool> linked(false);
+    linked.reserve(this->sncp()->number_of_shalfedges());
     SNC_decorator D(*this->sncp());
     SHalfedge_iterator e;
     CGAL_forall_shalfedges(e, *this->sncp()) {
@@ -598,6 +602,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
       Unique_hash_map< Halffacet_handle, UFH_facet>& hash,
       Union_find< Halffacet_handle>& uf) {
     Unique_hash_map< SHalfedge_handle, bool> linked(false);
+    linked.reserve(this->sncp()->number_of_shalfedges());
     SNC_decorator D(*this->sncp());
     SHalfedge_iterator u;
     CGAL_forall_shalfedges(u, *this->sncp()) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
@@ -549,6 +549,8 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
       Union_find< SFace_handle>& uf ) {
     Unique_hash_map< SHalfedge_handle, bool> linked(false);
     linked.reserve(this->sncp()->number_of_shalfedges());
+    this->sncp()->reserve_sm_boundary_items(this->sncp()->number_of_sfaces());
+
     SNC_decorator D(*this->sncp());
     SHalfedge_iterator e;
     CGAL_forall_shalfedges(e, *this->sncp()) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
@@ -656,6 +656,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
 
     SNC_decorator D(*this->sncp());
     Volume_setter setter(D);
+    setter.reserve(this->sncp()->number_of_sfaces());
 
     SFace_iterator sf;
     Volume_handle c;

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -484,10 +484,10 @@ public:
   }
 
   template <typename H>
-  bool is_boundary_object(H h)
+  bool is_boundary_object(H h) const
   { return boundary_item_[h]!=boost::none; }
   template <typename H>
-  bool is_sm_boundary_object(H h)
+  bool is_sm_boundary_object(H h) const
   { return sm_boundary_item_[h]!=boost::none; }
 
   template <typename H>

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -462,6 +462,10 @@ public:
     return *this;
   }
 
+  void reserve_sm_boundary_items(Size_type n) {
+    sm_boundary_item_.reserve(n);
+  }
+
   void clear_boundary() {
     boundary_item_.clear(boost::none);
     sm_boundary_item_.clear(boost::none);

--- a/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
@@ -205,7 +205,7 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
   Face_graph_index_adder<typename SNC_structure::Items,
                  PolygonMesh, SNC_structure,HalfedgeIndexMap> index_adder(P,himap);
 
-
+  S.reserve_sm_boundary_items(num_vertices(P));
   for(vertex_descriptor pv : vertices(P) ) {
 
     typename boost::property_traits<PMap>::reference npv = get(pmap,pv);


### PR DESCRIPTION
## Summary of Changes

This PR attempts to make the code in chained_map cleaner, with the main intention being to add a reserve method, and initialising the hash map on first access instead of during construction.

* Internalised chained_map_elem
* Put table/table_end/table_free into struct
* Rename parameters and variable names
* Init_table called from first call to access
* Delete table no longer called from access
* Delete old table after rehash, (removes need for old_table/old_table_end/old_table_free etc)
* Use constexpr for nullptr_key, and non_nullptr_key.
* Use constexpr for min_size, which is now 32 by default

## Release Management

* Affected package(s): Hash_map / Nef_3
* Issue(s) solved (if any): performance / cleaning
* License and copyright ownership: Returned to CGAL authors.

