### PR TITLE
Polyhedron Demo: Fix classname property for selection_item

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -2652,7 +2652,7 @@ QString MainWindow::get_item_stats()
       QString classname = item->property("classname").toString();
       if(classname.isEmpty())
          classname = item->metaObject()->className();
-      if(classnames.at(i).contains(classname))
+      if(classnames.at(i) == classname)
       {
         items[i] << s_item;
         break;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -95,7 +95,7 @@ struct Scene_polyhedron_selection_item_priv{
     item(parent)
   {
     filtered_graph = nullptr;
-    item->setProperty("classname", QString("surface_mesh"));
+    item->setProperty("classname", QString("surface_mesh_selection"));
   }
 
   void initializeBuffers(CGAL::Three::Viewer_interface *viewer) const;


### PR DESCRIPTION
## Summary of Changes
Statistics on selection items were merged with stats on surface_mesh_items because of a wrong value in , 
## Release Management

* Affected package(s): Polyhedron Demo