### PR TITLE
PMP::isotropic_remeshing() - improve split step

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -447,6 +447,10 @@ namespace internal {
           halfedge_descriptor hnew2 =
             CGAL::Euler::split_face(hnew, next(next(hnew, mesh_), mesh_), mesh_);
           put(ecmap_, edge(hnew2, mesh_), false);
+
+          double sqlen_new2 = sqlength(hnew2);
+          if (sqlen_new2 > sq_high)
+            long_edges.insert(long_edge(hnew2, sqlen_new2));
         }
 
         //do it again on the other side if we're not on boundary
@@ -456,6 +460,10 @@ namespace internal {
           halfedge_descriptor hnew2 =
             CGAL::Euler::split_face(prev(hnew_opp, mesh_), next(hnew_opp, mesh_), mesh_);
           put(ecmap_, edge(hnew2, mesh_), false);
+
+          double sqlen_new2 = sqlength(hnew2);
+          if (sqlen_new2 > sq_high)
+            long_edges.insert(long_edge(hnew2, sqlen_new2));
         }
       }
 #ifdef CGAL_PMP_REMESHING_VERBOSE


### PR DESCRIPTION
## Summary of Changes

The "split long edges" step of `PMP::isotropic_remeshing()` was not taking into account the edges created by splits. With this PR, newly created long edges are added to the range of long edges to be split.

## Release Management

* Affected package(s): PMP
* License and copyright ownership: unchanged

