### PR TITLE
PMP::Polyhedral_envelope:  Fix memory leak

### DIFF
--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -904,6 +904,9 @@ struct Lazy_construction_optional_for_polygonal_envelope
       CGAL_STATIC_THREAD_LOCAL_VARIABLE_0(LazyPointRep, rep);
 
       const typename AK::Point_3 ap = *oap;
+      if(rep.et != nullptr){
+        delete rep.et;
+      }
       rep = LazyPointRep(2,ap, ec, l1, l2, l3);
       typename LK::Point_3 lp(&rep);
       return boost::make_optional(lp);
@@ -942,6 +945,9 @@ struct Lazy_construction_optional_for_polygonal_envelope
 
       CGAL_STATIC_THREAD_LOCAL_VARIABLE_0(LazyPointRep, rep);
       const typename AK::Point_3 ap = *oap;
+      if(rep.et != nullptr){
+        delete rep.et;
+      }
       rep = LazyPointRep(2, ap, ec, l1, l2);
       typename LK::Point_3 lp(&rep);
       return boost::make_optional(lp);

--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -236,6 +236,7 @@ template <typename AT_, typename ET, typename E2A>
 class Lazy_rep : public Rep, public Depth_base
 {
   Lazy_rep (const Lazy_rep&) = delete; // cannot be copied.
+  Lazy_rep& operator= (const Lazy_rep&) = delete; // cannot be copied.
 
 public:
 
@@ -246,6 +247,25 @@ public:
 
   Lazy_rep ()
     : at(), et(nullptr){}
+
+  //move-constructor
+  Lazy_rep (Lazy_rep&& other)
+    : at(std::move(other.at)), et(other.et)
+  {
+    other.et = nullptr;
+  }
+
+  //move-assignment
+  Lazy_rep& operator= (Lazy_rep&& other)
+  {
+    if(this->et)
+    {
+      delete this->et;
+    }
+    this->et = other.et;
+    other.et = nullptr;
+    this->at = std::move(other.at);
+  }
 
   template<class A>
   Lazy_rep (A&& a)
@@ -904,9 +924,6 @@ struct Lazy_construction_optional_for_polygonal_envelope
       CGAL_STATIC_THREAD_LOCAL_VARIABLE_0(LazyPointRep, rep);
 
       const typename AK::Point_3 ap = *oap;
-      if(rep.et != nullptr){
-        delete rep.et;
-      }
       rep = LazyPointRep(2,ap, ec, l1, l2, l3);
       typename LK::Point_3 lp(&rep);
       return boost::make_optional(lp);
@@ -945,9 +962,6 @@ struct Lazy_construction_optional_for_polygonal_envelope
 
       CGAL_STATIC_THREAD_LOCAL_VARIABLE_0(LazyPointRep, rep);
       const typename AK::Point_3 ap = *oap;
-      if(rep.et != nullptr){
-        delete rep.et;
-      }
       rep = LazyPointRep(2, ap, ec, l1, l2);
       typename LK::Point_3 lp(&rep);
       return boost::make_optional(lp);

--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -253,6 +253,7 @@ public:
     : at(std::move(other.at)), et(other.et)
   {
     other.et = nullptr;
+    this->count = std::move(other.count);
   }
 
   //move-assignment
@@ -265,6 +266,7 @@ public:
     this->et = other.et;
     other.et = nullptr;
     this->at = std::move(other.at);
+    this->count = std::move(other.count);
   }
 
   template<class A>

--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -267,6 +267,7 @@ public:
     other.et = nullptr;
     this->at = std::move(other.at);
     this->count = std::move(other.count);
+    return *this;
   }
 
   template<class A>


### PR DESCRIPTION
## Summary of Changes

In case `update_exact()` is called the rep stores a non null pointer in `et` which must be deleted before a re-assignment.


## Release Management

* Affected package(s): PMP

