### PR TITLE
Kernel_23: Add NonZeroDimension_3

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Conic_x_monotone_arc_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Conic_x_monotone_arc_2.h
@@ -202,7 +202,7 @@ public:
     // Invalid arc:
     if (dir_res == EQUAL) return;
 
-    this->_info = (Conic_arc_2::IS_VALID | DEGREE_1);
+    this->_info = (static_cast<int>(Conic_arc_2::IS_VALID) | static_cast<int>(DEGREE_1));
     if (dir_res == SMALLER)
       this->_info = (this->_info | IS_DIRECTED_RIGHT);
 

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -39,8 +39,8 @@ Release date: December 2021
 -   Added `construct_centroid_2_object()` and `compute_determinant_2_object()` in `Projection_traits_xy_3`, `Projection_traits_xz_3`,
     and `Projection_traits_yz_3` classes.
 -   Added documentation for the class `Projection_traits_3`, which enables the use of 2D algorithms on the projections of 3D data onto an arbitrary plane.
--   Added the functor `NonZeroDimension_3`to the concept `Kernel` with `int operator(Kernel::Vector_3)`
-    which returns any dimension of the vector different from zero or `-1`.
+-   Added the functor `NonZeroCoordinateIndex_3`to the concept `Kernel` with `int operator(Kernel::Vector_3)`
+    which returns the index of any coordinate of the vector different from zero, or `-1`.
 
 
 ### [Polygon Mesh Processing](https://doc.cgal.org/5.4/Manual/packages.html#PkgPolygonMeshProcessing)

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -38,8 +38,10 @@ Release date: December 2021
 
 -   Added `construct_centroid_2_object()` and `compute_determinant_2_object()` in `Projection_traits_xy_3`, `Projection_traits_xz_3`,
     and `Projection_traits_yz_3` classes.
-
 -   Added documentation for the class `Projection_traits_3`, which enables the use of 2D algorithms on the projections of 3D data onto an arbitrary plane.
+-   Added the functor `NonZeroDimension_3`to the concept `Kernel` with `int operator(Kernel::Vector_3)`
+    which returns any dimension of the vector different from zero or `-1`.
+
 
 ### [Polygon Mesh Processing](https://doc.cgal.org/5.4/Manual/packages.html#PkgPolygonMeshProcessing)
 

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -9138,7 +9138,7 @@ public:
 
   \cgalRefines `AdaptableFunctor` (with one arguments)
 */
-class NonZeroDimension_3
+class NonZeroCoordinateIndex_3
 {
 public:
 

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -9147,10 +9147,10 @@ public:
   /// @{
 
   /*!
-    returns any of `0`, `1`, or `2`, if this dimension of vector `v` is not
-    equal to zero, and `-1` if `v` equals the null vector.
+    returns any of `0`, `1`, or `2` if the corresponding coordinate of the vector `v` is not
+    equal to zero, and `-1` if `v` is the null vector.
   */
-  int operator(const Kernel::Vector_3&v);
+  int operator(const Kernel::Vector_3& v);
 
   /// @}
 

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -9139,7 +9139,7 @@ public:
   \cgalRefines `AdaptableFunctor` (with one arguments)
 */
 class NonZeroDimension_3
-
+{
   /// \name Operations
   /// A model of this concept must provide:
   /// @{

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -9130,6 +9130,31 @@ public:
 }; /* end Kernel::LessZ_3 */
 
 
+
+
+/*!
+  \ingroup PkgKernel23ConceptsFunctionObjects
+  \cgalConcept
+
+  \cgalRefines `AdaptableFunctor` (with one arguments)
+*/
+class NonZeroDimension_3
+
+  /// \name Operations
+  /// A model of this concept must provide:
+  /// @{
+
+  /*!
+    returns any of `0`, `1`, or `2`, if this dimension of vector `v` is not
+    equal to zero, and `-1` if `v` equals the null vector.
+  */
+  int operator(const Kernel::Vector_3&v);
+
+  /// @}
+
+};
+
+
 /*!
   \ingroup PkgKernel23ConceptsFunctionObjects
   \cgalConcept

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -9140,6 +9140,8 @@ public:
 */
 class NonZeroDimension_3
 {
+public:
+
   /// \name Operations
   /// A model of this concept must provide:
   /// @{

--- a/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
@@ -1534,6 +1534,11 @@ public:
   typedef unspecified_type Is_degenerate_3;
 
   /*!
+    a model of `Kernel::HasNonZeroCoordinateIndex_3`
+  */
+  typedef unspecified_type Has_non_zero_coordinate_index_3;
+
+  /*!
     a model of `Kernel::HasOn_3`
   */
   typedef unspecified_type Has_on_3;

--- a/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
@@ -1534,11 +1534,6 @@ public:
   typedef unspecified_type Is_degenerate_3;
 
   /*!
-    a model of `Kernel::HasNonZeroCoordinateIndex_3`
-  */
-  typedef unspecified_type Has_non_zero_coordinate_index_3;
-
-  /*!
     a model of `Kernel::HasOn_3`
   */
   typedef unspecified_type Has_on_3;
@@ -1567,6 +1562,11 @@ public:
     a model of `Kernel::HasOnNegativeSide_3`
   */
   typedef unspecified_type Has_on_negative_side_3;
+
+  /*!
+    a model of `Kernel::NonZeroCoordinateIndex_3`
+  */
+  typedef unspecified_type Non_zero_coordinate_index_3;
 
   /*!
     a model of `Kernel::OrientedSide_3`

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -489,6 +489,7 @@
 - `Kernel::LessY_2`
 - `Kernel::LessY_3`
 - `Kernel::LessZ_3`
+- `Kernel::NonZeroDimension_3`
 - `Kernel::Orientation_2`
 - `Kernel::Orientation_3`
 - `Kernel::OrientedSide_2`

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -489,7 +489,7 @@
 - `Kernel::LessY_2`
 - `Kernel::LessY_3`
 - `Kernel::LessZ_3`
-- `Kernel::NonZeroDimension_3`
+- `Kernel::NonZeroCoordinateIndex_3`
 - `Kernel::Orientation_2`
 - `Kernel::Orientation_3`
 - `Kernel::OrientedSide_2`

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -40,7 +40,7 @@ namespace CommonKernelFunctors {
 
 
   template <typename K>
-  class Non_zero_dimension_3
+  class Non_zero_coordinate_index_3
   {
     typedef typename K::Vector_3 Vector_3;
 

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -49,19 +49,19 @@ namespace CommonKernelFunctors {
 
     result_type operator()(const Vector_3& vec) const
     {
-      if(certainly_not(is_zero(vec.x()))){
+      if(certainly_not(is_zero(vec.hx()))){
         return 0;
-      } else if(certainly_not(is_zero(vec.y()))){
+      } else if(certainly_not(is_zero(vec.hy()))){
         return 1;
-      }else if(certainly_not(is_zero(vec.z()))){
+      }else if(certainly_not(is_zero(vec.hz()))){
         return 2;
       }
 
-      if(! is_zero(vec.x())){
+      if(! is_zero(vec.hx())){
         return 0;
-      } else if(! is_zero(vec.y())){
+      } else if(! is_zero(vec.hy())){
         return 1;
-      } else if(! is_zero(vec.z())){
+      } else if(! is_zero(vec.hz())){
         return 2;
       }
 

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -582,8 +582,8 @@ CGAL_Kernel_pred(Less_y_3,
                  less_y_3_object)
 CGAL_Kernel_pred(Less_z_3,
                  less_z_3_object)
-CGAL_Kernel_pred(Non_zero_dimension_3,
-                 non_zero_dimension_3_object)
+CGAL_Kernel_pred(Non_zero_coordinate_index_3,
+                 non_zero_coordinate_index_3_object)
 CGAL_Kernel_pred_RT(Orientation_2,
                     orientation_2_object)
 CGAL_Kernel_pred_RT(Orientation_3,

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_vector_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_vector_3.h
@@ -27,7 +27,7 @@ _test_fct_vector_3(const R& )
  typedef typename  R::RT    RT;
  typedef typename  R::FT    FT;
 
- typedef typename R::Non_zero_dimension_3 Non_zero_dimension_3;
+ typedef typename R::Non_zero_coordinate_index_3 Non_zero_coordinate_index_3;
 
  RT  n0(  0 );
  RT  n1( 12 );
@@ -57,7 +57,7 @@ _test_fct_vector_3(const R& )
  CGAL::Vector_3<R>  v11(-n6, n11,-n12, n8);// ( 6, 8, -18)
  CGAL::Vector_3<R>  v12(n1, n2, -n3, n4);  // ( 6,-2, -3)
 
- Non_zero_dimension_3 nzd;
+ Non_zero_coordinate_index_3 nzd;
  assert( nzd(v0) == -1 );
  assert( nzd(v001) == 2 );
  assert( nzd(v011) == 1 );

--- a/Nef_3/include/CGAL/Nef_3/bounded_side_3.h
+++ b/Nef_3/include/CGAL/Nef_3/bounded_side_3.h
@@ -38,8 +38,8 @@ Bounded_side bounded_side_3(IteratorForward first,
 
   CGAL_assertion(!plane.is_degenerate());
 
-  typename R::Non_zero_dimension_3 non_zero_dimension_3;
-  int dir = non_zero_dimension_3(plane.orthogonal_vector());
+  typename R::Non_zero_coordinate_index_3 non_zero_coordinate_index_3;
+  int dir = non_zero_coordinate_index_3(plane.orthogonal_vector());
 
   if(dir == 0) {
     return bounded_side_2(first, last, point, YZ());


### PR DESCRIPTION
## Summary of Changes

Add a function object to the concept `Kernel` that enables to find any dimension of a 3D vector that is different from zero. 

- [x] Document the model

## Release Management

* Affected package(s): Kernel_23
* Feature/Small Feature (if any): [link](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/NonZeroDimension_3)
* Link to compiled documentation:  [link](https://cgal.github.io/6102/v3/Kernel_23/classKernel_1_1NonZeroDimension__3.html)
* License and copyright ownership: not changed

