### PR TITLE
Deal with memset, memcpy, fscanf...    and their safe equivalents

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_counting_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_counting_traits_2.h
@@ -885,7 +885,7 @@ public:
 
   /*! Clean all operation counters */
   void clear_counters()
-  { memset(m_counters, 0, sizeof(m_counters)); }
+  { memset_s(m_counters, sizeof(m_counters), 0, sizeof(m_counters)); }
 
 private:
   /*! The operation counters */

--- a/Arrangement_on_surface_2/include/CGAL/Arr_counting_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_counting_traits_2.h
@@ -27,6 +27,7 @@
 #include <iostream>
 #include <string.h>
 #include <atomic>
+#include <array>
 
 #include <CGAL/basic.h>
 #include <CGAL/Arr_enums.h>
@@ -885,11 +886,11 @@ public:
 
   /*! Clean all operation counters */
   void clear_counters()
-  { memset_s(m_counters, sizeof(m_counters), 0, sizeof(m_counters)); }
+  { m_counters = {}; }
 
 private:
   /*! The operation counters */
-  mutable size_t m_counters[NUMBER_OF_OPERATIONS];
+  mutable std::array<size_t, NUMBER_OF_OPERATIONS> m_counters;
 };
 
 template <typename Out_stream, class Base_traits>

--- a/Arrangement_on_surface_2/include/CGAL/IO/Fig_stream.h
+++ b/Arrangement_on_surface_2/include/CGAL/IO/Fig_stream.h
@@ -754,9 +754,9 @@ public:
 
     std::stringstream out;
     out << "0x"  << std::hex
-	<< std::setfill('0') << std::setw(2) << r
-	<< std::setfill('0') << std::setw(2) << g
-	<< std::setfill('0') << std::setw(2) << b;
+        << std::setfill('0') << std::setw(2) << r
+        << std::setfill('0') << std::setw(2) << g
+        << std::setfill('0') << std::setw(2) << b;
 
     // Write the color to the FIG file.
     _ofile << "0 "                        // Desginates a color pseudo-object.
@@ -1704,7 +1704,6 @@ protected:
     _ofile << ' ' << ix << ' ' << iy << ' ';
 
     // Write the text.
-    char    oct[10];
     int     i;
 
     for (i = 0; i < len_text; i++)
@@ -1716,9 +1715,11 @@ protected:
       }
       else
       {
-        // Convert the current character to an octal string and write it.
-        sprintf (oct, "\\%03o", text[i]);
-        _ofile << oct;
+        // Convert the current character to an octal string and write
+        // it.
+        std::stringstream out;
+        out << "\\" << std::setfill('0') << std::setw(3) << std::oct << text[i];
+        _ofile << out.str();
       }
     }
 

--- a/Arrangement_on_surface_2/include/CGAL/IO/Fig_stream.h
+++ b/Arrangement_on_surface_2/include/CGAL/IO/Fig_stream.h
@@ -20,6 +20,7 @@
 
 #include <vector>
 #include <fstream>
+#include <sstream>
 #include <cstdio>
 
 namespace CGAL {
@@ -750,14 +751,17 @@ public:
       return;
 
     // Prepare a string desribing the color.
-    char    color_desc [10];
 
-    sprintf ("#%02x%02x%02x", r, g, b);
+    std::stringstream out;
+    out << "0x"  << std::hex
+	<< std::setfill('0') << std::setw(2) << r
+	<< std::setfill('0') << std::setw(2) << g
+	<< std::setfill('0') << std::setw(2) << b;
 
     // Write the color to the FIG file.
     _ofile << "0 "                        // Desginates a color pseudo-object.
            << static_cast<int>(color) << ' '
-           << color_desc << std::endl;
+           << out.str() << std::endl;
 
     // Mark that the color is now defined.
     colors[static_cast<int>(color)] = true;

--- a/CGAL_Core/include/CGAL/CORE/BigFloat_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/BigFloat_impl.h
@@ -39,6 +39,7 @@
 
 #include <CGAL/disable_warnings.h>
 
+#include <string>
 #include <ctype.h>
 #include <CGAL/CORE/BigFloat.h>
 #include <CGAL/CORE/Expr.h>
@@ -1057,8 +1058,8 @@ void BigFloatRep :: fromString(const char *str, extLong prec ) {
 CGAL_INLINE_FUNCTION
 std::istream& BigFloatRep :: operator >>(std::istream& i) {
   int size = 20;
-  char *str = new char[size];
-  char *p = str;
+  std::string str;
+  str.reserve(size);
   char c;
   int d = 0, e = 0, s = 0;
   // d=1 means dot is found
@@ -1078,14 +1079,13 @@ std::istream& BigFloatRep :: operator >>(std::istream& i) {
   // Chen Li, "if (c == EOF)" is unsafe since c is of char type and
   // EOF is of int tyep with a negative value -1
   if (i.eof()) {
-    delete [] str;
     i.clear(std::ios::eofbit | std::ios::failbit);
     return i;
   }
 
   // the current content in "c" should be the first non-whitespace char
   if (c == '-' || c == '+') {
-    *p++ = c;
+    str += c;
     i.get(c);
   }
 
@@ -1097,19 +1097,8 @@ std::istream& BigFloatRep :: operator >>(std::istream& i) {
     //  xxxx.xxxe+xxx.xxx:
     if (e && (c == '.'))
       break;
-    if (p - str == size) {
-      char *t = str;
-      str = new char[size*2];
-      memcpy(str, t, size);
-      delete [] t;
-      p = str + size;
-      size *= 2;
-    }
-#ifdef CGAL_CORE_DEBUG
-    CGAL_assertion((p-str) < size);
-#endif
 
-    *p++ = c;
+    str += c;
     if (c == '.')
       d = 1;
     // Chen Li: fix a bug -- the sign of exponent can not happen before
@@ -1121,24 +1110,8 @@ std::istream& BigFloatRep :: operator >>(std::istream& i) {
       e = 1;
   }
 
-  // chenli: make sure that the p is still in the range
-  if (p - str >= size) {
-    std::size_t len = p - str;
-    char *t = str;
-    str = new char[len + 1];
-    memcpy(str, t, len);
-    delete [] t;
-    p = str + len;
-  }
-
-#ifdef CGAL_CORE_DEBUG
-  CGAL_assertion(p - str < size);
-#endif
-
-  *p = '\0';
   i.putback(c);
-  fromString(str);
-  delete [] str;
+  fromString(str.c_str());
   return i;
 }//operator >>
 

--- a/CGAL_Core/include/CGAL/CORE/CoreAux_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/CoreAux_impl.h
@@ -176,7 +176,6 @@ void core_error(std::string msg, std::string file, int lineno, bool err) {
      << msg << std::endl;
   outFile.close();
   if (err) {
-     char buf[65];
      std::cerr << (std::string("CORE ERROR") + " (file " + file + ", line "
                    + std::to_string(lineno) +"):" + msg + "\n").c_str();
      std::exit(1); //Note: do not call abort()

--- a/CGAL_Core/include/CGAL/CORE/CoreAux_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/CoreAux_impl.h
@@ -139,27 +139,6 @@ long gcd(long m, long n) {
   return p;
 }
 
-// char* core_itoa(int n, char* buffer, int buffer_size)
-//      returns a pointer to the null-terminated string in buffer
-// NOTES:
-// 0. Buffer size should be 17 bytes (resp., 33 bytes, 65 bytes) on 16-bit
-//      (resp., 32-bit, 64-bit) machines.  Formula: 1+sizeof(int)*8 bytes.
-// 1. itoa(...) is available on some stdlib.h, but it is
-//      not defined by ANSI-C and so not all compilers support it.
-// 2. Our use of sprintf(...) to do the job is known to
-//      be inefficient, but this is hardly critical for our usage.
-// 3. A more general program should take a 3rd argument (the radix of
-//      output number).  We assume radix 10.
-CGAL_INLINE_FUNCTION
-char * core_itoa(int n, char* buffer, int buffer_size) {
-#if   defined(_MSC_VER)
-  sprintf_s(buffer, buffer_size, "%d", n);
-#else
-  CGAL_USE(buffer_size);
-  std::sprintf(buffer, "%d", n);
-#endif
-        return buffer;
-}
 
 /// implements the "integer mantissa" function
 //      (See CORE_PATH/progs/ieee/frexp.cpp for details)
@@ -198,10 +177,8 @@ void core_error(std::string msg, std::string file, int lineno, bool err) {
   outFile.close();
   if (err) {
      char buf[65];
-     // perror((std::string("CORE ERROR") + " (file " + file + ", line "
-     //        + core_itoa(lineno,buf, 65) +"):" + msg + "\n").c_str());
      std::cerr << (std::string("CORE ERROR") + " (file " + file + ", line "
-                   + core_itoa(lineno,buf, 65) +"):" + msg + "\n").c_str();
+                   + std::to_string(lineno) +"):" + msg + "\n").c_str();
      std::exit(1); //Note: do not call abort()
   }
 }

--- a/CGAL_Core/include/CGAL/CORE/Real_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Real_impl.h
@@ -33,6 +33,7 @@
 
 #include <CGAL/disable_warnings.h>
 
+#include <string>
 #include <ctype.h>
 #include <CGAL/CORE/Real.h>
 #include <CGAL/tss.h>
@@ -189,8 +190,9 @@ void Real::constructFromString(const char *str, const extLong& prec )
 CGAL_INLINE_FUNCTION
 std::istream& operator >>(std::istream& i, Real& x) {
   int size = 20;
-  char *str = new char[size];
-  char *p = str;
+  std::string str;
+  str.reserve(size);
+
   char c;
   int d = 0, e = 0, s = 0;
   //  int done = 0;
@@ -211,13 +213,12 @@ std::istream& operator >>(std::istream& i, Real& x) {
 
   if (i.eof()) {
     i.clear(std::ios::eofbit | std::ios::failbit);
-    delete [] str;
     return i;
   }
 
   // the current content in "c" should be the first non-whitespace char
   if (c == '-' || c == '+') {
-    *p++ = c;
+    str += c;
     i.get(c);
   }
 
@@ -230,19 +231,9 @@ std::istream& operator >>(std::istream& i, Real& x) {
     //  xxxx.xxxe+xxx.xxx:
     if (e && (c == '.'))
       break;
-    if (p - str == size) {
-      char *t = str;
-      str = new char[size*2];
-      std::memcpy(str, t, size);
-      delete [] t;
-      p = str + size;
-      size *= 2;
-    }
-#ifdef CORE_DEBUG
-    CGAL_assertion((p-str) < size);
-#endif
 
-    *p++ = c;
+    str += c;
+
     if (c == '.')
       d = 1;
     // Chen Li: fix a bug -- the sign of exponent can not happen before
@@ -255,29 +246,13 @@ std::istream& operator >>(std::istream& i, Real& x) {
   }
 
   if (!i && !i.eof()) {
-    delete [] str;
     return i;
   }
-  // chenli: make sure that the p is still in the range
-  if (p - str >= size) {
-    std::ptrdiff_t len = p - str;
-    char *t = str;
-    str = new char[len + 1];
-    std::memcpy(str, t, len);
-    delete [] t;
-    p = str + len;
-  }
 
-#ifdef CORE_DEBUG
-  CGAL_assertion(p - str < size);
-#endif
-
-  *p = '\0';
   i.putback(c);
   i.clear();
   // old: x = Real(str, i.precision()); // use precision of input stream.
-  x = Real(str);  // default precision = get_static_defInputDigits()
-  delete [] str;
+  x = Real(str.c_str());  // default precision = get_static_defInputDigits()
   return i;
 }//operator >> (std::istream&, Real&)
 

--- a/Cone_spanners_2/include/CGAL/Cone_spanners_2/Plane_scan_tree_impl.h
+++ b/Cone_spanners_2/include/CGAL/Cone_spanners_2/Plane_scan_tree_impl.h
@@ -20,7 +20,7 @@
 
 #include <CGAL/license/Cone_spanners_2.h>
 
-
+#include <array>
 #include <stdexcept>
 
 namespace CGAL {
@@ -134,9 +134,8 @@ public:
     _Leaf (const key_compare& less, const value_compare& vless, tree_type *const t,
            _leaf_type *const prev = nullptr,
            _leaf_type *const next = nullptr)
-        : _node_type (less, vless, t), prev (prev), next (next) {
-        std::memset (values, 0, 2*sizeof(value_type*));
-    }
+      : _node_type (less, vless, t), values({nullptr,nullptr}), prev (prev), next (next)
+    {}
 
     /* Destructor.
      * Frees memory used for storing key-value pair, thus invalidating any
@@ -242,7 +241,7 @@ protected:
 
 private:
     /* Key-value pairs */
-    value_type* values[2];
+  std::array<value_type*,2> values;
 
     /* Linked list structure of the B+ tree */
     _leaf_type* prev;
@@ -268,11 +267,8 @@ public:
     typedef typename _node_type::tree_type      tree_type;
 
     _Internal (const Comp& less, const VComp& vless, tree_type *const t)
-        : _node_type(less, vless, t) {
-        std::memset (keys, 0, 2*sizeof(key_type*));
-        std::memset (children, 0, 3*sizeof(_node_type*));
-        std::memset (vMin, 0, 3*sizeof(mapped_type*));
-    }
+      : _node_type(less, vless, t), keys({nullptr, nullptr}), children({nullptr, nullptr, nullptr}), vMin({nullptr, nullptr, nullptr})
+    {}
 
     virtual ~_Internal() {
         keys[0] = nullptr;
@@ -492,9 +488,9 @@ protected:
     }
 
 private:
-    const key_type* keys[2];
-    _node_type* children[3];
-    const mapped_type* vMin[3];
+  std::array<const key_type*, 2> keys;
+  std::array< _node_type*, 3> children;
+  std::array<const mapped_type*, 3> vMin;
 };
 
 template <typename Key, typename T, typename Comp, typename VComp >

--- a/Nef_3/include/CGAL/Nef_3/OGL_helper.h
+++ b/Nef_3/include/CGAL/Nef_3/OGL_helper.h
@@ -22,6 +22,7 @@
 #include <qgl.h>
 #include <CGAL/glu.h>
 #include <cstdlib>
+#include <iostream>
 
 #define CGAL_NEF3_MARKED_VERTEX_COLOR 183,232,92
 #define CGAL_NEF3_MARKED_EDGE_COLOR 171,216,86
@@ -226,7 +227,7 @@ namespace OGL {
   inline void CGAL_GLU_TESS_CALLBACK errorCallback(GLenum errorCode)
   { const GLubyte *estring;
     estring = gluErrorString(errorCode);
-    fprintf(stderr, "Tessellation Error: %s\n", estring);
+    std::cerr << "Tessellation Error: " << estring << std::endl;
     std::exit (0);
   }
 

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -248,6 +248,8 @@ inline __m128d IA_opacify128(__m128d x)
 #  ifdef _MSC_VER
   // With VS, __m128d is a union, where volatile doesn't disappear automatically
   // However, this version generates wrong code with clang, check before enabling it for more compilers.
+  // The usage here is safe as we write from a __m128d to a __m128d
+  // and we know that this type has 16 bytes
   std::memcpy(&x, (void*)&e, 16);
   return x;
 #  else

--- a/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
@@ -184,7 +184,7 @@ jet_estimate_normals(
   using parameters::choose_parameter;
   using parameters::get_parameter;
 
-  CGAL_TRACE("Calls jet_estimate_normals()\n");
+  CGAL_TRACE_STREAM << "Calls jet_estimate_normals()\n";
 
   // basic geometric types
   typedef typename PointRange::iterator iterator;
@@ -221,13 +221,15 @@ jet_estimate_normals(
   // precondition: at least 2 nearest neighbors
   CGAL_point_set_processing_precondition(k >= 2 || neighbor_radius > FT(0));
 
-  std::size_t memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-  CGAL_TRACE("  Creates KD-tree\n");
+  std::size_t memory = CGAL::Memory_sizer().virtual_size();
+  CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+  CGAL_TRACE_STREAM << "  Creates KD-tree\n";
 
   Neighbor_query neighbor_query (points, point_map);
 
-  memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-  CGAL_TRACE("  Computes normals\n");
+  memory = CGAL::Memory_sizer().virtual_size();
+  CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+  CGAL_TRACE_STREAM << "  Computes normals\n";
 
   std::size_t nb_points = points.size();
 
@@ -251,8 +253,9 @@ jet_estimate_normals(
 
   callback_wrapper.join();
 
-  memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-  CGAL_TRACE("End of jet_estimate_normals()\n");
+  memory = CGAL::Memory_sizer().virtual_size();
+  CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+  CGAL_TRACE_STREAM << "End of jet_estimate_normals()\n";
 }
 
 

--- a/Point_set_processing_3/include/CGAL/mst_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/mst_orient_normals.h
@@ -245,7 +245,7 @@ mst_find_source(
     NormalMap normal_map, ///< property map: value_type of ForwardIterator -> Vector_3
     const Kernel& /*kernel*/)    ///< geometric traits.
 {
-    CGAL_TRACE("  mst_find_source()\n");
+  CGAL_TRACE_STREAM << "  mst_find_source()\n";
 
     // Input points types
     typedef typename boost::property_traits<NormalMap>::value_type Vector;
@@ -270,8 +270,8 @@ mst_find_source(
     Vector_ref normal = get(normal_map,*top_point);
     const Vector Z(0, 0, 1);
     if (Z * normal < 0) {
-      CGAL_TRACE("  Flip top point normal\n");
-    put(normal_map,*top_point, -normal);
+      CGAL_TRACE_STREAM << "  Flip top point normal\n";
+      put(normal_map,*top_point, -normal);
     }
 
     return top_point;
@@ -329,13 +329,15 @@ create_riemannian_graph(
     // Number of input points
     const std::size_t num_input_points = points.size();
 
-    std::size_t memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-    CGAL_TRACE("  Creates KD-tree\n");
+    std::size_t memory = CGAL::Memory_sizer().virtual_size();
+    CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+    CGAL_TRACE_STREAM << "  Creates KD-tree\n";
 
     Neighbor_query neighbor_query (points, point_map);
 
-    memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-    CGAL_TRACE("  Creates Riemannian Graph\n");
+    memory = CGAL::Memory_sizer().virtual_size();
+    CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+    CGAL_TRACE_STREAM << "  Creates Riemannian Graph\n";
 
     // Iterates over input points and creates Riemannian Graph:
     // - vertices are numbered like the input points index.
@@ -465,8 +467,9 @@ create_mst_graph(
     // Number of input points
     const std::size_t num_input_points = num_vertices(riemannian_graph) - 1;
 
-    std::size_t memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-    CGAL_TRACE("  Calls boost::prim_minimum_spanning_tree()\n");
+    std::size_t memory = CGAL::Memory_sizer().virtual_size();
+    CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+    CGAL_TRACE_STREAM << "  Calls boost::prim_minimum_spanning_tree()\n";
 
     // Computes Minimum Spanning Tree.
     std::size_t source_point_index = num_input_points;
@@ -478,8 +481,9 @@ create_mst_graph(
                                       weight_map( riemannian_graph_weight_map )
                                      .root_vertex( vertex(source_point_index, riemannian_graph) ));
 
-    memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-    CGAL_TRACE("  Creates MST Graph\n");
+    memory = CGAL::Memory_sizer().virtual_size();
+    CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+    CGAL_TRACE_STREAM << "  Creates MST Graph\n";
 
     // Converts predecessor map to a MST graph:
     // - vertices are numbered like the input points index.
@@ -605,7 +609,7 @@ mst_orient_normals(
     using parameters::choose_parameter;
     using parameters::get_parameter;
 
-    CGAL_TRACE("Calls mst_orient_normals()\n");
+    CGAL_TRACE_STREAM << "Calls mst_orient_normals()\n";
 
     typedef typename CGAL::GetPointMap<PointRange, NamedParameters>::type PointMap;
     typedef typename Point_set_processing_3::GetNormalMap<PointRange, NamedParameters>::type NormalMap;
@@ -643,8 +647,9 @@ mst_orient_normals(
     // Precondition: at least 2 nearest neighbors
     CGAL_point_set_processing_precondition(k >= 2);
 
-    std::size_t memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-    CGAL_TRACE("  Create Index_property_map\n");
+    std::size_t memory = CGAL::Memory_sizer().virtual_size();
+    CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+    CGAL_TRACE_STREAM << "  Create Index_property_map\n";
 
     // Create a property map Iterator -> index.
     // - if typename PointRange::iterator is a random access iterator (typically vector and deque),
@@ -686,8 +691,9 @@ mst_orient_normals(
                                            kernel,
                                            riemannian_graph);
 
-    memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-    CGAL_TRACE("  Calls boost::breadth_first_search()\n");
+    memory = CGAL::Memory_sizer().virtual_size();
+    CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+    CGAL_TRACE_STREAM << "  Calls boost::breadth_first_search()\n";
 
     const std::size_t num_input_points = distance(points.begin(), points.end());
     std::size_t source_point_index = num_input_points;
@@ -717,10 +723,11 @@ mst_orient_normals(
     std::copy(unoriented_points.begin(), unoriented_points.end(), first_unoriented_point);
 
     // At this stage, we have typically 0 unoriented normals if k is large enough
-    CGAL_TRACE("  => %u normals are unoriented\n", unoriented_points.size());
+    CGAL_TRACE_STREAM << "  => " << unoriented_points.size() << " normals are unoriented\n";
 
-    memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-    CGAL_TRACE("End of mst_orient_normals()\n");
+    memory = CGAL::Memory_sizer().virtual_size();
+    CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+    CGAL_TRACE_STREAM << "End of mst_orient_normals()\n";
 
     return first_unoriented_point;
 }

--- a/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
@@ -159,7 +159,7 @@ pca_estimate_normals(
   using parameters::choose_parameter;
   using parameters::get_parameter;
 
-  CGAL_TRACE("Calls pca_estimate_normals()\n");
+  CGAL_TRACE_STREAM << "Calls pca_estimate_normals()\n";
 
   // basic geometric types
   typedef typename CGAL::GetPointMap<PointRange, NamedParameters>::type PointMap;
@@ -192,13 +192,15 @@ pca_estimate_normals(
   // precondition: at least 2 nearest neighbors
   CGAL_point_set_processing_precondition(k >= 2);
 
-  std::size_t memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-  CGAL_TRACE("  Creates KD-tree\n");
+  std::size_t memory = CGAL::Memory_sizer().virtual_size();
+  CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+  CGAL_TRACE_STREAM << "  Creates KD-tree\n";
 
   Neighbor_query neighbor_query (points, point_map);
 
-  memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-  CGAL_TRACE("  Computes normals\n");
+  memory = CGAL::Memory_sizer().virtual_size();
+  CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+  CGAL_TRACE_STREAM << "  Computes normals\n";
 
   std::size_t nb_points = points.size();
 
@@ -223,8 +225,9 @@ pca_estimate_normals(
 
   callback_wrapper.join();
 
-  memory = CGAL::Memory_sizer().virtual_size(); CGAL_TRACE("  %ld Mb allocated\n", memory>>20);
-  CGAL_TRACE("End of pca_estimate_normals()\n");
+  memory = CGAL::Memory_sizer().virtual_size();
+  CGAL_TRACE_STREAM << (memory >> 20) << " Mb allocated\n";
+  CGAL_TRACE_STREAM << "End of pca_estimate_normals()\n";
 }
 
 /// \cond SKIP_IN_MANUAL

--- a/Poisson_surface_reconstruction_3/include/CGAL/Poisson_reconstruction_function.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/Poisson_reconstruction_function.h
@@ -770,7 +770,7 @@ private:
     SparseLinearAlgebraTraits_d solver, ///< sparse linear solver
     double lambda)
   {
-    CGAL_TRACE("Calls solve_poisson()\n");
+    CGAL_TRACE_STREAM << "Calls solve_poisson()\n";
 
     double time_init = clock();
 
@@ -786,7 +786,7 @@ private:
     m_tr->index_unconstrained_vertices();
     unsigned int nb_variables = static_cast<unsigned int>(m_tr->number_of_vertices()-1);
 
-    CGAL_TRACE("  Number of variables: %ld\n", (long)(nb_variables));
+    CGAL_TRACE_STREAM  << "  Number of variables: " <<  nb_variables << std::endl;
 
     // Assemble linear system A*X=B
     typename SparseLinearAlgebraTraits_d::Matrix A(nb_variables); // matrix is symmetric definite positive
@@ -815,9 +815,9 @@ private:
     clear_duals();
     clear_normals();
     duration_assembly = (clock() - time_init)/CLOCKS_PER_SEC;
-    CGAL_TRACE("  Creates matrix: done (%.2lf s)\n", duration_assembly);
+    CGAL_TRACE_STREAM << "  Creates matrix: done (" << duration_assembly << "sec.)\n";
 
-    CGAL_TRACE("  Solve sparse linear system...\n");
+    CGAL_TRACE_STREAM << "  Solve sparse linear system...\n";
 
     // Solve "A*X = B". On success, solution is (1/D) * X.
     time_init = clock();
@@ -827,7 +827,7 @@ private:
     CGAL_surface_reconstruction_points_assertion(D == 1.0);
     duration_solve = (clock() - time_init)/CLOCKS_PER_SEC;
 
-    CGAL_TRACE("  Solve sparse linear system: done (%.2lf s)\n", duration_solve);
+    CGAL_TRACE_STREAM << "  Solve sparse linear system: done (" << duration_solve << "sec.)\n";
 
     // copy function's values to vertices
     unsigned int index = 0;
@@ -835,7 +835,7 @@ private:
       if(!m_tr->is_constrained(v))
         v->f() = X[index++];
 
-    CGAL_TRACE("End of solve_poisson()\n");
+    CGAL_TRACE_STREAM << "End of solve_poisson()\n";
 
     return true;
   }

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -425,9 +425,7 @@ public:
     CGAL_precondition(type(&*x) == USED);
     EraseCounterStrategy::increment_erase_counter(*x);
     std::allocator_traits<allocator_type>::destroy(alloc, &*x);
-/*#ifndef CGAL_NO_ASSERTIONS
-    std::memset(&*x, 0, sizeof(T));
-#endif*/
+
     put_on_free_list(&*x);
     --size_;
   }

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -394,10 +394,6 @@ private:
 
     std::allocator_traits<allocator_type>::destroy(m_alloc, &*x);
 
-/* WE DON'T DO THAT BECAUSE OF THE ERASE COUNTER
-#ifndef CGAL_NO_ASSERTIONS
-    std::memset(&*x, 0, sizeof(T));
-#endif*/
     put_on_free_list(&*x, fl);
   }
 public:

--- a/Stream_support/include/CGAL/IO/trace.h
+++ b/Stream_support/include/CGAL/IO/trace.h
@@ -26,7 +26,7 @@ inline void CGAL_print_stderr(const char *fmt, ...)
 {
   va_list argp;
   va_start(argp, fmt);
-  vfprintf(stderr, fmt, argp);
+  vfprintf_s(stderr, fmt, argp);
   va_end(argp);
 }
 

--- a/Stream_support/include/CGAL/IO/trace.h
+++ b/Stream_support/include/CGAL/IO/trace.h
@@ -11,32 +11,13 @@
 #ifndef CGAL_IO_TRACE_H
 #define CGAL_IO_TRACE_H
 
-#include <stdio.h>
-#include <stdarg.h>
 #include <iostream>
-#include <fstream>
 
 /// \cond SKIP_IN_MANUAL
 
 // Trace utilities
 // ---------------
 
-// print_stderr() = printf-like function to print to stderr
-inline void CGAL_print_stderr(const char *fmt, ...)
-{
-  va_list argp;
-  va_start(argp, fmt);
-  vfprintf_s(stderr, fmt, argp);
-  va_end(argp);
-}
-
-// CGAL_TRACE() = printf-like function to print to stderr
-// if DEBUG_TRACE is defined (ignored otherwise)
-#ifdef DEBUG_TRACE
-#define CGAL_TRACE  CGAL_print_stderr
-#else
-  #define CGAL_TRACE  if (false) CGAL_print_stderr
-#endif
 
 // CGAL_TRACE_STREAM = C++ stream that prints to std::cerr
 // if DEBUG_TRACE is defined (ignored otherwise)

--- a/Surface_mesh_segmentation/include/CGAL/Surface_mesh_segmentation/internal/auxiliary/graph.h
+++ b/Surface_mesh_segmentation/include/CGAL/Surface_mesh_segmentation/internal/auxiliary/graph.h
@@ -109,7 +109,7 @@ a minimum cut on the following graph:
 
 ///////////////////////////////////////////////////
 
-#include <stdio.h>
+#include <iostream>
 #include "graph.h"
 
 void main()
@@ -125,16 +125,16 @@ void main()
 
         Graph::flowtype flow = g -> maxflow();
 
-        printf("Flow = %d\n", flow);
+        std::cout << "Flow = " << flow << std::endl;
         printf("Minimum cut:\n");
         if (g->what_segment(nodes[0]) == Graph::SOURCE)
-                printf("node0 is in the SOURCE set\n");
+                std::cout << "node0 is in the SOURCE set\n";
         else
-                printf("node0 is in the SINK set\n");
+                std::cout << "node0 is in the SINK set\n";
         if (g->what_segment(nodes[1]) == Graph::SOURCE)
-                printf("node1 is in the SOURCE set\n");
+                std::cout << "node1 is in the SOURCE set\n";
         else
-                printf("node1 is in the SINK set\n");
+                std::cout << "node1 is in the SINK set\n";
 
         delete g;
 }

--- a/Testsuite/include/CGAL/Testsuite/vc_debug_hook.h
+++ b/Testsuite/include/CGAL/Testsuite/vc_debug_hook.h
@@ -28,7 +28,7 @@ namespace
   {
     if ( type == _CRT_ASSERT )
     {
-      std::fprintf(stderr,msg);
+      std::cerr << msg << std::endl;
       *retval = 0 ;
       std::exit(255);
     }

--- a/Testsuite/include/CGAL/Testsuite/vc_debug_hook.h
+++ b/Testsuite/include/CGAL/Testsuite/vc_debug_hook.h
@@ -19,6 +19,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <crtdbg.h>
+#include <iostream>
 
 
 namespace
@@ -38,11 +39,11 @@ namespace
   {
     switch(n)
     {
-      case SIGSEGV: std::fprintf(stderr,"In CGAL_handle_signal, Program received signal SIGSEGV: Segmentation Fault."); break ;
-      case SIGFPE : std::fprintf(stderr,"In CGAL_handle_signal, Program received signal SIGFPE: Floating Point Execption."); break ;
-      case SIGILL : std::fprintf(stderr,"In CGAL_handle_signal, Program received signal SIGILL: Illegal Instruction."); break ;
+      case SIGSEGV: std::cerr << "In CGAL_handle_signal, Program received signal SIGSEGV: Segmentation Fault." << std::endl; break ;
+      case SIGFPE : std::cerr << "In CGAL_handle_signal, Program received signal SIGFPE: Floating Point Execption." << std::endl; break ;
+      case SIGILL : std::cerr << "In CGAL_handle_signal, Program received signal SIGILL: Illegal Instruction." << std::endl; break ;
       default:
-        std::fprintf(stderr,"In CGAL_handle_signal, Program received signal %d", n); break ;
+        std::cerr << "In CGAL_handle_signal, Program received signal " << n << std::endl; break ;
     }
 
     std::exit(128+n);


### PR DESCRIPTION
## Summary of Changes

As pointed out by @lrineau most of the usages ARE safe, in the sense that the sizes of source and target memory are constants known at compile time.

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #5991
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

