### PR TITLE
Remove some unintended artifacts from the documentation

### DIFF
--- a/Cone_spanners_2/include/CGAL/Compute_cone_boundaries_2.h
+++ b/Cone_spanners_2/include/CGAL/Compute_cone_boundaries_2.h
@@ -80,7 +80,7 @@ public:
      * and output them to `result` in the counterclockwise order.
      * Finally, the past-the-end iterator for the resulting directions is returned.
      *
-         * \tparam DirectionOutputIterator  an `OutputIterator` with value type `Direction_2`.
+     * \tparam DirectionOutputIterator  an `OutputIterator` with value type `Direction_2`.
      * \param cone_number The number of cones
      * \param initial_direction The direction of the first ray
      * \param result  The output iterator

--- a/Documentation/doc/Documentation/Developer_manual/Chapter_portability.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_portability.txt
@@ -296,9 +296,9 @@ up-to-date version of this list.
 
 <DT><B><TT>CGAL_CFG_NO_TMPL_IN_TMPL_PARAM</TT></B><DD>
 
-    Nested templates in template parameter, such as `template <
-    template <class T> class A>` are not supported by any compiler.
-    This flag is set if they are not supported.
+  Nested templates in template parameter, such as `template <
+  template <class T> class A>` are not supported by any compiler.
+  This flag is set if they are not supported.
 </DL>
 
 \subsection secworkaround_macros Macros connected to workarounds/compilers

--- a/Polyhedron/doc/Polyhedron/CGAL/Polyhedron_3.h
+++ b/Polyhedron/doc/Polyhedron/CGAL/Polyhedron_3.h
@@ -1330,7 +1330,7 @@ public:
     \image html euler_vertex.png
     \image latex euler_vertex.png
 
-\note
+    \note
     A special application of the split is
     `split_vertex(h,h->%next()->%opposite())` which is equivalent to an
     edge split of the halfedge `h->%next()` that creates a new


### PR DESCRIPTION
Some parts were due to to the markdown handling of 4 spaces meaning code converted to code and this was not the intention.


