### PR TITLE
Set CMake imported OpenMesh library as INTERFACE

### DIFF
--- a/Installation/cmake/modules/FindOpenMesh.cmake
+++ b/Installation/cmake/modules/FindOpenMesh.cmake
@@ -55,7 +55,7 @@ if(OpenMesh_FOUND AND NOT TARGET OpenMesh::OpenMesh)
   add_library(OpenMesh::OpenMesh UNKNOWN IMPORTED)
 
   if(TARGET OpenMeshCore)
-    target_link_libraries(OpenMesh::OpenMesh PUBLIC OpenMeshCore)
+    target_link_libraries(OpenMesh::OpenMesh INTERFACE OpenMeshCore)
     return()
   endif()
 


### PR DESCRIPTION
## Summary of Changes

I have ran into the following compiling issue:
```
 CMake Error at /lib/cmake/CGAL/FindOpenMesh.cmake:58 (target_link_libraries):
   IMPORTED library can only be used with the INTERFACE keyword of
   target_link_libraries
```

Not a CMake expert, but the proposed patch solved the issue for me.

## Release Management

* Affected package(s): CMake
* License and copyright ownership: unchanged

