### PR TITLE
Install ITK in Github action tests

### DIFF
--- a/.github/install.sh
+++ b/.github/install.sh
@@ -3,7 +3,7 @@ sudo add-apt-repository ppa:mikhailnov/pulseeffects -y
 sudo apt-get update
 sudo apt-get install -y  libmpfr-dev \
  libeigen3-dev qtbase5-dev libqt5sql5-sqlite libqt5opengl5-dev qtscript5-dev \
- libqt5svg5-dev qttools5-dev qttools5-dev-tools libboost1.72-dev zsh
+ libqt5svg5-dev qttools5-dev qttools5-dev-tools libboost-dev libinsighttoolkit4-dev zsh
 #update cmake to 3.18.4
 sudo apt purge --auto-remove cmake
 cd /tmp


### PR DESCRIPTION
## Summary of Changes

Add ITK as a dependency to our Github actions tests. For https://github.com/CGAL/cgal/pull/5597.

## Release Management

* Affected package(s): Github workflow

