### PR TITLE
Set CMP0064 to fix #5857

### DIFF
--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -74,6 +74,7 @@ function(expand_list_with_globbing list_name)
 endfunction()
 
 function(cgal_add_compilation_test exe_name)
+  cmake_policy(SET CMP0064 NEW)
   if(NOT CMAKE_VS_MSBUILD_COMMAND)
     if(TEST compilation_of__${exe_name})
       return()


### PR DESCRIPTION
## Summary of Changes

Set CMP0064 to fix #5857. The software iso2mesh uses declarations like `cmake_minimum_required(VERSION 2.6.2)`. That unset `CMP0064`, that we require. Use a local `cmake_policy` command.

## Release Management

* Affected package(s): Installation
* Issue(s) solved (if any): fix #5857


