### PR TITLE
Inconsistent display of CGAL::Interval_nt_advanced in documentation

### DIFF
--- a/Algebraic_foundations/doc/Algebraic_foundations/Concepts/FieldNumberType.h
+++ b/Algebraic_foundations/doc/Algebraic_foundations/Concepts/FieldNumberType.h
@@ -14,7 +14,7 @@ for Cartesian kernels.
 \cgalHasModel double
 \cgalHasModel `CGAL::Gmpq`
 \cgalHasModel `CGAL::Interval_nt`
-\cgalHasModel \ref CGAL::Interval_nt_advanced
+\cgalHasModel `CGAL::Interval_nt_advanced`
 \cgalHasModel `CGAL::Lazy_exact_nt<FieldNumberType>`
 \cgalHasModel `CGAL::Quotient<RingNumberType>`
 \cgalHasModel `leda_rational`

--- a/Algebraic_foundations/doc/Algebraic_foundations/Concepts/RingNumberType.h
+++ b/Algebraic_foundations/doc/Algebraic_foundations/Concepts/RingNumberType.h
@@ -14,8 +14,8 @@ for Homogeneous kernels.
 \cgalHasModel \cpp built-in number types
 \cgalHasModel `CGAL::Gmpq`
 \cgalHasModel `CGAL::Gmpz`
-\cgalHasModel` CGAL::Interval_nt`
-\cgalHasModel \ref CGAL::Interval_nt_advanced
+\cgalHasModel `CGAL::Interval_nt`
+\cgalHasModel `CGAL::Interval_nt_advanced`
 \cgalHasModel `CGAL::Lazy_exact_nt<RingNumberType>`
 \cgalHasModel `CGAL::MP_Float`
 \cgalHasModel `CGAL::Gmpzf`


### PR DESCRIPTION
The display of `CGAL::Interval_nt_advanced` is different from the other fields in the list

When looking at: https://cgal.geometryfactory.com/CGAL/Manual_doxygen_test/CGAL-5.3-Ic-163/master/Algebraic_foundations/hasModels.html we see:

![image](https://user-images.githubusercontent.com/5223533/124571648-46193200-de48-11eb-86ae-efb9fc50860a.png)

instead of:

![image](https://user-images.githubusercontent.com/5223533/124571749-5fba7980-de48-11eb-9b14-9732d7ba997f.png)


Note: the difference for: CGAL::Interval_nt_advanced
Note: similar occurs also a bit further down the page.
