### PR TITLE
fast dynamic_cast in Lazy_kernel::Construct_point_3

### DIFF
--- a/Filtered_kernel/include/CGAL/Lazy_kernel.h
+++ b/Filtered_kernel/include/CGAL/Lazy_kernel.h
@@ -413,12 +413,13 @@ public:
                          int
                          > LRint;
 
-      LR * lr = dynamic_cast<LR*>(p.ptr());
-      if(lr && (! lr->et)){
+      auto&& t = typeid(*p.ptr());
+      if(t.name() == typeid(LR).name()){
+        LR * lr = static_cast<LR*>(p.ptr());
         return std::get<1>(lr->l);
-      } else {
-        LRint* lrint = dynamic_cast<LRint*>(p.ptr());
-        if(lrint && (! lrint->et)){
+      }else{
+        if(t.name() == typeid(LRint).name()){
+          LRint* lrint = static_cast<LRint*>(p.ptr());
           return std::get<1>(lrint->l);
         }
       }
@@ -465,16 +466,17 @@ public:
                          int
                          > LRint;
 
-
-      LR * lr = dynamic_cast<LR*>(p.ptr());
-      if(lr && (! lr->et)){
+      auto&& t = typeid(*p.ptr());
+      if(t.name() == typeid(LR).name()){
+        LR * lr = static_cast<LR*>(p.ptr());
         return std::get<1>(lr->l);
       }else{
-        LRint* lrint = dynamic_cast<LRint*>(p.ptr());
-        if(lrint && (! lrint->et)){
+        if(t.name() == typeid(LRint).name()){
+          LRint* lrint = static_cast<LRint*>(p.ptr());
           return std::get<1>(lrint->l);
         }
       }
+
       return BaseClass().construct_point_3_object()(p);
     }
 

--- a/Filtered_kernel/include/CGAL/Lazy_kernel.h
+++ b/Filtered_kernel/include/CGAL/Lazy_kernel.h
@@ -346,15 +346,16 @@ public:
                          int
                          > LRint;
 
+      auto& obj = *p.ptr();
+      const char* tn = typeid(obj).name();
 
-      auto&& t = typeid(*p.ptr());
-      if(t.name() == typeid(LR).name()){
+      if(tn == typeid(LR).name()){
         LR * lr = static_cast<LR*>(p.ptr());
         if(lr->is_lazy()){
           return std::get<2>(lr->l);
         }
       }else{
-        if(t.name() == typeid(LRint).name()){
+        if(tn == typeid(LRint).name()){
           LRint* lrint = static_cast<LRint*>(p.ptr());
           if(lrint->is_lazy()){
             return std::get<2>(lrint->l);
@@ -397,15 +398,16 @@ public:
                          int
                          > LRint;
 
+      auto& obj = *p.ptr();
+      const char* tn = typeid(obj).name();
 
-      auto&& t = typeid(*p.ptr());
-      if(t.name() == typeid(LR).name()){
+      if(tn == typeid(LR).name()){
         LR * lr = static_cast<LR*>(p.ptr());
         if(lr->is_lazy()){
           return std::get<2>(lr->l);
         }
       }else{
-        if(t.name() == typeid(LRint).name()){
+        if(tn == typeid(LRint).name()){
           LRint* lrint = static_cast<LRint*>(p.ptr());
           if(lrint->is_lazy()){
             return std::get<2>(lrint->l);
@@ -455,14 +457,16 @@ public:
                          int
                          > LRint;
 
-      auto&& t = typeid(*p.ptr());
-      if(t.name() == typeid(LR).name()){
+      auto& obj = *p.ptr();
+      const char* tn = typeid(obj).name();
+
+      if(tn == typeid(LR).name()){
         LR * lr = static_cast<LR*>(p.ptr());
         if(lr->is_lazy()){
           return std::get<1>(lr->l);
         }
       }else{
-        if(t.name() == typeid(LRint).name()){
+        if(tn == typeid(LRint).name()){
           LRint* lrint = static_cast<LRint*>(p.ptr());
           if(lrint->is_lazy()){
             return std::get<1>(lrint->l);
@@ -512,14 +516,16 @@ public:
                          int
                          > LRint;
 
-      auto&& t = typeid(*p.ptr());
-      if(t.name() == typeid(LR).name()){
+      auto& obj = *p.ptr();
+      const char* tn = typeid(obj).name();
+
+      if(tn == typeid(LR).name()){
         LR * lr = static_cast<LR*>(p.ptr());
         if(lr->is_lazy()){
           return std::get<1>(lr->l);
         }
       }else{
-        if(t.name() == typeid(LRint).name()){
+        if(tn == typeid(LRint).name()){
           LRint* lrint = static_cast<LRint*>(p.ptr());
           if(lrint->is_lazy()){
             return std::get<1>(lrint->l);

--- a/Filtered_kernel/include/CGAL/Lazy_kernel.h
+++ b/Filtered_kernel/include/CGAL/Lazy_kernel.h
@@ -336,11 +336,32 @@ public:
                          FT
                          > LR;
 
+      typedef Lazy_rep_n<typename Approximate_kernel::Weighted_point_2,
+                         typename Exact_kernel::Weighted_point_2,
+                         typename Approximate_kernel::Construct_weighted_point_2,
+                         typename Exact_kernel::Construct_weighted_point_2,
+                         E2A_,
+                         Return_base_tag,
+                         Point_2,
+                         int
+                         > LRint;
 
-      LR * lr = dynamic_cast<LR*>(p.ptr());
-      if(lr && (! lr->et)){
-        return std::get<2>(lr->l);
+
+      auto&& t = typeid(*p.ptr());
+      if(t.name() == typeid(LR).name()){
+        LR * lr = static_cast<LR*>(p.ptr());
+        if(lr->is_lazy()){
+          return std::get<2>(lr->l);
+        }
+      }else{
+        if(t.name() == typeid(LRint).name()){
+          LRint* lrint = static_cast<LRint*>(p.ptr());
+          if(lrint->is_lazy()){
+            return std::get<2>(lrint->l);
+          }
+        }
       }
+
       return BaseClass().compute_weight_2_object()(p);
     }
 
@@ -366,11 +387,32 @@ public:
                          FT
                          > LR;
 
+      typedef Lazy_rep_n<typename Approximate_kernel::Weighted_point_3,
+                         typename Exact_kernel::Weighted_point_3,
+                         typename Approximate_kernel::Construct_weighted_point_3,
+                         typename Exact_kernel::Construct_weighted_point_3,
+                         E2A_,
+                         Return_base_tag,
+                         Point_3,
+                         int
+                         > LRint;
 
-      LR * lr = dynamic_cast<LR*>(p.ptr());
-      if(lr && (! lr->et)){
-        return std::get<2>(lr->l);
+
+      auto&& t = typeid(*p.ptr());
+      if(t.name() == typeid(LR).name()){
+        LR * lr = static_cast<LR*>(p.ptr());
+        if(lr->is_lazy()){
+          return std::get<2>(lr->l);
+        }
+      }else{
+        if(t.name() == typeid(LRint).name()){
+          LRint* lrint = static_cast<LRint*>(p.ptr());
+          if(lrint->is_lazy()){
+            return std::get<2>(lrint->l);
+          }
+        }
       }
+
       return BaseClass().compute_weight_3_object()(p);
     }
 
@@ -416,11 +458,15 @@ public:
       auto&& t = typeid(*p.ptr());
       if(t.name() == typeid(LR).name()){
         LR * lr = static_cast<LR*>(p.ptr());
-        return std::get<1>(lr->l);
+        if(lr->is_lazy()){
+          return std::get<1>(lr->l);
+        }
       }else{
         if(t.name() == typeid(LRint).name()){
           LRint* lrint = static_cast<LRint*>(p.ptr());
-          return std::get<1>(lrint->l);
+          if(lrint->is_lazy()){
+            return std::get<1>(lrint->l);
+          }
         }
       }
 
@@ -469,11 +515,15 @@ public:
       auto&& t = typeid(*p.ptr());
       if(t.name() == typeid(LR).name()){
         LR * lr = static_cast<LR*>(p.ptr());
-        return std::get<1>(lr->l);
+        if(lr->is_lazy()){
+          return std::get<1>(lr->l);
+        }
       }else{
         if(t.name() == typeid(LRint).name()){
           LRint* lrint = static_cast<LRint*>(p.ptr());
-          return std::get<1>(lrint->l);
+          if(lrint->is_lazy()){
+            return std::get<1>(lrint->l);
+          }
         }
       }
 
@@ -481,6 +531,7 @@ public:
     }
 
   };
+
 
   struct Less_xyz_3 : public BaseClass::Less_xyz_3
   {


### PR DESCRIPTION
## Summary of Changes

The Issue #5724 explains it all and the code was just copy pasted from the issue to the code. Thank you Marc.
I also reproduced the performance gain for the 3d periodic triangulation with a regular triangulation with constant weight.
I did not try to get rid of `LRint`.

## Release Management

* Affected package(s): Kernel_23
* Issue(s) solved (if any): fix #5724
