### PR TITLE
Remove duplicate code in SNC_const_decorator/SNC_decorator

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
@@ -343,15 +343,15 @@ class SNC_decorator : public SNC_const_decorator<Map> {
   }
 
   Halffacet_handle get_visible_facet( const Vertex_handle v,
-                                                       const Ray_3& ray) const
+                                      const Ray_3& ray) const
   { return Base::template get_visible_facet<Decorator_traits>(v, ray); }
 
   Halffacet_handle get_visible_facet( const Halfedge_handle e,
-                                                       const Ray_3& ray) const
+                                      const Ray_3& ray) const
   { return Base::template get_visible_facet<Decorator_traits>(e, ray); }
 
   Halffacet_handle get_visible_facet( const Halffacet_handle f,
-                                                       const Ray_3& ray) const
+                                      const Ray_3& ray) const
   { return Base::template get_visible_facet<Decorator_traits>(f, ray); }
 
   Halffacet_handle get_visible_facet( const Vertex_handle v,

--- a/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
@@ -342,20 +342,17 @@ class SNC_decorator : public SNC_const_decorator<Map> {
     return( e1!=e2 && SD.cyclic_adj_succ(e2)==e1);
   }
 
-  template <typename Traits = Self::Decorator_traits>
-  typename Traits::Halffacet_handle get_visible_facet( const typename Traits::Vertex_handle v,
+  Halffacet_handle get_visible_facet( const Vertex_handle v,
                                                        const Ray_3& ray) const
-  { return Base::template get_visible_facet<Traits>(v, ray); }
+  { return Base::template get_visible_facet<Decorator_traits>(v, ray); }
 
-  template <typename Traits = Self::Decorator_traits>
-  typename Traits::Halffacet_handle get_visible_facet( const typename Traits::Halfedge_handle e,
+  Halffacet_handle get_visible_facet( const Halfedge_handle e,
                                                        const Ray_3& ray) const
-  { return Base::template get_visible_facet<Traits>(e, ray); }
+  { return Base::template get_visible_facet<Decorator_traits>(e, ray); }
 
-  template <typename Traits = Self::Decorator_traits>
-  typename Traits::Halffacet_handle get_visible_facet( const typename Traits::Halffacet_handle f,
+  Halffacet_handle get_visible_facet( const Halffacet_handle f,
                                                        const Ray_3& ray) const
-  { return Base::template get_visible_facet<Traits>(f, ray); }
+  { return Base::template get_visible_facet<Decorator_traits>(f, ray); }
 
   Halffacet_handle get_visible_facet( const Vertex_handle v,
                                       const Segment_3& ray) const
@@ -672,9 +669,9 @@ class SNC_decorator : public SNC_const_decorator<Map> {
     return valid;
   }
 
-  template <typename Visitor, typename Traits = Self::Decorator_traits>
-  void visit_shell_objects(typename Traits::SFace_handle f, Visitor& V) const
-  { Base::template visit_shell_objects<Visitor, Traits>(f, V); }
+  template <typename Visitor>
+  void visit_shell_objects(SFace_handle f, Visitor& V) const
+  { Base::template visit_shell_objects<Visitor,Decorator_traits>(f, V); }
 
   Vertex_iterator   vertices_begin()   { return sncp()->vertices_begin(); }
   Vertex_iterator   vertices_end()     { return sncp()->vertices_end(); }

--- a/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
@@ -852,18 +852,12 @@ class SNC_decorator : public SNC_const_decorator<Map> {
     return c->shells_end();
   }
 
-  Size_type number_of_vertices() const
-  { return sncp()->number_of_vertices(); }
-  Size_type number_of_halfedges() const
-  { return sncp()->number_of_halfedges(); }
-  Size_type number_of_edges() const
-  { return sncp()->number_of_edges(); }
-  Size_type number_of_halffacets() const
-  { return sncp()->number_of_halffacets();}
-  Size_type number_of_facets() const
-  { return sncp()->number_of_facets();}
-  Size_type number_of_volumes() const
-  { return sncp()->number_of_volumes();}
+  using Base::number_of_vertices;
+  using Base::number_of_halfedges;
+  using Base::number_of_edges;
+  using Base::number_of_halffacets;
+  using Base::number_of_facets;
+  using Base::number_of_volumes;
 
 };
 

--- a/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
@@ -37,11 +37,11 @@ public:
 
   template <class H>
   const I& operator[](H h) const
-  { return Base::operator[](&*h); }
+  { return Base::operator[]((void*)&*h); }
 
   template <class H>
   I& operator[](H h)
-  { return Base::operator[](&*h); }
+  { return Base::operator[]((void*)&*h); }
 
 };
 


### PR DESCRIPTION
## Summary of Changes

This removes code duplication between `SNC_const_decorator` and `SNC_decorator`. The additional template parameter `Traits`, uses `SNC_decorator_traits` to provide both const and non-const handles such that the SNC_decorator version of the code can be replaced by a template instantiation. 

Other functions can potentially be de-duplicated in the same way.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): cleaning
* License and copyright ownership: Returned to CGAL authors.

