### PR TITLE
Create normal map only if normal estimation is done

### DIFF
--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -228,6 +228,9 @@ MainWindow::MainWindow(const QStringList &keywords, bool verbose, QWidget* paren
           this, SLOT(updateInfo()));
 
   connect(scene, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex & )),
+          this, SLOT(filterOperations()));
+
+  connect(scene, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex & )),
           this, SLOT(updateDisplayInfo()));
 
   connect(viewer, &Viewer::needNewContext,

--- a/Polyhedron/demo/Polyhedron/MainWindow.cpp
+++ b/Polyhedron/demo/Polyhedron/MainWindow.cpp
@@ -227,8 +227,9 @@ MainWindow::MainWindow(const QStringList &keywords, bool verbose, QWidget* paren
   connect(scene, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex & )),
           this, SLOT(updateInfo()));
 
-  connect(scene, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex & )),
-          this, SLOT(filterOperations()));
+ connect(scene, &Scene::dataChanged,
+         this, [this]() { filterOperations(false); });
+
 
   connect(scene, SIGNAL(dataChanged(const QModelIndex &, const QModelIndex & )),
           this, SLOT(updateDisplayInfo()));

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -366,7 +366,6 @@ protected Q_SLOTS:
   //!Hides not available operations and show available operations in all the
   //!menus.
   void filterOperations(bool hide);
-  void filterOperations(){ filterOperations(false); };
   //!Updates the bounding box and moves the camera to fits the scene.
   void recenterScene();
   //!Resizes the header of the scene view

--- a/Polyhedron/demo/Polyhedron/MainWindow.h
+++ b/Polyhedron/demo/Polyhedron/MainWindow.h
@@ -366,6 +366,7 @@ protected Q_SLOTS:
   //!Hides not available operations and show available operations in all the
   //!menus.
   void filterOperations(bool hide);
+  void filterOperations(){ filterOperations(false); };
   //!Updates the bounding box and moves the camera to fits the scene.
   void recenterScene();
   //!Resizes the header of the scene view

--- a/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
@@ -202,17 +202,17 @@ void Polyhedron_demo_point_set_normal_estimation_plugin::on_actionNormalEstimati
 
   if(item)
   {
+    // Gets options
+    Point_set_demo_normal_estimation_dialog dialog;
+    if(!dialog.exec())
+      return;
+
     // Gets point set
     Point_set* points = item->point_set();
     if(points == nullptr)
         return;
     if (!(points->has_normal_map()))
       points->add_normal_map();
-
-    // Gets options
-    Point_set_demo_normal_estimation_dialog dialog;
-    if(!dialog.exec())
-      return;
 
     QApplication::setOverrideCursor(Qt::BusyCursor);
     QApplication::processEvents();


### PR DESCRIPTION
Create normal map only if normal are estimated.

@lrineau `MainWindow::filterOperations(bool)` should be called once the normals are estimated as normal orientation should then become applicable. But it is not accessible from the plugin. If I manually unselect and select the item,  `MainWindow::filterOperations(bool)` is called but a call to `Scene::setSelectedItem(int)` does not help. Any idea or do I need to modify an interface?