### PR TITLE
Mesh_3 - warning message after bad initialization

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesher_3.h
@@ -45,6 +45,7 @@
 #include <CGAL/Mesher_level_visitors.h>
 #include <CGAL/Kernel_traits.h>
 #include <CGAL/point_generators_3.h>
+#include <CGAL/assertions_impl.h>
 
 #ifdef CGAL_MESH_3_USE_OLD_SURFACE_RESTRICTED_DELAUNAY_UPDATE
 #include <CGAL/Surface_mesher/Surface_mesher_visitor.h>
@@ -719,6 +720,20 @@ initialize()
   else
 #endif // CGAL_LINKED_WITH_TBB
   {
+
+    if (r_c3t3_.number_of_facets() == 0)
+    {
+      CGAL::warning_fail("c3t3.number_of_facets() == 0",
+        "CGAL/Mesh_3/Mesher_3.h",
+        725,
+        "Warning : The mesh refinement process can't start.\n"
+        "When calling refine_mesh_3(), the input `c3t3` should have been initialized and have "
+        "at least one facet in the complex. Try to solve this issue using :\n"
+        "\t- The automatic initialization provided by make_mesh_3()\n"
+        "\t- Adding more and better chosen points on the input surface\n"
+        "\t- defining the compilation macro CGAL_SEQUENTIAL_MESH_3_ADD_OUTSIDE_POINTS_ON_A_FAR_SPHERE\n");
+    }
+
     if (r_c3t3_.number_of_far_points() == 0 &&
         r_c3t3_.number_of_facets() == 0 &&
         (r_c3t3_.triangulation().dimension() < 3

--- a/STL_Extension/include/CGAL/assertions_impl.h
+++ b/STL_Extension/include/CGAL/assertions_impl.h
@@ -14,6 +14,9 @@
 //
 // Author(s)     : Geert-Jan Giezeman and Sven Schönherr
 
+#ifndef CGAL_ASSERTIONS_IMPL_H
+#define CGAL_ASSERTIONS_IMPL_H
+
 #ifdef CGAL_HEADER_ONLY
 #define CGAL_INLINE_FUNCTION inline
 #else
@@ -280,3 +283,5 @@ set_warning_behaviour(Failure_behaviour eb)
 }
 
 } //namespace CGAL
+
+#endif //CGAL_ASSERTIONS_IMPL_H


### PR DESCRIPTION
## Summary of Changes

This PR adds a warning message that is displayed without crashing when initialization of Mesh_3 has failed and refinement cannot start

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #5300
* License and copyright ownership: unchanged

