### PR TITLE
Remove useless moc include

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -421,6 +421,3 @@ void Scene_c3t3_item::copyProperties(Scene_item *item)
   show_cnc(c3t3_item->has_cnc());
 
 }
-
-#include "Scene_c3t3_item.moc"
-


### PR DESCRIPTION
needed only if Q_OBJECT or other macros are in the file

