### PR TITLE
Test deprecated result_of.h

### DIFF
--- a/STL_Extension/include/CGAL/result_of.h
+++ b/STL_Extension/include/CGAL/result_of.h
@@ -22,55 +22,5 @@
 #define CGAL_REPLACEMENT_HEADER "<CGAL/config.h>"
 
 #include <CGAL/config.h>
-#include <CGAL/disable_warnings.h>
-
-#if CGAL_CXX20 || __cpp_lib_is_invocable>=201703L
-
-  // C++>=17
-
-#elif CGAL_CXX11
-
-  #include <type_traits>
-
-#else // C++<11
-
-  // Address the warning C4003: not enough actual parameters for macro 'BOOST_PP_SEQ_DETAIL_IS_NOT_EMPTY'
-  // result_of.hpp includes files from boost/preprocessor
-  // This concerns boost 1_65_1
-  #if defined(BOOST_MSVC)
-    #pragma warning(push)
-    #pragma warning(disable: 4003)
-  #endif
-    #include <boost/utility/result_of.hpp>
-  #if defined(BOOST_MSVC)
-    #pragma warning(pop)
-  #endif
-  #include <boost/version.hpp>
-
-#endif // end C++<11
-
-namespace CGAL {
-namespace cpp11 {
-
-#if CGAL_CXX20 || __cpp_lib_is_invocable>=201703L
-
-  template<typename Signature> class result_of;
-  template<typename F, typename... Args>
-  class result_of<F(Args...)> : public std::invoke_result<F, Args...> { };
-
-#elif CGAL_CXX11
-
-  using std::result_of;
-
-#else // C++<11
-
-  using boost::result_of;
-
-#endif // end C++<11
-
-} // end cpp11
-} // end CGAL
-
-#include <CGAL/enable_warnings.h>
 
 #endif // CGAL_RESULT_OF_H

--- a/STL_Extension/test/STL_Extension/test_stl_extension.cpp
+++ b/STL_Extension/test/STL_Extension/test_stl_extension.cpp
@@ -50,6 +50,9 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/typeof/typeof.hpp>
 
+#include <CGAL/disable_warnings.h>
+#include <CGAL/result_of.h>
+#include<CGAL/enable_warnings.h>
 using namespace CGAL;
 
 struct item : public In_place_list_base<item> {
@@ -8217,6 +8220,27 @@ void test_make_sorted_pair() {
                           std::pair<int,int> >::value) );
 }
 
+void test_result_of() {
+  struct Result_functor
+  {
+    int operator()()
+    {
+      return 0;
+    }
+
+    float operator()(const int&)
+    {
+      return 0.0f;
+    }
+  };
+
+  typedef CGAL::cpp11::result_of<Result_functor(void)>::type result_type;
+  typedef CGAL::cpp11::result_of<Result_functor(int)>::type result_type_float;
+  CGAL_static_assertion((boost::is_same<result_type, int>::value));
+  CGAL_static_assertion((boost::is_same<result_type_float, float>::value));
+
+}
+
 int main() {
   init_global_data();
   test_Circulator_identity();
@@ -8239,6 +8263,7 @@ int main() {
   test_prev_next();
   test_copy_n();
   test_make_sorted_pair();
+  test_result_of();
   return 0;
 }
 // EOF //

--- a/STL_Extension/test/STL_Extension/test_stl_extension.cpp
+++ b/STL_Extension/test/STL_Extension/test_stl_extension.cpp
@@ -50,9 +50,8 @@
 #include <boost/type_traits/is_same.hpp>
 #include <boost/typeof/typeof.hpp>
 
-#include <CGAL/disable_warnings.h>
+#include <CGAL/internal/disable_deprecation_warnings_and_errors.h>
 #include <CGAL/result_of.h>
-#include<CGAL/enable_warnings.h>
 using namespace CGAL;
 
 struct item : public In_place_list_base<item> {

--- a/STL_Extension/test/STL_Extension/test_stl_extension.cpp
+++ b/STL_Extension/test/STL_Extension/test_stl_extension.cpp
@@ -8235,6 +8235,8 @@ void test_result_of() {
 
   typedef CGAL::cpp11::result_of<Result_functor(void)>::type result_type;
   typedef CGAL::cpp11::result_of<Result_functor(int)>::type result_type_float;
+  CGAL_USE_TYPE(result_type);
+  CGAL_USE_TYPE(result_type_float);
   CGAL_static_assertion((boost::is_same<result_type, int>::value));
   CGAL_static_assertion((boost::is_same<result_type_float, float>::value));
 


### PR DESCRIPTION

## Summary of Changes
Replace `result_of.h`'s content by a simple include to config.h, and test it in `test_stl_extension.cpp`

## Release Management

* Affected package(s):STL_Extension
* Issue(s) solved (if any): fix #5729
