### PR TITLE
Construct AABB tree by sorting

### DIFF
--- a/AABB_tree/include/CGAL/AABB_traits_construct_by_sorting.h
+++ b/AABB_tree/include/CGAL/AABB_traits_construct_by_sorting.h
@@ -1,0 +1,70 @@
+#ifndef AABB_TREE_TESTS_AABB_TRAITS_CONSTRUCT_BY_SORTING_H
+#define AABB_TREE_TESTS_AABB_TRAITS_CONSTRUCT_BY_SORTING_H
+
+#include <CGAL/AABB_traits.h>
+
+namespace CGAL {
+
+  // forward declaration
+  template<typename AABBTraits>
+  class AABB_tree;
+
+
+  template<typename GeomTraits, typename AABBPrimitive, typename BboxMap = Default>
+  class AABB_traits_construct_by_sorting : public AABB_traits<GeomTraits, AABBPrimitive, BboxMap> {
+
+  public:
+
+    class Split_primitives {
+      typedef AABB_traits<GeomTraits, AABBPrimitive, BboxMap> Traits;
+      const Traits &m_traits;
+      mutable bool has_been_sorted = false;
+
+    public:
+
+      struct Get_reference_point : public std::unary_function<const Primitive &, typename Traits::Point_3> {
+        const Traits &m_traits;
+        typedef internal::Primitive_helper<Traits> Helper;
+
+        Get_reference_point(const AABB_traits<GeomTraits, AABBPrimitive, BboxMap> &traits)
+                : m_traits(traits) {}
+
+        typename Traits::Point_3 operator()(const Primitive &p) const {
+          return Helper::get_reference_point(p, m_traits);
+        }
+      };
+
+      Split_primitives(const AABB_traits<GeomTraits, AABBPrimitive, BboxMap> &traits)
+              : m_traits(traits) {}
+
+      template<typename PrimitiveIterator>
+      void operator()(PrimitiveIterator first,
+                      PrimitiveIterator beyond,
+                      const typename AT::Bounding_box &bbox) const {
+
+        // If this is our first time splitting the primitives, sort them along the hilbert curve
+        // This should generally put nearby primitives close together in the list
+        if (!has_been_sorted) {
+
+          // Create a property map using our Get_reference_point functor
+          auto property_map = boost::make_function_property_map<Primitive, Traits::Point_3, Get_reference_point>(
+                  Get_reference_point(m_traits)
+          );
+
+          // Our search traits will use that property map
+          typedef CGAL::Spatial_sort_traits_adapter_3<Geom_traits, decltype(property_map)> Search_traits_3;
+
+          // Perform our hilbert sort using the search traits type with our custom property map
+          CGAL::hilbert_sort<CGAL::Parallel_if_available_tag>(first, beyond, Search_traits_3(property_map));
+
+          // In the future, it's not necessary to re-sort the primitives (we can blindly partition them in the middle)
+          has_been_sorted = true;
+        }
+      }
+    };
+
+    Split_primitives split_primitives_object() const { return Split_primitives(*this); }
+  };
+}
+
+#endif //AABB_TREE_TESTS_AABB_TRAITS_CONSTRUCT_BY_SORTING_H

--- a/AABB_tree/include/CGAL/AABB_traits_construct_by_sorting.h
+++ b/AABB_tree/include/CGAL/AABB_traits_construct_by_sorting.h
@@ -2,6 +2,14 @@
 #define AABB_TREE_TESTS_AABB_TRAITS_CONSTRUCT_BY_SORTING_H
 
 #include <CGAL/AABB_traits.h>
+#include <CGAL/hilbert_sort.h>
+#include <CGAL/spatial_sort.h>
+#include <CGAL/property_map.h>
+#include <CGAL/Spatial_sort_traits_adapter_3.h>
+
+#include <boost/property_map/function_property_map.hpp>
+#include <boost/optional.hpp>
+#include <boost/bind.hpp>
 
 namespace CGAL {
 

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -617,7 +617,7 @@ public:
 #else
     typename AABBTraits::Primitive::Datum_reference
 #endif
-    datum(Primitive& p)const
+    datum(Primitive& p) const
     {
       return Helper::get_datum(p, this->traits());
     }

--- a/AABB_tree/test/AABB_tree/aabb_any_all_benchmark.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_any_all_benchmark.cpp
@@ -11,6 +11,7 @@
 
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
+#include <CGAL/AABB_traits_construct_by_sorting.h>
 
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 #include <CGAL/Polyhedron_3.h>
@@ -64,7 +65,7 @@ boost::tuple<std::size_t, std::size_t, std::size_t, long> test(const char *name)
   typedef CGAL::Polyhedron_3<K> Polyhedron;
 
   typedef CGAL::AABB_face_graph_triangle_primitive<Polyhedron> Primitive;
-  typedef CGAL::AABB_traits<K, Primitive> Traits;
+  typedef CGAL::AABB_traits_construct_by_sorting<K, Primitive> Traits;
   typedef CGAL::AABB_tree<Traits> Tree;
 
   std::ifstream ifs(name);

--- a/AABB_tree/test/AABB_tree/aabb_any_all_benchmark.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_any_all_benchmark.cpp
@@ -28,26 +28,26 @@ const int runs = 10;
 
 template<typename Tree>
 struct FilterP {
-  const Tree* t;
+  const Tree *t;
 
   template<typename T>
-  bool operator()(const T& tt) { return !t->do_intersect(tt); }
+  bool operator()(const T &tt) { return !t->do_intersect(tt); }
 };
 
 
 template<typename ForwardIterator, typename Tree>
-std::size_t intersect(ForwardIterator b, ForwardIterator e, const Tree& tree, long& counter) {
-      typedef
-        typename Tree::AABB_traits::template Intersection_and_primitive_id<typename ForwardIterator::value_type>::Type
-        Obj_type;
+std::size_t intersect(ForwardIterator b, ForwardIterator e, const Tree &tree, long &counter) {
+  typedef
+  typename Tree::AABB_traits::template Intersection_and_primitive_id<typename ForwardIterator::value_type>::Type
+          Obj_type;
 
   std::vector<Obj_type> v;
   // bad educated guess
   v.reserve(elements);
-  for(; b != e; ++b) {
+  for (; b != e; ++b) {
     tree.all_intersections(*b, std::back_inserter(v));
     boost::optional<Obj_type> o = tree.any_intersection(*b);
-    if(o)
+    if (o)
       ++counter;
   }
 
@@ -55,7 +55,7 @@ std::size_t intersect(ForwardIterator b, ForwardIterator e, const Tree& tree, lo
 }
 
 template<typename K>
-boost::tuple<std::size_t, std::size_t, std::size_t, long> test(const char* name) {
+boost::tuple<std::size_t, std::size_t, std::size_t, long> test(const char *name) {
   typedef typename K::FT FT;
   typedef typename K::Ray_3 Ray;
   typedef typename K::Line_3 Line;
@@ -74,7 +74,7 @@ boost::tuple<std::size_t, std::size_t, std::size_t, long> test(const char* name)
 
   // Random seeded to 23, cube size equal to the magic number 2
   CGAL::Random r(23);
-  CGAL::Random_points_in_cube_3<Point, CGAL::Creator_uniform_3<FT, Point> > g( 2., r);
+  CGAL::Random_points_in_cube_3<Point, CGAL::Creator_uniform_3<FT, Point> > g(2., r);
 
   std::vector<Point> points;
   points.reserve(elements * 2);
@@ -85,8 +85,7 @@ boost::tuple<std::size_t, std::size_t, std::size_t, long> test(const char* name)
   lines.reserve(elements);
 
   // forward
-  for(std::size_t i = 0; i < points.size(); i += 2)
-  {
+  for (std::size_t i = 0; i < points.size(); i += 2) {
     lines.push_back(Line(points[i], points[i + 1]));
   }
 
@@ -94,24 +93,23 @@ boost::tuple<std::size_t, std::size_t, std::size_t, long> test(const char* name)
   rays.reserve(elements);
 
   // backwards
-  for(std::size_t i = points.size(); i != 0; i -= 2)
-  {
+  for (std::size_t i = points.size(); i != 0; i -= 2) {
     rays.push_back(Ray(points[i - 1], points[i - 2]));
   }
 
   std::vector<Segment> segments;
   segments.reserve(elements);
   // from both sides
-  for(std::size_t i = 0, j = points.size() - 1; i < j; ++i, --j)
-  {
+  for (std::size_t i = 0, j = points.size() - 1; i < j; ++i, --j) {
     segments.push_back(Segment(points[i], points[j]));
   }
 
   Tree tree(faces(polyhedron).first, faces(polyhedron).second, polyhedron);
 
   // filter all primitives that do not intersect
+  // TODO Is this causing a problem?
 
-  FilterP<Tree> p = { &tree };
+  FilterP<Tree> p = {&tree};
 
   lines.erase(std::remove_if(lines.begin(), lines.end(), p), lines.end());
 
@@ -121,29 +119,28 @@ boost::tuple<std::size_t, std::size_t, std::size_t, long> test(const char* name)
 
   boost::tuple<std::size_t, std::size_t, std::size_t, long> tu;
 
-    {
-      CGAL::Timer t;
-      t.start();
+  {
+    CGAL::Timer t;
+    t.start();
 
-      for(int i = 0; i < runs; ++i)
-      {
-        long counter = 0L;
-        tu = boost::make_tuple(intersect(lines.begin(), lines.end(), tree, counter),
-                               intersect(rays.begin(), rays.end(), tree, counter),
-                               intersect(segments.begin(), segments.end(), tree, counter),
-                               // cant use counter here
-                               0);
-        boost::get<3>(tu) = counter;
-      }
-      std::cout << t.time();
+    for (int i = 0; i < runs; ++i) {
+      long counter = 0L;
+      tu = boost::make_tuple(intersect(lines.begin(), lines.end(), tree, counter),
+                             intersect(rays.begin(), rays.end(), tree, counter),
+                             intersect(segments.begin(), segments.end(), tree, counter),
+              // cant use counter here
+                             0);
+      boost::get<3>(tu) = counter;
     }
+    std::cout << t.time();
+  }
 
   return tu;
 }
 
-int main()
-{
+int main() {
   const char* filename = "./data/finger.off";
+  //const char *filename = "./data/bunny00.off";
 
   std::cout << "| Simple cartesian float kernel | ";
   boost::tuple<std::size_t, std::size_t, std::size_t, long> t1 = test<CGAL::Simple_cartesian<float> >(filename);
@@ -153,16 +150,17 @@ int main()
   boost::tuple<std::size_t, std::size_t, std::size_t, long> t2 = test<CGAL::Cartesian<float> >(filename);
   std::cout << " | " << std::endl;
 
-  std::cout << "| Simple cartesian double kernel |";
+  std::cout << "| Simple cartesian double kernel | ";
   boost::tuple<std::size_t, std::size_t, std::size_t, long> t3 = test<CGAL::Simple_cartesian<double> >(filename);
   std::cout << " | " << std::endl;
 
-  std::cout << "| Cartesian double kernel |";
+  std::cout << "| Cartesian double kernel | ";
   boost::tuple<std::size_t, std::size_t, std::size_t, long> t4 = test<CGAL::Cartesian<double> >(filename);
   std::cout << " | " << std::endl;
 
-  std::cout << "| Epic kernel |";
-  boost::tuple<std::size_t, std::size_t, std::size_t, long> t5 = test<CGAL::Exact_predicates_inexact_constructions_kernel>(filename);
+  std::cout << "| Epic kernel | ";
+  boost::tuple<std::size_t, std::size_t, std::size_t, long> t5 = test<CGAL::Exact_predicates_inexact_constructions_kernel>(
+          filename);
   std::cout << " | " << std::endl;
 
   std::size_t a, b, c;


### PR DESCRIPTION
## Summary of Changes

This feature adds an additional class which is a model of the AABBTraits concept. When this traits type is substituted for the normal Traits class, the tree will be built by sorting the primitives along a space filling curve, rather than by recursively partitioning along the longest axis of their bounding box. This is a technique seen in Embree, which uses it to improve tree construction speed at the cost of the resulting tree quality.

## Release Management

* Affected package(s): AABB_tree
* Issue(s) solved (if any): N/A
* Feature/Small Feature (if any): [todo: create a feature page]()
* Link to compiled documentation (obligatory for small feature): [todo: compile and link documentation]()
* License and copyright ownership: Inria

