### PR TITLE
Fix a bad merge from PR "Re-organize I/O #4255"

### DIFF
--- a/Stream_support/examples/Stream_support/CMakeLists.txt
+++ b/Stream_support/examples/Stream_support/CMakeLists.txt
@@ -1,46 +1,20 @@
-# Created by the script cgal_create_CMakeLists
-# This is the CMake script for compiling a set of CGAL applications.
-
 cmake_minimum_required(VERSION 3.1...3.20)
 project(Stream_support_Examples)
 
-# CGAL and its components
 find_package(CGAL REQUIRED)
-include(${CGAL_USE_FILE})
 
-find_package(Boost QUIET)
+create_single_source_cgal_program( "Point_WKT.cpp" )
+create_single_source_cgal_program( "Polygon_WKT.cpp" )
+create_single_source_cgal_program( "Linestring_WKT.cpp" )
+create_single_source_cgal_program( "read_WKT.cpp" )
+create_single_source_cgal_program( "read_xml.cpp" )
 
-if(NOT Boost_FOUND)
-
-  message(
-    STATUS "This project requires the Boost library, and will not be compiled.")
-
-    create_single_source_cgal_program( "Point_WKT.cpp" )
-    create_single_source_cgal_program( "Polygon_WKT.cpp" )
-    create_single_source_cgal_program( "Linestring_WKT.cpp" )
-    create_single_source_cgal_program( "read_WKT.cpp" )
-
-    create_single_source_cgal_program( "read_xml.cpp" )
-
-    create_single_source_cgal_program( "iv2off.cpp" )
-    create_single_source_cgal_program( "off2iv.cpp" )
-    create_single_source_cgal_program( "off2off.cpp" )
-    create_single_source_cgal_program( "off2stl.cpp" )
-    create_single_source_cgal_program( "off2vrml.cpp" )
-    create_single_source_cgal_program( "off2wav.cpp" )
-    create_single_source_cgal_program( "off_bbox.cpp" )
-    create_single_source_cgal_program( "off_glue.cpp" )
-    create_single_source_cgal_program( "off_transform.cpp" )
-
-else ()
-  message(STATUS "This project requires the CGAL library, and will not be compiled.")
-  return()
-
-endif()
-
-create_single_source_cgal_program("Point_WKT.cpp")
-create_single_source_cgal_program("Polygon_WKT.cpp")
-create_single_source_cgal_program("Linestring_WKT.cpp")
-create_single_source_cgal_program("read_WKT.cpp")
-
-create_single_source_cgal_program("read_xml.cpp")
+create_single_source_cgal_program( "iv2off.cpp" )
+create_single_source_cgal_program( "off2iv.cpp" )
+create_single_source_cgal_program( "off2off.cpp" )
+create_single_source_cgal_program( "off2stl.cpp" )
+create_single_source_cgal_program( "off2vrml.cpp" )
+create_single_source_cgal_program( "off2wav.cpp" )
+create_single_source_cgal_program( "off_bbox.cpp" )
+create_single_source_cgal_program( "off_glue.cpp" )
+create_single_source_cgal_program( "off_transform.cpp" )


### PR DESCRIPTION
## Summary of Changes

<details><summary>Fix a bad merge from PR "Re-organize I/O #4255". Click to see the details...</summary>

Before my fix, the CMakeLists.txt could be sum-up that way:

```cmake
find_package(CGAL REQUIRED)
find_package(Boost QUIET)

if(NOT Boost_FOUND)
  message(
    STATUS "This project requires the Boost library, and will not be compiled.")

    create_single_source_cgal_program( "Point_WKT.cpp" )
    # [...]
else ()
  message(STATUS "This project requires the CGAL library, and will not be compiled.")
  return()
endif()
```

So, on *all platform*, as Boost is mandatory and always found, the
behavior was to display "This project requires the CGAL library, and
will not be compiled." and return, without configuring any target.

I have simplified the `CMakeLists.txt` to the simplest:

```cmake
cmake_minimum_required(VERSION 3.1...3.20)
project(Stream_support_Examples)

find_package(CGAL REQUIRED)

create_single_source_cgal_program( "Point_WKT.cpp" )
```

- `cmake_minimum_required` is mandatory and must be the first line,
- `project` is mandatory,
- `find_package(CGAL REQUIRED)`: no need to test `CGAL_FOUND`, because
  CGAL is required anyway. No need to search for Boost, because that is
  an implementation detail of CGAL, and the CMake file
  `CGALConfig.cmake` deals with that dependency
- and then the declaration of the targets.
</details>


## Release Management

* Affected package(s): Stream_support
* Issue(s) solved (if any): fix #4255
* License and copyright ownership: maintenance by GeometryFactory, no change to IP

