### PR TITLE
WIP AABB_tree: workaround for unbalanced kd tree

### DIFF
--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -830,12 +830,12 @@ public:
   template<typename Tr>
   bool AABB_tree<Tr>::build_kd_tree()
   {
-		Bbox_3 bb;
+    Bbox_3 bb;
     for(const Primitive& p : m_primitives){
-			bb = bb + Helper::get_reference_point(p, m_traits).bbox();
-		}
-		double dmin = (std::min)((std::min)(bb.xmax()-bb.xmin(), bb.ymax()-bb.ymin()),bb.zmax()-bb.zmin());
-		dmin /= 30.0;
+      bb = bb + Helper::get_reference_point(p, m_traits).bbox();
+    }
+    double dmin = (std::min)((std::min)(bb.xmax()-bb.xmin(), bb.ymax()-bb.ymin()),bb.zmax()-bb.zmin());
+    dmin /= 30.0;
 
     // iterate over primitives to get reference points on them
     std::vector<Point_and_primitive_id> points;
@@ -843,11 +843,11 @@ public:
     for(const Primitive& p : m_primitives)
       points.push_back( Point_and_primitive_id( Helper::get_reference_point(p, m_traits), p.id() ) );
 
-		First_of_pair_property_map<Point_and_primitive_id> foppm;
-		typename std::vector<Point_and_primitive_id>::iterator
-			it = grid_simplify_point_set(points, dmin, CGAL::parameters::point_map(foppm));
+    First_of_pair_property_map<Point_and_primitive_id> foppm;
+    typename std::vector<Point_and_primitive_id>::iterator
+      it = grid_simplify_point_set(points, dmin, CGAL::parameters::point_map(foppm));
 
-		std::cout << "Insert " << std::distance(points.begin(), it)  << " out of " << points.size() << " in the kd tree" << std::endl;
+    std::cout << "Insert " << std::distance(points.begin(), it)  << " out of " << points.size() << " in the kd tree" << std::endl;
     // clears current KD tree
     return build_kd_tree(points.begin(), it);
   }

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -832,10 +832,10 @@ public:
   {
     Bbox_3 bb;
     for(const Primitive& p : m_primitives){
-      bb = bb + Helper::get_reference_point(p, m_traits).bbox();
-    }
-    double dmin = (std::min)((std::min)(bb.xmax()-bb.xmin(), bb.ymax()-bb.ymin()),bb.zmax()-bb.zmin());
-    dmin /= 30.0;
+			bb = bb + Helper::get_reference_point(p, m_traits).bbox();
+		}
+		double dmax = (std::max)((std::max)(bb.xmax()-bb.xmin(), bb.ymax()-bb.ymin()),bb.zmax()-bb.zmin());
+		dmax /= 30.0;
 
     // iterate over primitives to get reference points on them
     std::vector<Point_and_primitive_id> points;
@@ -843,11 +843,10 @@ public:
     for(const Primitive& p : m_primitives)
       points.push_back( Point_and_primitive_id( Helper::get_reference_point(p, m_traits), p.id() ) );
 
-    First_of_pair_property_map<Point_and_primitive_id> foppm;
-    typename std::vector<Point_and_primitive_id>::iterator
-      it = grid_simplify_point_set(points, dmin, CGAL::parameters::point_map(foppm));
+		First_of_pair_property_map<Point_and_primitive_id> foppm;
+		typename std::vector<Point_and_primitive_id>::iterator
+			it = grid_simplify_point_set(points, dmax, CGAL::parameters::point_map(foppm));
 
-    std::cout << "Insert " << std::distance(points.begin(), it)  << " out of " << points.size() << " in the kd tree" << std::endl;
     // clears current KD tree
     return build_kd_tree(points.begin(), it);
   }

--- a/AABB_tree/package_info/AABB_tree/dependencies
+++ b/AABB_tree/package_info/AABB_tree/dependencies
@@ -12,6 +12,7 @@ Interval_support
 Kernel_23
 Modular_arithmetic
 Number_types
+Point_set_processing_3
 Profiling_tools
 Property_map
 STL_Extension


### PR DESCRIPTION
## Summary of Changes

For meshes with extremely dense clusters of triangles the kd tree which serves for acceleration of distance queries can be so unbalanced that it leads to a stack overflow  and at least to bad performance. 
This PR calls `grid_simplify()` with a rather adhoc chosen epsilion.  We also introduce a dependency on PMP.
It might also be a better idea to find a more balanced splitter in the kd tree (I should file an issue).

## Release Management

* Affected package(s): AABB_tree


