### PR TITLE
PMP: Forward the geometric traits in `orient_to_bound_a_volume()`

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
@@ -873,7 +873,7 @@ volume_connected_components(const TriangleMesh& tm,
   std::vector<Face_pair> si_faces;
   std::set< std::pair<std::size_t, std::size_t> > self_intersecting_cc; // due to self-intersections
   if (do_self_intersection_tests)
-    self_intersections(tm, std::back_inserter(si_faces));
+    self_intersections(tm, std::back_inserter(si_faces), np);
   std::vector<bool> is_involved_in_self_intersection(nb_cc, false);
 
   if (!si_faces.empty() && used_as_a_predicate)


### PR DESCRIPTION
## Summary of Changes

`volume_connected_components()` did not forward the geometric traits to an inner PMP function.

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): - 
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

