### PR TITLE
CGAL Core: Remove explicit instanciations: CGAL is header-only!

### DIFF
--- a/CGAL_Core/include/CGAL/CORE/Expr_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Expr_impl.h
@@ -1225,21 +1225,6 @@ CORE_MEMORY_IMPL(SqrtRep)
 
 CORE_MEMORY_IMPL(MultRep)
 CORE_MEMORY_IMPL(DivRep)
-
-
- template class AddSubRep<Add>;
- template class AddSubRep<Sub>;
-
-template class Realbase_for<long>;
-template class Realbase_for<double>;
-template class Realbase_for<BigInt>;
-template class Realbase_for<BigRat>;
-template class Realbase_for<BigFloat>;
-
- template class ConstPolyRep<Expr>;
- template class ConstPolyRep<BigFloat>;
- template class ConstPolyRep<BigInt>;
- template class ConstPolyRep<BigRat>;
 } //namespace CORE
 
 #include <CGAL/enable_warnings.h>


### PR DESCRIPTION
## Summary of Changes

Fix bug https://gitlab.com/Oslandia/SFCGAL/-/issues/245. Remove the explicit template instanciation from CGAL_Core.

## Release Management

For CGAL-5.3.x

* Affected package(s): CGAL_Core

