### PR TITLE
BGL - improve `get_property_map()`

### DIFF
--- a/BGL/include/CGAL/boost/graph/named_params_helper.h
+++ b/BGL/include/CGAL/boost/graph/named_params_helper.h
@@ -113,6 +113,13 @@ namespace CGAL {
     return pms.get_const_pmap(p, pmesh);
   }
 
+  template<typename PolygonMesh, typename PropertyTag>
+  typename property_map_selector<PolygonMesh, PropertyTag>::const_type
+  get_property_map(const PropertyTag& p, const PolygonMesh& pmesh)
+  {
+    return get_const_property_map(p, pmesh);
+  }
+
   // Shortcut for accessing the value type of the property map
   template <class Graph, class Property>
   class property_map_value {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -121,7 +121,7 @@ edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descriptor h,
 
   typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
-                             get_const_property_map(CGAL::vertex_point, pmesh));
+                             get_property_map(CGAL::vertex_point, pmesh));
 
   Geom_traits gt = choose_parameter<Geom_traits>(get_parameter(np, internal_np::geom_traits));
 
@@ -213,7 +213,7 @@ squared_edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descript
 
   typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
-                             get_const_property_map(CGAL::vertex_point, pmesh));
+                             get_property_map(CGAL::vertex_point, pmesh));
 
   Geom_traits gt = choose_parameter<Geom_traits>(get_parameter(np, internal_np::geom_traits));
 
@@ -473,7 +473,7 @@ face_area(typename boost::graph_traits<TriangleMesh>::face_descriptor f,
 
   typename GetVertexPointMap<TriangleMesh, CGAL_PMP_NP_CLASS>::const_type
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
-                             get_const_property_map(CGAL::vertex_point, tmesh));
+                             get_property_map(CGAL::vertex_point, tmesh));
 
   halfedge_descriptor hd = halfedge(f, tmesh);
   halfedge_descriptor nhd = next(hd, tmesh);
@@ -553,7 +553,7 @@ squared_face_area(typename boost::graph_traits<TriangleMesh>::face_descriptor f,
 
   typename GetVertexPointMap<TriangleMesh, CGAL_PMP_NP_CLASS>::const_type
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
-                             get_const_property_map(CGAL::vertex_point, tmesh));
+                             get_property_map(CGAL::vertex_point, tmesh));
 
   halfedge_descriptor hd = halfedge(f, tmesh);
   halfedge_descriptor nhd = next(hd, tmesh);
@@ -761,7 +761,7 @@ volume(const TriangleMesh& tmesh,
 
   typename GetVertexPointMap<TriangleMesh, CGAL_PMP_NP_CLASS>::const_type
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
-                             get_const_property_map(CGAL::vertex_point, tmesh));
+                             get_property_map(CGAL::vertex_point, tmesh));
   typename GetGeomTraits<TriangleMesh, CGAL_PMP_NP_CLASS>::type::Point_3 origin(0, 0, 0);
 
   typedef typename boost::graph_traits<TriangleMesh>::face_descriptor face_descriptor;
@@ -847,7 +847,7 @@ face_aspect_ratio(typename boost::graph_traits<TriangleMesh>::face_descriptor f,
 
   typename GetVertexPointMap<TriangleMesh, CGAL_PMP_NP_CLASS>::const_type
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
-                             get_const_property_map(CGAL::vertex_point, tmesh));
+                             get_property_map(CGAL::vertex_point, tmesh));
 
   halfedge_descriptor h = halfedge(f, tmesh);
 
@@ -958,7 +958,7 @@ centroid(const TriangleMesh& tmesh, const CGAL_PMP_NP_CLASS& np)
 
   typedef typename GetVertexPointMap<TriangleMesh, CGAL_PMP_NP_CLASS>::const_type Vpm;
   Vpm vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
-                             get_const_property_map(CGAL::vertex_point, tmesh));
+                             get_property_map(CGAL::vertex_point, tmesh));
 
   typedef typename GetGeomTraits<TriangleMesh, CGAL_PMP_NP_CLASS>::type Kernel;
   typedef typename Kernel::Point_3                                      Point_3;
@@ -1089,9 +1089,9 @@ void match_faces(const PolygonMesh1& m1, const PolygonMesh2& m2,
   using parameters::get_parameter;
 
   const VPMap1 vpm1 = choose_parameter(get_parameter(np1, internal_np::vertex_point),
-                                       get_const_property_map(vertex_point, m1));
+                                       get_property_map(vertex_point, m1));
   const VPMap2 vpm2 = choose_parameter(get_parameter(np2, internal_np::vertex_point),
-                                       get_const_property_map(vertex_point, m2));
+                                       get_property_map(vertex_point, m2));
   CGAL_static_assertion_msg((boost::is_same<typename boost::property_traits<VPMap1>::value_type,
                              typename boost::property_traits<VPMap2>::value_type>::value),
                             "Both vertex point maps must have the same point type.");

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
@@ -6,6 +6,7 @@
 #include <CGAL/Surface_mesh.h>
 
 #include <CGAL/Polygon_mesh_processing/bbox.h>
+#include <CGAL/Polygon_mesh_processing/measure.h>
 
 #include <CGAL/Bbox_3.h>
 


### PR DESCRIPTION
The function `get_property_map()` is very handy but I'm not sure it's worth having both `get_property_map()` and `get_const_property_map()` if we add an overload for `const PolygonMesh&` that automatically returns the `const` or `non const` version of the pmap.

I am not certain if this change would cause a problem elsewhere in CGAL that I have not thinked of.

@sloriot what do you think? We could test it in the release early stages to avoid issues

## Summary of Changes

Add an overload `const_type get_property_map(const PropertyTag& p, const PolygonMesh& pmesh)`

## Release Management

* Affected package(s): BGL
* License and copyright ownership: unchanged

