### PR TITLE
include non-deprecated headers

### DIFF
--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/AlgebraicCurveParser.cpp
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/AlgebraicCurveParser.cpp
@@ -20,7 +20,7 @@
 #include <CGAL/Polynomial_traits_d.h>
 #include <CGAL/polynomial_utils.h>
 
-#include <boost/spirit/include/phoenix.hpp>
+#include <boost/phoenix.hpp>
 #include <boost/spirit/include/qi.hpp>
 
 #include "AlgebraicCurveParser.h"

--- a/CGAL_ImageIO/include/CGAL/SEP_header.h
+++ b/CGAL_ImageIO/include/CGAL/SEP_header.h
@@ -22,11 +22,11 @@
 #include <boost/fusion/adapted/boost_tuple.hpp>
 #include <boost/array.hpp>
 #include <boost/spirit/include/qi.hpp>
-#include <boost/spirit/include/phoenix_core.hpp>
-#include <boost/spirit/include/phoenix_operator.hpp>
-#include <boost/spirit/include/phoenix_object.hpp>
-#include <boost/spirit/include/phoenix_stl.hpp>
-#include <boost/spirit/include/phoenix_fusion.hpp>
+#include <boost/phoenix/core.hpp>
+#include <boost/phoenix/operator.hpp>
+#include <boost/phoenix/object.hpp>
+#include <boost/phoenix/stl.hpp>
+#include <boost/phoenix/fusion.hpp>
 #include <boost/fusion/include/adapt_struct.hpp>
 
 #ifdef CGAL_SEP_READER_DEBUG


### PR DESCRIPTION
fixes 
```
/srv/CGAL/www/Members/testsuite/CGAL-5.4-Ic-121/Polyhedron_Demo/TestReport_lrineau_ArchLinux-clang-CXX20-Release.gz:/usr/local/boost/include/boost/spirit/include/phoenix_core.hpp:12:1: warning: This header is deprecated. Use <boost/phoenix/core.hpp> instead. [-W#pragma-messages]
/srv/CGAL/www/Members/testsuite/CGAL-5.4-Ic-121/Polyhedron_Demo/TestReport_lrineau_ArchLinux-clang-CXX20-Release.gz:/usr/local/boost/include/boost/spirit/include/phoenix_operator.hpp:12:1: warning: This header is deprecated. Use <boost/phoenix/operator.hpp> instead. [-W#pragma-messages]
/srv/CGAL/www/Members/testsuite/CGAL-5.4-Ic-121/Polyhedron_Demo/TestReport_lrineau_ArchLinux-clang-CXX20-Release.gz:/usr/local/boost/include/boost/spirit/include/phoenix_object.hpp:12:1: warning: This header is deprecated. Use <boost/phoenix/object.hpp> instead. [-W#pragma-messages]
/srv/CGAL/www/Members/testsuite/CGAL-5.4-Ic-121/Polyhedron_Demo/TestReport_lrineau_ArchLinux-clang-CXX20-Release.gz:/usr/local/boost/include/boost/spirit/include/phoenix_stl.hpp:12:1: warning: This header is deprecated. Use <boost/phoenix/stl.hpp> instead. [-W#pragma-messages]
/srv/CGAL/www/Members/testsuite/CGAL-5.4-Ic-121/Polyhedron_Demo/TestReport_lrineau_ArchLinux-clang-CXX20-Release.gz:/usr/local/boost/include/boost/spirit/include/phoenix_fusion.hpp:12:1: warning: This header is deprecated. Use <boost/phoenix/fusion.hpp> instead. [-W#pragma-messages]
/usr/local/boost/include/boost/spirit/include/phoenix.hpp:12:1: warning: This header is deprecated. Use <boost/phoenix.hpp> instead. [-W#pragma-messages]
BOOST_HEADER_DEPRECATED("<boost/phoenix.hpp>")
```

[here](https://cgal.geometryfactory.com/CGAL/testsuite//CGAL-5.4-I-119/Polyhedron_Demo/TestReport_lrineau_ArchLinux-clang-CXX20-Release.gz) and [there](https://cgal.geometryfactory.com/CGAL/testsuite//CGAL-5.4-I-119/Arrangement_on_surface_2_Demo/TestReport_lrineau_ArchLinux-clang-CXX20-Release.gz)