### PR TITLE
Replace CGAL_NEF_DEBUG with CGAL_USE_TRACE

### DIFF
--- a/Nef_2/include/CGAL/Nef_2/Segment_overlay_traits.h
+++ b/Nef_2/include/CGAL/Nef_2/Segment_overlay_traits.h
@@ -39,7 +39,7 @@
 #include <sstream>
 
 namespace CGAL {
-#ifdef CGAL_NEF_DEBUG
+#ifdef CGAL_USE_TRACE
 #define PIS(s) (s->first())
 #endif
 

--- a/Nef_3/include/CGAL/Nef_3/Binary_operation.h
+++ b/Nef_3/include/CGAL/Nef_3/Binary_operation.h
@@ -191,9 +191,8 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
       Halffacet_handle f;
 
       Point_3 p(normalized(ip));
-
+#ifdef CGAL_USE_TRACE
       CGAL_NEF_TRACEN("Intersection_call_back: intersection reported on " << p << " (normalized: " << normalized(p) << " )");
-#ifdef CGAL_NEF_DEBUG
       CGAL_NEF_TRACEN("edge 0 has source " << e0->source()->point() << " and direction " << e0->vector());
       if( CGAL::assign( e, o1)) {
         CGAL_NEF_TRACEN("edge 1 has source " << e->source()->point() << " and direction " << e->vector());

--- a/Nef_3/include/CGAL/Nef_3/SNC_const_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_const_decorator.h
@@ -323,12 +323,12 @@ public:
         CGAL_NEF_TRACEN("f_visible"<< f_visible->plane());
       }
       else if(fc.is_svertex()) {
-#ifdef CGAL_NEF_DEBUG
+#ifdef CGAL_USE_TRACE
         // TODO: is there any warranty that the outter facet cycle enty point is always at first
         // in the cycles list?
         ++fc; while( fc != fce)  { CGAL_assertion( fc.is_svertex()); ++fc; }
-#endif
         CGAL_NEF_TRACEN( "no adjacent facets were found (but incident edge(s)).");
+#endif
         f_visible = Halffacet_const_handle();
       }
       else


### PR DESCRIPTION
## Summary of Changes

Following on from #5246 I've since discovered three places in the code where `#ifdef CGAL_NEF_DEBUG` is used to disable the compilation of various bits of code. This never worked because CGAL_NEF_DEBUG is defined at the top of the file.

Simply replacing these for the newly introduced `CGAL_USE_TRACE` define (introduced in #5246) solves the problem and ensures this extra code isn't included unless explicitly wanted.

## Release Management

* Affected package(s): Nef_2 / Nef_3
* Issue(s) solved (if any): bugfix
* License and copyright ownership: Returned to CGAL authors.

