### PR TITLE
Documentation in github: Report issues in doxygen

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -50,7 +50,7 @@ jobs:
         run: |
           set -x
           sudo apt-get update && sudo apt-get install -y graphviz ssh bibtex2html
-          sudo pip install lxml 
+          sudo pip install lxml
           sudo pip install 'pyquery==1.4.1' # it seems to be the last py2 compatible version
           wget --no-verbose -O doxygen_exe https://cgal.geometryfactory.com/~mgimeno/doxygen/build_1_8_13/bin/doxygen
           sudo mv doxygen_exe /usr/bin/doxygen
@@ -65,6 +65,7 @@ jobs:
           mkdir -p build_doc && cd build_doc && cmake ../Documentation/doc
 
       - name: Build and Upload Doc
+        id: build_and_run
         if: steps.get_round.outputs.result != 'stop'
         run: |
           set -ex
@@ -77,7 +78,13 @@ jobs:
             if [ "$LIST_OF_PKGS" = "" ]; then
               exit 1
             fi
-            cd build_doc && make -j2 doc && make -j2 doc_with_postprocessing
+            cd build_doc && make -j2 doc
+            make -j2 doc_with_postprocessing 2>tmp.log
+            if [ -s tmp.log ]; then
+              content=`cat ./build_doc/tmp.log`
+              echo ::set-output name=DoxygenError::$(cat tmp.log)
+              exit 1
+            fi
             cd ..
             git clone https://CGAL:${{ secrets.PUSH_TO_CGAL_GITHUB_IO_TOKEN }}@github.com/CGAL/cgal.github.io.git
             mkdir -p cgal.github.io/${PR_NUMBER}/$ROUND
@@ -99,7 +106,7 @@ jobs:
 
       - name: Post address
         uses: actions/github-script@v3
-        if: steps.get_round.outputs.result != 'stop'
+        if: ${{ success() && steps.get_round.outputs.result != 'stop' }}
         with:
           script: |
             const address = "The documentation is built. It will be available, after a few minutes, here : https://cgal.github.io/${{ steps.get_pr_number.outputs.result }}/${{ steps.get_round.outputs.result }}/Manual/index.html"
@@ -108,4 +115,18 @@ jobs:
               repo: "cgal",
               issue_number: ${{ github.event.issue.number }},
               body: address
+            });
+
+      - name: Post error
+        uses: actions/github-script@v3
+        if: ${{ failure() && steps.get_round.outputs.result != 'stop' }}
+        with:
+          script: |
+            const error = "${{steps.build_and_run.outputs.DoxygenError}}"
+            const msg = "There was an error while building the doc: \n"+error
+            github.issues.createComment({
+              owner: "CGAL",
+              repo: "cgal",
+              issue_number: ${{ github.event.issue.number }},
+              body: msg
             });


### PR DESCRIPTION
## Summary of Changes

If a warning or an error is reported during the building of` doc_with_postprocessing`, stops the process and post a comment with the issue.
In the example below, the image `anchor.png` has been removed from the doc of `AABB_tree`. Here is the result of the `/build` command:

![image](https://user-images.githubusercontent.com/11310805/118496037-0d9c8800-b724-11eb-8620-cc201fa762ff.png)

## Release Management

* Affected package(s):CI
