### PR TITLE
AABB_Tree: Use unique reference points for each primitive

### DIFF
--- a/AABB_tree/include/CGAL/AABB_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_primitive.h
@@ -157,7 +157,7 @@ public:
   typename Base::Datum_reference
   datum() const { return get(m_obj_pmap,this->m_id); }
 
-  typename Base::Point_reference
+  decltype(auto)
   reference_point() const { return get(m_pt_pmap,this->m_id); }
 };
 
@@ -184,7 +184,7 @@ public:
 
   Datum_reference datum() const { return m_datum; }
 
-  typename Base::Point_reference
+  decltype(auto)
   reference_point() const { return get(m_pt_pmap,this->m_id); }
 };
 
@@ -209,7 +209,7 @@ public:
   typename Base::Datum_reference
   datum(const Shared_data& data) const { return get(data.first,this->m_id); }
 
-  typename Base::Point_reference
+  decltype(auto)
   reference_point(const Shared_data& data) const { return get(data.second,this->m_id); }
 
   static Shared_data construct_shared_data(ObjectPropertyMap obj, PointPropertyMap pt) {return Shared_data(obj,pt);}
@@ -238,7 +238,7 @@ public:
 
   Datum_reference datum(Shared_data) const { return m_datum; }
 
-  typename Base::Point_reference
+  decltype(auto)
   reference_point(const Shared_data& data) const { return get(data,this->m_id); }
 
   static Shared_data construct_shared_data(ObjectPropertyMap, PointPropertyMap pt) {return pt;}

--- a/AABB_tree/include/CGAL/AABB_tree/internal/Primitive_helper.h
+++ b/AABB_tree/include/CGAL/AABB_tree/internal/Primitive_helper.h
@@ -47,8 +47,8 @@ struct Primitive_helper<AABBTraits,true>{
   {
     return p.datum(traits.shared_data());
   }
-  typedef typename Point_result_type<typename AABBTraits::Primitive>::type Reference_point_type;
-  static Reference_point_type get_reference_point(const typename AABBTraits::Primitive& p,const AABBTraits& traits) {
+
+  static decltype(auto) get_reference_point(const typename AABBTraits::Primitive& p,const AABBTraits& traits) {
     return p.reference_point(traits.shared_data());
   }
 };
@@ -57,8 +57,8 @@ template <class AABBTraits>
 struct Primitive_helper<AABBTraits,false>{
   typedef typename Datum_result_type<typename AABBTraits::Primitive>::type Datum_type;
   static Datum_type get_datum(const typename AABBTraits::Primitive& p,const AABBTraits&) {return p.datum();}
-  typedef typename Point_result_type<typename AABBTraits::Primitive>::type Reference_point_type;
-  static Reference_point_type get_reference_point(const typename AABBTraits::Primitive& p,const AABBTraits&) {return p.reference_point();}
+
+  static decltype(auto) get_reference_point(const typename AABBTraits::Primitive& p,const AABBTraits&) {return p.reference_point();}
 };
 
 } } //namespace CGAL::internal

--- a/BGL/include/CGAL/boost/graph/property_maps.h
+++ b/BGL/include/CGAL/boost/graph/property_maps.h
@@ -154,30 +154,40 @@ struct One_point_from_face_descriptor_map{
   typedef typename boost::graph_traits<PolygonMesh>::face_descriptor key_type;
   typedef typename boost::property_traits< VertexPointMap >::value_type value_type;
   typedef typename boost::property_traits< VertexPointMap >::reference reference;
-  typedef boost::lvalue_property_map_tag category;
+  typedef boost::readable_property_map_tag category;
+
+  value_type bar(key_type f) const
+  {
+    const auto& p0 = get(m_vpm, target(halfedge(f, *m_pm), *m_pm));
+    const auto& p1 = get(m_vpm, target(next(halfedge(f, *m_pm), *m_pm), *m_pm));
+    const auto& p2 = get(m_vpm, source(halfedge(f, *m_pm), *m_pm));
+
+    return CGAL::barycenter(p0, 0.25, p1, 0.25, p2, 0.5);
+  }
 
   //get function for property map
   inline friend
-  reference
+  value_type
   get(const One_point_from_face_descriptor_map<PolygonMesh,VertexPointMap>& m,
       key_type f)
   {
-    return get(m.m_vpm, target(halfedge(f, *m.m_pm), *m.m_pm));
+    return m.bar(f);
   }
 
   inline friend
-  reference
+  value_type
   get(const One_point_from_face_descriptor_map<PolygonMesh,VertexPointMap>& m,
       const std::pair<key_type, const PolygonMesh*>& f)
   {
-    return get(m.m_vpm, target(halfedge(f.first, *m.m_pm), *m.m_pm));
+    return m.bar(f.first);
   }
 };
 
 //property map to access a point from an edge
 template < class PolygonMesh,
            class VertexPointMap = typename boost::property_map<PolygonMesh,vertex_point_t>::type >
-struct Source_point_from_edge_descriptor_map{
+struct Source_point_from_edge_descriptor_map
+{
   Source_point_from_edge_descriptor_map()  : m_pm(nullptr)
   {}
 
@@ -202,19 +212,21 @@ struct Source_point_from_edge_descriptor_map{
 
   //get function for property map
   inline friend
-  reference
+  value_type
   get(const Source_point_from_edge_descriptor_map<PolygonMesh,VertexPointMap>& pmap,
       key_type h)
   {
-    return get(pmap.m_vpm,  source(h, *pmap.m_pm) );
+    return CGAL::midpoint(get(pmap.m_vpm, source(h, *pmap.m_pm)),
+                          get(pmap.m_vpm, target(h, *pmap.m_pm)));
   }
 
   inline friend
-  reference
+  value_type
   get(const Source_point_from_edge_descriptor_map<PolygonMesh,VertexPointMap>& pmap,
       const std::pair<key_type, const PolygonMesh*>& h)
   {
-    return get(pmap.m_vpm,  source(h.first, *pmap.m_pm) );
+    return CGAL::midpoint(get(pmap.m_vpm, source(h.first, *pmap.m_pm)),
+                          get(pmap.m_vpm, target(h.first, *pmap.m_pm)));
   }
 };
 


### PR DESCRIPTION
## Summary of Changes

The AABB tree uses the primitives' reference points at two different steps: in the primitive splitting and for the internal KD tree. In the case of face graphs, the reference point is a vertex of the descriptor, which might not be optimal: elements will often share the same reference point and so the splitting of the trees will not necessarily reflect the correct ordering of elements while sweeping in a given direction, and thus a non-optimal tree.

The changes in this PR are just to illustrate and not final. On some code with heavy use of the AABB tree, it yields up to 20% speed-ups. However, it can also cause a noticeable slow down if the usage of the AABB tree is light, especially if the reference point is not cached (e.g. uncached PMP::slicer).

Another important aspect is that when a reference point is taken as a vertex, it is an exact value. On the other hand, the reference points here are constructions, which are not so important for the primitive splitting (at worst, a non-optimal AABB is used) but are important for the internal kd tree. Maybe these two reference points could be distinguished.

@CGAL/geometryfactory 

## Release Management

* Affected package(s): `AABB_tree`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

