### PR TITLE
Remove the OnSideMapRC when not needed

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
@@ -159,7 +159,6 @@ public:
 #ifdef CGAL_NEF_EXPLOIT_REFERENCE_COUNTING
   bool reference_counted;
 #endif
-  SNC_decorator D;
   Unique_hash_map<Vertex_handle, Oriented_side> OnSideMap;
 #ifdef CGAL_NEF_EXPLOIT_REFERENCE_COUNTING
   Unique_hash_map<const RT*, Oriented_side> OnSideMapRC;

--- a/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
@@ -35,7 +35,7 @@ class ComparePoints {
   ComparePoints(Coordinate c) : coord(c) {
     CGAL_assertion( c >= 0 && c <=2);
   }
-  CGAL::Comparison_result operator()(const Point_3 p1, const Point_3& p2) {
+  CGAL::Comparison_result operator()(const Point_3& p1, const Point_3& p2) {
     switch(coord) {
     case 0:
       CGAL_NEF_TRACEN("compare_x " << p1 << ", " << p2 << "=" << (int) CGAL::compare_x(p1, p2));
@@ -161,7 +161,9 @@ public:
 #endif
   SNC_decorator D;
   Unique_hash_map<Vertex_handle, Oriented_side> OnSideMap;
+#ifdef CGAL_NEF_EXPLOIT_REFERENCE_COUNTING
   Unique_hash_map<const RT*, Oriented_side> OnSideMapRC;
+#endif
 };
 
 template <class SNC_decorator>


### PR DESCRIPTION
## Summary of Changes

In SNC_k3_tree_traits a map is used to store the results of point comparisons. Two techniques are used, one of which is supposed to exploit reference counting (whatever that means) and is enabled by the define `CGAL_NEF_EXPLOIT_REFERENCE_COUNTING`, however regardless of whether the macro is defined the class member `OnSideMapRC` is present. (since its default constructed this has an overhead as discussed before with 512 elements)

This PR simply places OnSideMapRC into an `#ifdef` block.

I also noticed that p1 is not passed by reference, which is probably unintentional but the fix too small for its own PR.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): cleaning
* License and copyright ownership: Returned to CGAL authors.

