### PR TITLE
Update PLY.h

### DIFF
--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -175,7 +175,7 @@ public:
   bool has_simplex_specific_property(internal::PLY_read_number* property, Edge_index)
   {
     const std::string& name = property->name();
-    if(name == "v0" || name == "v1")
+    if(name == "vertex1" || name == "vertex2")
       return true;
     return false;
   }
@@ -365,8 +365,8 @@ public:
   void process_line(PLY_element& element, Edge_index& ei)
   {
     IntType v0, v1;
-    element.assign(v0, "v0");
-    element.assign(v1, "v1");
+    element.assign(v0, "vertex1");
+    element.assign(v1, "vertex2");
 
     Halfedge_index hi = m_mesh.halfedge(m_map_v2v[std::size_t(v0)],
         m_map_v2v[std::size_t(v1)]);
@@ -961,8 +961,8 @@ bool write_PLY(std::ostream& os,
     if(!eprinters.empty())
     {
       os << "element edge " << sm.number_of_edges() << std::endl;
-      os << "property int v0" << std::endl;
-      os << "property int v1" << std::endl;
+      os << "property int vertex1" << std::endl;
+      os << "property int vertex2" << std::endl;
       os << oss.str();
     }
   }

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -175,7 +175,12 @@ public:
   bool has_simplex_specific_property(internal::PLY_read_number* property, Edge_index)
   {
     const std::string& name = property->name();
-    if(name == "vertex1" || name == "vertex2")
+    //v0/v1 kept for backward compatibility
+    if(name == "vertex1" || name == "vertex2"
+#ifndef CGAL_NO_DEPRECATED_CODE    
+      || name == "v0" || name == "v1"
+#endif
+      )
       return true;
     return false;
   }


### PR DESCRIPTION
Aligned Edge property to PLY standard

_Please use the following template to help us managing pull requests._

## Summary of Changes

The PLY standard typically uses the following properties for edge elements:
property int vertex1  
property int vertex2

whereas PLY.h was using
property int v0
property int v1

This caused the resulting files to not be read properly by common software packages such as Blender or Meshlab when edge elements were written.


## Release Management

* Affected package(s):
* cgal\Surface_mesh\include\CGAL\Surface_mesh\IO\PLY.h
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

