### PR TITLE
Fix Doo Sabin subdivision for Gmpq-based kernels

### DIFF
--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/subdivision_masks_3.h
@@ -477,7 +477,7 @@ public:
 
   /// computes the Doo-Sabin point `pt` of the vertex pointed by the halfedge `he`.
   void corner_node(halfedge_descriptor he, Point& pt) {
-    size_t n = 0;
+    int n = 0;
     halfedge_descriptor hd = he;
     do{
       hd = next(hd, *(this->pmesh));
@@ -493,7 +493,7 @@ public:
       cv = cv/16;
     }  else {
       FT a;
-      for (size_t k = 0; k < n; ++k, he = next(he, *(this->pmesh))) {
+      for (int k = 0; k < n; ++k, he = next(he, *(this->pmesh))) {
         if (k == 0) a = (FT) ((5.0/n) + 1);
         else a = (FT) (3+2*std::cos(2*k*CGAL_PI/n))/n;
         cv = cv + (get(this->vpm, target(he, *(this->pmesh)))-CGAL::ORIGIN)*a;


### PR DESCRIPTION
This PR introduces a simple fix for Doo-Sabin subdivision, with regard to the issue described in #6073.  The problem is circumvented by simply switching a couple of `size_t` integers in the mask calculations for corner nodes to plain old (signed) `int`s.

I have tested the code with a `CGAL::Cartesian<CGAL::Gmpq>` kernel and it seems to be working fine.