### PR TITLE
Avoid some superfluous Triangulation_2 dependencies

### DIFF
--- a/Convex_hull_3/include/CGAL/Convex_hull_face_base_2.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_face_base_2.h
@@ -17,18 +17,19 @@
 
 #include <CGAL/license/Convex_hull_3.h>
 
+#include <CGAL/Triangulation_ds_face_base_2.h>
 
 #include <list>
-#include <CGAL/Triangulation_face_base_2.h>
 
 namespace CGAL {
 
 template < typename Info_, typename GT,
-           typename Fb = Triangulation_face_base_2<GT> >
+           typename Fb = Triangulation_ds_face_base_2< > >
 class Convex_hull_face_base_2
   : public Fb
 {
   Info_ _info;
+
 public:
   typedef typename Fb::Vertex_handle                   Vertex_handle;
   typedef typename Fb::Face_handle                     Face_handle;
@@ -36,6 +37,7 @@ public:
 
   typename std::list<Face_handle>::iterator it;
   std::list<typename GT::Point_3> points;
+
   template < typename TDS2 >
   struct Rebind_TDS {
     typedef typename Fb::template Rebind_TDS<TDS2>::Other       Fb2;
@@ -46,20 +48,23 @@ public:
     : Fb(), _info(0) {}
 
   Convex_hull_face_base_2(Vertex_handle v0,
-                                      Vertex_handle v1,
-                                      Vertex_handle v2)
+                          Vertex_handle v1,
+                          Vertex_handle v2)
     : Fb(v0, v1, v2), _info(0) {}
 
   Convex_hull_face_base_2(Vertex_handle v0,
-                                      Vertex_handle v1,
-                                      Vertex_handle v2,
-                                      Face_handle   n0,
-                                      Face_handle   n1,
-                                      Face_handle   n2 )
+                          Vertex_handle v1,
+                          Vertex_handle v2,
+                          Face_handle   n0,
+                          Face_handle   n1,
+                          Face_handle   n2 )
     : Fb(v0, v1, v2, n0, n1, n2), _info(0) {}
 
   const Info& info() const { return _info; }
   Info&       info()       { return _info; }
+
+  static int ccw(int i) {return Triangulation_cw_ccw_2::ccw(i);}
+  static int  cw(int i) {return Triangulation_cw_ccw_2::cw(i);}
 };
 
 } //namespace CGAL

--- a/Convex_hull_3/include/CGAL/Convex_hull_traits_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_traits_3.h
@@ -15,18 +15,16 @@
 
 #include <CGAL/license/Convex_hull_3.h>
 
-
 #include <CGAL/Polyhedron_3_fwd.h>
-#include <CGAL/Convex_hull_face_base_2.h>
 #include <CGAL/Projection_traits_xy_3.h>
 #include <CGAL/Projection_traits_xz_3.h>
 #include <CGAL/Projection_traits_yz_3.h>
-#include <list>
 #include <CGAL/Filtered_predicate.h>
 #include <CGAL/Cartesian_converter.h>
 #include <CGAL/Default.h>
 
 namespace CGAL {
+
 template < class R_ >
 class Point_triple
 {

--- a/Convex_hull_3/include/CGAL/Convex_hull_vertex_base_2.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_vertex_base_2.h
@@ -19,7 +19,7 @@
 
 #include <CGAL/Triangulation_ds_vertex_base_2.h>
 
-#include <list>
+#include <iostream>
 
 namespace CGAL {
 

--- a/Convex_hull_3/include/CGAL/Convex_hull_vertex_base_2.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_vertex_base_2.h
@@ -1,0 +1,86 @@
+// Copyright (c) 2011   Max-Planck-Institute Saarbruecken (Germany).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+//
+//
+// Author(s)     : Mael Rouxel-Labbé
+
+// vertex of a triangulation of any dimension <= 3
+
+#ifndef CGAL_CONVEX_HULL_VERTEX_BASE_2_H
+#define CGAL_CONVEX_HULL_VERTEX_BASE_2_H
+
+#include <CGAL/license/Convex_hull_3.h>
+
+#include <CGAL/Triangulation_ds_vertex_base_2.h>
+
+#include <list>
+
+namespace CGAL {
+
+template < typename Info_, typename GT,
+           typename Vb = Triangulation_ds_vertex_base_2< > >
+class Convex_hull_vertex_base_2
+  : public Vb
+{
+public:
+  typedef Info_                                                      Info;
+  typedef typename GT::Point_2                                       Point;
+
+  typedef typename Vb::Face_handle                                   Face_handle;
+  typedef typename Vb::Vertex_handle                                 Vertex_handle;
+
+private:
+  Info _info;
+  Point _p;
+
+public:
+  template < typename TDS2 >
+  struct Rebind_TDS
+  {
+    typedef typename Vb::template Rebind_TDS<TDS2>::Other            Vb2;
+    typedef Convex_hull_vertex_base_2<Info, GT, Vb2>                 Other;
+  };
+
+  Convex_hull_vertex_base_2()
+    : Vb() {}
+
+  Convex_hull_vertex_base_2(const Point& p)
+    : Vb(), _p(p) {}
+
+  Convex_hull_vertex_base_2(const Point& p, Face_handle f)
+    : Vb(f), _p(p) {}
+
+  Convex_hull_vertex_base_2(Face_handle f)
+    : Vb(f) {}
+
+  void set_point(const Point& p) { _p = p; }
+  const Point&  point() const { return _p; }
+  Point& point() { return _p; }
+
+  const Info& info() const { return _info; }
+  Info&       info()       { return _info; }
+};
+
+template <typename GT, typename Vb>
+std::istream&
+operator>>(std::istream &is, Convex_hull_vertex_base_2<GT, Vb>& v)
+{
+  return is >> static_cast<Vb&>(v) >> v.point();
+}
+
+template <typename GT, typename Vb>
+std::ostream&
+operator<<(std::ostream &os, const Convex_hull_vertex_base_2<GT, Vb>& v)
+{
+  return os << static_cast<const Vb&>(v) << v.point();
+}
+
+} //namespace CGAL
+
+#endif // CGAL_CONVEX_HULL_VERTEX_BASE_2_H

--- a/Convex_hull_3/include/CGAL/convex_hull_3.h
+++ b/Convex_hull_3/include/CGAL/convex_hull_3.h
@@ -17,18 +17,16 @@
 
 #include <CGAL/license/Convex_hull_3.h>
 
-#include <CGAL/disable_warnings.h>
-
-#include <CGAL/basic.h>
 #include <CGAL/algorithm.h>
 #include <CGAL/convex_hull_2.h>
+#include <CGAL/Convex_hull_traits_3.h>
+#include <CGAL/Convex_hull_2/ch_assertions.h>
+#include <CGAL/Convex_hull_face_base_2.h>
+#include <CGAL/Convex_hull_vertex_base_2.h>
 #include <CGAL/Projection_traits_xy_3.h>
 #include <CGAL/Projection_traits_xz_3.h>
 #include <CGAL/Projection_traits_yz_3.h>
-#include <CGAL/Convex_hull_traits_3.h>
-#include <CGAL/Convex_hull_2/ch_assertions.h>
 #include <CGAL/Triangulation_data_structure_2.h>
-#include <CGAL/Triangulation_vertex_base_with_info_2.h>
 #include <CGAL/Cartesian_converter.h>
 #include <CGAL/Simple_cartesian.h>
 
@@ -772,15 +770,15 @@ ch_quickhull_face_graph(std::list<typename Traits::Point_3>& points,
                         const Traits& traits)
 {
   typedef typename Traits::Point_3                            Point_3;
-  typedef typename Traits::Plane_3                                Plane_3;
-  typedef typename std::list<Point_3>::iterator           P3_iterator;
+  typedef typename Traits::Plane_3                            Plane_3;
+  typedef typename std::list<Point_3>::iterator               P3_iterator;
 
   typedef Triangulation_data_structure_2<
-    Triangulation_vertex_base_with_info_2<int, GT3_for_CH3<Traits> >,
-    Convex_hull_face_base_2<int, Traits> >                           Tds;
+    Convex_hull_vertex_base_2<int, GT3_for_CH3<Traits> >,
+    Convex_hull_face_base_2<int, Traits> >                    Tds;
 
-  typedef typename Tds::Vertex_handle                     Vertex_handle;
-  typedef typename Tds::Face_handle                     Face_handle;
+  typedef typename Tds::Vertex_handle                         Vertex_handle;
+  typedef typename Tds::Face_handle                           Face_handle;
 
   // found three points that are not collinear, so construct the plane defined
   // by these points and then find a point that has maximum distance from this
@@ -1110,7 +1108,5 @@ extreme_points_3(const InputRange& range, OutputIterator out)
 }
 
 } // namespace CGAL
-
-#include <CGAL/enable_warnings.h>
 
 #endif // CGAL_CONVEX_HULL_3_H

--- a/Convex_hull_3/package_info/Convex_hull_3/dependencies
+++ b/Convex_hull_3/package_info/Convex_hull_3/dependencies
@@ -24,5 +24,4 @@ Random_numbers
 STL_Extension
 Stream_support
 TDS_2
-Triangulation_2
 Triangulation_3

--- a/Convex_hull_3/test/Convex_hull_3/quickhull_degenerate_test_3.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/quickhull_degenerate_test_3.cpp
@@ -152,9 +152,6 @@ void test_collinear()
 
 }
 
-#include <CGAL/Triangulation_face_base_with_info_2.h>
-
-
 int main()
 {
   std::vector<Point_3> points;

--- a/Optimal_bounding_box/package_info/Optimal_bounding_box/dependencies
+++ b/Optimal_bounding_box/package_info/Optimal_bounding_box/dependencies
@@ -27,4 +27,3 @@ STL_Extension
 Solver_interface
 Stream_support
 TDS_2
-Triangulation_2

--- a/Polytope_distance_d/package_info/Polytope_distance_d/dependencies
+++ b/Polytope_distance_d/package_info/Polytope_distance_d/dependencies
@@ -32,4 +32,3 @@ Random_numbers
 STL_Extension
 Stream_support
 TDS_2
-Triangulation_2

--- a/TDS_2/include/CGAL/boost/graph/graph_traits_Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/boost/graph/graph_traits_Triangulation_data_structure_2.h
@@ -12,11 +12,9 @@
 #ifndef CGAL_GRAPH_TRAITS_TRIANGULATION_DATA_STRUCTURE_2_H
 #define CGAL_GRAPH_TRAITS_TRIANGULATION_DATA_STRUCTURE_2_H
 
-#include <functional>
-
 // include this to avoid a VC15 warning
 #include <CGAL/boost/graph/Named_function_parameters.h>
-#include <CGAL/boost/graph/internal/graph_traits_2D_triangulation_helper.h>
+#include <CGAL/boost/graph/internal/graph_traits_2D_TDS_helper.h>
 #include <CGAL/boost/graph/properties_Triangulation_data_structure_2.h>
 
 #include <CGAL/Triangulation_data_structure_2.h>
@@ -45,15 +43,15 @@ struct graph_traits<CGAL::Triangulation_data_structure_2<VB, FB> >
 
   typedef CGAL::Triangulation_data_structure_2<VB,FB> Triangulation_data_structure;
 
-  typedef typename Triangulation_data_structure::Vertex_handle                  vertex_descriptor;
-  typedef CGAL::internal::T2_halfedge_descriptor<Triangulation_data_structure>  halfedge_descriptor;
-  typedef CGAL::internal::T2_edge_descriptor<Triangulation_data_structure>      edge_descriptor;
-  typedef typename Triangulation_data_structure::Face_handle                    face_descriptor;
+  typedef typename Triangulation_data_structure::Vertex_handle                        vertex_descriptor;
+  typedef CGAL::internal::TDS2_halfedge_descriptor<Triangulation_data_structure>      halfedge_descriptor;
+  typedef CGAL::internal::TDS2_edge_descriptor<Triangulation_data_structure>          edge_descriptor;
+  typedef typename Triangulation_data_structure::Face_handle                          face_descriptor;
 
   typedef CGAL::Prevent_deref<typename Triangulation_data_structure::Vertex_iterator> vertex_iterator;
-  typedef CGAL::internal::T2_halfedge_iterator<Triangulation_data_structure,
+  typedef CGAL::internal::TDS2_halfedge_iterator<Triangulation_data_structure,
             typename Triangulation_data_structure::Edge_iterator>                     halfedge_iterator;
-  typedef CGAL::internal::T2_edge_iterator<Triangulation_data_structure,
+  typedef CGAL::internal::TDS2_edge_iterator<Triangulation_data_structure,
             typename Triangulation_data_structure::Edge_iterator>                     edge_iterator;
   typedef CGAL::Prevent_deref<typename Triangulation_data_structure::Face_iterator>   face_iterator;
 

--- a/TDS_2/include/CGAL/boost/graph/internal/graph_traits_2D_TDS_helper.h
+++ b/TDS_2/include/CGAL/boost/graph/internal/graph_traits_2D_TDS_helper.h
@@ -1,0 +1,322 @@
+// Copyright (c) 2019  GeometryFactory (France).  All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Mael Rouxel-Labbé
+
+#include <CGAL/Iterator_range.h>
+#include <CGAL/iterator.h>
+#include <CGAL/use.h>
+
+#include <boost/config.hpp>
+#include <boost/iterator_adaptors.hpp>
+#include <boost/graph/graph_traits.hpp>
+
+#include <iterator>
+#include <utility>
+
+#ifndef CGAL_GRAPH_TRAITS_2D_TDS_HELPERS
+#define CGAL_GRAPH_TRAITS_2D_TDS_HELPERS
+
+namespace CGAL {
+namespace internal {
+
+// A triangulation edge is a face handle + an int, and is thus actually a halfedge...
+template <class TDS>
+struct TDS2_halfedge_descriptor
+  : public TDS::Edge
+{
+  typedef typename TDS::Edge                                  Base;
+  typedef typename TDS::Face_handle                           Face_handle;
+
+  TDS2_halfedge_descriptor() {}
+  TDS2_halfedge_descriptor(Face_handle fh, int i) : Base(fh, i) { }
+  explicit TDS2_halfedge_descriptor(const Base& e) : Base(e) { }
+  TDS2_halfedge_descriptor(const TDS2_halfedge_descriptor& h) : Base(h) { }
+
+  const Base& base() const { return static_cast<const Base&>(*this); }
+
+  TDS2_halfedge_descriptor& operator=(const TDS2_halfedge_descriptor& h)
+  {
+    this->first = h.first;
+    this->second = h.second;
+    return *this;
+  }
+
+  friend std::size_t hash_value(const TDS2_halfedge_descriptor& e) {
+    return hash_value(e.first);
+  }
+};
+
+// An edge is just a halfedge, but we give it a complete structure to distinguish it from Tr::Edge
+template <typename TDS>
+struct TDS2_edge_descriptor
+{
+  typedef typename TDS::Face_handle                             Face_handle;
+
+  TDS2_edge_descriptor() : first(), second(0) { }
+  explicit TDS2_edge_descriptor(const typename TDS::Edge& e) : first(e.first), second(e.second) { }
+  TDS2_edge_descriptor(Face_handle fd, int i) : first(fd), second(i) { }
+
+  // so that we can still do stuff like tr.is_finite(edge_descriptor) without any hassle
+  operator std::pair<Face_handle, int>() const { return std::make_pair(first, second); }
+
+  friend std::size_t hash_value(const TDS2_edge_descriptor& h)
+  {
+    if(h.first == Face_handle())
+      return 0;
+
+    return hash_value(h.first < h.first->neighbor(h.second) ? h.first
+                                                            : h.first->neighbor(h.second));
+  }
+
+  bool operator==(const TDS2_edge_descriptor& other) const
+  {
+    if((first == other.first) && (second == other.second))
+      return true;
+
+    Face_handle fh = first->neighbor(second);
+    if(other.first != fh)
+      return false;
+
+    int i = fh->index(first);
+    return (other.second == i);
+  }
+  bool operator!=(TDS2_edge_descriptor& other) const { return ! (*this == other); }
+
+  void get_canonical_edge_representation(Face_handle& fh, int& i) const
+  {
+    Face_handle neigh_fh = fh->neighbor(i);
+    Face_handle canonical_fh = (fh < neigh_fh) ? fh : neigh_fh;
+
+    int canonical_i = (fh < neigh_fh) ? i : neigh_fh->index(fh);
+
+    fh = canonical_fh;
+    i = canonical_i;
+  }
+
+  bool operator<(const TDS2_edge_descriptor& other) const
+  {
+    if(*this == other)
+      return false;
+
+    Face_handle tfh = first;
+    int ti = second;
+    get_canonical_edge_representation(tfh, ti);
+
+    Face_handle ofh = other.first;
+    int oi = other.second;
+    get_canonical_edge_representation(ofh, oi);
+
+    if(tfh < ofh) return true;
+    if(tfh > ofh) return false;
+    return ti < oi;
+  }
+
+  Face_handle first;
+  int second;
+};
+
+// A halfedge iterator is just an edge iterator that duplicates everything twice,
+// to see the edge from either side.
+// Could probably be factorized with TDS2_edge_iterator, but it's clearer this way.
+template <typename TDS, typename EdgeIterator>
+struct TDS2_halfedge_iterator
+{
+private:
+  typedef TDS2_halfedge_iterator<TDS, EdgeIterator>             Self;
+  typedef EdgeIterator                                          Edge_iterator;
+  typedef TDS2_halfedge_descriptor<TDS>                         Descriptor;
+  typedef typename TDS::Face_handle                             Face_handle;
+
+public:
+  typedef Descriptor                                            value_type;
+  typedef value_type*                                           pointer;
+  typedef value_type&                                           reference;
+  typedef std::size_t                                           size_type;
+  typedef std::ptrdiff_t                                        difference_type;
+  typedef std::bidirectional_iterator_tag                       iterator_category;
+
+  TDS2_halfedge_iterator() { }
+  TDS2_halfedge_iterator(const Edge_iterator& feit) : it(feit), on_adjacent_face(false) { }
+
+  Self& operator++()
+  {
+    // If we are on the first face, move to the opposite face. If we are already on the opposite face,
+    // then it's time to move on the next edge
+    if(on_adjacent_face) {
+      ++it;
+      on_adjacent_face = false;
+    } else {
+      on_adjacent_face = true;
+    }
+
+    return *this;
+  }
+
+  Self& operator--()
+  {
+    // Note that while decreasing, we start from the opposite face
+    if(on_adjacent_face) {
+      on_adjacent_face = false;
+    } else {
+      --it;
+      on_adjacent_face = true;
+    }
+
+    return *this;
+  }
+
+  Self operator++(int) { Self tmp = *this; operator++(); return tmp; }
+  Self operator--(int) { Self tmp = *this; operator--(); return tmp; }
+
+  bool operator==(const Self& other) const { return it == other.it; }
+  bool operator!=(const Self& other) const { return !(*this == other); }
+
+  reference operator*() const
+  {
+    if(on_adjacent_face)
+    {
+      Face_handle neigh_f = it->first->neighbor(it->second);
+      hd = Descriptor(neigh_f, neigh_f->index(it->first));
+      return hd;
+    } else {
+      hd = Descriptor(it->first, it->second);
+      return hd;
+    }
+  }
+
+private:
+  Edge_iterator it;
+  bool on_adjacent_face;
+  mutable Descriptor hd;
+};
+
+template <typename TDS, typename EdgeIterator>
+struct TDS2_edge_iterator
+{
+private:
+  typedef TDS2_edge_iterator<TDS, EdgeIterator>                 Self;
+  typedef EdgeIterator                                          Edge_iterator;
+  typedef TDS2_edge_descriptor<TDS>                             Descriptor;
+
+public:
+  typedef Descriptor                                            value_type;
+  typedef value_type*                                           pointer;
+  typedef value_type&                                           reference;
+  typedef std::size_t                                           size_type;
+  typedef std::ptrdiff_t                                        difference_type;
+  typedef std::bidirectional_iterator_tag                       iterator_category;
+
+  TDS2_edge_iterator() { }
+  TDS2_edge_iterator(const Edge_iterator& feit) : it(feit) { }
+
+  bool operator==(const Self& other) const { return it == other.it; }
+  bool operator!=(const Self& other) const { return !(*this == other); }
+  Self& operator++() { ++it; return *this; }
+  Self& operator--() { --it; return *this; }
+  Self operator++(int) { Self tmp = *this; operator++(); return tmp; }
+  Self operator--(int) { Self tmp = *this; operator--(); return tmp; }
+
+  reference operator*() const
+  {
+    ed = Descriptor(*it);
+    return ed;
+  }
+
+private:
+  Edge_iterator it;
+  mutable Descriptor ed;
+};
+
+// Must distinguish TDS and triangulations circulators (later are filtered)
+template <class Circ, class E>
+class TDS2_Out_edge_circulator
+  : public Circ
+{
+private:
+  mutable E e;
+
+public:
+  typedef E value_type;
+  typedef E* pointer;
+  typedef E& reference;
+
+  TDS2_Out_edge_circulator() : Circ() {}
+  TDS2_Out_edge_circulator(Circ c) : Circ(c) {}
+
+  const E& operator*() const
+  {
+    E ed = static_cast<const Circ*>(this)->operator*();
+    e = E(ed.first->neighbor(ed.second), ed.first->neighbor(ed.second)->index(ed.first));
+    return e;
+  }
+};
+
+template <class Circ, class E>
+class TDS2_In_edge_circulator
+  : public Circ
+{
+private:
+  mutable E e;
+
+public:
+  typedef E value_type;
+  typedef E* pointer;
+  typedef E& reference;
+
+  TDS2_In_edge_circulator() : Circ() {}
+  TDS2_In_edge_circulator(Circ c) : Circ(c) {}
+
+  const E& operator*() const
+  {
+    typename Circ::value_type ed = static_cast<const Circ*>(this)->operator*();
+    e = E(ed);
+    return e;
+  }
+};
+
+} // namespace internal
+} // namespace CGAL
+
+namespace std {
+
+// workaround a bug detected on at least g++ 4.4 where boost::next(Iterator)
+// is picked as a candidate for next(h,g)
+template <typename TDS>
+struct iterator_traits< CGAL::internal::TDS2_halfedge_descriptor<TDS> >
+{
+  typedef void* iterator_category;
+  typedef void* difference_type;
+  typedef void* value_type;
+  typedef void* reference;
+};
+
+#if defined(BOOST_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable:4099) // For VC10 it is class hash
+#endif
+
+#ifndef CGAL_CFG_NO_STD_HASH
+
+template <class TDS>
+struct hash<CGAL::internal::TDS2_halfedge_descriptor<TDS> >
+{
+  std::size_t operator()(const CGAL::internal::TDS2_halfedge_descriptor<TDS>& e) const {
+    return hash_value(e);
+  }
+};
+
+#endif // CGAL_CFG_NO_STD_HASH
+
+#if defined(BOOST_MSVC)
+#  pragma warning(pop)
+#endif
+
+} // namespace std
+
+#endif // CGAL_GRAPH_TRAITS_2D_TDS_HELPERS

--- a/TDS_2/include/CGAL/boost/graph/properties_Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/boost/graph/properties_Triangulation_data_structure_2.h
@@ -12,7 +12,7 @@
 #define CGAL_PROPERTIES_TRIANGULATION_DATA_STRUCTURE_2_H
 
 #include <CGAL/Triangulation_data_structure_2.h>
-#include <CGAL/boost/graph/internal/graph_traits_2D_triangulation_helper.h>
+#include <CGAL/boost/graph/internal/graph_traits_2D_TDS_helper.h>
 #include <CGAL/boost/graph/internal/Has_member_id.h>
 
 #include <CGAL/boost/graph/Named_function_parameters.h>
@@ -81,7 +81,7 @@ public:
   typedef boost::readable_property_map_tag                         category;
   typedef int                                                      value_type;
   typedef int                                                      reference;
-  typedef CGAL::internal::T2_halfedge_descriptor<TDS>              key_type;
+  typedef CGAL::internal::TDS2_halfedge_descriptor<TDS>            key_type;
 
   typedef typename TDS::Face_handle                                face_descriptor;
 
@@ -112,7 +112,7 @@ public:
   typedef boost::readable_property_map_tag                           category;
   typedef int                                                        value_type;
   typedef int                                                        reference;
-  typedef CGAL::internal::T2_edge_descriptor<TDS>                    key_type;
+  typedef CGAL::internal::TDS2_edge_descriptor<TDS>                  key_type;
 
   typedef typename TDS::Face_handle                                  Face_handle;
 

--- a/Triangulation_2/include/CGAL/boost/graph/internal/graph_traits_2D_triangulation_helper.h
+++ b/Triangulation_2/include/CGAL/boost/graph/internal/graph_traits_2D_triangulation_helper.h
@@ -8,12 +8,11 @@
 //
 // Author(s)     : Mael Rouxel-Labbé
 
+#include <CGAL/boost/graph/internal/graph_traits_2D_TDS_helper.h>
 #include <CGAL/Iterator_range.h>
 #include <CGAL/iterator.h>
 #include <CGAL/use.h>
 
-#include <boost/config.hpp>
-#include <boost/iterator_adaptors.hpp>
 #include <boost/graph/graph_traits.hpp>
 
 #include <utility>
@@ -24,260 +23,19 @@
 namespace CGAL {
 namespace internal {
 
-// A triangulation edge is a face handle + an int, and is thus actually a halfedge...
-template <class Tr>
-struct T2_halfedge_descriptor
-  : public Tr::Edge
-{
-  typedef typename Tr::Edge                                   Base;
-  typedef typename Tr::Face_handle                            Face_handle;
+// just for clarity
+template <typename T>
+using T2_halfedge_descriptor = TDS2_halfedge_descriptor<T>;
 
-  T2_halfedge_descriptor() {}
-  T2_halfedge_descriptor(Face_handle fh, int i) : Base(fh, i) { }
-  explicit T2_halfedge_descriptor(const Base& e) : Base(e) { }
-  T2_halfedge_descriptor(const T2_halfedge_descriptor& h) : Base(h) { }
+template <typename T, typename EI>
+using T2_halfedge_iterator = TDS2_halfedge_iterator<T, EI>;
 
-  const Base& base() const { return static_cast<const Base&>(*this); }
+template <typename T>
+using T2_edge_descriptor = TDS2_edge_descriptor<T>;
 
-  T2_halfedge_descriptor& operator=(const T2_halfedge_descriptor& h)
-  {
-    this->first = h.first;
-    this->second = h.second;
-    return *this;
-  }
+template <typename T, typename EI>
+using T2_edge_iterator = TDS2_edge_iterator<T, EI>;
 
-  friend std::size_t hash_value(const T2_halfedge_descriptor& e) {
-    return hash_value(e.first);
-  }
-};
-
-// An edge is just a halfedge, but we give it a complete structure to distinguish it from Tr::Edge
-template <typename Tr>
-struct T2_edge_descriptor
-{
-  typedef typename Tr::Face_handle                              Face_handle;
-
-  T2_edge_descriptor() : first(), second(0) { }
-  explicit T2_edge_descriptor(const typename Tr::Edge& e) : first(e.first), second(e.second) { }
-  T2_edge_descriptor(Face_handle fd, int i) : first(fd), second(i) { }
-
-  // so that we can still do stuff like tr.is_finite(edge_descriptor) without any hassle
-  operator std::pair<Face_handle, int>() const { return std::make_pair(first, second); }
-
-  friend std::size_t hash_value(const T2_edge_descriptor& h)
-  {
-    if(h.first == Face_handle())
-      return 0;
-
-    return hash_value(h.first < h.first->neighbor(h.second) ? h.first
-                                                            : h.first->neighbor(h.second));
-  }
-
-  bool operator==(const T2_edge_descriptor& other) const
-  {
-    if((first == other.first) && (second == other.second))
-      return true;
-
-    Face_handle fh = first->neighbor(second);
-    if(other.first != fh)
-      return false;
-
-    int i = fh->index(first);
-    return (other.second == i);
-  }
-  bool operator!=(T2_edge_descriptor& other) const { return ! (*this == other); }
-
-  void get_canonical_edge_representation(Face_handle& fh, int& i) const
-  {
-    Face_handle neigh_fh = fh->neighbor(i);
-    Face_handle canonical_fh = (fh < neigh_fh) ? fh : neigh_fh;
-
-    int canonical_i = (fh < neigh_fh) ? i : neigh_fh->index(fh);
-
-    fh = canonical_fh;
-    i = canonical_i;
-  }
-
-  bool operator<(const T2_edge_descriptor& other) const
-  {
-    if(*this == other)
-      return false;
-
-    Face_handle tfh = first;
-    int ti = second;
-    get_canonical_edge_representation(tfh, ti);
-
-    Face_handle ofh = other.first;
-    int oi = other.second;
-    get_canonical_edge_representation(ofh, oi);
-
-    if(tfh < ofh) return true;
-    if(tfh > ofh) return false;
-    return ti < oi;
-  }
-
-  Face_handle first;
-  int second;
-};
-
-// A halfedge iterator is just an edge iterator that duplicates everything twice,
-// to see the edge from either side.
-// Could probably be factorized with T2_edge_iterator, but it's clearer this way.
-template <typename Tr, typename EdgeIterator>
-struct T2_halfedge_iterator
-{
-private:
-  typedef T2_halfedge_iterator<Tr, EdgeIterator>                Self;
-  typedef EdgeIterator                                          Edge_iterator;
-  typedef T2_halfedge_descriptor<Tr>                            Descriptor;
-  typedef typename Tr::Face_handle                              Face_handle;
-
-public:
-  typedef Descriptor                                            value_type;
-  typedef value_type*                                           pointer;
-  typedef value_type&                                           reference;
-  typedef std::size_t                                           size_type;
-  typedef std::ptrdiff_t                                        difference_type;
-  typedef std::bidirectional_iterator_tag                       iterator_category;
-
-  T2_halfedge_iterator() { }
-  T2_halfedge_iterator(const Edge_iterator& feit) : it(feit), on_adjacent_face(false) { }
-
-  Self& operator++()
-  {
-    // If we are on the first face, move to the opposite face. If we are already on the opposite face,
-    // then it's time to move on the next edge
-    if(on_adjacent_face) {
-      ++it;
-      on_adjacent_face = false;
-    } else {
-      on_adjacent_face = true;
-    }
-
-    return *this;
-  }
-
-  Self& operator--()
-  {
-    // Note that while decreasing, we start from the opposite face
-    if(on_adjacent_face) {
-      on_adjacent_face = false;
-    } else {
-      --it;
-      on_adjacent_face = true;
-    }
-
-    return *this;
-  }
-
-  Self operator++(int) { Self tmp = *this; operator++(); return tmp; }
-  Self operator--(int) { Self tmp = *this; operator--(); return tmp; }
-
-  bool operator==(const Self& other) const { return it == other.it; }
-  bool operator!=(const Self& other) const { return !(*this == other); }
-
-  reference operator*() const
-  {
-    if(on_adjacent_face)
-    {
-      Face_handle neigh_f = it->first->neighbor(it->second);
-      hd = Descriptor(neigh_f, neigh_f->index(it->first));
-      return hd;
-    } else {
-      hd = Descriptor(it->first, it->second);
-      return hd;
-    }
-  }
-
-private:
-  Edge_iterator it;
-  bool on_adjacent_face;
-  mutable Descriptor hd;
-};
-
-template <typename Tr, typename EdgeIterator>
-struct T2_edge_iterator
-{
-private:
-  typedef T2_edge_iterator<Tr, EdgeIterator>                    Self;
-  typedef EdgeIterator                                          Edge_iterator;
-  typedef T2_edge_descriptor<Tr>                                Descriptor;
-
-public:
-  typedef Descriptor                                            value_type;
-  typedef value_type*                                           pointer;
-  typedef value_type&                                           reference;
-  typedef std::size_t                                           size_type;
-  typedef std::ptrdiff_t                                        difference_type;
-  typedef std::bidirectional_iterator_tag                       iterator_category;
-
-  T2_edge_iterator() { }
-  T2_edge_iterator(const Edge_iterator& feit) : it(feit) { }
-
-  bool operator==(const Self& other) const { return it == other.it; }
-  bool operator!=(const Self& other) const { return !(*this == other); }
-  Self& operator++() { ++it; return *this; }
-  Self& operator--() { --it; return *this; }
-  Self operator++(int) { Self tmp = *this; operator++(); return tmp; }
-  Self operator--(int) { Self tmp = *this; operator--(); return tmp; }
-
-  reference operator*() const
-  {
-    ed = Descriptor(*it);
-    return ed;
-  }
-
-private:
-  Edge_iterator it;
-  mutable Descriptor ed;
-};
-
-// Must distinguish TDS and triangulations circulators (later are filtered)
-template <class Circ, class E>
-class TDS2_Out_edge_circulator
-  : public Circ
-{
-private:
-  mutable E e;
-
-public:
-  typedef E value_type;
-  typedef E* pointer;
-  typedef E& reference;
-
-  TDS2_Out_edge_circulator() : Circ() {}
-  TDS2_Out_edge_circulator(Circ c) : Circ(c) {}
-
-  const E& operator*() const
-  {
-    E ed = static_cast<const Circ*>(this)->operator*();
-    e = E(ed.first->neighbor(ed.second), ed.first->neighbor(ed.second)->index(ed.first));
-    return e;
-  }
-};
-
-template <class Circ, class E>
-class TDS2_In_edge_circulator
-  : public Circ
-{
-private:
-  mutable E e;
-
-public:
-  typedef E value_type;
-  typedef E* pointer;
-  typedef E& reference;
-
-  TDS2_In_edge_circulator() : Circ() {}
-  TDS2_In_edge_circulator(Circ c) : Circ(c) {}
-
-  const E& operator*() const
-  {
-    typename Circ::value_type ed = static_cast<const Circ*>(this)->operator*();
-    e = E(ed);
-    return e;
-  }
-};
 
 template <typename Tr>
 struct T2_edge_circulator
@@ -421,41 +179,5 @@ private:
 
 } // namespace internal
 } // namespace CGAL
-
-namespace std {
-
-// workaround a bug detected on at least g++ 4.4 where boost::next(Iterator)
-// is picked as a candidate for next(h,g)
-template <typename Tr>
-struct iterator_traits< CGAL::internal::T2_halfedge_descriptor<Tr> >
-{
-  typedef void* iterator_category;
-  typedef void* difference_type;
-  typedef void* value_type;
-  typedef void* reference;
-};
-
-#if defined(BOOST_MSVC)
-#  pragma warning(push)
-#  pragma warning(disable:4099) // For VC10 it is class hash
-#endif
-
-#ifndef CGAL_CFG_NO_STD_HASH
-
-template < class Tr>
-struct hash<CGAL::internal::T2_halfedge_descriptor<Tr> >
-{
-  std::size_t operator()(const CGAL::internal::T2_halfedge_descriptor<Tr>& e) const {
-    return hash_value(e);
-  }
-};
-
-#endif // CGAL_CFG_NO_STD_HASH
-
-#if defined(BOOST_MSVC)
-#  pragma warning(pop)
-#endif
-
-} // namespace std
 
 #endif // CGAL_GRAPH_TRAITS_2D_TRIANGULATION_HELPERS

--- a/Triangulation_2/include/CGAL/boost/graph/internal/properties_2D_triangulation.h
+++ b/Triangulation_2/include/CGAL/boost/graph/internal/properties_2D_triangulation.h
@@ -9,6 +9,7 @@
 // Author(s)     : Mael Rouxel-Labbé
 
 #include <CGAL/assertions.h>
+#include <CGAL/boost/graph/internal/graph_traits_2D_triangulation_helper.h>
 #include <CGAL/boost/graph/internal/Has_member_id.h>
 #include <CGAL/boost/graph/properties.h>
 
@@ -20,19 +21,13 @@
   #error CGAL_2D_TRIANGULATION is not defined
 #endif
 
-// note only the properties below are protected by the macro,
+// note that only the properties below are protected by the macro,
 // the rest of the file is the shared implementation of properties for all 2D triangulations
 #ifndef CGAL_BOOST_GRAPH_PROPERTIES_2D_TRIANGULATION_H
 #define CGAL_BOOST_GRAPH_PROPERTIES_2D_TRIANGULATION_H
 
 namespace CGAL {
 namespace internal {
-
-template <class Tr>
-struct T2_halfedge_descriptor;
-
-template <class Tr>
-struct T2_edge_descriptor;
 
 template <typename Tr>
 class T2_vertex_point_map


### PR DESCRIPTION
## Summary of Changes

`Convex_hull_3` (and packages including `Convex_hull_3`) had a slim dependency to `Triangulation_2` due to using `Triangulation_vertex_base_with_info_2` and `Triangulation_face_base_2`, and accidentally pulling `Triangulation_2` graph traits while using `TDS_2`'s graph traits.

This PR puts the TDS2 graph traits where they ought to be and add `Convex_hull_vertex_base_2` (pretty much a clone of  `Triangulation_vertex_base_with_info_2`) to get rid of the `Triangulation_2` dependency.

## Release Management

* Affected package(s):  `Convex_hull_3`, `Triangulation_2`, `TDS_2`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

