### PR TITLE
Polygon fixes efif

### DIFF
--- a/Boolean_set_operations_2/doc/Boolean_set_operations_2/Concepts/GeneralPolygonSetTraits_2.h
+++ b/Boolean_set_operations_2/doc/Boolean_set_operations_2/Concepts/GeneralPolygonSetTraits_2.h
@@ -61,30 +61,30 @@ typedef unspecified_type Construct_polygon_2;
 /*!
 a functor that constructs a general polygon with holes from a general polygon and, optionally, a range of holes. It uses the operator
 
-`void operator() (const General_polygon_2& pgn_boundary)` or
+`void operator() (const Polygon_2& pgn_boundary)` or
 
-`void operator() (const General_polygon_2& pgn_boundary, HolesInputIterator h_begin, HolesInputIterator h_end)` parameterized by the `HolesInputIterator` type.
+`void operator() (const Polygon_2& pgn_boundary, HolesInputIterator h_begin, HolesInputIterator h_end)` parameterized by the `HolesInputIterator` type.
 */
-typedef unspecified_type Construct_general_polygon_with_holes_2;
+typedef unspecified_type Construct_polygon_with_holes_2;
 
 /*!
 A functor for constructing the outer boundary of a polygon with holes. It uses the operator
 
-`General_polygon_2 operator()(const General_polygon_with_holes_2& pol_wh)`.
+`Polygon_2 operator()(const Polygon_with_holes_2& pol_wh)`.
 */
 typedef unspecified_type Construct_outer_boundary;
 
 /*!
 A functor for constructing the container of holes of a polygon with holes. It returns the begin/end iterators for the holes It uses the operator
 
-`std::pair<Hole_const_iterator, Hole_const_iterator> operator()(const General_polygon_with_holes_2& pol_wh)`.
+`std::pair<Hole_const_iterator, Hole_const_iterator> operator()(const Polygon_with_holes_2& pol_wh)`.
 */
 typedef unspecified_type Construct_holes;
 
 /*!
 A functor for checking if polygon with holes has no outer boundary. It uses the operator
 
-`bool operator()(const General_polygon_with_holes_2& pol_wh)`.
+`bool operator()(const Polygon_with_holes_2& pol_wh)`.
 */
 typedef unspecified_type Is_unbounded;
 
@@ -126,7 +126,7 @@ Construct_curves_2 construct_curves_2_object();
 /*!
 returns a functor that constructs a polygon with holes.
 */
-Construct_general_polygon_with_holes_2 construct_polygon_with_holes_2_object() const;
+Construct_polygon_with_holes_2 construct_polygon_with_holes_2_object() const;
 
 /*!
 returns a functor that obtains the outer boundary of a polygon with holes.

--- a/Boolean_set_operations_2/doc/Boolean_set_operations_2/Concepts/GeneralPolygonSetTraits_2.h
+++ b/Boolean_set_operations_2/doc/Boolean_set_operations_2/Concepts/GeneralPolygonSetTraits_2.h
@@ -141,9 +141,8 @@ Construct_holes construct_holes_object() const;
 /*!
 returns a functor that determines if the polygon with holes is unbounded
 */
-Is_unbounded construct_is_unbounded_object();
+Is_unbounded is_unbounded_object();
 
 /// @}
 
 }; /* end GeneralPolygonSetTraits_2 */
-

--- a/Boolean_set_operations_2/include/CGAL/Gps_segment_traits_2.h
+++ b/Boolean_set_operations_2/include/CGAL/Gps_segment_traits_2.h
@@ -35,9 +35,10 @@ class Gps_segment_traits_2 : public ArrSegmentTraits {
 
 public:
   // Polygon_2 type is required by GeneralPolygonSetTraits Concept
-  typedef CGAL::Polygon_2<Kernel_, Container_>          Polygon_2;
-  // Polygon_2 is a model of the GeneralPolygon2 concept.
-  typedef Polygon_2                                     General_polygon_2;
+  typedef CGAL::Polygon_2<Kernel_, Container_>  Polygon_2;
+
+  // Backward compatibility
+  typedef Polygon_2                             General_polygon_2;
 
   // Polygon_with_holes_2 can be a simple polygon , with holes that are
   // entirely inside him , or some vertices of the polygon and its holes
@@ -46,8 +47,9 @@ public:
   // Polygon_with_holes_2 type required by GeneralPolygonSetTraits Concept.
   typedef CGAL::Polygon_with_holes_2<Kernel_, Container_>
                                                 Polygon_with_holes_2;
-  // Polygon_with_Holes_2 is a model of the GeneralPolygonWithHoles2 concept.
+  // Backward compatibility
   typedef Polygon_with_holes_2                  General_polygon_with_holes_2;
+
   typedef typename Base::X_monotone_curve_2     X_monotone_curve_2;
 
   typedef Polygon_2_curve_iterator<X_monotone_curve_2, Polygon_2>

--- a/Boolean_set_operations_2/include/CGAL/Gps_segment_traits_2.h
+++ b/Boolean_set_operations_2/include/CGAL/Gps_segment_traits_2.h
@@ -144,8 +144,8 @@ public:
   Construct_holes construct_holes_object() const
   { return Construct_holes(); }
 
-  /* A functor for constructing a General_polygon_with_holes from a
-   * General_Polygon (and possibly a range of holes).
+  /* A functor for constructing a Polygon_with_holes from a polygon (and
+   * possibly a range of holes).
    *
    * constructs a general polygon with holes using a given general polygon
    * outer as the outer boundary and a given range of holes. If outer is an

--- a/Boolean_set_operations_2/include/CGAL/Gps_segment_traits_2.h
+++ b/Boolean_set_operations_2/include/CGAL/Gps_segment_traits_2.h
@@ -26,20 +26,18 @@
 
 namespace CGAL {
 
-template < class Kernel_,
-           class Container_ = std::vector<typename Kernel_::Point_2>,
-           class Arr_seg_traits_ = Arr_segment_traits_2<Kernel_> >
-class Gps_segment_traits_2 : public Arr_seg_traits_
-{
-  typedef Arr_seg_traits_                                               Base;
-  typedef Gps_segment_traits_2<Kernel_, Container_, Arr_seg_traits_>    Self;
+template <typename Kernel_,
+          typename Container_ = std::vector<typename Kernel_::Point_2>,
+          typename ArrSegmentTraits = Arr_segment_traits_2<Kernel_> >
+class Gps_segment_traits_2 : public ArrSegmentTraits {
+  typedef ArrSegmentTraits                                               Base;
+  typedef Gps_segment_traits_2<Kernel_, Container_, ArrSegmentTraits>    Self;
 
 public:
-
   // Polygon_2 type is required by GeneralPolygonSetTraits Concept
   typedef CGAL::Polygon_2<Kernel_, Container_>          Polygon_2;
   // Polygon_2 is a model of the GeneralPolygon2 concept.
-  typedef  Polygon_2                                    General_polygon_2;
+  typedef Polygon_2                                     General_polygon_2;
 
   // Polygon_with_holes_2 can be a simple polygon , with holes that are
   // entirely inside him , or some vertices of the polygon and its holes
@@ -49,7 +47,7 @@ public:
   typedef CGAL::Polygon_with_holes_2<Kernel_, Container_>
                                                 Polygon_with_holes_2;
   // Polygon_with_Holes_2 is a model of the GeneralPolygonWithHoles2 concept.
-  typedef  Polygon_with_holes_2                 General_polygon_with_holes_2;
+  typedef Polygon_with_holes_2                  General_polygon_with_holes_2;
   typedef typename Base::X_monotone_curve_2     X_monotone_curve_2;
 
   typedef Polygon_2_curve_iterator<X_monotone_curve_2, Polygon_2>
@@ -64,7 +62,7 @@ public:
    * A functor for constructing a polygon from a range of segments.
    */
   class Construct_polygon_2 {
-    typedef Gps_segment_traits_2<Kernel_, Container_, Arr_seg_traits_> Self;
+    typedef Gps_segment_traits_2<Kernel_, Container_, ArrSegmentTraits> Self;
     typedef Gps_traits_adaptor<Self>            Traits_adaptor;
 
     /*! The traits (in case it has state) */
@@ -101,11 +99,9 @@ public:
   class Construct_curves_2 {
   public:
     std::pair<Curve_const_iterator, Curve_const_iterator>
-    operator()(const General_polygon_2& pgn) const
-    {
+    operator()(const Polygon_2& pgn) const {
       Curve_const_iterator c_begin(&pgn, pgn.vertex_pairs_begin());
       Curve_const_iterator c_end(&pgn, pgn.vertex_pairs_end());
-
       return (std::make_pair(c_begin, c_end));
     }
   };
@@ -121,39 +117,30 @@ public:
    */
   class Construct_outer_boundary {
   public:
-    General_polygon_2 operator()(const  General_polygon_with_holes_2& pol_wh)
-      const
-    {
-      return pol_wh.outer_boundary();
-    }
+    Polygon_2 operator()(const Polygon_with_holes_2& pol_wh) const
+    { return pol_wh.outer_boundary(); }
   };
 
   Construct_outer_boundary construct_outer_boundary_object() const
-  {
-    return Construct_outer_boundary();
-  }
+  { return Construct_outer_boundary(); }
 
-  /* typedef from General_polygon_with_holes_2.
+  /* typedef from Polygon_with_holes_2.
    * Hole_const_iterator nested type is required by
    * GeneralPolygonWithHoles2 concept
    */
 
-  /*A functor for constructing the container of holes of a polygon with holes.
-   * It returns ths begin/end iterators for the holes
+  /* A functor for constructing the container of holes of a polygon with holes.
+   * It returns the begin/end iterators for the holes
    */
   class Construct_holes {
   public:
     std::pair<Hole_const_iterator, Hole_const_iterator>
-    operator()(const General_polygon_with_holes_2& pol_wh) const
-    {
-      return std::make_pair(pol_wh.holes_begin(), pol_wh.holes_end());
-    }
+    operator()(const Polygon_with_holes_2& pol_wh) const
+    { return std::make_pair(pol_wh.holes_begin(), pol_wh.holes_end()); }
   };
 
   Construct_holes construct_holes_object() const
-  {
-    return Construct_holes();
-  }
+  { return Construct_holes(); }
 
   /* A functor for constructing a General_polygon_with_holes from a
    * General_Polygon (and possibly a range of holes).
@@ -165,25 +152,19 @@ public:
    * polygons representing the holes must be strictly simple and pairwise
    * disjoint, except perhaps at the vertices.
    */
-  class Construct_general_polygon_with_holes_2 {
+  class Construct_polygon_with_holes_2 {
   public:
-    General_polygon_with_holes_2 operator()(const General_polygon_2&
-                                            pgn_boundary) const
-    {
-      return General_polygon_with_holes_2(pgn_boundary);
-    }
-    template <class HolesInputIterator>
-    General_polygon_with_holes_2 operator()(const General_polygon_2&
-                                            pgn_boundary,
-                                            HolesInputIterator h_begin,
-                                            HolesInputIterator h_end) const
-    {
-      return General_polygon_with_holes_2(pgn_boundary, h_begin,h_end);
-    }
+    Polygon_with_holes_2 operator()(const Polygon_2& pgn_boundary) const
+    { return Polygon_with_holes_2(pgn_boundary); }
+
+    template <typename HolesInputIterator>
+    Polygon_with_holes_2 operator()(const Polygon_2& pgn_boundary,
+                                    HolesInputIterator h_begin,
+                                    HolesInputIterator h_end) const
+    { return Polygon_with_holes_2(pgn_boundary, h_begin,h_end); }
   };
 
-  Construct_general_polygon_with_holes_2 construct_polygon_with_holes_2_object()
-    const
+  Construct_polygon_with_holes_2 construct_polygon_with_holes_2_object() const
   {
     return Construct_general_polygon_with_holes_2();
   }
@@ -191,16 +172,11 @@ public:
   //functor returns true if the outer boundary is unbounded, and false otherwise.
   class Is_unbounded {
   public:
-    bool operator()(const General_polygon_with_holes_2& pol_wh) const
-    {
-      return pol_wh.is_unbounded();
-    }
+    bool operator()(const Polygon_with_holes_2& pol_wh) const
+    { return pol_wh.is_unbounded(); }
   };
 
-  Is_unbounded construct_is_unbounded_object() const
-  {
-    return Is_unbounded();
-  }
+  Is_unbounded is_unbounded_object() const { return Is_unbounded(); }
 };
 
 } //namespace CGAL

--- a/Boolean_set_operations_2/include/CGAL/Gps_traits_2.h
+++ b/Boolean_set_operations_2/include/CGAL/Gps_traits_2.h
@@ -163,7 +163,7 @@ public:
     { return pol_wh.is_unbounded(); }
   };
 
-  Is_unbounded construct_is_unbounded_object() const { return Is_unbounded(); }
+  Is_unbounded is_unbounded_object() const { return Is_unbounded(); }
 
   // Equality operator
   class Equal_2 {

--- a/Boolean_set_operations_2/include/CGAL/Gps_traits_2.h
+++ b/Boolean_set_operations_2/include/CGAL/Gps_traits_2.h
@@ -24,7 +24,7 @@
 
 namespace CGAL {
 
-template <typename Arr_traits,
+template <typename ArrTraits_2,
           typename GeneralPolygon_2 = General_polygon_2<ArrTraits_2> >
 class Gps_traits_2 : public ArrTraits_2 {
   typedef ArrTraits_2                                   Base;
@@ -130,8 +130,7 @@ public:
    */
   class Construct_polygon_with_holes_2 {
   public:
-    General_polygon_with_holes_2
-    operator()(const Polygon_2& pgn_boundary) const
+    Polygon_with_holes_2 operator()(const Polygon_2& pgn_boundary) const
     { return Polygon_with_holes_2(pgn_boundary); }
 
     template <class HolesInputIterator>

--- a/Boolean_set_operations_2/include/CGAL/Gps_traits_2.h
+++ b/Boolean_set_operations_2/include/CGAL/Gps_traits_2.h
@@ -35,14 +35,14 @@ public:
   typedef typename Base::X_monotone_curve_2             X_monotone_curve_2;
   typedef typename Base::Multiplicity                   Multiplicity;
 
-  //Polygon_2 type is required by GeneralPolygonSetTraits Concept
+  // Polygon_2 type is required by GeneralPolygonSetTraits Concept
   typedef GeneralPolygon_2                              Polygon_2;
-  //Polygon_2 is a model of the GeneralPolygon2 concept
+  // Backward compatibility
   typedef Polygon_2                                     General_polygon_2;
 
-  //Polygon_with_holes_2 type required by GeneralPolygonSetTraits Concept.
+  // Polygon_with_holes_2 type required by GeneralPolygonSetTraits Concept.
   typedef CGAL::General_polygon_with_holes_2<Polygon_2> Polygon_with_holes_2;
-  //Polygon_with_Holes_2 is a model of the GeneralPolygonWithHoles2 concept.
+  // Backward compatibility
   typedef Polygon_with_holes_2
     General_polygon_with_holes_2;
 

--- a/Boolean_set_operations_2/include/CGAL/Gps_traits_2.h
+++ b/Boolean_set_operations_2/include/CGAL/Gps_traits_2.h
@@ -25,34 +25,30 @@
 namespace CGAL {
 
 template <typename Arr_traits,
-          typename General_polygon_t = General_polygon_2<Arr_traits> >
-class Gps_traits_2 : public Arr_traits
-{
-  typedef Arr_traits                                    Base;
-  typedef Gps_traits_2<Arr_traits,General_polygon_t>    Self;
+          typename GeneralPolygon_2 = General_polygon_2<ArrTraits_2> >
+class Gps_traits_2 : public ArrTraits_2 {
+  typedef ArrTraits_2                                   Base;
+  typedef Gps_traits_2<ArrTraits_2, GeneralPolygon_2>   Self;
 
 public:
-
   typedef typename Base::Point_2                        Point_2;
   typedef typename Base::X_monotone_curve_2             X_monotone_curve_2;
   typedef typename Base::Multiplicity                   Multiplicity;
 
   //Polygon_2 type is required by GeneralPolygonSetTraits Concept
-  typedef General_polygon_t                             Polygon_2;
+  typedef GeneralPolygon_2                              Polygon_2;
   //Polygon_2 is a model of the GeneralPolygon2 concept
   typedef Polygon_2                                     General_polygon_2;
 
   //Polygon_with_holes_2 type required by GeneralPolygonSetTraits Concept.
-  typedef CGAL::General_polygon_with_holes_2<General_polygon_2>
-                                                        Polygon_with_holes_2;
+  typedef CGAL::General_polygon_with_holes_2<Polygon_2> Polygon_with_holes_2;
   //Polygon_with_Holes_2 is a model of the GeneralPolygonWithHoles2 concept.
   typedef Polygon_with_holes_2
     General_polygon_with_holes_2;
 
-  typedef typename General_polygon_2::Curve_const_iterator
-                                                        Curve_const_iterator;
+  typedef typename Polygon_2::Curve_const_iterator      Curve_const_iterator;
 
-  typedef typename General_polygon_with_holes_2::Hole_const_iterator
+  typedef typename Polygon_with_holes_2::Hole_const_iterator
                                                         Hole_const_iterator;
 
   typedef typename Base::Compare_endpoints_xy_2         Compare_endpoints_xy_2;
@@ -64,9 +60,9 @@ public:
    */
   class Construct_polygon_2 {
   public:
-    template<class XCurveIterator>
-    void operator()(XCurveIterator begin, XCurveIterator end,
-                    General_polygon_2& pgn) const
+    template <class XCurveIterator>
+    void
+    operator()(XCurveIterator begin, XCurveIterator end, Polygon_2& pgn) const
     { pgn.init(begin, end); }
   };
 
@@ -76,12 +72,10 @@ public:
   /*!
    * A functor for scanning all x-monotone curves that form a polygon boundary.
    */
-  class Construct_curves_2
-  {
+  class Construct_curves_2 {
   public:
-
     std::pair<Curve_const_iterator, Curve_const_iterator>
-    operator()(const General_polygon_2& pgn) const
+    operator()(const Polygon_2& pgn) const
     { return std::make_pair(pgn.curves_begin(), pgn.curves_end()); }
   };
 
@@ -106,30 +100,26 @@ public:
   /*A functor for constructing the outer boundary of a polygon with holes*/
   class Construct_outer_boundary {
   public:
-    General_polygon_2 operator()(const  General_polygon_with_holes_2& pol_wh)
-      const
+    Polygon_2 operator()(const Polygon_with_holes_2& pol_wh) const
     { return pol_wh.outer_boundary(); }
   };
 
   Construct_outer_boundary construct_outer_boundary_object() const
   { return Construct_outer_boundary(); }
 
-  /* typedef from General_polygon_with_holes_2. Hole_const_iterator nested type
-   * is required by GeneralPolygonWithHoles2 concept
+  /* A functor for constructing the container of holes of a polygon with holes
    */
-  /*A functor for constructing the container of holes of a polygon with holes*/
   class Construct_holes {
   public:
     std::pair<Hole_const_iterator, Hole_const_iterator>
-    operator()(const General_polygon_with_holes_2& pol_wh) const
+    operator()(const Polygon_with_holes_2& pol_wh) const
     { return std::make_pair(pol_wh.holes_begin(), pol_wh.holes_end()); }
   };
 
-  Construct_holes construct_holes_object() const
-  { return Construct_holes(); }
+  Construct_holes construct_holes_object() const { return Construct_holes(); }
 
-  /* A functor for constructing a General_polygon_with_holes from a
-   * General_Polygon (and possibly a range of holes).
+  /* A functor for constructing a Polygon_with_holes_2 from a
+   * Polygon_2 (and possibly a range of holes).
    *
    * constructs a general polygon with holes using a given general polygon
    * outer as the outer boundary and a given range of holes. If outer is an
@@ -138,28 +128,26 @@ public:
    * polygons representing the holes must be strictly simple and pairwise
    * disjoint, except perhaps at the vertices.
    */
-  class Construct_general_polygon_with_holes_2 {
+  class Construct_polygon_with_holes_2 {
   public:
     General_polygon_with_holes_2
-    operator()(const General_polygon_2& pgn_boundary) const
-    { return General_polygon_with_holes_2(pgn_boundary); }
+    operator()(const Polygon_2& pgn_boundary) const
+    { return Polygon_with_holes_2(pgn_boundary); }
 
     template <class HolesInputIterator>
-    General_polygon_with_holes_2
-    operator()(const General_polygon_2& pgn_boundary,
-               HolesInputIterator h_begin,
-               HolesInputIterator h_end) const
-    { return General_polygon_with_holes_2(pgn_boundary, h_begin,h_end); }
+    Polygon_with_holes_2 operator()(const Polygon_2& pgn_boundary,
+                                    HolesInputIterator h_begin,
+                                    HolesInputIterator h_end) const
+    { return Polygon_with_holes_2(pgn_boundary, h_begin,h_end); }
   };
 
-  Construct_general_polygon_with_holes_2 construct_polygon_with_holes_2_object()
-    const
-  { return Construct_general_polygon_with_holes_2(); }
+  Construct_polygon_with_holes_2 construct_polygon_with_holes_2_object() const
+  { return Construct_polygon_with_holes_2(); }
 
   // Return true if the outer boundary is empty, and false otherwise.
   class Is_unbounded {
   public:
-    bool operator()(const  General_polygon_with_holes_2& pol_wh) const
+    bool operator()(const Polygon_with_holes_2& pol_wh) const
     { return pol_wh.is_unbounded(); }
   };
 
@@ -202,9 +190,7 @@ public:
     { return m_traits.equal_2_object()(cv1, cv2); }
 
     //! Compare two general polygons
-    bool operator()(const General_polygon_2& pgn1, const General_polygon_2& pgn2)
-      const
-    {
+    bool operator()(const Polygon_2& pgn1, const Polygon_2& pgn2) const {
       if (pgn1.size() != pgn2.size()) return false;
       if (pgn1.is_empty() && ! pgn2.is_empty()) return false;
       if (pgn2.is_empty()) return false;
@@ -224,9 +210,8 @@ public:
     }
 
     //! Compare two general polygons
-    bool operator()(const General_polygon_with_holes_2& pgn1,
-                    const General_polygon_with_holes_2& pgn2) const {
-
+    bool operator()(const Polygon_with_holes_2& pgn1,
+                    const Polygon_with_holes_2& pgn2) const {
       if (! operator()(pgn1.outer_boundary(), pgn2.outer_boundary()))
         return false;
       if (pgn1.number_of_holes(), pgn2.number_of_holes()) return false;

--- a/Minkowski_sum_2/include/CGAL/minkowski_sum_2.h
+++ b/Minkowski_sum_2/include/CGAL/minkowski_sum_2.h
@@ -761,10 +761,10 @@ minkowski_sum_by_decomposition_2
  const Decomposition_& decomp,
  const Gps_segment_traits_2<Kernel_, Container_>& traits)
 {
-  typedef Kernel_                               Kernel;
-  typedef Container_                            Container;
-  typedef Decomposition_                        Decomposition;
-  typedef Polygon_nop_decomposition_2<Kernel>   Nop_decomposition;
+  typedef Kernel_                                         Kernel;
+  typedef Container_                                      Container;
+  typedef Decomposition_                                  Decomposition;
+  typedef Polygon_nop_decomposition_2<Kernel, Container>  Nop_decomposition;
 
   if (pgn1.is_convex()) {
     Nop_decomposition decomp_nop;
@@ -839,11 +839,11 @@ minkowski_sum_by_decomposition_2
  const WithHolesDecomposition_& decomp_with_holes,
  const Gps_segment_traits_2<Kernel_, Container_>& traits)
 {
-  typedef Kernel_                               Kernel;
-  typedef Container_                            Container;
-  typedef NoHolesDecomposition_                 No_holes_decomposition;
-  typedef WithHolesDecomposition_               With_holes_decomposition;
-  typedef Polygon_nop_decomposition_2<Kernel>   Nop_decomposition;
+  typedef Kernel_                                         Kernel;
+  typedef Container_                                      Container;
+  typedef NoHolesDecomposition_                           No_holes_decomposition;
+  typedef WithHolesDecomposition_                         With_holes_decomposition;
+  typedef Polygon_nop_decomposition_2<Kernel, Container>  Nop_decomposition;
 
   Hole_filter_2<Kernel, Container> hole_filter;
   Polygon_with_holes_2<Kernel, Container> filtered_pgn1;
@@ -982,11 +982,11 @@ minkowski_sum_by_decomposition_2
  const WithHolesDecomposition_& decomp_with_holes,
  const Gps_segment_traits_2<Kernel_, Container_>& traits)
 {
-  typedef Kernel_                               Kernel;
-  typedef Container_                            Container;
-  typedef NoHolesDecomposition_                 No_holes_decomposition;
-  typedef WithHolesDecomposition_               With_holes_decomposition;
-  typedef Polygon_nop_decomposition_2<Kernel>   Nop_decomposition;
+  typedef Kernel_                                         Kernel;
+  typedef Container_                                      Container;
+  typedef NoHolesDecomposition_                           No_holes_decomposition;
+  typedef WithHolesDecomposition_                         With_holes_decomposition;
+  typedef Polygon_nop_decomposition_2<Kernel, Container>  Nop_decomposition;
 
   Hole_filter_2<Kernel, Container> hole_filter;
   Polygon_with_holes_2<Kernel,Container> filtered_pgn2;

--- a/Polygon/doc/Polygon/Concepts/GeneralPolygonWithHoles_2.h
+++ b/Polygon/doc/Polygon/Concepts/GeneralPolygonWithHoles_2.h
@@ -1,22 +1,18 @@
-
-/*!
-\ingroup PkgPolygon2Concepts
-\cgalConcept
-
-\cgalRefines `DefaultConstructible`
-\cgalRefines `CopyConstructible`
-\cgalRefines `Assignable`
-
-
-A model of this concept represents a general polygon with holes. The
-concept requires the ability to access the general polygon that
-represents the outer boundary and the general polygons that represent
-the holes.
-
-\cgalHasModel `CGAL::General_polygon_with_holes_2<General_polygon>`
-\cgalHasModel `CGAL::Polygon_with_holes_2<Kernel,Container>`
-
-*/
+/*! \ingroup PkgPolygon2Concepts
+ * \cgalConcept
+ *
+ * \cgalRefines `DefaultConstructible`
+ * \cgalRefines `CopyConstructible`
+ * \cgalRefines `Assignable`
+ *
+ * A model of this concept represents a general polygon with holes. The
+ * concept requires the ability to access the general polygon that
+ * represents the outer boundary and the general polygons that represent
+ * the holes.
+ *
+ * \cgalHasModel `CGAL::General_polygon_with_holes_2<Polygon>`
+ * \cgalHasModel `CGAL::Polygon_with_holes_2<Kernel,Container>`
+ */
 
 class GeneralPolygonWithHoles_2 {
 public:
@@ -24,16 +20,13 @@ public:
 /// \name Types
 /// @{
 
-/*!
-the general-polygon type used to represent the outer boundary and each hole.
-*/
-typedef unspecified_type General_polygon_2;
+/*! the polygon type used to represent the outer boundary and each hole.
+ */
+typedef unspecified_type Polygon_2;
 
-/*!
-a bidirectional iterator
-over the polygonal holes. Its value type is
-`General_polygon_2`.
-*/
+/*! a bidirectional iterator
+ * over the polygonal holes. Its value type is `Polygon_2`.
+ */
 typedef unspecified_type Hole_const_iterator;
 
 /// @}
@@ -41,27 +34,24 @@ typedef unspecified_type Hole_const_iterator;
 /// \name Creation
 /// @{
 
-/*!
-constructs a general polygon with holes using a given general polygon
-`outer` as the outer boundary and a given range of holes. If `outer`
-is an empty general polygon, then an unbounded polygon with holes will be
-created. The holes must be contained inside the outer boundary, and the
-polygons representing the holes must be simple and pairwise disjoint, except
-perhaps at the vertices.
-*/
-template <class InputIterator>
-GeneralPolygonWithHoles_2(General_polygon_2 & outer,
-InputIterator begin, InputIterator end);
+/*! constructs a general polygon with holes using a given general polygon
+ * `outer` as the outer boundary and a given range of holes. If `outer` is an
+ * empty general polygon, then an unbounded polygon with holes will be
+ * created. The holes must be contained inside the outer boundary, and the
+ * polygons representing the holes must be simple and pairwise disjoint, except
+ * perhaps at the vertices.
+ */
+template <typename InputIterator>
+GeneralPolygonWithHoles_2(Polygon_2 & outer,
+                          InputIterator begin, InputIterator end);
 
 /// @}
 
 /// \name Predicates
 /// @{
 
-/*!
-returns `true` if the outer boundary is empty, and `false`
-otherwise.
-*/
+/*! returns `true` if the outer boundary is empty, and `false` otherwise.
+ */
 bool is_unbounded();
 
 /// @}
@@ -69,22 +59,20 @@ bool is_unbounded();
 /// \name Access Functions
 /// @{
 
-/*!
-returns the general polygon that represents the outer boundary. Note that this polygon is not necessarily a valid (simple) general polygon because it may be relatively simple.
-*/
-const General_polygon_2 & outer_boundary() const;
+/*! returns the general polygon that represents the outer boundary. Note that
+ * this polygon is not necessarily a valid (simple) general polygon because it
+ * may be relatively simple.
+ */
+const Polygon_2& outer_boundary() const;
 
-/*!
-returns the begin iterator of the holes.
-*/
+/*! returns the begin iterator of the holes.
+ */
 Hole_const_iterator holes_begin() const;
 
-/*!
-returns the past-the-end iterator of the holes.
-*/
+/*! returns the past-the-end iterator of the holes.
+ */
 Hole_const_iterator holes_end() const;
 
 /// @}
 
 }; /* end GeneralPolygonWithHoles_2 */
-

--- a/Polygon/doc/Polygon/PackageDescription.txt
+++ b/Polygon/doc/Polygon/PackageDescription.txt
@@ -54,7 +54,7 @@ The assertion flags for the polygons and polygon operations use
 \cgalCRPSection{Classes}
 - `CGAL::Polygon_2<PolygonTraits_2, Container>`
 - `CGAL::Polygon_with_holes_2<PolygonTraits_2,Container>`
-- `CGAL::General_polygon_with_holes_2<General_polygon>`
+- `CGAL::General_polygon_with_holes_2<Polygon>`
 
 \cgalCRPSection{Global Functions}
 - `CGAL::area_2()`
@@ -76,4 +76,3 @@ The assertion flags for the polygons and polygon operations use
 - \link  PkgDrawPolygonWithHoles2 CGAL::draw<PH>() \endlink
 
 */
-

--- a/Polygon/include/CGAL/General_polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/General_polygon_with_holes_2.h
@@ -23,140 +23,90 @@
 
 namespace CGAL {
 
-/*!
-\ingroup PkgPolygon2Ref
-
-The class `General_polygon_with_holes_2` models the concept
-`GeneralPolygonWithHoles_2`. It represents a general polygon with
-holes. It is parameterized with a type `Polygon` used to define
-the exposed type `General_polygon_2`. This type represents the
-outer boundary of the general polygon and the outer boundaries of
-each hole.
-
-\tparam Polygon_ must have input and output operators.
-
-\cgalModels `GeneralPolygonWithHoles_2`
-
-*/
-template <class Polygon_>
-class General_polygon_with_holes_2
-{
+/*! \ingroup PkgPolygon2Ref
+ *
+ * The class `General_polygon_with_holes_2` models the concept
+ * `GeneralPolygonWithHoles_2`. It represents a general polygon with holes.
+ * It is parameterized with a type `Polygon` used to define the exposed
+ * type `Polygon_2`. This type represents the outer boundary of the general
+ * polygon and each hole.
+ *
+ * \tparam Polygon_ must have input and output operators.
+ *
+ * \cgalModels `GeneralPolygonWithHoles_2`
+ */
+template <typename Polygon_>
+class General_polygon_with_holes_2 {
 public:
-
 /// \name Definition
 
 /// @{
   /// polygon without hole type
-  typedef Polygon_                                                        General_polygon_2;
+  typedef Polygon_                                    Polygon_2;
+
+  // Backward compatibility
+  typedef Polygon_2                                   General_polygon_2;
 /// @}
 
-  typedef std::deque<General_polygon_2>               Holes_container;
+  typedef std::deque<Polygon_2>                       Holes_container;
 
   typedef typename Holes_container::iterator          Hole_iterator;
   typedef typename Holes_container::const_iterator    Hole_const_iterator;
 
-  typedef unsigned int                                 Size;
+  typedef unsigned int                                Size;
 
-  General_polygon_with_holes_2() : m_pgn()
+  General_polygon_with_holes_2() : m_pgn() {}
+
+
+  explicit General_polygon_with_holes_2(const Polygon_2& pgn_boundary) :
+    m_pgn(pgn_boundary)
   {}
 
-
-  explicit General_polygon_with_holes_2(const General_polygon_2& pgn_boundary)
-  : m_pgn(pgn_boundary)
+  template <typename HolesInputIterator>
+  General_polygon_with_holes_2(const Polygon_2& pgn_boundary,
+                               HolesInputIterator h_begin,
+                               HolesInputIterator h_end) :
+    m_pgn(pgn_boundary),
+    m_holes(h_begin, h_end)
   {}
 
+  Holes_container& holes() { return m_holes; }
 
-  template <class HolesInputIterator>
-  General_polygon_with_holes_2(const General_polygon_2& pgn_boundary,
-                       HolesInputIterator h_begin,
-                       HolesInputIterator h_end) : m_pgn(pgn_boundary),
-                                                   m_holes(h_begin, h_end)
-  {}
+  const Holes_container& holes() const { return m_holes; }
 
-  Holes_container& holes()
-  {
-    return m_holes;
-  }
+  Hole_iterator holes_begin() { return m_holes.begin(); }
 
-  const Holes_container& holes() const
-  {
-    return m_holes;
-  }
+  Hole_iterator holes_end() { return m_holes.end(); }
 
-  Hole_iterator holes_begin()
-  {
-    return m_holes.begin();
-  }
+  Hole_const_iterator holes_begin() const { return m_holes.begin(); }
 
-  Hole_iterator holes_end()
-  {
-    return m_holes.end();
-  }
+  Hole_const_iterator holes_end() const { return m_holes.end(); }
 
-  Hole_const_iterator holes_begin() const
-  {
-    return m_holes.begin();
-  }
+  bool is_unbounded() const { return m_pgn.is_empty(); }
 
-  Hole_const_iterator holes_end() const
-  {
-    return m_holes.end();
-  }
+  Polygon_2& outer_boundary() { return m_pgn; }
 
-  bool is_unbounded() const
-  {
-    return m_pgn.is_empty();
-  }
+  const Polygon_2& outer_boundary() const { return m_pgn; }
 
-  General_polygon_2& outer_boundary()
-  {
-    return m_pgn;
-  }
+  void add_hole(const Polygon_2& pgn_hole) { m_holes.push_back(pgn_hole); }
 
-  const General_polygon_2& outer_boundary() const
-  {
-    return m_pgn;
-  }
+  void erase_hole(Hole_iterator hit) { m_holes.erase(hit); }
 
-  void add_hole(const General_polygon_2& pgn_hole)
-  {
-    m_holes.push_back(pgn_hole);
-  }
+  bool has_holes() const { return (!m_holes.empty()); }
 
-  void erase_hole(Hole_iterator hit)
-  {
-    m_holes.erase(hit);
-  }
+  Size number_of_holes() const { return static_cast<Size>(m_holes.size()); }
 
-  bool has_holes() const
-  {
-    return (!m_holes.empty());
-  }
-
-  Size number_of_holes() const
-  {
-    return static_cast<Size>(m_holes.size());
-  }
-
-  void clear()
-  {
+  void clear() {
     m_pgn.clear();
     m_holes.clear();
   }
 
-  bool is_plane() const
-  {
-    return (m_pgn.is_empty() && m_holes.empty());
-  }
-
-
+  bool is_plane() const { return (m_pgn.is_empty() && m_holes.empty()); }
 
 protected:
-
-  General_polygon_2           m_pgn;
-  Holes_container            m_holes;
+  Polygon_2 m_pgn;
+  Holes_container m_holes;
 };
-
 
 //-----------------------------------------------------------------------//
 //                          operator<<
@@ -177,10 +127,9 @@ boundary is exported followed by the curves themselves.
 
 \relates General_polygon_with_holes_2
 */
-template <class Polygon_>
-std::ostream
-&operator<<(std::ostream &os, const General_polygon_with_holes_2<Polygon_>& p)
-{
+template <typename Polygon_>
+std::ostream&
+operator<<(std::ostream& os, const General_polygon_with_holes_2<Polygon_>& p) {
   typename General_polygon_with_holes_2<Polygon_>::Hole_const_iterator hit;
 
   switch(IO::get_mode(os)) {
@@ -225,19 +174,17 @@ outer boundary is followed by the curves themselves.
 
 \relates General_polygon_with_holes_2
 */
-template <class Polygon_>
-std::istream &operator>>(std::istream &is, General_polygon_with_holes_2<Polygon_>& p)
-{
+template <typename Polygon_>
+std::istream&
+operator>>(std::istream& is, General_polygon_with_holes_2<Polygon_>& p) {
   p.clear();
   is >> p.outer_boundary();
 
   unsigned int n_holes;
   is >> n_holes;
-  if (is)
-  {
+  if (is) {
     Polygon_ pgn_hole;
-    for (unsigned int i=0; i<n_holes; i++)
-    {
+    for (unsigned int i=0; i<n_holes; ++i) {
       is >> pgn_hole;
       p.add_hole(pgn_hole);
     }

--- a/Straight_skeleton_2/include/CGAL/create_offset_polygons_2.h
+++ b/Straight_skeleton_2/include/CGAL/create_offset_polygons_2.h
@@ -50,7 +50,7 @@ struct Is_same_type<U,U> { typedef Tag_true type ; } ;
 
 // The return type of create_interior/exterior_skeleton_and_offset_polygons_2:
 // - if polygon input is a model of 'GeneralPolygonWithHoles_2', the return type
-//   should be the internal (hole-less) polygon type GeneralPolygonWithHoles_2::General_polygon_2
+//   should be the internal (hole-less) polygon type GeneralPolygonWithHoles_2::Polygon_2
 // - if polygon input is just a sequence container of points (e.g. Polygon_2), then the same type
 //   is expected in output
 template <typename Polygon, typename OfK,
@@ -59,9 +59,9 @@ struct Default_return_polygon_type // Polygon type supports holes
 {
   typedef typename std::conditional<std::is_same<
                                       typename Kernel_traits<typename boost::range_value<
-                                        typename Polygon::General_polygon_2>::type>::Kernel,
+                                        typename Polygon::Polygon_2>::type>::Kernel,
                                       OfK>::value,
-                                    typename Polygon::General_polygon_2, // correct kernel
+                                    typename Polygon::Polygon_2, // correct kernel
                                     CGAL::Polygon_2<OfK> /*incorrect kernel*/ >::type type;
 };
 
@@ -85,7 +85,7 @@ struct Default_return_polygon_with_holes_type // Polygon type supports holes
 {
   typedef typename std::conditional<std::is_same<
                                       typename Kernel_traits<typename boost::range_value<
-                                        typename Polygon::General_polygon_2>::type>::Kernel,
+                                        typename Polygon::Polygon_2>::type>::Kernel,
                                       OfK>::value,
                                     Polygon, // correct kernel
                                     CGAL::Polygon_with_holes_2<OfK> /*incorrect kernel*/ >::type type;


### PR DESCRIPTION
## Summary of Changes

This pull requests solves 2 bugs and fixes one small mess:
1. The instantiation of Nop_polygon_decomposition<Kernal, Container> in the 2D Minkowski sum package was missing the explicit container. (It thus used the default one). When a specific container is provided the code didn't compile.
2. The required function `is_bounded_object()` in the GeneralPolygonSetTraits_2 concept was erroneously called `construct_is_bounded_object()`. It has been renamed.
3. Replaced the required nested type `General_polygon_2` with `Polygon_2` in the concept `GeneralPolygonWithHoles_2`

## Release Management

* Affected package(s): 2D Polygon, 2D Regularized Boolean Set Operations, and 2D Straight Skeleton
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any): https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Fix_GeneralPolygonWithHoles_2_Concept_nested_polygon_type
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: Tel Aviv Univ.

