### PR TITLE
MacOS Qt5 Guide Update

### DIFF
--- a/Documentation/doc/Documentation/Usage.txt
+++ b/Documentation/doc/Documentation/Usage.txt
@@ -166,10 +166,10 @@ if no debugging is intended. Users should thus run:
     cd CGAL-\cgalReleaseNumber/examples/Triangulation_2
     cmake -DCGAL_DIR=$HOME/CGAL-\cgalReleaseNumber -DCMAKE_BUILD_TYPE=Release . # we are here using a release tarball
 
-Note that the package Qt on brew is "keg-only", which means it cannot be "linked" with brew.
+After the Qt6 is released, the package Qt5 on brew is "keg-only", which means it is not "linked" with brew.
 You will have to specify the Qt5_DIR by hand to cmake, using something like
 
-    -DQt5_DIR=/usr/local/opt/qt/lib/cmake/Qt5
+    -DQt5_DIR=/usr/local/opt/qt@5/lib/cmake/Qt5
 
 where '/usr/local/` is actually your current brew installation directory.
 

--- a/Documentation/doc/Documentation/Usage.txt
+++ b/Documentation/doc/Documentation/Usage.txt
@@ -166,7 +166,7 @@ if no debugging is intended. Users should thus run:
     cd CGAL-\cgalReleaseNumber/examples/Triangulation_2
     cmake -DCGAL_DIR=$HOME/CGAL-\cgalReleaseNumber -DCMAKE_BUILD_TYPE=Release . # we are here using a release tarball
 
-After the Qt6 is released, the package Qt5 on brew is "keg-only", which means it is not "linked" with brew.
+The package Qt5 on brew is "keg-only", which means it is not "linked" with brew.
 In order to link against Qt5, you need to run:
 
     brew link qt@5

--- a/Documentation/doc/Documentation/Usage.txt
+++ b/Documentation/doc/Documentation/Usage.txt
@@ -167,11 +167,16 @@ if no debugging is intended. Users should thus run:
     cmake -DCGAL_DIR=$HOME/CGAL-\cgalReleaseNumber -DCMAKE_BUILD_TYPE=Release . # we are here using a release tarball
 
 After the Qt6 is released, the package Qt5 on brew is "keg-only", which means it is not "linked" with brew.
-You will have to specify the Qt5_DIR by hand to cmake, using something like
+In order to link against Qt5, you need to run:
 
-    -DQt5_DIR=/usr/local/opt/qt@5/lib/cmake/Qt5
+    brew link qt@5
 
-where '/usr/local/` is actually your current brew installation directory.
+After that, you will have to specify the Qt5_DIR by hand to cmake, using something like
+
+    -DQt5_DIR=/usr/local/opt/qt5/lib/cmake/Qt5
+
+where '/usr/local/` is actually your current brew installation directory. Check this directory
+to be sure where the Qt5 is placed on your machine.
 
 \subsection usage_configuring_cmake_gui Specifying Missing Dependencies
 


### PR DESCRIPTION
It was reported by the user that the current guide to compile CGAL examples with Qt5 on MacOS with brew is outdated:

-DQt5_DIR=/usr/local/opt/**qt**/lib/cmake/Qt5

and he could not succeed by following it.

I have checked that and indeed, after the Qt6 was introduced, the brew default Qt installation is Qt6, which is always linked to the `qt` folder whereas Qt5 is now linked to the `qt5` folder. I have updated the description to better explain how to link against Qt5.

## Release Management

* Affected package(s): `Documentation`
* Issue(s) solved (if any): reported in the mailing list 
* Feature/Small Feature (if any): doc bug fix
* Link to compiled documentation (obligatory for small feature): [docs](https://cgal.geometryfactory.com/~danston/Manual-qt5/usage.html#usage_configuring)
* License and copyright ownership: no change

