### PR TITLE
Remove redundant code for default parameter in side_of_plane_3

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/bounded_side_3.h
+++ b/Nef_3/include/CGAL/Nef_3/bounded_side_3.h
@@ -79,28 +79,12 @@ template <class IteratorForward, class R>
 Bounded_side bounded_side_3(IteratorForward first,
                             IteratorForward last,
                             const Point_3<R>& point,
-                            typename R::Plane_3 plane = typename R::Plane_3(0,0,0,0)) {
+                            const Plane_3<R>& plane) {
   typedef typename R::Point_2 Point_2;
   typedef typename R::Point_3 Point_3;
-  typedef typename R::Plane_3 Plane_3;
-
-  if(plane == Plane_3(0,0,0,0)) {
-    // TO TEST: code never tested
-    IteratorForward p(first);
-    Point_3 p0(*(p++));
-    CGAL_assertion(p != last);
-    Point_3 p1(*(p++));
-    CGAL_assertion(p != last);
-    Point_3 p2(*(p++));
-    plane = Plane_3(p0, p1, p2);
-
-    /* since we just need to project the points to a non-perpendicular plane
-       we don't need to care about the plane orientation */
-  }
 
   typename R::Non_zero_dimension_3 non_zero_dimension_3;
   int dir = non_zero_dimension_3(plane.orthogonal_vector());
-
 
   CGAL_assertion(!plane.is_degenerate());
   Point_2 (*t)(const Point_3&);


### PR DESCRIPTION
## Summary of Changes

This PR removes a check in the function `side_of_plane_3` that tests `if(plane == Plane_3(0,0,0,0))`. The check is needed so that when a parameter isn't given, an empty default parameter indicates that it should be populated from the points in the Iterator. However the function is never called without the plane parameter so the code is probably redundant, and the comment says it's not tested!

The `operator==` for an empty plane isn't trivial. For cartesian kernels, it invokes `equal_planeC3` which then in tern invokes `equal_directionC3` which calculates the signs of 3 determinants...

Removing the redundant code doesn't give much of a performance boost (about 2% in my tests) but I think it's worthwhile nonetheless.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): fix #5379 
* Feature/Small Feature (if any): cleaning
* License and copyright ownership: Returned to CGAL authors.

