### PR TITLE
Port Mesh_3 to oneAPI-TBB

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -46,7 +46,7 @@
 #include <boost/unordered_set.hpp>
 
 #ifdef CGAL_LINKED_WITH_TBB
-# include <tbb/parallel_do.h>
+# include <tbb/parallel_for_each.h>
 # include <mutex>
 #endif
 
@@ -1941,7 +1941,7 @@ private:
     // Parallel
     if (boost::is_convertible<Concurrency_tag, Parallel_tag>::value)
     {
-      tbb::parallel_do(
+      tbb::parallel_for_each(
         outdated_cells.begin(), outdated_cells.end(),
         Update_cell_facets<Self, FacetUpdater>(tr_, updater));
     }
@@ -2831,7 +2831,7 @@ rebuild_restricted_delaunay(ForwardIterator first_cell,
   // Parallel
   if (boost::is_convertible<Concurrency_tag, Parallel_tag>::value)
   {
-    tbb::parallel_do(first_cell, last_cell,
+    tbb::parallel_for_each(first_cell, last_cell,
       Update_cell<C3T3, Update_c3t3>(c3t3_, updater));
   }
   // Sequential
@@ -2853,7 +2853,7 @@ rebuild_restricted_delaunay(ForwardIterator first_cell,
   // Parallel
   if (boost::is_convertible<Concurrency_tag, Parallel_tag>::value)
   {
-    tbb::parallel_do(
+    tbb::parallel_for_each(
       facets.begin(), facets.end(),
       Update_facet<Self, C3T3, Update_c3t3, Vertex_to_proj_set>(
         *this, c3t3_, updater, vertex_to_proj)

--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
@@ -59,7 +59,7 @@ namespace CGAL {
   //              tbb::interface5::concurrent_hash_map
   template < class DSC, bool Const >
   std::size_t tbb_hasher(const std::pair<CGAL::internal::CC_iterator<DSC, Const>,
-                         CGAL::internal::CC_iterator<DSC, Const> >& p)
+                                         CGAL::internal::CC_iterator<DSC, Const> >& p)
   {
     return boost::hash<std::pair<CGAL::internal::CC_iterator<DSC, Const>,
                                  CGAL::internal::CC_iterator<DSC, Const> > >()(p);

--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_complex_3_in_triangulation_3_base.h
@@ -59,13 +59,29 @@ namespace CGAL {
   //              tbb::interface5::concurrent_hash_map
   template < class DSC, bool Const >
   std::size_t tbb_hasher(const std::pair<CGAL::internal::CC_iterator<DSC, Const>,
-                                         CGAL::internal::CC_iterator<DSC, Const> >& p)
+                         CGAL::internal::CC_iterator<DSC, Const> >& p)
   {
     return boost::hash<std::pair<CGAL::internal::CC_iterator<DSC, Const>,
                                  CGAL::internal::CC_iterator<DSC, Const> > >()(p);
   }
 
-
+  struct Hash_compare_for_TBB {
+    template < class DSC, bool Const >
+    std::size_t hash(const std::pair<CGAL::internal::CC_iterator<DSC, Const>,
+                           CGAL::internal::CC_iterator<DSC, Const> >& p) const
+    {
+      return tbb_hasher(p);
+    }
+    template < class DSC, bool Const >
+    std::size_t operator()(const CGAL::internal::CC_iterator<DSC, Const>& it)
+    {
+      return CGAL::internal::hash_value(it);
+    }
+    template <typename T>
+    bool equal(const T& v1, const T& v2) const {
+      return v1 == v2;
+    }
+  };
 }
 #endif
 
@@ -940,7 +956,8 @@ private:
 
   typedef typename Base::Pair_of_vertices Pair_of_vertices;
 #ifdef CGAL_LINKED_WITH_TBB
-  typedef tbb::concurrent_hash_map<Pair_of_vertices, int> Edge_facet_counter;
+  typedef tbb::concurrent_hash_map<Pair_of_vertices, int,
+                                   Hash_compare_for_TBB> Edge_facet_counter;
 #else // not CGAL_LINKED_WITH_TBB
   typedef std::map<Pair_of_vertices, int> Edge_facet_counter;
 #endif // not CGAL_LINKED_WITH_TBB

--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
@@ -49,7 +49,7 @@
 #ifdef CGAL_LINKED_WITH_TBB
 # include <atomic>
 # include <mutex>
-# include <tbb/parallel_do.h>
+# include <tbb/parallel_for_each.h>
 # include <tbb/concurrent_vector.h>
 #endif
 
@@ -794,7 +794,7 @@ compute_moves(Moving_vertices_set& moving_vertices)
     tbb::concurrent_vector<Vertex_handle> vertices_not_moving_any_more;
 
     // Get move for each moving vertex
-    tbb::parallel_do(
+    tbb::parallel_for_each(
           moving_vertices.begin(), moving_vertices.end(),
           Compute_move<Self, Sizing_field, Moves_vector>(
             *this, sizing_field_, moves, do_freeze_, vertices_not_moving_any_more,
@@ -1033,7 +1033,7 @@ fill_sizing_field()
       std::vector< std::pair<Bare_point, FT> > > Local_list;
     Local_list local_lists;
 
-    tbb::parallel_do(
+    tbb::parallel_for_each(
       tr_.finite_vertices_begin(), tr_.finite_vertices_end(),
       Compute_sizing_field_value<Self, Local_list>(*this, tr_.geom_traits(), local_lists)
     );

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -26,7 +26,7 @@
 #include <CGAL/Mesh_3/Mesher_level_default_implementations.h>
 #ifdef CGAL_LINKED_WITH_TBB
   #include <tbb/enumerable_thread_specific.h>
-  #include <tbb/parallel_do.h>
+  #include <tbb/parallel_for_each.h>
 #endif
 
 #include <CGAL/Meshes/Filtered_deque_container.h>
@@ -993,8 +993,8 @@ scan_triangulation_impl()
 # endif
     add_to_TLS_lists(true);
 
-    // PARALLEL_DO
-    tbb::parallel_do(
+    // PARALLEL FOR_EACH
+    tbb::parallel_for_each(
       this->r_tr_.finite_facets_begin(), this->r_tr_.finite_facets_end(),
       typename Rf_base::template Scan_facet<Self>(*this)
     );

--- a/Mesh_3/test/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/test/Mesh_3/CMakeLists.txt
@@ -127,8 +127,6 @@ if ( CGAL_FOUND )
         execution___of__test_meshing_verbose
         execution___of__test_meshing_polyhedron_with_features
         execution___of__test_meshing_implicit_function
-        execution___of__test_meshing_3D_image
-        execution___of__test_meshing_3D_gray_image
         execution___of__test_meshing_unit_tetrahedron
         execution___of__test_meshing_polyhedron
         execution___of__test_meshing_polyhedral_complex
@@ -136,7 +134,13 @@ if ( CGAL_FOUND )
         execution___of__test_mesh_3_issue_1554
         execution___of__test_mesh_polyhedral_domain_with_features_deprecated
         execution___of__test_mesh_cell_base_3
-      PROPERTY RUN_SERIAL 1)
+        PROPERTY RUN_SERIAL 1)
+      if(TARGET test_meshing_3D_image)
+        set_property(TEST
+          execution___of__test_meshing_3D_image
+          execution___of__test_meshing_3D_gray_image
+          PROPERTY RUN_SERIAL 1)
+      endif()
     endif()
   endif()
   if(TARGET ITT::ITT)


### PR DESCRIPTION
## Summary of Changes

The work was already mostly done in PR #4892, but there was still two issues:
  - `tbb::parallel_do` has been removed, and `tbb::parall_for_each` was to be used instead,
  - the support for `tbb_hasher` has been removed.

This time, I have tested in a container were intel-oneapi-tbb-common-devel-2021.3.0-2021.3.0-511.noarch was installed, but not tbb version 2020.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #5845
* License and copyright ownership: maintenance by GeometryFactory

