### PR TITLE
remove remaining mentions to setup.exe

### DIFF
--- a/Documentation/doc/Documentation/Third_party.txt
+++ b/Documentation/doc/Documentation/Third_party.txt
@@ -89,8 +89,8 @@ solution, and we recommend to use them.
 These libraries can be obtained from <A HREF="https://gmplib.org/">`https://gmplib.org/`</A>
 and <A HREF="https://www.mpfr.org/">`https://www.mpfr.org/`</A>.
 Since Visual \cpp is not properly supported by the \sc{Gmp} and \sc{Mpfr} projects,
-we provide precompiled versions of \sc{Gmp} and \sc{Mpfr}, which can be downloaded with the installer
-<a href="https://github.com/CGAL/cgal/releases">`CGAL-\cgalReleaseNumber``-Setup.exe`</a>.
+we provide precompiled versions of \sc{Gmp} and \sc{Mpfr}, which can be downloaded
+from the <a href="https://github.com/CGAL/cgal/releases">assets of a release</a>.
 
 \section secoptional3rdpartysoftware Optional Third Party Libraries
 

--- a/Documentation/doc/Documentation/windows.txt
+++ b/Documentation/doc/Documentation/windows.txt
@@ -190,17 +190,6 @@ as this will help `cmake` to find Boost.</li>
 <li>Add the path to the Boost `dlls` (`C:\dev\libboost_1_71_0\lib64-msvc-XX.Y`) files to the `PATH` environment variable.</li>
 </ul>
 
-\subsection ssect-installer-install-cgal Installing CGAL Itself
-
-Download and run `CGAL-\cgalReleaseNumber``-Setup.exe` from
-<a href="https://www.cgal.org/download/windows.html">https://www.cgal.org/download/windows.html</a>.
-It is a self extracting executable that downloads the \cgal header files, and optionally the source code of the
-examples and demos. Additionally, it can download the precompiled versions of \gmp and \mpfr. You must
-specify if you want the 32 or the 64 bit versions of these two libraries.
-
-Setting the environment variable `CGAL_DIR` to `C:\dev\CGAL-\cgalReleaseNumber` is a good idea
-to help `cmake` to find \cgal during the configuration process, detailed in the next section.
-
 \subsection ssect-installer-compile-example Compiling an Example
 
 We assume that you have downloaded the examples with the \cgal Installer.

--- a/Scripts/developer_scripts/create_new_release
+++ b/Scripts/developer_scripts/create_new_release
@@ -326,22 +326,3 @@ if [ -n "$DO_PUBLIC" ]; then
     rm -f "$HTML_DIR/CGAL-last-public"
     ln -s "${release_name}-public" "$HTML_DIR/CGAL-last-public"
 fi
-
-if [ -n "$DO_PUBLIC" ]; then
-  if docker version > /dev/null; then
-    # Re-extract the full version of CGAL, with examples/, and doc_html/
-    rm -rf ./${public_release_name}
-    tar -xf "${HTML_DIR}/${release_name}-public/${public_release_name}.tar.xz"
-    # Build the Windows installer
-    docker pull cgal/cgal-nsis-dockerfile
-    docker create -v `realpath ${DESTINATION}/${public_release_name}`:/mnt/cgal_release:ro,z \
-                  -v ${SOURCES_DIR}:/mnt/cgal_sources:ro,z                    \
-                  cgal/cgal-nsis-dockerfile
-    container_id=`docker ps -q -l`
-    docker start -a ${container_id}
-    docker cp ${container_id}:/nsis_release/${public_release_name}-Setup.exe "${HTML_DIR}/${release_name}-public/"
-    docker rm ${container_id}
-  else
-    echo "Cannot use Docker, the Windows installer will not be created" >&2
-  fi
-fi


### PR DESCRIPTION
Follow up of #5451

Thanks @albert-github for the report.

Modifications of `windows.txt` were already removed [here](https://github.com/CGAL/cgal/pull/5451/files#diff-f7a36d44b5e3f85dbf2f65258c85ce9327e0424bba4e7e488b5f197d47ba3b33) so I don't understand how they can still be here. I checked the status of the file after the merge of the PR and it was still here.