### PR TITLE
Mesh 2 and Kernel - add predicate oriented_side_2(segment, triangle)

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -4268,6 +4268,8 @@ namespace CartesianKernelFunctors {
     typedef typename K::Circle_2       Circle_2;
     typedef typename K::Line_2         Line_2;
     typedef typename K::Triangle_2     Triangle_2;
+    typedef typename K::Segment_2      Segment_2;
+    typedef typename K::FT             FT;
   public:
     typedef typename K::Oriented_side  result_type;
 
@@ -4303,6 +4305,36 @@ namespace CartesianKernelFunctors {
          && collinear_are_ordered_along_line(t.vertex(2), p, t.vertex(3)))
         ? result_type(ON_ORIENTED_BOUNDARY)
         : opposite(ot);
+    }
+
+    result_type
+    operator()(const Segment_2& s, const Triangle_2& t) const
+    {
+      typename K::Construct_source_2 source;
+      typename K::Construct_target_2 target;
+      const Point_2 a = source(s);
+      const Point_2 b = target(s);
+      const FT dX = b.x() - a.x();
+      const FT dY = b.y() - a.y();
+
+      const Point_2& p0 = t[0];
+      const Point_2& p1 = t[1];
+      const Point_2& p2 = t[2];
+      const FT R0 = p0.x() * p0.x() + p0.y() * p0.y();
+      const FT R1 = p1.x() * p1.x() + p1.y() * p1.y();
+      const FT R2 = p2.x() * p2.x() + p2.y() * p2.y();
+      const FT denominator = (p1.x() - p0.x()) * (p2.y() - p0.y()) +
+                             (p0.x() - p2.x()) * (p1.y() - p0.y());
+      const FT det = 2 * denominator * (a.x() * dY - a.y() * dX)
+                       - (R2 - R1) * (p0.x() * dX + p0.y() * dY)
+                       - (R0 - R2) * (p1.x() * dX + p1.y() * dY)
+                       - (R1 - R0) * (p2.x() * dX + p2.y() * dY);
+      if (det < 0)
+        return CGAL::ON_NEGATIVE_SIDE;
+      else if (det == 0.)
+        return CGAL::ON_ORIENTED_BOUNDARY;
+      else
+        return CGAL::ON_POSITIVE_SIDE;
     }
   };
 

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
@@ -4670,6 +4670,7 @@ namespace HomogeneousKernelFunctors {
     typedef typename K::Circle_2       Circle_2;
     typedef typename K::Line_2         Line_2;
     typedef typename K::Triangle_2     Triangle_2;
+    typedef typename K::Segment_2      Segment_2;
   public:
     typedef typename K::Oriented_side  result_type;
 
@@ -4708,6 +4709,33 @@ namespace HomogeneousKernelFunctors {
          && collinear_are_ordered_along_line(t.vertex(2), p, t.vertex(3)))
         ? ON_ORIENTED_BOUNDARY
         : -ot;
+    }
+
+    result_type
+    operator()(const Segment_2& s, const Triangle_2& t) const
+    {
+      typename K::Construct_source_2 source;
+      typename K::Construct_target_2 target;
+      typename K::Construct_circumcenter_2 circumcenter;
+      typename K::Orientation_2 orientation;
+
+      const Point_2 a = source(s);
+      const Point_2 b = target(s);
+      const Point_2 cc = circumcenter(t);
+
+      CGAL::Orientation o_abc = orientation(a, b, cc);
+      if (o_abc == CGAL::COLLINEAR)
+        return CGAL::ON_ORIENTED_BOUNDARY;
+
+      CGAL::Orientation o_abt = orientation(a, b, t[0]);
+      if (o_abt == CGAL::COLLINEAR)
+        o_abt = orientation(a, b, t[1]);
+      if (o_abt == CGAL::COLLINEAR)
+        o_abt = orientation(a, b, t[2]);
+      CGAL_assertion(o_abt != CGAL::COLLINEAR);
+
+      if (o_abc == o_abt) return CGAL::ON_POSITIVE_SIDE;
+      else                return CGAL::ON_NEGATIVE_SIDE;
     }
   };
 

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -9258,6 +9258,15 @@ public:
   Oriented_side operator()(const Kernel::Triangle_2&t,
                            const Kernel::Point_2&p);
 
+  /*!
+  * returns \ref CGAL::ON_ORIENTED_BOUNDARY,
+  * \ref CGAL::ON_NEGATIVE_SIDE, or the constant \ref CGAL::ON_POSITIVE_SIDE,
+  * depending on the position of the circumcenter of `t` relative
+  * to the oriented supporting line of `s`.
+  */
+  Oriented_side operator()(const Kernel::Segment_2& s,
+                           const Kernel::Triangle_2& t);
+
   /// @}
 
 }; /* end Kernel::OrientedSide_2 */

--- a/Mesh_2/doc/Mesh_2/Concepts/ConformingDelaunayTriangulationTraits_2.h
+++ b/Mesh_2/doc/Mesh_2/Concepts/ConformingDelaunayTriangulationTraits_2.h
@@ -92,6 +92,16 @@ points `p`, `q`, `r` (`q` being the vertex of the angle).
 */
 typedef unspecified_type Angle_2;
 
+/*!
+Predicate object. Must provide the operator
+`CGAL::Oriented_side operator()(Segment_2 s, Triangle_2 t)` that
+returns \ref ON_ORIENTED_BOUNDARY, \ref ON_NEGATIVE_SIDE,
+or \ref ON_POSITIVE_SIDE,
+depending on the position of the circumcenter of `t` relative
+to the oriented supporting line of `s`.
+*/
+typedef unspecified_type Oriented_side_2;
+
 /// @}
 
 

--- a/Mesh_2/include/CGAL/Constrained_voronoi_diagram_2.h
+++ b/Mesh_2/include/CGAL/Constrained_voronoi_diagram_2.h
@@ -242,25 +242,9 @@ private:
   bool segment_hides_circumcenter(const Segment& seg,
                                   const Triangle& tr)
   {
-    Point a = seg.source();
-    Point b = seg.target();
-    double dX = b.x() - a.x();
-    double dY = b.y() - a.y();
-
-    const Point& p0 = tr[0];
-    const Point& p1 = tr[1];
-    const Point& p2 = tr[2];
-    double R0 = p0.x()*p0.x() + p0.y()*p0.y();
-    double R1 = p1.x()*p1.x() + p1.y()*p1.y();
-    double R2 = p2.x()*p2.x() + p2.y()*p2.y();
-    double denominator = (p1.x()-p0.x())*(p2.y()-p0.y()) +
-                                   (p0.x()-p2.x())*(p1.y()-p0.y());
-
-    double det = 2*denominator * (a.x()*dY - a.y()*dX)
-                    - (R2-R1) * (p0.x()*dX + p0.y()*dY)
-                    - (R0-R2) * (p1.x()*dX + p1.y()*dY)
-                    - (R1-R0) * (p2.x()*dX + p2.y()*dY);
-    return (det <= 0);
+    typename Geom_traits::Oriented_side_2 os
+      = m_cdt.geom_traits().oriented_side_2_object();
+    return (os(seg, tr) != CGAL::ON_POSITIVE_SIDE);
   }
 
   // tags with their sights, with respect to the Edge constraint,

--- a/Mesh_2/include/CGAL/Mesh_2/Mesh_global_optimizer_2.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Mesh_global_optimizer_2.h
@@ -352,7 +352,7 @@ private:
       sum += CGAL::sqrt(*it);
 
 #ifdef CGAL_MESH_2_OPTIMIZER_VERBOSE
-    sum_moves_ = sum/big_moves_.size();
+    sum_moves_ = sum/FT(big_moves_.size());
 #endif
 
     return ( sum/FT(big_moves_.size()) < convergence_ratio_ );

--- a/Mesh_2/include/CGAL/Mesh_2/Mesh_sizing_field.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Mesh_sizing_field.h
@@ -169,7 +169,7 @@ private:
     typename Tr::Edge_circulator end = ec;
 
     FT sum_len(0.);
-    FT nb = 0.;
+    unsigned int nb = 0;
     do
     {
       Edge e = *ec;
@@ -187,7 +187,7 @@ private:
     while(++ec != end);
     // nb == 0 could happen if there is an isolated point.
     if( 0 != nb )
-      return sum_len/nb;
+      return sum_len/FT(nb);
     else
      // Use outside faces to compute size of point
       return 1.;//todo


### PR DESCRIPTION
## Summary of Changes

This PR introduces a new predicate `Oriented_side_2 operator()(Segment_2 s, Triangle_2 t)` that checks on which side of the oriented supporting line of `s` is the circumcenter of `t`.
Lloyd for Mesh_2 can hence benefit of a new filtered predicate.

## Release Management

* Affected package(s): Mesh_2, Kernel
* Issue(s) solved (if any): fix #5627
* Feature/Small Feature (if any): todo
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: unchanged

