### PR TITLE
Remove c++17 deprecation warning

### DIFF
--- a/Interpolation/examples/Interpolation/sibson_interpolation_vertex_with_info_2.cpp
+++ b/Interpolation/examples/Interpolation/sibson_interpolation_vertex_with_info_2.cpp
@@ -50,8 +50,13 @@ struct Value_function
 
 template <typename V, typename G>
 struct Gradient_function
-  : public std::iterator<std::output_iterator_tag, void, void, void, void>
 {
+  typedef void value_type;
+  typedef void Distance;
+  typedef void Pointer;
+  typedef void Reference;
+  typedef std::output_iterator_tag category;
+
   typedef V                                                argument_type;
   typedef std::pair<G, bool>                               result_type;
 


### PR DESCRIPTION

Fixes
```
         C:\cgal_root\CGAL-5.4-Ic-75\test\Interpolation_Examples\sibson_interpolation_vertex_with_info_2.cpp(53,17): warning C4996: 'std::iterator<std::output_iterator_tag,void,void,void,void>': warning STL4015: The std::iterator class template (used as a base class to provide typedefs) is deprecated in C++17. (The <iterator> header is NOT deprecated.) The C++ Standard has never required user-defined iterators to derive from std::iterator. To fix this warning, stop deriving from std::iterator and start providing publicly accessible typedefs named iterator_category, value_type, difference_type, pointer, and reference. Note that value_type is required to be non-const, even for constant iterators. You can define _SILENCE_CXX17_ITERATOR_BASE_CLASS_DEPRECATION_WARNING or _SILENCE_ALL_CXX17_DEPRECATION_WARNINGS to acknowledge that you have received this warning. [C:\cgal_root\CGAL-5.4-Ic-75\cmake\platforms\MSVC-2022-Preview-Release\test\Interpolation_Examples\sibson_interpolation_vertex_with_info_2.vcxproj]
```

for example [here](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.4-Ic-75/Interpolation_Examples/TestReport_Sosno_MSVC-2022-Preview-Release.gz)
