### PR TITLE
autotest_cgal_with_ctest: Fix to allow the `errexit` option (`bash -e`)

### DIFF
--- a/Scripts/developer_scripts/autotest_cgal_with_ctest
+++ b/Scripts/developer_scripts/autotest_cgal_with_ctest
@@ -97,8 +97,10 @@ download_latest()
   fi
     log "${ACTUAL_LOGFILE}" "getting LATEST"
     if [ -n "${USE_CURL}" ]; then
+      echo "using curl..."
       ${CURL} ${CURL_OPTS} "${LATEST_LOCATION}" >> "${ACTUAL_LOGFILE}" 2>&1
     else
+      echo "using wget..."
       ${WGET} ${WGET_OPTS} "${LATEST_LOCATION}" >> "${ACTUAL_LOGFILE}" 2>&1
     fi
   if [ ! -f "LATEST" ]; then


### PR DESCRIPTION
## Summary of Changes

`Scripts/developer_scripts/autotest_cgal_with_ctest`: a fix to allow the `errexit` option (`bash -e`).

## Release Management

* Affected package(s): Scripts

@sloriot: As far as I know, it can be merged without testing. Testsuite machines uses a copy of that script.
