### PR TITLE
Remove dead ftp link

### DIFF
--- a/Documentation/doc/biblio/cgal_manual.bib
+++ b/Documentation/doc/biblio/cgal_manual.bib
@@ -1339,7 +1339,6 @@ Teillaud"
   ,number       = {ECG-TR-122201-01}
   ,address      = {Sophia-Antipolis}
   ,month        = may
-  ,url          = {ftp://ftp-sop.inria.fr/prisme/ECG/Reports/Month12/ECG-TR-122201-01.ps.gz}
 }
 
 @inproceedings{ cgal:ke-rctac-03


### PR DESCRIPTION
## Summary of Changes

Removing rather than updating because there is no exact match on nice (i.e. hal) platforms but it is easy enough to find anyway.

## Release Management

* Affected package(s): `Documentation`
* Issue(s) solved (if any): fix #5751

