### PR TITLE
Fix not clearing mesh after failing to read

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_surface_mesh_item.cpp
@@ -1573,6 +1573,8 @@ Scene_surface_mesh_item::load_obj(std::istream& in)
     {
       CGAL::Polygon_mesh_processing::repair_polygon_soup(points, faces);
       CGAL::Polygon_mesh_processing::orient_polygon_soup(points, faces);
+
+      clear(*(d->smesh_));
       CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh(points, faces, *(d->smesh_));
     }
   }


### PR DESCRIPTION
## Summary of Changes

`CGAL::IO::read_polygon_mesh()` does not clear the mesh before writing, and does not clear the mesh if it fails to read.

In the demo, we try to read via `CGAL::IO::read_polygon_mesh()` first, and if that fails through the `read_polygon_soup -> repair -> orient -> soup_to_mesh` pipeline. However, the mesh needs to be cleared before calling that pipeline.

## Release Management

* Affected package(s): `Polyhedron`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

