### PR TITLE
Add with_marks parameter to shell_to_nef

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/shell_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/shell_to_nef_3.h
@@ -62,9 +62,10 @@ class Shell_to_nef_3
 
  private:
   SNC_structure& S;
+  bool with_marks;
  public:
 
-  Shell_to_nef_3(SNC_structure& S_) : S(S_) {}
+  Shell_to_nef_3(SNC_structure& S_, bool m_) : S(S_), with_marks(m_) {}
 
   void visit(Vertex_const_handle ) {}
   void visit(Halfedge_const_handle ) {}
@@ -83,7 +84,7 @@ class Shell_to_nef_3
     Vertex_const_handle pv = sf->center_vertex();
     Vertex_handle nv = S.new_vertex();
     nv->point() = pv->point();
-    nv->mark() = true;
+    nv->mark() = with_marks ? pv->mark() : true;
 
     SM_decorator SM(&*nv);
     SHalfedge_around_sface_const_circulator
@@ -91,7 +92,7 @@ class Shell_to_nef_3
 
     SVertex_handle sv_0 =
       SM.new_svertex(pe->source()->point());
-    sv_0->mark() = true;
+    sv_0->mark() = with_marks ? pe->source()->mark() : true;
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
     sv_0->set_index(pe->source()->get_index());
 #endif
@@ -100,7 +101,7 @@ class Shell_to_nef_3
 
     do {
       SVertex_handle sv = SM.new_svertex(pe->source()->point());
-      sv->mark() = true;
+      sv->mark() = with_marks ? pe->source()->mark() : true;
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
       sv->set_index(pe->source()->get_index());
 #endif
@@ -108,7 +109,8 @@ class Shell_to_nef_3
       SHalfedge_handle e = SM.new_shalfedge_pair(sv_prev, sv);
       e->circle() = pe_prev->circle();
       e->twin()->circle() = pe_prev->twin()->circle();
-      e->mark() = e->twin()->mark() = true;
+      e->mark() = with_marks ? pe_prev->mark() : true;
+      e->twin()->mark() = with_marks ? pe_prev->twin()->mark() : true;
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
       e->set_index(pe_prev->get_index());
       e->twin()->set_index(pe_prev->twin()->get_index());
@@ -123,7 +125,8 @@ class Shell_to_nef_3
     e = SM.new_shalfedge_pair(sv_prev, sv_0);
     e->circle() = pe_prev->circle();
     e->twin()->circle() = pe_prev->twin()->circle();
-    e->mark() = e->twin()->mark() = true;
+    e->mark() = with_marks ? pe_prev->mark() : true;
+    e->twin()->mark() = with_marks ? pe_prev->twin()->mark() : true;
 #ifndef CGAL_NEF_NO_INDEXED_ITEMS
     e->set_index(pe_prev->get_index());
     e->twin()->set_index(pe_prev->twin()->get_index());
@@ -144,9 +147,10 @@ class Shell_to_nef_3
 template <class Nef_polyhedron>
 void shell_to_nef_3(const Nef_polyhedron& N,
                     typename Nef_polyhedron::SFace_const_handle sf,
-                    typename Nef_polyhedron::SNC_structure& S)
+                    typename Nef_polyhedron::SNC_structure& S,
+                    bool with_marks = false)
 {
-  Shell_to_nef_3<typename Nef_polyhedron::SNC_structure> s2n(S);
+  Shell_to_nef_3<typename Nef_polyhedron::SNC_structure> s2n(S,with_marks);
   N.visit_shell_objects(sf, s2n);
 }
 


### PR DESCRIPTION
## Summary of Changes

Within my project, I often want to create a union of non-intersecting nef polyhedra. (I call this group, rather than union) Since there are no intersections performing a binary operation is expensive. Using the `delegate` API I create a combined nef by adding another nef using `CGAL::shell_to_nef_3` as can be seen here: https://github.com/GilesBathgate/RapCAD/blob/master/src/cgalprimitive.cpp#L348-L368

This works, but as a side effect, I lose the marks that were set during previous binary operations. This PR adds a new parameter to shell_to_nef_3 to allow the marks to be copied from the original.

## Release Management

* Affected package(s): Nef_3
* Feature/Small Feature (if any): small feature
* License and copyright ownership: Returned to CGAL authors.

