### PR TITLE
Remove CGAL_NEF3_TRIANGULATE_FACETS

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -44,6 +44,7 @@
 
 namespace CGAL {
 
+#ifdef CGAL_NEF3_TRIANGULATE_FACETS
 template <typename Triangle_3>
 void sort_triangle_by_lexicographically_smaller_vertex
 (const Triangle_3& t, int& a, int& b, int& c) {
@@ -79,6 +80,7 @@ struct Compare_triangle_3 {
     return false; // the two triangles are equivalent
   }
 };
+#endif
 
 template <class Traits>
 class K3_tree
@@ -885,7 +887,9 @@ typename Object_list::difference_type n_vertices = std::distance(objects.begin()
     Unique_hash_map< Vertex_handle, bool> v_mark(false);
     Unique_hash_map< Halfedge_handle, bool> e_mark(false);
     Unique_hash_map< Halffacet_handle, bool> f_mark(false);
+#ifdef CGAL_NEF3_TRIANGULATE_FACETS
     std::map< Triangle_3, bool, Compare_triangle_3<Triangle_3> > t_mark;
+#endif
     for( typename Objects_around_segment::Iterator oar = objects.begin();
          oar != objects.end(); ++oar) {
       for( typename Object_list::const_iterator o = (*oar).begin();

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -24,14 +24,6 @@
 #include <CGAL/Cartesian.h>
 #include <boost/container/deque.hpp>
 
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-#include <CGAL/Constrained_triangulation_2.h>
-#include <CGAL/Triangulation_data_structure_2.h>
-#include <CGAL/Projection_traits_xy_3.h>
-#include <CGAL/Projection_traits_yz_3.h>
-#include <CGAL/Projection_traits_xz_3.h>
-#include <CGAL/Constrained_triangulation_face_base_2.h>
-#endif
 
 #include <deque>
 #include <sstream>
@@ -44,43 +36,6 @@
 
 namespace CGAL {
 
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-template <typename Triangle_3>
-void sort_triangle_by_lexicographically_smaller_vertex
-(const Triangle_3& t, int& a, int& b, int& c) {
-  typedef typename Triangle_3::R Kernel;
-  a = 0;
-  for( int i = 1; i < 3; ++i) {
-    if( compare_xyz<Kernel>( t[a], t[i]) == SMALLER)
-      a = i;
-  }
-  b = (a + 1) % 3;
-  c = (b + 1) % 3;
-  if( compare_xyz<Kernel>( t[b], t[c]) == LARGER)
-    std::swap( b, c);
-  return;
-}
-
-template <typename Triangle_3>
-struct Compare_triangle_3 {
-  typedef typename Triangle_3::R Kernel;
-  bool operator()( const Triangle_3& t1, const Triangle_3& t2) const {
-    int v1[3], v2[3];
-    sort_triangle_by_lexicographically_smaller_vertex
-      ( t1, v1[0], v1[1], v1[2]);
-    sort_triangle_by_lexicographically_smaller_vertex
-      ( t2, v2[0], v2[1], v2[2]);
-    for( int i = 0; i < 3; ++i) {
-      Comparison_result c = compare_xyz<Kernel>( t1[v1[i]], t2[v2[i]]);
-      if( c == SMALLER)
-        return true;
-      else if( c == LARGER)
-        return false;
-    }
-    return false; // the two triangles are equivalent
-  }
-};
-#endif
 
 template <class Traits>
 class K3_tree
@@ -161,89 +116,6 @@ private:
   Coordinate coord;
 };
 
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-  template<typename SNC_structure, typename Kernel>
-  class Triangulation_handler {
-
-    typedef typename CGAL::Triangulation_vertex_base_2<Kernel>                      Vb;
-    typedef typename CGAL::Constrained_triangulation_face_base_2<Kernel>            Fb;
-    typedef typename CGAL::Triangulation_data_structure_2<Vb,Fb>                    TDS;
-    typedef typename CGAL::No_constraint_intersection_requiring_constructions_tag   Itag;
-    typedef typename CGAL::Constrained_triangulation_2<Kernel,TDS,Itag>             CT;
-
-    typedef typename CT::Face_handle           Face_handle;
-    typedef typename CT::Finite_faces_iterator Finite_face_iterator;
-    typedef typename CT::Edge                  Edge;
-
-    typedef typename SNC_structure::Halffacet_cycle_iterator
-                                    Halffacet_cycle_iterator;
-    typedef typename SNC_structure::SHalfedge_around_facet_circulator
-                                    SHalfedge_around_facet_circulator;
-
-    CT ct;
-    CGAL::Unique_hash_map<Face_handle, bool> visited;
-    Finite_face_iterator fi;
-
-  public:
-    template<typename Halffacet_handle>
-    Triangulation_handler(Halffacet_handle f) : visited(false) {
-
-      typedef typename SNC_structure::Halffacet_cycle_iterator
-                                      Halffacet_cycle_iterator;
-      typedef typename SNC_structure::SHalfedge_around_facet_circulator
-                                      SHalfedge_around_facet_circulator;
-
-      Halffacet_cycle_iterator fci;
-      for(fci=f->facet_cycles_begin(); fci!=f->facet_cycles_end(); ++fci) {
-        if(fci.is_shalfedge()) {
-          SHalfedge_around_facet_circulator sfc(fci), send(sfc);
-          CGAL_For_all(sfc,send) {
-            ct.insert_constraint(sfc->source()->source()->point(),
-                                 sfc->source()->twin()->source()->point());
-          }
-        }
-      }
-      CGAL_assertion(ct.is_valid());
-
-      typename CT::Face_handle infinite = ct.infinite_face();
-      typename CT::Vertex_handle ctv = infinite->vertex(1);
-      if(ct.is_infinite(ctv)) ctv = infinite->vertex(2);
-      CGAL_assertion(!ct.is_infinite(ctv));
-
-      typename CT::Face_handle opposite;
-      typename CT::Face_circulator vc(ctv,infinite);
-      do { opposite = vc++;
-      } while(!ct.is_constrained(CT::Edge(vc,vc->index(opposite))));
-      typename CT::Face_handle first = vc;
-
-      traverse_triangulation(first, first->index(opposite));
-
-      fi = ct.finite_faces_begin();
-    }
-
-    void traverse_triangulation(Face_handle f, int parent) {
-      visited[f] = true;
-      if(!ct.is_constrained(Edge(f,ct.cw(parent))) && !visited[f->neighbor(ct.cw(parent))]) {
-        Face_handle child(f->neighbor(ct.cw(parent)));
-        traverse_triangulation(child, child->index(f));
-      }
-      if(!ct.is_constrained(Edge(f,ct.cw(parent))) && !visited[f->neighbor(ct.cw(parent))]) {
-        Face_handle child(f->neighbor(ct.cw(parent)));
-        traverse_triangulation(child, child->index(f));
-      }
-    }
-
-    template<typename Triangle_3>
-    bool get_next_triangle(Triangle_3& tr) {
-      if(fi == ct.finite_faces_end()) return false;
-      ++fi;
-      while(fi != ct.finite_faces_end() && visited[fi] == false) ++fi;
-      if(fi == ct.finite_faces_end()) return false;
-      tr = Triangle_3(fi->vertex(0)->point(), fi->vertex(1)->point(), fi->vertex(2)->point());
-      return true;
-    }
-  };
-#endif
 
 public:
   friend class Objects_along_ray;
@@ -257,9 +129,6 @@ typedef typename Traits::Infimaximal_box Infimaximal_box;
 typedef typename Traits::Vertex_handle Vertex_handle;
 typedef typename Traits::Halfedge_handle Halfedge_handle;
 typedef typename Traits::Halffacet_handle Halffacet_handle;
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-typedef typename Traits::Halffacet_triangle_handle Halffacet_triangle_handle;
-#endif
 typedef typename Traits::Object_handle Object_handle;
 typedef std::vector<Object_handle> Object_list;
 typedef typename Object_list::const_iterator Object_const_iterator;
@@ -318,16 +187,6 @@ public:
         left_node->transform(t);
          right_node->transform(t);
           splitting_plane = splitting_plane.transform(t);
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-    } else {
-      Halffacet_triangle_handle tri;
-      typename Object_list::iterator o;
-      for(o = object_list.begin(); o != object_list.end(); ++o)
-        if(assign(tri,*o)) {
-          tri.transform(t);
-          *o = make_object(tri);
-        }
-#endif // CGAL_NEF3_TRIANGULATE_FACETS
     }
   }
 
@@ -802,55 +661,7 @@ public:
     CGAL_forall_edges( e, *W)
       objects.push_back(make_object(Halfedge_handle(e)));
     CGAL_forall_facets( f, *W) {
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-      typedef typename SNC_structure::SHalfedge_around_facet_circulator
-                                      SHalfedge_around_facet_circulator;
-      typedef typename SNC_structure::Halffacet_cycle_iterator
-                                      Halffacet_cycle_iterator;
-
-      Halffacet_cycle_iterator fci = f->facet_cycles_begin();
-      CGAL_assertion(fci.is_shalfedge());
-      SHalfedge_around_facet_circulator safc(fci);
-      if(circulator_size(safc) > 10) {
-      typedef typename CGAL::Projection_traits_xy_3<Kernel>       XY;
-      typedef typename CGAL::Projection_traits_yz_3<Kernel>       YZ;
-      typedef typename CGAL::Projection_traits_xz_3<Kernel>       XZ;
-
-      Triangle_3 tr;
-
-      Vector_3 orth = f->plane().orthogonal_vector();
-      int c = CGAL::abs(orth[0]) > CGAL::abs(orth[1]) ? 0 : 1;
-      c = CGAL::abs(orth[2]) > CGAL::abs(orth[c]) ? 2 : c;
-
-      std::list<Triangle_3> triangles;
-      if(c == 0) {
-        Triangulation_handler<SNC_structure, YZ> th(f);
-        while(th.get_next_triangle(tr)) {
-          triangles.push_front(tr);
-          Halffacet_triangle_handle th( f, *triangles.begin());
-          objects.push_back(make_object(th));
-        }
-      } else if(c == 1) {
-        Triangulation_handler<SNC_structure, XZ> th(f);
-        while(th.get_next_triangle(tr)) {
-          triangles.push_front(tr);
-          Halffacet_triangle_handle th( f, *triangles.begin());
-          objects.push_back(make_object(th));
-        }
-      } else if(c == 2) {
-        Triangulation_handler<SNC_structure, XY> th(f);
-        while(th.get_next_triangle(tr)) {
-          triangles.push_front(tr);
-          Halffacet_triangle_handle th( f, *triangles.begin());
-          objects.push_back(make_object(th));
-        }
-      } else
-              CGAL_error_msg( "wrong value");
-      } else
-        objects.push_back(make_object(Halffacet_handle(f)));
-#else
       objects.push_back(make_object(Halffacet_handle(f)));
-#endif // CGAL_NEF3_TRIANGULATE_FACETS
     }
     Object_iterator oli=objects.begin()+v_end;
     root = build_kdtree( objects, oli, 0);
@@ -887,9 +698,6 @@ typename Object_list::difference_type n_vertices = std::distance(objects.begin()
     Unique_hash_map< Vertex_handle, bool> v_mark(false);
     Unique_hash_map< Halfedge_handle, bool> e_mark(false);
     Unique_hash_map< Halffacet_handle, bool> f_mark(false);
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-    std::map< Triangle_3, bool, Compare_triangle_3<Triangle_3> > t_mark;
-#endif
     for( typename Objects_around_segment::Iterator oar = objects.begin();
          oar != objects.end(); ++oar) {
       for( typename Object_list::const_iterator o = (*oar).begin();
@@ -897,9 +705,6 @@ typename Object_list::difference_type n_vertices = std::distance(objects.begin()
         Vertex_handle v;
         Halfedge_handle e;
         Halffacet_handle f;
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-        Halffacet_triangle_handle t;
-#endif
         if( CGAL::assign( v, *o)) {
           if( !v_mark[v]) {
             O.push_back(*o);
@@ -918,15 +723,6 @@ typename Object_list::difference_type n_vertices = std::distance(objects.begin()
             f_mark[f] = true;
           }
         }
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-        else if(CGAL::assign(t, *o)) {
-          Triangle_3 tr = t.get_triangle();
-          if( !t_mark[tr]) {
-            O.push_back(*o);
-            t_mark[tr] = true;
-          }
-        }
-#endif
         else
           CGAL_error_msg( "wrong handle");
       }
@@ -1013,10 +809,6 @@ std::string dump_object_list( const Object_list& O, int level = 0) {
   Vertex_handle v;
   Halfedge_handle e;
   Halffacet_handle f;
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-  typename Object_list::size_type t_count = 0;
-  Halffacet_triangle_handle t;
-#endif
   for( o = O.begin(); o != O.end(); ++o) {
     if( CGAL::assign( v, *o)) {
       if( level) os << v->point() << std::endl;
@@ -1031,19 +823,10 @@ std::string dump_object_list( const Object_list& O, int level = 0) {
       if( level) os << "facet" << std::endl;
       ++f_count;
     }
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-    else if( CGAL::assign(t, *o)) {
-      if( level) os << "triangle" << std::endl;
-      ++t_count;
-    }
-#endif
     else
       CGAL_error_msg( "wrong handle");
   }
   os << v_count << "v " << e_count << "e " << f_count << "f ";
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-  os  << t_count << "t ";
-#endif
   return os.str();
  }
 

--- a/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
@@ -108,10 +108,6 @@ public:
   typedef typename Decorator_traits::Halfedge_handle Halfedge_handle;
   typedef typename Decorator_traits::Halffacet_handle Halffacet_handle;
 
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-  typedef typename SNC_structure::Halffacet_triangle_handle
-                                  Halffacet_triangle_handle;
-#endif
   typedef typename SNC_structure::Object_handle Object_handle;
 
   typedef typename Decorator_traits::Halffacet_cycle_iterator
@@ -145,10 +141,6 @@ public:
     ( const Point_3& pop, Halfedge_handle e, Depth depth);
   template<typename Depth> Oriented_side operator()
     ( const Point_3& pop, Halffacet_handle f, Depth depth);
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-  template<typename Depth> Oriented_side operator()
-    ( const Point_3& pop, Halffacet_triangle_handle f, Depth depth);
-#endif
 #ifdef CGAL_NEF_EXPLOIT_REFERENCE_COUNTING
   bool reference_counted;
 #endif
@@ -287,10 +279,6 @@ public:
   typedef typename Decorator_traits::Vertex_handle Vertex_handle;
   typedef typename Decorator_traits::Halfedge_handle Halfedge_handle;
   typedef typename Decorator_traits::Halffacet_handle Halffacet_handle;
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-  typedef typename SNC_structure::Halffacet_triangle_handle
-                                  Halffacet_triangle_handle;
-#endif
 
   typedef typename SNC_structure::Object_handle Object_handle;
   typedef std::vector<Object_handle> Object_list;
@@ -332,19 +320,12 @@ Side_of_plane<SNC_decorator>::operator()
   Vertex_handle v;
   Halfedge_handle e;
   Halffacet_handle f;
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-  Halffacet_triangle_handle t;
-#endif
   if( CGAL::assign( v, o))
     return (*this)(pop, v, depth);
   else if( CGAL::assign( e, o))
     return (*this)(pop, e, depth);
   else if( CGAL::assign( f, o))
     return (*this)(pop, f, depth);
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-  else if( CGAL::assign( t, o))
-    return (*this)(pop, t, depth);
-#endif
   else
     CGAL_error_msg( "wrong handle");
 
@@ -461,63 +442,6 @@ Side_of_plane<SNC_decorator>::operator()
   return ON_ORIENTED_BOUNDARY;
 }
 
-#ifdef CGAL_NEF3_TRIANGULATE_FACETS
-template <typename SNC_decorator>
-template <typename Depth>
-Oriented_side
-Side_of_plane<SNC_decorator>::operator()
-( const Point_3& pop, Halffacet_triangle_handle t, Depth depth) {
-  bool on_positive_side = false, on_negative_side = false;
-  Triangle_3 tr(t.get_triangle());
-  for( int i = 0; i < 3; ++i) {
-    Oriented_side side = ON_ORIENTED_BOUNDARY;
-    Comparison_result cr;
-    if(
-#ifdef CGAL_NEF_EXPLOIT_REFERENCE_COUNTING
-       !reference_counted ||
-#endif
-       !OnSideMapRC.is_defined(&(tr[i].hw()))) {
-      switch(depth%3) {
-      case 0:
-        cr = CGAL::compare_x(tr[i], pop);
-        side = cr == LARGER ? ON_POSITIVE_SIDE :
-                 cr == SMALLER ? ON_NEGATIVE_SIDE : ON_ORIENTED_BOUNDARY;
-        break;
-      case 1:
-        cr = CGAL::compare_y(tr[i], pop);
-        side = cr == LARGER ? ON_POSITIVE_SIDE :
-                 cr == SMALLER ? ON_NEGATIVE_SIDE : ON_ORIENTED_BOUNDARY;
-        break;
-      case 2:
-        cr = CGAL::compare_z(tr[i], pop);
-        side = cr == LARGER ? ON_POSITIVE_SIDE :
-                 cr == SMALLER ? ON_NEGATIVE_SIDE : ON_ORIENTED_BOUNDARY;
-        break;
-      default: CGAL_error_msg( "wrong value");
-      }
-#ifdef CGAL_NEF_EXPLOIT_REFERENCE_COUNTING
-      if(reference_counted)
-        OnSideMapRC[&(tr[i].hw())] = side;
-    } else if(reference_counted)
-      side = OnSideMapRC[&(tr[i].hw())];
-#endif
-    if( side == ON_POSITIVE_SIDE)
-      on_positive_side = true;
-    else if( side == ON_NEGATIVE_SIDE)
-      on_negative_side = true;
-  }
-  if( on_positive_side && on_negative_side)
-    return ON_ORIENTED_BOUNDARY;
-  if( !on_positive_side && !on_negative_side)
-    return ON_ORIENTED_BOUNDARY;
-  if( on_positive_side) {
-    CGAL_assertion( !on_negative_side);
-    return ON_POSITIVE_SIDE;
-  }
-  CGAL_assertion( on_negative_side);
-  return ON_NEGATIVE_SIDE;
-}
-#endif
 
 /*
    As for the edges, if a facet is tanget to the plane it is not considered as


### PR DESCRIPTION
## Summary of Changes

Compiling CGAL with the define `CGAL_NEF3_TRIANGULATE_FACETS` set (which also requires CGAL_NEF_EXPLOIT_REFERENCE_COUNTING otherwise there is a compile error) doesn't work. There is a compile error here: https://github.com/CGAL/cgal/blob/68c44a162df2c5577a7f5f51bf45ac1d349ed143/Packages/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h#L250

Where `CT::Edge` should be preceded by a typename keyword. As such I would assume that the code isn't tested or used publically. I tested the code against the performance benchmark (spheregrid/shiftedspheregrid) and didn't find any performance benefit. I propose therefore that the code should be removed, and removing it correctly can be achieved using a tool called `unifdef` using the following: `grep CGAL_NEF3_TRIANGULATE_FACETS * -Rl | xargs unifdef -UCGAL_NEF3_TRIANGULATE_FACETS -m`

I have applied the command to the code for this PR. 

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): cleaning
* License and copyright ownership: Returned to CGAL Authors.
