### PR TITLE
Fixed Memory Leaks in RANSAC

### DIFF
--- a/Shape_detection/examples/Shape_detection/efficient_RANSAC_with_callback.cpp
+++ b/Shape_detection/examples/Shape_detection/efficient_RANSAC_with_callback.cpp
@@ -82,6 +82,7 @@ int main (int argc, char** argv) {
 
   // Detect registered shapes with the default parameters.
   ransac.detect(Efficient_ransac::Parameters(), timeout_callback);
+  assert(ransac.shapes().size() > 0);
 
   return EXIT_SUCCESS;
 }

--- a/Shape_detection/examples/Shape_detection/efficient_RANSAC_with_callback.cpp
+++ b/Shape_detection/examples/Shape_detection/efficient_RANSAC_with_callback.cpp
@@ -82,7 +82,6 @@ int main (int argc, char** argv) {
 
   // Detect registered shapes with the default parameters.
   ransac.detect(Efficient_ransac::Parameters(), timeout_callback);
-  assert(ransac.shapes().size() > 0);
 
   return EXIT_SUCCESS;
 }

--- a/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
@@ -584,10 +584,7 @@ public:
                    m_required_samples);
 
                 if (callback && !callback(num_invalid / double(m_num_total_points))) {
-                  clear_octrees();
-                  clear_shape_factories();
-                  clear_candidates(candidates);
-                  m_num_available_points -= num_invalid;
+                  clear(num_invalid);
                   return false;
                 }
 
@@ -600,10 +597,7 @@ public:
               for(typename std::vector<Shape *(*)()>::iterator it =
                     m_shape_factories.begin(); it != m_shape_factories.end(); it++)        {
                 if (callback && !callback(num_invalid / double(m_num_total_points))) {
-                  clear_octrees();
-                  clear_shape_factories();
-                  clear_candidates(candidates);
-                  m_num_available_points -= num_invalid;
+                  clear(num_invalid);
                   return false;
                 }
                 Shape *p = (Shape *) (*it)();
@@ -673,10 +667,7 @@ public:
               get_best_candidate(candidates, m_num_available_points - num_invalid);
 
       if (callback && !callback(num_invalid / double(m_num_total_points))) {
-        clear_octrees();
-        clear_shape_factories();
-        clear_candidates(candidates);
-        m_num_available_points -= num_invalid;
+        clear(num_invalid);
         return false;
       }
 
@@ -702,10 +693,7 @@ public:
                                           m_options.cluster_epsilon);
 
       if (callback && !callback(num_invalid / double(m_num_total_points))) {
-        clear_octrees();
-        clear_shape_factories();
-        clear_candidates(candidates);
-        m_num_available_points -= num_invalid;
+        clear(num_invalid);
         return false;
       }
       // check score against min_points and clear out candidates if too low
@@ -724,10 +712,7 @@ public:
         best_candidate = nullptr;
 
         if (callback && !callback(num_invalid / double(m_num_total_points))) {
-          clear_octrees();
-          clear_shape_factories();
-          clear_candidates(candidates);
-          m_num_available_points -= num_invalid;
+          clear(num_invalid);
           return false;
         }
 
@@ -756,10 +741,7 @@ public:
         candidates.resize(empty);
 
         if (callback && !callback(num_invalid / double(m_num_total_points))) {
-          clear_octrees();
-          clear_shape_factories();
-          clear_candidates(candidates);
-          m_num_available_points -= num_invalid;
+          clear(num_invalid);
           return false;
         }
       } else if (stop_probability((std::size_t) best_candidate->expected_value(),
@@ -776,10 +758,7 @@ public:
                 boost::shared_ptr<Shape>(best_candidate));
 
         if (callback && !callback(num_invalid / double(m_num_total_points))) {
-          clear_octrees();
-          clear_shape_factories();
-          clear_candidates(candidates);
-          m_num_available_points -= num_invalid;
+          clear(num_invalid);
           return false;
         }
 
@@ -816,10 +795,7 @@ public:
         best_expected = 0;
 
         if (callback && !callback(num_invalid / double(m_num_total_points))) {
-          clear_octrees();
-          clear_shape_factories();
-          clear_candidates(candidates);
-          m_num_available_points -= num_invalid;
+          clear(num_invalid);
           return false;
         }
 
@@ -851,10 +827,7 @@ public:
         }
 
         if (callback && !callback(num_invalid / double(m_num_total_points))) {
-          clear_octrees();
-          clear_shape_factories();
-          clear_candidates(candidates);
-          m_num_available_points -= num_invalid;
+          clear(num_invalid);
           return false;
         }
 
@@ -877,10 +850,7 @@ public:
         ++generated_candidates;
 
       if (callback && !callback(num_invalid / double(m_num_total_points))) {
-        clear_octrees();
-        clear_shape_factories();
-        clear_candidates(candidates);
-        m_num_available_points -= num_invalid;
+        clear(num_invalid);
         return false;
       }
 
@@ -894,9 +864,7 @@ public:
              || best_expected >= m_options.min_points);
 
     // Clean up remaining candidates.
-    clear_candidates(candidates);
-    m_num_available_points -= num_invalid;
-
+    clear_candidates(num_invalid, candidates);
     return true;
   }
 
@@ -961,11 +929,21 @@ public:
   /// @}
 
 private:
-  void clear_candidates(std::vector<Shape *>& candidates) {
+  void clear(const std::size_t num_invalid) {
+
+    clear_octrees();
+    clear_shape_factories();
+    clear_candidates(num_invalid, candidates);
+  }
+
+  void clear_candidates(
+    const std::size_t num_invalid, std::vector<Shape *>& candidates) {
+
     for (std::size_t i = 0; i < candidates.size(); i++) {
       delete candidates[i];
     }
     candidates.resize(0);
+    m_num_available_points -= num_invalid;
   }
 
   int select_random_octree_level() {

--- a/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
@@ -584,7 +584,7 @@ public:
                    m_required_samples);
 
                 if (callback && !callback(num_invalid / double(m_num_total_points))) {
-                  clear(num_invalid);
+                  clear(num_invalid, candidates);
                   return false;
                 }
 
@@ -597,7 +597,7 @@ public:
               for(typename std::vector<Shape *(*)()>::iterator it =
                     m_shape_factories.begin(); it != m_shape_factories.end(); it++)        {
                 if (callback && !callback(num_invalid / double(m_num_total_points))) {
-                  clear(num_invalid);
+                  clear(num_invalid, candidates);
                   return false;
                 }
                 Shape *p = (Shape *) (*it)();
@@ -667,7 +667,7 @@ public:
               get_best_candidate(candidates, m_num_available_points - num_invalid);
 
       if (callback && !callback(num_invalid / double(m_num_total_points))) {
-        clear(num_invalid);
+        clear(num_invalid, candidates);
         return false;
       }
 
@@ -693,7 +693,7 @@ public:
                                           m_options.cluster_epsilon);
 
       if (callback && !callback(num_invalid / double(m_num_total_points))) {
-        clear(num_invalid);
+        clear(num_invalid, candidates);
         return false;
       }
       // check score against min_points and clear out candidates if too low
@@ -712,7 +712,7 @@ public:
         best_candidate = nullptr;
 
         if (callback && !callback(num_invalid / double(m_num_total_points))) {
-          clear(num_invalid);
+          clear(num_invalid, candidates);
           return false;
         }
 
@@ -741,7 +741,7 @@ public:
         candidates.resize(empty);
 
         if (callback && !callback(num_invalid / double(m_num_total_points))) {
-          clear(num_invalid);
+          clear(num_invalid, candidates);
           return false;
         }
       } else if (stop_probability((std::size_t) best_candidate->expected_value(),
@@ -758,7 +758,7 @@ public:
                 boost::shared_ptr<Shape>(best_candidate));
 
         if (callback && !callback(num_invalid / double(m_num_total_points))) {
-          clear(num_invalid);
+          clear(num_invalid, candidates);
           return false;
         }
 
@@ -795,7 +795,7 @@ public:
         best_expected = 0;
 
         if (callback && !callback(num_invalid / double(m_num_total_points))) {
-          clear(num_invalid);
+          clear(num_invalid, candidates);
           return false;
         }
 
@@ -827,7 +827,7 @@ public:
         }
 
         if (callback && !callback(num_invalid / double(m_num_total_points))) {
-          clear(num_invalid);
+          clear(num_invalid, candidates);
           return false;
         }
 
@@ -850,7 +850,7 @@ public:
         ++generated_candidates;
 
       if (callback && !callback(num_invalid / double(m_num_total_points))) {
-        clear(num_invalid);
+        clear(num_invalid, candidates);
         return false;
       }
 
@@ -929,7 +929,8 @@ public:
   /// @}
 
 private:
-  void clear(const std::size_t num_invalid) {
+  void clear(
+    const std::size_t num_invalid, std::vector<Shape *>& candidates) {
 
     clear_octrees();
     clear_shape_factories();

--- a/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Efficient_RANSAC.h
@@ -480,8 +480,11 @@ public:
         return false;
     }
 
-    if (callback && !callback(0.))
+    if (callback && !callback(0.)) {
+      clear_octrees();
+      clear_shape_factories();
       return false;
+    }
 
     // Reset data structures possibly used by former search
     m_extracted_shapes =
@@ -580,8 +583,13 @@ public:
                    m_shape_index,
                    m_required_samples);
 
-                if (callback && !callback(num_invalid / double(m_num_total_points)))
+                if (callback && !callback(num_invalid / double(m_num_total_points))) {
+                  clear_octrees();
+                  clear_shape_factories();
+                  clear_candidates(candidates);
+                  m_num_available_points -= num_invalid;
                   return false;
+                }
 
               } while (m_shape_index[first_sample] != -1 || !done);
 
@@ -591,8 +599,13 @@ public:
               bool candidate_success = false;
               for(typename std::vector<Shape *(*)()>::iterator it =
                     m_shape_factories.begin(); it != m_shape_factories.end(); it++)        {
-                if (callback && !callback(num_invalid / double(m_num_total_points)))
+                if (callback && !callback(num_invalid / double(m_num_total_points))) {
+                  clear_octrees();
+                  clear_shape_factories();
+                  clear_candidates(candidates);
+                  m_num_available_points -= num_invalid;
                   return false;
+                }
                 Shape *p = (Shape *) (*it)();
                 //compute the primitive and says if the candidate is valid
                 p->compute(indices,
@@ -659,8 +672,13 @@ public:
       Shape *best_candidate =
               get_best_candidate(candidates, m_num_available_points - num_invalid);
 
-      if (callback && !callback(num_invalid / double(m_num_total_points)))
+      if (callback && !callback(num_invalid / double(m_num_total_points))) {
+        clear_octrees();
+        clear_shape_factories();
+        clear_candidates(candidates);
+        m_num_available_points -= num_invalid;
         return false;
+      }
 
       // If search is done and the best candidate is too small, we are done.
       if (!keep_searching && best_candidate->m_score < m_options.min_points)
@@ -683,8 +701,13 @@ public:
       best_candidate->connected_component(best_candidate->m_indices,
                                           m_options.cluster_epsilon);
 
-      if (callback && !callback(num_invalid / double(m_num_total_points)))
+      if (callback && !callback(num_invalid / double(m_num_total_points))) {
+        clear_octrees();
+        clear_shape_factories();
+        clear_candidates(candidates);
+        m_num_available_points -= num_invalid;
         return false;
+      }
       // check score against min_points and clear out candidates if too low
       if (best_candidate->indices_of_assigned_points().size() <
           m_options.min_points) {
@@ -700,8 +723,13 @@ public:
         delete best_candidate;
         best_candidate = nullptr;
 
-        if (callback && !callback(num_invalid / double(m_num_total_points)))
+        if (callback && !callback(num_invalid / double(m_num_total_points))) {
+          clear_octrees();
+          clear_shape_factories();
+          clear_candidates(candidates);
+          m_num_available_points -= num_invalid;
           return false;
+        }
 
         // Trimming candidates list
         std::size_t empty = 0, occupied = 0;
@@ -727,8 +755,13 @@ public:
 
         candidates.resize(empty);
 
-        if (callback && !callback(num_invalid / double(m_num_total_points)))
+        if (callback && !callback(num_invalid / double(m_num_total_points))) {
+          clear_octrees();
+          clear_shape_factories();
+          clear_candidates(candidates);
+          m_num_available_points -= num_invalid;
           return false;
+        }
       } else if (stop_probability((std::size_t) best_candidate->expected_value(),
                                   (m_num_available_points - num_invalid),
                                   generated_candidates,
@@ -742,8 +775,13 @@ public:
         m_extracted_shapes->push_back(
                 boost::shared_ptr<Shape>(best_candidate));
 
-        if (callback && !callback(num_invalid / double(m_num_total_points)))
+        if (callback && !callback(num_invalid / double(m_num_total_points))) {
+          clear_octrees();
+          clear_shape_factories();
+          clear_candidates(candidates);
+          m_num_available_points -= num_invalid;
           return false;
+        }
 
         //2. remove the points
         const std::vector<std::size_t> &indices_points_best_candidate =
@@ -777,8 +815,13 @@ public:
         failed_candidates = 0;
         best_expected = 0;
 
-        if (callback && !callback(num_invalid / double(m_num_total_points)))
+        if (callback && !callback(num_invalid / double(m_num_total_points))) {
+          clear_octrees();
+          clear_shape_factories();
+          clear_candidates(candidates);
+          m_num_available_points -= num_invalid;
           return false;
+        }
 
         std::vector<std::size_t> subset_sizes(m_num_subsets);
         subset_sizes[0] = m_available_octree_sizes[0];
@@ -807,8 +850,13 @@ public:
           }
         }
 
-        if (callback && !callback(num_invalid / double(m_num_total_points)))
+        if (callback && !callback(num_invalid / double(m_num_total_points))) {
+          clear_octrees();
+          clear_shape_factories();
+          clear_candidates(candidates);
+          m_num_available_points -= num_invalid;
           return false;
+        }
 
         std::size_t start = 0, end = candidates.size() - 1;
         while (start < end) {
@@ -828,8 +876,13 @@ public:
       } else if (!keep_searching)
         ++generated_candidates;
 
-      if (callback && !callback(num_invalid / double(m_num_total_points)))
+      if (callback && !callback(num_invalid / double(m_num_total_points))) {
+        clear_octrees();
+        clear_shape_factories();
+        clear_candidates(candidates);
+        m_num_available_points -= num_invalid;
         return false;
+      }
 
       keep_searching = (stop_probability(m_options.min_points,
                                          m_num_available_points - num_invalid,
@@ -841,11 +894,7 @@ public:
              || best_expected >= m_options.min_points);
 
     // Clean up remaining candidates.
-    for (std::size_t i = 0; i < candidates.size(); i++)
-      delete candidates[i];
-
-    candidates.resize(0);
-
+    clear_candidates(candidates);
     m_num_available_points -= num_invalid;
 
     return true;
@@ -912,6 +961,13 @@ public:
   /// @}
 
 private:
+  void clear_candidates(std::vector<Shape *>& candidates) {
+    for (std::size_t i = 0; i < candidates.size(); i++) {
+      delete candidates[i];
+    }
+    candidates.resize(0);
+  }
+
   int select_random_octree_level() {
     auto upper_bound = static_cast<unsigned int>(m_global_octree->maxLevel() + 1);
     return (int) get_default_random()(upper_bound);


### PR DESCRIPTION
This PR fixes multiple memory leaks in the Efficient RANSAC algorithm.

When running:

```
leaks -atExit -- ./efficient_RANSAC_with_callback
```
on `macOS`, the following output is revealed:

```
Process:         efficient_RANSAC_with_callback [36107]
Path:            /Users/USER/Documents/*/efficient_RANSAC_with_callback
Load Address:    0x101c1a000
Identifier:      efficient_RANSAC_with_callback
Version:         ???
Code Type:       X86-64
Platform:        macOS
Parent Process:  leaks [36106]

Date/Time:       2021-07-08 17:23:15.712 +0200
Launch Time:     2021-07-08 17:23:14.672 +0200
OS Version:      macOS 11.2.3 (20D91)
Report Version:  7
Analysis Tool:   /usr/bin/leaks

Physical footprint:         10.4M
Physical footprint (peak):  13.9M
----

leaks Report Version: 4.0
Process 36107: 830 nodes malloced for 610 KB
Process 36107: 656 leaks for 611328 total leaked bytes.

    656 (597K) << TOTAL >>
```

This PR fixes that.

## Release Management

* Affected package(s): `Shape_detection`
* Issue(s) solved (if any): memory leaks
* Feature/Small Feature (if any): bug fix
* License and copyright ownership: no changes

