### PR TITLE
Allow polygon soups to use an `std::array` point type in PM_to_PS

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_mesh_to_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_mesh_to_polygon_soup.h
@@ -16,6 +16,7 @@
 #include <CGAL/license/Polygon_mesh_processing/repair.h>
 
 #include <CGAL/algorithm.h>
+#include <CGAL/assertions.h>
 #include <CGAL/boost/graph/iterator.h>
 #include <CGAL/boost/graph/Named_function_parameters.h>
 #include <CGAL/boost/graph/named_params_helper.h>
@@ -27,6 +28,7 @@
 #include <boost/range/reference.hpp>
 
 #include <array>
+#include <type_traits>
 
 namespace CGAL {
 namespace Polygon_mesh_processing {


### PR DESCRIPTION
## Summary of Changes

`polygon_soup_to_polygon_mesh()` allows points to be of type `std::array<FT, 3>`, this PR allows the reverse.

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

