### PR TITLE
Add option to use a relaxed order

### DIFF
--- a/BGL/include/CGAL/boost/graph/parameters_interface.h
+++ b/BGL/include/CGAL/boost/graph/parameters_interface.h
@@ -133,6 +133,7 @@ CGAL_add_named_parameter(use_one_sided_hausdorff_t, use_one_sided_hausdorff, use
 CGAL_add_named_parameter(get_cost_policy_t, get_cost_policy, get_cost)
 CGAL_add_named_parameter(get_placement_policy_t, get_placement_policy, get_placement)
 CGAL_add_named_parameter(filter_t, filter, filter)
+CGAL_add_named_parameter(use_relaxed_order_t, use_relaxed_order, use_relaxed_order)
 
 //to be documented
 CGAL_add_named_parameter(face_normal_t, face_normal, face_normal_map)

--- a/Mesh_3/include/CGAL/Mesh_3/Sliver_perturber.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Sliver_perturber.h
@@ -57,14 +57,7 @@
 #endif
 
 #include <boost/format.hpp>
-#ifdef CGAL_MESH_3_USE_RELAXED_HEAP
-#  error This option CGAL_MESH_3_USE_RELAXED_HEAP is no longer supported
-// The reason is that the Boost relaxed heap does not ensure a strict order
-// of the priority queue.
-#include <boost/pending/relaxed_heap.hpp>
-#else
 #include <CGAL/Modifiable_priority_queue.h>
-#endif //CGAL_MESH_3_USE_RELAXED_HEAP
 #include <boost/ptr_container/ptr_vector.hpp>
 #include <boost/type_traits/is_convertible.hpp>
 
@@ -507,11 +500,8 @@ private:
   };
 
   typedef std::less<PVertex> less_PVertex;
-  #ifdef CGAL_MESH_3_USE_RELAXED_HEAP
-  typedef boost::relaxed_heap<PVertex, less_PVertex, PVertex_id> PQueue;
-  #else
-  typedef ::CGAL::internal::mutable_queue_with_remove<PVertex,std::vector<PVertex>, less_PVertex, PVertex_id> PQueue;
-  #endif //CGAL_MESH_3_USE_RELAXED_HEAP
+  typedef Modifiable_priority_queue<PVertex, less_PVertex, PVertex_id> PQueue;
+
 
 public:
   /**
@@ -942,10 +932,9 @@ perturb(const FT& sliver_bound, PQueue& pqueue, Visitor& visitor) const
   {
     this->create_task_group();
 
-    while (pqueue.size() > 0)
+    while (!pqueue.empty())
     {
-      PVertex pv = pqueue.top();
-      pqueue.pop();
+      PVertex pv = pqueue.top_and_pop();
       enqueue_task(pv, sliver_bound,
                    visitor, bad_vertices);
     }
@@ -977,8 +966,7 @@ perturb(const FT& sliver_bound, PQueue& pqueue, Visitor& visitor) const
     while ( !is_time_limit_reached() && !pqueue.empty() )
     {
       // Get pqueue head
-      PVertex pv = pqueue.top();
-      pqueue.pop();
+      PVertex pv = pqueue.top_and_pop();
       --pqueue_size;
 
       CGAL_assertion(pv.is_perturbable());
@@ -1245,7 +1233,7 @@ update_priority_queue(const PVertex& pv, PQueue& pqueue) const
     }
     else
     {
-      pqueue.remove(pv);
+      pqueue.erase(pv);
       return -1;
     }
   }

--- a/Polyline_simplification_2/include/CGAL/Polyline_simplification_2/simplify.h
+++ b/Polyline_simplification_2/include/CGAL/Polyline_simplification_2/simplify.h
@@ -335,7 +335,7 @@ operator()()
       } else {
         (*u)->set_cost(*dist);
         if(mpq->contains(*u)){
-          mpq->update(*u, true);
+          mpq->update(*u);
         }
         else{
           mpq->push(*u);
@@ -353,7 +353,7 @@ operator()()
       } else {
         (*w)->set_cost(*dist);
         if(mpq->contains(*w)){
-          mpq->update(*w, true);
+          mpq->update(*w);
         }
         else{
           mpq->push(*w);

--- a/STL_Extension/include/CGAL/Modifiable_priority_queue.h
+++ b/STL_Extension/include/CGAL/Modifiable_priority_queue.h
@@ -13,45 +13,11 @@
 
 #include <climits> // Needed by the following Boost header for CHAR_BIT.
 #include <boost/optional.hpp>
+
 #ifdef CGAL_SURFACE_MESH_SIMPLIFICATION_USE_RELAXED_HEAP
 #include <boost/pending/relaxed_heap.hpp>
 #else
 #include <CGAL/STL_Extension/internal/boost/mutable_queue.hpp>
-
-namespace CGAL {
-  namespace internal {
-template <class IndexedType,
-          class RandomAccessContainer = std::vector<IndexedType>,
-          class Comp = std::less<typename RandomAccessContainer::value_type>,
-          class ID = ::boost::identity_property_map >
-class mutable_queue_with_remove : public internal::boost_::mutable_queue<IndexedType,RandomAccessContainer,Comp,ID>
-{
-  typedef internal::boost_::mutable_queue<IndexedType,RandomAccessContainer,Comp,ID> Base;
-public:
-  typedef typename Base::size_type size_type;
-  typedef typename Base::Node Node;
-
-  mutable_queue_with_remove(size_type n, const Comp& x=Comp(), const ID& _id=ID()) : Base(n,x,_id,true)
-  {}
-
-  void remove(const IndexedType& x){
-    //first place element at the top
-    size_type current_pos = this->index_array[ get(this->id, x) ];
-    this->c[current_pos] = x;
-
-    Node node(this->c.begin(), this->c.end(), this->c.begin()+current_pos, this->id);
-    while (node.has_parent())
-      node.swap(node.parent(), this->index_array);
-    //then pop it
-    this->pop();
-  }
-
-  bool contains(const IndexedType& x) const {
-    return this->index_array[ get(this->id, x) ] !=this->index_array.size();
-  }
-};
-
-} } //namespace CGAL::internal
 #endif //CGAL_SURFACE_MESH_SIMPLIFICATION_USE_RELAXED_HEAP
 
 namespace CGAL {
@@ -73,7 +39,7 @@ public:
   #ifdef CGAL_SURFACE_MESH_SIMPLIFICATION_USE_RELAXED_HEAP
   typedef boost::relaxed_heap<IndexedType,Compare,ID> Heap;
   #else
-  typedef  internal::mutable_queue_with_remove<IndexedType,std::vector<IndexedType>,Compare,ID> Heap;
+  typedef  internal::boost_::mutable_queue<IndexedType,std::vector<IndexedType>,Compare,ID> Heap;
   #endif //CGAL_SURFACE_MESH_SIMPLIFICATION_USE_RELAXED_HEAP
   typedef typename Heap::value_type value_type;
   typedef typename Heap::size_type  size_type;

--- a/STL_Extension/include/CGAL/Modifiable_priority_queue.h
+++ b/STL_Extension/include/CGAL/Modifiable_priority_queue.h
@@ -11,13 +11,12 @@
 #ifndef CGAL_MODIFIABLE_PRIORITY_QUEUE_H
 #define CGAL_MODIFIABLE_PRIORITY_QUEUE_H
 
-#include <climits> // Neeeded by the following Boost header for CHAR_BIT.
+#include <climits> // Needed by the following Boost header for CHAR_BIT.
 #include <boost/optional.hpp>
 #ifdef CGAL_SURFACE_MESH_SIMPLIFICATION_USE_RELAXED_HEAP
 #include <boost/pending/relaxed_heap.hpp>
 #else
 #include <CGAL/STL_Extension/internal/boost/mutable_queue.hpp>
-
 
 namespace CGAL {
   namespace internal {
@@ -83,11 +82,13 @@ public:
 
 public:
 
-  Modifiable_priority_queue( size_type largest_ID, Compare const& c, ID const& id ) : mHeap(largest_ID,c,id) {}
+  Modifiable_priority_queue( size_type largest_ID, Compare const& c = Compare(), ID const& id = ID() ) : mHeap(largest_ID,c,id) {}
 
   handle push ( value_type const& v ) { mHeap.push(v) ; return handle(true) ; }
 
   handle update ( value_type const& v, handle h ) { mHeap.update(v); return h ; }
+
+  void update ( value_type const& v ) { mHeap.update(v); }
 
   handle erase ( value_type const& v, handle  ) { mHeap.remove(v); return null_handle() ; }
   handle erase ( value_type const& v  ) { mHeap.remove(v); return null_handle() ; }
@@ -110,6 +111,14 @@ public:
       r = boost::optional<value_type>(v) ;
     }
     return r ;
+  }
+
+  value_type top_and_pop()
+  {
+    CGAL_precondition(!empty());
+    value_type v = top();
+    pop();
+    return v;
   }
 
   static handle null_handle() { return handle(false); }

--- a/STL_Extension/include/CGAL/Modifiable_priority_queue.h
+++ b/STL_Extension/include/CGAL/Modifiable_priority_queue.h
@@ -17,11 +17,13 @@
 #include <CGAL/STL_Extension/internal/boost/relaxed_heap.hpp>
 #include <CGAL/STL_Extension/internal/boost/mutable_queue.hpp>
 
+#include <boost/heap/fibonacci_heap.hpp>
+
 #include <type_traits>
 
 namespace CGAL {
 
-enum Heap_type { CGAL_BOOST_PENDING_MUTABLE_QUEUE, CGAL_BOOST_PENDING_RELAXED_HEAP };
+enum Heap_type { CGAL_BOOST_FIBONACCI_HEAP, CGAL_BOOST_PENDING_MUTABLE_QUEUE, CGAL_BOOST_PENDING_RELAXED_HEAP };
 
 template <class IndexedType_
          ,class Compare_ = std::less<IndexedType_>
@@ -87,6 +89,88 @@ private:
 
   Heap mHeap ;
 
+} ;
+
+template <class IndexedType_
+         ,class Compare_ 
+         ,class ID_>
+class Modifiable_priority_queue<IndexedType_, Compare_, ID_, CGAL_BOOST_FIBONACCI_HEAP>
+{
+public:
+
+  typedef Modifiable_priority_queue Self;
+
+  typedef IndexedType_ IndexedType ;
+  typedef Compare_     Compare;
+  typedef ID_          ID ;
+
+  struct Reverse_compare{
+    const Compare c;
+    Reverse_compare(){}
+    Reverse_compare(Compare const& c):c(c){}
+    template<typename T>
+     bool operator() (T const& a, T const& b) const
+     {
+       return !c(a,b);
+     }
+  };
+
+  typedef boost::heap::fibonacci_heap<IndexedType,boost::heap::compare<Reverse_compare> > Heap;
+
+  typedef typename Heap::value_type value_type;
+  typedef typename Heap::size_type  size_type;
+
+public:
+
+  Modifiable_priority_queue( size_type largest_ID, Compare const& c = Compare(), ID const& id = ID() )
+    : mHeap(Reverse_compare(c))
+    , mID(id)
+    , mHandles(largest_ID)
+  {}
+
+  void push ( value_type const& v ) { mHandles[get(mID, v)]=mHeap.push(v) ; }
+
+  void update ( value_type const& v ) { mHeap.update(mHandles[get(mID, v)]); }
+
+  void erase ( value_type const& v  ) { 
+    auto vid = get(mID, v);
+    mHeap.erase(mHandles[vid]);
+    mHandles[vid]=typename Heap::handle_type();
+  }
+
+  value_type top() const { return mHeap.top(); }
+
+  void pop() { mHeap.pop(); }
+
+  bool empty() const { return mHeap.empty() ; }
+
+  bool contains ( value_type const& v ) { return mHandles[get(mID, v)] != typename Heap::handle_type(); }
+
+  boost::optional<value_type> extract_top()
+  {
+    boost::optional<value_type> r ;
+    if ( !empty() )
+    {
+      value_type v = top();
+      pop();
+      r = boost::optional<value_type>(v) ;
+    }
+    return r ;
+  }
+
+  value_type top_and_pop()
+  {
+    CGAL_precondition(!empty());
+    value_type v = top();
+    pop();
+    return v;
+  }
+
+private:
+
+  Heap mHeap ;
+  ID mID;
+  std::vector<typename Heap::handle_type> mHandles;
 } ;
 
 } //namespace CGAL

--- a/STL_Extension/include/CGAL/Modifiable_priority_queue.h
+++ b/STL_Extension/include/CGAL/Modifiable_priority_queue.h
@@ -78,22 +78,17 @@ public:
   typedef typename Heap::value_type value_type;
   typedef typename Heap::size_type  size_type;
 
-  typedef bool handle ;
-
 public:
 
   Modifiable_priority_queue( size_type largest_ID, Compare const& c = Compare(), ID const& id = ID() ) : mHeap(largest_ID,c,id) {}
 
-  handle push ( value_type const& v ) { mHeap.push(v) ; return handle(true) ; }
-
-  handle update ( value_type const& v, handle h ) { mHeap.update(v); return h ; }
+  void push ( value_type const& v ) { mHeap.push(v) ; }
 
   void update ( value_type const& v ) { mHeap.update(v); }
 
-  handle erase ( value_type const& v, handle  ) { mHeap.remove(v); return null_handle() ; }
-  handle erase ( value_type const& v  ) { mHeap.remove(v); return null_handle() ; }
+  void erase ( value_type const& v  ) { mHeap.remove(v); }
 
-  value_type top() const { return mHeap.top() ; }
+  value_type top() const { return mHeap.top(); }
 
   void pop() { mHeap.pop(); }
 
@@ -120,8 +115,6 @@ public:
     pop();
     return v;
   }
-
-  static handle null_handle() { return handle(false); }
 
 private:
 

--- a/STL_Extension/include/CGAL/Modifiable_priority_queue.h
+++ b/STL_Extension/include/CGAL/Modifiable_priority_queue.h
@@ -14,17 +14,19 @@
 #include <climits> // Needed by the following Boost header for CHAR_BIT.
 #include <boost/optional.hpp>
 
-#ifdef CGAL_SURFACE_MESH_SIMPLIFICATION_USE_RELAXED_HEAP
-#include <boost/pending/relaxed_heap.hpp>
-#else
+#include <CGAL/STL_Extension/internal/boost/relaxed_heap.hpp>
 #include <CGAL/STL_Extension/internal/boost/mutable_queue.hpp>
-#endif //CGAL_SURFACE_MESH_SIMPLIFICATION_USE_RELAXED_HEAP
+
+#include <type_traits>
 
 namespace CGAL {
+
+enum Heap_type { CGAL_BOOST_PENDING_MUTABLE_QUEUE, CGAL_BOOST_PENDING_RELAXED_HEAP };
 
 template <class IndexedType_
          ,class Compare_ = std::less<IndexedType_>
          ,class ID_      = boost::identity_property_map
+         , Heap_type heap_type = CGAL_BOOST_PENDING_MUTABLE_QUEUE
          >
 class Modifiable_priority_queue
 {
@@ -36,11 +38,10 @@ public:
   typedef Compare_     Compare;
   typedef ID_          ID ;
 
-  #ifdef CGAL_SURFACE_MESH_SIMPLIFICATION_USE_RELAXED_HEAP
-  typedef boost::relaxed_heap<IndexedType,Compare,ID> Heap;
-  #else
-  typedef  internal::boost_::mutable_queue<IndexedType,std::vector<IndexedType>,Compare,ID> Heap;
-  #endif //CGAL_SURFACE_MESH_SIMPLIFICATION_USE_RELAXED_HEAP
+  typedef std::conditional_t<heap_type == CGAL_BOOST_PENDING_MUTABLE_QUEUE,
+                             internal::boost_::mutable_queue<IndexedType,std::vector<IndexedType>,Compare,ID>,
+                             internal::boost_::relaxed_heap<IndexedType,Compare,ID> > Heap;
+
   typedef typename Heap::value_type value_type;
   typedef typename Heap::size_type  size_type;
 

--- a/STL_Extension/include/CGAL/STL_Extension/internal/boost/mutable_queue.hpp
+++ b/STL_Extension/include/CGAL/STL_Extension/internal/boost/mutable_queue.hpp
@@ -65,14 +65,10 @@ namespace boost_ {
     typedef Compare value_compare;
     typedef ID id_generator;
 
-    mutable_queue(size_type n, const Comp& x, const ID& _id)
-      : index_array(n), comp(x), id(_id) {
-      c.reserve(n);
-    }
-//SL: added this constructor so that index_array is filled with
+//SL: updated this constructor so that index_array is filled with
 //    indices equals to n. Maintaining this property in pop allows
 //    to have a method to detect if an element is in the queue
-    mutable_queue(size_type n, const Comp& x, const ID& _id,bool)
+    mutable_queue(size_type n, const Comp& x, const ID& _id)
       : index_array(n,n), comp(x), id(_id) {
       c.reserve(n);
     }
@@ -134,6 +130,24 @@ namespace boost_ {
 
     void clear() { c.clear(); }
 
+//SL: added remove and contains functions
+//    (historically in CGAL::internal::mutable_queue_with_remove with no good
+//     reason now that the present file is shipped with CGAL)
+    void remove(const IndexedType& x){
+      //first place element at the top
+      size_type current_pos = index_array[ get(id, x) ];
+      c[current_pos] = x;
+
+      Node node(c.begin(), c.end(), c.begin()+current_pos, id);
+      while (node.has_parent())
+        node.swap(node.parent(), index_array);
+      //then pop it
+      pop();
+    }
+
+    bool contains(const IndexedType& x) const {
+      return index_array[ get(id, x) ] != index_array.size();
+    }
 #if 0
         // dwa 2003/7/11 - I don't know what compiler is supposed to
         // be able to compile this, but is_heap is not standard!!

--- a/STL_Extension/include/CGAL/STL_Extension/internal/boost/relaxed_heap.hpp
+++ b/STL_Extension/include/CGAL/STL_Extension/internal/boost/relaxed_heap.hpp
@@ -1,0 +1,752 @@
+//
+//=======================================================================
+// Copyright 2004 The Trustees of Indiana University.
+// Use, modification and distribution is subject to the Boost Software
+// License, Version 1.0. (See accompanying file LICENSE_1_0.txt or copy at
+// http://www.boost.org/LICENSE_1_0.txt)
+//
+// Authors: Douglas Gregor
+//          Andrew Lumsdaine
+//=======================================================================
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: BSL-1.0
+//
+// NOTE: this file have been taken from boost 1.77 for using
+//       with Modificable_priority_queue
+//       original file is <boost/pending/relaxed_heap.hpp>
+//
+
+#ifndef BOOST_RELAXED_HEAP_HEADER
+#define BOOST_RELAXED_HEAP_HEADER
+
+
+#include <functional>
+#include <boost/property_map/property_map.hpp>
+#include <boost/optional.hpp>
+#include <vector>
+#include <climits> // for CHAR_BIT
+#include <boost/none.hpp>
+
+#ifdef BOOST_RELAXED_HEAP_DEBUG
+#include <iostream>
+#endif // BOOST_RELAXED_HEAP_DEBUG
+
+#if defined(BOOST_MSVC)
+#pragma warning(push)
+#pragma warning(disable : 4355) // complaint about using 'this' to
+#endif // initialize a member
+
+namespace CGAL { namespace internal {
+namespace boost_ {
+
+template < typename IndexedType, typename Compare = std::less< IndexedType >,
+    typename ID = boost::identity_property_map >
+class relaxed_heap
+{
+    struct group;
+
+    typedef relaxed_heap self_type;
+    typedef std::size_t rank_type;
+
+public:
+    typedef IndexedType value_type;
+    typedef rank_type size_type;
+
+private:
+    /**
+     * The kind of key that a group has. The actual values are discussed
+     * in-depth in the documentation of the @c kind field of the @c group
+     * structure. Note that the order of the enumerators *IS* important
+     * and must not be changed.
+     */
+    enum group_key_kind
+    {
+        smallest_key,
+        stored_key,
+        largest_key
+    };
+
+    struct group
+    {
+        explicit group(group_key_kind kind = largest_key)
+        : kind(kind), parent(this), rank(0)
+        {
+        }
+
+        /** The value associated with this group. This value is only valid
+         *  when @c kind!=largest_key (which indicates a deleted
+         *  element). Note that the use of boost::optional increases the
+         *  memory requirements slightly but does not result in extraneous
+         *  memory allocations or deallocations. The optional could be
+         *  eliminated when @c value_type is a model of
+         *  DefaultConstructible.
+         */
+        ::boost::optional< value_type > value;
+
+        /**
+         * The kind of key stored at this group. This may be @c
+         * smallest_key, which indicates that the key is infinitely small;
+         * @c largest_key, which indicates that the key is infinitely
+         * large; or @c stored_key, which means that the key is unknown,
+         * but its relationship to other keys can be determined via the
+         * comparison function object.
+         */
+        group_key_kind kind;
+
+        /// The parent of this group. Will only be NULL for the dummy root group
+        group* parent;
+
+        /// The rank of this group. Equivalent to the number of children in
+        /// the group.
+        rank_type rank;
+
+        /** The children of this group. For the dummy root group, these are
+         * the roots. This is an array of length log n containing pointers
+         * to the child groups.
+         */
+        group** children;
+    };
+
+    size_type log_base_2(size_type n) // log2 is a macro on some platforms
+    {
+        size_type leading_zeroes = 0;
+        do
+        {
+            size_type next = n << 1;
+            if (n == (next >> 1))
+            {
+                ++leading_zeroes;
+                n = next;
+            }
+            else
+            {
+                break;
+            }
+        } while (true);
+        return sizeof(size_type) * CHAR_BIT - leading_zeroes - 1;
+    }
+
+public:
+    relaxed_heap(
+        size_type n, const Compare& compare = Compare(), const ID& id = ID())
+    : compare(compare), id(id), root(smallest_key), groups(n), smallest_value(0)
+    {
+        if (n == 0)
+        {
+            root.children = new group*[1];
+            return;
+        }
+
+        log_n = log_base_2(n);
+        if (log_n == 0)
+            log_n = 1;
+        size_type g = n / log_n;
+        if (n % log_n > 0)
+            ++g;
+        size_type log_g = log_base_2(g);
+        size_type r = log_g;
+
+        // Reserve an appropriate amount of space for data structures, so
+        // that we do not need to expand them.
+        index_to_group.resize(g);
+        A.resize(r + 1, 0);
+        root.rank = r + 1;
+        root.children = new group*[(log_g + 1) * (g + 1)];
+        for (rank_type i = 0; i < r + 1; ++i)
+            root.children[i] = 0;
+
+        // Build initial heap
+        size_type idx = 0;
+        while (idx < g)
+        {
+            root.children[r] = &index_to_group[idx];
+            idx = build_tree(root, idx, r, log_g + 1);
+            if (idx != g)
+                r = static_cast< size_type >(log_base_2(g - idx));
+        }
+    }
+
+    ~relaxed_heap() { delete[] root.children; }
+
+    void push(const value_type& x)
+    {
+        groups[get(id, x)] = x;
+        update(x);
+    }
+
+    void update(const value_type& x)
+    {
+        group* a = &index_to_group[get(id, x) / log_n];
+        if (!a->value || *a->value == x || compare(x, *a->value))
+        {
+            if (a != smallest_value)
+                smallest_value = 0;
+            a->kind = stored_key;
+            a->value = x;
+            promote(a);
+        }
+    }
+
+    void remove(const value_type& x)
+    {
+        group* a = &index_to_group[get(id, x) / log_n];
+        assert(groups[get(id, x)]);
+        a->value = x;
+        a->kind = smallest_key;
+        promote(a);
+        smallest_value = a;
+        pop();
+    }
+
+    value_type& top()
+    {
+        find_smallest();
+        assert(smallest_value->value != boost::none);
+        return *smallest_value->value;
+    }
+
+    const value_type& top() const
+    {
+        find_smallest();
+        assert(smallest_value->value != boost::none);
+        return *smallest_value->value;
+    }
+
+    bool empty() const
+    {
+        find_smallest();
+        return !smallest_value || (smallest_value->kind == largest_key);
+    }
+
+    bool contains(const value_type& x) const
+    {
+        return static_cast< bool >(groups[get(id, x)]);
+    }
+
+    void pop()
+    {
+        // Fill in smallest_value. This is the group x.
+        find_smallest();
+        group* x = smallest_value;
+        smallest_value = 0;
+
+        // Make x a leaf, giving it the smallest value within its group
+        rank_type r = x->rank;
+        group* p = x->parent;
+        {
+            assert(x->value != boost::none);
+
+            // Find x's group
+            size_type start = get(id, *x->value) - get(id, *x->value) % log_n;
+            size_type end = start + log_n;
+            if (end > groups.size())
+                end = groups.size();
+
+            // Remove the smallest value from the group, and find the new
+            // smallest value.
+            groups[get(id, *x->value)].reset();
+            x->value.reset();
+            x->kind = largest_key;
+            for (size_type i = start; i < end; ++i)
+            {
+                if (groups[i] && (!x->value || compare(*groups[i], *x->value)))
+                {
+                    x->kind = stored_key;
+                    x->value = groups[i];
+                }
+            }
+        }
+        x->rank = 0;
+
+        // Combine prior children of x with x
+        group* y = x;
+        for (size_type c = 0; c < r; ++c)
+        {
+            group* child = x->children[c];
+            if (A[c] == child)
+                A[c] = 0;
+            y = combine(y, child);
+        }
+
+        // If we got back something other than x, let y take x's place
+        if (y != x)
+        {
+            y->parent = p;
+            p->children[r] = y;
+
+            assert(r == y->rank);
+            if (A[y->rank] == x)
+                A[y->rank] = do_compare(y, p) ? y : 0;
+        }
+    }
+
+#ifdef BOOST_RELAXED_HEAP_DEBUG
+    /*************************************************************************
+     * Debugging support                                                     *
+     *************************************************************************/
+    void dump_tree() { dump_tree(std::cout); }
+    void dump_tree(std::ostream& out) { dump_tree(out, &root); }
+
+    void dump_tree(std::ostream& out, group* p, bool in_progress = false)
+    {
+        if (!in_progress)
+        {
+            out << "digraph heap {\n"
+                << "  edge[dir=\"back\"];\n";
+        }
+
+        size_type p_index = 0;
+        if (p != &root)
+            while (&index_to_group[p_index] != p)
+                ++p_index;
+
+        for (size_type i = 0; i < p->rank; ++i)
+        {
+            group* c = p->children[i];
+            if (c)
+            {
+                size_type c_index = 0;
+                if (c != &root)
+                    while (&index_to_group[c_index] != c)
+                        ++c_index;
+
+                out << "  ";
+                if (p == &root)
+                    out << 'p';
+                else
+                    out << p_index;
+                out << " -> ";
+                if (c == &root)
+                    out << 'p';
+                else
+                    out << c_index;
+                if (A[c->rank] == c)
+                    out << " [style=\"dotted\"]";
+                out << ";\n";
+                dump_tree(out, c, true);
+
+                // Emit node information
+                out << "  ";
+                if (c == &root)
+                    out << 'p';
+                else
+                    out << c_index;
+                out << " [label=\"";
+                if (c == &root)
+                    out << 'p';
+                else
+                    out << c_index;
+                out << ":";
+                size_type start = c_index * log_n;
+                size_type end = start + log_n;
+                if (end > groups.size())
+                    end = groups.size();
+                while (start != end)
+                {
+                    if (groups[start])
+                    {
+                        out << " " << get(id, *groups[start]);
+                        if (*groups[start] == *c->value)
+                            out << "(*)";
+                    }
+                    ++start;
+                }
+                out << '"';
+
+                if (do_compare(c, p))
+                {
+                    out << "  ";
+                    if (c == &root)
+                        out << 'p';
+                    else
+                        out << c_index;
+                    out << ", style=\"filled\", fillcolor=\"gray\"";
+                }
+                out << "];\n";
+            }
+            else
+            {
+                assert(p->parent == p);
+            }
+        }
+        if (!in_progress)
+            out << "}\n";
+    }
+
+    bool valid()
+    {
+        // Check that the ranks in the A array match the ranks of the
+        // groups stored there. Also, the active groups must be the last
+        // child of their parent.
+        for (size_type r = 0; r < A.size(); ++r)
+        {
+            if (A[r] && A[r]->rank != r)
+                return false;
+
+            if (A[r] && A[r]->parent->children[A[r]->parent->rank - 1] != A[r])
+                return false;
+        }
+
+        // The root must have no value and a key of -Infinity
+        if (root.kind != smallest_key)
+            return false;
+
+        return valid(&root);
+    }
+
+    bool valid(group* p)
+    {
+        for (size_type i = 0; i < p->rank; ++i)
+        {
+            group* c = p->children[i];
+            if (c)
+            {
+                // Check link structure
+                if (c->parent != p)
+                    return false;
+                if (c->rank != i)
+                    return false;
+
+                // A bad group must be active
+                if (do_compare(c, p) && A[i] != c)
+                    return false;
+
+                // Check recursively
+                if (!valid(c))
+                    return false;
+            }
+            else
+            {
+                // Only the root may
+                if (p != &root)
+                    return false;
+            }
+        }
+        return true;
+    }
+
+#endif // BOOST_RELAXED_HEAP_DEBUG
+
+private:
+    size_type build_tree(
+        group& parent, size_type idx, size_type r, size_type max_rank)
+    {
+        group& this_group = index_to_group[idx];
+        this_group.parent = &parent;
+        ++idx;
+
+        this_group.children = root.children + (idx * max_rank);
+        this_group.rank = r;
+        for (size_type i = 0; i < r; ++i)
+        {
+            this_group.children[i] = &index_to_group[idx];
+            idx = build_tree(this_group, idx, i, max_rank);
+        }
+        return idx;
+    }
+
+    void find_smallest() const
+    {
+        group** roots = root.children;
+
+        if (!smallest_value)
+        {
+            std::size_t i;
+            for (i = 0; i < root.rank; ++i)
+            {
+                if (roots[i]
+                    && (!smallest_value
+                        || do_compare(roots[i], smallest_value)))
+                {
+                    smallest_value = roots[i];
+                }
+            }
+            for (i = 0; i < A.size(); ++i)
+            {
+                if (A[i]
+                    && (!smallest_value || do_compare(A[i], smallest_value)))
+                    smallest_value = A[i];
+            }
+        }
+    }
+
+    bool do_compare(group* x, group* y) const
+    {
+        return (x->kind < y->kind
+            || (x->kind == y->kind && x->kind == stored_key
+                && compare(*x->value, *y->value)));
+    }
+
+    void promote(group* a)
+    {
+        assert(a != 0);
+        rank_type r = a->rank;
+        group* p = a->parent;
+        assert(p != 0);
+        if (do_compare(a, p))
+        {
+            // s is the rank + 1 sibling
+            group* s = p->rank > r + 1 ? p->children[r + 1] : 0;
+
+            // If a is the last child of p
+            if (r == p->rank - 1)
+            {
+                if (!A[r])
+                    A[r] = a;
+                else if (A[r] != a)
+                    pair_transform(a);
+            }
+            else
+            {
+                assert(s != 0);
+                if (A[r + 1] == s)
+                    active_sibling_transform(a, s);
+                else
+                    good_sibling_transform(a, s);
+            }
+        }
+    }
+
+    group* combine(group* a1, group* a2)
+    {
+        assert(a1->rank == a2->rank);
+        if (do_compare(a2, a1))
+            do_swap(a1, a2);
+        a1->children[a1->rank++] = a2;
+        a2->parent = a1;
+        clean(a1);
+        return a1;
+    }
+
+    void clean(group* q)
+    {
+        if (2 > q->rank)
+            return;
+        group* qp = q->children[q->rank - 1];
+        rank_type s = q->rank - 2;
+        group* x = q->children[s];
+        group* xp = qp->children[s];
+        assert(s == x->rank);
+
+        // If x is active, swap x and xp
+        if (A[s] == x)
+        {
+            q->children[s] = xp;
+            xp->parent = q;
+            qp->children[s] = x;
+            x->parent = qp;
+        }
+    }
+
+    void pair_transform(group* a)
+    {
+#if defined(BOOST_RELAXED_HEAP_DEBUG) && BOOST_RELAXED_HEAP_DEBUG > 1
+        std::cerr << "- pair transform\n";
+#endif
+        rank_type r = a->rank;
+
+        // p is a's parent
+        group* p = a->parent;
+        assert(p != 0);
+
+        // g is p's parent (a's grandparent)
+        group* g = p->parent;
+        assert(g != 0);
+
+        // a' <- A(r)
+        assert(A[r] != 0);
+        group* ap = A[r];
+        assert(ap != 0);
+
+        // A(r) <- nil
+        A[r] = 0;
+
+        // let a' have parent p'
+        group* pp = ap->parent;
+        assert(pp != 0);
+
+        // let a' have grandparent g'
+        group* gp = pp->parent;
+        assert(gp != 0);
+
+        // Remove a and a' from their parents
+        assert(ap
+            == pp->children[pp->rank - 1]); // Guaranteed because ap is active
+        --pp->rank;
+
+        // Guaranteed by caller
+        assert(a == p->children[p->rank - 1]);
+        --p->rank;
+
+        // Note: a, ap, p, pp all have rank r
+        if (do_compare(pp, p))
+        {
+            do_swap(a, ap);
+            do_swap(p, pp);
+            do_swap(g, gp);
+        }
+
+        // Assuming k(p) <= k(p')
+        // make p' the rank r child of p
+        assert(r == p->rank);
+        p->children[p->rank++] = pp;
+        pp->parent = p;
+
+        // Combine a, ap into a rank r+1 group c
+        group* c = combine(a, ap);
+
+        // make c the rank r+1 child of g'
+        assert(gp->rank > r + 1);
+        gp->children[r + 1] = c;
+        c->parent = gp;
+
+#if defined(BOOST_RELAXED_HEAP_DEBUG) && BOOST_RELAXED_HEAP_DEBUG > 1
+        std::cerr << "After pair transform...\n";
+        dump_tree();
+#endif
+
+        if (A[r + 1] == pp)
+            A[r + 1] = c;
+        else
+            promote(c);
+    }
+
+    void active_sibling_transform(group* a, group* s)
+    {
+#if defined(BOOST_RELAXED_HEAP_DEBUG) && BOOST_RELAXED_HEAP_DEBUG > 1
+        std::cerr << "- active sibling transform\n";
+#endif
+        group* p = a->parent;
+        group* g = p->parent;
+
+        // remove a, s from their parents
+        assert(s->parent == p);
+        assert(p->children[p->rank - 1] == s);
+        --p->rank;
+        assert(p->children[p->rank - 1] == a);
+        --p->rank;
+
+        rank_type r = a->rank;
+        A[r + 1] = 0;
+        a = combine(p, a);
+        group* c = combine(a, s);
+
+        // make c the rank r+2 child of g
+        assert(g->children[r + 2] == p);
+        g->children[r + 2] = c;
+        c->parent = g;
+        if (A[r + 2] == p)
+            A[r + 2] = c;
+        else
+            promote(c);
+    }
+
+    void good_sibling_transform(group* a, group* s)
+    {
+#if defined(BOOST_RELAXED_HEAP_DEBUG) && BOOST_RELAXED_HEAP_DEBUG > 1
+        std::cerr << "- good sibling transform\n";
+#endif
+        rank_type r = a->rank;
+        group* c = s->children[s->rank - 1];
+        assert(c->rank == r);
+        if (A[r] == c)
+        {
+#if defined(BOOST_RELAXED_HEAP_DEBUG) && BOOST_RELAXED_HEAP_DEBUG > 1
+            std::cerr << "- good sibling pair transform\n";
+#endif
+            A[r] = 0;
+            group* p = a->parent;
+
+            // Remove c from its parent
+            --s->rank;
+
+            // Make s the rank r child of p
+            s->parent = p;
+            p->children[r] = s;
+
+            // combine a, c and let the result by the rank r+1 child of p
+            assert(p->rank > r + 1);
+            group* x = combine(a, c);
+            x->parent = p;
+            p->children[r + 1] = x;
+
+            if (A[r + 1] == s)
+                A[r + 1] = x;
+            else
+                promote(x);
+
+#if defined(BOOST_RELAXED_HEAP_DEBUG) && BOOST_RELAXED_HEAP_DEBUG > 1
+            dump_tree(std::cerr);
+#endif
+            //      pair_transform(a);
+        }
+        else
+        {
+            // Clean operation
+            group* p = a->parent;
+            s->children[r] = a;
+            a->parent = s;
+            p->children[r] = c;
+            c->parent = p;
+
+            promote(a);
+        }
+    }
+
+    static void do_swap(group*& x, group*& y)
+    {
+        group* tmp = x;
+        x = y;
+        y = tmp;
+    }
+
+    /// Function object that compares two values in the heap
+    Compare compare;
+
+    /// Mapping from values to indices in the range [0, n).
+    ID id;
+
+    /** The root group of the queue. This group is special because it will
+     *  never store a value, but it acts as a parent to all of the
+     *  roots. Thus, its list of children is the list of roots.
+     */
+    group root;
+
+    /** Mapping from the group index of a value to the group associated
+     *  with that value. If a value is not in the queue, then the "value"
+     *  field will be empty.
+     */
+    std::vector< group > index_to_group;
+
+    /** Flat data structure containing the values in each of the
+     *  groups. It will be indexed via the id of the values. The groups
+     *  are each log_n long, with the last group potentially being
+     *  smaller.
+     */
+    std::vector< ::boost::optional< value_type > > groups;
+
+    /** The list of active groups, indexed by rank. When A[r] is null,
+     *  there is no active group of rank r. Otherwise, A[r] is the active
+     *  group of rank r.
+     */
+    std::vector< group* > A;
+
+    /** The group containing the smallest value in the queue, which must
+     *  be either a root or an active group. If this group is null, then we
+     *  will need to search for this group when it is needed.
+     */
+    mutable group* smallest_value;
+
+    /// Cached value log_base_2(n)
+    size_type log_n;
+};
+
+} } } // end namespace CGAL::internal::boost_
+
+#if defined(BOOST_MSVC)
+#pragma warning(pop)
+#endif
+
+#endif // BOOST_RELAXED_HEAP_HEADER

--- a/STL_Extension/include/CGAL/STL_Extension/internal/boost/relaxed_heap.hpp
+++ b/STL_Extension/include/CGAL/STL_Extension/internal/boost/relaxed_heap.hpp
@@ -13,9 +13,9 @@
 // $Id$
 // SPDX-License-Identifier: BSL-1.0
 //
-// NOTE: this file have been taken from boost 1.77 for using
-//       with Modificable_priority_queue
-//       original file is <boost/pending/relaxed_heap.hpp>
+// NOTE: this file has been taken from boost 1.77 to use
+//       with Modificable_priority_queue.
+//       The original file is <boost/pending/relaxed_heap.hpp>
 //
 
 #ifndef BOOST_RELAXED_HEAP_HEADER

--- a/STL_Extension/test/STL_Extension/test_Modifiable_priority_queue.cpp
+++ b/STL_Extension/test/STL_Extension/test_Modifiable_priority_queue.cpp
@@ -41,7 +41,6 @@ int queue_size(Queue& q,int n){
 
 int main()
 {
-  #ifndef CGAL_SURFACE_MESH_SIMPLIFICATION_USE_RELAXED_HEAP
   //testing min-heap
   typedef CGAL::Modifiable_priority_queue<Type*,Less,First_of_pair> Queue;
   Queue q(45,Queue::Compare(),Queue::ID());
@@ -210,8 +209,4 @@ int main()
   std::cout << "OK" << std::endl;
 
   return 0;
-  #else
-  std::cerr << "ERROR: Nothing is tested" << std::endl;
-  return 1;
-  #endif
 }

--- a/STL_Extension/test/STL_Extension/test_Modifiable_priority_queue.cpp
+++ b/STL_Extension/test/STL_Extension/test_Modifiable_priority_queue.cpp
@@ -73,7 +73,7 @@ int main()
   assert( q.top()->first == 4 );
   assert( queue_size(q,45) == 4 );
 
-  q.erase(&data[0]+4,false);
+  q.erase(&data[0]+4);
   assert( q.top()->first == 1 );
   assert( queue_size(q,45) == 3 );
 
@@ -82,7 +82,7 @@ int main()
   assert( queue_size(q,45) == 4 );
 
   data[5].second=43;
-  q.update(&data[0]+5,true);
+  q.update(&data[0]+5);
   assert( q.top()->first == 1 );
   assert( queue_size(q,45) == 4 );
 
@@ -110,19 +110,19 @@ int main()
   assert( q.top()->first == 0 );
   assert( queue_size(q,45) == 4 );
 
-  q.erase(&data[0]+1,true);
+  q.erase(&data[0]+1);
   assert( q.top()->first == 0 );
   assert( queue_size(q,45) == 3 );
 
-  q.erase(&data[0]+2,true);
+  q.erase(&data[0]+2);
   assert( q.top()->first == 0 );
   assert( queue_size(q,45) == 2 );
 
-  q.erase(&data[0],true);
+  q.erase(&data[0]);
   assert( q.top()->first == 3 );
   assert( queue_size(q,45) == 1 );
 
-  q.erase(&data[0]+3,true);
+  q.erase(&data[0]+3);
   assert( queue_size(q,45) == 0 );
   assert( q.empty() );
 
@@ -152,13 +152,13 @@ int main()
 
   for (unsigned int i=0;i<10;++i){
     data[i].second=9-i;
-    q.update(&data[0]+i,true);
+    q.update(&data[0]+i);
     assert(q.top()->first==i);
   }
 
 //testing contains
   for (int i=0;i<10;++i){
-    q.erase(&data[0]+i,true);
+    q.erase(&data[0]+i);
     assert(queue_size(q,45)==9-i);
   }
 
@@ -172,20 +172,20 @@ int main()
 
   for (unsigned int i=0;i<9;++i){
     data[i].second=10+i;
-    q.update(&data[0]+i,true);
+    q.update(&data[0]+i);
     assert(q.top()->first==i+1);
   }
 
 //revert order
   for (unsigned int i=0;i<10;++i){
     data[9-i].second=i;
-    q.update(&data[0]+9-i,true);
+    q.update(&data[0]+9-i);
     assert(q.top()->first==9);
   }
 //testing remove (emulate pop)
   for (std::size_t i=0;i<10;++i){
     assert(q.top()->first==9-i);
-    q.erase(&data[0]-i+9,true);
+    q.erase(&data[0]-i+9);
   }
   assert( q.empty() );
 
@@ -199,7 +199,7 @@ int main()
 
   for (std::size_t i=0;i<10;++i){
     assert(q.top()->first==0);
-    q.erase(&data[0]-i+9,true);
+    q.erase(&data[0]-i+9);
     for (std::size_t k=0;k<9-i;++k)
       assert(q.contains(&data[0]+k)==true);
     for (std::size_t k=0;k<i+1;++k)

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/edge_collapse.h
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/edge_collapse.h
@@ -87,6 +87,15 @@ the number of edges effectively removed.
                      in case of non-constant complexity for index access.}
      \cgalParamExtra{This parameter is only used by debug functions and is usually not needed for users.}
    \cgalParamNEnd
+
+  \cgalParamNBegin{use_relaxed_order}
+     \cgalParamDescription{a Boolean tag indicating if the ordering of elements to be collapsed in the priority queue can be relaxed}
+     \cgalParamType{Either `CGAL::Tag_true` or `CGAL::Tag_false`}
+     \cgalParamDefault{`CGAL::Tag_false()`}
+     \cgalParamExtra{Using a relaxed order will allow the algorithm to use a faster priority queue.
+                     However, if for example a user expects that all elements shorter than a given value to be collapsed,
+                     a relaxed order shall not be used.}
+   \cgalParamNEnd
 \cgalNamedParamsEnd
 
 \cgalHeading{Semantics}

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/edge_collapse.h
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/edge_collapse.h
@@ -93,8 +93,8 @@ the number of edges effectively removed.
      \cgalParamType{Either `CGAL::Tag_true` or `CGAL::Tag_false`}
      \cgalParamDefault{`CGAL::Tag_false()`}
      \cgalParamExtra{Using a relaxed order will allow the algorithm to use a faster priority queue.
-                     However, if for example a user expects that all elements shorter than a given value to be collapsed,
-                     a relaxed order shall not be used.}
+                     However, the ordering of the priority queue is no longer strict and there is a possibility
+                     that some elements that ought to have been collapsed are not actually collapsed.}
    \cgalParamNEnd
 \cgalNamedParamsEnd
 

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/edge_collapse.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/edge_collapse.h
@@ -25,7 +25,8 @@ namespace CGAL {
 namespace Surface_mesh_simplification {
 namespace internal {
 
-template<class TM,
+template<bool use_relaxed_order,
+         class TM,
          class GT,
          class ShouldStop,
          class VertexIndexMap,
@@ -52,7 +53,7 @@ int edge_collapse(TM& tmesh,
 {
   typedef EdgeCollapse<TM, GT, ShouldStop,
                        VertexIndexMap, VertexPointMap, HalfedgeIndexMap, EdgeIsConstrainedMap,
-                       GetCost, GetPlacement, ShouldIgnore, Visitor> Algorithm;
+                       GetCost, GetPlacement, ShouldIgnore, Visitor,use_relaxed_order> Algorithm;
 
   Algorithm algorithm(tmesh, traits, should_stop, vim, vpm, him, ecm, get_cost, get_placement, should_ignore, visitor);
 
@@ -90,8 +91,11 @@ int edge_collapse(TM& tmesh,
   using parameters::get_parameter;
 
   typedef typename GetGeomTraits<TM, NamedParameters>::type                   Geom_traits;
+  typedef typename internal_np::Lookup_named_param_def <
+    internal_np::use_relaxed_order_t, NamedParameters, Tag_false> ::type  Use_relaxed_order;
 
-  return internal::edge_collapse(tmesh, should_stop,
+  return internal::edge_collapse<Use_relaxed_order::value>
+                                (tmesh, should_stop,
                                  choose_parameter<Geom_traits>(get_parameter(np, internal_np::geom_traits)),
                                  CGAL::get_initialized_vertex_index_map(tmesh, np),
                                  choose_parameter(get_parameter(np, internal_np::vertex_point),

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
@@ -313,7 +313,6 @@ private:
     CGAL_expensive_assertion(mPQ->contains(h));
 
     mPQ->update(h);
-    data.set_is_in_PQ();
 
     CGAL_assertion(data.is_in_PQ());
     CGAL_expensive_assertion(mPQ->contains(h));

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
@@ -89,7 +89,8 @@ template<class TM_,
          class GetCost_,
          class GetPlacement_,
          class ShouldIgnore_,
-         class VisitorT_>
+         class VisitorT_,
+         bool use_relaxed_heap>
 class EdgeCollapse
 {
   typedef EdgeCollapse                                                    Self;
@@ -173,7 +174,9 @@ public:
     const Self* m_algorithm;
   };
 
-  typedef Modifiable_priority_queue<halfedge_descriptor, Compare_cost, edge_id>     PQ;
+  static const Heap_type hp = use_relaxed_heap ? CGAL_BOOST_PENDING_RELAXED_HEAP
+                                               : CGAL_BOOST_PENDING_MUTABLE_QUEUE;
+  typedef Modifiable_priority_queue<halfedge_descriptor, Compare_cost, edge_id, hp>     PQ;
 
   // An Edge_data is associated with EVERY _ edge in the mesh (collapsable or not).
   // It contains the edge status wrt the priority queue
@@ -399,8 +402,8 @@ private:
   CGAL_SMS_DEBUG_CODE(unsigned m_step;)
 };
 
-  template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V>
-  EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 EdgeCollapse(Triangle_mesh& tmesh,
              const Geom_traits& traits,
              const Should_stop& should_stop,
@@ -441,9 +444,9 @@ EdgeCollapse(Triangle_mesh& tmesh,
 #endif
 }
 
-template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V>
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
 int
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 run()
 {
   CGAL_expensive_precondition(is_valid_polygon_mesh(m_tm) && CGAL::is_triangle_mesh(m_tm));
@@ -468,9 +471,9 @@ run()
   return r;
 }
 
-template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V>
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
 void
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 collect()
 {
   CGAL_SMS_TRACE(0, "collecting edges...");
@@ -577,9 +580,9 @@ collect()
   CGAL_SMS_TRACE(0, "Initial edge count: " << m_initial_edge_count);
 }
 
-template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V>
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
 void
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 loop()
 {
   CGAL_SMS_TRACE(0, "Collapsing edges...");
@@ -666,9 +669,9 @@ loop()
   }
 }
 
-template<class TM, class GT, class SP, class VIM, class VPM, class HIM, class ECM, class CF, class PF, class SI, class V>
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
 bool
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 is_border_or_constrained(const vertex_descriptor v) const
 {
   for(halfedge_descriptor h : halfedges_around_target(v, m_tm))
@@ -680,9 +683,9 @@ is_border_or_constrained(const vertex_descriptor v) const
   return false;
 }
 
-template<class TM, class GT, class SP, class VIM, class VPM, class HIM, class ECM, class CF, class PF, class SI, class V>
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
 bool
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 is_constrained(const vertex_descriptor v) const
 {
   for(halfedge_descriptor h : halfedges_around_target(v, m_tm))
@@ -701,9 +704,9 @@ is_constrained(const vertex_descriptor v) const
 // The link condition is as follows: for every vertex 'k' adjacent to both 'p and 'q',
 // "p,k,q" is a facet of the mesh.
 //
-  template<class TM, class GT, class SP, class VIM, class VPM, class HIM, class ECM, class CF, class PF, class SI, class V>
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
 bool
-  EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+  EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 is_collapse_topologically_valid(const Profile& profile)
 {
   bool res = true;
@@ -869,17 +872,17 @@ is_collapse_topologically_valid(const Profile& profile)
   return res;
 }
 
-template<class TM, class GT, class SP, class VIM, class VPM, class HIM, class ECM, class CF, class PF, class SI, class V>
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
 bool
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 is_tetrahedron(const halfedge_descriptor h)
 {
   return CGAL::is_tetrahedron(h, m_tm);
 }
 
-template<class TM, class GT, class SP, class VIM, class VPM, class HIM, class ECM, class CF, class PF, class SI, class V>
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
 bool
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 is_open_triangle(const halfedge_descriptor h1)
 {
   bool res = false;
@@ -908,9 +911,9 @@ is_open_triangle(const halfedge_descriptor h1)
 // respective areas is no greater than a max value and the internal
 // dihedral angle formed by their supporting planes is no greater than
 // a given threshold
-template<class TM, class GT, class SP, class VIM, class VPM, class HIM, class ECM, class CF, class PF, class SI, class V>
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
 bool
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 are_shared_triangles_valid(const Point& p0, const Point& p1, const Point& p2, const Point& p3) const
 {
   bool res = false;
@@ -960,9 +963,9 @@ are_shared_triangles_valid(const Point& p0, const Point& p1, const Point& p2, co
 }
 
 // Returns the directed halfedge connecting v0 to v1, if exists.
-template<class TM, class GT, class SP, class VIM, class VPM, class HIM, class ECM, class CF, class PF, class SI, class V>
-typename EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::halfedge_descriptor
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
+typename EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::halfedge_descriptor
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 find_connection(const vertex_descriptor v0,
                 const vertex_descriptor v1) const
 {
@@ -977,9 +980,9 @@ find_connection(const vertex_descriptor v0,
 
 // Given the edge 'e' around the link for the collapsinge edge "v0-v1", finds the vertex that makes a triangle adjacent to 'e' but exterior to the link (i.e not containing v0 nor v1)
 // If 'e' is a null handle OR 'e' is a border edge, there is no such triangle and a null handle is returned.
-template<class TM, class GT, class SP, class VIM, class VPM, class HIM, class ECM, class CF, class PF, class SI, class V>
-typename EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::vertex_descriptor
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
+typename EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::vertex_descriptor
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 find_exterior_link_triangle_3rd_vertex(const halfedge_descriptor e,
                                        const vertex_descriptor v0,
                                        const vertex_descriptor v1) const
@@ -1013,9 +1016,9 @@ find_exterior_link_triangle_3rd_vertex(const halfedge_descriptor e,
 // A collapse is geometrically valid if, in the resulting local mesh no two adjacent triangles form an internal dihedral angle
 // greater than a fixed threshold (i.e. triangles do not "fold" into each other)
 //
-template<class TM, class GT, class SP, class VIM, class VPM, class HIM, class ECM, class CF, class PF, class SI, class V>
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
 bool
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 is_collapse_geometrically_valid(const Profile& profile, Placement_type k0)
 {
   bool res = false;
@@ -1112,9 +1115,9 @@ is_collapse_geometrically_valid(const Profile& profile, Placement_type k0)
   return res;
 }
 
-template<class TM, class GT, class SP, class VIM, class VPM, class HIM, class ECM, class CF, class PF, class SI, class V>
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
 void
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 collapse(const Profile& profile,
          Placement_type placement)
 {
@@ -1215,9 +1218,9 @@ collapse(const Profile& profile,
   CGAL_SMS_DEBUG_CODE(++m_step;)
 }
 
-template<class TM, class GT, class SP, class VIM, class VPM, class HIM, class ECM, class CF, class PF, class SI, class V>
+template<class TM, class GT, class SP, class VIM, class VPM,class HIM, class ECM, class CF, class PF, class SI, class V, bool URH>
 void
-EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V>::
+EdgeCollapse<TM,GT,SP,VIM,VPM,HIM,ECM,CF,PF,SI,V,URH>::
 update_neighbors(const vertex_descriptor v_kept)
 {
   CGAL_SMS_TRACE(3,"Updating cost of neighboring edges...");


### PR DESCRIPTION
Add an template parameter to `Modifiable_priority_queue` that enables us to pick the relaxed heap instead of the mutable heap.
This enables us to offer in the API of SMS a parameter to use a relaxed ordering to get faster mesh simplification if cost ordering can be relaxed.

On Iphigenia with default cost/placement I have with the non-relaxed heap:
```
1002507 edges removed.
52761 final edges.
Time elapsed: 12418ms
```
and with the relaxed heap:
```
1002507 edges removed.
52761 final edges.
Time elapsed: 10428ms
```

Note that I also imported the boost header because in recent boost version it triggers a deprecation warning.