### PR TITLE
Filter the needle/cap predicates of PMP::shape_predicates.h

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/shape_predicates.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/shape_predicates.h
@@ -22,10 +22,15 @@
 #include <CGAL/array.h>
 #include <CGAL/boost/graph/iterator.h>
 #include <CGAL/boost/graph/helpers.h>
+#include <CGAL/Cartesian_converter.h>
+#include <CGAL/Exact_kernel_selector.h>
+#include <CGAL/Filtered_predicate.h>
+#include <CGAL/Simple_cartesian.h>
 
 #include <boost/range/has_range_iterator.hpp>
 #include <boost/graph/graph_traits.hpp>
 
+#include <array>
 #include <limits>
 #include <map>
 #include <utility>
@@ -319,6 +324,87 @@ OutputIterator degenerate_faces(const TriangleMesh& tm, OutputIterator out)
   return degenerate_faces(faces(tm), tm, out, CGAL::parameters::all_default());
 }
 
+namespace internal {
+
+template <typename K, template <class Kernel> class Pred>
+struct Get_filtered_predicate_RT
+{
+  typedef typename Exact_kernel_selector<K>::Exact_kernel_rt                   Exact_kernel_rt;
+  typedef typename Exact_kernel_selector<K>::C2E_rt                            C2E_rt;
+  typedef Simple_cartesian<Interval_nt_advanced>                               Approximate_kernel;
+  typedef Cartesian_converter<K, Approximate_kernel>                           C2F;
+
+  typedef Filtered_predicate<Pred<Exact_kernel_rt>,
+                             Pred<Approximate_kernel>,
+                             C2E_rt, C2F> type;
+};
+
+// predicates
+
+template <typename K>
+struct Is_edge_length_ratio_over_threshold_impl
+{
+  typedef int result_type;
+
+  /// Computes the ratio between the longest edge's length and the shortest edge's length
+  /// and compares with a user-defined bound.
+  /// Returns -1 if the ratio is below the bound, and 0, 1, or 2 otherwise, with the value
+  /// indicating the shortest halfedge.
+  int operator()(const typename K::Point_3& p,
+                 const typename K::Point_3& q,
+                 const typename K::Point_3& r,
+                 const typename K::FT threshold_squared) const
+  {
+    typedef typename K::FT                                                     FT;
+
+    FT sq_length_0 = K().compute_squared_distance_3_object()(p, q);
+
+    FT min_sq_length = sq_length_0, max_sq_length = sq_length_0;
+    int min_id = 0;
+
+    auto get_min_max = [&](const typename K::Point_3& pa, const typename K::Point_3& pb, int id) -> void
+    {
+      const FT sq_length = K().compute_squared_distance_3_object()(pa, pb);
+
+      if(max_sq_length < sq_length)
+        max_sq_length = sq_length;
+
+      if(sq_length < min_sq_length)
+      {
+        min_sq_length = sq_length;
+        min_id = id;
+      }
+    };
+
+    get_min_max(q, r, 1);
+    get_min_max(r, p, 2);
+
+    if(min_sq_length == 0)
+      return min_id;
+
+    if(compare(max_sq_length, threshold_squared * min_sq_length) != CGAL::SMALLER)
+      return min_id;
+    else
+      return -1;
+  }
+};
+
+template<typename K, bool has_filtered_predicates = K::Has_filtered_predicates>
+struct Is_edge_length_ratio_over_threshold
+  : public Is_edge_length_ratio_over_threshold_impl<K>
+{
+  using Is_edge_length_ratio_over_threshold_impl<K>::operator();
+};
+
+template<typename K>
+struct Is_edge_length_ratio_over_threshold<K, true>
+  : public Get_filtered_predicate_RT<K, Is_edge_length_ratio_over_threshold_impl>::type
+{
+  using Get_filtered_predicate_RT<K, Is_edge_length_ratio_over_threshold_impl>::type::operator();
+};
+
+} // namespace internal
+
 /// \ingroup PMP_repairing_grp
 /// checks whether a triangle face is needle.
 /// A triangle is said to be a <i>needle</i> if its longest edge is much longer than its shortest edge.
@@ -364,55 +450,31 @@ is_needle_triangle_face(typename boost::graph_traits<TriangleMesh>::face_descrip
   using parameters::get_parameter;
   using parameters::choose_parameter;
 
-  typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor   halfedge_descriptor;
+  typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor       halfedge_descriptor;
 
   typedef typename GetVertexPointMap<TriangleMesh, NamedParameters>::const_type VertexPointMap;
   VertexPointMap vpmap = choose_parameter(get_parameter(np, internal_np::vertex_point),
                                           get_const_property_map(vertex_point, tm));
 
-  typedef typename GetGeomTraits<TriangleMesh, NamedParameters>::type       Traits;
-  Traits traits = choose_parameter<Traits>(get_parameter(np, internal_np::geom_traits));
+  typedef typename GetGeomTraits<TriangleMesh, NamedParameters>::type           Traits;
+  Traits traits = choose_parameter<Traits>(get_parameter(np, internal_np::geom_traits)); // @fixme lost
 
-  typedef typename Traits::FT                                               FT;
+  const halfedge_descriptor h = halfedge(f, tm);
 
-  CGAL::Halfedge_around_face_iterator<TriangleMesh> hit, hend;
-  boost::tie(hit, hend) = CGAL::halfedges_around_face(halfedge(f, tm), tm);
-  CGAL_precondition(std::distance(hit, hend) == 3);
+  internal::Is_edge_length_ratio_over_threshold<Traits> pred;
+  const int res = pred(get(vpmap, source(h, tm)),
+                       get(vpmap, target(h, tm)),
+                       get(vpmap, target(next(h, tm), tm)),
+                       square(threshold));
 
-  const halfedge_descriptor h0 = *hit++;
-  FT sq_length = traits.compute_squared_distance_3_object()(get(vpmap, source(h0, tm)),
-                                                            get(vpmap, target(h0, tm)));
-
-  FT min_sq_length = sq_length, max_sq_length = sq_length;
-  halfedge_descriptor min_h = h0;
-
-  for(; hit!=hend; ++hit)
-  {
-    const halfedge_descriptor h = *hit;
-    sq_length = traits.compute_squared_distance_3_object()(get(vpmap, source(h, tm)),
-                                                           get(vpmap, target(h, tm)));
-
-    if(max_sq_length < sq_length)
-      max_sq_length = sq_length;
-
-    if(min_sq_length > sq_length)
-    {
-      min_h = h;
-      min_sq_length = sq_length;
-    }
-  }
-
-  if(min_sq_length == 0)
-    return min_h;
-
-  const FT sq_threshold = square(FT(threshold));
-  if(max_sq_length / min_sq_length >= sq_threshold)
-  {
-    CGAL_assertion(min_h != boost::graph_traits<TriangleMesh>::null_halfedge());
-    return min_h;
-  }
-  else
+  if(res == -1)
     return boost::graph_traits<TriangleMesh>::null_halfedge();
+  if(res == 0)
+    return h;
+  if(res == 1)
+    return next(h, tm);
+  else
+    return prev(h, tm);
 }
 
 template <typename TriangleMesh>
@@ -423,6 +485,78 @@ is_needle_triangle_face(typename boost::graph_traits<TriangleMesh>::face_descrip
 {
   return is_needle_triangle_face(f, tm, threshold, parameters::all_default());
 }
+
+namespace internal {
+
+template <typename K>
+struct Is_cap_angle_over_threshold_impl
+{
+  typedef int result_type;
+
+  /// Computes the ratio between the longest edge's length and the shortest edge's length
+  /// and compares with a user-defined bound.
+  /// Returns -1 if the ratio is below the bound, and 0, 1, or 2 otherwise, with the value
+  /// indicating the shortest halfedge.
+  int operator()(const typename K::Point_3& p,
+                 const typename K::Point_3& q,
+                 const typename K::Point_3& r,
+                 const typename K::FT threshold_squared) const
+  {
+    typedef typename K::FT                                                     FT;
+    typedef typename K::Vector_3                                               Vector_3;
+
+    std::array<FT, 3> sq_lengths = { K().compute_squared_distance_3_object()(p, q),
+                                     K().compute_squared_distance_3_object()(q, r),
+                                     K().compute_squared_distance_3_object()(r, p) };
+
+    // If even one edge is degenerate, it cannot be a cap
+    if(is_zero(sq_lengths[0]) || is_zero(sq_lengths[1]) || is_zero(sq_lengths[2]))
+      return -1;
+
+    auto handle_triplet = [&](const typename K::Point_3& pa,
+                              const typename K::Point_3& pb,
+                              const typename K::Point_3& pc, int pos) -> bool
+    {
+      const Vector_3 vc = K().construct_vector_3_object()(pb, pc);
+      const Vector_3 va = K().construct_vector_3_object()(pb, pa);
+      const FT dot_ca = K().compute_scalar_product_3_object()(vc, va);
+      const bool neg_sp = !(is_positive(dot_ca));
+      if(!neg_sp)
+        return false;
+
+      const FT sq_c = sq_lengths[(pos+1)%3];
+      const FT sq_a = sq_lengths[pos];
+
+      return (compare(square(dot_ca), threshold_squared * sq_c * sq_a) != CGAL::SMALLER);
+    };
+
+    // halfedge 0 is between p and q, so cap at q => return halfedge 2 (r to p)
+    if(handle_triplet(p, q, r, 0))
+      return 2;
+    if(handle_triplet(q, r, p, 1))
+      return 0;
+    if(handle_triplet(r, p, q, 2))
+      return 1;
+
+    return -1;
+  }
+};
+
+template<typename K, bool has_filtered_predicates = K::Has_filtered_predicates>
+struct Is_cap_angle_over_threshold
+  : public Is_cap_angle_over_threshold_impl<K>
+{
+  using Is_cap_angle_over_threshold_impl<K>::operator();
+};
+
+template<typename K>
+struct Is_cap_angle_over_threshold<K, true>
+  : public Get_filtered_predicate_RT<K, Is_cap_angle_over_threshold_impl>::type
+{
+  using Get_filtered_predicate_RT<K, Is_cap_angle_over_threshold_impl>::type::operator();
+};
+
+} // namespace internal
 
 /// \ingroup PMP_repairing_grp
 /// checks whether a triangle face is a cap.
@@ -485,43 +619,22 @@ is_cap_triangle_face(typename boost::graph_traits<TriangleMesh>::face_descriptor
   typedef typename Traits::FT                                               FT;
   typedef typename Traits::Vector_3                                         Vector_3;
 
-  const FT sq_threshold = square(FT(threshold));
-  const halfedge_descriptor h0 = halfedge(f, tm);
+  const halfedge_descriptor h = halfedge(f, tm);
 
-  std::array<FT, 3> sq_lengths;
-  int pos = 0;
-  for(halfedge_descriptor h : halfedges_around_face(h0, tm))
-  {
-    const FT sq_d = traits.compute_squared_distance_3_object()(get(vpmap, source(h, tm)),
-                                                               get(vpmap, target(h, tm)));
+  internal::Is_cap_angle_over_threshold<Traits> pred;
+  const int res = pred(get(vpmap, source(h, tm)),
+                       get(vpmap, target(h, tm)),
+                       get(vpmap, target(next(h, tm), tm)),
+                       square(threshold));
 
-    // If even one edge is degenerate, it cannot be a cap
-    if(sq_d == 0)
-      return boost::graph_traits<TriangleMesh>::null_halfedge();
-
-    sq_lengths[pos++] = sq_d;
-  }
-
-  pos = 0;
-  for(halfedge_descriptor h : halfedges_around_face(h0, tm))
-  {
-    const vertex_descriptor v0 = source(h, tm);
-    const vertex_descriptor v1 = target(h, tm);
-    const vertex_descriptor v2 = target(next(h, tm), tm);
-    const Vector_3 a = traits.construct_vector_3_object()(get(vpmap, v1), get(vpmap, v2));
-    const Vector_3 b = traits.construct_vector_3_object()(get(vpmap, v1), get(vpmap, v0));
-    const FT dot_ab = traits.compute_scalar_product_3_object()(a, b);
-    const bool neg_sp = (dot_ab <= 0);
-    const FT sq_a = sq_lengths[(pos+1)%3];
-    const FT sq_b = sq_lengths[pos];
-    const FT sq_cos = dot_ab * dot_ab / (sq_a * sq_b);
-
-    if(neg_sp && sq_cos >= sq_threshold)
-      return prev(h, tm);
-
-    ++pos;
-  }
-  return boost::graph_traits<TriangleMesh>::null_halfedge();
+  if(res == -1)
+    return boost::graph_traits<TriangleMesh>::null_halfedge();
+  if(res == 0)
+    return h;
+  if(res == 1)
+    return next(h, tm);
+  else
+    return prev(h, tm);
 }
 
 template <typename TriangleMesh>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_shape_predicates.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_shape_predicates.cpp
@@ -99,13 +99,17 @@ void test_needles_and_caps(const char* fname)
   res = PMP::is_needle_triangle_face(f, mesh, 20);
   assert(res == boost::graph_traits<Surface_mesh>::null_halfedge());
   res = PMP::is_needle_triangle_face(f, mesh, 10 * CGAL::sqrt(FT(2) - eps));
+  assert(res != boost::graph_traits<Surface_mesh>::null_halfedge());
   assert(mesh.point(target(res, mesh)) == Point_3(1,0,1));
   res = PMP::is_needle_triangle_face(f, mesh, 1);
+  assert(res != boost::graph_traits<Surface_mesh>::null_halfedge());
   assert(mesh.point(target(res, mesh)) == Point_3(1,0,1));
 
   res = PMP::is_cap_triangle_face(f, mesh, 0./*cos(pi/2)*/);
+  assert(res != boost::graph_traits<Surface_mesh>::null_halfedge());
   assert(mesh.point(target(res, mesh)) == Point_3(0,0,1));
   res = PMP::is_cap_triangle_face(f, mesh, std::cos(2 * CGAL_PI / 3));
+  assert(res != boost::graph_traits<Surface_mesh>::null_halfedge());
   assert(mesh.point(target(res, mesh)) == Point_3(0,0,1));
   res = PMP::is_cap_triangle_face(f, mesh, std::cos(0.75 * CGAL_PI));
   assert(res == boost::graph_traits<Surface_mesh>::null_halfedge());
@@ -116,15 +120,17 @@ void test_needles_and_caps(const char* fname)
   res = PMP::is_needle_triangle_face(f, mesh, 2);
   assert(res == boost::graph_traits<Surface_mesh>::null_halfedge());
   res = PMP::is_needle_triangle_face(f, mesh, 1.9);
+  assert(res != boost::graph_traits<Surface_mesh>::null_halfedge());
   assert(mesh.point(target(res, mesh)) == Point_3(0,0,2) ||
          mesh.point(target(res, mesh)) == Point_3(1,0,2));
   res = PMP::is_needle_triangle_face(f, mesh, 1);
+  assert(res != boost::graph_traits<Surface_mesh>::null_halfedge());
   assert(mesh.point(target(res, mesh)) == Point_3(0,0,2) ||
          mesh.point(target(res, mesh)) == Point_3(1,0,2));
 
   res = PMP::is_cap_triangle_face(f, mesh, 0./*cos(pi/2)*/);
-  assert(res != boost::graph_traits<Surface_mesh>::null_halfedge() &&
-         mesh.point(target(res, mesh)) != Point_3(0,0,2) &&
+  assert(res != boost::graph_traits<Surface_mesh>::null_halfedge());
+  assert(mesh.point(target(res, mesh)) != Point_3(0,0,2) &&
          mesh.point(target(res, mesh)) != Point_3(1,0,2));
   res = PMP::is_cap_triangle_face(f, mesh, std::cos(2 * CGAL_PI / 3));
   assert(res != boost::graph_traits<Surface_mesh>::null_halfedge());


### PR DESCRIPTION
## Summary of Changes

- [ ] Fix the default construction of `Traits`?
- [ ] Square thresholds
- [ ] Get_filtered_predicate_RT somewhere in the kernel?

## Release Management

* Affected package(s):
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): - 
* License and copyright ownership: no change

