### PR TITLE
Fix detection of warnings in test results

### DIFF
--- a/Testsuite/test/collect_cgal_testresults_from_cmake
+++ b/Testsuite/test/collect_cgal_testresults_from_cmake
@@ -50,7 +50,7 @@ print_testresult()
       # 'QMessageBox::warning'.
       if grep -v -F 'CMake Warning at /usr/share/cmake/Modules/FindBoost' CompilerOutput_$1 ProgramOutput.*.$1 | grep -i -E -q '(^|[^a-zA-Z_,:-])warning'
       then
-        if grep -v -F 'CMake Warning at /usr/share/cmake/Modules/FindBoost' CompilerOutput_$1 ProgramOutput.*.$1 | grep -i -E '(^|[^a-zA-Z_,:-])warning' | grep -i -q "include[/\]CGAL\|cmake"
+        if grep -v -F 'CMake Warning at /usr/share/cmake/Modules/FindBoost' CompilerOutput_$1 ProgramOutput.*.$1 | grep -i -E '(^|[^a-zA-Z_,:-])warning' | grep -i -q "include[/\]CGAL\|cmake|CGAL warning"
         then
           RESULT="w"
         else

--- a/Testsuite/test/parse-ctest-dashboard-xml.py
+++ b/Testsuite/test/parse-ctest-dashboard-xml.py
@@ -76,7 +76,7 @@ for t_id in range(0, len(tests)):
             labels.add(label)
             tests_per_label[label].append(t)
 
-warning_pattern=re.compile(r'(.*([^a-zA-Z_,:-])([^\d]\s)warning).*?(\[|\n)', flags=re.IGNORECASE)
+warning_pattern=re.compile(r'(.*([^a-zA-Z_,:-])warning)', flags=re.IGNORECASE)
 w_det=re.compile("warning");
 filter_pattern=re.compile(r'cmake|cgal', flags=re.IGNORECASE);
 with open_file_create_dir(result_file_name.format(dir=os.getcwd(),


### PR DESCRIPTION
## Summary of Changes

Fix detection of warnings in test results. Fix the regular expression to match "CGAL warning" and detect a `w`.

## Release Management

* Affected package(s): Testsuite

(I tried to apply the patch to `5.2.x-branch` but got a warning.)
