### PR TITLE
Mesh_2: Fix write_vtu in ASCII

### DIFF
--- a/Mesh_2/include/CGAL/IO/write_vtu.h
+++ b/Mesh_2/include/CGAL/IO/write_vtu.h
@@ -74,7 +74,7 @@ write_cells_tag_2(std::ostream& os,
                                  tr.constrained_edges_end())) * sizeof(std::size_t);
   }
   else {
-    os << "\">\n";
+    os << ">\n";
     for(typename CDT::Finite_faces_iterator
             fit = tr.finite_faces_begin(),
             end = tr.finite_faces_end();
@@ -102,7 +102,7 @@ write_cells_tag_2(std::ostream& os,
     // 1 offset (size_t) per cell + length of the encoded data (size_t)
   }
   else {
-    os << "\">\n";
+    os << ">\n";
     std::size_t cells_offset = 0;
     for(typename CDT::Finite_faces_iterator fit =
         tr.finite_faces_begin() ;
@@ -131,7 +131,7 @@ write_cells_tag_2(std::ostream& os,
     // 1 unsigned char per cell + length of the encoded data (size_t)
   }
   else {
-    os << "\">\n";
+    os << ">\n";
     for(typename CDT::Finite_faces_iterator fit =
         tr.finite_faces_begin() ;
         fit != tr.finite_faces_end() ;

--- a/Mesh_2/include/CGAL/IO/write_vtu.h
+++ b/Mesh_2/include/CGAL/IO/write_vtu.h
@@ -87,6 +87,17 @@ write_cells_tag_2(std::ostream& os,
         os << V[fit->vertex(1)] << " ";
       }
     }
+    for(typename CDT::Constrained_edges_iterator
+          cei = tr.constrained_edges_begin(),
+          end = tr.constrained_edges_end();
+        cei != end; ++cei)
+    {
+      for(int i=0; i<3; ++i)
+      {
+        if(i != cei->second)
+          os << V[cei->first->vertex(i)] << " ";
+      }
+    }
     os << "      </DataArray>\n";
   }
 
@@ -115,6 +126,13 @@ write_cells_tag_2(std::ostream& os,
         os << cells_offset << " ";
       }
     }
+    for(std::size_t i = 0, end = std::distance(tr.constrained_edges_begin(),
+                                               tr.constrained_edges_end());
+        i < end; ++i)
+    {
+      cells_offset += 2;
+      os << cells_offset << " ";
+    }
     os << "      </DataArray>\n";
   }
 
@@ -141,6 +159,12 @@ write_cells_tag_2(std::ostream& os,
       {
         os << "5 ";
       }
+    }
+    for(std::size_t i = 0, end = std::distance(tr.constrained_edges_begin(),
+                                               tr.constrained_edges_end());
+        i < end; ++i)
+    {
+      os << "3 ";
     }
     os << "      </DataArray>\n";
   }


### PR DESCRIPTION
## Summary of Changes

`write_vtu`, from PR #3297 (CGAL-4.14) was buggy with `ASCII_MODE`, because of spurious `"` in the output file.

*I found out while trying to debug the experimental NURBS mesher.*

## Release Management

* Affected package(s): Mesh_2
* License and copyright ownership: maintenance by GF
