### PR TITLE
Mesh_3 - document CGAL::remove_far_points_in_mesh_3()

### DIFF
--- a/Mesh_3/doc/Mesh_3/CGAL/make_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/make_mesh_3.h
@@ -143,6 +143,7 @@ optimization processes.
 \sa `perturb_mesh_3()`
 \sa `lloyd_optimize_mesh_3()`
 \sa `odt_optimize_mesh_3()`
+\sa `CGAL::remove_far_points_in_mesh_3()`
 \sa `parameters::exude()`
 \sa `parameters::no_exude()`
 \sa `parameters::perturb()`

--- a/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/refine_mesh_3.h
@@ -137,6 +137,7 @@ optimization processes.
 \sa `CGAL::perturb_mesh_3()`
 \sa `CGAL::lloyd_optimize_mesh_3()`
 \sa `CGAL::odt_optimize_mesh_3()`
+\sa `CGAL::remove_far_points_in_mesh_3()`
 \sa `CGAL::parameters::exude`
 \sa `CGAL::parameters::no_exude`
 \sa `CGAL::parameters::perturb`

--- a/Mesh_3/doc/Mesh_3/Doxyfile.in
+++ b/Mesh_3/doc/Mesh_3/Doxyfile.in
@@ -5,7 +5,8 @@ ALIASES += "cgalDescribePolylineType=A polyline is defined as a sequence of poin
 
 INPUT += \
       ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/Polyhedral_complex_mesh_domain_3.h \
-      ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/Mesh_domain_with_polyline_features_3.h
+      ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/Mesh_domain_with_polyline_features_3.h \
+      ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/remove_far_points_in_mesh_3.h
 
 PROJECT_NAME = "CGAL ${CGAL_DOC_VERSION} - 3D Mesh Generation"
 HTML_EXTRA_FILES           =  ${CGAL_PACKAGE_DOC_DIR}/fig/implicit_domain_3.jpg \

--- a/Mesh_3/doc/Mesh_3/PackageDescription.txt
+++ b/Mesh_3/doc/Mesh_3/PackageDescription.txt
@@ -114,6 +114,7 @@ and their associated classes:
 - `CGAL::perturb_mesh_3()`
 - `CGAL::lloyd_optimize_mesh_3()`
 - `CGAL::odt_optimize_mesh_3()`
+- `CGAL::remove_far_points_in_mesh_3()`
 - `CGAL::facets_in_complex_3_to_triangle_mesh()`
 
 \cgalCRPSection{CGAL::parameters Functions}

--- a/Mesh_3/include/CGAL/remove_far_points_in_mesh_3.h
+++ b/Mesh_3/include/CGAL/remove_far_points_in_mesh_3.h
@@ -71,6 +71,21 @@ private:
 
 } // namespace Mesh_3
 
+/*!
+\ingroup PkgMesh3Functions
+
+The concurrent version of the tetrahedral mesh generation algorithm implemented in
+`CGAL::make_mesh_3()` and `CGAL::refine_mesh_3()` inserts a small set of
+auxiliary vertices that belong to the triangulation but are isolated from the complex
+at the end of the meshing process.
+
+This function removes these so called "far points" from `c3t3.triangulation()`,
+without modifying the mesh complex.
+
+\tparam C3T3 is required to be a model of the concept `MeshComplex_3InTriangulation_3`.
+The argument `c3t3` is passed by
+reference as its underlying triangulation is modified by the function.
+*/
 template <typename C3T3>
 void
 remove_far_points_in_mesh_3(C3T3& c3t3)

--- a/Mesh_3/include/CGAL/remove_far_points_in_mesh_3.h
+++ b/Mesh_3/include/CGAL/remove_far_points_in_mesh_3.h
@@ -74,11 +74,10 @@ private:
 /*!
 \ingroup PkgMesh3Functions
 
-The concurrent version of the tetrahedral mesh generation algorithm implemented in
-`CGAL::make_mesh_3()` and `CGAL::refine_mesh_3()` inserts a small set of
-auxiliary vertices that belong to the triangulation but are isolated from the complex
-at the end of the meshing process.
-
+For efficiency reasons, the concurrent version of the tetrahedral mesh generation algorithm
+implemented in `CGAL::make_mesh_3()` and `CGAL::refine_mesh_3()` inserts
+a small set of auxiliary vertices outside the bounding box of the mesh domain.
+At the that end of the meshing process, they belong to the triangulation but are isolated from the complex.
 This function removes these so called "far points" from `c3t3.triangulation()`,
 without modifying the mesh complex.
 


### PR DESCRIPTION
## Summary of Changes

This PR documents the function `CGAL::remove_far_points_in_mesh_3()` that removes as a post processing the "far points" inserted to help the concurrent version of the mesher being more efficient.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #5846
* [Small Feature](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Remove_far_points), pre-approved by @lrineau 21 September 2021
* [Link to compiled documentation](https://cgal.github.io/5999/v1/Mesh_3/group__PkgMesh3Functions.html#ga957cd22e1a4a82dc21b9d8659ff936d5)
* License and copyright ownership: unchanged

