### PR TITLE
Adding items to central MATHJAX_CODEFILE

### DIFF
--- a/Documentation/doc/resources/1.8.13/CGAL_mathjax.js
+++ b/Documentation/doc/resources/1.8.13/CGAL_mathjax.js
@@ -25,6 +25,8 @@ MathJax.Hub.Config(
           ccProd: [ "{\\prod_{#1}^{#2}{#3}}", 3],
           pyr: [ "{\\operatorname{Pyr}}", 0],
           aff: [ "{\\operatorname{aff}}", 0],
+          Ac: [ "{\\cal A}", 0],
+          Sc: [ "{\\cal S}", 0],
       }
   }
 }

--- a/Documentation/doc/resources/1.8.14/CGAL_mathjax.js
+++ b/Documentation/doc/resources/1.8.14/CGAL_mathjax.js
@@ -25,6 +25,8 @@ MathJax.Hub.Config(
           ccProd: [ "{\\prod_{#1}^{#2}{#3}}", 3],
           pyr: [ "{\\operatorname{Pyr}}", 0],
           aff: [ "{\\operatorname{aff}}", 0],
+          Ac: [ "{\\cal A}", 0],
+          Sc: [ "{\\cal S}", 0],
       }
   }
 }

--- a/Documentation/doc/resources/1.8.20/CGAL_mathjax.js
+++ b/Documentation/doc/resources/1.8.20/CGAL_mathjax.js
@@ -25,6 +25,8 @@ MathJax.Hub.Config(
           ccProd: [ "{\\prod_{#1}^{#2}{#3}}", 3],
           pyr: [ "{\\operatorname{Pyr}}", 0],
           aff: [ "{\\operatorname{aff}}", 0],
+          Ac: [ "{\\cal A}", 0],
+          Sc: [ "{\\cal S}", 0],
       }
   }
 }

--- a/Documentation/doc/resources/1.8.4/CGAL_mathjax.js
+++ b/Documentation/doc/resources/1.8.4/CGAL_mathjax.js
@@ -25,6 +25,8 @@ MathJax.Hub.Config(
           ccProd: [ "{\\prod_{#1}^{#2}{#3}}", 3],
           pyr: [ "{\\operatorname{Pyr}}", 0],
           aff: [ "{\\operatorname{aff}}", 0],
+          Ac: [ "{\\cal A}", 0],
+          Sc: [ "{\\cal S}", 0],
       }
   }
 }

--- a/Snap_rounding_2/doc/Snap_rounding_2/CGAL/Snap_rounding_2.h
+++ b/Snap_rounding_2/doc/Snap_rounding_2/CGAL/Snap_rounding_2.h
@@ -3,8 +3,6 @@ namespace CGAL {
 /*!
 \ingroup PkgSnapRounding2Ref
 
-<span style="display:none">\f$ \def\A{{\cal A}} \f$ \f$ \def\S{{\cal S}} \f$</span>
-
 \tparam Traits must be a model of `SnapRoundingTraits_2`.
 \tparam InputIterator must be an iterator with value type `Traits::Segment_2`.
 \tparam OutputContainer must be a container with a method `push_back(const OutputContainer::value_type& c)`,
@@ -49,9 +47,9 @@ half-the-width-of-a-pixel away from any non-incident edge
 \cgalCite{cgal:hp-isr-02}. This package supports both methods. Algorithmic
 details and experimental results are given in \cgalCite{cgal:hp-isr-02}.
 
-Given a finite collection \f$ \S\f$ of segments in the plane, the
-arrangement of \f$ \S\f$ denoted \f$ \A(\S)\f$ is the subdivision of the plane
-into vertices, edges, and faces induced by \f$ \S\f$. A <I>vertex</I> of the arrangement is either a segment endpoint or
+Given a finite collection \f$ \Sc\f$ of segments in the plane, the
+arrangement of \f$ \Sc\f$ denoted \f$ \Ac(\Sc)\f$ is the subdivision of the plane
+into vertices, edges, and faces induced by \f$ \Sc\f$. A <I>vertex</I> of the arrangement is either a segment endpoint or
 the intersection of two segments. Given an arrangement of segments
 whose vertices are represented with arbitrary-precision coordinates,
 SR proceeds as follows. We tile the plane

--- a/Snap_rounding_2/doc/Snap_rounding_2/Snap_rounding_2.txt
+++ b/Snap_rounding_2/doc/Snap_rounding_2/Snap_rounding_2.txt
@@ -10,8 +10,6 @@ namespace CGAL {
 
 \section Snap_rounding_2Introduction Introduction
 
-<span style="display:none">\f$ \def\A{{\cal A}} \f$ \f$ \def\S{{\cal S}} \f$</span>
-
 Snap Rounding (SR, for short) is a well known method for converting
 arbitrary-precision arrangements of segments into a fixed-precision
 representation \cgalCite{gght-srlse-97}, \cgalCite{gm-rad-98}, \cgalCite{h-psifp-99}. In
@@ -28,9 +26,9 @@ An arrangement of segments before (a) and after (b) SR (hot pixels are shaded)
 
 \section Snap_rounding_2What What is Snap Rounding/Iterated Snap Rounding
 
-Given a finite collection \f$ \S\f$ of segments in the plane, the
-arrangement of \f$ \S\f$ denoted \f$ \A(\S)\f$ is the subdivision of the plane
-into vertices, edges, and faces induced by \f$ \S\f$. A <I>vertex</I> of the arrangement is either a segment endpoint or
+Given a finite collection \f$ \Sc\f$ of segments in the plane, the
+arrangement of \f$ \Sc\f$ denoted \f$ \Ac(\Sc)\f$ is the subdivision of the plane
+into vertices, edges, and faces induced by \f$ \Sc\f$. A <I>vertex</I> of the arrangement is either a segment endpoint or
 the intersection of two segments. Given an arrangement of segments
 whose vertices are represented with arbitrary-precision coordinates,
 the function `snap_rounding_2()` proceeds as follows. We tile the plane


### PR DESCRIPTION
In pull request  #4644 a central MATHJAX_CODEFILE was introduced, but the snap rounding package was omitted, so this is corrected here.
For the MathJax V3 ( see #5707) this change is even mandatory (the current construct doesn't work).

