### PR TITLE
Unset fail bit and add assertions about the state of a stream

### DIFF
--- a/Point_set_processing_3/include/CGAL/IO/read_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_off_points.h
@@ -190,12 +190,13 @@ bool read_OFF(std::istream& is,
           put(normal_map, pwn, normal); // normal_map[&pwn] = normal
         *output++ = pwn;
         pointsRead++;
+
       }
       // ...or skip comment line
     }
     // Skip remaining lines
   }
-
+  is.clear(is.rdstate() & ~std::ios_base::failbit); // set by getline
   return true;
 }
 

--- a/Point_set_processing_3/include/CGAL/IO/read_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_off_points.h
@@ -196,7 +196,9 @@ bool read_OFF(std::istream& is,
     }
     // Skip remaining lines
   }
-  is.clear(is.rdstate() & ~std::ios_base::failbit); // set by getline
+  if(is.eof()) {
+    is.clear(is.rdstate() & ~std::ios_base::failbit); // set by getline
+  }
   return true;
 }
 

--- a/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
@@ -179,6 +179,7 @@ bool read_XYZ(std::istream& is,
       return false;
     }
   }
+  is.clear(is.rdstate() & ~std::ios_base::failbit); // set by getline
 
   return true;
 }

--- a/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
@@ -179,7 +179,9 @@ bool read_XYZ(std::istream& is,
       return false;
     }
   }
-  is.clear(is.rdstate() & ~std::ios_base::failbit); // set by getline
+  if(is.eof()) {
+    is.clear(is.rdstate() & ~std::ios_base::failbit); // set by getline
+  }
 
   return true;
 }

--- a/Point_set_processing_3/test/Point_set_processing_3/test_deprecated_io_point_set.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/test_deprecated_io_point_set.cpp
@@ -77,134 +77,150 @@ points[1] = std::make_pair(Point_3(0,1,0), Color{0,255,0,255});
 points[2] = std::make_pair(Point_3(0,0,1), Color{0,0,255,255});
 
 
-std::ofstream os;
-std::ifstream is;
 bool ok;
 std::vector<Point_3> ps;
 ps.push_back(Point_3(1,0,0));
 ps.push_back(Point_3(0,1,0));
 ps.push_back(Point_3(0,0,1));
+
+
 //LAS
 #ifdef CGAL_LINKED_WITH_LASLIB
-os.open("tmp.las", std::ios::binary);
-ok = CGAL::write_las_points_with_properties(os, points,
-                                                 CGAL::make_las_point_writer(CGAL::First_of_pair_property_map<PointWithColor>()),
-                                                 std::make_pair(GetRedMap(),CGAL::LAS_property::R()),
-                                                 std::make_pair(GetGreenMap(), CGAL::LAS_property::G()),
-                                                 std::make_pair(GetBlueMap(), CGAL::LAS_property::B()),
-                                                 std::make_pair(GetAlphaMap(), CGAL::LAS_property::I())
-                                                 );
-os.close();
-assert(ok);
-points.clear();
-is.open("tmp.las", std::ios::binary);
-ok = CGAL::read_las_points_with_properties(is, std::back_inserter (points),
-                                    CGAL::make_las_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
-                                    std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
-                                                    CGAL::Construct_array(),
-                                                    CGAL::LAS_property::R(),
-                                                    CGAL::LAS_property::G(),
-                                                    CGAL::LAS_property::B(),
-                                                    CGAL::LAS_property::I()));
-is.close();
-assert(ok);
-assert(points.size() == 3);
-assert(points[1].second[1] == 255);
 
-os.open("tmp.las", std::ios_base::binary);
-CGAL::write_las_points(os, ps, CGAL::parameters::all_default());
-os.close();
-assert(ok);
-ps.clear();
-is.open("tmp.las", std::ios::binary);
-ok = CGAL::read_las_points(is, std::back_inserter (ps),CGAL::parameters::all_default());
-is.close();
-assert(ok);
-assert(ps.size() == 3);
+ {
+   std::ofstream os("tmp1.las", std::ios::binary);
+   ok = CGAL::write_las_points_with_properties(os, points,
+					       CGAL::make_las_point_writer(CGAL::First_of_pair_property_map<PointWithColor>()),
+					       std::make_pair(GetRedMap(),CGAL::LAS_property::R()),
+					       std::make_pair(GetGreenMap(), CGAL::LAS_property::G()),
+					       std::make_pair(GetBlueMap(), CGAL::LAS_property::B()),
+					       std::make_pair(GetAlphaMap(), CGAL::LAS_property::I())
+					       );
+   assert(ok);
+
+ }
+
+ {
+   points.clear();
+   std::ifstream is("tmp1.las", std::ios::binary);
+   ok = CGAL::read_las_points_with_properties(is, std::back_inserter (points),
+					      CGAL::make_las_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
+					      std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
+							      CGAL::Construct_array(),
+							      CGAL::LAS_property::R(),
+							      CGAL::LAS_property::G(),
+							      CGAL::LAS_property::B(),
+							      CGAL::LAS_property::I()));
+   assert(ok);
+   assert(points.size() == 3);
+   assert(points[1].second[1] == 255);
+ }
+
+ {
+   std::ofstream os("tmp2.las", std::ios_base::binary);
+   CGAL::write_las_points(os, ps, CGAL::parameters::all_default());
+   assert(ok);
+ }
+
+ {
+   ps.clear();
+   std::ifstream is("tmp2.las", std::ios::binary);
+   ok = CGAL::read_las_points(is, std::back_inserter (ps),CGAL::parameters::all_default());
+   assert(ok);
+   assert(ps.size() == 3);
+ }
 #endif
 
 
 //PLY
-os.open("tmp.ply");
-assert(os.good());
-ok = CGAL::write_ply_points_with_properties(os, points,
-                                            CGAL::make_ply_point_writer (CGAL::First_of_pair_property_map<PointWithColor>()),
-                                            std::make_pair(GetRedMap(),CGAL::PLY_property<unsigned short>("red")),
-                                            std::make_pair(GetGreenMap(), CGAL::PLY_property<unsigned short>("green")),
-                                            std::make_pair(GetBlueMap(), CGAL::PLY_property<unsigned short>("blue")),
-                                            std::make_pair(GetAlphaMap(), CGAL::PLY_property<unsigned short>("alpha"))
-                                            );
-os.close();
-assert(! os.fail());
-assert(ok);
+ {
+   std::ofstream os("tmp1.ply");
+   assert(os.good());
+   ok = CGAL::write_ply_points_with_properties(os, points,
+					       CGAL::make_ply_point_writer (CGAL::First_of_pair_property_map<PointWithColor>()),
+					       std::make_pair(GetRedMap(),CGAL::PLY_property<unsigned short>("red")),
+					       std::make_pair(GetGreenMap(), CGAL::PLY_property<unsigned short>("green")),
+					       std::make_pair(GetBlueMap(), CGAL::PLY_property<unsigned short>("blue")),
+					       std::make_pair(GetAlphaMap(), CGAL::PLY_property<unsigned short>("alpha"))
+					       );
+   assert(! os.fail());
+   assert(ok);
+ }
 
-is.open("tmp.ply");
-assert(is.good());
-points.clear();
-ok = CGAL::read_ply_points_with_properties(is, std::back_inserter (points),
-                                    CGAL::make_ply_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
-                                    std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
-                                                    CGAL::Construct_array(),
-                                                    CGAL::PLY_property<unsigned short>("red"),
-                                                    CGAL::PLY_property<unsigned short>("green"),
-                                                    CGAL::PLY_property<unsigned short>("blue"),
-                                                    CGAL::PLY_property<unsigned short>("alpha")));
-is.close();
-assert(! is.fail());
-assert(ok);
-assert(points.size() == 3);
-assert(points[1].second[1] == 255);
+ {
+   std::ifstream is("tmp1.ply");
+   assert(is.good());
+   points.clear();
+   ok = CGAL::read_ply_points_with_properties(is, std::back_inserter (points),
+					      CGAL::make_ply_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
+					      std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
+							      CGAL::Construct_array(),
+							      CGAL::PLY_property<unsigned short>("red"),
+							      CGAL::PLY_property<unsigned short>("green"),
+							      CGAL::PLY_property<unsigned short>("blue"),
+							      CGAL::PLY_property<unsigned short>("alpha")));
+   assert(! is.fail());
+   assert(ok);
+   assert(points.size() == 3);
+   assert(points[1].second[1] == 255);
+ }
 
-os.open("tmp.ply");
-assert(os.good());
-ok = CGAL::write_ply_points(os, ps, CGAL::parameters::all_default());
-os.close();
-assert(! os.fail());
-assert(ok);
+ {
+   std::ofstream os("tmp2.ply");
+   assert(os.good());
+   ok = CGAL::write_ply_points(os, ps, CGAL::parameters::all_default());
+   assert(! os.fail());
+   assert(ok);
+ }
 
-is.open("tmp.ply");
-assert(is.good());
-ps.clear();
-ok = CGAL::read_ply_points(is, std::back_inserter (ps),
-                           CGAL::parameters::all_default());
-is.close();
-assert(! is.fail());
-assert(ok);
-assert(ps.size() == 3);
+ {
+   std::ifstream is("tmp2.ply");
+   assert(is.good());
+   ps.clear();
+   ok = CGAL::read_ply_points(is, std::back_inserter (ps),
+			      CGAL::parameters::all_default());
+   assert(! is.fail());
+   assert(ok);
+   assert(ps.size() == 3);
+ }
 
 //OFF
-os.open("tmp.off");
-assert(os.good());
-ok = CGAL::write_off_points(os, ps, CGAL::parameters::all_default());
-os.close();
-assert(! os.fail());
-assert(ok);
+ {
+   std::ofstream os("tmp.off");
+   assert(os.good());
+   ok = CGAL::write_off_points(os, ps, CGAL::parameters::all_default());
+   assert(! os.fail());
+   assert(ok);
+ }
 
-is.open("tmp.off");
-assert(is.good());
-ps.clear();
-ok = CGAL::read_off_points(is, std::back_inserter (ps),
-                           CGAL::parameters::all_default());
-is.close();
-assert(! is.fail());
-assert(ok);
-assert(ps.size() == 3);
+ {
+   std::ifstream is("tmp.off");
+   assert(is.good());
+   ps.clear();
+   ok = CGAL::read_off_points(is, std::back_inserter (ps),
+			      CGAL::parameters::all_default());
+   assert(! is.fail());
+   assert(ok);
+   assert(ps.size() == 3);
+ }
 
 //XYZ
-os.open("tmp.xyz");
-assert(os.good());
-ok = CGAL::write_xyz_points(os, ps, CGAL::parameters::all_default());
-os.close();
-assert(! os.fail());
-assert(ok);
+ {
+   std::ofstream os("tmp.xyz");
+   assert(os.good());
+   ok = CGAL::write_xyz_points(os, ps, CGAL::parameters::all_default());
+   assert(! os.fail());
+   assert(ok);
+ }
 
-is.open("tmp.xyz");
-assert(is.good());
-ps.clear();
-ok = CGAL::read_xyz_points(is, std::back_inserter (ps),
-                           CGAL::parameters::all_default());
-is.close();
-assert(! is.fail());
-assert(ok);
-assert(ps.size() == 3);
+ {
+   std::ifstream is("tmp.xyz");
+   assert(is.good());
+   ps.clear();
+   ok = CGAL::read_xyz_points(is, std::back_inserter (ps),
+			      CGAL::parameters::all_default());
+   assert(! is.fail());
+   assert(ok);
+   assert(ps.size() == 3);
+ }
 }

--- a/Point_set_processing_3/test/Point_set_processing_3/test_deprecated_io_point_set.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/test_deprecated_io_point_set.cpp
@@ -90,12 +90,12 @@ ps.push_back(Point_3(0,0,1));
  {
    std::ofstream os("tmp1.las", std::ios::binary);
    ok = CGAL::write_las_points_with_properties(os, points,
-					       CGAL::make_las_point_writer(CGAL::First_of_pair_property_map<PointWithColor>()),
-					       std::make_pair(GetRedMap(),CGAL::LAS_property::R()),
-					       std::make_pair(GetGreenMap(), CGAL::LAS_property::G()),
-					       std::make_pair(GetBlueMap(), CGAL::LAS_property::B()),
-					       std::make_pair(GetAlphaMap(), CGAL::LAS_property::I())
-					       );
+                                               CGAL::make_las_point_writer(CGAL::First_of_pair_property_map<PointWithColor>()),
+                                               std::make_pair(GetRedMap(),CGAL::LAS_property::R()),
+                                               std::make_pair(GetGreenMap(), CGAL::LAS_property::G()),
+                                               std::make_pair(GetBlueMap(), CGAL::LAS_property::B()),
+                                               std::make_pair(GetAlphaMap(), CGAL::LAS_property::I())
+                                               );
    assert(ok);
 
  }
@@ -104,13 +104,13 @@ ps.push_back(Point_3(0,0,1));
    points.clear();
    std::ifstream is("tmp1.las", std::ios::binary);
    ok = CGAL::read_las_points_with_properties(is, std::back_inserter (points),
-					      CGAL::make_las_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
-					      std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
-							      CGAL::Construct_array(),
-							      CGAL::LAS_property::R(),
-							      CGAL::LAS_property::G(),
-							      CGAL::LAS_property::B(),
-							      CGAL::LAS_property::I()));
+                                              CGAL::make_las_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
+                                              std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
+                                                              CGAL::Construct_array(),
+                                                              CGAL::LAS_property::R(),
+                                                              CGAL::LAS_property::G(),
+                                                              CGAL::LAS_property::B(),
+                                                              CGAL::LAS_property::I()));
    assert(ok);
    assert(points.size() == 3);
    assert(points[1].second[1] == 255);
@@ -137,12 +137,12 @@ ps.push_back(Point_3(0,0,1));
    std::ofstream os("tmp1.ply");
    assert(os.good());
    ok = CGAL::write_ply_points_with_properties(os, points,
-					       CGAL::make_ply_point_writer (CGAL::First_of_pair_property_map<PointWithColor>()),
-					       std::make_pair(GetRedMap(),CGAL::PLY_property<unsigned short>("red")),
-					       std::make_pair(GetGreenMap(), CGAL::PLY_property<unsigned short>("green")),
-					       std::make_pair(GetBlueMap(), CGAL::PLY_property<unsigned short>("blue")),
-					       std::make_pair(GetAlphaMap(), CGAL::PLY_property<unsigned short>("alpha"))
-					       );
+                                               CGAL::make_ply_point_writer (CGAL::First_of_pair_property_map<PointWithColor>()),
+                                               std::make_pair(GetRedMap(),CGAL::PLY_property<unsigned short>("red")),
+                                               std::make_pair(GetGreenMap(), CGAL::PLY_property<unsigned short>("green")),
+                                               std::make_pair(GetBlueMap(), CGAL::PLY_property<unsigned short>("blue")),
+                                               std::make_pair(GetAlphaMap(), CGAL::PLY_property<unsigned short>("alpha"))
+                                               );
    assert(! os.fail());
    assert(ok);
  }
@@ -152,13 +152,13 @@ ps.push_back(Point_3(0,0,1));
    assert(is.good());
    points.clear();
    ok = CGAL::read_ply_points_with_properties(is, std::back_inserter (points),
-					      CGAL::make_ply_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
-					      std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
-							      CGAL::Construct_array(),
-							      CGAL::PLY_property<unsigned short>("red"),
-							      CGAL::PLY_property<unsigned short>("green"),
-							      CGAL::PLY_property<unsigned short>("blue"),
-							      CGAL::PLY_property<unsigned short>("alpha")));
+                                              CGAL::make_ply_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
+                                              std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
+                                                              CGAL::Construct_array(),
+                                                              CGAL::PLY_property<unsigned short>("red"),
+                                                              CGAL::PLY_property<unsigned short>("green"),
+                                                              CGAL::PLY_property<unsigned short>("blue"),
+                                                              CGAL::PLY_property<unsigned short>("alpha")));
    assert(! is.fail());
    assert(ok);
    assert(points.size() == 3);
@@ -178,7 +178,7 @@ ps.push_back(Point_3(0,0,1));
    assert(is.good());
    ps.clear();
    ok = CGAL::read_ply_points(is, std::back_inserter (ps),
-			      CGAL::parameters::all_default());
+                              CGAL::parameters::all_default());
    assert(! is.fail());
    assert(ok);
    assert(ps.size() == 3);
@@ -198,7 +198,7 @@ ps.push_back(Point_3(0,0,1));
    assert(is.good());
    ps.clear();
    ok = CGAL::read_off_points(is, std::back_inserter (ps),
-			      CGAL::parameters::all_default());
+                              CGAL::parameters::all_default());
    assert(! is.fail());
    assert(ok);
    assert(ps.size() == 3);
@@ -218,7 +218,7 @@ ps.push_back(Point_3(0,0,1));
    assert(is.good());
    ps.clear();
    ok = CGAL::read_xyz_points(is, std::back_inserter (ps),
-			      CGAL::parameters::all_default());
+                              CGAL::parameters::all_default());
    assert(! is.fail());
    assert(ok);
    assert(ps.size() == 3);

--- a/Point_set_processing_3/test/Point_set_processing_3/test_deprecated_io_point_set.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/test_deprecated_io_point_set.cpp
@@ -122,8 +122,11 @@ is.close();
 assert(ok);
 assert(ps.size() == 3);
 #endif
+
+
 //PLY
 os.open("tmp.ply");
+assert(os.good());
 ok = CGAL::write_ply_points_with_properties(os, points,
                                             CGAL::make_ply_point_writer (CGAL::First_of_pair_property_map<PointWithColor>()),
                                             std::make_pair(GetRedMap(),CGAL::PLY_property<unsigned short>("red")),
@@ -132,9 +135,11 @@ ok = CGAL::write_ply_points_with_properties(os, points,
                                             std::make_pair(GetAlphaMap(), CGAL::PLY_property<unsigned short>("alpha"))
                                             );
 os.close();
+assert(! os.fail());
 assert(ok);
 
 is.open("tmp.ply");
+assert(is.good());
 points.clear();
 ok = CGAL::read_ply_points_with_properties(is, std::back_inserter (points),
                                     CGAL::make_ply_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
@@ -145,48 +150,61 @@ ok = CGAL::read_ply_points_with_properties(is, std::back_inserter (points),
                                                     CGAL::PLY_property<unsigned short>("blue"),
                                                     CGAL::PLY_property<unsigned short>("alpha")));
 is.close();
+assert(! is.fail());
 assert(ok);
 assert(points.size() == 3);
 assert(points[1].second[1] == 255);
 
 os.open("tmp.ply");
+assert(os.good());
 ok = CGAL::write_ply_points(os, ps, CGAL::parameters::all_default());
 os.close();
+assert(! os.fail());
 assert(ok);
 
 is.open("tmp.ply");
+assert(is.good());
 ps.clear();
 ok = CGAL::read_ply_points(is, std::back_inserter (ps),
                            CGAL::parameters::all_default());
 is.close();
+assert(! is.fail());
 assert(ok);
 assert(ps.size() == 3);
 
 //OFF
 os.open("tmp.off");
+assert(os.good());
 ok = CGAL::write_off_points(os, ps, CGAL::parameters::all_default());
 os.close();
+assert(! os.fail());
 assert(ok);
 
 is.open("tmp.off");
+assert(is.good());
 ps.clear();
 ok = CGAL::read_off_points(is, std::back_inserter (ps),
                            CGAL::parameters::all_default());
 is.close();
+assert(! is.fail());
 assert(ok);
 assert(ps.size() == 3);
 
 //XYZ
 os.open("tmp.xyz");
+assert(os.good());
 ok = CGAL::write_xyz_points(os, ps, CGAL::parameters::all_default());
 os.close();
+assert(! os.fail());
 assert(ok);
 
 is.open("tmp.xyz");
+assert(is.good());
 ps.clear();
 ok = CGAL::read_xyz_points(is, std::back_inserter (ps),
                            CGAL::parameters::all_default());
 is.close();
+assert(! is.fail());
 assert(ok);
 assert(ps.size() == 3);
 }


### PR DESCRIPTION
## Summary of Changes

After reading a line too much with a  `while(getline())` we must reset the failbit.

I spotted this while trying to track down a runtime error in the [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.4-Ic-7/Point_set_processing_3/TestReport_Sosno_MSVC-2019-Community-Release.gz)

## Release Management

* Affected package(s): Point Set Processing
