### PR TITLE
Fix some UB / sanitizer errors

### DIFF
--- a/TDS_2/include/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/Triangulation_data_structure_2.h
@@ -1984,13 +1984,16 @@ copy_tds(const TDS_src& tds_src,
     CGAL_triangulation_precondition( tds_src.is_vertex(vert));
 
   clear();
-  size_type n = tds_src.number_of_vertices();
   set_dimension(tds_src.dimension());
 
-  // Number of pointers to cell/vertex to copy per cell.
-  int dim = (std::max)(1, dimension() + 1);
+  if(tds_src.number_of_vertices() == 0)
+    return Vertex_handle();
 
-  if(n == 0) {return Vertex_handle();}
+  // Number of pointers to face/vertex to copy per face.
+  const int dim = (std::max)(1, dimension() + 1);
+
+  // Number of neighbors to set in each face (dim -1 has a single face)
+  const int nn = (std::max)(0, dimension() + 1);
 
   //initializes maps
   Unique_hash_map<typename TDS_src::Vertex_handle,Vertex_handle> vmap;
@@ -2012,7 +2015,7 @@ copy_tds(const TDS_src& tds_src,
     convert_face(*fit1, *fh);
   }
 
-  //link vertices to a cell
+  //link vertices to a face
   vit1 = tds_src.vertices_begin();
   for ( ; vit1 != tds_src.vertices_end(); vit1++) {
     vmap[vit1]->set_face(fmap[vit1->face()]);
@@ -2021,10 +2024,10 @@ copy_tds(const TDS_src& tds_src,
   //update vertices and neighbor pointers
   fit1 = tds_src.faces().begin();
   for ( ; fit1 != tds_src.faces_end(); ++fit1) {
-      for (int j = 0; j < dim ; ++j) {
+      for (int j = 0; j < dim ; ++j)
         fmap[fit1]->set_vertex(j, vmap[fit1->vertex(j)] );
+      for (int j = 0; j < nn ; ++j)
         fmap[fit1]->set_neighbor(j, fmap[fit1->neighbor(j)]);
-      }
     }
 
   // remove the post condition because it is false when copying the

--- a/TDS_2/include/CGAL/Triangulation_ds_face_base_2.h
+++ b/TDS_2/include/CGAL/Triangulation_ds_face_base_2.h
@@ -235,7 +235,7 @@ Triangulation_ds_face_base_2<TDS> ::
 set_neighbor(int i, Face_handle n)
 {
   CGAL_triangulation_precondition( i == 0 || i == 1 || i == 2);
-  CGAL_triangulation_precondition( this != &*n );
+  CGAL_triangulation_precondition( this != n.operator->() );
   N[i] = n;
 }
 

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -4047,6 +4047,9 @@ copy_tds(const TDS_src& tds,
   // Number of pointers to cell/vertex to copy per cell.
   const int dim = (std::max)(1, dimension() + 1);
 
+  // Number of neighbors to set
+  const int nn = (std::max)(0, dimension() + 1);
+
   // Initializes maps
   Unique_hash_map< typename TDS_src::Vertex_handle,Vertex_handle > V;
   Unique_hash_map< typename TDS_src::Cell_handle,Cell_handle > F;
@@ -4077,7 +4080,7 @@ copy_tds(const TDS_src& tds,
   // Hook neighbor pointers of the cells.
   for (typename TDS_src::Cell_iterator cit2 = tds.cells().begin();
           cit2 != tds.cells_end(); ++cit2) {
-    for (int j = 0; j < dim; j++)
+    for (int j = 0; j < nn; j++)
       F[cit2]->set_neighbor(j, F[cit2->neighbor(j)] );
   }
 

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -4039,32 +4039,24 @@ copy_tds(const TDS_src& tds,
                                           || tds.is_vertex(vert) );
 
   clear();
-
-  size_type n = tds.number_of_vertices();
   set_dimension(tds.dimension());
 
-  if (n == 0)  return Vertex_handle();
+  if(tds.number_of_vertices() == 0)
+    return Vertex_handle();
 
   // Number of pointers to cell/vertex to copy per cell.
-  int dim = (std::max)(1, dimension() + 1);
+  const int dim = (std::max)(1, dimension() + 1);
 
-  // Create the vertices.
-  std::vector<typename TDS_src::Vertex_handle> TV(n);
-  size_type i = 0;
-
-  for (typename TDS_src::Vertex_iterator vit = tds.vertices_begin();
-       vit != tds.vertices_end(); ++vit)
-    TV[i++] = vit;
-
-  CGAL_triangulation_assertion( i == n );
-
+  // Initializes maps
   Unique_hash_map< typename TDS_src::Vertex_handle,Vertex_handle > V;
   Unique_hash_map< typename TDS_src::Cell_handle,Cell_handle > F;
 
-  for (i=0; i <= n-1; ++i){
-    Vertex_handle vh=create_vertex( convert_vertex(*TV[i]) );
-    V[ TV[i] ] = vh;
-    convert_vertex(*TV[i],*vh);
+  // Create the vertices.
+  for (typename TDS_src::Vertex_iterator vit = tds.vertices_begin();
+       vit != tds.vertices_end(); ++vit) {
+    Vertex_handle vh = create_vertex( convert_vertex(*vit) );
+    V[vit] = vh;
+    convert_vertex(*vit,*vh);
   }
 
   // Create the cells.

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_triangulation_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_triangulation_2.h
@@ -132,9 +132,14 @@ _test_cls_triangulation_2( const Triangul & )
   assert( T1.number_of_vertices() == 0 );
 
   Triangul T3(T1);
-  Triangul T4 = T1;
-  T3.swap(T1);
+  assert(T3.tds().vertices().size() == T1.tds().vertices().size());
+  assert(T3.tds().faces().size() == T1.tds().faces().size());
 
+  Triangul T4 = T1;
+  assert(T4.tds().vertices().size() == T1.tds().vertices().size());
+  assert(T4.tds().faces().size() == T1.tds().faces().size());
+
+  T3.swap(T1);
 
   /**************************/
   /******* INSERTIONS *******/
@@ -162,6 +167,10 @@ _test_cls_triangulation_2( const Triangul & )
   assert( T0_1.number_of_faces() == 0);
   assert( T0_1.is_valid() );
 
+  Triangul T0_1b(T0_1);
+  assert(T0_1b.tds().vertices().size() == T0_1.tds().vertices().size());
+  assert(T0_1b.tds().faces().size() == T0_1.tds().faces().size());
+
   // test insert_first()
   Triangul T0_2;
   Vertex_handle v0_2_0 =   T0_2.insert_first(p0);
@@ -183,6 +192,10 @@ _test_cls_triangulation_2( const Triangul & )
   assert( T1_2.number_of_vertices() == 2 );
   assert( T1_2.number_of_faces() == 0 );
   assert( T1_2.is_valid() );
+
+  Triangul T1_2b(T1_2);
+  assert(T1_2b.tds().vertices().size() == T1_2.tds().vertices().size());
+  assert(T1_2b.tds().faces().size() == T1_2.tds().faces().size());
 
   // p1,p3,p2  [endpoints first]
   Triangul T1_3_0;

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
@@ -228,6 +228,9 @@ _test_cls_triangulation_3(const Triangulation &)
   assert(T0.number_of_vertices() == 1);
   assert(T0.is_valid());
 
+  Cls T0d0(T0);
+  assert(T0 == T0d0);
+
   if (! del) // to avoid doing the following tests for both Delaunay
     // and non Delaunay triangulations
     {
@@ -241,6 +244,9 @@ _test_cls_triangulation_3(const Triangulation &)
   assert(T0.dimension() == 1);
   assert(T0.number_of_vertices() == 2);
   assert(T0.is_valid());
+
+  Cls T0d1(T0);
+  assert(T0 == T0d1);
 
   if (! del) // to avoid doing the following tests for both Delaunay
     // and non Delaunay triangulations
@@ -256,6 +262,9 @@ _test_cls_triangulation_3(const Triangulation &)
   assert(T0.number_of_vertices() == 3);
   assert(T0.is_valid());
 
+  Cls T0d2(T0);
+  assert(T0 == T0d2);
+
   if (! del) // to avoid doing the following tests for both Delaunay
     // and non Delaunay triangulations
     {
@@ -269,6 +278,9 @@ _test_cls_triangulation_3(const Triangulation &)
   assert(T0.dimension() == 3);
   assert(T0.number_of_vertices() == 4);
   assert(T0.is_valid());
+
+  Cls T0d3(T0);
+  assert(T0 == T0d3);
 
   if (! del) // to avoid doing the following tests for both Delaunay
     // and non Delaunay triangulations

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
@@ -190,7 +190,21 @@ _test_cls_triangulation_3(const Triangulation &)
   //########################################################################
 
 
-  /**************CONSTRUCTORS (1)*********************/
+  /************** CONSTRUCTORS (1)********************/
+
+  Cls Tm1;
+  assert( Tm1.dimension() == -1 );
+  assert( Tm1.number_of_vertices() == 0 );
+
+  Cls Tm3(Tm1);
+  assert(Tm3 == Tm1);
+
+  Cls Tm4 = Tm1;
+  assert(Tm4 == Tm1);
+
+  Tm3.swap(Tm1);
+
+  /************** INSERTIONS *************************/
   /************** and I/O ****************************/
 
   std::cout << "    Constructor " << std::endl;


### PR DESCRIPTION
## Summary of Changes

Fix a number of small abuses resulting in UB / sanitizer errors.

Minor optimization in `TDS_3::copy_tds()`.

## Release Management

* Affected package(s): `TDS_23`, `Triangulation_23`
* Issue(s) solved (if any): fix #5855
* Feature/Small Feature (if any): NA
* License and copyright ownership: No change

In dim -1, there is only one vertex and one face, no neighbor
in position '0' to set.