### PR TITLE
Basic_viewer: Restore compatibility shader code

### DIFF
--- a/GraphicsView/include/CGAL/Basic_shaders.h
+++ b/GraphicsView/include/CGAL/Basic_shaders.h
@@ -176,17 +176,17 @@ void main(void)
 //  compatibility shaders
 
 const char vertex_source_color_comp[]=R"DELIM(
-in highp vec4 vertex;
-in highp vec3 normal;
-in highp vec3 color;
+varying highp vec4 vertex;
+varying highp vec3 normal;
+varying highp vec3 color;
 
 uniform highp mat4 mvp_matrix;
 uniform highp mat4 mv_matrix;
 uniform highp float point_size;
 
-out highp vec4 fP;
-out highp vec3 fN;
-out highp vec4 fColor;
+varying highp vec4 fP;
+varying highp vec3 fN;
+varying highp vec4 fColor;
 
 void main(void)
 {
@@ -204,17 +204,15 @@ void main(void)
 )DELIM";
 
 const char fragment_source_color_comp[]=R"DELIM(
-in highp vec4 fP;
-in highp vec3 fN;
-in highp vec4 fColor;
+varying highp vec4 fP;
+varying highp vec3 fN;
+varying highp vec4 fColor;
 
 uniform highp vec4 light_pos;
 uniform highp vec4 light_diff;
 uniform highp vec4 light_spec;
 uniform highp vec4 light_amb;
 uniform highp float spec_power ;
-
-out highp vec4 out_color;
 
 void main(void)
 {
@@ -229,18 +227,18 @@ void main(void)
   highp vec4 diffuse = max(dot(N,L), 0.0) * light_diff * fColor;
   highp vec4 specular = pow(max(dot(R,V), 0.0), spec_power) * light_spec;
 
-  out_color = light_amb*fColor + diffuse;
+  gl_FragColor = light_amb*fColor + diffuse;
 }
 )DELIM";
 
 const char vertex_source_p_l_comp[]=R"DELIM(
-in highp vec4 vertex;
-in highp vec3 color;
+varying highp vec4 vertex;
+varying highp vec3 color;
 
 uniform highp mat4 mvp_matrix;
 uniform highp float point_size;
 
-out highp vec4 fColor;
+varying highp vec4 fColor;
 
 void main(void)
 {
@@ -251,11 +249,10 @@ void main(void)
 )DELIM";
 
 const char fragment_source_p_l_comp[]=R"DELIM(
-in highp vec4 fColor;
-out highp vec4 out_color;
+varying highp vec4 fColor;
 void main(void)
 {
-  out_color = fColor;
+  gl_FragColor = fColor;
 }
 )DELIM";
 


### PR DESCRIPTION
## Summary of Changes

In 5.3, the code for the compatibility shaders has been broken. It uses GLSL 150 syntax, which is the same syntax as the non-compatibility shader code. 

## Release Management

* Affected package(s):GraphicsView
* Issue(s) solved (if any): fix #5933
