### PR TITLE
AABB tree concept fixes + Construct_projected_point_3(P3, P3)

### DIFF
--- a/AABB_tree/doc/AABB_tree/Concepts/AABBGeomTraits.h
+++ b/AABB_tree/doc/AABB_tree/Concepts/AABBGeomTraits.h
@@ -3,13 +3,19 @@
 \ingroup PkgAABBTreeConcepts
 \cgalConcept
 
-The concept `AABBGeomTraits` defines the requirements for the first template parameter of the class `CGAL::AABB_traits<AABBGeomTraits, AABBPrimitive>`. It provides predicates and constructors to detect and compute intersections between query objects and the primitives stored in the AABB tree. In addition, it contains predicates and constructors to compute distances between a point query and the primitives stored in the AABB tree.
+The concept `AABBGeomTraits` defines the requirements for the first template parameter of the class
+`CGAL::AABB_traits<AABBGeomTraits, AABBPrimitive>`. It provides predicates and constructors to detect
+and compute intersections between query objects and the primitives stored in the AABB tree.
+In addition, it contains predicates and constructors to compute distances between a point query
+and the primitives stored in the AABB tree.
 
 \cgalRefines `SearchGeomTraits_3`
 
-\cgalHasModel Any 3D Kernel is a model of this traits concept.
+\cgalHasModel All models of the concept `Kernel`
 
 \sa `CGAL::AABB_traits<AABBGeomTraits,AABBPrimitive>`
+\sa `CGAL::AABB_tree<AABBTraits>`
+\sa `AABBPrimitive`
 
 */
 
@@ -20,109 +26,114 @@ public:
 /// @{
 
 /*!
-A number type model of `Field`.
-*/
-typedef unspecified_type FT;
-
-/*!
-Sphere type, that should be consistent with the distance function chosen for the distance queries, namely the `Squared_distance_3` functor.
-*/
-typedef unspecified_type Sphere_3;
-
-/*!
-Point type.
-*/
-typedef unspecified_type Point_3;
-
-/*!
 A functor object to detect intersections between two geometric objects.
-Provides the operators:
-`bool operator()(const Type_1& type_1, const Type_2& type_2);`
-where `Type_1` and `Type_2` are relevant types
-among `Ray_3`, `Segment_3`, `Line_3`, `Triangle_3`, `Plane_3` and `Bbox_3`. Relevant herein means that a line primitive (ray, segment, line) is tested against a planar or solid primitive (plane, triangle, box), and a solid primitive is tested against another solid primitive (box against box). The operator returns `true` iff `type_1` and `type_2` have a non empty intersection.
+Provides the following operators:
+
+`bool operator()(Query, Bbox_3)`,
+
+`bool operator()(Query, Primitive::Datum)`,
+
+`bool operator()(Sphere_3, Bbox_3)`.
+
+The operator returns `true` iff there exists a non-empty intersection.
 */
 typedef unspecified_type Do_intersect_3;
 
 /*!
 A functor object to construct the intersection between two geometric objects.
 
-Provides the operators:
-`decltype(auto) operator()(const A& a, const B& b);`
-where `A` and `B` are any relevant types among `Ray_3`, `Segment_3`, `Line_3`,
-`Triangle_3`, `Plane_3` and `Bbox_3`.
-Relevant herein means that a line primitive (ray, segment, line) is tested
-against a planar or solid primitive (plane, triangle, box).
-A model of `Kernel::Intersect_3` fulfills those requirements.
+Provides the operator:
+
+`return_type operator()(const Query& q, const Primitive::Datum& d)`,
+
+which computes the intersection between `q` and `d`. The type of the returned object
+must be a `boost::optional` of a `boost::variant` of the possible intersection types.
 */
 typedef unspecified_type Intersect_3;
 
 /*!
-A functor object to construct the sphere centered at one point and passing through another one. Provides the operator:
-- `Sphere_3 operator()(const Point_3& p, const FT & sr)` which returns the sphere centered at `p` with `sr` as squared radius.
+A functor object to construct the sphere centered at one point and passing through another one.
+Provides the operator:
+
+`Sphere_3 operator()(const Point_3& p, const FT & sr)`,
+
+which returns the sphere centered at `p` with `sr` as squared radius.
 */
 typedef unspecified_type Construct_sphere_3;
 
 /*!
-A functor object to compute the point on a geometric primitive which is closest from a query. Provides the operator:
-`Point_3 operator()(const Type_2& type_2, const Point_3& p);` where `Type_2` can be any of the following types : `Segment_3`, `Ray_3`, or `Triangle_3`.
-The operator returns the point on `type_2` which is closest to `p`.
+A functor object to compute the point on a geometric primitive which is closest from a query.
+Provides the operator:
+
+`Point_3 operator()(const Primitive::Datum& d, const Point_3& p)`,
+
+which returns the point on `d` that is closest to `p`.
 */
 typedef unspecified_type Construct_projected_point_3;
 
 /*!
-A functor object to compare the distance of two points wrt a third one.
-Provides the operator:
-`CGAL::Comparision_result operator()(const Point_3& p1, const Point_3& p2, const Point_3& p3)`. The operator compare the distance between `p1 and `p2`, and between `p2` and `p3`.
+A functor object to compare the distance of two points wrt a third one. Provides the operator:
+
+`CGAL::Comparision_result operator()(const Point_3& p1, const Point_3& p2, const Point_3& p3)`,
+
+which compares the distance between `p1 and `p2`, and between `p2` and `p3`.
 */
 typedef unspecified_type Compare_distance_3;
 
 /*!
-A functor object to detect if a point lies inside a sphere or not.
+A functor object to compute the squared radius of a sphere.
 Provides the operator:
-`bool operator()(const Sphere_3& s, const Point_3& p);` which returns `true` iff the closed volume bounded by `s` contains `p`.
-*/
-typedef unspecified_type Has_on_bounded_side_3;
 
-/*!
-A functor object to compute the squared radius of a sphere. Provides the operator:
-`FT operator()(const Sphere_3& s);` which returns the squared radius of `s`.
+`FT operator()(const Sphere_3& s),`
+
+which returns the squared radius of `s`.
 */
 typedef unspecified_type Compute_squared_radius_3;
 
 /*!
 A functor object to compute the squared distance between two points. Provides the operator:
-`FT operator()(const Point_3& p, const Point_3& q);}` which returns the squared distance between `p` and `q`.
+
+`FT operator()(const Point_3& p, const Point_3& q),`
+
+which returns the squared distance between `p` and `q`.
 */
 typedef unspecified_type Compute_squared_distance_3;
 
 /*!
 A functor object to compare the x-coordinates of two points. Provides the operator:
-`bool operator()(const Point_3& p, const Point_3& q);}` which returns `true` if the x-coordinate of `p` is smaller
-than the x-coordinate of `q`.
+
+`bool operator()(const Point_3& p, const Point_3& q)`,
+
+ which returns `true` iff the x-coordinate of `p` is smaller than the x-coordinate of `q`.
 */
 typedef unspecified_type Less_x_3;
 
 /*!
 A functor object to compare the y-coordinates of two points. Provides the operator:
-`bool operator()(const Point_3& p, const Point_3& q);}` which returns `true` if the y-coordinate of `p` is smaller
-than the y-coordinate of `q`.
+
+`bool operator()(const Point_3& p, const Point_3& q)`,
+
+which returns `true` iff the y-coordinate of `p` is smaller than the y-coordinate of `q`.
 */
 typedef unspecified_type Less_y_3;
 
 /*!
 A functor object to compare the z-coordinates of two points. Provides the operator:
-`bool operator()(const Point_3& p, const Point_3& q);}` which returns `true` if the z-coordinate of `p` is smaller
-than the z-coordinate of `q`.
+
+`bool operator()(const Point_3& p, const Point_3& q)`,
+
+which returns `true` iff the z-coordinate of `p` is smaller than the z-coordinate of `q`.
 */
 typedef unspecified_type Less_z_3;
 
 /*!
 A functor object to compare two points. Provides the operator:
-`bool operator()(const Point_3& p, const Point_3& q);}` which returns `true` if `p` is equal to `q`.
+
+`bool operator()(const Point_3& p, const Point_3& q)`,
+
+which returns `true` iff `p` is equal to `q`.
 */
 typedef unspecified_type Equal_3;
-
-
 
 /// @}
 
@@ -130,7 +141,7 @@ typedef unspecified_type Equal_3;
 /// @{
 
 /*!
-returns the intersection detection functor.
+returns the intersection detection predicate.
 */
 Do_intersect_3 do_intersect_3_object();
 
@@ -150,14 +161,9 @@ returns the closest point constructor.
 Construct_projected_point_3 construct_projected_point_3_object();
 
 /*!
-returns the compare distance constructor.
+returns the compare distance predicate.
 */
 Compare_distance_3 compare_distance_3_object();
-
-/*!
-returns the closest point constructor.
-*/
-Has_on_bounded_side_3 has_on_bounded_side_3_object();
 
 /*!
 returns the squared radius functor.
@@ -170,22 +176,22 @@ returns the squared distance functor.
 Compute_squared_distance_3 compute_squared_distance_3_object();
 
 /*!
-returns the `Less_x_3` functor.
+returns the `Less_x_3` predicate.
 */
 Less_x_3 less_x_3_object();
 
 /*!
-returns the `Less_y_3` functor.
+returns the `Less_y_3` predicate.
 */
 Less_y_3 less_y_3_object();
 
 /*!
-returns the `Less_z_3` functor.
+returns the `Less_z_3` predicate.
 */
 Less_z_3 less_z_3_object();
 
 /*!
-returns the equal functor.
+returns the equal predicate.
 */
 Equal_3 equal_3_object();
 

--- a/AABB_tree/doc/AABB_tree/Concepts/AABBRayIntersectionGeomTraits.h
+++ b/AABB_tree/doc/AABB_tree/Concepts/AABBRayIntersectionGeomTraits.h
@@ -8,7 +8,8 @@ concept `AABBGeomTraits`. In addition to the types required by
 define the Intersection_distance functor.
 
 \cgalRefines `AABBGeomTraits`
-\cgalHasModel Any 3D Kernel is a model of this concept.
+
+\cgalHasModel All models of the concept `Kernel`
 
 \sa `CGAL::AABB_traits<AABBGeomTraits,AABBPrimitive>`
 \sa `CGAL::AABB_tree<AABBTraits>`
@@ -17,11 +18,6 @@ define the Intersection_distance functor.
 */
 class AABBRayIntersectionGeomTraits {
 public:
-  /*!
-    Type of a 3D point.
-  */
-  typedef unspecified_type Point_3;
-
   /*!
     Type of a 3D ray.
   */

--- a/AABB_tree/doc/AABB_tree/Concepts/AABBRayIntersectionTraits.h
+++ b/AABB_tree/doc/AABB_tree/Concepts/AABBRayIntersectionTraits.h
@@ -9,7 +9,6 @@ distance of an intersection along a ray.
 
 \cgalHasModel `CGAL::AABB_traits<AABBGeomTraits,AABBPrimitive>`
 
-\sa `CGAL::AABB_traits<AABBGeomTraits,AABBPrimitive>`
 \sa `CGAL::AABB_tree<AABBTraits>`
 \sa `AABBPrimitive`
 

--- a/AABB_tree/doc/AABB_tree/PackageDescription.txt
+++ b/AABB_tree/doc/AABB_tree/PackageDescription.txt
@@ -25,8 +25,10 @@
 \cgalCRPSection{Concepts}
 - `AABBPrimitive`
 - `AABBPrimitiveWithSharedData`
-- `AABBTraits`
 - `AABBGeomTraits`
+- `AABBTraits`
+- `AABBRayIntersectionGeomTraits`
+- `AABBRayIntersectionTraits`
 
 \cgalCRPSection{Classes}
 - `CGAL::AABB_traits<GeomTraits,Primitive>`

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -160,7 +160,7 @@ class AABB_tree;
 /// \tparam BboxMap must be a model of `ReadablePropertyMap` that has as key type a primitive id,
 ///                 and as value type a `Bounding_box`.
 ///                 If the type is `Default` the `Datum` must have the
-///                 member function `bbox()` that returns the bounding box  of the primitive.
+///                 member function `bbox()` that returns the bounding box of the primitive.
 ///
 /// If the argument `GeomTraits` is a model of the concept \ref
 /// AABBRayIntersectionGeomTraits, this class is also a model of \ref

--- a/AABB_tree/include/CGAL/AABB_traits.h
+++ b/AABB_tree/include/CGAL/AABB_traits.h
@@ -366,7 +366,7 @@ public:
     template<typename Query>
     boost::optional< typename Intersection_and_primitive_id<Query>::Type >
     operator()(const Query& query, const typename AT::Primitive& primitive) const {
-      auto inter_res = GeomTraits().intersect_3_object()(internal::Primitive_helper<AT>::get_datum(primitive,m_traits),query);
+      auto inter_res = GeomTraits().intersect_3_object()(query, internal::Primitive_helper<AT>::get_datum(primitive,m_traits));
       if (!inter_res)
         return boost::none;
       return boost::make_optional( std::make_pair(*inter_res, primitive.id()) );
@@ -391,9 +391,9 @@ public:
       GeomTraits geom_traits;
       Point closest_point = geom_traits.construct_projected_point_3_object()(
         internal::Primitive_helper<AT>::get_datum(pr,m_traits), p);
-      return
-        geom_traits.compare_distance_3_object()(p, closest_point, bound)==LARGER ?
-        bound : closest_point;
+
+      return (geom_traits.compare_distance_3_object()(p, closest_point, bound) == LARGER) ?
+               bound : closest_point;
     }
   };
 
@@ -406,15 +406,6 @@ public:
       typedef typename AT::FT FT;
       typedef typename AT::Primitive Primitive;
   public:
-      template <class Solid>
-      CGAL::Comparison_result operator()(const Point& p, const Solid& pr, const Point& bound) const
-      {
-          return GeomTraits().do_intersect_3_object()
-          (GeomTraits().construct_sphere_3_object()
-          (p, GeomTraits().compute_squared_distance_3_object()(p, bound)), pr)?
-          CGAL::SMALLER : CGAL::LARGER;
-      }
-
       CGAL::Comparison_result operator()(const Point& p, const Bounding_box& bb, const Point& bound, Tag_true) const
       {
           return GeomTraits().do_intersect_3_object()
@@ -436,6 +427,16 @@ public:
         return (*this)(p, bb, bound, Boolean_tag<internal::Has_static_filters<GeomTraits>::value>());
       }
 
+      // The following functions seem unused...?
+      template <class Solid>
+      CGAL::Comparison_result operator()(const Point& p, const Solid& pr, const Point& bound) const
+      {
+          return GeomTraits().do_intersect_3_object()
+          (GeomTraits().construct_sphere_3_object()
+          (p, GeomTraits().compute_squared_distance_3_object()(p, bound)), pr)?
+          CGAL::SMALLER : CGAL::LARGER;
+      }
+
       template <class Solid>
       CGAL::Comparison_result operator()(const Point& p, const Solid& pr, const FT& sq_distance) const
       {
@@ -445,7 +446,6 @@ public:
           CGAL::SMALLER :
           CGAL::LARGER;
       }
-
   };
 
   Closest_point closest_point_object() const {return Closest_point(*this);}

--- a/AABB_tree/test/AABB_tree/aabb_test_is_ray_intersection_geomtraits.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_is_ray_intersection_geomtraits.cpp
@@ -12,14 +12,12 @@ struct AABBGeomTraits {
   typedef nope Intersect_3;
   typedef nope Construct_sphere_3;
   typedef nope Compute_closest_point_3;
-  typedef nope Has_on_bounded_side_3;
   typedef nope Compute_squared_radius_3;
   typedef nope Compute_squared_distance_3;
   Do_intersect_3 do_intersect_3_object();
   Intersect_3 intersect_3_object();
   Construct_sphere_3 construct_sphere_3_object();
   Compute_closest_point_3 compute_closest_point_3_object();
-  Has_on_bounded_side_3 has_on_bounded_side_3_object();
   Compute_squared_radius_3 compute_squared_radius_3_object();
   Compute_squared_distance_3 compute_squared_distance_3_object();
 }; /* end AABBGeomTraits */

--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -3341,8 +3341,17 @@ namespace CartesianKernelFunctors {
     typedef typename K::Segment_3  Segment_3;
     typedef typename K::Ray_3      Ray_3;
     typedef typename K::FT         FT;
+
   public:
-    typedef Point_3                result_type;
+    template<typename>
+    struct result {
+      typedef const Point_3 type;
+    };
+
+    template<typename F>
+    struct result<F(Point_3, Point_3)> {
+      typedef const Point_3& type;
+    };
 
     Point_3
     operator()( const Line_3& l, const Point_3& p ) const
@@ -3369,15 +3378,19 @@ namespace CartesianKernelFunctors {
 
     Point_3
     operator()( const Triangle_3& t, const Point_3& p ) const
-    { return CommonKernelFunctors::Construct_projected_point_3<K>()(p,t,K()); }
+    { return CommonKernelFunctors::Construct_projected_point_3<K>()(t,p,K()); }
 
     Point_3
     operator()( const Segment_3& s, const Point_3& p ) const
-    { return CommonKernelFunctors::Construct_projected_point_3<K>()(p,s,K()); }
+    { return CommonKernelFunctors::Construct_projected_point_3<K>()(s,p,K()); }
 
     Point_3
     operator()( const Ray_3& r, const Point_3& p ) const
-    { return CommonKernelFunctors::Construct_projected_point_3<K>()(p,r,K()); }
+    { return CommonKernelFunctors::Construct_projected_point_3<K>()(r,p,K()); }
+
+    const Point_3&
+    operator()( const Point_3& p, const Point_3& q) const
+    { return CommonKernelFunctors::Construct_projected_point_3<K>()(p,q,K()); }
   };
 
   template <class K>

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
@@ -3398,8 +3398,17 @@ namespace HomogeneousKernelFunctors {
     typedef typename K::Triangle_3 Triangle_3;
     typedef typename K::Segment_3  Segment_3;
     typedef typename K::Ray_3      Ray_3;
+
   public:
-    typedef Point_3          result_type;
+    template<typename>
+    struct result {
+      typedef const Point_3 type;
+    };
+
+    template<typename F>
+    struct result<F(Point_3, Point_3)> {
+      typedef const Point_3& type;
+    };
 
     Point_3
     operator()( const Line_3& l, const Point_3& p ) const
@@ -3429,15 +3438,19 @@ namespace HomogeneousKernelFunctors {
 
     Point_3
     operator()( const Triangle_3& t, const Point_3& p ) const
-    { return CommonKernelFunctors::Construct_projected_point_3<K>()(p,t,K()); }
+    { return CommonKernelFunctors::Construct_projected_point_3<K>()(t,p,K()); }
 
     Point_3
     operator()( const Segment_3& s, const Point_3& p ) const
-    { return CommonKernelFunctors::Construct_projected_point_3<K>()(p,s,K()); }
+    { return CommonKernelFunctors::Construct_projected_point_3<K>()(s,p,K()); }
 
     Point_3
     operator()( const Ray_3& r, const Point_3& p ) const
-    { return CommonKernelFunctors::Construct_projected_point_3<K>()(p,r,K()); }
+    { return CommonKernelFunctors::Construct_projected_point_3<K>()(r,p,K()); }
+
+    const Point_3&
+    operator()( const Point_3& p, const Point_3& q) const
+    { return CommonKernelFunctors::Construct_projected_point_3<K>()(p,q,K()); }
   };
 
   template <class K>

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -2850,8 +2850,8 @@ namespace CommonKernelFunctors {
 
   public:
     typename K::Point_3
-    operator()(const typename K::Point_3& origin,
-               const typename K::Triangle_3& triangle,
+    operator()(const typename K::Triangle_3& triangle,
+               const typename K::Point_3& origin,
                const K& k)
     {
       typedef typename K::Point_3 Point_3;
@@ -2890,18 +2890,18 @@ namespace CommonKernelFunctors {
         if(linf_ab > linf_ac) {
           if(linf_ab > linf_bc) {
             // ab is the maximal segment
-            return this->operator()(origin, seg(a, b), k);
+            return this->operator()(seg(a, b), origin, k);
           } else {
             // ab > ac, bc >= ab, use bc
-            return this->operator()(origin, seg(b, c), k);
+            return this->operator()(seg(b, c), origin, k);
           }
         } else { // ab <= ac
           if(linf_ac > linf_bc) {
             // ac is the maximal segment
-            return this->operator()(origin, seg(a, c), k);
+            return this->operator()(seg(a, c), origin, k);
           } else {
             // ab <= ac, ac <= bc, use bc
-            return this->operator()(origin, seg(b, c), k);
+            return this->operator()(seg(b, c), origin, k);
           }
         }
       } // degenerate plane
@@ -2923,8 +2923,8 @@ namespace CommonKernelFunctors {
     }
 
     typename K::Point_3
-    operator()(const typename K::Point_3& query,
-               const typename K::Segment_3& segment,
+    operator()(const typename K::Segment_3& segment,
+               const typename K::Point_3& query,
                const K& k)
     {
 
@@ -2945,8 +2945,8 @@ namespace CommonKernelFunctors {
     }
 
     typename K::Point_3
-    operator()(const typename K::Point_3& query,
-               const typename K::Ray_3& ray,
+    operator()(const typename K::Ray_3& ray,
+               const typename K::Point_3& query,
                const K& k)
     {
       if ( ray.to_vector() * (query-ray.source()) <= 0)
@@ -2955,6 +2955,14 @@ namespace CommonKernelFunctors {
       {
         return k.construct_projected_point_3_object()(ray.supporting_line(), query);
       }
+    }
+
+    const typename K::Point_3&
+    operator()(const typename K::Point_3& point,
+               const typename K::Point_3&,
+               const K&)
+    {
+      return point;
     }
 
     // code for operator for plane and point is defined in
@@ -3005,7 +3013,6 @@ namespace CommonKernelFunctors {
   public:
     typedef typename K::Boolean     result_type;
 
-    // There are 36 combinaisons, so I use a template.
     template <class T1, class T2>
     result_type
     operator()(const T1& t1, const T2& t2) const
@@ -3018,7 +3025,6 @@ namespace CommonKernelFunctors {
   public:
     typedef typename K::Boolean     result_type;
 
-    // There are x combinaisons, so I use a template.
     template <class T1, class T2>
     result_type
     operator()(const T1& t1, const T2& t2) const

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_constructions_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_constructions_3.h
@@ -131,6 +131,8 @@ _test_fct_constructions_3(const R& r)
   assert( r.construct_projected_point_3_object()(ray, Point(-1,0,0)) == Point(0,0,0));
   assert( r.construct_projected_point_3_object()(s, Point(-1,0,0)) == Point(0,0,0));
   assert( r.construct_projected_point_3_object()(s, Point(2,0,0)) == Point(1,1,0));
+  assert( r.construct_projected_point_3_object()(Point(0,0,0), Point(2,0,0)) == Point(0,0,0));
+
   return true;
 }
 

--- a/Spatial_searching/doc/Spatial_searching/Concepts/SearchGeomTraits_3.h
+++ b/Spatial_searching/doc/Spatial_searching/Concepts/SearchGeomTraits_3.h
@@ -5,8 +5,7 @@
 The concept `SearchGeomTraits_3` defines the requirements for the template
 parameter of the search traits classes.
 
-\cgalHasModel `Simple_cartesian<double>`
-\cgalHasModel `Simple_cartesian<Gmpq>`
+\cgalHasModel All models of the concept `Kernel`
 
 */
 


### PR DESCRIPTION
## Summary of Changes

The description of the requirements within `AABBGeomTraits` (esp. `Do_intersect_3` & `Intersect_3`) did not match the code. Some more requirements also seem poorly documented and even useless (`Construct_min/max_vertex_3`, `Construct_iso_cuboid_3`), but I have left them there in case the traits class is used somewhere else.

Also add `Construct_projected_point_3(Point_3, Point_3)` for kernel models. Intentionally not a new requirement of the concept `Kernel` since this only arises if you use a point as datum in the `AABB_tree`.

CC: @palliez 

## Release Management

* Affected package(s): `AABB_tree`, kernels
* Issue(s) solved (if any): fix #6013
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

