### PR TITLE
Call is-termimal functor only on degree 2 nodes

### DIFF
--- a/BGL/include/CGAL/boost/graph/split_graph_into_polylines.h
+++ b/BGL/include/CGAL/boost/graph/split_graph_into_polylines.h
@@ -153,7 +153,7 @@ void duplicate_terminal_vertices(Graph& graph,
   {
     typename boost::graph_traits<OrigGraph>::vertex_descriptor orig_v = graph[v];
     typename boost::graph_traits<Graph>::degree_size_type deg = degree(v, graph);
-    if ((deg != 0 && is_terminal(orig_v, orig)) || deg > 2)
+    if (deg != 2 || is_terminal(orig_v, orig))
       {
         out_edge_iterator b, e;
         boost::tie(b, e) = out_edges(v, graph);


### PR DESCRIPTION
I was surprised by the former implementation as from the doc (and my memory) the functor should be called only on degree 2 nodes. Degree 0 nodes have to be terminal.