### PR TITLE
Skip shared edges which are border edges

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h
@@ -316,6 +316,7 @@ void split_along_edges(TriangleMesh& tm,
   std::set<halfedge_descriptor> extra_border_hedges;
   for(std::size_t k=0; k<nb_shared_edges; ++k)
   {
+    if (is_border(shared_edges[k], tm)) continue;
     for(halfedge_descriptor h : halfedges_around_target(target(shared_edges[k], tm), tm))
       if(is_border(h, tm))
         extra_border_hedges.insert(h);
@@ -334,6 +335,7 @@ void split_along_edges(TriangleMesh& tm,
   // now duplicate the edge and set its pointers
   for(std::size_t k=0; k<nb_shared_edges; ++k)
   {
+    if (is_border(shared_edges[k], tm)) continue;
     halfedge_descriptor h    = halfedge(shared_edges[k], tm);
     face_descriptor fh = face(h, tm);
     //add edge

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_clip.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_clip.cpp
@@ -497,6 +497,64 @@ void test()
     PMP::clip(tm1, K::Plane_3(0,-1,0,0));
     assert(vertices(tm1).size() == 7);
   }
+
+  {
+    TriangleMesh tm1;
+    std::ifstream("data-coref/open_large_cube.off") >> tm1;
+    PMP::clip(tm1, K::Plane_3(0,0,1,-1), CGAL::parameters::use_compact_clipper(false));
+    assert(vertices(tm1).size()==753);
+  }
+
+  {
+    TriangleMesh tm1;
+    std::ifstream("data-coref/open_large_cube.off") >> tm1;
+    std::size_t nbv = vertices(tm1).size();
+    PMP::clip(tm1, K::Plane_3(0,0,1,-1), CGAL::parameters::use_compact_clipper(true));
+    assert(vertices(tm1).size()==nbv+2); // because of the plane diagonal
+  }
+
+  {
+    TriangleMesh tm1;
+    std::ifstream("data-coref/open_large_cube.off") >> tm1;
+    PMP::clip(tm1, K::Plane_3(0,0,1,-1), CGAL::parameters::use_compact_clipper(false).allow_self_intersections(true));
+    assert(vertices(tm1).size()==753);
+  }
+
+  {
+    TriangleMesh tm1;
+    std::ifstream("data-coref/open_large_cube.off") >> tm1;
+    std::size_t nbv = vertices(tm1).size();
+    PMP::clip(tm1, K::Plane_3(0,0,1,-1), CGAL::parameters::use_compact_clipper(true).allow_self_intersections(true));
+    assert(vertices(tm1).size()==nbv+2); // because of the plane diagonal
+  }
+
+  {
+    TriangleMesh tm1;
+    std::ifstream("data-coref/open_large_cube.off") >> tm1;
+    PMP::clip(tm1, K::Plane_3(0,0,-1,1), CGAL::parameters::use_compact_clipper(false));
+    assert(vertices(tm1).size()==0);
+  }
+
+  {
+    TriangleMesh tm1;
+    std::ifstream("data-coref/open_large_cube.off") >> tm1;
+    PMP::clip(tm1, K::Plane_3(0,0,-1,1), CGAL::parameters::use_compact_clipper(true));
+    assert(vertices(tm1).size()==176);
+  }
+
+  {
+    TriangleMesh tm1;
+    std::ifstream("data-coref/open_large_cube.off") >> tm1;
+    PMP::clip(tm1, K::Plane_3(0,0,-1,1), CGAL::parameters::use_compact_clipper(false).allow_self_intersections(true));
+    assert(vertices(tm1).size()==0);
+  }
+
+  {
+    TriangleMesh tm1;
+    std::ifstream("data-coref/open_large_cube.off") >> tm1;
+    PMP::clip(tm1, K::Plane_3(0,0,-1,1), CGAL::parameters::use_compact_clipper(true).allow_self_intersections(true));
+    assert(vertices(tm1).size()==176);
+  }
 }
 
 template <class Mesh>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_clip.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_clip.cpp
@@ -831,12 +831,15 @@ void test_isocuboid()
              .allow_self_intersections(true));
   PMP::split_connected_components(tm, meshes, params::all_default());
   assert(meshes.size() == 4);
-  //if the order is not deterministc, put the num_vertices in a list and check
-  //if the list does contain all those numbers.
-  assert(vertices(meshes[0]).size() == 22);
-  assert(vertices(meshes[1]).size() == 23);
-  assert(vertices(meshes[2]).size() == 7);
-  assert(vertices(meshes[3]).size() == 4);
+
+  std::set<std::size_t> sizes;
+  for (int i=0; i<4; ++i)
+    sizes.insert(vertices(meshes[i]).size());
+
+  assert(sizes.count(22)==1);
+  assert(sizes.count(23)==1);
+  assert(sizes.count(7)==1);
+  assert(sizes.count(4)==1);
 
   CGAL::clear(tm);
   meshes.clear();

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_clip.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_clip.cpp
@@ -502,7 +502,7 @@ void test()
 template <class Mesh>
 void test_split_plane()
 {
-  // test with a clipper mesh
+//test with a splitter mesh
   Mesh tm1;
   std::ifstream input("data-coref/elephant.off");
   input >> tm1;
@@ -529,7 +529,45 @@ void test_split_plane()
   CGAL::clear(tm1);
   meshes.clear();
 
-  //test with SI
+//test with a non-closed splitter mesh (border edges in the plane)
+  input.open("data-coref/open_large_cube.off");
+  input >> tm1;
+
+  if(!input)
+  {
+    std::cerr<<"File not found. Aborting."<<std::endl;
+    assert(false);
+    return ;
+  }
+  input.close();
+
+  PMP::split(tm1,K::Plane_3(0,0,1,-1));
+  PMP::split_connected_components(tm1, meshes, params::all_default());
+  assert(meshes.size() == 281);
+
+  CGAL::clear(tm1);
+  meshes.clear();
+
+//test with a non-closed splitter mesh (border edges in the plane)
+  input.open("data-coref/open_large_cube.off");
+  input >> tm1;
+
+  if(!input)
+  {
+    std::cerr<<"File not found. Aborting."<<std::endl;
+    assert(false);
+    return ;
+  }
+  input.close();
+
+  PMP::split(tm1,K::Plane_3(0,-1,0,0.3));
+  PMP::split_connected_components(tm1, meshes, params::all_default());
+  assert(meshes.size() == 2);
+
+  CGAL::clear(tm1);
+  meshes.clear();
+
+//test with SI
   std::ifstream("data-clip/tet_si_to_split.off") >> tm1;
   if(num_vertices(tm1) == 0)
   {


### PR DESCRIPTION
## Summary of Changes

Skip shared edges which are already border edges in split_along_edges in Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h.

## Release Management

* Affected package(s): Polygon_mesh_processing
* Issue(s) solved: fix #5867


