### PR TITLE
Three Documentation Fix

### DIFF
--- a/Three/doc/Three/PackageDescription.txt
+++ b/Three/doc/Three/PackageDescription.txt
@@ -12,7 +12,6 @@
 \cgalPkgSummaryEnd
 \cgalPkgShortInfoBegin
 \cgalPkgSince{4.8}
-\cgalPkgBib{cgal:rlfg-pd}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd


### PR DESCRIPTION
## Summary of Changes

Remove bibref in Three package as it is not in the package overview.

## Release Management

* Affected package(s):Three
* Issue(s) solved (if any): fix #5786
