### PR TITLE
Intersections_3: Fix do_intersect(sphere/triangle) if FT has no division

### DIFF
--- a/Distance_3/include/CGAL/squared_distance_3_0.h
+++ b/Distance_3/include/CGAL/squared_distance_3_0.h
@@ -202,6 +202,23 @@ squared_distance_to_plane(const typename K::Vector_3 & normal,
   return FT(dot*dot) /
     FT(wmult((K*)0, squared_length, diff.hw(), diff.hw()));
 }
+  
+template <class K>
+void
+squared_distance_to_plane_RT(const typename K::Vector_3 & normal,
+                             const typename K::Vector_3 & diff,
+                             typename K::RT& num,
+                             typename K::RT& den,
+                             const K& k)
+{
+  typedef typename K::RT RT;
+  typedef typename K::FT FT;
+  RT dot, squared_length;
+  dot = wdot(normal, diff, k);
+  squared_length = wdot(normal, normal, k);
+  num =  square(dot);
+  den = wmult((K*)0, squared_length, diff.hw(), diff.hw());
+}
 
 
 template <class K>
@@ -218,7 +235,55 @@ squared_distance_to_line(const typename K::Vector_3 & dir,
                               (K*)0, RT(wdot(dir, dir, k)), diff.hw(), diff.hw()));
 }
 
+template <class K>
+void
+squared_distance_to_line_RT(const typename K::Vector_3 & dir,
+                            const typename K::Vector_3 & diff,
+                            typename K::RT& num,
+                            typename K::RT& den,
+                            const K& k,
+                            Cartesian_tag)
+{
+  typedef typename K::Vector_3 Vector_3;
+  typedef typename K::RT RT;
+  typedef typename K::FT FT;
+  Vector_3 wcr = wcross(dir, diff, k);
+  num = wcr*wcr;
+  den = wmult((K*)0, RT(wdot(dir, dir, k)), diff.hw(), diff.hw());
+}
 
+template <class K>
+void
+squared_distance_to_line_RT(const typename K::Vector_3 & dir,
+                            const typename K::Vector_3 & diff,
+                            typename K::RT& num,
+                            typename K::RT& den,
+                            const K& k,
+                            Homogeneous_tag)
+{
+  typedef typename K::Vector_3 Vector_3;
+  typedef typename K::RT RT;
+  typedef typename K::FT FT;
+  Vector_3 wcr = wcross(dir, diff, k);
+  FT ft = FT(wcr*wcr)/FT(wmult(
+                               (K*)0, RT(wdot(dir, dir, k)), diff.hw(), diff.hw()));
+  num = Rational_traits<FT>().numerator(ft);
+  den = Rational_traits<FT>().denominator(ft);
+}
+
+template <class K>
+void
+squared_distance_to_line_RT(const typename K::Vector_3 & dir,
+                            const typename K::Vector_3 & diff,
+                            typename K::RT& num,
+                            typename K::RT& den,
+                            const K& k)
+{
+  typedef typename K::Kernel_tag Tag;
+  Tag tag;
+  squared_distance_to_line_RT(dir,diff,num,den,k,tag);
+}
+                                       
 template <class K>
 inline
 bool

--- a/Distance_3/include/CGAL/squared_distance_3_0.h
+++ b/Distance_3/include/CGAL/squared_distance_3_0.h
@@ -202,7 +202,7 @@ squared_distance_to_plane(const typename K::Vector_3 & normal,
   return FT(dot*dot) /
     FT(wmult((K*)0, squared_length, diff.hw(), diff.hw()));
 }
-  
+
 template <class K>
 void
 squared_distance_to_plane_RT(const typename K::Vector_3 & normal,
@@ -283,7 +283,7 @@ squared_distance_to_line_RT(const typename K::Vector_3 & dir,
   Tag tag;
   squared_distance_to_line_RT(dir,diff,num,den,k,tag);
 }
-                                       
+
 template <class K>
 inline
 bool

--- a/Distance_3/include/CGAL/squared_distance_3_0.h
+++ b/Distance_3/include/CGAL/squared_distance_3_0.h
@@ -188,22 +188,6 @@ squared_distance(const typename K::Point_3 & pt1,
   return k.compute_squared_distance_3_object()(pt1, pt2);
 }
 
-
-template <class K>
-typename K::FT
-squared_distance_to_plane(const typename K::Vector_3 & normal,
-                          const typename K::Vector_3 & diff,
-                          const K& k)
-{
-  typedef typename K::RT RT;
-  typedef typename K::FT FT;
-  RT dot, squared_length;
-  dot = wdot(normal, diff, k);
-  squared_length = wdot(normal, normal, k);
-  return FT(dot*dot) /
-    FT(wmult((K*)0, squared_length, diff.hw(), diff.hw()));
-}
-
 template <class K>
 void
 squared_distance_to_plane_RT(const typename K::Vector_3 & normal,
@@ -213,63 +197,24 @@ squared_distance_to_plane_RT(const typename K::Vector_3 & normal,
                              const K& k)
 {
   typedef typename K::RT RT;
-  typedef typename K::FT FT;
   RT dot, squared_length;
   dot = wdot(normal, diff, k);
   squared_length = wdot(normal, normal, k);
-  num =  square(dot);
+  num = square(dot);
   den = wmult((K*)0, squared_length, diff.hw(), diff.hw());
 }
 
-
 template <class K>
 typename K::FT
-squared_distance_to_line(const typename K::Vector_3 & dir,
-                         const typename K::Vector_3 & diff,
-                         const K& k)
+squared_distance_to_plane(const typename K::Vector_3 & normal,
+                          const typename K::Vector_3 & diff,
+                          const K& k)
 {
-  typedef typename K::Vector_3 Vector_3;
   typedef typename K::RT RT;
   typedef typename K::FT FT;
-  Vector_3 wcr = wcross(dir, diff, k);
-  return FT(wcr*wcr)/FT(wmult(
-                              (K*)0, RT(wdot(dir, dir, k)), diff.hw(), diff.hw()));
-}
-
-template <class K>
-void
-squared_distance_to_line_RT(const typename K::Vector_3 & dir,
-                            const typename K::Vector_3 & diff,
-                            typename K::RT& num,
-                            typename K::RT& den,
-                            const K& k,
-                            Cartesian_tag)
-{
-  typedef typename K::Vector_3 Vector_3;
-  typedef typename K::RT RT;
-  typedef typename K::FT FT;
-  Vector_3 wcr = wcross(dir, diff, k);
-  num = wcr*wcr;
-  den = wmult((K*)0, RT(wdot(dir, dir, k)), diff.hw(), diff.hw());
-}
-
-template <class K>
-void
-squared_distance_to_line_RT(const typename K::Vector_3 & dir,
-                            const typename K::Vector_3 & diff,
-                            typename K::RT& num,
-                            typename K::RT& den,
-                            const K& k,
-                            Homogeneous_tag)
-{
-  typedef typename K::Vector_3 Vector_3;
-  typedef typename K::RT RT;
-  typedef typename K::FT FT;
-  Vector_3 wcr = wcross(dir, diff, k);
-  FT ft = FT(wcr*wcr)/FT(wmult(
-                               (K*)0, RT(wdot(dir, dir, k)), diff.hw(), diff.hw()));
-  num = Rational_traits<FT>().numerator(ft);
-  den = Rational_traits<FT>().denominator(ft);
+  RT num, den;
+  squared_distance_to_plane_RT(normal, diff, num, den, k);
+  return Rational_traits<FT>().make_rational(num, den);
 }
 
 template <class K>
@@ -280,9 +225,23 @@ squared_distance_to_line_RT(const typename K::Vector_3 & dir,
                             typename K::RT& den,
                             const K& k)
 {
-  typedef typename K::Kernel_tag Tag;
-  Tag tag;
-  squared_distance_to_line_RT(dir,diff,num,den,k,tag);
+  typedef typename K::Vector_3 Vector_3;
+  Vector_3 wcr = wcross(dir, diff, k);
+  num = wdot(wcr, wcr, k);
+  den = wmult((K*)0, wdot(dir, dir, k), diff.hw(), diff.hw());
+}
+
+template <class K>
+typename K::FT
+squared_distance_to_line(const typename K::Vector_3 & dir,
+                         const typename K::Vector_3 & diff,
+                         const K& k)
+{
+  typedef typename K::RT RT;
+  typedef typename K::FT FT;
+  RT num, den;
+  squared_distance_to_line_RT(dir, diff, num, den, k);
+  return Rational_traits<FT>().make_rational(num, den);
 }
 
 template <class K>

--- a/Distance_3/include/CGAL/squared_distance_3_0.h
+++ b/Distance_3/include/CGAL/squared_distance_3_0.h
@@ -26,6 +26,7 @@
 #include <CGAL/Weighted_point_3.h>
 #include <CGAL/Vector_3.h>
 #include <CGAL/number_utils.h>
+#include <CGAL/Rational_traits.h>
 
 namespace CGAL {
 

--- a/Distance_3/include/CGAL/squared_distance_3_1.h
+++ b/Distance_3/include/CGAL/squared_distance_3_1.h
@@ -43,7 +43,7 @@ squared_distance(
   Vector_3 diff = construct_vector(line.point(), pt);
   return internal::squared_distance_to_line(dir, diff, k);
 }
-  
+
 template <class K>
 void
 squared_distance_RT(
@@ -103,7 +103,7 @@ squared_distance_RT(
   typedef typename K::Vector_3 Vector_3;
   typedef typename K::RT RT;
   typedef typename K::FT FT;
-  
+
     Vector_3 diff = construct_vector(ray.source(), pt);
     const Vector_3 &dir = ray.direction().vector();
     if (!is_acute_angle(dir,diff, k) ){
@@ -128,7 +128,7 @@ squared_distance_RT(
   typename K::Construct_vector_3 construct_vector;
   typedef typename K::Vector_3 Vector_3;
   typedef typename K::RT RT;
-  
+
     Vector_3 diff = construct_vector(ray.source(), pt);
     const Vector_3 &dir = ray.direction().vector();
     if (!is_acute_angle(dir,diff, k) ){
@@ -152,7 +152,7 @@ squared_distance_RT(
   Tag tag;
   squared_distance_RT(pt,ray,num,den,k,tag);
 }
-  
+
 
 template <class K>
 inline

--- a/Distance_3/include/CGAL/squared_distance_3_1.h
+++ b/Distance_3/include/CGAL/squared_distance_3_1.h
@@ -49,8 +49,8 @@ void
 squared_distance_RT(
     const typename K::Point_3 &pt,
     const typename K::Line_3 &line,
-    typename K::RT num,
-    typename K::RT den,
+    typename K::RT& num,
+    typename K::RT& den,
     const K& k)
 {
   typedef typename K::Vector_3 Vector_3;
@@ -94,8 +94,8 @@ void
 squared_distance_RT(
     const typename K::Point_3 &pt,
     const typename K::Ray_3 &ray,
-    typename K::RT num,
-    typename K::RT den,
+    typename K::RT& num,
+    typename K::RT& den,
     const K& k,
     Homogeneous_tag&)
 {
@@ -120,8 +120,8 @@ void
 squared_distance_RT(
     const typename K::Point_3 &pt,
     const typename K::Ray_3 &ray,
-    typename K::RT num,
-    typename K::RT den,
+    typename K::RT& num,
+    typename K::RT& den,
     const K& k,
     Cartesian_tag& )
 {
@@ -144,8 +144,8 @@ void
 squared_distance_RT(
     const typename K::Point_3 &pt,
     const typename K::Ray_3 &ray,
-    typename K::RT num,
-    typename K::RT den,
+    typename K::RT& num,
+    typename K::RT& den,
     const K& k)
 {
   typedef typename K::Kernel_tag Tag;

--- a/Distance_3/include/CGAL/squared_distance_3_1.h
+++ b/Distance_3/include/CGAL/squared_distance_3_1.h
@@ -216,6 +216,7 @@ squared_distance_RT(
       FT ft = FT(diff*diff);
       num = Rational_traits<FT>().numerator(ft);
       den = Rational_traits<FT>().denominator(ft);
+      return;
     }
     RT e = wdot(segvec,segvec, k);
     if ( (d * segvec.hw()) > (e * diff.hw())){

--- a/Distance_3/include/CGAL/squared_distance_3_2.h
+++ b/Distance_3/include/CGAL/squared_distance_3_2.h
@@ -286,7 +286,7 @@ squared_distance_to_triangle_RT(
       {
         // the projection of pt is inside the triangle
         inside = true;
-        return squared_distance_to_plane_RT(normal, vector(t0, pt), num, den, k);
+        squared_distance_to_plane_RT(normal, vector(t0, pt), num, den, k);
       }
       else {
         // The case normal==NULL_VECTOR covers the case when the triangle

--- a/Distance_3/include/CGAL/squared_distance_3_2.h
+++ b/Distance_3/include/CGAL/squared_distance_3_2.h
@@ -262,6 +262,65 @@ squared_distance_to_triangle(
 }
 
 template <class K>
+inline void
+squared_distance_to_triangle_RT(
+    const typename K::Point_3 & pt,
+    const typename K::Point_3 & t0,
+    const typename K::Point_3 & t1,
+    const typename K::Point_3 & t2,
+    bool & inside,
+    typename K::RT& num,
+    typename K::RT& den,
+    const K& k)
+{
+  typename K::Construct_vector_3 vector;
+  typedef typename K::Vector_3 Vector_3;
+  const Vector_3 e1 = vector(t0, t1);
+  const Vector_3 oe3 = vector(t0, t2);
+  const Vector_3 normal = wcross(e1, oe3, k);
+
+  if(normal != NULL_VECTOR
+     && on_left_of_triangle_edge(pt, normal, t0, t1, k)
+     && on_left_of_triangle_edge(pt, normal, t1, t2, k)
+     && on_left_of_triangle_edge(pt, normal, t2, t0, k))
+      {
+        // the projection of pt is inside the triangle
+        inside = true;
+        return squared_distance_to_plane_RT(normal, vector(t0, pt), num, den, k);
+      }
+      else {
+        // The case normal==NULL_VECTOR covers the case when the triangle
+        // is colinear, or even more degenerate. In that case, we can
+        // simply take also the distance to the three segments.
+
+        squared_distance_RT(pt,
+                           typename K::Segment_3(t2, t0),
+                           num,
+                           den,
+                           k);
+        typename K::RT num2, den2;
+        squared_distance_RT(pt,
+                            typename K::Segment_3(t1, t2),
+                            num2,
+                            den2,
+                            k);
+        if(compare_quotients(num2,den2,num,den) == SMALLER){
+          num =  num2;
+          den = den2;
+        }
+        squared_distance_RT(pt,
+                            typename K::Segment_3(t0, t1),
+                            num2,
+                            den2,
+                            k);
+        if(compare_quotients(num2,den2,num,den) == SMALLER){
+          num =  num2;
+          den = den2;
+        }
+      }
+}
+
+template <class K>
 inline typename K::FT
 squared_distance(
     const typename K::Point_3 & pt,
@@ -276,6 +335,27 @@ squared_distance(
                                       vertex(t, 2),
                                       inside,
                                       k);
+}
+
+template <class K>
+void
+squared_distance_RT(
+    const typename K::Point_3 & pt,
+    const typename K::Triangle_3 & t,
+    typename K::RT& num,
+    typename K::RT& den,
+    const K& k)
+{
+  typename K::Construct_vertex_3 vertex;
+  bool inside = false;
+  squared_distance_to_triangle_RT(pt,
+                                  vertex(t, 0),
+                                  vertex(t, 1),
+                                  vertex(t, 2),
+                                  inside,
+                                  num,
+                                  den,
+                                  k);
 }
 
 } // namespace internal

--- a/Distance_3/include/CGAL/squared_distance_3_2.h
+++ b/Distance_3/include/CGAL/squared_distance_3_2.h
@@ -219,49 +219,6 @@ on_left_of_triangle_edge(const typename K::Point_3 & pt,
 }
 
 template <class K>
-inline typename K::FT
-squared_distance_to_triangle(
-    const typename K::Point_3 & pt,
-    const typename K::Point_3 & t0,
-    const typename K::Point_3 & t1,
-    const typename K::Point_3 & t2,
-    bool & inside,
-    const K& k)
-{
-  typename K::Construct_vector_3 vector;
-  typedef typename K::Vector_3 Vector_3;
-  const Vector_3 e1 = vector(t0, t1);
-  const Vector_3 oe3 = vector(t0, t2);
-  const Vector_3 normal = wcross(e1, oe3, k);
-
-  if(normal != NULL_VECTOR
-     && on_left_of_triangle_edge(pt, normal, t0, t1, k)
-     && on_left_of_triangle_edge(pt, normal, t1, t2, k)
-     && on_left_of_triangle_edge(pt, normal, t2, t0, k))
-      {
-        // the projection of pt is inside the triangle
-        inside = true;
-        return squared_distance_to_plane(normal, vector(t0, pt), k);
-      }
-      else {
-        // The case normal==NULL_VECTOR covers the case when the triangle
-        // is colinear, or even more degenerate. In that case, we can
-        // simply take also the distance to the three segments.
-        typename K::FT d1 = squared_distance(pt,
-                                             typename K::Segment_3(t2, t0),
-                                             k);
-        typename K::FT d2 = squared_distance(pt,
-                                             typename K::Segment_3(t1, t2),
-                                             k);
-        typename K::FT d3 = squared_distance(pt,
-                                             typename K::Segment_3(t0, t1),
-                                             k);
-
-        return (std::min)( (std::min)(d1, d2), d3);
-      }
-}
-
-template <class K>
 inline void
 squared_distance_to_triangle_RT(
     const typename K::Point_3 & pt,
@@ -279,62 +236,50 @@ squared_distance_to_triangle_RT(
   const Vector_3 oe3 = vector(t0, t2);
   const Vector_3 normal = wcross(e1, oe3, k);
 
-  if(normal != NULL_VECTOR
-     && on_left_of_triangle_edge(pt, normal, t0, t1, k)
-     && on_left_of_triangle_edge(pt, normal, t1, t2, k)
-     && on_left_of_triangle_edge(pt, normal, t2, t0, k))
-      {
-        // the projection of pt is inside the triangle
-        inside = true;
-        squared_distance_to_plane_RT(normal, vector(t0, pt), num, den, k);
-      }
-      else {
-        // The case normal==NULL_VECTOR covers the case when the triangle
-        // is colinear, or even more degenerate. In that case, we can
-        // simply take also the distance to the three segments.
+  if(normal == NULL_VECTOR) {
+    // The case normal==NULL_VECTOR covers the case when the triangle
+    // is colinear, or even more degenerate. In that case, we can
+    // simply take also the distance to the three segments.
+    squared_distance_RT(pt, typename K::Segment_3(t2, t0), num, den, k);
 
-        squared_distance_RT(pt,
-                           typename K::Segment_3(t2, t0),
-                           num,
-                           den,
-                           k);
-        typename K::RT num2, den2;
-        squared_distance_RT(pt,
-                            typename K::Segment_3(t1, t2),
-                            num2,
-                            den2,
-                            k);
-        if(compare_quotients(num2,den2,num,den) == SMALLER){
-          num =  num2;
-          den = den2;
-        }
-        squared_distance_RT(pt,
-                            typename K::Segment_3(t0, t1),
-                            num2,
-                            den2,
-                            k);
-        if(compare_quotients(num2,den2,num,den) == SMALLER){
-          num =  num2;
-          den = den2;
-        }
-      }
-}
+    typename K::RT num2, den2;
+    squared_distance_RT(pt, typename K::Segment_3(t1, t2), num2, den2, k);
+    if(compare_quotients(num2,den2, num,den) == SMALLER) {
+      num = num2;
+      den = den2;
+    }
 
-template <class K>
-inline typename K::FT
-squared_distance(
-    const typename K::Point_3 & pt,
-    const typename K::Triangle_3 & t,
-    const K& k)
-{
-  typename K::Construct_vertex_3 vertex;
-  bool inside = false;
-  return squared_distance_to_triangle(pt,
-                                      vertex(t, 0),
-                                      vertex(t, 1),
-                                      vertex(t, 2),
-                                      inside,
-                                      k);
+    // should not be needed since at most 2 edges cover the full triangle in the degenerate case
+    squared_distance_RT(pt, typename K::Segment_3(t0, t1), num2, den2, k);
+    if(compare_quotients(num2,den2, num,den) == SMALLER){
+      num = num2;
+      den = den2;
+    }
+
+    return;
+  }
+
+  const bool b01 = on_left_of_triangle_edge(pt, normal, t0, t1, k);
+  if(!b01) {
+    squared_distance_RT(pt, typename K::Segment_3(t0, t1), num, den, k);
+    return;
+  }
+
+  const bool b12 = on_left_of_triangle_edge(pt, normal, t1, t2, k);
+  if(!b12) {
+    squared_distance_RT(pt, typename K::Segment_3(t1, t2), num, den, k);
+    return;
+  }
+
+  const bool b20 = on_left_of_triangle_edge(pt, normal, t2, t0, k);
+  if(!b20) {
+    squared_distance_RT(pt, typename K::Segment_3(t2, t0), num, den, k);
+    return;
+  }
+
+  // The projection of pt is inside the triangle
+  inside = true;
+  squared_distance_to_plane_RT(normal, vector(t0, pt), num, den, k);
 }
 
 template <class K>
@@ -356,6 +301,82 @@ squared_distance_RT(
                                   num,
                                   den,
                                   k);
+}
+
+template <class K>
+inline typename K::FT
+squared_distance_to_triangle(
+    const typename K::Point_3 & pt,
+    const typename K::Point_3 & t0,
+    const typename K::Point_3 & t1,
+    const typename K::Point_3 & t2,
+    bool & inside,
+    const K& k)
+{
+  typename K::Construct_vector_3 vector;
+  typedef typename K::Vector_3 Vector_3;
+  const Vector_3 e1 = vector(t0, t1);
+  const Vector_3 oe3 = vector(t0, t2);
+  const Vector_3 normal = wcross(e1, oe3, k);
+
+  if(normal == NULL_VECTOR) {
+    // The case normal==NULL_VECTOR covers the case when the triangle
+    // is colinear, or even more degenerate. In that case, we can
+    // simply take also the distance to the three segments.
+    typename K::FT d1 = squared_distance(pt, typename K::Segment_3(t2, t0), k);
+    typename K::FT d2 = squared_distance(pt, typename K::Segment_3(t1, t2), k);
+
+    // should not be needed since at most 2 edges cover the full triangle in the degenerate case
+    typename K::FT d3 = squared_distance(pt, typename K::Segment_3(t0, t1), k);
+
+    return (std::min)( (std::min)(d1, d2), d3);
+  }
+
+  const bool b01 = on_left_of_triangle_edge(pt, normal, t0, t1, k);
+  if(!b01) {
+    return internal::squared_distance(pt, typename K::Segment_3(t0, t1), k);
+  }
+
+  const bool b12 = on_left_of_triangle_edge(pt, normal, t1, t2, k);
+  if(!b12) {
+    return internal::squared_distance(pt, typename K::Segment_3(t1, t2), k);
+  }
+
+  const bool b20 = on_left_of_triangle_edge(pt, normal, t2, t0, k);
+  if(!b20) {
+    return internal::squared_distance(pt, typename K::Segment_3(t2, t0), k);
+  }
+
+  // The projection of pt is inside the triangle
+  inside = true;
+  return squared_distance_to_plane(normal, vector(t0, pt), k);
+}
+
+template <class K>
+inline typename K::FT
+squared_distance(
+    const typename K::Point_3 & pt,
+    const typename K::Triangle_3 & t,
+    const K& k)
+{
+  // @todo if the factorized code is used in the end, then the function above, i.e.
+  // squared_distance_to_triangle(), should be removed
+#ifdef CGAL_DISTANCE_3_USE_RT_FUNCTIONS_IN_FT_FUNCTIONS
+  typedef typename K::RT RT;
+  typedef typename K::FT FT;
+  RT num, den;
+  squared_distance_RT(pt, t, num, den, k);
+  return Rational_traits<FT>().make_rational(num, den);
+#else
+  typename K::Construct_vertex_3 vertex;
+  bool inside = false;
+  return squared_distance_to_triangle(pt,
+                                      vertex(t, 0),
+                                      vertex(t, 1),
+                                      vertex(t, 2),
+                                      inside,
+                                      k);
+#endif
 }
 
 } // namespace internal

--- a/Distance_3/include/CGAL/squared_distance_3_2.h
+++ b/Distance_3/include/CGAL/squared_distance_3_2.h
@@ -359,16 +359,7 @@ squared_distance(
     const typename K::Triangle_3 & t,
     const K& k)
 {
-  // @todo if the factorized code is used in the end, then the function above, i.e.
-  // squared_distance_to_triangle(), should be removed
-#ifdef CGAL_DISTANCE_3_USE_RT_FUNCTIONS_IN_FT_FUNCTIONS
-  typedef typename K::RT RT;
-  typedef typename K::FT FT;
-  RT num, den;
-  squared_distance_RT(pt, t, num, den, k);
-  return Rational_traits<FT>().make_rational(num, den);
-#else
-  typename K::Construct_vertex_3 vertex;
+  typename K::Construct_vertex_3 vertex = k.construct_vertex_3_object();
   bool inside = false;
   return squared_distance_to_triangle(pt,
                                       vertex(t, 0),
@@ -376,7 +367,6 @@ squared_distance(
                                       vertex(t, 2),
                                       inside,
                                       k);
-#endif
 }
 
 } // namespace internal

--- a/Distance_3/package_info/Distance_3/dependencies
+++ b/Distance_3/package_info/Distance_3/dependencies
@@ -2,7 +2,9 @@ Algebraic_foundations
 Distance_2
 Distance_3
 Installation
+Interval_support
 Kernel_23
+Modular_arithmetic
 Number_types
 Profiling_tools
 STL_Extension

--- a/Distance_3/test/Distance_3/test_distance_3.cpp
+++ b/Distance_3/test/Distance_3/test_distance_3.cpp
@@ -112,6 +112,17 @@ struct Test {
   {
     std::cout << "Point - Triangle\n";
     check_squared_distance (p(0, 1, 2), T(p(0, 0, 0), p( 2, 0, 0), p( 0, 2, 0)), 4);
+
+    T t(p(0,0,0), p(3,0,0), p(3,3,0));
+    check_squared_distance (p(-1, -1, 0), t, 2);
+    check_squared_distance (p(-1,  0, 0), t, 1);
+    check_squared_distance (p(0, 0, 0), t, 0);
+    check_squared_distance (p(1, 0, 0), t, 0);
+    check_squared_distance (p(4, 0, 0), t, 1);
+    check_squared_distance (p(1, -1, 0), t, 1);
+    check_squared_distance (p(1, 1, 1), t, 1);
+    check_squared_distance (p(1, 0, 1), t, 1);
+    check_squared_distance (p(0, 0, 1), t, 1);
   }
 
   void P_Tet()

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Triangle_3_Sphere_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Triangle_3_Sphere_3_do_intersect.h
@@ -40,7 +40,7 @@ do_intersect(const typename K::Sphere_3 &sp,
 {
   typedef typename K::RT RT;
   RT num, den;
-  
+
   CGAL::internal::squared_distance_RT(sp.center(), tr, num, den, k);
   return ! (compare_quotients<RT>(num, den,
                                   Rational_traits<typename K::FT>().numerator(sp.squared_radius()),
@@ -54,7 +54,7 @@ do_intersect(const typename K::Triangle_3 &tr,
              const typename K::Sphere_3 &sp,
              const K & k)
 {
-  return do_intersect(sp, tr, k); 
+  return do_intersect(sp, tr, k);
 }
 
 
@@ -67,14 +67,14 @@ do_intersect(const typename K::Line_3 &lin,
 {
   typedef typename K::RT RT;
   RT num, den;
-  
+
   CGAL::internal::squared_distance_RT(sp.center(), lin, num, den, k);
   return ! (compare_quotients<RT>(num, den,
                                   Rational_traits<typename K::FT>().numerator(sp.squared_radius()),
                                   Rational_traits<typename K::FT>().denominator(sp.squared_radius())) == LARGER);
 
 }
-  
+
 template <class K>
 inline
 typename K::Boolean
@@ -96,7 +96,7 @@ do_intersect(const typename K::Sphere_3 &sp,
 {
   typedef typename K::RT RT;
   RT num, den;
-  
+
   CGAL::internal::squared_distance_RT(sp.center(), ray, num, den, k);
   return ! (compare_quotients<RT>(num, den,
                                   Rational_traits<typename K::FT>().numerator(sp.squared_radius()),
@@ -123,7 +123,7 @@ do_intersect(const typename K::Sphere_3 &sp,
 {
   typedef typename K::RT RT;
   RT num, den;
-  
+
   CGAL::internal::squared_distance_RT(sp.center(), seg, num, den, k);
   return ! (compare_quotients<RT>(num, den,
                                   Rational_traits<typename K::FT>().numerator(sp.squared_radius()),

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Triangle_3_Sphere_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Triangle_3_Sphere_3_do_intersect.h
@@ -15,7 +15,7 @@
 
 #include <CGAL/squared_distance_3_2.h>
 #include <CGAL/Intersection_traits_3.h>
-
+#include <CGAL/Rational_traits.h>
 namespace CGAL {
 
 template <class K>
@@ -36,9 +36,15 @@ inline
 typename K::Boolean
 do_intersect(const typename K::Sphere_3 &sp,
              const typename K::Triangle_3 &tr,
-             const K & /* k */)
+             const K & k)
 {
-  return squared_distance(sp.center(), tr) <= sp.squared_radius();
+  typedef typename K::RT RT;
+  RT num, den;
+  
+  CGAL::internal::squared_distance_RT(sp.center(), tr, num, den, k);
+  return ! (compare_quotients<RT>(num, den,
+                                  Rational_traits<typename K::FT>().numerator(sp.squared_radius()),
+                                  Rational_traits<typename K::FT>().denominator(sp.squared_radius())) == LARGER);
 }
 
 template <class K>
@@ -46,18 +52,9 @@ inline
 typename K::Boolean
 do_intersect(const typename K::Triangle_3 &tr,
              const typename K::Sphere_3 &sp,
-             const K & /* k */)
+             const K & k)
 {
-  return squared_distance(sp.center(), tr) <= sp.squared_radius();
-}
-template <class K>
-inline
-typename K::Boolean
-do_intersect(const typename K::Sphere_3 &sp,
-             const typename K::Line_3 &lin,
-             const K & /* k */)
-{
-  return squared_distance(sp.center(), lin) <= sp.squared_radius();
+  return do_intersect(sp, tr, k); 
 }
 
 
@@ -66,9 +63,26 @@ inline
 typename K::Boolean
 do_intersect(const typename K::Line_3 &lin,
              const typename K::Sphere_3 &sp,
-             const K & /* k */)
+             const K & k)
 {
-  return squared_distance(sp.center(), lin) <= sp.squared_radius();
+  typedef typename K::RT RT;
+  RT num, den;
+  
+  CGAL::internal::squared_distance_RT(sp.center(), lin, num, den, k);
+  return ! (compare_quotients<RT>(num, den,
+                                  Rational_traits<typename K::FT>().numerator(sp.squared_radius()),
+                                  Rational_traits<typename K::FT>().denominator(sp.squared_radius())) == LARGER);
+
+}
+  
+template <class K>
+inline
+typename K::Boolean
+do_intersect(const typename K::Sphere_3 &sp,
+             const typename K::Line_3 &lin,
+             const K & k)
+{
+  return do_intersect(lin,sp,k);
 }
 
 
@@ -78,9 +92,15 @@ inline
 typename K::Boolean
 do_intersect(const typename K::Sphere_3 &sp,
              const typename K::Ray_3 &ray,
-             const K & /* k */)
+             const K & k)
 {
-  return squared_distance(sp.center(), ray) <= sp.squared_radius();
+  typedef typename K::RT RT;
+  RT num, den;
+  
+  CGAL::internal::squared_distance_RT(sp.center(), ray, num, den, k);
+  return ! (compare_quotients<RT>(num, den,
+                                  Rational_traits<typename K::FT>().numerator(sp.squared_radius()),
+                                  Rational_traits<typename K::FT>().denominator(sp.squared_radius())) == LARGER);
 }
 
 
@@ -89,9 +109,9 @@ inline
 typename K::Boolean
 do_intersect(const typename K::Ray_3 &ray,
              const typename K::Sphere_3 &sp,
-             const K & /* k */)
+             const K & k)
 {
-  return squared_distance(sp.center(), ray) <= sp.squared_radius();
+  return do_intersect(sp,ray,k);
 }
 
 template <class K>
@@ -99,9 +119,15 @@ inline
 typename K::Boolean
 do_intersect(const typename K::Sphere_3 &sp,
              const typename K::Segment_3 &seg,
-             const K & /* k */)
+             const K & k)
 {
-  return squared_distance(sp.center(), seg) <= sp.squared_radius();
+  typedef typename K::RT RT;
+  RT num, den;
+  
+  CGAL::internal::squared_distance_RT(sp.center(), seg, num, den, k);
+  return ! (compare_quotients<RT>(num, den,
+                                  Rational_traits<typename K::FT>().numerator(sp.squared_radius()),
+                                  Rational_traits<typename K::FT>().denominator(sp.squared_radius())) == LARGER);
 }
 
 
@@ -110,9 +136,9 @@ inline
 typename K::Boolean
 do_intersect(const typename K::Segment_3 &seg,
              const typename K::Sphere_3 &sp,
-             const K & /* k */)
+             const K & k)
 {
-  return squared_distance(sp.center(), seg) <= sp.squared_radius();
+  return do_intersect(sp,seg,k);
 }
 
 } // namespace internal

--- a/Intersections_3/test/Intersections_3/test_intersections_3.cpp
+++ b/Intersections_3/test/Intersections_3/test_intersections_3.cpp
@@ -184,12 +184,12 @@ struct Test {
     assert(do_intersect(sph, L(q,r)));
     assert(do_intersect(sph, L(s,q)));
     assert(! do_intersect(sph, L(s,r)));
-    /*
+    
     assert(do_intersect(sph, R(p,r)));
     assert(do_intersect(sph, R(q,r)));
     assert(do_intersect(sph, R(s,q)));
     assert(! do_intersect(sph, R(s,r)));
-    */
+    
   }  
 
 

--- a/Intersections_3/test/Intersections_3/test_intersections_3.cpp
+++ b/Intersections_3/test/Intersections_3/test_intersections_3.cpp
@@ -179,12 +179,12 @@ struct Test {
     assert(do_intersect(sph, S(q,r)));
     assert(do_intersect(sph, S(s,q)));
     assert(! do_intersect(sph, S(s,r)));
-    /*
+    
     assert(do_intersect(sph, L(p,r)));
     assert(do_intersect(sph, L(q,r)));
     assert(do_intersect(sph, L(s,q)));
     assert(! do_intersect(sph, L(s,r)));
-  
+    /*
     assert(do_intersect(sph, R(p,r)));
     assert(do_intersect(sph, R(q,r)));
     assert(do_intersect(sph, R(s,q)));

--- a/Intersections_3/test/Intersections_3/test_intersections_3.cpp
+++ b/Intersections_3/test/Intersections_3/test_intersections_3.cpp
@@ -174,23 +174,23 @@ struct Test {
     assert(! do_intersect(sph, Tr(r,s,t)));
 
     assert(! do_intersect(sph, Tr(s,s2,s3)));
-    
+
     assert(do_intersect(sph, S(p,r)));
     assert(do_intersect(sph, S(q,r)));
     assert(do_intersect(sph, S(s,q)));
     assert(! do_intersect(sph, S(s,r)));
-    
+
     assert(do_intersect(sph, L(p,r)));
     assert(do_intersect(sph, L(q,r)));
     assert(do_intersect(sph, L(s,q)));
     assert(! do_intersect(sph, L(s,r)));
-    
+
     assert(do_intersect(sph, R(p,r)));
     assert(do_intersect(sph, R(q,r)));
     assert(do_intersect(sph, R(s,q)));
     assert(! do_intersect(sph, R(s,r)));
-    
-  }  
+
+  }
 
 
   void Cub_Cub()

--- a/Intersections_3/test/Intersections_3/test_intersections_3.cpp
+++ b/Intersections_3/test/Intersections_3/test_intersections_3.cpp
@@ -161,14 +161,36 @@ struct Test {
 
   void P_do_intersect()
   {
-    P p(0,0,0), q(1,0,0), r(2,0,0), s(10,10,10);
+    P p(0,0,0), q(1,0,0), r(2,0,0), s(10,10,10), s2(10,10,0), s3(10,-10,-1), t(3,0,0);
     Sph sph(p,1);
     Cub cub(p,r);
     assert(do_intersect(q,sph));
     assert(do_intersect(sph,q));
     assert(! do_intersect(s,cub));
     assert(! do_intersect(cub,s));
-  }
+
+    assert(do_intersect(sph, Tr(p,q,s)));
+    assert(do_intersect(sph, Tr(r,q,s)));
+    assert(! do_intersect(sph, Tr(r,s,t)));
+
+    assert(! do_intersect(sph, Tr(s,s2,s3)));
+    
+    assert(do_intersect(sph, S(p,r)));
+    assert(do_intersect(sph, S(q,r)));
+    assert(do_intersect(sph, S(s,q)));
+    assert(! do_intersect(sph, S(s,r)));
+    /*
+    assert(do_intersect(sph, L(p,r)));
+    assert(do_intersect(sph, L(q,r)));
+    assert(do_intersect(sph, L(s,q)));
+    assert(! do_intersect(sph, L(s,r)));
+  
+    assert(do_intersect(sph, R(p,r)));
+    assert(do_intersect(sph, R(q,r)));
+    assert(do_intersect(sph, R(s,q)));
+    assert(! do_intersect(sph, R(s,r)));
+    */
+  }  
 
 
   void Cub_Cub()
@@ -1265,6 +1287,7 @@ struct Test {
     Bbox_L();
     Bbox_R();
     Bbox_Tr();
+
   }
 };
 


### PR DESCRIPTION
## Summary of Changes

The do_intersect function for triangle/sphere was never tested for a number type without division, and had bugs.
The test ` test_intersections_3.cpp`  passes.   I also added the fixes and the test for sphere/segment ,sphere/ray and sphere line which do pass.
 

## Release Management

NYA flag because there is some temporary code behind a macro, need to bench on Windows to take a final decision on "RT functions" being used in "FT functions".

* Affected package(s): Intersections_3
* Issue(s) solved (if any): 
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

