### PR TITLE
Added Missing Call to the Remove Method in the Reconstruction Tutorial

### DIFF
--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/tutorial_example.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/tutorial_example.cpp
@@ -63,10 +63,11 @@ int main(int argc, char*argv[])
   ///////////////////////////////////////////////////////////////////
   //! [Outlier removal]
 
-  CGAL::remove_outliers<CGAL::Sequential_tag>
+  typename Point_set::iterator rout_it = CGAL::remove_outliers<CGAL::Sequential_tag>
     (points,
      24, // Number of neighbors considered for evaluation
      points.parameters().threshold_percent (5.0)); // Percentage of points to remove
+  points.remove(rout_it, points.end());
 
   std::cout << points.number_of_removed_points()
             << " point(s) are outliers." << std::endl;
@@ -86,7 +87,8 @@ int main(int argc, char*argv[])
   double spacing = CGAL::compute_average_spacing<CGAL::Sequential_tag> (points, 6);
 
   // Simplify using a grid of size 2 * average spacing
-  CGAL::grid_simplify_point_set (points, 2. * spacing);
+  typename Point_set::iterator gsim_it = CGAL::grid_simplify_point_set (points, 2. * spacing);
+  points.remove(gsim_it, points.end());
 
   std::cout << points.number_of_removed_points()
             << " point(s) removed after simplification." << std::endl;


### PR DESCRIPTION
This little PR fixes the issue #6050.

## Release Management

* Affected package(s): `Poisson_surface_reconstruction`
* Issue(s) solved (if any): fix #6050
* Feature/Small Feature (if any): bug fix
* Link to compiled documentation (obligatory for small feature): no docs changed
* License and copyright ownership: no changes

