### PR TITLE
VD_2: Make Handle_adaptor a model of Handle

### DIFF
--- a/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Handle_adaptor.h
+++ b/Voronoi_diagram_2/include/CGAL/Voronoi_diagram_2/Handle_adaptor.h
@@ -33,6 +33,8 @@ class Handle_adaptor
   typedef T&     reference;
   typedef const T*  const_pointer;
   typedef const T&  const_reference;
+  typedef void iterator_category;
+  typedef std::ptrdiff_t difference_type;
 
  public:
   Handle_adaptor() : t() {}


### PR DESCRIPTION
## Summary of Changes

Make `CGAL::VoronoiDiagram_2::Internal::Handle_adaptor<T>` a model of `Handle`. Fix issue #5961.


## Release Management

* Affected package(s): Voronoi_diagram_2
* Issue(s) solved (if any): fix #5961
* License and copyright ownership: N/A
