### PR TITLE
Polyline_simplification: Bugfix in Points_in_constraint_iterator

### DIFF
--- a/Polyline_simplification_2/test/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/test/Polyline_simplification_2/CMakeLists.txt
@@ -36,8 +36,7 @@ endif()
 # Creating entries for all .cpp/.C files with "main" routine
 # ##########################################################
 
+create_single_source_cgal_program( "issue-5774.cpp" )
 create_single_source_cgal_program( "simplify_polygon_test.cpp" )
 
 create_single_source_cgal_program( "simplify_polyline_with_duplicate_points.cpp" )
-
-

--- a/Polyline_simplification_2/test/Polyline_simplification_2/issue-5774.cpp
+++ b/Polyline_simplification_2/test/Polyline_simplification_2/issue-5774.cpp
@@ -1,0 +1,78 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polyline_simplification_2/simplify.h>
+
+#include <iostream>
+#include <string>
+#include <vector>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Point_2<K> Point;
+typedef std::vector<Point> Polyline_2;
+namespace PS = CGAL::Polyline_simplification_2;
+typedef PS::Vertex_base_2<K> Vb;
+typedef CGAL::Constrained_triangulation_face_base_2<K> Fb;
+typedef CGAL::Triangulation_data_structure_2<Vb, Fb> TDS;
+typedef CGAL::Constrained_Delaunay_triangulation_2<K, TDS, CGAL::Exact_predicates_tag> CDT;
+typedef CGAL::Constrained_triangulation_plus_2<CDT> CT;
+typedef PS::Stop_below_count_ratio_threshold Stop;
+typedef PS::Squared_distance_cost Cost;
+
+void print_coords(Polyline_2 polyline) {
+  std::cout << std::endl;
+  std::cout << "Simplified coordinates:" << std::endl << std::endl;
+
+  // Print out the simplified coordinates
+  unsigned int i = 0;
+  for (Point coord : polyline) {
+    std::cout << "[ ";
+    std::cout << coord.x();
+    std::cout << ", ";
+    std::cout << coord.y();
+    std::cout << " ]";
+    if (i != polyline.size() - 1) std::cout << ",";
+    i++;
+  }
+  std::cout << std::endl << std::endl;
+}
+
+void simplify_test() {
+  // Hard code a minimum working example where running PS::simplify results in
+  // self-intersections. There are no self-intersections when {27, 9} is
+  // omitted.
+  std::vector<std::vector<int>> coords = {
+      {64, 20}, {33, 27}, {27, 9}, {33, 18}, {44, 18}, {44, 8},
+      {24, 0},  {0, 13},  {9, 49}, {84, 41}, {83, 29}, {64, 20},
+  };
+  // Simplification outputs:
+  // [ 64, 20 ],[ 27, 9 ],[ 44, 18 ],[ 24, 0 ],
+  // [ 9, 49 ],[ 83, 29 ],[ 64, 20 ],[ 64, 20 ]
+
+  // Create polyline for simplifying later
+  Polyline_2 polyline;
+
+  // Insert coordinates into polyline
+  for (std::vector<int> coord : coords) {
+    Point pt(coord[0], coord[1]);
+    polyline.push_back(pt);
+  }
+
+  // Insert polyline into ct and run simplify()
+  CT ct;
+  ct.insert_constraint(polyline.begin(), polyline.end());
+  PS::simplify(ct, Cost(), Stop(0.2));
+  Polyline_2 polyline_simplified;
+
+  // Transfer simplified coordinates from ct to polyline for easy handling
+  auto cit = ct.constraints_begin();
+  for (auto vit = ct.points_in_constraint_begin(*cit);
+       vit != ct.points_in_constraint_end(*cit); vit++) {
+    polyline_simplified.push_back(*vit);
+  }
+
+  print_coords(polyline_simplified);
+  assert(polyline_simplified.size() == 4);
+}
+
+int main() {
+  simplify_test();
+}

--- a/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
@@ -46,12 +46,13 @@ private:
   class Node {
   public:
     explicit Node(Vertex_handle vh, bool input = false)
-      : vertex_(vh), id(-1), input(input)
+      : vertex_(vh), point_(vertex_->point()), id(-1), input(input)
     {}
-    const Point& point() const { return vertex_->point(); }
+    const Point& point() const { return point_; }
     Vertex_handle vertex() const { return vertex_; }
   private:
     Vertex_handle vertex_;
+    Point point_;
   public:
     int id;
     bool input;
@@ -70,7 +71,7 @@ public:
     >
   {
   public:
-    Point_it() : Vertex_it::iterator_adaptor_() {}
+    Point_it() : Point_it::iterator_adaptor_() {}
     Point_it(typename Vertex_list::all_iterator it) : Point_it::iterator_adaptor_(it) {}
   private:
     friend class boost::iterator_core_access;
@@ -633,10 +634,12 @@ Polyline_constraint_hierarchy_2<T,Compare,Point>::remove_points_without_correspo
 {
   std::size_t n = 0;
   for(Point_it it = points_in_constraint_begin(cid);
-      it != points_in_constraint_end(cid); ++it) {
+      it != points_in_constraint_end(cid);) {
     if(cid.vl_ptr()->is_skipped(it.base())) {
       it = cid.vl_ptr()->erase(it.base());
       ++n;
+    }else{
+      ++it;
     }
   }
   return n;


### PR DESCRIPTION
## Summary of Changes

When simplifying a polyline constraint in a triangulation the Points_in_constraint_iterator permits to traverse the input sequence of points. This is broken.  This draft only adds debug code and not a fix.

This PR undoes the PR #4213. The vertex handle in the Node class survives a simplification as it it is in a `Compact_container` but if after the simplification the user adds a new constraint that will recycle the vertex object and put another point in there.

The real bug though was spotted by Mael in the function that removes the points in the skip list for which the vertex was removed.

## Release Management

* Affected package(s): Polyline Simplification
* Issue(s) solved (if any):  [stackoverflow](https://stackoverflow.com/questions/67855845/cgal-polyline-simplification-results-in-self-intersection)
* License and copyright ownership: maintenance

