### PR TITLE
Simplify assign in Object.h

### DIFF
--- a/STL_Extension/include/CGAL/Object.h
+++ b/STL_Extension/include/CGAL/Object.h
@@ -76,25 +76,10 @@ class Object
     template <class T>
     bool assign(T &t) const
     {
-      if(obj) {
-        #ifdef CGAL_USE_ANY_BAD_CAST
-        try {
-          t = boost::any_cast<T>(*obj);
-          return true;
-        } catch(...) {
-          return false;
-        }
-        #else
-        const T* res =  boost::any_cast<T>(&(*obj));
-        if (res){
-          t=*res;
-          return true;
-        }
-        return false;
-        #endif
-      } else {
-        return false;
-      }
+      const T* res = boost::any_cast<T>(obj.get());
+      if (!res) return false;
+      t = *res;
+      return true;
     }
 
     bool
@@ -174,19 +159,13 @@ template <class T>
 inline
 const T * object_cast(const Object * o)
 {
-  if(o->obj)
-    return boost::any_cast<T>((o->obj).get());
-  else
-    return nullptr;
+  return boost::any_cast<T>((o->obj).get());
 }
 
 template <class T>
 inline
 T object_cast(const Object & o)
 {
-  if(!o.obj)
-    throw Bad_object_cast();
-
   const T * result = boost::any_cast<T>((o.obj).get());
   if (!result)
     throw Bad_object_cast();


### PR DESCRIPTION
## Summary of Changes

In the assign operation of Object.h there is a check to see if obj is null: `if(obj) ... `.  however the function any_cast of boost any.hpp already makes the check as follows:

```c++
    template<typename ValueType>
    ValueType * any_cast(any * operand)
    {
        return operand && operand->type() == typeid(ValueType)
                    ? &static_cast<any::holder<ValueType> *>(operand->content)->held
                    : 0;
    }
 ```
 
Usually, a null check is not worth optimising away but given that this really calls `operator bool` of shared_ptr it does have an impact that shows up in the profiler. Either way, this PR makes the code simpler and cleaner. The CGAL_USE_ANY_BAD_CAST code is never used and would be a bad solution anyway.

## Release Management

* Affected package(s): STL_ext
* Issue(s) solved (if any): cleaning/performance
* License and copyright ownership: Returned to CGAL authors.

