### PR TITLE
Try to fix a warning

### DIFF
--- a/QP_solver/include/CGAL/QP_solver/functors.h
+++ b/QP_solver/include/CGAL/QP_solver/functors.h
@@ -254,6 +254,7 @@ public:
     : map(m), d(v)
   {}
 
+#if defined(BOOST_MSVC) && (_MSC_VER < 1920) // 1920 is Visual Studio 2019 version 16.0.0
   // Added as workaround for VC2017 with /arch:AVX to fix
   // https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-I-95/QP_solver/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Release-64bits.gz
   Map_with_default& operator=(const Map_with_default& other)
@@ -262,6 +263,7 @@ public:
     d = other.d;
     return *this;
   }
+#endif
 
   // operator()
   const mapped_type& operator() (key_type n) const {


### PR DESCRIPTION
Check that [this warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-4.14-I-95/QP_solver/TestReport_afabri_x64_Cygwin-Windows10_MSVC2017-Release-64bits.gz) does not reappear.

Try to fix:
```
Convex_hull_3_Examples/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz:/usr/local/boost/include/boost/iterator/transform_iterator.hpp:79:9: warning: implicitly-declared 'constexpr CGAL::Map_with_default<std::map<long unsigned int, bool> >::Map_with_default(const CGAL::Map_with_default<std::map<long unsigned int, bool> >&)' is deprecated [-Wdeprecated-copy]
Convex_hull_3_Examples/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz:/usr/local/boost/include/boost/iterator/transform_iterator.hpp:79:9: warning: implicitly-declared 'constexpr CGAL::Map_with_default<std::map<long unsigned int, CGAL::Sign> >::Map_with_default(const CGAL::Map_with_default<std::map<long unsigned int, CGAL::Sign> >&)' is deprecated [-Wdeprecated-copy]
Convex_hull_3_Examples/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz:/usr/local/boost/include/boost/iterator/transform_iterator.hpp:79:9: warning: implicitly-declared 'constexpr CGAL::Map_with_default<std::map<long unsigned int, double, std::less<long unsigned int>, std::allocator<std::pair<const long unsigned int, double> > > >::Map_with_default(const CGAL::Map_with_default<std::map<long unsigned int, double, std::less<long unsigned int>, std::allocator<std::pair<const long unsigned int, double> > > >&)' is deprecated [-Wdeprecated-copy]
Convex_hull_3_Examples/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz:/usr/local/boost/include/boost/iterator/transform_iterator.hpp:92:21: warning: implicitly-declared 'constexpr CGAL::Map_with_default<std::map<long unsigned int, bool> >::Map_with_default(const CGAL::Map_with_default<std::map<long unsigned int, bool> >&)' is deprecated [-Wdeprecated-copy]
Convex_hull_3_Examples/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz:/usr/local/boost/include/boost/iterator/transform_iterator.hpp:92:21: warning: implicitly-declared 'constexpr CGAL::Map_with_default<std::map<long unsigned int, CGAL::Sign> >::Map_with_default(const CGAL::Map_with_default<std::map<long unsigned int, CGAL::Sign> >&)' is deprecated [-Wdeprecated-copy]
Convex_hull_3_Examples/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz:/usr/local/boost/include/boost/iterator/transform_iterator.hpp:92:21: warning: implicitly-declared 'constexpr CGAL::Map_with_default<std::map<long unsigned int, double, std::less<long unsigned int>, std::allocator<std::pair<const long unsigned int, double> > > >::Map_with_default(const CGAL::Map_with_default<std::map<long unsigned int, double, std::less<long unsigned int>, std::allocator<std::pair<const long unsigned int, double> > > >&)' is deprecated [-Wdeprecated-copy]

Convex_hull_3/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz:/usr/local/boost/include/boost/iterator/transform_iterator.hpp:79:9: warning: implicitly-declared 'constexpr CGAL::Map_with_default<std::map<long unsigned int, bool> >::Map_with_default(const CGAL::Map_with_default<std::map<long unsigned int, bool> >&)' is deprecated [-Wdeprecated-copy]
Convex_hull_3/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz:/usr/local/boost/include/boost/iterator/transform_iterator.hpp:79:9: warning: implicitly-declared 'constexpr CGAL::Map_with_default<std::map<long unsigned int, CGAL::Sign> >::Map_with_default(const CGAL::Map_with_default<std::map<long unsigned int, CGAL::Sign> >&)' is deprecated [-Wdeprecated-copy]
Convex_hull_3/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz:/usr/local/boost/include/boost/iterator/transform_iterator.hpp:79:9: warning: implicitly-declared 'constexpr CGAL::Map_with_default<std::map<long unsigned int, double, std::less<long unsigned int>, std::allocator<std::pair<const long unsigned int, double> > > >::Map_with_default(const CGAL::Map_with_default<std::map<long unsigned int, double, std::less<long unsigned int>, std::allocator<std::pair<const long unsigned int, double> > > >&)' is deprecated [-Wdeprecated-copy]
Convex_hull_3/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz:/usr/local/boost/include/boost/iterator/transform_iterator.hpp:92:21: warning: implicitly-declared 'constexpr CGAL::Map_with_default<std::map<long unsigned int, bool> >::Map_with_default(const CGAL::Map_with_default<std::map<long unsigned int, bool> >&)' is deprecated [-Wdeprecated-copy]
Convex_hull_3/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz:/usr/local/boost/include/boost/iterator/transform_iterator.hpp:92:21: warning: implicitly-declared 'constexpr CGAL::Map_with_default<std::map<long unsigned int, CGAL::Sign> >::Map_with_default(const CGAL::Map_with_default<std::map<long unsigned int, CGAL::Sign> >&)' is deprecated [-Wdeprecated-copy]
Convex_hull_3/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz:/usr/local/boost/include/boost/iterator/transform_iterator.hpp:92:21: warning: implicitly-declared 'constexpr CGAL::Map_with_default<std::map<long unsigned int, double, std::less<long unsigned int>, std::allocator<std::pair<const long unsigned int, double> > > >::Map_with_default(const CGAL::Map_with_default<std::map<long unsigned int, double, std::less<long unsigned int>, std::allocator<std::pair<const long unsigned int, double> > > >&)' is deprecated [-Wdeprecated-copy]
```
