### PR TITLE
Bug fix: `remove_outliers` was removing ALL points when no outliers were found

### DIFF
--- a/Point_set_processing_3/include/CGAL/remove_outliers.h
+++ b/Point_set_processing_3/include/CGAL/remove_outliers.h
@@ -266,7 +266,7 @@ remove_outliers(
 
   // Replaces [points.begin(), points.end()) range by the sorted content.
   iterator pit = points.begin();
-  iterator out = points.begin();
+  iterator out = points.end();
 
   for (auto sit = sorted_points.begin(); sit != sorted_points.end(); ++ sit)
   {

--- a/Point_set_processing_3/include/CGAL/remove_outliers.h
+++ b/Point_set_processing_3/include/CGAL/remove_outliers.h
@@ -247,9 +247,9 @@ remove_outliers(
 
   if (threshold_distance != FT(0))
     f2r = std::partition (sorted_points.begin(), sorted_points.end(),
-                          [sq_threshold_distance = CGAL::square(threshold_distance)](const std::pair<FT, value_type>& p) -> bool 
-                          { 
-                            return p.first < sq_threshold_distance; 
+                          [sq_threshold_distance = CGAL::square(threshold_distance)](const std::pair<FT, value_type>& p) -> bool
+                          {
+                            return p.first < sq_threshold_distance;
                           });
 
   iterator out = points.end();

--- a/Point_set_processing_3/include/CGAL/remove_outliers.h
+++ b/Point_set_processing_3/include/CGAL/remove_outliers.h
@@ -247,9 +247,9 @@ remove_outliers(
 
   if (threshold_distance != FT(0))
     f2r = std::partition (sorted_points.begin(), sorted_points.end(),
-                          [&threshold_distance](const std::pair<FT, value_type>& p) -> bool
-                          {
-                            return p.first < threshold_distance * threshold_distance;
+                          [sq_threshold_distance = CGAL::square(threshold_distance)](const std::pair<FT, value_type>& p) -> bool 
+                          { 
+                            return p.first < sq_threshold_distance; 
                           });
 
   if (static_cast<std::size_t>(std::distance (sorted_points.begin(), f2r)) < first_index_to_remove)

--- a/Point_set_processing_3/include/CGAL/remove_outliers.h
+++ b/Point_set_processing_3/include/CGAL/remove_outliers.h
@@ -252,28 +252,32 @@ remove_outliers(
                             return p.first < sq_threshold_distance; 
                           });
 
-  if (static_cast<std::size_t>(std::distance (sorted_points.begin(), f2r)) < first_index_to_remove)
-  {
-    std::nth_element (f2r,
-                      sorted_points.begin() + first_index_to_remove,
-                      sorted_points.end(),
-                      [](const std::pair<FT, value_type>& v1, const std::pair<FT, value_type>& v2)
-                      {
-                        return v1.first<v2.first;
-                      });
-    f2r = sorted_points.begin() + first_index_to_remove;
-  }
-
-  // Replaces [points.begin(), points.end()) range by the sorted content.
-  iterator pit = points.begin();
   iterator out = points.end();
 
-  for (auto sit = sorted_points.begin(); sit != sorted_points.end(); ++ sit)
+  if (f2r != sorted_points.end())
   {
-    *pit = sit->second;
-    if (sit == f2r)
-      out = pit;
-    ++ pit;
+    if (static_cast<std::size_t>(std::distance (sorted_points.begin(), f2r)) < first_index_to_remove)
+    {
+      std::nth_element (f2r,
+                        sorted_points.begin() + first_index_to_remove,
+                        sorted_points.end(),
+                        [](const std::pair<FT, value_type>& v1, const std::pair<FT, value_type>& v2)
+                        {
+                          return v1.first<v2.first;
+                        });
+      f2r = sorted_points.begin() + first_index_to_remove;
+    }
+
+    // Replaces [points.begin(), points.end()) range by the sorted content.
+    iterator pit = points.begin();
+
+    for (auto sit = sorted_points.begin(); sit != sorted_points.end(); ++ sit)
+    {
+      *pit = sit->second;
+      if (sit == f2r)
+        out = pit;
+      ++ pit;
+    }
   }
 
   callback_wrapper.join();


### PR DESCRIPTION
Bug in current code: when no outliers are found, `f2r` is `sorted_points.end()`. So, `if (sit == f2r)` is never true, and `out` keeps its initial value, which is `points.begin()`.

Note: if we don't care about sorting the elements (I'm not sure), a probably better fix would be to test `f2r` and skip the whole loop if it is equal to `sorted_points.end()`. I let you decide what is best.

Side remark: at line 250, why is `threshold_distance` captured by reference?