### PR TITLE
First search for TBB in config mode

### DIFF
--- a/Installation/cmake/modules/FindTBB.cmake
+++ b/Installation/cmake/modules/FindTBB.cmake
@@ -189,6 +189,11 @@ endmacro()
 #  Now to actually find TBB
 #
 
+#start with CONFIG Mode
+find_package(TBB QUIET NO_MODULE)
+if(TBB_FOUND)
+  return()
+endif()#TBB_FOUND
 # Get path, convert backslashes as ${ENV_${var}}
 getenv_path(TBB_ROOT)
 


### PR DESCRIPTION
## Summary of Changes
Add a first call to `find_package(TBB QUIET NO_MODULE)` in our `FindTBB.cmake`, to bypass it in case it is sufficient. This fixes the bug that occurs with oneAPI.
## Release Management

* Affected package(s):Installation
* Issue(s) solved (if any): fix #5676
