### PR TITLE
Warnings Mesh_3 regarding non existing file (documentation)

### DIFF
--- a/Mesh_3/doc/Mesh_3/Mesh_3.txt
+++ b/Mesh_3/doc/Mesh_3/Mesh_3.txt
@@ -731,7 +731,7 @@ that call is replaced by:
 
 The code of the function `initialize_triangulation_from_labeled_image()` is
 in the non-documented header \ref
-CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h\. As it is
+CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h. As it is
 undocumented and may be removed or modified at any time, if you wish to
 use it then you should copy-paste it to your user code. The code of that
 function is rather complicated. The following lines show how to insert new
@@ -789,7 +789,7 @@ create a 3D image using the undocumented API of CGAL_ImageIO.
 \snippet Mesh_3/mesh_3D_image_with_custom_initialization.cpp Create the image
 
 The code of the function `%random_labeled_image()` is in the header file \ref
-Mesh_3/random_labeled_image.h\.
+Mesh_3/random_labeled_image.h.
 
 
 The example \ref Mesh_3/mesh_3D_gray_image_with_custom_initialization.cpp is another
@@ -805,7 +805,7 @@ the segmented image example above, the code consists in:
 
 The code of the function `initialize_triangulation_from_gray_image()` is
 in the non-documented header \ref
-CGAL/Mesh_3/initialize_triangulation_from_gray_image.h\. As it is
+CGAL/Mesh_3/initialize_triangulation_from_gray_image.h. As it is
 undocumented and may be removed or modified at any time, if you wish to
 use it then you should copy-paste it to your user code.
 


### PR DESCRIPTION
Currently we get a number of warnings when building the documentation for Mesh_3:
```
/home/cgal-testsuite/cgal_doc_build/CGAL-5.3.1-I-169/doc/Mesh_3/Mesh_3.txt:743: warning: unable to resolve reference to 'CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h\' for \ref command
/home/cgal-testsuite/cgal_doc_build/CGAL-5.3.1-I-169/doc/Mesh_3/Mesh_3.txt:801: warning: unable to resolve reference to 'Mesh_3/random_labeled_image.h\' for \ref command
/home/cgal-testsuite/cgal_doc_build/CGAL-5.3.1-I-169/doc/Mesh_3/Mesh_3.txt:817: warning: unable to resolve reference to 'CGAL/Mesh_3/initialize_triangulation_from_gray_image.h\' for \ref command
```
Note the backslash at the end of the file name.

Most likely an attempt was made to escape the dot to not have it as part of the filename, though at least in doxygen 1.8.13 a closing dot was not seen as part of the filename.
Looking at the other escape character of doxygen: the commercial at sign, this was apparently working as escape in the filename as well, though in doxygen 1.8.15 this was not the case anymore either.
During one of the last changes also the backslash lost this possibility for this case and this is now consistent.

The current change (removing the backslashes) doesn't look like to alter the behavior for the 1.8.13 and master version in respect to CGAL.



