### PR TITLE
CGAL:: Use std atomic and threads

### DIFF
--- a/Apollonius_graph_2/include/CGAL/Apollonius_graph_2/comparator_profiler.h
+++ b/Apollonius_graph_2/include/CGAL/Apollonius_graph_2/comparator_profiler.h
@@ -19,6 +19,7 @@
 
 
 #include <CGAL/Apollonius_graph_2/basic.h>
+#include <atomic>
 
 namespace CGAL {
 
@@ -32,8 +33,8 @@ public:
   typedef bool bool_;
   typedef unsigned long long_;
 #else
-  typedef CGAL::cpp11::atomic<bool> bool_;
-  typedef CGAL::cpp11::atomic<unsigned long> long_;
+  typedef std::atomic<bool> bool_;
+  typedef std::atomic<unsigned long> long_;
 #endif
 
   static bool_ count_cases;

--- a/Apollonius_graph_2/include/CGAL/Apollonius_graph_2/comparator_profiler.h
+++ b/Apollonius_graph_2/include/CGAL/Apollonius_graph_2/comparator_profiler.h
@@ -19,7 +19,6 @@
 
 
 #include <CGAL/Apollonius_graph_2/basic.h>
-#include <CGAL/atomic.h>
 
 namespace CGAL {
 

--- a/Apollonius_graph_2/include/CGAL/Apollonius_graph_2/predicate_profiler.h
+++ b/Apollonius_graph_2/include/CGAL/Apollonius_graph_2/predicate_profiler.h
@@ -19,6 +19,7 @@
 
 
 #include <CGAL/Apollonius_graph_2/basic.h>
+#include <atomic>
 
 #define AG2_PROFILE_PREDICATES
 
@@ -32,7 +33,7 @@ public:
 #ifdef CGAL_NO_ATOMIC
   typedef unsigned long long_;
 #else
-  typedef CGAL::cpp11::atomic<unsigned long> long_;
+  typedef std::atomic<unsigned long> long_;
 #endif
 
   // high level predicates

--- a/Apollonius_graph_2/include/CGAL/Apollonius_graph_2/predicate_profiler.h
+++ b/Apollonius_graph_2/include/CGAL/Apollonius_graph_2/predicate_profiler.h
@@ -19,7 +19,6 @@
 
 
 #include <CGAL/Apollonius_graph_2/basic.h>
-#include <CGAL/atomic.h>
 
 #define AG2_PROFILE_PREDICATES
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_circle_segment_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_circle_segment_traits_2.h
@@ -28,6 +28,7 @@
 #include <CGAL/Arr_geometry_traits/Circle_segment_2.h>
 
 #include <fstream>
+#include <atomic>
 
 namespace CGAL {
 
@@ -79,7 +80,7 @@ public:
 #ifdef CGAL_NO_ATOMIC
     static unsigned int index;
 #else
-    static CGAL::cpp11::atomic<unsigned int> index;
+    static std::atomic<unsigned int> index;
 #endif
     return (++index);
   }

--- a/Arrangement_on_surface_2/include/CGAL/Arr_circle_segment_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_circle_segment_traits_2.h
@@ -23,7 +23,6 @@
  * The header file for the Arr_circle_segment_traits_2<Kenrel> class.
  */
 
-#include <CGAL/atomic.h>
 #include <CGAL/tags.h>
 #include <CGAL/Arr_tags.h>
 #include <CGAL/Arr_geometry_traits/Circle_segment_2.h>

--- a/Arrangement_on_surface_2/include/CGAL/Arr_conic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_conic_traits_2.h
@@ -24,7 +24,6 @@
 
 #include <fstream>
 
-#include <CGAL/atomic.h>
 #include <CGAL/tags.h>
 #include <CGAL/Arr_tags.h>
 #include <CGAL/Arr_geometry_traits/Conic_arc_2.h>

--- a/Arrangement_on_surface_2/include/CGAL/Arr_conic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_conic_traits_2.h
@@ -23,6 +23,7 @@
  */
 
 #include <fstream>
+#include <atomic>
 
 #include <CGAL/tags.h>
 #include <CGAL/Arr_tags.h>
@@ -107,7 +108,7 @@ public:
 #ifdef CGAL_NO_ATOMIC
     static unsigned int index;
 #else
-    static CGAL::cpp11::atomic<unsigned int> index;
+    static std::atomic<unsigned int> index;
 #endif
     return (++index);
   }

--- a/Arrangement_on_surface_2/include/CGAL/Arr_counting_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_counting_traits_2.h
@@ -28,7 +28,6 @@
 #include <string.h>
 
 #include <CGAL/basic.h>
-#include <CGAL/atomic.h>
 #include <CGAL/Arr_enums.h>
 #include <CGAL/Arr_tags.h>
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_counting_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_counting_traits_2.h
@@ -26,6 +26,7 @@
 
 #include <iostream>
 #include <string.h>
+#include <atomic>
 
 #include <CGAL/basic.h>
 #include <CGAL/Arr_enums.h>
@@ -949,7 +950,7 @@ public:
 #ifdef CGAL_NO_ATOMIC
     static unsigned int counter;
 #else
-    static CGAL::cpp11::atomic<unsigned int> counter;
+    static std::atomic<size_t> counter;
 #endif
     if (doit) ++counter;
     return counter;

--- a/Box_intersection_d/include/CGAL/Box_intersection_d/Box_d.h
+++ b/Box_intersection_d/include/CGAL/Box_intersection_d/Box_d.h
@@ -21,7 +21,6 @@
 #include <CGAL/Bbox_2.h>
 #include <CGAL/Bbox_3.h>
 #include <CGAL/Box_intersection_d/box_limits.h>
-#include <CGAL/atomic.h>
 
 #include <algorithm>
 #include <array>

--- a/Box_intersection_d/include/CGAL/Box_intersection_d/Box_d.h
+++ b/Box_intersection_d/include/CGAL/Box_intersection_d/Box_d.h
@@ -24,6 +24,7 @@
 
 #include <algorithm>
 #include <array>
+#include <atomic>
 
 namespace CGAL {
 
@@ -37,7 +38,7 @@ struct Unique_numbers {
 #ifdef CGAL_NO_ATOMIC
       static std::size_t n = 0;
 #else
-      static CGAL::cpp11::atomic<std::size_t> n; // initialized to 0
+      static std::atomic<std::size_t> n; // initialized to 0
 #endif
       i = n++;
     }

--- a/CGAL_Core/include/CGAL/CORE/CoreDefs.h
+++ b/CGAL_Core/include/CGAL/CORE/CoreDefs.h
@@ -29,7 +29,6 @@
 #define _CORE_COREDEFS_H_
 
 #include <CGAL/CORE/extLong.h>
-#include <CGAL/atomic.h>
 #include <CGAL/disable_warnings.h>
 
 #ifdef CGAL_HEADER_ONLY

--- a/CGAL_Core/include/CGAL/CORE/CoreDefs.h
+++ b/CGAL_Core/include/CGAL/CORE/CoreDefs.h
@@ -31,6 +31,8 @@
 #include <CGAL/CORE/extLong.h>
 #include <CGAL/disable_warnings.h>
 
+#include <atomic>
+
 #ifdef CGAL_HEADER_ONLY
 
   #define CGAL_GLOBAL_STATE_VAR(TYPE, NAME, VALUE)  \
@@ -74,7 +76,7 @@ namespace CORE {
 #ifdef CGAL_NO_ATOMIC
 CGAL_GLOBAL_STATE_VAR(bool, AbortFlag, true)
 #else
-CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<bool>, AbortFlag, true)
+CGAL_GLOBAL_STATE_VAR(std::atomic<bool>, AbortFlag, true)
 #endif
 
 /// Invalid Flag -- initiallly value is non-negative
@@ -85,7 +87,7 @@ CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<bool>, AbortFlag, true)
 #ifdef CGAL_NO_ATOMIC
 CGAL_GLOBAL_STATE_VAR(int, InvalidFlag, 0)
 #else
-CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<int>, InvalidFlag, 0)
+CGAL_GLOBAL_STATE_VAR(std::atomic<int>, InvalidFlag, 0)
 #endif
 
 /// Escape Precision in bits
@@ -101,7 +103,7 @@ CGAL_GLOBAL_STATE_VAR(long, EscapePrecFlag, 0)
 #ifdef CGAL_NO_ATOMIC
 CGAL_GLOBAL_STATE_VAR(bool, EscapePrecWarning, true)
 #else
-CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<bool>, EscapePrecWarning, true)
+CGAL_GLOBAL_STATE_VAR(std::atomic<bool>, EscapePrecWarning, true)
 #endif
 
 // These following two values determine the precision of computing
@@ -123,7 +125,7 @@ CGAL_GLOBAL_STATE_VAR(extLong, defAbsPrec, CORE_posInfty)
 #ifdef CGAL_NO_ATOMIC
     CGAL_GLOBAL_STATE_VAR(long, defBigFloatOutputDigits, 10)
 #else
-    CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<long>, defBigFloatOutputDigits, 10)
+    CGAL_GLOBAL_STATE_VAR(std::atomic<long>, defBigFloatOutputDigits, 10)
 #endif
 
 /// default input precision in digits for converting a string to a Real or Expr
@@ -137,7 +139,7 @@ CGAL_GLOBAL_STATE_VAR(extLong, defInputDigits, CORE_posInfty)
 #ifdef CGAL_NO_ATOMIC
 CGAL_GLOBAL_STATE_VAR(long, defOutputDigits, 10) // == get_static_defBigFloatOutputDigits()
 #else
-CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<long>, defOutputDigits, 10) // == get_static_defBigFloatOutputDigits()
+CGAL_GLOBAL_STATE_VAR(std::atomic<long>, defOutputDigits, 10) // == get_static_defBigFloatOutputDigits()
 #endif
 
 /// default input precision in digits for converting a string to a BigFloat
@@ -145,7 +147,7 @@ CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<long>, defOutputDigits, 10) // == get_
 #ifdef CGAL_NO_ATOMIC
 CGAL_GLOBAL_STATE_VAR(long, defBigFloatInputDigits, 16)
 #else
-CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<long>, defBigFloatInputDigits, 16)
+CGAL_GLOBAL_STATE_VAR(std::atomic<long>, defBigFloatInputDigits, 16)
 #endif
 
 inline
@@ -168,7 +170,7 @@ CGAL_GLOBAL_STATE_VAR(extLong, defBFsqrtAbsPrec, 54)
 #ifdef CGAL_NO_ATOMIC
 CGAL_GLOBAL_STATE_VAR(bool, fpFilterFlag, true)
 #else
-CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<bool>, fpFilterFlag, true)
+CGAL_GLOBAL_STATE_VAR(std::atomic<bool>, fpFilterFlag, true)
 #endif
 
 
@@ -176,7 +178,7 @@ CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<bool>, fpFilterFlag, true)
 #ifdef CGAL_NO_ATOMIC
 CGAL_GLOBAL_STATE_VAR(bool, incrementalEvalFlag, true)
 #else
-CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<bool>, incrementalEvalFlag, true)
+CGAL_GLOBAL_STATE_VAR(std::atomic<bool>, incrementalEvalFlag, true)
 #endif
 
 
@@ -184,7 +186,7 @@ CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<bool>, incrementalEvalFlag, true)
 #ifdef CGAL_NO_ATOMIC
 CGAL_GLOBAL_STATE_VAR(bool, progressiveEvalFlag, true)
 #else
-CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<bool>, progressiveEvalFlag, true)
+CGAL_GLOBAL_STATE_VAR(std::atomic<bool>, progressiveEvalFlag, true)
 #endif
 
 
@@ -192,14 +194,14 @@ CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<bool>, progressiveEvalFlag, true)
 #ifdef CGAL_NO_ATOMIC
 CGAL_GLOBAL_STATE_VAR(bool, rationalReduceFlag, false)
 #else
-CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<bool>, rationalReduceFlag, false)
+CGAL_GLOBAL_STATE_VAR(std::atomic<bool>, rationalReduceFlag, false)
 #endif
 
 /// default initial (bit) precision for AddSub Progressive Evaluation
 #ifdef CGAL_NO_ATOMIC
 CGAL_GLOBAL_STATE_VAR(long, defInitialProgressivePrec, 64)
 #else
-CGAL_GLOBAL_STATE_VAR(CGAL::cpp11::atomic<long>, defInitialProgressivePrec, 64)
+CGAL_GLOBAL_STATE_VAR(std::atomic<long>, defInitialProgressivePrec, 64)
 #endif
 
 //////////////////////////////////////////////////////////////

--- a/CGAL_Core/include/CGAL/CORE/CoreDefs_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/CoreDefs_impl.h
@@ -24,6 +24,8 @@
 
 #include "CGAL/CORE/CoreDefs.h"
 
+#include <atomic>
+
 namespace CORE {
 
 //  Default Values
@@ -50,7 +52,7 @@ int IOErrorFlag = 0;
 #ifdef CGAL_NO_ATOMIC
 bool AbortFlag = true;
 #else
-CGAL::cpp11::atomic<bool> AbortFlag(true);
+std::atomic<bool> AbortFlag(true);
 #endif
 
 /**
@@ -61,7 +63,7 @@ CGAL::cpp11::atomic<bool> AbortFlag(true);
 #ifdef CGAL_NO_ATOMIC
 int InvalidFlag = 0;
 #else
-CGAL::cpp11::atomic<int> InvalidFlag(0);
+std::atomic<int> InvalidFlag(0);
 #endif
 
 /* ************************************************************
@@ -97,7 +99,7 @@ long EscapePrecFlag = 0;
 #ifdef CGAL_NO_ATOMIC
 bool EscapePrecWarning = true;
 #else
-CGAL::cpp11::atomic<bool> EscapePrecWarning(true);
+std::atomic<bool> EscapePrecWarning(true);
 #endif
 
 /** The Composite Precision [defAbsPrec, defRelPrec]
@@ -117,7 +119,7 @@ extLong defRelPrec = 60;
 #ifdef CGAL_NO_ATOMIC
 long defBigFloatOutputDigits = 10;
 #else
-CGAL::cpp11::atomic<long> defBigFloatOutputDigits(10);
+std::atomic<long> defBigFloatOutputDigits(10);
 #endif
 
 /**  NORMALLY, we like to make this equal to defBigFloatOutputDigits
@@ -125,7 +127,7 @@ CGAL::cpp11::atomic<long> defBigFloatOutputDigits(10);
 #ifdef CGAL_NO_ATOMIC
 long defOutputDigits = 10;
 #else
-CGAL::cpp11::atomic<long> defOutputDigits(10); // == defBigFloatOutputDigits;
+std::atomic<long> defOutputDigits(10); // == defBigFloatOutputDigits;
 #endif
 
 /** String Input Precision */
@@ -142,7 +144,7 @@ extLong defInputDigits = CORE_posInfty;
 #ifdef CGAL_NO_ATOMIC
 long defBigFloatInputDigits = 16;
 #else
-CGAL::cpp11::atomic<long> defBigFloatInputDigits(16);
+std::atomic<long> defBigFloatInputDigits(16);
 #endif
 
 /* ************************************************************
@@ -154,7 +156,7 @@ CGAL::cpp11::atomic<long> defBigFloatInputDigits(16);
 #ifdef CGAL_NO_ATOMIC
 bool fpFilterFlag = true;
 #else
-CGAL::cpp11::atomic<bool> fpFilterFlag(true);
+std::atomic<bool> fpFilterFlag(true);
 #endif
 
 /** IncrementaL evaluation flag
@@ -163,7 +165,7 @@ CGAL::cpp11::atomic<bool> fpFilterFlag(true);
 #ifdef CGAL_NO_ATOMIC
 bool incrementalEvalFlag = true;
 #else
-CGAL::cpp11::atomic<bool> incrementalEvalFlag(true);
+std::atomic<bool> incrementalEvalFlag(true);
 #endif
 
 /** Progressive evaluation flag
@@ -171,7 +173,7 @@ CGAL::cpp11::atomic<bool> incrementalEvalFlag(true);
 #ifdef CGAL_NO_ATOMIC
 bool progressiveEvalFlag = true;
 #else
-CGAL::cpp11::atomic<bool> progressiveEvalFlag(true);
+std::atomic<bool> progressiveEvalFlag(true);
 #endif
 
 /** Initial progressive evaluation precision
@@ -179,7 +181,7 @@ CGAL::cpp11::atomic<bool> progressiveEvalFlag(true);
 #ifdef CGAL_NO_ATOMIC
 long defInitialProgressivePrec = 64;
 #else
-CGAL::cpp11::atomic<long> defInitialProgressivePrec(64);
+std::atomic<long> defInitialProgressivePrec(64);
 #endif
 
 /** RATIONAL REDUCTION FLAG
@@ -187,7 +189,7 @@ CGAL::cpp11::atomic<long> defInitialProgressivePrec(64);
 #ifdef CGAL_NO_ATOMIC
 bool rationalReduceFlag = false;
 #else
-CGAL::cpp11::atomic<bool> rationalReduceFlag(false);
+std::atomic<bool> rationalReduceFlag(false);
 #endif
 #endif // CGAL_HEADER_ONLY
 

--- a/Installation/include/CGAL/atomic.h
+++ b/Installation/include/CGAL/atomic.h
@@ -10,6 +10,9 @@
 #ifndef CGAL_ATOMIC_H
 #define CGAL_ATOMIC_H
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/atomic.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/config.h>"
+
 #include <CGAL/config.h>
 
 #ifdef CGAL_HAS_THREADS

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -645,6 +645,9 @@ using std::max;
 #  include <unordered_set>
 #  include <unordered_map>
 #  include <functional>
+#  include <thread>
+#  include <chrono>
+#  include <atomic>
 //
 namespace CGAL {
 //
@@ -663,6 +666,16 @@ namespace CGAL {
     using std::is_enum;
     using std::unordered_set;
     using std::unordered_map;
+    using std::atomic;
+    using std::memory_order_relaxed;
+    using std::memory_order_consume;
+    using std::memory_order_acquire;
+    using std::memory_order_release;
+    using std::memory_order_acq_rel;
+    using std::memory_order_seq_cst;
+    using std::atomic_thread_fence;
+    using std::thread;
+
   }
 //
   namespace cpp0x = cpp11;

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -55,6 +55,7 @@
 #include <boost/format.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <string>
+#include <atomic>
 
 namespace CGAL {
 namespace Mesh_3 {
@@ -212,7 +213,7 @@ public:
            std::size_t maximal_number_of_vertices = 0,
            Mesh_error_code* error_code = 0
 #ifndef CGAL_NO_ATOMIC
-           , CGAL::cpp11::atomic<bool>* stop_ptr = 0
+           , std::atomic<bool>* stop_ptr = 0
 #endif
            );
 
@@ -284,7 +285,7 @@ private:
 
 #ifndef CGAL_NO_ATOMIC
   /// Pointer to the atomic Boolean that can stop the process
-  CGAL::cpp11::atomic<bool>* const stop_ptr;
+  std::atomic<bool>* const stop_ptr;
 #endif
 
 #ifdef CGAL_LINKED_WITH_TBB
@@ -343,7 +344,7 @@ Mesher_3<C3T3,MC,MD>::Mesher_3(C3T3& c3t3,
                                std::size_t maximal_number_of_vertices,
                                Mesh_error_code* error_code
 #ifndef CGAL_NO_ATOMIC
-                               , CGAL::cpp11::atomic<bool>* stop_ptr
+                               , std::atomic<bool>* stop_ptr
 #endif
                                )
 : Base(c3t3.bbox(),

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -36,7 +36,6 @@
 #include <CGAL/Mesher_level_visitors.h>
 #include <CGAL/Kernel_traits.h>
 #include <CGAL/point_generators_3.h>
-#include <CGAL/atomic.h>
 
 #ifdef CGAL_MESH_3_USE_OLD_SURFACE_RESTRICTED_DELAUNAY_UPDATE
 #include <CGAL/Surface_mesher/Surface_mesher_visitor.h>

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -309,7 +309,7 @@ private:
   bool forced_stop() const {
 #ifndef CGAL_NO_ATOMIC
     if(stop_ptr != 0 &&
-       stop_ptr->load(CGAL::cpp11::memory_order_acquire) == true)
+       stop_ptr->load(std::memory_order_acquire) == true)
     {
       if(error_code_ != 0) *error_code_ = CGAL_MESH_3_STOPPED;
       return true;

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_level.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_level.h
@@ -23,7 +23,6 @@
   #include <CGAL/Mesh_3/Profiling_tools.h>
 #endif
 
-#include <CGAL/atomic.h>
 #include <CGAL/Mesh_3/Worksharing_data_structures.h>
 
 #ifdef CGAL_CONCURRENT_MESH_3_PROFILING

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_level.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_level.h
@@ -1157,7 +1157,7 @@ public:
   bool forced_stop() const {
 #ifndef CGAL_NO_ATOMIC
     if(m_stop_ptr != 0 &&
-       m_stop_ptr->load(CGAL::cpp11::memory_order_acquire) == true)
+       m_stop_ptr->load(std::memory_order_acquire) == true)
     {
       CGAL_assertion(m_empty_root_task != 0);
       m_empty_root_task->cancel_group_execution();

--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_level.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_level.h
@@ -36,7 +36,7 @@
 # include <tbb/task.h>
 #endif
 
-#include <string>
+#include <atomic>
 
 namespace CGAL { namespace Mesh_3 {
 
@@ -676,7 +676,7 @@ public:
   void set_lock_ds(Lock_data_structure *) {}
   void set_worksharing_ds(WorksharingDataStructureType *) {}
 #ifndef CGAL_NO_ATOMIC
-  void set_stop_pointer(CGAL::cpp11::atomic<bool>*) {}
+  void set_stop_pointer(std::atomic<bool>*) {}
 #endif
 
 protected:
@@ -1148,7 +1148,7 @@ public:
   }
 
 #ifndef CGAL_NO_ATOMIC
-  void set_stop_pointer(CGAL::cpp11::atomic<bool>* stop_ptr)
+  void set_stop_pointer(std::atomic<bool>* stop_ptr)
   {
     m_stop_ptr = stop_ptr;
   }
@@ -1178,7 +1178,7 @@ protected:
 
   tbb::task *m_empty_root_task;
 #ifndef CGAL_NO_ATOMIC
-  CGAL::cpp11::atomic<bool>* m_stop_ptr;
+  std::atomic<bool>* m_stop_ptr;
 #endif
 
 private:

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -70,6 +70,7 @@
 #include <string>
 #include <utility>
 #include <vector>
+#include <atomic>
 
 namespace CGAL {
 namespace Mesh_3 {
@@ -143,7 +144,7 @@ public:
                              std::size_t maximal_number_of_vertices = 0,
                              Mesh_error_code* error_code = 0
 #ifndef CGAL_NO_ATOMIC
-                             , CGAL::cpp11::atomic<bool>* stop_ptr = 0
+                             , std::atomic<bool>* stop_ptr = 0
 #endif
                              );
 
@@ -469,7 +470,7 @@ private:
   Mesh_error_code* const error_code_;
 #ifndef CGAL_NO_ATOMIC
   /// Pointer to the atomic Boolean that can stop the process
-  CGAL::cpp11::atomic<bool>* const stop_ptr_;
+  std::atomic<bool>* const stop_ptr_;
 #endif
 };
 
@@ -481,7 +482,7 @@ Protect_edges_sizing_field(C3T3& c3t3, const MD& domain,
                            std::size_t maximal_number_of_vertices,
                            Mesh_error_code* error_code
 #ifndef CGAL_NO_ATOMIC
-                           , CGAL::cpp11::atomic<bool>* stop_ptr
+                           , std::atomic<bool>* stop_ptr
 #endif
                            )
   : c3t3_(c3t3)

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -157,7 +157,7 @@ public:
   bool forced_stop() const {
 #ifndef CGAL_NO_ATOMIC
     if(stop_ptr_ != 0 &&
-       stop_ptr_->load(CGAL::cpp11::memory_order_acquire) == true)
+       stop_ptr_->load(std::memory_order_acquire) == true)
     {
       if(error_code_ != 0) *error_code_ = CGAL_MESH_3_STOPPED;
       return true;

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -46,7 +46,6 @@
 #include <CGAL/iterator.h>
 #include <CGAL/number_utils.h>
 #include <CGAL/Delaunay_triangulation_3.h>
-#include <CGAL/atomic.h>
 
 #include <CGAL/boost/iterator/transform_iterator.hpp>
 

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
@@ -26,7 +26,6 @@
   #include <tbb/blocked_range.h>
   #include <tbb/parallel_for.h>
 #endif
-#include <CGAL/atomic.h>
 
 #include <CGAL/Meshes/Filtered_deque_container.h>
 #include <CGAL/Meshes/Filtered_multimap_container.h>

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
@@ -371,7 +371,7 @@ public:
   {
 #ifndef CGAL_NO_ATOMIC
     if(m_stop_ptr != 0 &&
-       m_stop_ptr->load(CGAL::cpp11::memory_order_acquire) == true)
+       m_stop_ptr->load(std::memory_order_acquire) == true)
     {
       return true;
     }

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
@@ -40,7 +40,7 @@
 #include <boost/mpl/if.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 #include <sstream>
-
+#include <atomic>
 
 namespace CGAL {
 
@@ -318,7 +318,7 @@ public:
                  C3T3& c3t3,
                  std::size_t maximal_number_of_vertices
 #ifndef CGAL_NO_ATOMIC
-                , CGAL::cpp11::atomic<bool>* stop_ptr
+                , std::atomic<bool>* stop_ptr
 #endif
                 );
   // For parallel
@@ -331,7 +331,7 @@ public:
                  WorksharingDataStructureType *worksharing_ds,
                  std::size_t maximal_number_of_vertices
 #ifndef CGAL_NO_ATOMIC
-                , CGAL::cpp11::atomic<bool>* stop_ptr
+                , std::atomic<bool>* stop_ptr
 #endif
                 );
 
@@ -572,7 +572,7 @@ private:
 
 #ifndef CGAL_NO_ATOMIC
   /// Pointer to the atomic Boolean that can stop the process
-  CGAL::cpp11::atomic<bool>* const m_stop_ptr;
+  std::atomic<bool>* const m_stop_ptr;
 #endif
 private:
   // Disabled copy constructor
@@ -594,7 +594,7 @@ Refine_cells_3(Tr& triangulation,
                C3T3& c3t3,
                std::size_t maximal_number_of_vertices
 #ifndef CGAL_NO_ATOMIC
-               , CGAL::cpp11::atomic<bool>* stop_ptr
+               , std::atomic<bool>* stop_ptr
 #endif
                )
   : Mesher_level<Tr, Self, Cell_handle, P_,
@@ -627,7 +627,7 @@ Refine_cells_3(Tr& triangulation,
                WorksharingDataStructureType *worksharing_ds,
                std::size_t maximal_number_of_vertices
 #ifndef CGAL_NO_ATOMIC
-               , CGAL::cpp11::atomic<bool>* stop_ptr
+               , std::atomic<bool>* stop_ptr
 #endif
                )
   : Mesher_level<Tr, Self, Cell_handle, P_,

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -50,6 +50,7 @@
 #include <CGAL/tuple.h>
 #include <boost/type_traits/is_convertible.hpp>
 #include <sstream>
+#include <atomic>
 
 namespace CGAL {
 
@@ -254,7 +255,7 @@ public:
                        const Criteria& criteria,
                        std::size_t maximal_number_of_vertices
 #ifndef CGAL_NO_ATOMIC
-                       , CGAL::cpp11::atomic<bool>* stop_ptr
+                       , std::atomic<bool>* stop_ptr
 #endif
                        )
     : r_tr_(tr)
@@ -608,7 +609,7 @@ protected:
   std::size_t m_maximal_number_of_vertices_;
 #ifndef CGAL_NO_ATOMIC
   /// Pointer to the atomic Boolean that can stop the process
-  CGAL::cpp11::atomic<bool>* const m_stop_ptr;
+  std::atomic<bool>* const m_stop_ptr;
 #endif
 }; // end class template Refine_facets_3_base
 
@@ -776,7 +777,7 @@ public:
                   int mesh_topology,
                   std::size_t maximal_number_of_vertices
 #ifndef CGAL_NO_ATOMIC
-                  , CGAL::cpp11::atomic<bool>* stop_ptr
+                  , std::atomic<bool>* stop_ptr
 #endif
                   );
   // For parallel
@@ -789,7 +790,7 @@ public:
                   WorksharingDataStructureType *worksharing_ds,
                   std::size_t maximal_number_of_vertices
 #ifndef CGAL_NO_ATOMIC
-                  , CGAL::cpp11::atomic<bool>* stop_ptr
+                  , std::atomic<bool>* stop_ptr
 #endif
                   );
 
@@ -909,7 +910,7 @@ Refine_facets_3(Tr& triangulation,
                 int mesh_topology,
                 std::size_t maximal_number_of_vertices
 #ifndef CGAL_NO_ATOMIC
-                , CGAL::cpp11::atomic<bool>* stop_ptr
+                , std::atomic<bool>* stop_ptr
 #endif
                 )
   : Rf_base(triangulation, c3t3, oracle, criteria, mesh_topology,
@@ -938,7 +939,7 @@ Refine_facets_3(Tr& triangulation,
                 WorksharingDataStructureType *worksharing_ds,
                 std::size_t maximal_number_of_vertices
 #ifndef CGAL_NO_ATOMIC
-                , CGAL::cpp11::atomic<bool>* stop_ptr
+                , std::atomic<bool>* stop_ptr
 #endif
                 )
   : Rf_base(triangulation, c3t3, oracle, criteria, maximal_number_of_vertices

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -41,7 +41,6 @@
 #include <CGAL/Mesh_3/Dump_c3t3.h>
 
 #include <CGAL/Object.h>
-#include <CGAL/atomic.h>
 
 #include <boost/format.hpp>
 #include <boost/optional.hpp>

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -275,7 +275,7 @@ public:
   {
 #ifndef CGAL_NO_ATOMIC
     if(m_stop_ptr != 0 &&
-       m_stop_ptr->load(CGAL::cpp11::memory_order_acquire) == true)
+       m_stop_ptr->load(std::memory_order_acquire) == true)
     {
       return true;
     }

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_manifold_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_manifold_base.h
@@ -30,6 +30,7 @@
 
 #include <set>
 #include <vector>
+#include <atomic>
 
 namespace CGAL {
 
@@ -307,7 +308,7 @@ public:
                               int mesh_topology,
                               std::size_t maximal_number_of_vertices
 #ifndef CGAL_NO_ATOMIC
-                              , CGAL::cpp11::atomic<bool>* stop_ptr
+                              , std::atomic<bool>* stop_ptr
 #endif
                               )
     : Base(triangulation,

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_manifold_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_manifold_base.h
@@ -19,7 +19,6 @@
 
 #include <CGAL/Mesh_facet_topology.h>
 
-#include <CGAL/atomic.h>
 #include <CGAL/utility.h>
 #include <CGAL/Time_stamper.h>
 

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_manifold_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_manifold_base.h
@@ -446,7 +446,7 @@ public:
 
 #ifndef CGAL_NO_ATOMIC
       if(this->m_stop_ptr != 0 &&
-         this->m_stop_ptr->load(CGAL::cpp11::memory_order_acquire) == true)
+         this->m_stop_ptr->load(std::memory_order_acquire) == true)
       {
         return true;
       }

--- a/Mesh_3/include/CGAL/Mesh_vertex_base_3.h
+++ b/Mesh_3/include/CGAL/Mesh_vertex_base_3.h
@@ -66,6 +66,13 @@ template <>
 class Mesh_vertex_base_3_base<Parallel_tag>
 {
 public:
+  Mesh_vertex_base_3_base()
+  {}
+
+  Mesh_vertex_base_3_base( const Mesh_vertex_base_3_base& c)
+  {
+    m_erase_counter.store(c.erase_counter());
+  }
 
   // Erase counter (cf. Compact_container)
   unsigned int erase_counter() const

--- a/Mesh_3/include/CGAL/Mesh_vertex_base_3.h
+++ b/Mesh_3/include/CGAL/Mesh_vertex_base_3.h
@@ -28,6 +28,7 @@
 #include <CGAL/Mesh_3/io_signature.h>
 #include <CGAL/Has_timestamp.h>
 #include <CGAL/tags.h>
+#include <atomic>
 
 namespace CGAL {
 

--- a/Mesh_3/include/CGAL/Mesh_vertex_base_3.h
+++ b/Mesh_3/include/CGAL/Mesh_vertex_base_3.h
@@ -81,7 +81,7 @@ public:
   }
 
 protected:
-  typedef tbb::atomic<unsigned int> Erase_counter_type;
+  typedef std::atomic<unsigned int> Erase_counter_type;
   Erase_counter_type                m_erase_counter;
 
 };

--- a/Mesh_3/include/CGAL/make_mesh_3.h
+++ b/Mesh_3/include/CGAL/make_mesh_3.h
@@ -32,6 +32,8 @@
 #include <boost/mpl/has_xxx.hpp>
 #include <boost/parameter/preprocessor.hpp>
 
+#include <atomic>
+
 namespace CGAL {
 
 namespace parameters {
@@ -192,7 +194,7 @@ void init_c3t3_with_features(C3T3& c3t3,
                              std::size_t maximal_number_of_vertices = 0,
                              Mesh_error_code* pointer_to_error_code = 0
 #ifndef CGAL_NO_ATOMIC
-                             , CGAL::cpp11::atomic<bool>* pointer_to_stop = 0
+                             , std::atomic<bool>* pointer_to_stop = 0
 #endif
                              )
 {

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -28,7 +28,6 @@
 #include <CGAL/Mesh_3/Mesher_3.h>
 #include <CGAL/Mesh_error_code.h>
 #include <CGAL/optimize_mesh_3.h>
-#include <CGAL/atomic.h>
 
 #include <boost/parameter/preprocessor.hpp>
 

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -31,6 +31,8 @@
 
 #include <boost/parameter/preprocessor.hpp>
 
+#include <atomic>
+
 namespace CGAL {
 
 namespace details {
@@ -195,7 +197,7 @@ struct Manifold_options {
 // Various Mesh_3 option
 struct Mesh_3_options {
 #ifndef CGAL_NO_ATOMIC
-      typedef CGAL::cpp11::atomic<bool>* Pointer_to_stop_atomic_boolean_t;
+      typedef std::atomic<bool>* Pointer_to_stop_atomic_boolean_t;
 #else
       typedef bool* Pointer_to_stop_atomic_boolean_t;
 #endif

--- a/Nef_3/include/CGAL/Nef_3/SNC_indexed_items.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_indexed_items.h
@@ -23,6 +23,8 @@
 #include <CGAL/Nef_3/SHalfloop.h>
 #include <CGAL/Nef_3/SFace.h>
 
+#include <atomic>
+
 #undef CGAL_NEF_DEBUG
 #define CGAL_NEF_DEBUG 83
 #include <CGAL/Nef_2/debug.h>
@@ -39,7 +41,7 @@ class Index_generator {
 #ifdef CGAL_NO_ATOMIC
     static int unique;
 #else
-    static CGAL::cpp11::atomic<int> unique;
+    static std::atomic<int> unique;
 #endif
     return unique++;
   }

--- a/Nef_3/include/CGAL/Nef_3/SNC_indexed_items.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_indexed_items.h
@@ -15,9 +15,6 @@
 
 #include <CGAL/license/Nef_3.h>
 
-
-#include <CGAL/atomic.h>
-
 #include <CGAL/Nef_3/Vertex.h>
 #include <CGAL/Nef_3/Halfedge.h>
 #include <CGAL/Nef_3/Halffacet.h>

--- a/Number_types/include/CGAL/Counted_number.h
+++ b/Number_types/include/CGAL/Counted_number.h
@@ -21,6 +21,7 @@
 #include <CGAL/number_type_basic.h>
 #include <CGAL/boost/iterator/transform_iterator.hpp> // for Root_of_selector
 #include <iostream>
+#include <atomic>
 
 namespace CGAL {
 
@@ -29,7 +30,7 @@ class Counted_number {
 #ifdef CGAL_NO_ATOMIC
     static unsigned long
 #else
-    static CGAL::cpp11::atomic<unsigned long>
+    static std::atomic<unsigned long>
 #endif
                          s_neg_count, s_add_count, s_sub_count,
                          s_mul_count, s_div_count,
@@ -279,64 +280,64 @@ template< class NT >
 unsigned long Counted_number<NT>::s_mod_count = 0;
 #else
 template <class NT>
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_neg_count;
+std::atomic<unsigned long> Counted_number<NT>::s_neg_count;
 
 template <class NT>
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_add_count;
+std::atomic<unsigned long> Counted_number<NT>::s_add_count;
 
 template <class NT>
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_sub_count;
+std::atomic<unsigned long> Counted_number<NT>::s_sub_count;
 
 template <class NT>
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_mul_count;
+std::atomic<unsigned long> Counted_number<NT>::s_mul_count;
 
 template <class NT>
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_div_count;
+std::atomic<unsigned long> Counted_number<NT>::s_div_count;
 
 template <class NT>
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_eq_count;
+std::atomic<unsigned long> Counted_number<NT>::s_eq_count;
 
 template <class NT>
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_comp_count;
+std::atomic<unsigned long> Counted_number<NT>::s_comp_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_simplify_count;
+std::atomic<unsigned long> Counted_number<NT>::s_simplify_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_unit_part_count;
+std::atomic<unsigned long> Counted_number<NT>::s_unit_part_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_is_zero_count;
+std::atomic<unsigned long> Counted_number<NT>::s_is_zero_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_is_one_count;
+std::atomic<unsigned long> Counted_number<NT>::s_is_one_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_square_count;
+std::atomic<unsigned long> Counted_number<NT>::s_square_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_integral_division_count;
+std::atomic<unsigned long> Counted_number<NT>::s_integral_division_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_is_square_count;
+std::atomic<unsigned long> Counted_number<NT>::s_is_square_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_sqrt_count;
+std::atomic<unsigned long> Counted_number<NT>::s_sqrt_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_kth_root_count;
+std::atomic<unsigned long> Counted_number<NT>::s_kth_root_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_root_of_count;
+std::atomic<unsigned long> Counted_number<NT>::s_root_of_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_gcd_count;
+std::atomic<unsigned long> Counted_number<NT>::s_gcd_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_div_mod_count;
+std::atomic<unsigned long> Counted_number<NT>::s_div_mod_count;
 
 template< class NT >
-CGAL::cpp11::atomic<unsigned long> Counted_number<NT>::s_mod_count;
+std::atomic<unsigned long> Counted_number<NT>::s_mod_count;
 #endif
 
 

--- a/Number_types/include/CGAL/Counted_number.h
+++ b/Number_types/include/CGAL/Counted_number.h
@@ -19,7 +19,6 @@
 #define CGAL_COUNTED_NUMBER_H
 
 #include <CGAL/number_type_basic.h>
-#include <CGAL/atomic.h>
 #include <CGAL/boost/iterator/transform_iterator.hpp> // for Root_of_selector
 #include <iostream>
 

--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Callback_wrapper.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Callback_wrapper.h
@@ -13,7 +13,8 @@
 #define CGAL_PSP_INTERNAL_CALLBACK_WRAPPER_H
 
 #include <CGAL/license/Point_set_processing_3.h>
-
+#include <atomic>
+#include <thread>
 #include <functional>
 
 
@@ -90,11 +91,11 @@ template <>
 class Callback_wrapper<CGAL::Parallel_tag>
 {
   const std::function<bool(double)>& m_callback;
-  cpp11::atomic<std::size_t>* m_advancement;
-  cpp11::atomic<bool>* m_interrupted;
+  std::atomic<std::size_t>* m_advancement;
+  std::atomic<bool>* m_interrupted;
   std::size_t m_size;
   bool m_creator;
-  cpp11::thread* m_thread;
+  std::thread* m_thread;
 
   // assignment operator shouldn't be used (m_callback is const ref)
   Callback_wrapper& operator= (const Callback_wrapper&)
@@ -108,17 +109,17 @@ public:
                      std::size_t advancement = 0,
                      bool interrupted = false)
     : m_callback (callback)
-    , m_advancement (new cpp11::atomic<std::size_t>())
-    , m_interrupted (new cpp11::atomic<bool>())
+    , m_advancement (new std::atomic<std::size_t>())
+    , m_interrupted (new std::atomic<bool>())
     , m_size (size)
     , m_creator (true)
     , m_thread (nullptr)
   {
-    // cpp11::atomic only has default constructor, initialization done in two steps
+    // std::atomic only has default constructor, initialization done in two steps
     *m_advancement = advancement;
     *m_interrupted = interrupted;
     if (m_callback)
-      m_thread = new cpp11::thread (*this);
+      m_thread = new std::thread (*this);
   }
 
   Callback_wrapper (const Callback_wrapper& other)
@@ -149,11 +150,11 @@ public:
     *m_advancement = advancement;
     *m_interrupted = interrupted;
     if (m_callback)
-      m_thread = new cpp11::thread (*this);
+      m_thread = new std::thread (*this);
   }
 
-  cpp11::atomic<std::size_t>& advancement() { return *m_advancement; }
-  cpp11::atomic<bool>& interrupted() { return *m_interrupted; }
+  std::atomic<std::size_t>& advancement() { return *m_advancement; }
+  std::atomic<bool>& interrupted() { return *m_interrupted; }
   void join()
   {
     if (m_thread != nullptr)

--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Callback_wrapper.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Callback_wrapper.h
@@ -16,7 +16,6 @@
 
 #include <functional>
 
-#include <CGAL/thread.h>
 
 namespace CGAL {
 namespace Point_set_processing_3 {

--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Callback_wrapper.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Callback_wrapper.h
@@ -168,7 +168,9 @@ public:
         *m_interrupted = true;
       if (*m_interrupted)
         return;
-      cpp11::sleep_for (0.00001);
+      typedef std::chrono::nanoseconds nanoseconds;
+      nanoseconds ns (nanoseconds::rep (1000000000.0 * 0.00001));
+      std::this_thread::sleep_for(ns);
     }
     if (m_callback)
       m_callback (1.);

--- a/Polyhedron/demo/Polyhedron/Use_ssh.cpp
+++ b/Polyhedron/demo/Polyhedron/Use_ssh.cpp
@@ -302,9 +302,7 @@ bool push_file(ssh_session &session,
   //some versions of libssh don't copy everything without this.
   //This is the case for the official version on Ubuntu 18.04
   std::chrono::duration<int, std::micro> timespan(size);
-  typedef std::chrono::nanoseconds nanoseconds;
-  nanoseconds ns (nanoseconds::rep (1000000000 * timespan));
-  std::this_thread::sleep_for(ns);
+  std::this_thread::sleep_for(timespan);
   if (res != SSH_OK)
   {
     std::cerr<< "Can't write to remote file: %s\n"

--- a/Polyhedron/demo/Polyhedron/Use_ssh.cpp
+++ b/Polyhedron/demo/Polyhedron/Use_ssh.cpp
@@ -303,7 +303,7 @@ bool push_file(ssh_session &session,
   //This is the case for the official version on Ubuntu 18.04
   std::chrono::duration<int, std::micro> timespan(size);
   typedef std::chrono::nanoseconds nanoseconds;
-  nanoseconds ns (nanoseconds::rep (1000000000.0 * timespan));
+  nanoseconds ns (nanoseconds::rep (1000000000 * timespan));
   std::this_thread::sleep_for(ns);
   if (res != SSH_OK)
   {

--- a/Polyhedron/demo/Polyhedron/Use_ssh.cpp
+++ b/Polyhedron/demo/Polyhedron/Use_ssh.cpp
@@ -302,7 +302,9 @@ bool push_file(ssh_session &session,
   //some versions of libssh don't copy everything without this.
   //This is the case for the official version on Ubuntu 18.04
   std::chrono::duration<int, std::micro> timespan(size);
-  std::this_thread::sleep_for(timespan);
+  typedef std::chrono::nanoseconds nanoseconds;
+  nanoseconds ns (nanoseconds::rep (1000000000.0 * timespan));
+  std::this_thread::sleep_for(ns);
   if (res != SSH_OK)
   {
     std::cerr<< "Can't write to remote file: %s\n"

--- a/Polyhedron/demo/Polyhedron/include/run_with_qprogressdialog.h
+++ b/Polyhedron/demo/Polyhedron/include/run_with_qprogressdialog.h
@@ -3,7 +3,6 @@
 
 #include <QProgressDialog>
 #include <CGAL/Real_timer.h>
-#include <CGAL/thread.h>
 
 #include "Callback_signaler.h"
 

--- a/Polyhedron/demo/Polyhedron/include/run_with_qprogressdialog.h
+++ b/Polyhedron/demo/Polyhedron/include/run_with_qprogressdialog.h
@@ -6,6 +6,8 @@
 
 #include "Callback_signaler.h"
 
+#include <atomic>
+
 typedef CGAL::Parallel_if_available_tag Concurrency_tag;
 
 class Signal_callback
@@ -111,7 +113,7 @@ void run_with_qprogressdialog (Functor& functor,
 #ifdef CGAL_HAS_STD_THREADS
   if (boost::is_convertible<ConcurrencyTag, CGAL::Parallel_tag>::value)
   {
-    CGAL::cpp11::thread thread (functor);
+    std::thread thread (functor);
 
     while (*signal_callback->latest_adv != 1. &&
            *signal_callback->state)

--- a/Polyhedron/demo/Polyhedron/include/run_with_qprogressdialog.h
+++ b/Polyhedron/demo/Polyhedron/include/run_with_qprogressdialog.h
@@ -118,7 +118,9 @@ void run_with_qprogressdialog (Functor& functor,
     while (*signal_callback->latest_adv != 1. &&
            *signal_callback->state)
     {
-      CGAL::cpp11::sleep_for (0.1);
+      typedef std::chrono::nanoseconds nanoseconds;
+      nanoseconds ns (nanoseconds::rep (1000000000.0 * 0.1));
+      std::this_thread::sleep_for(ns);
       QApplication::processEvents ();
     }
 

--- a/Profiling_tools/include/CGAL/Profile_counter.h
+++ b/Profiling_tools/include/CGAL/Profile_counter.h
@@ -48,6 +48,7 @@
 #include <iomanip>
 #include <string>
 #include <map>
+#include <atomic>
 
 #include <CGAL/disable_warnings.h>
 

--- a/Profiling_tools/include/CGAL/Profile_counter.h
+++ b/Profiling_tools/include/CGAL/Profile_counter.h
@@ -92,7 +92,7 @@ struct Profile_counter
     Profile_counter(const std::string & ss)
       : s(ss)
     {
-      i = 0; // needed here because of tbb::atomic
+      i = 0; // needed here because of std::atomic
     }
 
     void operator++() { ++i; }
@@ -107,7 +107,7 @@ struct Profile_counter
 
 private:
 #ifdef CGAL_CONCURRENT_PROFILE
-    tbb::atomic<unsigned int> i;
+    std::atomic<unsigned int> i;
 #else
     unsigned int i;
 #endif
@@ -167,7 +167,7 @@ struct Profile_branch_counter
     Profile_branch_counter(const std::string & ss)
       : s(ss)
     {
-      i = j = 0; // needed here because of tbb::atomic
+      i = j = 0; // needed here because of std::atomic
     }
 
     void operator++() { ++i; }
@@ -183,7 +183,7 @@ struct Profile_branch_counter
 
 private:
 #ifdef CGAL_CONCURRENT_PROFILE
-    tbb::atomic<unsigned int> i, j;
+    std::atomic<unsigned int> i, j;
 #else
     unsigned int i, j;
 #endif
@@ -196,7 +196,7 @@ struct Profile_branch_counter_3
     Profile_branch_counter_3(const std::string & ss)
       : s(ss)
     {
-      i = j = k = 0; // needed here because of tbb::atomic
+      i = j = k = 0; // needed here because of std::atomic
     }
 
     void operator++() { ++i; }
@@ -214,7 +214,7 @@ struct Profile_branch_counter_3
 
 private:
 #ifdef CGAL_CONCURRENT_PROFILE
-    tbb::atomic<unsigned int> i, j, k;
+    std::atomic<unsigned int> i, j, k;
 #else
     unsigned int i, j, k;
 #endif

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -31,7 +31,6 @@
 #include <CGAL/iterator.h>
 #include <CGAL/CC_safe_handle.h>
 #include <CGAL/Time_stamper.h>
-#include <CGAL/atomic.h>
 
 #include <tbb/enumerable_thread_specific.h>
 #include <tbb/queuing_mutex.h>

--- a/STL_Extension/include/CGAL/Time_stamper.h
+++ b/STL_Extension/include/CGAL/Time_stamper.h
@@ -13,7 +13,6 @@
 #define CGAL_TIME_STAMPER_H
 
 #include <CGAL/Has_timestamp.h>
-#include <CGAL/atomic.h>
 
 namespace CGAL {
 

--- a/STL_Extension/include/CGAL/thread.h
+++ b/STL_Extension/include/CGAL/thread.h
@@ -12,6 +12,9 @@
 #ifndef CGAL_THREAD_H
 #define CGAL_THREAD_H
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/thread.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/config.h>"
+
 #include <CGAL/config.h>
 
 /*


### PR DESCRIPTION
## Summary of Changes
Deprecate `cpp11::atomic` and `cpp11::threads` and use std versions instead

## Release Management

* Affected package(s):Installation
