### PR TITLE
Consider NaNs as a filter failure in Filtered_construction.h

### DIFF
--- a/Filtered_kernel/include/CGAL/Filtered_construction.h
+++ b/Filtered_kernel/include/CGAL/Filtered_construction.h
@@ -48,13 +48,17 @@ public:
     Protect_FPU_rounding<Protection> P1;
     try
     {
-      return From_Filtered( Filter_construction(To_Filtered(a1)) );
+      result_type res = From_Filtered(Filter_construction(To_Filtered(a1)));
+
+      // Catch potential NaNs which may appear e.g. if the filtered kernel's number type is interval-based
+      // with one bound of the interval is infinity and the base kernel's number type is double.
+      if(res == res)
+        return res;
     }
-    catch (Uncertain_conversion_exception&)
-    {
-      Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
-      return From_Exact( Exact_construction(To_Exact(a1)) );
-    }
+    catch (Uncertain_conversion_exception&) { }
+
+    Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
+    return From_Exact(Exact_construction(To_Exact(a1)));
   }
   template <class A1, class A2>
   result_type
@@ -63,15 +67,19 @@ public:
     Protect_FPU_rounding<Protection> P1;
     try
     {
-      return From_Filtered( Filter_construction(To_Filtered(a1),
-                                                To_Filtered(a2)) );
+      result_type res = From_Filtered(Filter_construction(To_Filtered(a1),
+                                                          To_Filtered(a2)));
+
+      // Catch potential NaNs which may appear e.g. if the filtered kernel's number type is interval-based
+      // with one bound of the interval is infinity and the base kernel's number type is double.
+      if(res == res)
+        return res;
     }
-    catch (Uncertain_conversion_exception&)
-    {
-      Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
-      return From_Exact( Exact_construction(To_Exact(a1),
-                                            To_Exact(a2)) );
-    }
+    catch (Uncertain_conversion_exception&) { }
+
+    Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
+    return From_Exact(Exact_construction(To_Exact(a1),
+                                         To_Exact(a2)));
   }
 
   template <class A1, class A2, class A3>
@@ -81,24 +89,24 @@ public:
     Protect_FPU_rounding<Protection> P1;
     try
     {
-      return From_Filtered( Filter_construction(To_Filtered(a1),
-                                                To_Filtered(a2),
-                                                To_Filtered(a3)) );
-    }
-    catch (Uncertain_conversion_exception&)
-    {
-      Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
-      return From_Exact( Exact_construction(To_Exact(a1),
-                                            To_Exact(a2),
-                                            To_Exact(a3)) );
-    }
-  }
+      result_type res = From_Filtered(Filter_construction(To_Filtered(a1),
+                                                          To_Filtered(a2),
+                                                          To_Filtered(a3)));
 
+      // Catch potential NaNs which may appear e.g. if the filtered kernel's number type is interval-based
+      // with one bound of the interval is infinity and the base kernel's number type is double.
+      if(res == res)
+        return res;
+    }
+    catch (Uncertain_conversion_exception&) { }
+
+    Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
+    return From_Exact(Exact_construction(To_Exact(a1),
+                                         To_Exact(a2),
+                                         To_Exact(a3)));
+  }
 };
 
-
-
 } //namespace CGAL
-
 
 #endif // CGAL_FILTERED_CONSTRUCTION_H


### PR DESCRIPTION
**Non-definitive patch, to be discussed**

## Summary of Changes

Currently, the sanity of the result of a filtered construction is not checked, to the point that you can even have NaNs sneaking through. This PR is a patch that was provided to prevent NaNs from appearing in Segment_Delaunay_graph_2 under some specific kernel choices. It calls `Kernel_object::operator==()` as a way to get down to `FT::operator==` and detect NaNs. (Note that all `FT` have a `is_valid()` function that would check `is_nan`, but kernel objects do not have `is_valid()`).

Althought that patch will catch NaNs, it costs a comparison and could have some annoying effect on some exact number types. 

Another way to go at it would be to aggressively check the precision of the output, see comments in https://github.com/CGAL/cgal/issues/44 and specifically https://github.com/CGAL/cgal/issues/44#issuecomment-499388882, quoted below for convenience:

	  After a discussion with @MaelRL  one way to solve the precision issue of filtered constructions could be:
	  
	  ```
	  diff --git a/Cartesian_kernel/include/CGAL/Cartesian_converter.h b/Cartesian_kernel/include/CGAL/Cartesian_converter.h
	  index 33f941b330..0f75679cb5 100644
	  --- a/Cartesian_kernel/include/CGAL/Cartesian_converter.h
	  +++ b/Cartesian_kernel/include/CGAL/Cartesian_converter.h
	  @@ -220,6 +220,12 @@ public:
	          return Point_2(c(a.x()), c(a.y()));
	       }
	   
	  +    bool has_enough_precision(const const typename K1::Point_2 &a) const
	  +    {
	  +      return a.x().width() < get_relative_precision_of_to_double() &&
	  +             a.y().width() < get_relative_precision_of_to_double();
	  +    }
	  +
	       typename K2::Weighted_point_2
	       operator()(const typename K1::Weighted_point_2 &a) const
	       {
	  diff --git a/Filtered_kernel/include/CGAL/Filtered_construction.h b/Filtered_kernel/include/CGAL/Filtered_construction.h
	  index 16e16f4cad..f9b1131e97 100644
	  --- a/Filtered_kernel/include/CGAL/Filtered_construction.h
	  +++ b/Filtered_kernel/include/CGAL/Filtered_construction.h
	  @@ -90,17 +90,18 @@ public:
	       Protect_FPU_rounding<Protection> P1;
	       try
	       {
	  -      return From_Filtered( Filter_construction(To_Filtered(a1),
	  -                                               To_Filtered(a2),
	  -                                               To_Filtered(a3)) );
	  +      typename Filtered_construction::result_type res = Filter_construction(To_Filtered(a1),
	  +                                                                            To_Filtered(a2),
	  +                                                                            To_Filtered(a3)) );
	  +      if ( From_Filtered.has_enough_precision(res) )
	  +        return From_Filtered(res)
	       }
	       catch (Uncertain_conversion_exception&)
	  -    {
	  -      Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
	  -      return From_Exact( Exact_construction(To_Exact(a1),
	  -                                           To_Exact(a2),
	  -                                           To_Exact(a3)) );
	  -    }
	  +    {}
	  +    Protect_FPU_rounding<!Protection> P(CGAL_FE_TONEAREST);
	  +    return From_Exact( Exact_construction(To_Exact(a1),
	  +                                        To_Exact(a2),
	  +                                        To_Exact(a3)) );
	     }
	   
	   };
	  ```
	  
	  We have to do some tricks to avoid call `width()` as a member type to restrict it `Interval_nt` but the global idea is here.

See also patch from @mglisse in `Interval_nt::to_double()` : https://github.com/mglisse/cgal/blob/NewKernel_d-Epack-glisse/Number_types/include/CGAL/Interval_nt.h#L1107

@CGAL/geometryfactory 

## Release Management

* Affected package(s): `Filtered_kernel`
* Issue(s) solved (if any): -
* License and copyright ownership: No change

