### PR TITLE
Mesh distance: use spatially sorted sample points

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -1050,7 +1050,7 @@ double approximate_Hausdorff_distance(
   Point_3 hint = get(vpm, *vertices(tm).first);
 
   return internal::approximate_Hausdorff_distance_impl<Concurrency_tag, Kernel>
-    (original_sample_points, tree, hint);
+    (sample_points, tree, hint);
 }
 
 template <class Concurrency_tag, class Kernel, class TriangleMesh,


### PR DESCRIPTION
## Summary of Changes

The Hausdorff distance code makes a copy of the provided sample points and sorts them spatially such that the hints provided to the AABB tree will be good. There is an apparent mistake in the code though and instead of the spatially sorted sample points, the original (unsorted) ones are given to the AABB tree. The sorted ones are in fact never used.
This PR changes the code such that the sorted points are used.

## Release Management

* Affected package(s): Polygon_mesh_processing