### PR TITLE
Incorrect documentation for enum in Three package

### DIFF
--- a/Three/include/CGAL/Three/Scene_interface.h
+++ b/Three/include/CGAL/Three/Scene_interface.h
@@ -26,15 +26,15 @@
 */
 enum RenderingMode
 {
-  Points = 0, //! Renders only points without lighting.
-  PointsPlusNormals, //!Renders points and normals.
-  Wireframe, //!Renders only edges.
-  Flat, //!Renders only faces, with a lighting per face.
-  FlatPlusEdges, //!Renders flat faces and edges.
-  Gouraud, //!Renders only faces, with a lighting per vertex.
-  GouraudPlusEdges, //!Renders faces with a lighting per vertex, and edges.
-  ShadedPoints, //!Renders only points with lighting.
-  NumberOfRenderingMode //!Number of values in this enum.
+  Points = 0,           //!< Renders only points without lighting.
+  PointsPlusNormals,    //!< Renders points and normals.
+  Wireframe,            //!< Renders only edges.
+  Flat,                 //!< Renders only faces, with a lighting per face.
+  FlatPlusEdges,        //!< Renders flat faces and edges.
+  Gouraud,              //!< Renders only faces, with a lighting per vertex.
+  GouraudPlusEdges,     //!< Renders faces with a lighting per vertex, and edges.
+  ShadedPoints,         //!< Renders only points with lighting.
+  NumberOfRenderingMode //!< Number of values in this enum.
 };
 
 


### PR DESCRIPTION
Though not yet released ...
The documentation after the enum values signal, according to the text, documentation after the enum value but the used documentation starter `//!` is incorrect, should be `//!<`.
(see results on page doc_output/Three/group__PkgThreeRef.html)

Old:
![image](https://user-images.githubusercontent.com/5223533/120798427-a103f480-c53d-11eb-99a7-3046f534f60d.png)

and
![image](https://user-images.githubusercontent.com/5223533/120798477-b416c480-c53d-11eb-979b-09bb059112db.png)

New:
![image](https://user-images.githubusercontent.com/5223533/120798521-c264e080-c53d-11eb-935f-ffa2ffac288e.png)

and
![image](https://user-images.githubusercontent.com/5223533/120798559-cf81cf80-c53d-11eb-98a8-9ef1007757c2.png)


