### PR TITLE
Silence warning message in ARAP

### DIFF
--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/MVC_post_processor_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/MVC_post_processor_3.h
@@ -726,7 +726,9 @@ public:
 
     // Not sure how to handle non-simple yet @fixme
     if(!is_param_border_simple) {
+#ifdef CGAL_SMP_ARAP_DEBUG
       std::cerr << "Border is not simple!" << std::endl;
+#endif
       return ERROR_NON_CONVEX_BORDER;
     }
 


### PR DESCRIPTION
## Summary of Changes

Hide a `std::cerr` message behind debug macros.

## Release Management

* Affected package(s): `Surface_mesh_parameterization`
* Issue(s) solved (if any): cgal-discuss
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

