### PR TITLE
CGAL/Mesh_3/experimental/AABB_filtered_projection_traits.h: Remove  boost::remove_const<..> from the index type

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/experimental/AABB_filtered_projection_traits.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/AABB_filtered_projection_traits.h
@@ -48,7 +48,7 @@ class Filtered_projection_traits
 
   typedef typename boost::property_traits<IndexPropertyMap>::value_type Index_type;
 
-  typedef std::set<typename boost::remove_const<Index_type>::type> Set_of_indices;
+  typedef std::set<Index_type> Set_of_indices;
 
 public:
   template <typename IndexToIgnoreIterator>


### PR DESCRIPTION
## Summary of Changes

In `<CGAL/Mesh_3/experimental/AABB_filtered_projection_traits.h>`, remove `boost::remove_const<..>` from the index type, because that prevent to insert `const` items otherwise.

It does not seem to be necessary. Actually, I really do not see why it could have been necessary in the past.

_Describe what your pull request changes to CGAL (this can be skipped if it solves an issue already in the tracker or if it is a Feature or Small Feature submitted to the CGAL Wiki)._

## Release Management

* Affected package(s): Mesh_3, Polyhedron demo

