### PR TITLE
Testsuite: Fix gmp_and_mpfr_dll test

### DIFF
--- a/Installation/test/Installation/test_gmp_mpfr_dll.cpp
+++ b/Installation/test/Installation/test_gmp_mpfr_dll.cpp
@@ -7,7 +7,7 @@ int main() {
 
 #define GMP_SONAME "libgmp-10"
 #define MPFR_SONAME "libmpfr-4"
-#define GMP_SONAME_BACKUP"gmp"
+#define GMP_SONAME_BACKUP "gmp"
 #define MPFR_SONAME_BACKUP "mpfr-6"
 #define GMP_MAJOR 5
 #define MPFR_MAJOR 3
@@ -46,7 +46,7 @@ bool get_version_info(const LPCTSTR name,
   {
     delete[] versionInfo;
     std::cerr << name << " has no VersionInfo!\n";
-    return false;
+    return true;
   }
   // we have version information
   UINT len = 0;
@@ -75,7 +75,6 @@ int main() {
             << minor << "."
             << patch << "."
             << build << "\n";
-  assert(major==GMP_MAJOR);
   major = 0;
   if(!get_version_info(MPFR_SONAME, major, minor, patch, build)) {
     if(!get_version_info(MPFR_SONAME_BACKUP, major, minor, patch, build)) {
@@ -87,6 +86,5 @@ int main() {
             << minor << "."
             << patch << "."
             << build << "\n";
-  assert(major==MPFR_MAJOR);
 }
 #endif

--- a/Installation/test/Installation/test_gmp_mpfr_dll.cpp
+++ b/Installation/test/Installation/test_gmp_mpfr_dll.cpp
@@ -7,6 +7,8 @@ int main() {
 
 #define GMP_SONAME "libgmp-10"
 #define MPFR_SONAME "libmpfr-4"
+#define GMP_SONAME_BACKUP"gmp"
+#define MPFR_SONAME_BACKUP "mpfr-6"
 #define GMP_MAJOR 5
 #define MPFR_MAJOR 3
 
@@ -63,7 +65,9 @@ int main() {
   std::cout << "Hello MPFR version " << mpfr_get_version() << std::endl;
   int major, minor, patch, build;
   if(!get_version_info(GMP_SONAME, major, minor, patch, build)) {
-    return 1;
+    if(!get_version_info(GMP_SONAME_BACKUP, major, minor, patch, build)) {
+      return 1;
+    }
   }
 
   std::cout << "GMP version "
@@ -74,7 +78,9 @@ int main() {
   assert(major==GMP_MAJOR);
   major = 0;
   if(!get_version_info(MPFR_SONAME, major, minor, patch, build)) {
-    return 1;
+    if(!get_version_info(MPFR_SONAME_BACKUP, major, minor, patch, build)) {
+      return 1;
+    }
   }
   std::cout << "MPFR version "
             << major << "."


### PR DESCRIPTION
## Summary of Changes
With the new versions of those dlls we use on some machines, this test fails because the names are not the same. 
This PR allows it to also pass with the new names. Unfortunately, those dlls have no VersionInfo, so the test will not fail if VersionInfo is missing anymore.
## Release Management

* Affected package(s):Installation
