### PR TITLE
Testsuite: Adapt ctest scripts for use with cygwin

### DIFF
--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -84,7 +84,9 @@ function(cgal_add_compilation_test exe_name)
       APPEND PROPERTY LABELS "${PROJECT_NAME}")
     set_property(TEST "compilation_of__${exe_name}"
       APPEND PROPERTY FIXTURES_REQUIRED "check_build_system_SetupFixture")
-  elseif(NOT TEST compilation_of__${PROJECT_NAME})#CMAKE_VS_MSBUILD_COMMAND
+  elseif(NOT TARGET compilation_of__${PROJECT_NAME})#CMAKE_VS_MSBUILD_COMMAND
+    #this target is just a flag, to deal with the scope problem with the tests
+    add_custom_target(compilation_of__${PROJECT_NAME})
     add_test(NAME "compilation_of__${PROJECT_NAME}"
       COMMAND ${TIME_COMMAND} "${CMAKE_VS_MSBUILD_COMMAND}" "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.sln" "-m:$ENV{NUMBER_OF_PROCESSORS}" "/t:Build" "/p:Configuration=$<CONFIG>")
     set_property(TEST "compilation_of__${PROJECT_NAME}"
@@ -93,6 +95,13 @@ function(cgal_add_compilation_test exe_name)
       APPEND PROPERTY FIXTURES_REQUIRED "check_build_system_SetupFixture")
     set_tests_properties("compilation_of__${PROJECT_NAME}"
       PROPERTIES RUN_SERIAL TRUE)
+    #because of the scope of the tests, this part cannot go in the relevant CMakeLists
+    if("${PROJECT_NAME}" STREQUAL "Polyhedron_Demo")
+      set_tests_properties(compilation_of__Polyhedron_Demo PROPERTIES TIMEOUT 2400)
+    elseif("${PROJECT_NAME}" STREQUAL "Mesh_3_Tests" OR "${PROJECT_NAME}" STREQUAL "Mesh_3_Examples")
+      set_tests_properties(compilation_of__${PROJECT_NAME} PROPERTIES TIMEOUT 1600)
+    endif()
+
   endif()#CMAKE_VS_MSBUILD_COMMAND
   if(NOT TARGET ALL_CGAL_TARGETS)
     add_custom_target( ALL_CGAL_TARGETS )

--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -32,9 +32,6 @@ if(CGAL_RUN_TESTS_THROUGH_SSH)
   find_program(scp_executable scp)
 endif()
 
-if(CMAKE_VS_MSBUILD_COMMAND)
-  find_program(MSBUILD_CMD NAMES msbuild.exe)
-endif()
 # Process a list, and replace items contains a file pattern (like
 # `*.off`) by the sublist that corresponds to the globbing of the
 # pattern in the directory `${CMAKE_CURRENT_SOURCE_DIR}`.
@@ -89,7 +86,7 @@ function(cgal_add_compilation_test exe_name)
       APPEND PROPERTY FIXTURES_REQUIRED "check_build_system_SetupFixture")
   elseif(NOT TEST compilation_of__${PROJECT_NAME})#CMAKE_VS_MSBUILD_COMMAND
     add_test(NAME "compilation_of__${PROJECT_NAME}"
-      COMMAND ${TIME_COMMAND} "${MSBUILD_CMD}" "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.sln" "-m:$ENV{NUMBER_OF_PROCESSORS}" "/t:Build" "/p:Configuration=$<CONFIG>")
+      COMMAND ${TIME_COMMAND} "${CMAKE_VS_MSBUILD_COMMAND}" "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.sln" "-m:$ENV{NUMBER_OF_PROCESSORS}" "/t:Build" "/p:Configuration=$<CONFIG>")
     set_property(TEST "compilation_of__${PROJECT_NAME}"
       APPEND PROPERTY LABELS "${PROJECT_NAME}")
     set_property(TEST "compilation_of__${PROJECT_NAME}"

--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -32,7 +32,7 @@ if(CGAL_RUN_TESTS_THROUGH_SSH)
   find_program(scp_executable scp)
 endif()
 
-if(CGAL_WIN32_CMAKE_ON_CYGWIN)
+if(CMAKE_VS_MSBUILD_COMMAND)
   find_program(MSBUILD_CMD NAMES msbuild.exe)
 endif()
 # Process a list, and replace items contains a file pattern (like
@@ -77,7 +77,7 @@ function(expand_list_with_globbing list_name)
 endfunction()
 
 function(cgal_add_compilation_test exe_name)
-  if(NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+  if(NOT CMAKE_VS_MSBUILD_COMMAND)
     if(TEST compilation_of__${exe_name})
       return()
     endif()
@@ -87,7 +87,7 @@ function(cgal_add_compilation_test exe_name)
       APPEND PROPERTY LABELS "${PROJECT_NAME}")
     set_property(TEST "compilation_of__${exe_name}"
       APPEND PROPERTY FIXTURES_REQUIRED "check_build_system_SetupFixture")
-  elseif(NOT TEST compilation_of__${PROJECT_NAME})#CGAL_WIN32_CMAKE_ON_CYGWIN
+  elseif(NOT TEST compilation_of__${PROJECT_NAME})#CMAKE_VS_MSBUILD_COMMAND
     add_test(NAME "compilation_of__${PROJECT_NAME}"
       COMMAND ${TIME_COMMAND} "${MSBUILD_CMD}" "${PROJECT_BINARY_DIR}/${PROJECT_NAME}.sln" "-m:$ENV{NUMBER_OF_PROCESSORS}" "/t:Build" "/p:Configuration=$<CONFIG>")
     set_property(TEST "compilation_of__${PROJECT_NAME}"
@@ -96,7 +96,7 @@ function(cgal_add_compilation_test exe_name)
       APPEND PROPERTY FIXTURES_REQUIRED "check_build_system_SetupFixture")
     set_tests_properties("compilation_of__${PROJECT_NAME}"
       PROPERTIES RUN_SERIAL TRUE)
-  endif()#CGAL_WIN32_CMAKE_ON_CYGWIN
+  endif()#CMAKE_VS_MSBUILD_COMMAND
   if(NOT TARGET ALL_CGAL_TARGETS)
     add_custom_target( ALL_CGAL_TARGETS )
   endif()
@@ -149,13 +149,13 @@ function(cgal_setup_test_properties test_name)
   endif()
 
   if(exe_name)
-    if(NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+    if(NOT CMAKE_VS_MSBUILD_COMMAND)
       set_property(TEST "${test_name}"
         APPEND PROPERTY DEPENDS "compilation_of__${exe_name}")
-    else()#CGAL_WIN32_CMAKE_ON_CYGWIN
+    else()#CMAKE_VS_MSBUILD_COMMAND
       set_property(TEST "${test_name}"
         APPEND PROPERTY DEPENDS "compilation_of__${PROJECT_NAME}")
-    endif()#CGAL_WIN32_CMAKE_ON_CYGWIN
+    endif()#CMAKE_VS_MSBUILD_COMMAND
   endif()
 
   get_filename_component(_source_dir_abs ${CMAKE_CURRENT_SOURCE_DIR} ABSOLUTE)
@@ -236,13 +236,13 @@ function(cgal_setup_test_properties test_name)
     if(exe_name)
       set_property(TEST ${test_name}
         APPEND PROPERTY FIXTURES_REQUIRED "${exe_name}")
-      if(NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+      if(NOT CMAKE_VS_MSBUILD_COMMAND)
         set_property(TEST "compilation_of__${exe_name}"
           PROPERTY FIXTURES_SETUP "${exe_name}")
-      else()#CGAL_WIN32_CMAKE_ON_CYGWIN
+      else()#CMAKE_VS_MSBUILD_COMMAND
         set_property(TEST "compilation_of__${PROJECT_NAME}"
           PROPERTY FIXTURES_SETUP "${exe_name}")
-      endif()#CGAL_WIN32_CMAKE_ON_CYGWIN
+      endif()#CMAKE_VS_MSBUILD_COMMAND
       if((ANDROID OR CGAL_RUN_TESTS_THROUGH_SSH) AND NOT TEST push_of__${exe_name})
         if(ANDROID)
           add_test(NAME "push_of__${exe_name}"

--- a/Installation/demo/CMakeLists.txt
+++ b/Installation/demo/CMakeLists.txt
@@ -1,5 +1,6 @@
 cmake_minimum_required(VERSION 3.12...3.20)
 project(CGAL_DEMOS)
+
 if(CGAL_BRANCH_BUILD)
 
   foreach(package ${CGAL_CONFIGURED_PACKAGES})

--- a/Installation/demo/CMakeLists.txt
+++ b/Installation/demo/CMakeLists.txt
@@ -1,6 +1,5 @@
 cmake_minimum_required(VERSION 3.12...3.20)
 project(CGAL_DEMOS)
-
 if(CGAL_BRANCH_BUILD)
 
   foreach(package ${CGAL_CONFIGURED_PACKAGES})

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -49,7 +49,7 @@ include(${CGAL_USE_FILE})
 find_package(
   Qt5 QUIET
   COMPONENTS OpenGL Script Widgets
-  OPTIONAL_COMPONENTS ScriptTools WebSockets)
+  OPTIONAL_COMPONENTS ScriptTools WebSockets Network)
 
 set_package_properties(
   Qt5 PROPERTIES
@@ -422,7 +422,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS CGAL_PMP)
 
   #WS Server
-  if(TARGET Qt5::WebSockets)
+  if(TARGET Qt5::WebSockets AND TARGET Qt5::Network)
     add_executable(WS_server Server_ws.cpp)
     target_link_libraries(WS_server PUBLIC Qt5::WebSockets Qt5::Widgets Qt5::Network)
     message(

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -241,23 +241,11 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   target_link_libraries(point_dialog PUBLIC Qt5::OpenGL Qt5::Gui Qt5::Script
                                             Qt5::Widgets)
 
-  add_custom_target(all_scene_items)
-  if(BUILD_TESTING)
-    cgal_add_compilation_test(all_scene_items)
-    set_property(
-      TEST compilation_of__all_scene_items
-      APPEND
-      PROPERTY DEPENDS compilation_of__demo_framework)
-    set_property(TEST compilation_of__all_scene_items APPEND PROPERTY TIMEOUT
-                                                                      1700)
-  endif(BUILD_TESTING)
-
   macro(add_item item_name)
     add_library(${item_name} SHARED ${ARGN})
     target_link_libraries(
       ${item_name} PUBLIC demo_framework ${CGAL_LIBRARIES} Qt5::OpenGL Qt5::Gui
                           Qt5::Script Qt5::Widgets)
-    add_dependencies(all_scene_items ${item_name})
     add_to_cached_list(CGAL_EXECUTABLE_TARGETS ${item_name})
   endmacro(add_item)
 

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -48,7 +48,7 @@ include(${CGAL_USE_FILE})
 
 find_package(
   Qt5 QUIET
-  COMPONENTS OpenGL Script
+  COMPONENTS OpenGL Script Widgets
   OPTIONAL_COMPONENTS ScriptTools WebSockets)
 
 set_package_properties(
@@ -424,7 +424,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   #WS Server
   if(TARGET Qt5::WebSockets)
     add_executable(WS_server Server_ws.cpp)
-    target_link_libraries(WS_server PUBLIC Qt5::WebSockets)
+    target_link_libraries(WS_server PUBLIC Qt5::WebSockets Qt5::Widgets Qt5::Network)
     message(
       STATUS "Qt5WebSockets was found. Using WebSockets is therefore possible.")
   endif()

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -217,7 +217,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
       STATUS "Qt5WebSockets was found. Using WebSockets is therefore possible.")
   endif()
 
-  cgal_add_compilation_test(demo_framework)
+  #compilation_of__demo_framework is defined in polyhedron_demo_macros.cmake
   # Let's define `three_EXPORT` during the compilation of `demo_framework`,
   # in addition of `demo_framework_EXPORT` (defined automatically by
   # CMake). That is to deal with the visibility of symbols of

--- a/Polyhedron/demo/Polyhedron/Plugins/Camera_position/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Camera_position/CMakeLists.txt
@@ -8,5 +8,4 @@ polyhedron_demo_plugin(camera_positions_plugin
     KEYWORDS Viewer)
 
 add_dependencies(camera_positions_plugin demo_framework)
-target_link_libraries( camera_positions_plugin PUBLIC demo_framework)
 target_link_libraries(camera_positions_plugin PUBLIC demo_framework)

--- a/Polyhedron/demo/Polyhedron/Plugins/Camera_position/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Camera_position/CMakeLists.txt
@@ -10,4 +10,3 @@ polyhedron_demo_plugin(camera_positions_plugin
 add_dependencies(camera_positions_plugin demo_framework)
 target_link_libraries( camera_positions_plugin PUBLIC demo_framework)
 target_link_libraries(camera_positions_plugin PUBLIC demo_framework)
-

--- a/Polyhedron/demo/Polyhedron/Plugins/Camera_position/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Camera_position/CMakeLists.txt
@@ -7,5 +7,7 @@ polyhedron_demo_plugin(camera_positions_plugin
     ${cameraUI_FILES}
     KEYWORDS Viewer)
 
+add_dependencies(camera_positions_plugin demo_framework)
 target_link_libraries( camera_positions_plugin PUBLIC demo_framework)
 target_link_libraries(camera_positions_plugin PUBLIC demo_framework)
+

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/CMakeLists.txt
@@ -47,7 +47,7 @@ if(TARGET CGAL::Eigen3_support)
     scene_color_ramp
     CGAL::Eigen3_support)
 
-    if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+    if(BUILD_TESTING AND NOT CMAKE_VS_MSBUILD_COMMAND)
       set_tests_properties(
         compilation_of__classification_plugin
         PROPERTIES RESOURCE_LOCK Selection_test_resources)

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/CMakeLists.txt
@@ -47,6 +47,12 @@ if(TARGET CGAL::Eigen3_support)
     scene_color_ramp
     CGAL::Eigen3_support)
 
+    if(BUILD_TESTING)
+      set_tests_properties(
+        compilation_of__classification_plugin
+        PROPERTIES RESOURCE_LOCK Selection_test_resources)
+    endif()
+
   if(TARGET CGAL::Boost_serialization_support AND TARGET CGAL::Boost_iostreams_support)
     target_link_libraries(classification_plugin PUBLIC
       CGAL::Boost_serialization_support

--- a/Polyhedron/demo/Polyhedron/Plugins/Classification/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Classification/CMakeLists.txt
@@ -47,7 +47,7 @@ if(TARGET CGAL::Eigen3_support)
     scene_color_ramp
     CGAL::Eigen3_support)
 
-    if(BUILD_TESTING)
+    if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
       set_tests_properties(
         compilation_of__classification_plugin
         PROPERTIES RESOURCE_LOCK Selection_test_resources)

--- a/Polyhedron/demo/Polyhedron/Plugins/Convex_hull/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Convex_hull/CMakeLists.txt
@@ -10,7 +10,7 @@ polyhedron_demo_plugin(kernel_plugin Kernel_plugin)
 target_link_libraries(kernel_plugin PUBLIC scene_surface_mesh_item)
 
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
   set_tests_properties(
     compilation_of__convex_hull_plugin
     PROPERTIES RESOURCE_LOCK Selection_test_resources)

--- a/Polyhedron/demo/Polyhedron/Plugins/Convex_hull/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Convex_hull/CMakeLists.txt
@@ -8,3 +8,10 @@ target_link_libraries(
 
 polyhedron_demo_plugin(kernel_plugin Kernel_plugin)
 target_link_libraries(kernel_plugin PUBLIC scene_surface_mesh_item)
+
+
+if(BUILD_TESTING)
+  set_tests_properties(
+    compilation_of__convex_hull_plugin
+    PROPERTIES RESOURCE_LOCK Selection_test_resources)
+endif()

--- a/Polyhedron/demo/Polyhedron/Plugins/Convex_hull/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Convex_hull/CMakeLists.txt
@@ -10,7 +10,7 @@ polyhedron_demo_plugin(kernel_plugin Kernel_plugin)
 target_link_libraries(kernel_plugin PUBLIC scene_surface_mesh_item)
 
 
-if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+if(BUILD_TESTING AND NOT CMAKE_VS_MSBUILD_COMMAND)
   set_tests_properties(
     compilation_of__convex_hull_plugin
     PROPERTIES RESOURCE_LOCK Selection_test_resources)

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(
   PUBLIC scene_surface_mesh_item scene_points_with_normal_item
          scene_polylines_item)
 
-     if(BUILD_TESTING)
+     if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
        set_tests_properties(
          compilation_of__create_obb_mesh_plugin
          PROPERTIES RESOURCE_LOCK Selection_test_resources)

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/CMakeLists.txt
@@ -37,3 +37,9 @@ target_link_libraries(
   basic_generator_plugin
   PUBLIC scene_surface_mesh_item scene_points_with_normal_item
          scene_polylines_item)
+
+     if(BUILD_TESTING)
+       set_tests_properties(
+         compilation_of__create_obb_mesh_plugin
+         PROPERTIES RESOURCE_LOCK Selection_test_resources)
+     endif()

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/CMakeLists.txt
@@ -38,7 +38,7 @@ target_link_libraries(
   PUBLIC scene_surface_mesh_item scene_points_with_normal_item
          scene_polylines_item)
 
-     if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+     if(BUILD_TESTING AND NOT CMAKE_VS_MSBUILD_COMMAND)
        set_tests_properties(
          compilation_of__create_obb_mesh_plugin
          PROPERTIES RESOURCE_LOCK Selection_test_resources)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -52,6 +52,7 @@ if(TARGET CGAL::Eigen3_support)
         DESCRIPTION "A large scale non-linear optimization library."
         PURPOSE "Can be used as a solver in the smoothing plugin.")
         target_link_libraries(extrude_plugin PUBLIC CGAL::Eigen3_support)
+
         if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
           set_tests_properties(
             compilation_of__extrude_plugin
@@ -163,7 +164,6 @@ polyhedron_demo_plugin(engrave_text_plugin Engrave_text_plugin
 target_link_libraries(
   engrave_text_plugin PUBLIC scene_surface_mesh_item scene_selection_item
                              scene_polylines_item)
-
 
 if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
   set_tests_properties(

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -53,7 +53,7 @@ if(TARGET CGAL::Eigen3_support)
         PURPOSE "Can be used as a solver in the smoothing plugin.")
         target_link_libraries(extrude_plugin PUBLIC CGAL::Eigen3_support)
 
-        if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+        if(BUILD_TESTING AND NOT CMAKE_VS_MSBUILD_COMMAND)
           set_tests_properties(
             compilation_of__extrude_plugin
             compilation_of__fairing_plugin
@@ -165,7 +165,7 @@ target_link_libraries(
   engrave_text_plugin PUBLIC scene_surface_mesh_item scene_selection_item
                              scene_polylines_item)
 
-if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+if(BUILD_TESTING AND NOT CMAKE_VS_MSBUILD_COMMAND)
   set_tests_properties(
     compilation_of__join_and_split_plugin
     compilation_of__selection_plugin

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -52,17 +52,15 @@ if(TARGET CGAL::Eigen3_support)
         DESCRIPTION "A large scale non-linear optimization library."
         PURPOSE "Can be used as a solver in the smoothing plugin.")
         target_link_libraries(extrude_plugin PUBLIC CGAL::Eigen3_support)
-        if(BUILD_TESTING)
+        if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
           set_tests_properties(
             compilation_of__extrude_plugin
             compilation_of__fairing_plugin
             PROPERTIES RESOURCE_LOCK Selection_test_resources)
-        endif()
-        if(BUILD_TESTING)
           set_tests_properties(
-            compilation_of__hole_filling_plugin
-            compilation_of__smoothing_plugin
-            PROPERTIES RESOURCE_LOCK Selection_test_resources)
+          compilation_of__hole_filling_plugin
+          compilation_of__smoothing_plugin
+          PROPERTIES RESOURCE_LOCK Selection_test_resources)
         endif()
   else()
     message(
@@ -167,7 +165,7 @@ target_link_libraries(
                              scene_polylines_item)
 
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
   set_tests_properties(
     compilation_of__join_and_split_plugin
     compilation_of__selection_plugin

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/CMakeLists.txt
@@ -52,6 +52,18 @@ if(TARGET CGAL::Eigen3_support)
         DESCRIPTION "A large scale non-linear optimization library."
         PURPOSE "Can be used as a solver in the smoothing plugin.")
         target_link_libraries(extrude_plugin PUBLIC CGAL::Eigen3_support)
+        if(BUILD_TESTING)
+          set_tests_properties(
+            compilation_of__extrude_plugin
+            compilation_of__fairing_plugin
+            PROPERTIES RESOURCE_LOCK Selection_test_resources)
+        endif()
+        if(BUILD_TESTING)
+          set_tests_properties(
+            compilation_of__hole_filling_plugin
+            compilation_of__smoothing_plugin
+            PROPERTIES RESOURCE_LOCK Selection_test_resources)
+        endif()
   else()
     message(
       STATUS
@@ -153,3 +165,16 @@ polyhedron_demo_plugin(engrave_text_plugin Engrave_text_plugin
 target_link_libraries(
   engrave_text_plugin PUBLIC scene_surface_mesh_item scene_selection_item
                              scene_polylines_item)
+
+
+if(BUILD_TESTING)
+  set_tests_properties(
+    compilation_of__join_and_split_plugin
+    compilation_of__selection_plugin
+    compilation_of__triangulate_facets_plugin
+    compilation_of__isotropic_remeshing_plugin
+    compilation_of__random_perturbation_plugin
+    compilation_of__engrave_text_plugin
+    compilation_of__degenerated_faces_plugin
+    PROPERTIES RESOURCE_LOCK Selection_test_resources)
+endif()

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
@@ -15,6 +15,12 @@ if(NOT CGAL_DISABLE_GMP)
     target_link_libraries(
       parameterization_plugin PUBLIC scene_surface_mesh_item scene_textured_item
                                      scene_selection_item CGAL::Eigen3_support)
+    if(BUILD_TESTING)
+      set_tests_properties(
+        compilation_of__parameterization_plugin
+        PROPERTIES RESOURCE_LOCK Selection_test_resources)
+    endif()
+
   else()
     message(
       STATUS
@@ -26,7 +32,11 @@ if(NOT CGAL_DISABLE_GMP)
   polyhedron_demo_plugin(mesh_segmentation_plugin Mesh_segmentation_plugin
                          ${segmentationUI_FILES})
   target_link_libraries(mesh_segmentation_plugin PUBLIC scene_surface_mesh_item)
-
+  if(BUILD_TESTING)
+    set_tests_properties(
+      compilation_of__mesh_segmentation_plugin
+      PROPERTIES RESOURCE_LOCK Selection_test_resources)
+  endif()
 
   qt5_wrap_ui( mesh_simplificationUI_FILES  Mesh_simplification_dialog.ui)
   polyhedron_demo_plugin(mesh_simplification_plugin Mesh_simplification_plugin ${mesh_simplificationUI_FILES})

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
@@ -16,7 +16,7 @@ if(NOT CGAL_DISABLE_GMP)
       parameterization_plugin PUBLIC scene_surface_mesh_item scene_textured_item
                                      scene_selection_item CGAL::Eigen3_support)
 
-    if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+    if(BUILD_TESTING AND NOT CMAKE_VS_MSBUILD_COMMAND)
       set_tests_properties(
         compilation_of__parameterization_plugin
         PROPERTIES RESOURCE_LOCK Selection_test_resources)
@@ -34,7 +34,7 @@ if(NOT CGAL_DISABLE_GMP)
                          ${segmentationUI_FILES})
   target_link_libraries(mesh_segmentation_plugin PUBLIC scene_surface_mesh_item)
 
-  if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+  if(BUILD_TESTING AND NOT CMAKE_VS_MSBUILD_COMMAND)
     set_tests_properties(
       compilation_of__mesh_segmentation_plugin
       PROPERTIES RESOURCE_LOCK Selection_test_resources)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
@@ -15,6 +15,7 @@ if(NOT CGAL_DISABLE_GMP)
     target_link_libraries(
       parameterization_plugin PUBLIC scene_surface_mesh_item scene_textured_item
                                      scene_selection_item CGAL::Eigen3_support)
+
     if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
       set_tests_properties(
         compilation_of__parameterization_plugin
@@ -32,6 +33,7 @@ if(NOT CGAL_DISABLE_GMP)
   polyhedron_demo_plugin(mesh_segmentation_plugin Mesh_segmentation_plugin
                          ${segmentationUI_FILES})
   target_link_libraries(mesh_segmentation_plugin PUBLIC scene_surface_mesh_item)
+
   if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
     set_tests_properties(
       compilation_of__mesh_segmentation_plugin

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/CMakeLists.txt
@@ -15,7 +15,7 @@ if(NOT CGAL_DISABLE_GMP)
     target_link_libraries(
       parameterization_plugin PUBLIC scene_surface_mesh_item scene_textured_item
                                      scene_selection_item CGAL::Eigen3_support)
-    if(BUILD_TESTING)
+    if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
       set_tests_properties(
         compilation_of__parameterization_plugin
         PROPERTIES RESOURCE_LOCK Selection_test_resources)
@@ -32,7 +32,7 @@ if(NOT CGAL_DISABLE_GMP)
   polyhedron_demo_plugin(mesh_segmentation_plugin Mesh_segmentation_plugin
                          ${segmentationUI_FILES})
   target_link_libraries(mesh_segmentation_plugin PUBLIC scene_surface_mesh_item)
-  if(BUILD_TESTING)
+  if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
     set_tests_properties(
       compilation_of__mesh_segmentation_plugin
       PROPERTIES RESOURCE_LOCK Selection_test_resources)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/CMakeLists.txt
@@ -9,4 +9,11 @@ else()
     STATUS
       "NOTICE: The polyhedron edit plugin require Eigen 3.2 (or higher) and will not be available."
   )
+
+if(BUILD_TESTING)
+  set_tests_properties(
+    compilation_of__edit_plugin
+    PROPERTIES RESOURCE_LOCK Selection_test_resources)
+endif()
+
 endif()

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/CMakeLists.txt
@@ -4,16 +4,16 @@ if(EIGEN3_FOUND AND "${EIGEN3_VERSION}" VERSION_GREATER "3.1.90")
   polyhedron_demo_plugin(edit_plugin Edit_polyhedron_plugin Deform_mesh.ui)
   target_link_libraries(edit_plugin PUBLIC scene_surface_mesh_item
                                            scene_edit_item scene_selection_item)
+
+  if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+    set_tests_properties(
+      compilation_of__edit_plugin
+      PROPERTIES RESOURCE_LOCK Selection_test_resources)
+  endif()
+
 else()
   message(
     STATUS
       "NOTICE: The polyhedron edit plugin require Eigen 3.2 (or higher) and will not be available."
   )
-
-if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
-  set_tests_properties(
-    compilation_of__edit_plugin
-    PROPERTIES RESOURCE_LOCK Selection_test_resources)
-endif()
-
 endif()

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/CMakeLists.txt
@@ -10,7 +10,7 @@ else()
       "NOTICE: The polyhedron edit plugin require Eigen 3.2 (or higher) and will not be available."
   )
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
   set_tests_properties(
     compilation_of__edit_plugin
     PROPERTIES RESOURCE_LOCK Selection_test_resources)

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/CMakeLists.txt
@@ -5,7 +5,7 @@ if(EIGEN3_FOUND AND "${EIGEN3_VERSION}" VERSION_GREATER "3.1.90")
   target_link_libraries(edit_plugin PUBLIC scene_surface_mesh_item
                                            scene_edit_item scene_selection_item)
 
-  if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+  if(BUILD_TESTING AND NOT CMAKE_VS_MSBUILD_COMMAND)
     set_tests_properties(
       compilation_of__edit_plugin
       PROPERTIES RESOURCE_LOCK Selection_test_resources)

--- a/Polyhedron/demo/Polyhedron/polyhedron_demo_macros.cmake
+++ b/Polyhedron/demo/Polyhedron/polyhedron_demo_macros.cmake
@@ -34,8 +34,27 @@ include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
     # Link with the demo_framework
     if(TARGET demo_framework)
       target_link_libraries( ${plugin_name} PUBLIC demo_framework)
+      add_dependencies(${plugin_name} demo_framework)
+      if(BUILD_TESTING)
+
+        if(NOT TARGET compilation_of__demo_framework)
+              # This custom target is useless. It is used only as a flag to
+              # detect that the test has already been created.
+              add_custom_target(compilation_of__demo_framework)
+              add_dependencies( compilation_of__demo_framework demo_framework )
+              add_test(NAME "compilation_of__demo_framework"
+                COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target "demo_framework" --config "$<CONFIG>")
+              set_property(TEST "compilation_of__demo_framework"
+                APPEND PROPERTY LABELS "CGAL_build_system")
+              set_property(TEST "compilation_of__demo_framework"
+                PROPERTY FIXTURES_SETUP "check_build_system_SetupFixture")
+              set_property(TEST "compilation_of__demo_framework"
+                APPEND PROPERTY DEPENDS "compilation_of__CGAL_Qt5_moc_and_resources")
+            endif()
+      endif()
     else()
       target_link_libraries( ${plugin_name} PUBLIC Polyhedron_demo_framework)
+      add_dependencies(${plugin_name} Polyhedron_demo_framework)
     endif()
     # Link with CGAL
     target_link_libraries( ${plugin_name} PUBLIC ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES} )

--- a/Polyhedron/demo/Polyhedron/polyhedron_demo_macros.cmake
+++ b/Polyhedron/demo/Polyhedron/polyhedron_demo_macros.cmake
@@ -28,10 +28,6 @@ include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
       PROPERTY LIBRARY_OUTPUT_DIRECTORY
       "${CGAL_POLYHEDRON_DEMO_PLUGINS_DIR}")
     cgal_add_compilation_test(${plugin_name})
-    if(BUILD_TESTING)
-      set_property(TEST compilation_of__${plugin_name}
-        APPEND PROPERTY DEPENDS compilation_of__all_scene_items)
-    endif()
     add_to_cached_list( CGAL_EXECUTABLE_TARGETS ${plugin_name} )
     # Link with Qt
     target_link_libraries( ${plugin_name} PUBLIC ${QT_LIBRARIES} )

--- a/Polyhedron/demo/Polyhedron/polyhedron_demo_macros.cmake
+++ b/Polyhedron/demo/Polyhedron/polyhedron_demo_macros.cmake
@@ -35,7 +35,7 @@ include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
     if(TARGET demo_framework)
       target_link_libraries( ${plugin_name} PUBLIC demo_framework)
       add_dependencies(${plugin_name} demo_framework)
-      if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
+      if(BUILD_TESTING AND NOT CMAKE_VS_MSBUILD_COMMAND)
         if(NOT TARGET compilation_of__demo_framework)
               # This custom target is useless. It is used only as a flag to
               # detect that the test has already been created.

--- a/Polyhedron/demo/Polyhedron/polyhedron_demo_macros.cmake
+++ b/Polyhedron/demo/Polyhedron/polyhedron_demo_macros.cmake
@@ -35,8 +35,7 @@ include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
     if(TARGET demo_framework)
       target_link_libraries( ${plugin_name} PUBLIC demo_framework)
       add_dependencies(${plugin_name} demo_framework)
-      if(BUILD_TESTING)
-
+      if(BUILD_TESTING AND NOT CGAL_WIN32_CMAKE_ON_CYGWIN)
         if(NOT TARGET compilation_of__demo_framework)
               # This custom target is useless. It is used only as a flag to
               # detect that the test has already been created.
@@ -44,13 +43,14 @@ include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
               add_dependencies( compilation_of__demo_framework demo_framework )
               add_test(NAME "compilation_of__demo_framework"
                 COMMAND "${CMAKE_COMMAND}" --build "${CMAKE_BINARY_DIR}" --target "demo_framework" --config "$<CONFIG>")
+
               set_property(TEST "compilation_of__demo_framework"
                 APPEND PROPERTY LABELS "CGAL_build_system")
               set_property(TEST "compilation_of__demo_framework"
                 PROPERTY FIXTURES_SETUP "check_build_system_SetupFixture")
               set_property(TEST "compilation_of__demo_framework"
                 APPEND PROPERTY DEPENDS "compilation_of__CGAL_Qt5_moc_and_resources")
-            endif()
+        endif()
       endif()
     else()
       target_link_libraries( ${plugin_name} PUBLIC Polyhedron_demo_framework)

--- a/Scripts/developer_scripts/autotest_cgal_with_ctest
+++ b/Scripts/developer_scripts/autotest_cgal_with_ctest
@@ -1,6 +1,4 @@
 #!/bin/bash
-
-#!/bin/bash
 #usage : script [-c -l -n -s -k] testsuite_dir
 
 ##########################
@@ -23,7 +21,7 @@ export TAR="tar"
 export GUNZIP="gunzip"
 export COMPRESSOR="gzip"
 export CONSOLE_OUTPUT="y"
-export CGAL_HOME=`pwd`
+export CGAL_HOME=$(pwd | sed -E 's/\/cygdrive\/([a-z])\//\U\1:\//')
 export USE_TARGZ="y"
 export USE_TARBZ="n"
 export CGAL_RELEASE=""
@@ -283,6 +281,8 @@ if [ -n "${SCRIPTS_DIR}" ]; then
 else
   CGAL_DIR=`readlink "${CGAL_HOME}/CGAL-I"`
 fi
+
+CGAL_DIR=$(echo "$CGAL_DIR" | sed -E 's/\/cygdrive\/([a-z])\//\U\1:\//')
 
 CGAL_RELEASE_ID=$(cat last_release_id)
 for HOST in ${BUILD_HOSTS}; do

--- a/Scripts/developer_scripts/run_testsuite_with_ctest
+++ b/Scripts/developer_scripts/run_testsuite_with_ctest
@@ -322,7 +322,9 @@ run_test_on_platform()
   echo "TESTER_NAME ${CGAL_TESTER}" >> "$RESULT_FILE"
   echo "TESTER_ADDRESS ${TESTER_ADDRESS}" >> "$RESULT_FILE"
   echo "CGAL_TEST_PLATFORM ${PLATFORM}" >> "$RESULT_FILE"
-  grep -e "^-- USING " "${CGAL_BINARY_DIR}/installation.log" >> $RESULT_FILE
+  grep -e "^-- USING " "${CGAL_BINARY_DIR}/installation.log"|sort -u >> $RESULT_FILE
+  #Use sed to get the content of DEBUG or RELEASE CXX FLAGS so that Multiconfiguration platforms do provide their CXXXFLAGS to the testsuite page (that greps USING CXXFLAGS to get info)
+  sed -i -E 's/(^-- USING )(DEBUG|RELEASE) (CXXFLAGS)/\1\3/' $RESULT_FILE
   echo "------------" >> "$RESULT_FILE"
   #if git branch, create empty scm file for python script
   if [ -n "${SCRIPTS_DIR}" ]; then

--- a/Scripts/developer_scripts/run_testsuite_with_ctest
+++ b/Scripts/developer_scripts/run_testsuite_with_ctest
@@ -258,7 +258,7 @@ run_test_on_platform()
   CGAL_BINARY_DIR=${CGAL_BINARY_DIR_BASE}/${PLATFORM}
   cd "${CGAL_BINARY_DIR}"
   log "${ACTUAL_LOGFILE}.test.${PLATFORM}" "Testing on host ${HOST} and platform ${PLATFORM}"
-  
+
   if [ -f "${REFERENCE_PLATFORMS_DIR}/${PLATFORM}/setup" ]; then
     source "${REFERENCE_PLATFORMS_DIR}/${PLATFORM}/setup"
   else
@@ -274,7 +274,7 @@ run_test_on_platform()
     CMAKE_OPTS="${CMAKE_OPTS} -DWITH_examples=ON -DWITH_demos=ON"
   fi
   if [ -z "${SHOW_PROGRESS}" ]; then
-    cmake ${INIT_FILE:+"-C${INIT_FILE}"} -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR  >package_installation.log 2>&1 
+    cmake ${INIT_FILE:+"-C${INIT_FILE}"} -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR  >package_installation.log 2>&1
   else
     cmake ${INIT_FILE:+"-C${INIT_FILE}"} -DBUILD_TESTING=ON ${CMAKE_OPTS} $CGAL_DIR 2>&1 |tee package_installation.log
   fi
@@ -294,14 +294,28 @@ run_test_on_platform()
   #unsets the limit of 1024 bits for the logs through ssh
   echo "SET(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 1000000000)" > CTestCustom.cmake
   echo "SET(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE 1000000000)" >> CTestCustom.cmake
-  CTEST_OPTS="-T Start -T Test --timeout 1200 -j${NUMBER_OF_PROCESSORS} ${DO_NOT_TEST:+-E execution___of__} "
+
+  CTEST_OPTS="-T Start -T Test --timeout 1200  ${DO_NOT_TEST:+-E execution___of__}"
+  FULL_OPTS=${CTEST_OPTS}
+  echo "NUMBER_OF_PROCESSORS = ${NUMBER_OF_PROCESSORS}"
   if uname | grep -q "CYGWIN"; then
-    CTEST_OPTS="-C ${CONFIG_TYPE} ${CTEST_OPTS} -V"
+    CTEST_OPTS="-C ${CONFIG_TYPE} ${CTEST_OPTS}"
+    FULL_OPTS="${CTEST_OPTS} -LE Polyhedron_Demo -V"
   fi
   if [ -z "${SHOW_PROGRESS}" ]; then
-    ctest ${TO_TEST:+-L ${TO_TEST} } ${CTEST_OPTS} ${KEEP_TESTS:+-FC .}> tmp.txt
+    ctest ${TO_TEST:+-L ${TO_TEST} } ${FULL_OPTS} -j${NUMBER_OF_PROCESSORS} ${KEEP_TESTS:+-FC .}> tmp.txt
+    if uname | grep -q "CYGWIN"; then
+          if [[ $TO_TEST == *"Polyhedron_Demo"* ]]; then
+        ctest ${CTEST_OPTS} -L Polyhedron_Demo ${KEEP_TESTS:+-FC .}>> tmp.txt
+      fi
+    fi
   else
-    ctest ${TO_TEST:+-L ${TO_TEST} } ${CTEST_OPTS} ${KEEP_TESTS:+-FC .} |tee tmp.txt
+    ctest ${TO_TEST:+-L ${TO_TEST} } -j${NUMBER_OF_PROCESSORS} ${FULL_OPTS} ${KEEP_TESTS:+-FC .} |tee tmp.txt
+    if uname | grep -q "CYGWIN"; then
+          if [[ $TO_TEST == *"Polyhedron_Demo"* ]]; then
+        ctest ${CTEST_OPTS} -L Polyhedron_Demo ${KEEP_TESTS:+-FC .} |tee -a tmp.txt
+          fi
+    fi
   fi
   #####################
   ##   GET RESULTS   ##
@@ -373,7 +387,7 @@ run_test_on_host()
 setup_dirs
 
 
-# Setup cmake 
+# Setup cmake
 log "${ACTUAL_LOGFILE}" "running the testsuites"
 if [ -n "${CONSOLE_OUTPUT}" ]; then
     printf "\n-------------------------------------------------------\n"

--- a/Scripts/developer_scripts/run_testsuite_with_ctest
+++ b/Scripts/developer_scripts/run_testsuite_with_ctest
@@ -259,8 +259,8 @@ run_test_on_platform()
   cd "${CGAL_BINARY_DIR}"
   log "${ACTUAL_LOGFILE}.test.${PLATFORM}" "Testing on host ${HOST} and platform ${PLATFORM}"
 
-  if [ -f "${REFERENCE_PLATFORMS_DIR}/${PLATFORM}/setup" ]; then
-    source "${REFERENCE_PLATFORMS_DIR}/${PLATFORM}/setup"
+  if [ -f "${CGAL_HOME}/${REFERENCE_PLATFORMS_DIR}/${PLATFORM}/setup" ]; then
+    source "${CGAL_HOME}/${REFERENCE_PLATFORMS_DIR}/${PLATFORM}/setup"
   else
     INIT_FILE="${CGAL_HOME}/${REFERENCE_PLATFORMS_DIR}/${PLATFORM}.cmake"
   fi
@@ -295,27 +295,14 @@ run_test_on_platform()
   echo "SET(CTEST_CUSTOM_MAXIMUM_PASSED_TEST_OUTPUT_SIZE 1000000000)" > CTestCustom.cmake
   echo "SET(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE 1000000000)" >> CTestCustom.cmake
 
-  CTEST_OPTS="-T Start -T Test --timeout 1200  ${DO_NOT_TEST:+-E execution___of__}"
-  FULL_OPTS=${CTEST_OPTS}
-  echo "NUMBER_OF_PROCESSORS = ${NUMBER_OF_PROCESSORS}"
+  CTEST_OPTS="-T Start -T Test --timeout 1200 ${DO_NOT_TEST:+-E execution___of__}"
   if uname | grep -q "CYGWIN"; then
     CTEST_OPTS="-C ${CONFIG_TYPE} ${CTEST_OPTS}"
-    FULL_OPTS="${CTEST_OPTS} -LE Polyhedron_Demo -V"
   fi
   if [ -z "${SHOW_PROGRESS}" ]; then
-    ctest ${TO_TEST:+-L ${TO_TEST} } ${FULL_OPTS} -j${NUMBER_OF_PROCESSORS} ${KEEP_TESTS:+-FC .}> tmp.txt
-    if uname | grep -q "CYGWIN"; then
-          if [[ $TO_TEST == *"Polyhedron_Demo"* ]]; then
-        ctest ${CTEST_OPTS} -L Polyhedron_Demo ${KEEP_TESTS:+-FC .}>> tmp.txt
-      fi
-    fi
+    ctest ${TO_TEST:+-L ${TO_TEST} } ${CTEST_OPTS} -j${NUMBER_OF_PROCESSORS} ${KEEP_TESTS:+-FC .}>tmp.txt
   else
-    ctest ${TO_TEST:+-L ${TO_TEST} } -j${NUMBER_OF_PROCESSORS} ${FULL_OPTS} ${KEEP_TESTS:+-FC .} |tee tmp.txt
-    if uname | grep -q "CYGWIN"; then
-          if [[ $TO_TEST == *"Polyhedron_Demo"* ]]; then
-        ctest ${CTEST_OPTS} -L Polyhedron_Demo ${KEEP_TESTS:+-FC .} |tee -a tmp.txt
-          fi
-    fi
+    ctest ${TO_TEST:+-L ${TO_TEST} } ${CTEST_OPTS} -j${NUMBER_OF_PROCESSORS} ${KEEP_TESTS:+-FC .}|tee tmp.txt
   fi
   #####################
   ##   GET RESULTS   ##

--- a/Snap_rounding_2/test/Snap_rounding_2/CMakeLists.txt
+++ b/Snap_rounding_2/test/Snap_rounding_2/CMakeLists.txt
@@ -19,7 +19,7 @@ function(add_Snap_rounding_tests name)
     cgal_add_test(${name} TEST_NAME ${test_name} ARGUMENTS ${data_dir}/${file}
                   ${data_dir}/output_${file})
     add_test(NAME "${test_name}_compare_results"
-             COMMAND ${CMAKE_COMMAND} -E compare_files
+             COMMAND ${CMAKE_COMMAND} -E compare_files --ignore-eol
                      ${data_dir}/output_${file} ${data_dir}/gold_${file})
     cgal_setup_test_properties("${test_name}_compare_results")
     set_property(

--- a/Testsuite/test/parse-ctest-dashboard-xml.py
+++ b/Testsuite/test/parse-ctest-dashboard-xml.py
@@ -87,7 +87,7 @@ with open_file_create_dir(result_file_name.format(dir=os.getcwd(),
                 if t['Status'] != 'passed':
                     result_for_label='n'
                 elif t['Output'] != None:
-                  for m in re.finditer(r'(.*([^a-zA-Z_,:-])([^\d]\s)warning).*?(\[|\n)', lines, flags=re.IGNORECASE):
+                  for m in re.finditer(r'(.*([^a-zA-Z_,:-])([^\d]\s)warning).*?(\[|\n)', t['Output'], flags=re.IGNORECASE):
                         n = re.search(r'cmake|cgal', m.group(0), flags=re.IGNORECASE)
                         if n:
                             result_for_label='w'

--- a/Testsuite/test/parse-ctest-dashboard-xml.py
+++ b/Testsuite/test/parse-ctest-dashboard-xml.py
@@ -86,7 +86,7 @@ with open_file_create_dir(result_file_name.format(dir=os.getcwd(),
                 print("   {result} {name} in {time} s : {value} ".format(result = "successful " if (t['Status'] == 'passed') else "ERROR:     ", name = t['Name'], value = t['ExitValue'] if(t['ExitValue'] != "") else "SUCCESS" , time = t['ExecutionTime']), file=error)
                 if t['Status'] != 'passed':
                     result_for_label='n'
-                elif t['Output'] != None and re.search(r'(^|[^a-zA-Z_,:-])warning', t['Output'], flags=re.IGNORECASE):
+                elif t['Output'] != None and re.search(r'(^|[^a-zA-Z_,:-])([^0]\s)warning', t['Output'], flags=re.IGNORECASE):
                     result_for_label='w'
 
                 with io.open("{}/ProgramOutput.{}".format(label, t['Name']), mode="w", encoding="utf-8") as f:

--- a/Testsuite/test/parse-ctest-dashboard-xml.py
+++ b/Testsuite/test/parse-ctest-dashboard-xml.py
@@ -86,8 +86,14 @@ with open_file_create_dir(result_file_name.format(dir=os.getcwd(),
                 print("   {result} {name} in {time} s : {value} ".format(result = "successful " if (t['Status'] == 'passed') else "ERROR:     ", name = t['Name'], value = t['ExitValue'] if(t['ExitValue'] != "") else "SUCCESS" , time = t['ExecutionTime']), file=error)
                 if t['Status'] != 'passed':
                     result_for_label='n'
-                elif t['Output'] != None and re.search(r'(^|[^a-zA-Z_,:-])([^0]\s)warning', t['Output'], flags=re.IGNORECASE):
-                    result_for_label='w'
+                elif t['Output'] != None:
+                  for m in re.finditer(r'(.*([^a-zA-Z_,:-])([^\d]\s)warning).*?(\[|\n)', lines, flags=re.IGNORECASE):
+                        n = re.search(r'cmake|cgal', m.group(0), flags=re.IGNORECASE)
+                        if n:
+                            result_for_label='w'
+                            break;
+                        else:
+                            result_for_label='t'
 
                 with io.open("{}/ProgramOutput.{}".format(label, t['Name']), mode="w", encoding="utf-8") as f:
                     print("{}/ProgramOutput.{}".format(label, t['Name']))


### PR DESCRIPTION
## Summary of Changes
Change the ctest scripts to work on windows and  directly use MSBuild and its internal parallelism feature for compilation tests. 

## TODO
 - [x] Update collect_results_from_ctest to get the "t" for external warnings
 - [x] Find out why (and fix) the CXX FLAGS that do not appear in the testsuite page
## Release Management

* Affected package(s):Testsuite
