### PR TITLE
Mesh_3 - fix missing initializer warning

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
+++ b/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
@@ -525,10 +525,10 @@ polylines_to_protect
                                  Image_word_type> Enriched_pixel;
 
           array<array<Enriched_pixel, 2>, 2> square =
-            {{ {{ { pix00, Point_3(), Domain_type(), 0, false },
-                  { pix01, Point_3(), Domain_type(), 0, false } }},
-               {{ { pix10, Point_3(), Domain_type(), 0, false },
-                  { pix11, Point_3(), Domain_type(), 0, false } }} }};
+            {{ {{ { pix00, Point_3(), Domain_type(), 0, false, false },
+                  { pix01, Point_3(), Domain_type(), 0, false, false } }},
+               {{ { pix10, Point_3(), Domain_type(), 0, false, false },
+                  { pix11, Point_3(), Domain_type(), 0, false, false } }} }};
 
           std::map<Domain_type, int> pixel_values_set;
           for(int ii = 0; ii < 2; ++ii) {


### PR DESCRIPTION
## Summary of Changes

This PR fixes the warning (missing parameter in initializer list) introduced by PR #5587 :
```
missing initializer for member 'CGAL::Mesh_3::internal::Enriched_pixel` 
```

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

