### PR TITLE
Polygon Mesh Processing:  Add measure functions not using sqrt

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
@@ -193,9 +193,11 @@ The page \ref bgl_namedparameters "Named Parameters" describes their usage.
 
 \cgalCRPSection{Geometric Measure Functions}
 - \link measure_grp `CGAL::Polygon_mesh_processing::face_area()` \endlink
+- \link measure_grp `CGAL::Polygon_mesh_processing::squared_face_area()` \endlink
 - \link measure_grp `CGAL::Polygon_mesh_processing::area()` \endlink
 - \link measure_grp `CGAL::Polygon_mesh_processing::volume()` \endlink
 - \link measure_grp `CGAL::Polygon_mesh_processing::edge_length()` \endlink
+- \link measure_grp `CGAL::Polygon_mesh_processing::squared_edge_length()` \endlink
 - \link measure_grp `CGAL::Polygon_mesh_processing::face_border_length()` \endlink
 - \link measure_grp `CGAL::Polygon_mesh_processing::centroid()` \endlink
 - \link measure_grp `CGAL::Polygon_mesh_processing::match_faces()` \endlink

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -23,7 +23,6 @@
 #include <CGAL/boost/graph/properties.h>
 #include <CGAL/Polygon_mesh_processing/internal/named_function_params.h>
 #include <CGAL/Polygon_mesh_processing/internal/named_params_helper.h>
-#include <CGAL/squared_distance_3.h>
 #include <CGAL/Kernel/global_functions_3.h>
 
 #include <CGAL/Lazy.h> // needed for CGAL::exact(FT)/CGAL::exact(Lazy_exact_nt<T>)
@@ -113,6 +112,8 @@ edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descriptor h,
             const PolygonMesh& pmesh,
             const NamedParameters& np)
 {
+  typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type Geom_traits;
+
   using parameters::choose_parameter;
   using parameters::get_parameter;
 
@@ -122,8 +123,10 @@ edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descriptor h,
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                              get_const_property_map(CGAL::vertex_point, pmesh));
 
-  return CGAL::approximate_sqrt(CGAL::squared_distance(get(vpm, source(h, pmesh)),
-                                                       get(vpm, target(h, pmesh))));
+  Geom_traits gt = choose_parameter<Geom_traits>(get_parameter(np, internal_np::geom_traits));
+
+  return CGAL::approximate_sqrt(gt.compute_squared_distance_3_object()(get(vpm, source(h, pmesh)),
+								       get(vpm, target(h, pmesh))));
 }
 
 template<typename PolygonMesh>
@@ -201,6 +204,8 @@ squared_edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descript
                     const PolygonMesh& pmesh,
                     const NamedParameters& np)
 {
+  typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type Geom_traits;
+
   using parameters::choose_parameter;
   using parameters::get_parameter;
 
@@ -210,8 +215,10 @@ squared_edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descript
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                              get_const_property_map(CGAL::vertex_point, pmesh));
 
-  return CGAL::squared_distance(get(vpm, source(h, pmesh)),
-                                get(vpm, target(h, pmesh)));
+  Geom_traits gt = choose_parameter<Geom_traits>(get_parameter(np, internal_np::geom_traits));
+
+  return gt.compute_squared_distance_3_object()(get(vpm, source(h, pmesh)),
+						get(vpm, target(h, pmesh)));
 }
 
 template<typename PolygonMesh>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -23,7 +23,7 @@
 #include <CGAL/boost/graph/properties.h>
 #include <CGAL/Polygon_mesh_processing/internal/named_function_params.h>
 #include <CGAL/Polygon_mesh_processing/internal/named_params_helper.h>
-#include <CGAL/Kernel/global_functions_3.h>
+
 
 #include <CGAL/Lazy.h> // needed for CGAL::exact(FT)/CGAL::exact(Lazy_exact_nt<T>)
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -126,7 +126,7 @@ edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descriptor h,
   Geom_traits gt = choose_parameter<Geom_traits>(get_parameter(np, internal_np::geom_traits));
 
   return CGAL::approximate_sqrt(gt.compute_squared_distance_3_object()(get(vpm, source(h, pmesh)),
-								       get(vpm, target(h, pmesh))));
+                                                                       get(vpm, target(h, pmesh))));
 }
 
 template<typename PolygonMesh>
@@ -218,7 +218,7 @@ squared_edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descript
   Geom_traits gt = choose_parameter<Geom_traits>(get_parameter(np, internal_np::geom_traits));
 
   return gt.compute_squared_distance_3_object()(get(vpm, source(h, pmesh)),
-						get(vpm, target(h, pmesh)));
+                                                get(vpm, target(h, pmesh)));
 }
 
 template<typename PolygonMesh>
@@ -541,8 +541,8 @@ FT
 typename GetGeomTraits<TriangleMesh, CGAL_PMP_NP_CLASS>::type::FT
 #endif
 squared_face_area(typename boost::graph_traits<TriangleMesh>::face_descriptor f,
-		  const TriangleMesh& tmesh,
-		  const CGAL_PMP_NP_CLASS& np)
+                  const TriangleMesh& tmesh,
+                  const CGAL_PMP_NP_CLASS& np)
 {
   using parameters::choose_parameter;
   using parameters::get_parameter;
@@ -562,8 +562,8 @@ squared_face_area(typename boost::graph_traits<TriangleMesh>::face_descriptor f,
   GT traits = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
 
   return traits.compute_squared_area_3_object()(get(vpm, source(hd, tmesh)),
-						get(vpm, target(hd, tmesh)),
-						get(vpm, target(nhd, tmesh)));
+                                                get(vpm, target(hd, tmesh)),
+                                                get(vpm, target(nhd, tmesh)));
 }
 
 template<typename TriangleMesh>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -70,7 +70,7 @@ inline void rearrange_face_ids(boost::container::small_vector<std::size_t, 4>& i
   * @tparam PolygonMesh a model of `HalfedgeGraph`
   * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
   *
-  * @param h one halfedge of the edge to compute the length
+  * @param h one halfedge of the edge whose length is computed
   * @param pmesh the polygon mesh to which `h` belongs
   * @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
   *
@@ -99,6 +99,7 @@ inline void rearrange_face_ids(boost::container::small_vector<std::size_t, 4>& i
   * If `FT` does not have a `sqrt()` operation, the square root computation
   * will be done approximately.
   *
+  * @sa `squared_edge_length()`
   * @sa `face_border_length()`
   */
 template<typename PolygonMesh,
@@ -114,6 +115,8 @@ edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descriptor h,
 {
   using parameters::choose_parameter;
   using parameters::get_parameter;
+
+  CGAL_precondition(boost::graph_traits<PolygonMesh>::null_halfedge() != h);
 
   typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
@@ -159,7 +162,7 @@ edge_length(typename boost::graph_traits<PolygonMesh>::edge_descriptor e,
   * @tparam PolygonMesh a model of `HalfedgeGraph`
   * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
   *
-  * @param h one halfedge of the edge to compute the squared length
+  * @param h one halfedge of the edge whose squared length is computed
   * @param pmesh the polygon mesh to which `h` belongs
   * @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
   *
@@ -195,25 +198,27 @@ FT
 typename GetGeomTraits<PolygonMesh, NamedParameters>::type::FT
 #endif
 squared_edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descriptor h,
-		    const PolygonMesh& pmesh,
-		    const NamedParameters& np)
+                    const PolygonMesh& pmesh,
+                    const NamedParameters& np)
 {
   using parameters::choose_parameter;
   using parameters::get_parameter;
+
+  CGAL_precondition(boost::graph_traits<PolygonMesh>::null_halfedge() != h);
 
   typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                              get_const_property_map(CGAL::vertex_point, pmesh));
 
   return CGAL::squared_distance(get(vpm, source(h, pmesh)),
-				get(vpm, target(h, pmesh)));
+                                get(vpm, target(h, pmesh)));
 }
 
 template<typename PolygonMesh>
 typename CGAL::Kernel_traits<typename property_map_value<PolygonMesh,
 CGAL::vertex_point_t>::type>::Kernel::FT
 squared_edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descriptor h,
-		    const PolygonMesh& pmesh)
+                    const PolygonMesh& pmesh)
 {
   return squared_edge_length(h, pmesh, CGAL::Polygon_mesh_processing::parameters::all_default());
 }
@@ -222,8 +227,8 @@ template<typename PolygonMesh,
          typename NamedParameters>
 typename GetGeomTraits<PolygonMesh, NamedParameters>::type::FT
 squared_edge_length(typename boost::graph_traits<PolygonMesh>::edge_descriptor e,
-		    const PolygonMesh& pmesh,
-		    const NamedParameters& np)
+                    const PolygonMesh& pmesh,
+                    const NamedParameters& np)
 {
   return squared_edge_length(halfedge(e, pmesh), pmesh, np);
 }
@@ -232,12 +237,12 @@ template<typename PolygonMesh>
 typename CGAL::Kernel_traits<typename property_map_value<PolygonMesh,
 CGAL::vertex_point_t>::type>::Kernel::FT
 squared_edge_length(typename boost::graph_traits<PolygonMesh>::edge_descriptor e,
-		    const PolygonMesh& pmesh)
+                    const PolygonMesh& pmesh)
 {
   return squared_edge_length(halfedge(e, pmesh), pmesh);
 }
 
-  
+
 /**
   * \ingroup measure_grp
   * computes the length of the border polyline
@@ -246,7 +251,7 @@ squared_edge_length(typename boost::graph_traits<PolygonMesh>::edge_descriptor e
   * @tparam PolygonMesh a model of `HalfedgeGraph`
   * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
   *
-  * @param h a halfedge of the border polyline of which the length is computed
+  * @param h a halfedge of the border polyline whose length is computed
   * @param pmesh the polygon mesh to which `h` belongs
   * @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
   *
@@ -403,10 +408,10 @@ longest_border(const PolygonMesh& pmesh)
   * computes the area of a face of a given
   * triangulated surface mesh.
   *
-  * @tparam TriangleMesh a model of `HalfedgeGraph`
+  * @tparam TriangleMesh a model of `FaceGraph`
   * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
   *
-  * @param f the face of which the area is computed
+  * @param f the face whose area is computed
   * @param tmesh the triangulated surface mesh to which `f` belongs
   * @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
   *
@@ -438,6 +443,7 @@ longest_border(const PolygonMesh& pmesh)
   * If `Kernel::FT` does not have a `sqrt()` operation, the square root computation
   * will be done approximately.
   *
+  * @sa `squared_face_area()`
   * @sa `area()`
   */
 template<typename TriangleMesh,
@@ -487,10 +493,10 @@ face_area(typename boost::graph_traits<TriangleMesh>::face_descriptor f,
   * computes the squared area of a face of a given
   * triangulated surface mesh.
   *
-  * @tparam TriangleMesh a model of `HalfedgeGraph`
+  * @tparam TriangleMesh a model of `FaceGraph`
   * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
   *
-  * @param f the face of which the squared area is computed
+  * @param f the face whose squared area is computed
   * @param tmesh the triangulated surface mesh to which `f` belongs
   * @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
   *
@@ -528,8 +534,8 @@ FT
 typename GetGeomTraits<TriangleMesh, CGAL_PMP_NP_CLASS>::type::FT
 #endif
 squared_face_area(typename boost::graph_traits<TriangleMesh>::face_descriptor f,
-          const TriangleMesh& tmesh,
-          const CGAL_PMP_NP_CLASS& np)
+		  const TriangleMesh& tmesh,
+		  const CGAL_PMP_NP_CLASS& np)
 {
   using parameters::choose_parameter;
   using parameters::get_parameter;
@@ -571,10 +577,10 @@ squared_face_area(typename boost::graph_traits<TriangleMesh>::face_descriptor f,
   * @tparam FaceRange range of `boost::graph_traits<PolygonMesh>::%face_descriptor`,
           model of `Range`.
           Its iterator type is `InputIterator`.
-  * @tparam TriangleMesh a model of `HalfedgeGraph`
+  * @tparam TriangleMesh a model of `FaceGraph`
   * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
   *
-  * @param face_range the range of faces of which the area is computed
+  * @param face_range the range of faces of whose area is computed
   * @param tmesh the triangulated surface mesh to which the faces of `face_range` belong
   * @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
   *
@@ -641,7 +647,7 @@ area(FaceRange face_range, const TriangleMesh& tmesh)
   * \ingroup measure_grp
   * computes the surface area of a triangulated surface mesh.
   *
-  * @tparam TriangleMesh a model of `HalfedgeGraph`
+  * @tparam TriangleMesh a model of `FaceGraph`
   * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
   *
   * @param tmesh the triangulated surface mesh
@@ -784,7 +790,7 @@ volume(const TriangleMesh& tmesh)
   * @tparam TriangleMesh a model of `HalfedgeGraph`
   * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
   *
-  * @param f the face of which the aspect ratio is computed
+  * @param f the face whose aspect ratio is computed
   * @param tmesh the triangulated surface mesh to which `f` belongs
   * @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
   *

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -346,6 +346,10 @@ longest_border(const PolygonMesh& pmesh)
   * or the geometric traits class deduced from the point property map
   * of `tmesh`.
   *
+  * \warning This function involves a square root computation.
+  * If `Kernel::FT` does not have a `sqrt()` operation, the square root computation
+  * will be done approximately.
+  *
   * @sa `area()`
   */
 template<typename TriangleMesh,

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
@@ -55,6 +55,13 @@ void test_pmesh(const Mesh& pmesh)
       continue;
     else
     {
+       FT edge_length = PMP::edge_length(h, pmesh);
+       FT squared_edge_length = PMP::squared_edge_length(h, pmesh);
+       std::cout << "squared edge length = " << squared_edge_length << std::endl;
+       std::cout << "edge length = " << edge_length << std::endl;
+
+      FT  squared_face_area = PMP::squared_face_area(face(h, pmesh), pmesh);
+      std::cout << "squared face area = " << squared_face_area << std::endl;
       FT face_area = PMP::face_area(face(h, pmesh), pmesh);
       std::cout << "face area = " << face_area << std::endl;
       assert(face_area > 0);


### PR DESCRIPTION
## Summary of Changes

Add functions for the case that we only want to compare squared distances (for example for a priority queue).

## Release Management

* Affected package(s): PMP

* Small Feature:  [link ](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/PMP::squared_edge_length)
* Link to compiled documentation (obligatory for small feature) 
   - [`squared_edge_length()`](https://cgal.github.io/5941/v2/Polygon_mesh_processing/group__measure__grp.html#ga30fa03722cd7aa599f6dcb115f54fec5)
   - [`squared_face_area()`](https://cgal.github.io/5941/v2/Polygon_mesh_processing/group__measure__grp.html#ga6eda3738815fd678df225f79ccfc3e03)
* License and copyright ownership: unchanged 

