### PR TITLE
Fix grammar in Triangulation_on_sphere_2

### DIFF
--- a/Triangulation_on_sphere_2/doc/Triangulation_on_sphere_2/Triangulation_on_sphere_2.txt
+++ b/Triangulation_on_sphere_2/doc/Triangulation_on_sphere_2/Triangulation_on_sphere_2.txt
@@ -12,7 +12,7 @@ namespace CGAL {
 <img src="header.png" style="max-width:70%;"/>
 </center>
 
-This chapter describes two-dimensional triangulations on the sphere of \cgal. It is organized as follows:
+This chapter describes two-dimensional triangulations on the sphere. It is organized as follows:
 <ul>
   <li>Section \ref Section_2D_ToS_Definitions introduces the main definitions about triangulations on the sphere.</li>
   <li>Section \ref Section_2D_ToS_Implementation details the way two-dimensional triangulations on the sphere


### PR DESCRIPTION
## Summary of Changes

Remove "of CGAL" from the intro since 

1) People reading the document probably already know its related to CGAL

2) It reads as: "the sphere of CGAL" instead of belonging to CGAL, you could use "This chapter describes CGAL's two-dimensional triangulations on the sphere." but I think it's superfluous.

## Release Management

* Affected package(s): Triangulations_on_sphere_2
* Issue(s) solved (if any): documentation grammar.
* Feature/Small Feature (if any): small
* License and copyright ownership: Returned to CGAL authors.

