### PR TITLE
Ctest Testsuite: Speed up python parsing script

### DIFF
--- a/Scripts/developer_scripts/run_testsuite_with_ctest
+++ b/Scripts/developer_scripts/run_testsuite_with_ctest
@@ -318,7 +318,7 @@ run_test_on_platform()
   else
     echo "CGAL_VERSION ${CGAL_GIT_VERSION}">> "$RESULT_FILE"
   fi
-  sed -n '/The CXX compiler/s/-- The CXX compiler identification is/COMPILER_VERSION =/p' < "${CGAL_BINARY_DIR}/installation.log" |sed -E "s/ = (.*)/\ = '\1\'/>> "$RESULT_FILE"
+  sed -n '/The CXX compiler/s/-- The CXX compiler identification is/COMPILER_VERSION =/p' < "${CGAL_BINARY_DIR}/installation.log" |sed -E "s/ = (.*)/\ = '\1\'/">> "$RESULT_FILE"
   echo "TESTER ${CGAL_TESTER}" >> "$RESULT_FILE"
   echo "TESTER_NAME ${CGAL_TESTER}" >> "$RESULT_FILE"
   echo "TESTER_ADDRESS ${TESTER_ADDRESS}" >> "$RESULT_FILE"

--- a/Scripts/developer_scripts/run_testsuite_with_ctest
+++ b/Scripts/developer_scripts/run_testsuite_with_ctest
@@ -318,7 +318,7 @@ run_test_on_platform()
   else
     echo "CGAL_VERSION ${CGAL_GIT_VERSION}">> "$RESULT_FILE"
   fi
-  sed -n '/The CXX compiler/s/-- The CXX compiler identification is/COMPILER_VERSION = /p' < "${CGAL_BINARY_DIR}/installation.log" >> "$RESULT_FILE"
+  sed -n '/The CXX compiler/s/-- The CXX compiler identification is/COMPILER_VERSION =/p' < "${CGAL_BINARY_DIR}/installation.log" |sed -E "s/ = (.*)/\ = '\1\'/>> "$RESULT_FILE"
   echo "TESTER ${CGAL_TESTER}" >> "$RESULT_FILE"
   echo "TESTER_NAME ${CGAL_TESTER}" >> "$RESULT_FILE"
   echo "TESTER_ADDRESS ${TESTER_ADDRESS}" >> "$RESULT_FILE"

--- a/Scripts/developer_scripts/run_testsuite_with_ctest
+++ b/Scripts/developer_scripts/run_testsuite_with_ctest
@@ -318,6 +318,7 @@ run_test_on_platform()
   else
     echo "CGAL_VERSION ${CGAL_GIT_VERSION}">> "$RESULT_FILE"
   fi
+  sed -n '/The CXX compiler/s/-- The CXX compiler identification is/COMPILER_VERSION = /p' < "${CGAL_BINARY_DIR}/installation.log" >> "$RESULT_FILE"
   echo "TESTER ${CGAL_TESTER}" >> "$RESULT_FILE"
   echo "TESTER_NAME ${CGAL_TESTER}" >> "$RESULT_FILE"
   echo "TESTER_ADDRESS ${TESTER_ADDRESS}" >> "$RESULT_FILE"

--- a/Testsuite/test/parse-ctest-dashboard-xml.py
+++ b/Testsuite/test/parse-ctest-dashboard-xml.py
@@ -77,6 +77,8 @@ for t_id in range(0, len(tests)):
             tests_per_label[label].append(t)
 
 warning_pattern=re.compile(r'(.*([^a-zA-Z_,:-])([^\d]\s)warning).*?(\[|\n)', flags=re.IGNORECASE)
+w_det=re.compile("warning");
+filter_pattern=re.compile(r'cmake|cgal', flags=re.IGNORECASE);
 with open_file_create_dir(result_file_name.format(dir=os.getcwd(),
                                                   tester=tester_name,
                                                   platform=platform_name), 'a+') as results:
@@ -87,12 +89,12 @@ with open_file_create_dir(result_file_name.format(dir=os.getcwd(),
                 print("   {result} {name} in {time} s : {value} ".format(result = "successful " if (t['Status'] == 'passed') else "ERROR:     ", name = t['Name'], value = t['ExitValue'] if(t['ExitValue'] != "") else "SUCCESS" , time = t['ExecutionTime']), file=error)
                 if t['Status'] != 'passed':
                     result_for_label='n'
-                elif t['Output'] != None and re.search("warning", t['Output'], flags=re.IGNORECASE):
+                elif t['Output'] != None and w_det.search(t['Output']):
                     entries = re.split("\n+", t['Output'])
                     for entry in entries:
                         m=warning_pattern.search(entry)
                         if m:
-                            n = re.search(r'cmake|cgal', m.group(0), flags=re.IGNORECASE)
+                            n = filter_pattern.search(m.group(0))
                             if n:
                                 result_for_label='w'
                                 break;

--- a/Testsuite/test/parse-ctest-dashboard-xml.py
+++ b/Testsuite/test/parse-ctest-dashboard-xml.py
@@ -76,6 +76,7 @@ for t_id in range(0, len(tests)):
             labels.add(label)
             tests_per_label[label].append(t)
 
+warning_pattern=re.compile(r'(.*([^a-zA-Z_,:-])([^\d]\s)warning).*?(\[|\n)', flags=re.IGNORECASE)
 with open_file_create_dir(result_file_name.format(dir=os.getcwd(),
                                                   tester=tester_name,
                                                   platform=platform_name), 'a+') as results:
@@ -86,14 +87,17 @@ with open_file_create_dir(result_file_name.format(dir=os.getcwd(),
                 print("   {result} {name} in {time} s : {value} ".format(result = "successful " if (t['Status'] == 'passed') else "ERROR:     ", name = t['Name'], value = t['ExitValue'] if(t['ExitValue'] != "") else "SUCCESS" , time = t['ExecutionTime']), file=error)
                 if t['Status'] != 'passed':
                     result_for_label='n'
-                elif t['Output'] != None:
-                  for m in re.finditer(r'(.*([^a-zA-Z_,:-])([^\d]\s)warning).*?(\[|\n)', t['Output'], flags=re.IGNORECASE):
-                        n = re.search(r'cmake|cgal', m.group(0), flags=re.IGNORECASE)
-                        if n:
-                            result_for_label='w'
-                            break;
-                        else:
-                            result_for_label='t'
+                elif t['Output'] != None and re.search("warning", t['Output'], flags=re.IGNORECASE):
+                    entries = re.split("\n+", t['Output'])
+                    for entry in entries:
+                        m=warning_pattern.search(entry)
+                        if m:
+                            n = re.search(r'cmake|cgal', m.group(0), flags=re.IGNORECASE)
+                            if n:
+                                result_for_label='w'
+                                break;
+                            else:
+                                result_for_label='t'
 
                 with io.open("{}/ProgramOutput.{}".format(label, t['Name']), mode="w", encoding="utf-8") as f:
                     print("{}/ProgramOutput.{}".format(label, t['Name']))


### PR DESCRIPTION
## Summary of Changes
This PR should speed up by several hundreds of times the python script parsing the ctest results of a testsuite.
## Release Management

* Affected package(s):Testsuite
