### PR TITLE
Add inline vtk_image_sharing_same_data_pointer

### DIFF
--- a/CGAL_ImageIO/include/CGAL/Image_3_vtk_interface.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3_vtk_interface.h
@@ -84,6 +84,7 @@ struct VTK_type_generator<boost::uint32_t> {
   typedef vtkUnsignedIntArray ArrayType;
 };
 
+inline
 ::vtkImageData* vtk_image_sharing_same_data_pointer(Image_3& image)
 {
   vtkImageData* vtk_image = vtkImageData::New();


### PR DESCRIPTION
Fix possible duplicate symbol:
`duplicate symbol 'CGAL::vtk_image_sharing_same_data_pointer(CGAL::Image_3&)'`

## Summary of Changes

Proposed solution add `inline` to `vtk_image_sharing_same_data_pointer ` in `Image_3_vtk_interface.h` following approach with `read_vtk_image_data` in `read_vtk_image_data.h` 

## Release Management

* Affected package(s): CGAL_ImageIO
* License and copyright ownership: Unchanged

