### PR TITLE
Remove CGAL_NEF3_FACET_WITH_BOX

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/Binary_operation.h
+++ b/Nef_3/include/CGAL/Nef_3/Binary_operation.h
@@ -313,12 +313,6 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
     //    CGAL_NEF_SETDTHREAD(19*43*131);
     CGAL_NEF_TRACEN("=> binary operation");
 
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-    SNC_constructor C1(snc1);
-    C1.create_box();
-    SNC_constructor C2(snc2);
-    C2.create_box();
-#endif
 
     CGAL_NEF_TRACEN("\nnumber of vertices (so far...) = "
                     << this->sncp()->number_of_vertices());

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -258,9 +258,6 @@ typedef typename Traits::Halffacet_handle Halffacet_handle;
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
 typedef typename Traits::Halffacet_triangle_handle Halffacet_triangle_handle;
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-typedef typename Traits::Partial_facet Partial_facet;
-#endif
 typedef typename Traits::Object_handle Object_handle;
 typedef std::vector<Object_handle> Object_list;
 typedef typename Object_list::const_iterator Object_const_iterator;
@@ -899,9 +896,6 @@ typename Object_list::difference_type n_vertices = std::distance(objects.begin()
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
         Halffacet_triangle_handle t;
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-        Partial_facet pf;
-#endif
         if( CGAL::assign( v, *o)) {
           if( !v_mark[v]) {
             O.push_back(*o);
@@ -927,11 +921,6 @@ typename Object_list::difference_type n_vertices = std::distance(objects.begin()
             O.push_back(*o);
             t_mark[tr] = true;
           }
-        }
-#endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-        else if(CGAL::assign(pf, *o)) {
-          CGAL_error_msg( "wrong type");
         }
 #endif
         else
@@ -1024,10 +1013,6 @@ std::string dump_object_list( const Object_list& O, int level = 0) {
   typename Object_list::size_type t_count = 0;
   Halffacet_triangle_handle t;
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-  typename Object_list::size_type p_count = 0;
-  Partial_facet pf;
-#endif
   for( o = O.begin(); o != O.end(); ++o) {
     if( CGAL::assign( v, *o)) {
       if( level) os << v->point() << std::endl;
@@ -1048,21 +1033,12 @@ std::string dump_object_list( const Object_list& O, int level = 0) {
       ++t_count;
     }
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-    else if( CGAL::assign(pf, *o)) {
-      if( level) pf.debug();
-      ++p_count;
-    }
-#endif
     else
       CGAL_error_msg( "wrong handle");
   }
   os << v_count << "v " << e_count << "e " << f_count << "f ";
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
   os  << t_count << "t ";
-#endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-  os  << p_count << "p ";
 #endif
   return os.str();
  }
@@ -1224,19 +1200,6 @@ bool classify_objects(Object_iterator start, Object_iterator end,
   Point_3 point_on_plane(partition_plane.point());
 
   for( o = start; o != end; ++o) {
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-    Partial_facet pf;
-    if(CGAL::assign(pf, *o)) {
-      Partial_facet pfn,pfp;
-      if(pf.divide(partition_plane, pfn, pfp)) {
-        *o1 = make_object(pfn);
-        ++o1;
-        *o2 = make_object(pfp);
-        ++o2;
-        continue;
-      }
-    }
-#endif
     Oriented_side side = sop( point_on_plane, *o, depth);
     if( side == ON_NEGATIVE_SIDE || side == ON_ORIENTED_BOUNDARY) {
       *o1 = *o;

--- a/Nef_3/include/CGAL/Nef_3/Nef_box.h
+++ b/Nef_3/include/CGAL/Nef_3/Nef_box.h
@@ -87,17 +87,6 @@ class Nef_box : public Box_intersection_d::Box_d< double, 3 > {
       init( true );
     } else {
       init( false );
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-      std::pair<double, double> q[3];
-      q[0] = CGAL::to_interval( f->b.min_coord(0) );
-      q[1] = CGAL::to_interval( f->b.min_coord(1) );
-      q[2] = CGAL::to_interval( f->b.min_coord(2) );
-      Box_intersection_d::Box_d< double, 3 >::extend(q);
-      q[0] = CGAL::to_interval( f->b.max_coord(0) );
-      q[1] = CGAL::to_interval( f->b.max_coord(1) );
-      q[2] = CGAL::to_interval( f->b.max_coord(2) );
-      Box_intersection_d::Box_d< double, 3 >::extend(q);
-#else
       Halffacet_cycle_iterator cycle_it = f->facet_cycles_begin();
       if( cycle_it.is_shalfedge() ) {
         SHalfedge_iterator edge_it(cycle_it);
@@ -109,7 +98,6 @@ class Nef_box : public Box_intersection_d::Box_d< double, 3 > {
         }
       } else
         CGAL_error_msg( "is facet first cycle a SHalfloop?");
-#endif
     }
   }
 

--- a/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
@@ -112,9 +112,6 @@ public:
   typedef typename SNC_structure::Halffacet_triangle_handle
                                   Halffacet_triangle_handle;
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-  typedef typename SNC_structure::Partial_facet Partial_facet;
-#endif
   typedef typename SNC_structure::Object_handle Object_handle;
 
   typedef typename Decorator_traits::Halffacet_cycle_iterator
@@ -151,10 +148,6 @@ public:
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
   template<typename Depth> Oriented_side operator()
     ( const Point_3& pop, Halffacet_triangle_handle f, Depth depth);
-#endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-  template<typename Depth> Oriented_side operator()
-    ( const Point_3& pop, Partial_facet& f, Depth depth);
 #endif
 #ifdef CGAL_NEF_EXPLOIT_REFERENCE_COUNTING
   bool reference_counted;
@@ -298,9 +291,6 @@ public:
   typedef typename SNC_structure::Halffacet_triangle_handle
                                   Halffacet_triangle_handle;
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-  typedef typename SNC_structure::Partial_facet Partial_facet;
-#endif
 
   typedef typename SNC_structure::Object_handle Object_handle;
   typedef std::vector<Object_handle> Object_list;
@@ -345,19 +335,12 @@ Side_of_plane<SNC_decorator>::operator()
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
   Halffacet_triangle_handle t;
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-  Partial_facet pf;
-#endif
   if( CGAL::assign( v, o))
     return (*this)(pop, v, depth);
   else if( CGAL::assign( e, o))
     return (*this)(pop, e, depth);
   else if( CGAL::assign( f, o))
     return (*this)(pop, f, depth);
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-  else if( CGAL::assign(pf, o))
-    return (*this)(pop, pf, depth);
-#endif
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
   else if( CGAL::assign( t, o))
     return (*this)(pop, t, depth);
@@ -547,17 +530,6 @@ Side_of_plane<SNC_decorator>::operator()
    as far as two vertices located on different sides of the plane.
 */
 
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-template <class SNC_decorator>
-template <typename Depth>
-Oriented_side
-Side_of_plane<SNC_decorator>::operator()
-  (const Point_3& pop, Partial_facet& pf, Depth depth) {
-  CGAL_error_msg( "not implemented yet");
-
-  return ON_ORIENTED_BOUNDARY;
-}
-#endif
 
 template <class SNC_decorator>
 template <typename Depth>

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -168,9 +168,6 @@ public:
   typedef typename Decorator_traits::Halffacet_triangle_handle
                                      Halffacet_triangle_handle;
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-  typedef typename SNC_structure::Partial_facet Partial_facet;
-#endif
   typedef typename SNC_structure::Point_3 Point_3;
   typedef typename SNC_structure::Plane_3 Plane_3;
   typedef typename SNC_structure::Segment_3 Segment_3;
@@ -372,23 +369,6 @@ public:
         CGAL_NEF_TRACEN("add facet " << f->plane());
         objects.push_back(make_object(Halffacet_handle(f)));
       }
-#elif defined CGAL_NEF3_FACET_WITH_BOX
-#ifndef CGAL_NEF3_PARTITION_MINIMUM
-#define CGAL_NEF3_PARTITION_MINIMUM 6
-#endif
-      Halffacet_cycle_iterator fci = f->facet_cycles_begin();
-      CGAL_assertion(fci.is_shalfedge());
-      SHalfedge_around_facet_circulator safc(fci), send(safc);
-      int length = 0;
-      int stop = CGAL_NEF3_PARTITION_MINIMUM;
-      while(++length < stop && ++safc != send);
-      if(length >= stop) {
-        CGAL_NEF_TRACEN("use Partial facets ");
-        Partial_facet pf(f);
-        objects.push_back(make_object(pf));
-      } else {
-        objects.push_back(make_object(Halffacet_handle(f)));
-      }
 #else
       objects.push_back(make_object(Halffacet_handle(f)));
 #endif
@@ -561,9 +541,6 @@ public:
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
     Halffacet_triangle_handle t;
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-    Partial_facet pf;
-#endif
     bool hit = false;
     Point_3 eor = CGAL::ORIGIN; // 'end of ray', the latest ray's hit point
     Objects_along_ray objects = candidate_provider->objects_along_ray(ray);
@@ -628,21 +605,6 @@ public:
             _CGAL_NEF_TRACEN("the facet becomes the new hit object");
           }
         }
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-        else if( CGAL::assign(pf, *o) && ((mask&4) != 0)) {
-          CGAL_NEF_TRACEN("new ray shooting");
-          Point_3 q;
-          if( is.does_intersect_internally( ray, pf, q) ) {
-            if( hit && !has_smaller_distance_to_point( ray.source(), q, eor))
-              continue;
-            if( !candidate_provider->is_point_on_cell( q, objects_iterator))
-              continue;
-            eor = q;
-            result = make_object(pf.f);
-            hit = true;
-          }
-        }
-#endif
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
         else if( CGAL::assign( t, *o) && ((mask&8) != 0)) {
           Point_3 q;
@@ -691,9 +653,6 @@ public:
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
     Halffacet_triangle_handle t;
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-    Partial_facet pf;
-#endif
     Object_list candidates = candidate_provider->objects_around_point(p);
     Object_list_iterator o = candidates.begin();
     bool found = false;
@@ -733,16 +692,6 @@ public:
         }
       }
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-      else if( CGAL::assign(pf, *o)) {
-        CGAL_NEF_TRACEN("new locate ");
-        if ( is.does_contain_internally( pf, p) ) {
-          _CGAL_NEF_TRACEN("found on partial facet...");
-          result = make_object(pf.f);
-          found = true;
-        }
-      }
-#endif
       o++;
     }
     if( !found) {
@@ -768,9 +717,6 @@ public:
     Halffacet_handle f;
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
     Halffacet_triangle_handle t;
-#endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-    Partial_facet pf;
 #endif
     Object_list candidates = candidate_provider->objects_around_point(p);
     Object_list_iterator o = candidates.begin();
@@ -872,18 +818,6 @@ public:
           s = Segment_3(p, normalized(ip));
           result = make_object(f);
         }
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-      } else if( CGAL::assign(pf, *o)) {
-        CGAL_NEF_TRACEN("new locate ");
-        if ( is.does_contain_internally( pf, p) ) {
-          _CGAL_NEF_TRACEN("found on partial facet...");
-          return make_object(pf.f);
-        }
-        if( is.does_intersect_internally(s,pf,ip)) {
-          s = Segment_3(p, normalized(ip));
-          result = make_object(pf.f);
-        }
-#endif
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
       } else if( CGAL::assign(t, *o)) {
         CGAL_NEF_TRACEN("test triangle of facet " << t->plane());
@@ -961,14 +895,6 @@ public:
       if(f->plane().oriented_side(p) == ON_NEGATIVE_SIDE)
         f = f->twin();
       return make_object(f->incident_volume());
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-    } else if( CGAL::assign(pf, *o)) {
-      CGAL_error_msg( "should not be executed");
-      Halffacet_handle f = pf.f;
-      if(f->plane().oriented_side(p) == ON_NEGATIVE_SIDE)
-        f = f->twin();
-      return make_object(f->incident_volume());
-#endif
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
     } else if( CGAL::assign(t, result)) {
       f = t;
@@ -1007,9 +933,6 @@ public:
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
     Halffacet_triangle_handle t;
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-    Partial_facet pf;
-#endif
     Object_list_iterator o;
     Object_list objects = candidate_provider->objects_around_segment(s);
     CGAL_for_each( o, objects) {
@@ -1043,11 +966,6 @@ public:
           _CGAL_NEF_TRACEN("edge intersects facet on plane "<<f->plane()<<" on "<<q);
         }
       }
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-        else if( CGAL::assign(pf, *o)) {
-          CGAL_error_msg( "not implemented yet");
-        }
-#endif
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
       else if( CGAL::assign( t, *o)) {
         Point_3 q;
@@ -1084,9 +1002,6 @@ public:
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
     Halffacet_triangle_handle t;
 #endif
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-    Partial_facet pf;
-#endif
     Object_list_iterator o;
     Object_list objects = candidate_provider->objects_around_segment(s);
     CGAL_for_each( o, objects) {
@@ -1111,11 +1026,6 @@ public:
       else if( CGAL::assign( f, *o)) {
         /* do nothing */
       }
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-        else if( CGAL::assign(pf, *o)) {
-          CGAL_error_msg( "not implemented yet");
-        }
-#endif
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
       else if( CGAL::assign( t, *o)) {
         /* do nothing */
@@ -1140,9 +1050,6 @@ public:
     Vertex_handle v;
     Halfedge_handle e;
     Halffacet_handle f;
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-    Partial_facet pf;
-#endif
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
     Halffacet_triangle_handle t;
 #endif
@@ -1168,11 +1075,6 @@ public:
           _CGAL_NEF_TRACEN("edge intersects facet on plane "<<f->plane()<<" on "<<q);
         }
       }
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-      else if( CGAL::assign(pf, *o)) {
-        CGAL_error_msg( "not implemented yet");
-      }
-#endif
 #ifdef CGAL_NEF3_TRIANGULATE_FACETS
       else if( CGAL::assign( t, *o)) {
         Point_3 q;

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -27,9 +27,6 @@
 #include <CGAL/Nef_3/SNC_iteration.h>
 #include <CGAL/Nef_2/iterator_tools.h>
 #include <CGAL/Nef_S2/Sphere_geometry.h>
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-#include <CGAL/Box_intersection_d/Box_d.h>
-#endif
 #include <list>
 
 #undef CGAL_NEF_DEBUG
@@ -129,29 +126,6 @@ public:
   and iterators. There's no type |SHalfloop_iterator|, as there is
   at most one |SLoop| pair per vertex.}*/
 
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-  template<class Refs>
-  class Facet_with_box : public Items::template Halffacet<Refs> {
-  public:
-    typedef typename Items::template Halffacet<Refs> Halffacet;
-    typedef typename Refs::FT FT;
-    typedef typename Box_intersection_d::Box_d<FT,3> Box;
-
-    Box b;
-
-    Facet_with_box() : Halffacet(), b() {}
-    Facet_with_box(const Plane_3& h, Mark m) : Halffacet(h,m) {}
-    Facet_with_box(const Facet_with_box<Refs>& f) : Halffacet(f) {
-      b = f.b;
-    }
-
-    Facet_with_box<Refs>& operator=(const Facet_with_box<Refs>& f) {
-      (Halffacet) *this = (Halffacet) f;
-      b = f.b;
-      return *this;
-    }
-  };
-#endif
 
  public:
   typedef Sphere_map                                        Vertex_base;
@@ -163,11 +137,7 @@ public:
   typedef typename Vertex_list::iterator                    Vertex_iterator;
   typedef typename Vertex_list::const_iterator              Vertex_const_iterator;
 
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-  typedef Facet_with_box<SNC_structure>                     Halffacet_base;
-#else
   typedef typename Items::template Halffacet<SNC_structure> Halffacet_base;
-#endif
   typedef SNC_in_place_list_halffacet<Halffacet_base>       Halffacet;
   typedef CGAL::In_place_list<Halffacet,false>              Halffacet_list;
   typedef CGAL_ALLOCATOR(Halffacet)                         Halffacet_alloc;
@@ -455,229 +425,6 @@ public:
           move_shalfedge_around_facet<SHalfedge_iterator> >
           SHalfedge_around_facet_circulator;
 
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-  typedef std::pair<SHalfedge_around_facet_circulator,
-                    SHalfedge_around_facet_circulator> Outer_cycle;
-  typedef std::pair<SHalfedge_around_facet_circulator,
-                    SHalfedge_around_facet_circulator> Inner_cycle;
-
-  class Partial_facet {
-  public:
-    Halffacet_handle f;
-
-    std::list<Outer_cycle> outer_cycles;
-    std::list<Inner_cycle> inner_cycles;
-    std::list<Point_3>     isolated_vertices;
-
-    typedef typename std::list<Outer_cycle>::iterator Outer_cycle_iterator;
-    typedef typename std::list<Inner_cycle>::iterator Inner_cycle_iterator;
-    typedef typename std::list<Point_3>::iterator Isolated_vertex_iterator;
-
-    Partial_facet() {}
-
-    Partial_facet(const Partial_facet& pf) {
-      f = pf.f;
-      outer_cycles = pf.outer_cycles;
-      inner_cycles = pf.inner_cycles;
-      isolated_vertices = pf.isolated_vertices;
-    }
-
-    Partial_facet& operator=(const Partial_facet& pf) {
-      f = pf.f;
-      outer_cycles = pf.outer_cycles;
-      inner_cycles = pf.inner_cycles;
-      isolated_vertices = pf.isolated_vertices;
-      return *this;
-    }
-
-    explicit Partial_facet(Halffacet_handle fin) : f(fin) {
-      Halffacet_cycle_iterator fc = f->facet_cycles_begin();
-      for(;fc != f->facet_cycles_end();++fc) {
-        if(fc.is_shalfedge()) {
-          SHalfedge_around_facet_circulator se(fc), se_next(se);
-          ++se_next;
-          if(fc == f->facet_cycles_begin()) {
-            outer_cycles.push_back(Outer_cycle(se, se));
-            //            outer_cycles.push_back(Outer_cycle(se_next, se));
-          } else {
-            inner_cycles.push_back(Inner_cycle(se, se));
-            //            inner_cycles.push_back(Inner_cycle(se_next, se));
-          }
-        } else if(fc.is_shalfloop()) {
-          SHalfloop_handle l(fc);
-          isolated_vertices.push_back(l->incident_sface()->center_vertex()->point());
-        } else
-          CGAL_error_msg( "wrong value");
-      }
-    }
-
-    Outer_cycle_iterator outer_cycles_begin() { return outer_cycles.begin(); }
-    Inner_cycle_iterator inner_cycles_begin() { return inner_cycles.begin(); }
-    Isolated_vertex_iterator isolated_vertices_begin() { return isolated_vertices.begin(); }
-
-    Outer_cycle_iterator outer_cycles_end() { return outer_cycles.end(); }
-    Inner_cycle_iterator inner_cycles_end() { return inner_cycles.end(); }
-    Isolated_vertex_iterator isolated_vertices_end() { return isolated_vertices.end(); }
-
-    bool divide(const Plane_3& p, Partial_facet& pf1, Partial_facet& pf2) {
-      //      std::cerr << "divide " << std::endl;
-      //      debug();
-      pf1.f = pf2.f = f;
-      Outer_cycle_iterator oc = outer_cycles.begin();
-      for(;oc != outer_cycles.end(); ++oc) {
-        bool next = false;
-        //        CGAL_assertion(oc->first != oc->second);
-        SHalfedge_around_facet_circulator se = oc->first, se_begin(se), se_new(se), se_end;
-        Oriented_side ref = p.oriented_side(se->source()->source()->point()), cur;
-        //        std::cerr << "start " << se->source()->source()->point() << ":" << ref << std::endl;
-        ++se;
-        while(ref == ON_ORIENTED_BOUNDARY && se != oc->second) {
-          ref = p.oriented_side(se->source()->source()->point());
-          ++se;
-        }
-        if(se == oc->second)
-          return false;
-
-        for(;se != oc->second;++se) {
-          cur = p.oriented_side(se->source()->source()->point());
-          //          std::cerr << "current " << se->source()->source()->point() << ":" << cur  << std::endl;
-          if(cur != ref) {
-            CGAL_assertion(ref != ON_ORIENTED_BOUNDARY);
-            if(cur == ON_ORIENTED_BOUNDARY) {
-              next = true;
-              continue;
-            }
-            se_end = se;
-            if(next)
-              --se_end;
-            if(cur == ON_NEGATIVE_SIDE) {
-              pf2.outer_cycles.push_back(Outer_cycle(se_begin, se_end));
-            } else if(cur == ON_POSITIVE_SIDE) {
-              pf1.outer_cycles.push_back(Outer_cycle(se_begin, se_end));
-            }
-            se_begin = se_new;
-            if(next)
-              ++se_begin;
-            ref = cur;
-          } else
-              se_new = se;
-          next = false;
-        }
-        //        std::cerr << "end of cycle " << ref << std::endl;
-        if(next) {
-          if(ref == ON_POSITIVE_SIDE) {
-            pf1.outer_cycles.push_back(Outer_cycle(se_new, se));
-            pf2.outer_cycles.push_back(Outer_cycle(se_begin, --se));
-          } else {
-            pf2.outer_cycles.push_back(Outer_cycle(se_new, se));
-            pf1.outer_cycles.push_back(Outer_cycle(se_begin, --se));
-          }
-        } else {
-          if(ref == ON_POSITIVE_SIDE)
-            pf2.outer_cycles.push_back(Outer_cycle(se_begin, se));
-          else if(ref == ON_NEGATIVE_SIDE)
-            pf1.outer_cycles.push_back(Outer_cycle(se_begin, se));
-        }
-      }
-
-      Inner_cycle_iterator ic = inner_cycles.begin();
-      for(;ic != inner_cycles.end(); ++ic) {
-        bool next = false;
-        SHalfedge_around_facet_circulator se = ic->first, se_begin(se), se_new(se), se_end;
-        Oriented_side ref = p.oriented_side(se->source()->source()->point()), cur;
-        ++se;
-        while(ref == ON_ORIENTED_BOUNDARY && se != ic->second) {
-          ref = p.oriented_side(se->source()->source()->point());
-          ++se;
-        }
-        if(se == ic->second)
-          return false;
-
-        for(;se != ic->second; ++se) {
-          cur = p.oriented_side(se->source()->source()->point());
-          if(cur != ref) {
-            CGAL_assertion(ref != ON_ORIENTED_BOUNDARY);
-            if(cur == ON_ORIENTED_BOUNDARY) {
-              next = true;
-              continue;
-            }
-            se_end = se;
-            if(next)
-              --se_end;
-            if(cur == ON_NEGATIVE_SIDE) {
-              pf2.inner_cycles.push_back(Inner_cycle(se_begin, se_end));
-            } else if(cur == ON_POSITIVE_SIDE) {
-              pf1.inner_cycles.push_back(Inner_cycle(se_begin, se_end));
-            }
-            se_begin = se_new;
-            if(next)
-              ++se_begin;
-            ref = cur;
-          } else
-              se_new = se;
-          next = false;
-        }
-        if(next) {
-          if(ref == ON_POSITIVE_SIDE) {
-            pf1.inner_cycles.push_back(Inner_cycle(se_new, se));
-            pf2.inner_cycles.push_back(Inner_cycle(se_begin, --se));
-          } else {
-            pf2.inner_cycles.push_back(Inner_cycle(se_new, se));
-            pf1.inner_cycles.push_back(Inner_cycle(se_begin, --se));
-          }
-        } else {
-          if(ref == ON_POSITIVE_SIDE)
-            pf2.inner_cycles.push_back(Inner_cycle(se_begin, se));
-          else if(ref == ON_NEGATIVE_SIDE)
-            pf1.inner_cycles.push_back(Inner_cycle(se_begin, se));
-        }
-      }
-
-      Isolated_vertex_iterator iv = isolated_vertices.begin();
-      for(;iv != isolated_vertices.end();++iv) {
-        Oriented_side side = p.oriented_side(*iv);
-        if( side == ON_NEGATIVE_SIDE || side == ON_ORIENTED_BOUNDARY)
-          pf1.isolated_vertices.push_back(*iv);
-        if( side == ON_POSITIVE_SIDE || side == ON_ORIENTED_BOUNDARY)
-          pf1.isolated_vertices.push_back(*iv);
-      }
-      //      std::cerr << "into " << std::endl;
-      //      pf1.debug();
-      //      pf2.debug();
-      return true;
-    }
-
-    void debug() {
-      std::cerr << "Partial_facet " << std::endl;
-      std::cerr << "Box " << std::endl;
-      std::cerr << " " << f->b.min_coord(0) << std::endl;
-      std::cerr << " " << f->b.min_coord(1) << std::endl;
-      std::cerr << " " << f->b.min_coord(2) << std::endl;
-      std::cerr << " " << f->b.max_coord(0) << std::endl;
-      std::cerr << " " << f->b.max_coord(1) << std::endl;
-      std::cerr << " " << f->b.max_coord(2) << std::endl;
-
-      Outer_cycle_iterator oc = outer_cycles_begin();
-      for(; oc != outer_cycles_end(); ++oc) {
-        std::cerr << "Outer cycle " << std::endl;
-        SHalfedge_around_facet_circulator sb(oc->first), se(oc->second);
-        CGAL_For_all(sb,se) {
-          std::cerr << "  " << sb->source()->source()->point() << std::endl;
-        }
-      }
-
-      Inner_cycle_iterator ic = inner_cycles_begin();
-      for(; ic != inner_cycles_end(); ++ic) {
-        std::cerr << "Inner cycle " << std::endl;
-        SHalfedge_around_facet_circulator sb(ic->first), se(ic->second);
-        CGAL_For_all(sb,se) {
-          std::cerr << "  " << sb->source()->source()->point() << std::endl;
-        }
-      }
-    }
-  };
-
-#endif
 
   /*{\Mcreation 3}*/
   /*{\Mtext |\Mname| is default and copy constructible. Note that copy

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -1851,29 +1851,6 @@ protected:
       CGAL_forall_halffacets(fi,snc()) {
         if(is_standard(fi) || ninety) {
           fi->plane() = fi->plane().transform( aff);
-#ifdef CGAL_NEF3_FACET_WITH_BOX
-          typedef typename Halffacet::Box Box;
-          bool first = true;
-          Halffacet_cycle_iterator cycle_it = fi->facet_cycles_begin();
-          if( cycle_it.is_shalfedge() ) {
-            SHalfedge_iterator edge_it(cycle_it);
-            SHalfedge_around_facet_circulator
-              start( edge_it ), end( edge_it );
-            CGAL_For_all( start, end ) {
-              const Point_3& p = start->source()->source()->point();
-              typename Kernel::FT q[3];
-              q[0] = p.x();
-              q[1] = p.y();
-              q[2] = p.z();
-              if(first) {
-                fi->b = Box(q,q);
-                first = false;
-              } else
-                fi->b.extend(q);
-            }
-          } else
-            CGAL_error_msg( "is facet first cycle a SHalfloop?");
-#endif
         }
       }
 


### PR DESCRIPTION
## Summary of Changes

Compiling CGAL with the define CGAL_NEF3_FACET_WITH_BOX set doesn't work. There are a number of compile errors and the implementation is missing here:

https://github.com/CGAL/cgal/blob/a8e87526348d2d1faa2ea893747314853ee6868d/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h#L550-L560

As such I would assume that the code isn't tested or used publically, so I propose therefore that the code should be removed, and removing it correctly can be achieved using a tool called unifdef using the following: 

`grep CGAL_NEF3_FACET_WITH_BOX * -Rl | xargs unifdef -UCGAL_NEF3_FACET_WITH_BOX -m`

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): cleaning
* License and copyright ownership: Returned to CGAL authors

