### PR TITLE
Filtered Kernel Construct Cartesian Iterator Return Type Fix

### DIFF
--- a/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_2.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_2.h
@@ -42,6 +42,8 @@ public:
   typedef std::random_access_iterator_tag iterator_category;
   typedef FT                              value_type;
   typedef int                             difference_type;
+  typedef void                            pointer;
+  typedef value_type                      reference;
 
   Cartesian_coordinate_iterator_2()
     : var((const P*) nullptr), index(0) {}
@@ -53,7 +55,7 @@ public:
     : var(v), index(_index) {}
 
 
-  decltype(auto)
+  reference
   operator*() const {
     if (const P* const* p = boost::get<const P*>(&var))
       return (*p)->cartesian(index);
@@ -118,7 +120,7 @@ public:
     return index - x.index;
   }
 
-  decltype(auto)
+  reference
   operator[](difference_type i) const {
     return *(*this + i);
   }

--- a/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_2.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_2.h
@@ -55,7 +55,7 @@ public:
     : var(v), index(_index) {}
 
 
-  const FT
+  decltype(auto)
   operator*() const {
     if (const P* const* p = boost::get<const P*>(&var))
       return (*p)->cartesian(index);
@@ -64,7 +64,8 @@ public:
     return (*v)->cartesian(index);
   }
 
-  Self&  operator++() {
+  Self&
+  operator++() {
     index++;
     return *this;
   }
@@ -91,7 +92,7 @@ public:
 
   Self&
   operator+=(difference_type i) {
-    index+=i;
+    index += i;
     return *this;
   }
 
@@ -107,7 +108,8 @@ public:
     return tmp += i;
   }
 
-  Self operator-(difference_type i) const {
+  Self
+  operator-(difference_type i) const {
     Self tmp=*this;
     return tmp -= i;
   }
@@ -118,19 +120,23 @@ public:
     return index - x.index;
   }
 
-  decltype(auto) operator[](difference_type i) const {
+  decltype(auto)
+  operator[](difference_type i) const {
     return *(*this + i);
   }
 
-  bool operator==(const Self& x) const {
+  bool
+  operator==(const Self& x) const {
     return (var == x.var) && (index == x.index);
   }
 
-  bool operator!=(const Self& x) const {
+  bool
+  operator!=(const Self& x) const {
     return ! (*this==x);
   }
 
-  bool operator<(const Self& x) const
+  bool
+  operator<(const Self& x) const
   {
     return (x - *this) > 0;
   }

--- a/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_2.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_2.h
@@ -118,7 +118,7 @@ public:
     return index - x.index;
   }
 
-  reference operator[](difference_type i) const {
+  decltype(auto) operator[](difference_type i) const {
     return *(*this + i);
   }
 

--- a/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_2.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_2.h
@@ -42,8 +42,6 @@ public:
   typedef std::random_access_iterator_tag iterator_category;
   typedef FT                              value_type;
   typedef int                             difference_type;
-  typedef const value_type&               reference;
-  typedef const value_type*               pointer;
 
   Cartesian_coordinate_iterator_2()
     : var((const P*) nullptr), index(0) {}

--- a/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_3.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_3.h
@@ -42,8 +42,6 @@ public:
   typedef std::random_access_iterator_tag iterator_category;
   typedef FT                              value_type;
   typedef int                             difference_type;
-  typedef const value_type&               reference;
-  typedef const value_type*               pointer;
 
   Cartesian_coordinate_iterator_3()
     : var((const P*) nullptr), index(0) {}

--- a/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_3.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_3.h
@@ -42,6 +42,8 @@ public:
   typedef std::random_access_iterator_tag iterator_category;
   typedef FT                              value_type;
   typedef int                             difference_type;
+  typedef void                            pointer;
+  typedef value_type                      reference;
 
   Cartesian_coordinate_iterator_3()
     : var((const P*) nullptr), index(0) {}
@@ -53,7 +55,7 @@ public:
     : var(v), index(_index) {}
 
 
-  decltype(auto)
+  reference
   operator*() const {
     if (const P* const* p = boost::get<const P*>(&var))
       return (*p)->cartesian(index);
@@ -118,7 +120,7 @@ public:
     return index - x.index;
   }
 
-  decltype(auto)
+  reference
   operator[](difference_type i) const {
     return *(*this + i);
   }

--- a/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_3.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_3.h
@@ -115,7 +115,7 @@ public:
     return index - x.index;
   }
 
-  reference operator[](difference_type i) const {
+  decltype(auto) operator[](difference_type i) const {
     return *(*this + i);
   }
 

--- a/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_3.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/Cartesian_coordinate_iterator_3.h
@@ -27,6 +27,8 @@ namespace CGAL {
 template <class K>
 class Cartesian_coordinate_iterator_3
 {
+
+protected:
   typedef typename K::Point_3 P;
   typedef typename K::Vector_3 V;
   boost::variant<const P*, const V*> var;
@@ -46,13 +48,14 @@ public:
   Cartesian_coordinate_iterator_3()
     : var((const P*) nullptr), index(0) {}
 
-  Cartesian_coordinate_iterator_3(const P *const p, int _index = 0)
+  Cartesian_coordinate_iterator_3(const P * const p, int _index = 0)
     : var(p), index(_index) {}
 
-  Cartesian_coordinate_iterator_3(const V *const v, int _index = 0)
+  Cartesian_coordinate_iterator_3(const V * const v, int _index = 0)
     : var(v), index(_index) {}
 
-  const FT
+
+  decltype(auto)
   operator*() const {
     if (const P* const* p = boost::get<const P*>(&var))
       return (*p)->cartesian(index);
@@ -61,7 +64,8 @@ public:
     return (*v)->cartesian(index);
   }
 
-  Self&  operator++() {
+  Self&
+  operator++() {
     index++;
     return *this;
   }
@@ -88,7 +92,7 @@ public:
 
   Self&
   operator+=(difference_type i) {
-    index+=i;
+    index += i;
     return *this;
   }
 
@@ -104,7 +108,8 @@ public:
     return tmp += i;
   }
 
-  Self operator-(difference_type i) const {
+  Self
+  operator-(difference_type i) const {
     Self tmp=*this;
     return tmp -= i;
   }
@@ -115,19 +120,23 @@ public:
     return index - x.index;
   }
 
-  decltype(auto) operator[](difference_type i) const {
+  decltype(auto)
+  operator[](difference_type i) const {
     return *(*this + i);
   }
 
-  bool operator==(const Self& x) const {
-    return (var == x.var) && (index == x.index) ;
+  bool
+  operator==(const Self& x) const {
+    return (var == x.var) && (index == x.index);
   }
 
-  bool operator!=(const Self& x) const {
+  bool
+  operator!=(const Self& x) const {
     return ! (*this==x);
   }
 
-  bool operator<(const Self& x) const
+  bool
+  operator<(const Self& x) const
   {
     return (x - *this) > 0;
   }

--- a/Filtered_kernel/test/Filtered_kernel/test_cartesian_const_iterator.cpp
+++ b/Filtered_kernel/test/Filtered_kernel/test_cartesian_const_iterator.cpp
@@ -1,0 +1,37 @@
+#include <CGAL/Search_traits_2.h>
+#include <CGAL/Search_traits_3.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
+using Kernel = CGAL::Exact_predicates_exact_constructions_kernel;
+
+using FT = typename Kernel::FT;
+using Point_2 = typename Kernel::Point_2;
+using Point_3 = typename Kernel::Point_3;
+
+using Traits_2 = CGAL::Search_traits_2<Kernel>;
+using Traits_3 = CGAL::Search_traits_3<Kernel>;
+
+int main() {
+
+  // Testing 2D.
+  Traits_2 traits_2;
+  auto construct_it_2 = traits_2.construct_cartesian_const_iterator_d_object();
+  const Point_2 pp2(1,2);
+  const Point_2 qq2(2,3);
+  const auto p2 = construct_it_2(pp2);
+  const auto q2 = construct_it_2(qq2);
+  const FT d2 = p2[0] - q2[0];
+  assert(d2 < FT(0));
+
+  // Testing 3D.
+  Traits_3 traits_3;
+  auto construct_it_3 = traits_3.construct_cartesian_const_iterator_d_object();
+  const Point_3 pp3(1,2,3);
+  const Point_3 qq3(2,3,4);
+  const auto p3 = construct_it_3(pp3);
+  const auto q3 = construct_it_3(qq3);
+  const FT d3 = q3[2] - p3[2];
+  assert(d3 > FT(0));
+
+  return EXIT_SUCCESS;
+}

--- a/Filtered_kernel/test/Filtered_kernel/test_cartesian_const_iterator.cpp
+++ b/Filtered_kernel/test/Filtered_kernel/test_cartesian_const_iterator.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <CGAL/Search_traits_2.h>
 #include <CGAL/Search_traits_3.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
@@ -23,6 +24,10 @@ int main() {
   const FT d2 = p2[0] - q2[0];
   assert(d2 < FT(0));
 
+  const auto plen2 = std::distance(construct_it_2(pp2), construct_it_2(pp2, 0));
+  const auto qlen2 = std::distance(construct_it_2(qq2), construct_it_2(qq2, 0));
+  assert(plen2 == 2 && qlen2 == 2);
+
   // Testing 3D.
   Traits_3 traits_3;
   auto construct_it_3 = traits_3.construct_cartesian_const_iterator_d_object();
@@ -32,6 +37,10 @@ int main() {
   const auto q3 = construct_it_3(qq3);
   const FT d3 = q3[2] - p3[2];
   assert(d3 > FT(0));
+
+  const auto plen3 = std::distance(construct_it_3(pp3), construct_it_3(pp3, 0));
+  const auto qlen3 = std::distance(construct_it_3(qq3), construct_it_3(qq3, 0));
+  assert(plen3 == 3 && qlen3 == 3);
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
This little PR proposes a fix for the issue #5878 by changing some return types in the `Construct_cartesian_iterator_2` and `Construct_cartesian_iterator_3` classes of the `Filtered_kernel`.

Tasks:
- [x] Check memory leaking.

## Release Management

* Affected package(s): `Filtered_kernel`
* Issue(s) solved (if any): fix #5878
* Feature/Small Feature (if any): bug
* License and copyright ownership: no changes

