### PR TITLE
Polyhedron Demo: Fix Scene Recentering while Scaled

### DIFF
--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -2119,4 +2119,15 @@ void Viewer::onTextMessageSocketReceived(QString message)
 #endif
 
 const QVector3D& Viewer::scaler()const { return d->scaler; }
+void Viewer::showEntireScene()
+{
+  CGAL::QGLViewer::showEntireScene();
+  CGAL::Bbox_3 bbox = CGAL::Three::Three::scene()->bbox();
+
+  CGAL::qglviewer::Vec vmin(((float)bbox.xmin()+offset().x)*d->scaler.x(), ((float)bbox.ymin()+offset().y)*d->scaler.y(), ((float)bbox.zmin()+offset().z)*d->scaler.z()),
+      vmax(((float)bbox.xmax()+offset().x)*d->scaler.x(), ((float)bbox.ymax()+offset().y)*d->scaler.y(), ((float)bbox.zmax()+offset().z)*d->scaler.z());
+  camera()->setPivotPoint((vmin+vmax)*0.5);
+  camera()->setSceneBoundingBox(vmin, vmax);
+  camera()->fitBoundingBox(vmin, vmax);
+}
 #include "Viewer.moc"

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -139,6 +139,7 @@ public Q_SLOTS:
   void onTextMessageSocketReceived(QString message);
 #endif
   void scaleScene();
+  void showEntireScene()Q_DECL_OVERRIDE;
 protected:
   void paintEvent(QPaintEvent *)Q_DECL_OVERRIDE;
   void paintGL()Q_DECL_OVERRIDE;

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -287,6 +287,8 @@ public:
   //!  A vector indicating the scaling factors to apply to the scene when displaying it.
   //!  It can be useful when a scene is very large along one of it's coordinates, making it hard to visualize it.
   virtual const QVector3D& scaler() const = 0;
+
+  virtual void showEntireScene() = 0;
 }; // end class Viewer_interface
 }
 }


### PR DESCRIPTION
## Summary of Changes

If the user asks for a scene recentering while the scnee is scaled, the camera gets lost. This is a fix for that problem.
## Release Management
Base don 5.2 because the Scene Scaling appeared in 5.2
