### PR TITLE
Mesh a polyhedral complex in Polyhedron demo

### DIFF
--- a/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
@@ -100,12 +100,12 @@ with a model of the concept `IntersectionGeometricTraits_3`.
 \sa `CGAL::Mesh_polyhedron_3<IGT_>`
 */
 template < class IGT_,
-           class Polyhedron = typename Mesh_polyhedron_3<IGT_>::type,
+           class Polyhedron_ = typename Mesh_polyhedron_3<IGT_>::type,
            class TriangleAccessor=CGAL::Default
            >
 class Polyhedral_complex_mesh_domain_3
   : public Mesh_domain_with_polyline_features_3<
-      Polyhedral_mesh_domain_3< Polyhedron,
+      Polyhedral_mesh_domain_3< Polyhedron_,
                                 IGT_,
                                 CGAL::Default,
                                 int,   //Use_patch_id_tag
@@ -113,6 +113,7 @@ class Polyhedral_complex_mesh_domain_3
 {
 public:
   /// The base class
+  typedef Polyhedron_ Polyhedron;
   typedef Mesh_domain_with_polyline_features_3<
     Polyhedral_mesh_domain_3<
       Polyhedron, IGT_, CGAL::Default,
@@ -123,21 +124,6 @@ private:
   typedef Polyhedral_mesh_domain_3<Polyhedron, IGT_, CGAL::Default,
                                    int, Tag_true >       BaseBase;
   typedef Polyhedral_complex_mesh_domain_3<IGT_, Polyhedron>  Self;
-
-protected:
-  typedef typename Base::Surface_patch_index Patch_id;
-  typedef typename boost::property_map<Polyhedron,
-                                       CGAL::vertex_incident_patches_t<Patch_id>
-                                       >::type VIPMap;
-  typedef typename boost::property_traits<VIPMap>::value_type Set_of_indices;
-
-  typedef boost::adjacency_list<
-    boost::setS, // this avoids parallel edges
-    boost::vecS,
-    boost::undirectedS,
-    typename IGT::Point_3,
-    Set_of_indices> Featured_edges_copy_graph;
-
   /// @endcond
 
 public:
@@ -167,6 +153,7 @@ public:
   typedef typename Base::AABB_tree            AABB_tree;
   typedef typename Base::AABB_primitive       AABB_primitive;
   typedef typename Base::AABB_primitive_id    AABB_primitive_id;
+  typedef typename Base::Surface_patch_index  Patch_id;
   // Backward compatibility
 #ifndef CGAL_MESH_3_NO_DEPRECATED_SURFACE_INDEX
   typedef Surface_patch_index                 Surface_index;
@@ -180,8 +167,23 @@ public:
   typedef std::vector<Point_3> Bare_polyline;
   typedef Mesh_3::Polyline_with_context<Surface_patch_index, Curve_index,
                                         Bare_polyline > Polyline_with_context;
+
+protected:
+  typedef typename boost::property_map<Polyhedron,
+    CGAL::vertex_incident_patches_t<Patch_id>
+  >::type VIPMap;
+  typedef typename boost::property_traits<VIPMap>::value_type Set_of_indices;
+
+  typedef boost::adjacency_list<
+    boost::setS, // this avoids parallel edges
+    boost::vecS,
+    boost::undirectedS,
+    typename IGT::Point_3,
+    Set_of_indices> Featured_edges_copy_graph;
+
   /// @endcond
 
+public:
   /// Constructor
   /*! Constructs a domain defined by a set of polyhedral surfaces,
   describing a polyhedral complex.

--- a/Polyhedron/demo/Polyhedron/C3t3_type.h
+++ b/Polyhedron/demo/Polyhedron/C3t3_type.h
@@ -28,6 +28,8 @@
 #include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
 #include <CGAL/Mesh_domain_with_polyline_features_3.h>
 
+#include <CGAL/Polyhedral_complex_mesh_domain_3.h>
+
 #include <CGAL/tags.h>
 
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_IMPLICIT_FUNCTIONS
@@ -51,6 +53,8 @@ private:
 typedef CGAL::Polyhedral_mesh_domain_with_features_3<
           EPICK, SMesh, CGAL::Default, int> Polyhedral_mesh_domain;
 // The last `Tag_true` says the Patch_id type will be int, and not pair<int, int>
+
+typedef CGAL::Polyhedral_complex_mesh_domain_3<EPICK, SMesh> Polyhedral_complex_mesh_domain;
 
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_SEGMENTED_IMAGES
 typedef CGAL::Labeled_mesh_domain_3<EPICK, int, int>            Image_domain;

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Surf_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Surf_io_plugin.cpp
@@ -104,6 +104,14 @@ CGAL::Three::Scene_item* Surf_io_plugin::actual_load(QFileInfo fileinfo)
     FaceGraphItem *patch = new FaceGraphItem(patches[i]);
     patch->setName(QString("Patch #%1").arg(i));
     patch->setColor(colors_[i]);
+
+    patch->setProperty("inner material id", material_data[i].innerRegion.first);
+    patch->setProperty("inner material name",
+                       QString(material_data[i].innerRegion.second.data()));
+    patch->setProperty("outer material id", material_data[i].outerRegion.first);
+    patch->setProperty("outer material name",
+                       QString(material_data[i].outerRegion.second.data()));
+
     CGAL::Three::Three::scene()->addItem(patch);
     CGAL::Three::Three::scene()->changeGroup(patch, group);
   }

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -4,6 +4,7 @@
 #ifdef CGAL_POLYHEDRON_DEMO_USE_SURFACE_MESHER
 #include <CGAL/Three/Polyhedron_demo_plugin_interface.h>
 #include <CGAL/Three/Three.h>
+#include <CGAL/Three/Scene_group_item.h>
 #include "Messages_interface.h"
 
 #include <QObject>
@@ -16,6 +17,7 @@
 #include <QMessageBox>
 #include <QDesktopServices>
 #include <QUrl>
+#include <QVariant>
 #include <fstream>
 
 #include <gsl/pointers>
@@ -214,6 +216,7 @@ private:
     QList<gsl::not_null<Scene_surface_mesh_item*>> sm_items;
     Scene_surface_mesh_item* bounding_sm_item;
     Scene_polylines_item* polylines_item;
+    QList<std::pair<QVariant, QVariant>> incident_subdomains;
   };
   struct Image_mesh_items {
     Image_mesh_items(gsl::not_null<Scene_image_item*> ptr) : image_item(ptr) {}
@@ -328,7 +331,12 @@ boost::optional<QString> Mesh_3_plugin::get_items_or_return_error_string() const
             image_items.polylines_item = polylines_item;
           }
         }
-      } else {
+      }
+      else if (auto group =
+        qobject_cast<CGAL::Three::Scene_group_item*>(scene->item(ind))) {
+        continue;
+      }
+      else {
         return tr("Wrong selection of items");
       }
     } catch (const boost::bad_get&) { return tr("Wrong selection of items"); }
@@ -663,20 +671,44 @@ void Mesh_3_plugin::mesh_3(const Mesh_type mesh_type,
     const auto bounding_sm_item = poly_items.bounding_sm_item;
     const auto polylines_item = poly_items.polylines_item;
     QList<const SMesh*> polyhedrons;
-    if(mesh_type != Mesh_type::SURFACE_ONLY) {
+    QList<std::pair<int, int> > incident_sub;
+
+    bool material_ids_valid = true;
+    for (auto sm_item : sm_items)
+    {
+      if(!sm_item->property("inner material id").isValid()
+         || !sm_item->property("outer material id").isValid())
+      {
+        material_ids_valid = false;
+        break;
+      }
+      else
+      {
+        incident_sub.append(std::make_pair<int, int>(
+            sm_item->property("inner material id").toInt(),
+            sm_item->property("outer material id").toInt()));
+      }
+    }
+
+    if(mesh_type != Mesh_type::SURFACE_ONLY && !material_ids_valid)
+    {
       sm_items.removeAll(make_not_null(bounding_sm_item));
     }
-    std::transform(sm_items.begin(), sm_items.end(),
-                   std::back_inserter(polyhedrons),
-                   [](Scene_surface_mesh_item* item) {
-                     return item->polyhedron();
-                   });
+
     Scene_polylines_item::Polylines_container plc;
     SMesh* bounding_polyhedron = (bounding_sm_item == nullptr)
                                      ? nullptr
                                      : bounding_sm_item->polyhedron();
 
-    thread = cgal_code_mesh_3(
+    std::transform(sm_items.begin(), sm_items.end(),
+      std::back_inserter(polyhedrons),
+      [](Scene_surface_mesh_item* item) {
+        return item->polyhedron();
+      });
+
+    if(bounding_polyhedron != nullptr)
+    {
+      thread = cgal_code_mesh_3(
         polyhedrons,
         (polylines_item == nullptr) ? plc : polylines_item->polylines,
         bounding_polyhedron,
@@ -692,8 +724,27 @@ void Mesh_3_plugin::mesh_3(const Mesh_type mesh_type,
         sharp_edges_angle_bound,
         manifold,
         mesh_type == Mesh_type::SURFACE_ONLY);
+    }
+    else if(!incident_sub.empty())
+    {
+      thread = cgal_code_mesh_3(
+        polyhedrons,
+        incident_sub,
+        item_name,
+        angle,
+        facets_sizing,
+        approx,
+        tets_sizing,
+        edges_sizing,
+        tets_shape,
+        protect_features,
+        protect_borders,
+        sharp_edges_angle_bound,
+        manifold,
+        mesh_type == Mesh_type::SURFACE_ONLY);
+     }
     break;
-  }
+  }//end case POLYHEDRAL_MESH_ITEMS
   // Image
 #  ifdef CGAL_MESH_3_DEMO_ACTIVATE_IMPLICIT_FUNCTIONS
   case IMPLICIT_MESH_ITEMS: {

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -332,7 +332,7 @@ boost::optional<QString> Mesh_3_plugin::get_items_or_return_error_string() const
           }
         }
       }
-      else if (auto group =
+      else if (nullptr !=
         qobject_cast<CGAL::Three::Scene_group_item*>(scene->item(ind))) {
         continue;
       }

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
@@ -131,6 +131,101 @@ Meshing_thread* cgal_code_mesh_3(QList<const SMesh*> pMeshes,
   return new Meshing_thread(p_mesh_function, p_new_item);
 }
 
+Meshing_thread* cgal_code_mesh_3(const QList<const SMesh*> pMeshes,
+                                 const QList<std::pair<int, int> >& incident_subdomains,
+                                 QString filename,
+                                 const double facet_angle,
+                                 const double facet_sizing,
+                                 const double facet_approx,
+                                 const double tet_sizing,
+                                 const double edge_size,
+                                 const double tet_shape,
+                                 bool protect_features,
+                                 bool protect_borders,
+                                 const double sharp_edges_angle,
+                                 const int manifold,
+                                 const bool surface_only)
+{
+  if (pMeshes.empty() && incident_subdomains.empty()) return 0;
+
+  std::cerr << "Meshing file \"" << qPrintable(filename) << "\"\n";
+  std::cerr << "  angle: " << facet_angle << std::endl
+    << "  edge size bound: " << edge_size << std::endl
+    << "  facets size bound: " << facet_sizing << std::endl
+    << "  approximation bound: " << facet_approx << std::endl;
+  if (!surface_only)
+    std::cerr << "  tetrahedra size bound: " << tet_sizing << std::endl;
+
+  CGAL::Real_timer timer;
+  timer.start();
+
+  std::vector<SMesh> patches;
+  std::transform(pMeshes.begin(), pMeshes.end(),
+    std::back_inserter(patches),
+    [](const SMesh* sm) {
+      return *sm;
+    });
+
+  // Create domain
+  Polyhedral_complex_mesh_domain* p_domain
+    = new Polyhedral_complex_mesh_domain(patches.begin(),
+                                         patches.end(),
+                                         incident_subdomains.begin(),
+                                         incident_subdomains.end());
+
+  // Features
+  if (protect_features) {
+      //includes detection of borders in the surface case
+    p_domain->detect_features(sharp_edges_angle);
+  }
+  else if (protect_borders) {
+    p_domain->detect_borders();
+  }
+
+  Scene_c3t3_item* p_new_item = new Scene_c3t3_item(surface_only);
+  if (protect_features) {
+    p_new_item->set_sharp_edges_angle(sharp_edges_angle);
+  }
+  else if (protect_borders) {
+    p_new_item->set_detect_borders(true);
+  }
+
+  QString tooltip = QString("<div>From \"") + filename +
+    QString("\" with the following mesh parameters"
+      "<ul>"
+      "<li>Angle: %1</li>"
+      "<li>Edge size bound: %2</li>"
+      "<li>Facets size bound: %3</li>"
+      "<li>Approximation bound: %4</li>")
+    .arg(facet_angle)
+    .arg(edge_size)
+    .arg(facet_sizing)
+    .arg(facet_approx);
+  if (!surface_only)
+    tooltip += QString("<li>Tetrahedra size bound: %1</li>")
+    .arg(tet_sizing);
+  tooltip += "</ul></div>";
+
+  p_new_item->setProperty("toolTip", tooltip);
+  Mesh_parameters param;
+  param.facet_angle = facet_angle;
+  param.facet_sizing = facet_sizing;
+  param.facet_approx = facet_approx;
+  param.tet_sizing = tet_sizing;
+  param.tet_shape = tet_shape;
+  param.edge_sizing = edge_size;
+  param.manifold = manifold;
+  param.protect_features = protect_features || protect_borders;
+  param.use_sizing_field_with_aabb_tree = protect_features;
+
+  typedef ::Mesh_function<Polyhedral_complex_mesh_domain,
+                          Mesh_fnt::Polyhedral_domain_tag> Mesh_function;
+  Mesh_function* p_mesh_function = new Mesh_function(p_new_item->c3t3(),
+                                                     p_domain,
+                                                     param);
+  return new Meshing_thread(p_mesh_function, p_new_item);
+}
+
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_IMPLICIT_FUNCTIONS
 
 Meshing_thread* cgal_code_mesh_3(const Implicit_function_interface* pfunction,

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.h
@@ -35,6 +35,22 @@ Meshing_thread* cgal_code_mesh_3(QList<const SMesh*> pMeshes,
                                  const double sharp_edges_angle,
                                  const int manifold,
                                  const bool surface_only);
+
+Meshing_thread* cgal_code_mesh_3(const QList<const SMesh*> pMeshes,
+                                 const QList<std::pair<int, int> >& incident_subdomains,
+                                 QString filename,
+                                 const double facet_angle,
+                                 const double facet_sizing,
+                                 const double facet_approx,
+                                 const double tet_sizing,
+                                 const double edge_size,
+                                 const double tet_shape,
+                                 bool protect_features,
+                                 bool protect_border,
+                                 const double sharp_edges_angle,
+                                 const int manifold,
+                                 const bool surface_only);
+
 #ifdef CGAL_MESH_3_DEMO_ACTIVATE_IMPLICIT_FUNCTIONS
 Meshing_thread* cgal_code_mesh_3(const Implicit_function_interface* pfunction,
                                  const double facet_angle,


### PR DESCRIPTION
## Summary of Changes

After reading a polyhedral complex from file format `.surf`, the demo is now able to run Mesh_3 on the corresponding polyhedral complex.

This PR also fixes the class `Polyhedral_complex_mesh_domain_3` to make it work with `Surface_mesh` as underlying polyhedron type - some `typedef`'s had to be made public.

## Release Management

* Affected package(s): Mesh_3, Polyhedron demo
* License and copyright ownership: unchanged

