### PR TITLE
Fix links concerning Projection_traits_3

### DIFF
--- a/Barycentric_coordinates_2/doc/Barycentric_coordinates_2/Concepts/BarycentricTraits_2.h
+++ b/Barycentric_coordinates_2/doc/Barycentric_coordinates_2/Concepts/BarycentricTraits_2.h
@@ -11,6 +11,7 @@ coordinates from the namespace `CGAL::Barycentric_coordinates`.
 
 \cgalHasModel
 - All models of `Kernel`
+- `CGAL::Projection_traits_3<K>`
 - `CGAL::Projection_traits_xy_3<K>`
 - `CGAL::Projection_traits_yz_3<K>`
 - `CGAL::Projection_traits_xz_3<K>`

--- a/Kernel_23/doc/Kernel_23/CGAL/Projection_traits_3.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Projection_traits_3.h
@@ -20,6 +20,7 @@ provides exact predicates.
 \cgalModels `ConstrainedTriangulationTraits_2`
 \cgalModels `PolygonTraits_2`
 \cgalModels `ConformingDelaunayTriangulationTraits_2`
+\cgalModels `Barycentric_coordinates::BarycentricTraits_2`
 
 \sa `CGAL::Projection_traits_xy_3`
 \sa `CGAL::Projection_traits_xz_3`

--- a/Kernel_23/doc/Kernel_23/CGAL/Projection_traits_xy_3.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Projection_traits_xy_3.h
@@ -32,7 +32,7 @@ provides exact predicates.
 \cgalModels `ConvexHullTraits_2`
 \cgalModels `DelaunayMeshTraits_2`
 \cgalModels `AnalyticWeightTraits_2`
-\cgalModels `BarycentricTraits_2`
+\cgalModels `Barycentric_coordinates::BarycentricTraits_2`
 
 \sa `CGAL::Projection_traits_3`
 */

--- a/Kernel_23/doc/Kernel_23/dependencies
+++ b/Kernel_23/doc/Kernel_23/dependencies
@@ -5,6 +5,7 @@ Convex_hull_2
 Triangulation_2
 Mesh_2
 Number_types
+Barycentric_coordinates_2
 Algebraic_foundations
 Circular_kernel_2
 Circular_kernel_3

--- a/Triangulation_2/doc/Triangulation_2/Concepts/ConstrainedTriangulationTraits_2.h
+++ b/Triangulation_2/doc/Triangulation_2/Concepts/ConstrainedTriangulationTraits_2.h
@@ -20,6 +20,7 @@ to compute the squared distance between a point and a line
 \cgalRefines `TriangulationTraits_2`
 
 \cgalHasModel All \cgal Kernels
+\cgalHasModel `CGAL::Projection_traits_3<K>`
 \cgalHasModel `CGAL::Projection_traits_xy_3<K>`
 \cgalHasModel `CGAL::Projection_traits_yz_3<K>`
 \cgalHasModel `CGAL::Projection_traits_xz_3<K>`

--- a/Triangulation_2/doc/Triangulation_2/Concepts/DelaunayTriangulationTraits_2.h
+++ b/Triangulation_2/doc/Triangulation_2/Concepts/DelaunayTriangulationTraits_2.h
@@ -23,6 +23,8 @@ required if the  method `nearest_vertex()` is used.
 
 
 \cgalHasModel \cgal kernels
+\cgalHasModel `CGAL::Projection_traits_3<K>` (not for dual Voronoi functions)
+\cgalHasModel `CGAL::Projection_traits_xy_3<K>` (not for dual Voronoi functions)
 \cgalHasModel `CGAL::Projection_traits_xy_3<K>` (not for dual Voronoi functions)
 \cgalHasModel `CGAL::Projection_traits_yz_3<K>` (not for dual Voronoi functions)
 \cgalHasModel `CGAL::Projection_traits_xz_3<K>` (not for dual Voronoi functions)
@@ -169,4 +171,3 @@ Construct_ray_2 construct_ray_2_object();
 /// @}
 
 }; /* end DelaunayTriangulationTraits_2 */
-

--- a/Triangulation_2/doc/Triangulation_2/Concepts/TriangulationTraits_2.h
+++ b/Triangulation_2/doc/Triangulation_2/Concepts/TriangulationTraits_2.h
@@ -13,6 +13,7 @@ triangulation and some function object types for the required
 predicates on those primitives.
 
 \cgalHasModel All models of `Kernel`.
+\cgalHasModel `CGAL::Projection_traits_3<K>`
 \cgalHasModel `CGAL::Projection_traits_xy_3<K>`
 \cgalHasModel `CGAL::Projection_traits_yz_3<K>`
 \cgalHasModel `CGAL::Projection_traits_xz_3<K>`
@@ -261,4 +262,3 @@ Construct_circumcenter_2 construct_circumcenter_2_object();
 /// @}
 
 }; /* end TriangulationTraits_2 */
-


### PR DESCRIPTION


## Summary of Changes

Add link [here](https://cgal.geometryfactory.com/CGAL/doc/master/Triangulation_2/classConstrainedTriangulationTraits__2.html)

Add namespace `Barycentric_coordinates` [here](https://cgal.geometryfactory.com/CGAL/doc/master/Kernel_23/classCGAL_1_1Projection__traits__xy__3.html).


