### PR TITLE
Remove shadow declaration of parameter space

### DIFF
--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2/Event_comparer.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2/Event_comparer.h
@@ -98,8 +98,6 @@ public:
       const Point_2& pt1 = e1->point();
       if (is_isolated2 || is_closed_interior2) {
         const Point_2& pt2 = e2->point();
-        Arr_parameter_space ps_x2 = e2->parameter_space_in_x();
-        Arr_parameter_space ps_y2 = e2->parameter_space_in_y();
         return _compare_points(pt1, ps_x1, ps_y1, pt2, ps_x2, ps_y2);
       }
       Arr_curve_end ind2;


### PR DESCRIPTION
## Summary of Changes

Declaration is redundant as event parameter space is assigned earlier in function.

## Release Management

* Affected package(s): 2D Intersection of Curves (Surface_sweep_2)
* License and copyright ownership: Unchanged

