### PR TITLE
Minor improvements for OFF/XYZ point set IO

### DIFF
--- a/Point_set_processing_3/include/CGAL/IO/read_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_off_points.h
@@ -168,8 +168,7 @@ bool read_OFF(std::istream& is,
       double nx,ny,nz;
       if (iss >> IO::iformat(x) >> IO::iformat(y) >> IO::iformat(z))
       {
-        //the extra `()` seem to fix a very strange bug. Without them, the put() won't compile.
-        Point point((FT(x)), (FT(y)), (FT(z)));
+        Point point{FT(x), FT(y), FT(z)};
         Vector normal = CGAL::NULL_VECTOR;
         // ... + normal...
         if (iss >> IO::iformat(nx))

--- a/Point_set_processing_3/include/CGAL/IO/read_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_off_points.h
@@ -123,6 +123,7 @@ bool read_OFF(std::istream& is,
   }
 
   // scan points
+  std::string signature;
   long pointsCount = 0, facesCount = 0, edgesCount = 0; // number of items in file
   int pointsRead = 0; // current number of points read
   int lineNumber = 0; // current line number
@@ -142,12 +143,10 @@ bool read_OFF(std::istream& is,
     // Reads file signature on first line
     if (lineNumber == 1)
     {
-      std::string signature;
-      if ( !(iss >> signature)
-        || (signature != "OFF" && signature != "NOFF") )
+      if ( !(iss >> signature) || (signature != "OFF" && signature != "NOFF") )
       {
         // if wrong file format
-        std::cerr << "Incorrect file format line " << lineNumber << " of file" << std::endl;
+        std::cerr << "Error line " << lineNumber << " of file (unexpected header)" << std::endl;
         return false;
       }
     }
@@ -184,6 +183,12 @@ bool read_OFF(std::istream& is,
             return false;
           }
         }
+        else if (signature == "NOFF")
+        {
+          std::cerr << "Error line " << lineNumber << " of file (expected normal coordinates)" << std::endl;
+          return false;
+        }
+
         Enriched_point pwn;
         put(point_map,  pwn, point);  // point_map[&pwn] = point
         if (has_normals)

--- a/Point_set_processing_3/include/CGAL/IO/read_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_off_points.h
@@ -138,7 +138,7 @@ bool read_OFF(std::istream& is,
     if (line.empty () || line[0] == '#')
       continue;
 
-    lineNumber++;
+    ++lineNumber;
 
     // Reads file signature on first line
     if (lineNumber == 1)
@@ -150,13 +150,12 @@ bool read_OFF(std::istream& is,
         return false;
       }
     }
-
     // Reads number of points on 2nd line
     else if (lineNumber == 2)
     {
       if ( !(iss >> pointsCount >> facesCount >> edgesCount) )
       {
-        std::cerr << "Error line " << lineNumber << " of file" << std::endl;
+        std::cerr << "Error line " << lineNumber << " of file (incorrect header format)" << std::endl;
         return false;
       }
     }
@@ -179,7 +178,7 @@ bool read_OFF(std::istream& is,
           if(iss  >> IO::iformat(ny) >> IO::iformat(nz)){
             normal = Vector(FT(nx),FT(ny),FT(nz));
           } else {
-            std::cerr << "Error line " << lineNumber << " of file" << std::endl;
+            std::cerr << "Error line " << lineNumber << " of file (incomplete normal coordinates)" << std::endl;
             return false;
           }
         }
@@ -193,17 +192,16 @@ bool read_OFF(std::istream& is,
         put(point_map,  pwn, point);  // point_map[&pwn] = point
         if (has_normals)
           put(normal_map, pwn, normal); // normal_map[&pwn] = normal
-        *output++ = pwn;
-        pointsRead++;
 
+        *output++ = pwn;
+        ++pointsRead;
       }
-      // ...or skip comment line
     }
-    // Skip remaining lines
   }
-  if(is.eof()) {
+
+  if(is.eof())
     is.clear(is.rdstate() & ~std::ios_base::failbit); // set by getline
-  }
+
   return true;
 }
 

--- a/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
@@ -139,35 +139,37 @@ bool read_XYZ(std::istream& is,
       continue;
     }
     // ...or reads position...
-    else {
+    else
+    {
       iss.clear();
       iss.str(line);
       if (iss >> iformat(x) >> iformat(y) >> iformat(z))
+      {
+        Point point(x,y,z);
+        Vector normal = CGAL::NULL_VECTOR;
+        // ... + normal...
+        if (iss >> iformat(nx))
         {
-          Point point(x,y,z);
-          Vector normal = CGAL::NULL_VECTOR;
-          // ... + normal...
-          if (iss >> iformat(nx))
-            {
-              // In case we could read one number, we expect that there are two more
-              if(iss  >> iformat(ny) >> iformat(nz)){
-                normal = Vector(nx,ny,nz);
-              } else {
-                std::cerr << "Error line " << lineNumber << " of file" << std::endl;
-                return false;
-              }
-            }
-          Enriched_point pwn;
-          put(point_map,  pwn, point);  // point_map[pwn] = point
-
-          if (has_normals)
-            put(normal_map, pwn, normal); // normal_map[pwn] = normal
-
-          *output++ = pwn;
-          continue;
+          // In case we could read one number, we expect that there are two more
+          if(iss >> iformat(ny) >> iformat(nz)){
+            normal = Vector(nx,ny,nz);
+          } else {
+            std::cerr << "Error line " << lineNumber << " of file (incomplete normal coordinates)" << std::endl;
+            return false;
+          }
         }
 
+        Enriched_point pwn;
+        put(point_map,  pwn, point);  // point_map[pwn] = point
+
+        if (has_normals)
+          put(normal_map, pwn, normal); // normal_map[pwn] = normal
+
+        *output++ = pwn;
+        continue;
+      }
     }
+
     // ...or skips number of points on first line (optional)
     if (lineNumber == 1 && std::istringstream(line) >> pointsCount)
     {
@@ -175,13 +177,13 @@ bool read_XYZ(std::istream& is,
     }
     else // if wrong file format
     {
-      std::cerr << "Error line " << lineNumber << " of file" << std::endl;
+      std::cerr << "Error line " << lineNumber << " of file (expected point coordinates)" << std::endl;
       return false;
     }
   }
-  if(is.eof()) {
+
+  if(is.eof())
     is.clear(is.rdstate() & ~std::ios_base::failbit); // set by getline
-  }
 
   return true;
 }

--- a/Point_set_processing_3/include/CGAL/IO/write_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_off_points.h
@@ -46,14 +46,13 @@ bool write_OFF_PSP(std::ostream& os,
 {
   using CGAL::parameters::choose_parameter;
   using CGAL::parameters::get_parameter;
+  using CGAL::parameters::is_default_parameter;
 
   // basic geometric types
   typedef typename CGAL::GetPointMap<PointRange, CGAL_BGL_NP_CLASS>::type                         PointMap;
   typedef typename Point_set_processing_3::GetNormalMap<PointRange, CGAL_BGL_NP_CLASS>::type      NormalMap;
 
-  bool has_normals = !(std::is_same<NormalMap,
-                                    typename Point_set_processing_3::GetNormalMap<
-                                      PointRange, CGAL_BGL_NP_CLASS>::NoMap>::value);
+  const bool has_normals = !(is_default_parameter(get_parameter(np, internal_np::normal_map)));
 
   PointMap point_map = choose_parameter<PointMap>(get_parameter(np, internal_np::point_map));
   NormalMap normal_map = choose_parameter<NormalMap>(get_parameter(np, internal_np::normal_map));
@@ -69,7 +68,10 @@ bool write_OFF_PSP(std::ostream& os,
   set_stream_precision_from_NP(os, np);
 
   // Write header
-  os << "NOFF" << std::endl;
+  if (has_normals)
+    os << "NOFF" << std::endl;
+  else
+    os << "OFF" << std::endl;
   os << points.size() << " 0 0" << std::endl;
 
   // Write positions + normals

--- a/Point_set_processing_3/test/Point_set_processing_3/test_deprecated_io_point_set.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/test_deprecated_io_point_set.cpp
@@ -24,7 +24,8 @@ typedef std::array<unsigned short, 4> Color;
 typedef std::pair<Point_3, Color> PointWithColor;
 typedef CGAL::Nth_of_tuple_property_map<1, PointWithColor> Color_map;
 
-struct GetRedMap{
+struct GetRedMap
+{
   typedef PointWithColor key_type;
   typedef unsigned short value_type;
   typedef const value_type& reference;
@@ -35,7 +36,8 @@ unsigned short get(const GetRedMap&, const PointWithColor& p)
   return p.second[0];
 }
 
-struct GetGreenMap{
+struct GetGreenMap
+{
   typedef PointWithColor key_type;
   typedef unsigned short value_type;
   typedef const value_type& reference;
@@ -46,7 +48,8 @@ unsigned short get(const GetGreenMap&, const PointWithColor& p)
   return p.second[1];
 }
 
-struct GetBlueMap{
+struct GetBlueMap
+{
   typedef PointWithColor key_type;
   typedef unsigned short value_type;
   typedef const value_type& reference;
@@ -57,12 +60,14 @@ unsigned short get(const GetBlueMap&, const PointWithColor& p)
   return p.second[2];
 }
 
-struct GetAlphaMap{
+struct GetAlphaMap
+{
   typedef PointWithColor key_type;
   typedef unsigned short value_type;
   typedef const value_type& reference;
   typedef boost::lvalue_property_map_tag category;
 };
+
 unsigned short get(const GetAlphaMap&, const PointWithColor& p)
 {
   return p.second[3];
@@ -70,157 +75,155 @@ unsigned short get(const GetAlphaMap&, const PointWithColor& p)
 
 int main()
 {
+  std::vector<PointWithColor> points(3);
+  points[0] = std::make_pair(Point_3(1,0,0), Color{255,0,0,255});
+  points[1] = std::make_pair(Point_3(0,1,0), Color{0,255,0,255});
+  points[2] = std::make_pair(Point_3(0,0,1), Color{0,0,255,255});
 
-std::vector<PointWithColor> points(3);
-points[0] = std::make_pair(Point_3(1,0,0), Color{255,0,0,255});
-points[1] = std::make_pair(Point_3(0,1,0), Color{0,255,0,255});
-points[2] = std::make_pair(Point_3(0,0,1), Color{0,0,255,255});
+  bool ok;
+  std::vector<Point_3> ps;
+  ps.push_back(Point_3(1,0,0));
+  ps.push_back(Point_3(0,1,0));
+  ps.push_back(Point_3(0,0,1));
 
-
-bool ok;
-std::vector<Point_3> ps;
-ps.push_back(Point_3(1,0,0));
-ps.push_back(Point_3(0,1,0));
-ps.push_back(Point_3(0,0,1));
-
-
-//LAS
+  //LAS
 #ifdef CGAL_LINKED_WITH_LASLIB
+  {
+    std::ofstream os("tmp1.las", std::ios::binary);
+    ok = CGAL::write_las_points_with_properties(os, points,
+                                                CGAL::make_las_point_writer(CGAL::First_of_pair_property_map<PointWithColor>()),
+                                                std::make_pair(GetRedMap(),CGAL::LAS_property::R()),
+                                                std::make_pair(GetGreenMap(), CGAL::LAS_property::G()),
+                                                std::make_pair(GetBlueMap(), CGAL::LAS_property::B()),
+                                                std::make_pair(GetAlphaMap(), CGAL::LAS_property::I())
+                                                );
+    assert(ok);
 
- {
-   std::ofstream os("tmp1.las", std::ios::binary);
-   ok = CGAL::write_las_points_with_properties(os, points,
-                                               CGAL::make_las_point_writer(CGAL::First_of_pair_property_map<PointWithColor>()),
-                                               std::make_pair(GetRedMap(),CGAL::LAS_property::R()),
-                                               std::make_pair(GetGreenMap(), CGAL::LAS_property::G()),
-                                               std::make_pair(GetBlueMap(), CGAL::LAS_property::B()),
-                                               std::make_pair(GetAlphaMap(), CGAL::LAS_property::I())
-                                               );
-   assert(ok);
+  }
 
- }
+  {
+    points.clear();
+    std::ifstream is("tmp1.las", std::ios::binary);
+    ok = CGAL::read_las_points_with_properties(is, std::back_inserter (points),
+                                               CGAL::make_las_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
+                                               std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
+                                                               CGAL::Construct_array(),
+                                                               CGAL::LAS_property::R(),
+                                                               CGAL::LAS_property::G(),
+                                                               CGAL::LAS_property::B(),
+                                                               CGAL::LAS_property::I()));
+    assert(ok);
+    assert(points.size() == 3);
+    assert(points[1].second[1] == 255);
+  }
 
- {
-   points.clear();
-   std::ifstream is("tmp1.las", std::ios::binary);
-   ok = CGAL::read_las_points_with_properties(is, std::back_inserter (points),
-                                              CGAL::make_las_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
-                                              std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
-                                                              CGAL::Construct_array(),
-                                                              CGAL::LAS_property::R(),
-                                                              CGAL::LAS_property::G(),
-                                                              CGAL::LAS_property::B(),
-                                                              CGAL::LAS_property::I()));
-   assert(ok);
-   assert(points.size() == 3);
-   assert(points[1].second[1] == 255);
- }
+  {
+    std::ofstream os("tmp2.las", std::ios_base::binary);
+    CGAL::write_las_points(os, ps, CGAL::parameters::all_default());
+    assert(ok);
+  }
 
- {
-   std::ofstream os("tmp2.las", std::ios_base::binary);
-   CGAL::write_las_points(os, ps, CGAL::parameters::all_default());
-   assert(ok);
- }
-
- {
-   ps.clear();
-   std::ifstream is("tmp2.las", std::ios::binary);
-   ok = CGAL::read_las_points(is, std::back_inserter (ps),CGAL::parameters::all_default());
-   assert(ok);
-   assert(ps.size() == 3);
- }
+  {
+    ps.clear();
+    std::ifstream is("tmp2.las", std::ios::binary);
+    ok = CGAL::read_las_points(is, std::back_inserter (ps),CGAL::parameters::all_default());
+    assert(ok);
+    assert(ps.size() == 3);
+  }
 #endif
 
+  //PLY
+  {
+    std::ofstream os("tmp1.ply");
+    assert(os.good());
+    ok = CGAL::write_ply_points_with_properties(os, points,
+                                                CGAL::make_ply_point_writer (CGAL::First_of_pair_property_map<PointWithColor>()),
+                                                std::make_pair(GetRedMap(),CGAL::PLY_property<unsigned short>("red")),
+                                                std::make_pair(GetGreenMap(), CGAL::PLY_property<unsigned short>("green")),
+                                                std::make_pair(GetBlueMap(), CGAL::PLY_property<unsigned short>("blue")),
+                                                std::make_pair(GetAlphaMap(), CGAL::PLY_property<unsigned short>("alpha"))
+                                                );
+    assert(! os.fail());
+    assert(ok);
+  }
 
-//PLY
- {
-   std::ofstream os("tmp1.ply");
-   assert(os.good());
-   ok = CGAL::write_ply_points_with_properties(os, points,
-                                               CGAL::make_ply_point_writer (CGAL::First_of_pair_property_map<PointWithColor>()),
-                                               std::make_pair(GetRedMap(),CGAL::PLY_property<unsigned short>("red")),
-                                               std::make_pair(GetGreenMap(), CGAL::PLY_property<unsigned short>("green")),
-                                               std::make_pair(GetBlueMap(), CGAL::PLY_property<unsigned short>("blue")),
-                                               std::make_pair(GetAlphaMap(), CGAL::PLY_property<unsigned short>("alpha"))
-                                               );
-   assert(! os.fail());
-   assert(ok);
- }
+  {
+    std::ifstream is("tmp1.ply");
+    assert(is.good());
+    points.clear();
+    ok = CGAL::read_ply_points_with_properties(is, std::back_inserter (points),
+                                               CGAL::make_ply_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
+                                               std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
+                                                               CGAL::Construct_array(),
+                                                               CGAL::PLY_property<unsigned short>("red"),
+                                                               CGAL::PLY_property<unsigned short>("green"),
+                                                               CGAL::PLY_property<unsigned short>("blue"),
+                                                               CGAL::PLY_property<unsigned short>("alpha")));
+    assert(! is.fail());
+    assert(ok);
+    assert(points.size() == 3);
+    assert(points[1].second[1] == 255);
+  }
 
- {
-   std::ifstream is("tmp1.ply");
-   assert(is.good());
-   points.clear();
-   ok = CGAL::read_ply_points_with_properties(is, std::back_inserter (points),
-                                              CGAL::make_ply_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
-                                              std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
-                                                              CGAL::Construct_array(),
-                                                              CGAL::PLY_property<unsigned short>("red"),
-                                                              CGAL::PLY_property<unsigned short>("green"),
-                                                              CGAL::PLY_property<unsigned short>("blue"),
-                                                              CGAL::PLY_property<unsigned short>("alpha")));
-   assert(! is.fail());
-   assert(ok);
-   assert(points.size() == 3);
-   assert(points[1].second[1] == 255);
- }
+  {
+    std::ofstream os("tmp2.ply");
+    assert(os.good());
+    ok = CGAL::write_ply_points(os, ps, CGAL::parameters::all_default());
+    assert(! os.fail());
+    assert(ok);
+  }
 
- {
-   std::ofstream os("tmp2.ply");
-   assert(os.good());
-   ok = CGAL::write_ply_points(os, ps, CGAL::parameters::all_default());
-   assert(! os.fail());
-   assert(ok);
- }
+  {
+    std::ifstream is("tmp2.ply");
+    assert(is.good());
+    ps.clear();
+    ok = CGAL::read_ply_points(is, std::back_inserter (ps),
+                               CGAL::parameters::all_default());
+    assert(! is.fail());
+    assert(ok);
+    assert(ps.size() == 3);
+  }
 
- {
-   std::ifstream is("tmp2.ply");
-   assert(is.good());
-   ps.clear();
-   ok = CGAL::read_ply_points(is, std::back_inserter (ps),
-                              CGAL::parameters::all_default());
-   assert(! is.fail());
-   assert(ok);
-   assert(ps.size() == 3);
- }
+  //OFF
+  {
+    std::ofstream os("tmp.off");
+    assert(os.good());
+    ok = CGAL::write_off_points(os, ps, CGAL::parameters::all_default());
+    assert(! os.fail());
+    assert(ok);
+  }
 
-//OFF
- {
-   std::ofstream os("tmp.off");
-   assert(os.good());
-   ok = CGAL::write_off_points(os, ps, CGAL::parameters::all_default());
-   assert(! os.fail());
-   assert(ok);
- }
+  {
+    std::ifstream is("tmp.off");
+    assert(is.good());
+    ps.clear();
+    ok = CGAL::read_off_points(is, std::back_inserter (ps),
+                               CGAL::parameters::all_default());
+    assert(! is.fail());
+    assert(ok);
+    assert(ps.size() == 3);
+  }
 
- {
-   std::ifstream is("tmp.off");
-   assert(is.good());
-   ps.clear();
-   ok = CGAL::read_off_points(is, std::back_inserter (ps),
-                              CGAL::parameters::all_default());
-   assert(! is.fail());
-   assert(ok);
-   assert(ps.size() == 3);
- }
+  //XYZ
+  {
+    std::ofstream os("tmp.xyz");
+    assert(os.good());
+    ok = CGAL::write_xyz_points(os, ps, CGAL::parameters::all_default());
+    assert(! os.fail());
+    assert(ok);
+  }
 
-//XYZ
- {
-   std::ofstream os("tmp.xyz");
-   assert(os.good());
-   ok = CGAL::write_xyz_points(os, ps, CGAL::parameters::all_default());
-   assert(! os.fail());
-   assert(ok);
- }
+  {
+    std::ifstream is("tmp.xyz");
+    assert(is.good());
+    ps.clear();
+    ok = CGAL::read_xyz_points(is, std::back_inserter (ps),
+                               CGAL::parameters::all_default());
+    assert(! is.fail());
+    assert(ok);
+    assert(ps.size() == 3);
+  }
 
- {
-   std::ifstream is("tmp.xyz");
-   assert(is.good());
-   ps.clear();
-   ok = CGAL::read_xyz_points(is, std::back_inserter (ps),
-                              CGAL::parameters::all_default());
-   assert(! is.fail());
-   assert(ok);
-   assert(ps.size() == 3);
- }
+  std::cout << "Done" << std::endl;
+  return EXIT_SUCCESS;
 }

--- a/Point_set_processing_3/test/Point_set_processing_3/test_read_write_point_set.cpp
+++ b/Point_set_processing_3/test/Point_set_processing_3/test_read_write_point_set.cpp
@@ -79,6 +79,8 @@ bool points_are_equal(const std::vector<Point_3>& ps,
 
 bool test_points_with_np(std::string s)
 {
+  std::cout << "test_points_with_np(" << s << ")" << std::endl;
+
   std::vector<PointVectorPair> points;
   points.push_back(std::make_pair(Point_3(0,0,0), Vector_3(0,0,0)));
   points.push_back(std::make_pair(Point_3(1,0,0), Vector_3(1,0,0)));
@@ -109,50 +111,50 @@ void test_##TYPE(const std::string& s)                                          
 {                                                                                                  \
   std::cout << "Test Point_set_3: " << s << " extension: " << #TYPE << std::endl;                  \
   CGAL::Point_set_3<Point_3, Vector_3> ps;                                                         \
-  bool ok = CGAL::IO::read_##TYPE(s, ps);                                                              \
+  bool ok = CGAL::IO::read_##TYPE(s, ps);                                                          \
   assert(ok);                                                                                      \
   ps.clear();                                                                                      \
-  ok = CGAL::IO::read_##TYPE(s.c_str(), ps);                                                           \
+  ok = CGAL::IO::read_##TYPE(s.c_str(), ps);                                                       \
   assert(ok);                                                                                      \
   ps.clear();                                                                                      \
   std::ifstream in(s);                                                                             \
-  ok = CGAL::IO::read_##TYPE(in, ps);                                                                  \
+  ok = CGAL::IO::read_##TYPE(in, ps);                                                              \
   assert(ok);                                                                                      \
   const char* ext = type;                                                                          \
   std::string fname = "tmp.";                                                                      \
   fname.append(ext);                                                                               \
-  ok = CGAL::IO::write_##TYPE(fname, ps);                                                              \
+  ok = CGAL::IO::write_##TYPE(fname, ps);                                                          \
   assert(ok);                                                                                      \
-  ok = CGAL::IO::write_##TYPE(fname, ps, CGAL::parameters::stream_precision(10));                      \
+  ok = CGAL::IO::write_##TYPE(fname, ps, CGAL::parameters::stream_precision(10));                  \
   assert(ok);                                                                                      \
-  ok = CGAL::IO::write_##TYPE(fname.c_str(), ps);                                                      \
+  ok = CGAL::IO::write_##TYPE(fname.c_str(), ps);                                                  \
   assert(ok);                                                                                      \
-  ok = CGAL::IO::write_##TYPE(fname.c_str(), ps, CGAL::parameters::stream_precision(10));              \
+  ok = CGAL::IO::write_##TYPE(fname.c_str(), ps, CGAL::parameters::stream_precision(10));          \
   assert(ok);                                                                                      \
   std::ofstream out(fname);                                                                        \
-  ok = CGAL::IO::write_##TYPE(out, ps);                                                                \
+  ok = CGAL::IO::write_##TYPE(out, ps);                                                            \
   assert(ok);                                                                                      \
   std::ofstream out2(fname);                                                                       \
-  ok = CGAL::IO::write_##TYPE(out2, ps, CGAL::parameters::stream_precision(10));                       \
+  ok = CGAL::IO::write_##TYPE(out2, ps, CGAL::parameters::stream_precision(10));                   \
   assert(ok);                                                                                      \
   CGAL::Point_set_3<Point_3, Vector_3> ps2;                                                        \
   std::ifstream is(fname);                                                                         \
-  ok = CGAL::IO::read_##TYPE(is, ps2);                                                                 \
+  ok = CGAL::IO::read_##TYPE(is, ps2);                                                             \
   assert(ok);                                                                                      \
   assert(ps_are_equal(ps, ps2));                                                                   \
-  ok = CGAL::IO::write_point_set(fname, ps2);                                                          \
+  ok = CGAL::IO::write_point_set(fname, ps2);                                                      \
   assert(ok);                                                                                      \
-  ok = CGAL::IO::write_point_set(fname, ps2, CGAL::parameters::stream_precision(10));                  \
+  ok = CGAL::IO::write_point_set(fname, ps2, CGAL::parameters::stream_precision(10));              \
   assert(ok);                                                                                      \
-  ok = CGAL::IO::write_point_set(fname.c_str(), ps2);                                                  \
+  ok = CGAL::IO::write_point_set(fname.c_str(), ps2);                                              \
   assert(ok);                                                                                      \
-  ok = CGAL::IO::write_point_set(fname.c_str(), ps2, CGAL::parameters::stream_precision(10));          \
+  ok = CGAL::IO::write_point_set(fname.c_str(), ps2, CGAL::parameters::stream_precision(10));      \
   assert(ok);                                                                                      \
   ps2.clear();                                                                                     \
-  ok = CGAL::IO::read_point_set(fname, ps2);                                                           \
+  ok = CGAL::IO::read_point_set(fname, ps2);                                                       \
   assert(ok);                                                                                      \
   assert(ps_are_equal(ps, ps2));                                                                   \
-  }
+}
 
 CGAL_DEF_TEST_POINT_SET_3_FUNCTION(XYZ, "xyz")
 CGAL_DEF_TEST_POINT_SET_3_FUNCTION(OFF, "off")
@@ -212,44 +214,55 @@ void test_points_##TYPE(const std::string& s)                                   
 {                                                                                                  \
   std::cout << "Test points: " << s << " extension: " << #TYPE << std::endl;                       \
   std::vector<Point_3> ps;                                                                         \
-  bool ok = CGAL::IO::read_##TYPE(s, std::back_inserter(ps));                                          \
+  std::cout << "  Reading string..." << std::endl;                                                 \
+  bool ok = CGAL::IO::read_##TYPE(s, std::back_inserter(ps));                                      \
   assert(ok);                                                                                      \
   ps.clear();                                                                                      \
-  ok = CGAL::IO::read_##TYPE(s.c_str(), std::back_inserter(ps));                                       \
+  std::cout << "  Reading const string..." << std::endl;                                           \
+  ok = CGAL::IO::read_##TYPE(s.c_str(), std::back_inserter(ps));                                   \
   assert(ok);                                                                                      \
   ps.clear();                                                                                      \
+  std::cout << "  Reading stream..." << std::endl;                                                 \
   std::ifstream in(s);                                                                             \
-  ok = CGAL::IO::read_##TYPE(in, std::back_inserter(ps));                                              \
+  ok = CGAL::IO::read_##TYPE(in, std::back_inserter(ps));                                          \
   assert(ok);                                                                                      \
   const char* ext = type;                                                                          \
   std::string fname = "tmp.";                                                                      \
   fname.append(ext);                                                                               \
-  ok = CGAL::IO::write_##TYPE(fname, ps);                                                              \
+  std::cout << "  Writing string..." << fname << std::endl;                                        \
+  ok = CGAL::IO::write_##TYPE(fname, ps);                                                          \
   assert(ok);                                                                                      \
-  ok = CGAL::IO::write_##TYPE(fname, ps, CGAL::parameters::stream_precision(10));                      \
+  std::cout << "  Writing string with NP..." << std::endl;                                         \
+  ok = CGAL::IO::write_##TYPE(fname, ps, CGAL::parameters::stream_precision(10));                  \
   assert(ok);                                                                                      \
-  ok = CGAL::IO::write_##TYPE(fname.c_str(), ps);                                                      \
+  std::cout << "  Writing const string..." << std::endl;                                           \
+  ok = CGAL::IO::write_##TYPE(fname.c_str(), ps);                                                  \
   assert(ok);                                                                                      \
-  ok = CGAL::IO::write_##TYPE(fname.c_str(), ps, CGAL::parameters::stream_precision(10));              \
+  std::cout << "  Writing const string with NP..." << std::endl;                                   \
+  ok = CGAL::IO::write_##TYPE(fname.c_str(), ps, CGAL::parameters::stream_precision(10));          \
   assert(ok);                                                                                      \
+  std::cout << "  Writing stream..." << std::endl;                                                 \
   std::ofstream out(fname);                                                                        \
-  ok = CGAL::IO::write_##TYPE(out, ps);                                                                \
+  ok = CGAL::IO::write_##TYPE(out, ps);                                                            \
   assert(ok);                                                                                      \
+  std::cout << "  Writing stream with NP..." << std::endl;                                         \
   std::ofstream out2(fname);                                                                       \
-  ok = CGAL::IO::write_##TYPE(out2, ps, CGAL::parameters::stream_precision(10));                       \
+  ok = CGAL::IO::write_##TYPE(out2, ps, CGAL::parameters::stream_precision(10));                   \
   assert(ok);                                                                                      \
+  std::cout << "  Reading previous output..." << std::endl;                                        \
   std::vector<Point_3> ps2;                                                                        \
   std::ifstream is(fname);                                                                         \
-  ok = CGAL::IO::read_##TYPE(is, std::back_inserter(ps2));                                             \
+  ok = CGAL::IO::read_##TYPE(is, std::back_inserter(ps2));                                         \
   assert(ok);                                                                                      \
   assert(points_are_equal(ps, ps2));                                                               \
-  ok = CGAL::IO::write_points(fname, ps2);                                                             \
+  std::cout << "  Last iteration... " << fname << std::endl;                                       \
+  ok = CGAL::IO::write_points(fname, ps2);                                                         \
   assert(ok);                                                                                      \
   ps2.clear();                                                                                     \
-  ok = CGAL::IO::read_points(fname, std::back_inserter(ps2));                                          \
+  ok = CGAL::IO::read_points(fname, std::back_inserter(ps2));                                      \
   assert(ok);                                                                                      \
   assert(points_are_equal(ps, ps2));                                                               \
-  }
+}
 
 CGAL_DEF_TEST_POINTS_FUNCTION(XYZ, "xyz")
 CGAL_DEF_TEST_POINTS_FUNCTION(OFF, "off")


### PR DESCRIPTION
## Summary of Changes

Some cleaning while investigating whether readers should return an error if a normal map is passed (see https://github.com/CGAL/cgal/issues/6125#issuecomment-970724654).

## Release Management

* Affected package(s): `Point_set_processing_3`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

