### PR TITLE
Extra white space at bottom of page

### DIFF
--- a/Documentation/doc/resources/1.8.20/header_package.html
+++ b/Documentation/doc/resources/1.8.20/header_package.html
@@ -12,6 +12,7 @@
 <!-- <link href="$relpath^../Manual/tabs.css" rel="stylesheet" type="text/css"/> -->
 <script type="text/javascript" src="$relpath^../Manual/jquery.js"></script>
 <script type="text/javascript" src="$relpath^../Manual/dynsections.js"></script>
+<script src="$relpath^../Manual/hacks.js" type="text/javascript"></script>
 <!-- Manually include treeview and search to avoid bloat and to fix
      paths to the directory Manual . -->
 <!-- $.treeview -->
@@ -41,7 +42,6 @@ MathJax.Hub.Config({
 });
 </script>
 $mathjax
-<script src="$relpath^../Manual/hacks.js" type="text/javascript"></script>
 <script src="$relpath^modules.js" type="text/javascript"></script>
 $extrastylesheet
 </head>


### PR DESCRIPTION
Below the bottom blue block we see for the packages some extra white space. For the Manual page this white space is not present.
The reason is the placing of the "hack.js" code.

Note the problem was only observed with Firefox.

The old situation:

![image](https://user-images.githubusercontent.com/5223533/117634508-42866900-b17f-11eb-8363-43d13c1948e6.png)

The corrected situation:

![image](https://user-images.githubusercontent.com/5223533/117634732-81b4ba00-b17f-11eb-927a-76f23350edbe.png)

