### PR TITLE
Convex_decomposition_3: Address warning issued by clang

### DIFF
--- a/Nef_2/include/CGAL/Nef_2/Polynomial_impl.h
+++ b/Nef_2/include/CGAL/Nef_2/Polynomial_impl.h
@@ -87,15 +87,23 @@ Polynomial<int> Polynomial<int>::gcd(
   int f1c = f1.content(), f2c = f2.content();
   f1 /= f1c; f2 /= f2c;
   int F = CGAL::gcd(f1c,f2c);
-  Polynomial<int> q,r; int M=1,D;
+  Polynomial<int> q,r;
+  int D;
+#ifdef CGAL_USE_TRACE
+  int M=1;
   bool first = true;
+#endif
   while ( ! f2.is_zero() ) {
     Polynomial<int>::pseudo_div(f1,f2,q,r,D);
+#ifdef CGAL_USE_TRACE
     if (!first) M*=D;
+#endif
     CGAL_NEF_TRACEV(f1);CGAL_NEF_TRACEV(f2);CGAL_NEF_TRACEV(q);CGAL_NEF_TRACEV(r);CGAL_NEF_TRACEV(M);
     r /= r.content();
     f1=f2; f2=r;
+#ifdef CGAL_USE_TRACE
     first=false;
+#endif
   }
   CGAL_NEF_TRACEV(f1.content());
   return Polynomial<int>(F)*f1.abs();


### PR DESCRIPTION
## Summary of Changes

Protect code that gets only used when tracing is switched on.

## Release Management

* Affected package(s): Convex_decomposition_3
* Issue(s) solved (if any): fix #0000, fix #6165


