### PR TITLE
Nef_3 performance - has_on_after_intersection in SNC_constructor

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
@@ -831,7 +831,7 @@ public:
                            ec->circle());
         Sphere_point sp(intersection(c, seg.sphere_circle()));
         CGAL_NEF_TRACEN(seg <<" has_on " << sp);
-        if(!seg.has_on(sp))
+        if(!seg.has_on_after_intersection(sp))
           sp = sp.antipode();
         sv = D.new_svertex(sp);
         CGAL_NEF_TRACEN("new svertex 3 " << normalized(sp));
@@ -2063,7 +2063,7 @@ class SNC_constructor<SNC_indexed_items, SNC_structure_>
                            ec->circle());
         Sphere_point sp(intersection(c, seg.sphere_circle()));
         CGAL_NEF_TRACEN(seg <<" has_on " << sp);
-        if(!seg.has_on(sp))
+        if(!seg.has_on_after_intersection(sp))
           sp = sp.antipode();
         sv = D.new_svertex(sp);
         CGAL_NEF_TRACEN("new svertex 3 " << normalized(sp));

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_segment.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_segment.h
@@ -177,7 +177,7 @@ void split_halfcircle(Sphere_segment<R>& s1,
   Plane_3 h(Point_3(0,0,0),(target()-CGAL::ORIGIN));
   Sphere_point<R> p =
     CGAL::intersection(sphere_circle(),Sphere_circle<R>(h));
-  if ( !has_on(p) ) p = p.antipode();
+  if ( !has_on_after_intersection(p) ) p = p.antipode();
   s1 = Sphere_segment<R>(this->ptr()->ps_,p,this->ptr()->c_);
   s2 = Sphere_segment<R>(p,this->ptr()->pt_,this->ptr()->c_);
 }


### PR DESCRIPTION
## Summary of Changes

I stumbled across some code and found that the following change seems to work, and gives a performance boost of about 20% when using the Nef_3_benchmark project. I am not sure if this is correct, but similar usage of the function is present in SM_overlayer.h

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): #5379 
* Feature/Small Feature (if any): speed
* License and copyright ownership: Returned to CGAL authors

