### PR TITLE
Use features available in std instead of boost

### DIFF
--- a/Alpha_shapes_3/examples/Alpha_shapes_3/visible_alpha_shape_facets_to_OFF.cpp
+++ b/Alpha_shapes_3/examples/Alpha_shapes_3/visible_alpha_shape_facets_to_OFF.cpp
@@ -8,8 +8,8 @@
 #include <fstream>
 #include <vector>
 
-#include <boost/unordered_set.hpp>
-#include <boost/unordered_map.hpp>
+#include <unordered_set>
+#include <unordered_map>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Gt;
 
@@ -48,7 +48,7 @@ int main()
 
 // collect alpha-shape facets accessible from the infinity
   // marks the cells that are in the same component as the infinite vertex by flooding
-  boost::unordered_set< Alpha_shape_3::Cell_handle > marked_cells;
+  std::unordered_set< Alpha_shape_3::Cell_handle > marked_cells;
   std::vector< Alpha_shape_3::Cell_handle > queue;
   queue.push_back( as.infinite_cell() );
 
@@ -86,7 +86,7 @@ int main()
 
 // dump into OFF format
   // assign an id per vertex
-  boost::unordered_map< Alpha_shape_3::Vertex_handle, std::size_t> vids;
+  std::unordered_map< Alpha_shape_3::Vertex_handle, std::size_t> vids;
   points.clear();
 
   for(Alpha_shape_3::Facet f : filtered_regular_facets)

--- a/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_overlay_ss_visitor.h
+++ b/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_overlay_ss_visitor.h
@@ -24,8 +24,9 @@
 
 #include <boost/variant.hpp>
 #include <boost/optional.hpp>
-#include <boost/unordered_map.hpp>
 #include <boost/variant/apply_visitor.hpp>
+
+#include <unordered_map>
 
 #include <CGAL/Arr_tags.h>
 #include <CGAL/Surface_sweep_2/Arr_construction_ss_visitor.h>
@@ -114,7 +115,7 @@ protected:
                                                         Halfedge_map;
 
   typedef std::pair<Cell_handle_red, Cell_handle_blue>  Handle_info;
-  typedef boost::unordered_map<Vertex_handle, Handle_info, Handle_hash_function>
+  typedef std::unordered_map<Vertex_handle, Handle_info, Handle_hash_function>
                                                         Vertex_map;
 
   // Side categoties:

--- a/BGL/examples/BGL_LCC/copy_lcc.cpp
+++ b/BGL/examples/BGL_LCC/copy_lcc.cpp
@@ -11,7 +11,7 @@
 #include <iostream>
 #include <fstream>
 #include <iterator>
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 
@@ -50,8 +50,8 @@ int main(int argc, char* argv[])
     typedef boost::graph_traits<Source>::vertex_descriptor   tm_vertex_descriptor;
     typedef boost::graph_traits<Source>::halfedge_descriptor tm_halfedge_descriptor;
 
-    boost::unordered_map<source_vertex_descriptor, tm_vertex_descriptor> v2v;
-    boost::unordered_map<source_halfedge_descriptor, tm_halfedge_descriptor> h2h;
+    std::unordered_map<source_vertex_descriptor, tm_vertex_descriptor> v2v;
+    std::unordered_map<source_halfedge_descriptor, tm_halfedge_descriptor> h2h;
 
     CGAL::copy_face_graph(T1, S, CGAL::parameters::vertex_to_vertex_output_iterator(std::inserter(v2v, v2v.end()))
                                                   .halfedge_to_halfedge_output_iterator(std::inserter(h2h, h2h.end())));

--- a/BGL/examples/BGL_graphcut/face_selection_borders_regularization_example.cpp
+++ b/BGL/examples/BGL_graphcut/face_selection_borders_regularization_example.cpp
@@ -23,7 +23,7 @@ int main(int argc, char** argv)
   Mesh mesh;
   CGAL::IO::read_OFF (in, mesh);
 
-  boost::unordered_map<Face_index, bool> is_selected_map;
+  std::unordered_map<Face_index, bool> is_selected_map;
 
   // randomly select 1/3 of faces
   std::size_t nb_selected_before = 0;

--- a/BGL/examples/BGL_polyhedron_3/copy_polyhedron.cpp
+++ b/BGL/examples/BGL_polyhedron_3/copy_polyhedron.cpp
@@ -16,7 +16,7 @@
 #include <fstream>
 #include <iterator>
 
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
@@ -56,9 +56,9 @@ int main(int argc, char* argv[])
     typedef boost::graph_traits<Target2>::face_descriptor     tm_face_descriptor;
 
     // Use an unordered_map to keep track of elements.
-    boost::unordered_map<sm_vertex_descriptor, tm_vertex_descriptor>     v2v;
-    boost::unordered_map<sm_halfedge_descriptor, tm_halfedge_descriptor> h2h;
-    boost::unordered_map<sm_face_descriptor, tm_face_descriptor>         f2f;
+    std::unordered_map<sm_vertex_descriptor, tm_vertex_descriptor>     v2v;
+    std::unordered_map<sm_halfedge_descriptor, tm_halfedge_descriptor> h2h;
+    std::unordered_map<sm_face_descriptor, tm_face_descriptor>         f2f;
 
     CGAL::copy_face_graph(S, T2, CGAL::parameters::vertex_to_vertex_output_iterator(std::inserter(v2v, v2v.end()))
                                  .halfedge_to_halfedge_output_iterator(std::inserter(h2h, h2h.end()))
@@ -83,9 +83,9 @@ int main(int argc, char* argv[])
     typedef boost::graph_traits<Source>::face_descriptor   tm_face_descriptor;
 
 
-    boost::unordered_map<source_vertex_descriptor, tm_vertex_descriptor> v2v;
-    boost::unordered_map<source_halfedge_descriptor, tm_halfedge_descriptor> h2h;
-    boost::unordered_map<source_face_descriptor, tm_face_descriptor> f2f;
+    std::unordered_map<source_vertex_descriptor, tm_vertex_descriptor> v2v;
+    std::unordered_map<source_halfedge_descriptor, tm_halfedge_descriptor> h2h;
+    std::unordered_map<source_face_descriptor, tm_face_descriptor> f2f;
     CGAL::copy_face_graph(T1, S, CGAL::parameters::vertex_to_vertex_map(boost::make_assoc_property_map(v2v))
                           .halfedge_to_halfedge_output_iterator(std::inserter(h2h, h2h.end()))
                           .face_to_face_map(boost::make_assoc_property_map(f2f)));

--- a/BGL/include/CGAL/boost/graph/Face_filtered_graph.h
+++ b/BGL/include/CGAL/boost/graph/Face_filtered_graph.h
@@ -26,8 +26,8 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/range/has_range_iterator.hpp>
-#include <boost/unordered_set.hpp>
 
+#include <unordered_set>
 #include <bitset>
 #include <utility>
 #include <vector>
@@ -486,8 +486,8 @@ struct Face_filtered_graph
     selected_halfedges.reset();
 
     typedef typename boost::property_traits<FacePatchIndexMap>::value_type Patch_index;
-    boost::unordered_set<Patch_index> pids(boost::begin(selected_face_patch_indices),
-                                           boost::end(selected_face_patch_indices));
+    std::unordered_set<Patch_index> pids(boost::begin(selected_face_patch_indices),
+                                         boost::end(selected_face_patch_indices));
 
     for(face_descriptor fd : faces(_graph) )
     {
@@ -625,8 +625,8 @@ struct Face_filtered_graph
     // In that case, we will find a non-visited halfedge that has for target a vertex
     // that is already visited.
 
-    boost::unordered_set<vertex_descriptor> vertices_visited;
-    boost::unordered_set<halfedge_descriptor> halfedges_handled;
+    std::unordered_set<vertex_descriptor> vertices_visited;
+    std::unordered_set<halfedge_descriptor> halfedges_handled;
 
     for(halfedge_descriptor hd : halfedges(*this))
     {

--- a/BGL/include/CGAL/boost/graph/Seam_mesh.h
+++ b/BGL/include/CGAL/boost/graph/Seam_mesh.h
@@ -21,8 +21,8 @@
 #include <CGAL/Unique_hash_map.h>
 
 #include <boost/iterator/iterator_facade.hpp>
-#include <boost/unordered_set.hpp>
 
+#include <unordered_set>
 #include <fstream>
 #include <functional>
 #include <iostream>

--- a/BGL/include/CGAL/boost/graph/copy_face_graph.h
+++ b/BGL/include/CGAL/boost/graph/copy_face_graph.h
@@ -23,9 +23,10 @@
 #include <CGAL/Named_function_parameters.h>
 #include <CGAL/boost/graph/named_params_helper.h>
 #include <CGAL/property_map.h>
-#include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 #include <boost/iterator/function_output_iterator.hpp>
+
+#include <unordered_map>
 
 namespace CGAL {
 

--- a/BGL/include/CGAL/boost/graph/selection.h
+++ b/BGL/include/CGAL/boost/graph/selection.h
@@ -14,7 +14,6 @@
 
 #include <boost/graph/graph_traits.hpp>
 #include <CGAL/boost/graph/iterator.h>
-#include <boost/unordered_set.hpp>
 
 #include <CGAL/boost/graph/Dual.h>
 #include <boost/graph/filtered_graph.hpp>
@@ -22,6 +21,8 @@
 
 #include <CGAL/boost/graph/alpha_expansion_graphcut.h>
 #include <CGAL/squared_distance_3.h>
+
+#include <unordered_set>
 
 namespace CGAL {
 
@@ -1037,7 +1038,7 @@ void expand_face_selection_for_removal(const FaceRange& faces_to_be_deleted,
   typedef typename boost::graph_traits<TriangleMesh>::face_descriptor face_descriptor;
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor halfedge_descriptor;
 
-  boost::unordered_set<vertex_descriptor> vertices_queue;
+  std::unordered_set<vertex_descriptor> vertices_queue;
 
   // collect vertices belonging to at least a triangle that will be removed
   for(face_descriptor fd : faces_to_be_deleted)
@@ -1130,8 +1131,8 @@ int euler_characteristic_of_selection(const FaceRange& face_selection,
   typedef typename boost::graph_traits<PolygonMesh>::face_descriptor face_descriptor;
   typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor halfedge_descriptor;
   typedef typename boost::graph_traits<PolygonMesh>::edge_descriptor edge_descriptor;
-  boost::unordered_set<vertex_descriptor> sel_vertices;
-  boost::unordered_set<edge_descriptor> sel_edges;
+  std::unordered_set<vertex_descriptor> sel_vertices;
+  std::unordered_set<edge_descriptor> sel_edges;
   for(face_descriptor f : face_selection)
   {
     for(halfedge_descriptor h : halfedges_around_face(halfedge(f, pm), pm))

--- a/BGL/test/BGL/test_Face_filtered_graph.cpp
+++ b/BGL/test/BGL/test_Face_filtered_graph.cpp
@@ -6,16 +6,16 @@
 #include "test_Prefix.h"
 
 #include <boost/numeric/conversion/cast.hpp>
-#include <boost/unordered_set.hpp>
-#include <boost/unordered_map.hpp>
 
+#include <unordered_map>
+#include <unordered_set>
 #include <fstream>
 #include <map>
 #include <memory>
 #include <utility>
 #include <cassert>
 
-typedef boost::unordered_set<std::size_t> id_map;
+typedef std::unordered_set<std::size_t> id_map;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -25,7 +25,7 @@ void test_halfedge_around_vertex_iterator(const  Graph& g)
   typedef typename boost::graph_traits<Graph>::face_descriptor g_face_descriptor;
   typedef CGAL::Face_filtered_graph<Graph> Adapter;
   CGAL_GRAPH_TRAITS_MEMBERS(Adapter);
-  boost::unordered_map<g_face_descriptor, std::size_t> map(num_faces(g));
+  std::unordered_map<g_face_descriptor, std::size_t> map(num_faces(g));
   PMP::connected_components(g, boost::make_assoc_property_map(map));
 
   Adapter fg(g, 0, boost::make_assoc_property_map(map));
@@ -526,7 +526,7 @@ int main()
     *sm, fccmap, CGAL::parameters::edge_is_constrained_map(Constraint<SM, SM::Property_map<boost::graph_traits<SM>::vertex_descriptor,
                                                            SM::Point> >(*sm, positions)));
 
-  boost::unordered_set<long unsigned int> pids;
+  std::unordered_set<long unsigned int> pids;
   pids.insert(0);
   pids.insert(2);
   SM_Adapter sm_adapter(*sm, pids, fccmap);

--- a/BGL/test/BGL/test_Manifold_face_removal.cpp
+++ b/BGL/test/BGL/test_Manifold_face_removal.cpp
@@ -2,12 +2,14 @@
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Surface_mesh/IO.h>
 
-#include <boost/unordered_map.hpp>
+
 #include <boost/property_map/property_map.hpp>
 
 #include <iostream>
 #include <fstream>
 #include <set>
+#include <unordered_map>
+
 #include <CGAL/boost/graph/selection.h>
 #include <CGAL/boost/graph/helpers.h>
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
@@ -83,7 +85,7 @@ int main()
   input >> sm;
 
 // define my selection of faces to remove
-  boost::unordered_map<face_descriptor, bool> is_selected_map;
+  std::unordered_map<face_descriptor, bool> is_selected_map;
 
   const int selection_indices[30] = {652,18,328,698,322,212,808,353,706,869,646,352,788,696,714,796,937,2892,374,697,227,501,786,794,345,16,21,581,347,723};
   std::set<int> index_set(&selection_indices[0], &selection_indices[0]+30);

--- a/BGL/test/BGL/test_Properties.cpp
+++ b/BGL/test/BGL/test_Properties.cpp
@@ -2,7 +2,7 @@
 
 #include <CGAL/boost/graph/Euler_operations.h>
 
-#include <boost/unordered_set.hpp>
+#include <unordered_set>
 
 // #define CGAL_TEST_PROPERTIES_DEBUG
 
@@ -72,7 +72,7 @@ void test_uniqueness(const Graph&,
     begin2 = boost::begin(range),
     end = boost::end(range);
 
-  typedef boost::unordered_set<typename IndexPropertyMap::value_type> id_map;
+  typedef std::unordered_set<typename IndexPropertyMap::value_type> id_map;
   typedef std::pair<typename id_map::iterator, bool> resultp;
 
   id_map m;
@@ -217,7 +217,8 @@ void test_initialized_index_maps_const(const Graph& g)
 
   // Writable pmap
   typedef typename boost::graph_traits<Graph>::edge_descriptor          edge_descriptor;
-  typedef boost::unordered_map<edge_descriptor, int>                    EdgeIndexMap;
+  typedef std::unordered_map<edge_descriptor, int,
+                             boost::hash<edge_descriptor>>              EdgeIndexMap;
   typedef CGAL::RW_property_map<edge_descriptor, int, EdgeIndexMap>     EdgeIdPropertyMap;
 
   EdgeIndexMap eim;
@@ -321,7 +322,8 @@ void test_initialized_index_maps(Graph& g)
 
   // Writable pmap
   typedef typename boost::graph_traits<Graph>::edge_descriptor          edge_descriptor;
-  typedef boost::unordered_map<edge_descriptor, int>                    EdgeIndexMap;
+  typedef std::unordered_map<edge_descriptor, int, boost::hash<edge_descriptor>>
+                                                                        EdgeIndexMap;
   typedef CGAL::RW_property_map<edge_descriptor, int, EdgeIndexMap>     EdgeIdPropertyMap;
 
   EdgeIndexMap eim;

--- a/BGL/test/BGL/test_Regularize_face_selection_borders.cpp
+++ b/BGL/test/BGL/test_Regularize_face_selection_borders.cpp
@@ -1,14 +1,15 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Surface_mesh/IO.h>
+#include <CGAL/boost/graph/selection.h>
 
-#include <boost/unordered_map.hpp>
 #include <boost/property_map/property_map.hpp>
 
 #include <iostream>
 #include <fstream>
 #include <set>
-#include <CGAL/boost/graph/selection.h>
+#include <unordered_map>
+
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 typedef CGAL::Surface_mesh<Kernel::Point_3> SM;
@@ -21,7 +22,7 @@ int main()
   input >> sm;
 
 // define my selection of faces to remove
-  boost::unordered_map<face_descriptor, bool> is_selected_map;
+  std::unordered_map<face_descriptor, bool> is_selected_map;
 
   const int selection_indices[30] = {652,18,328,698,322,212,808,353,706,869,646,352,788,696,714,796,937,2892,374,697,227,501,786,794,345,16,21,581,347,723};
   std::set<int> index_set(&selection_indices[0], &selection_indices[0]+30);

--- a/BGL/test/BGL/test_graph_traits.cpp
+++ b/BGL/test/BGL/test_graph_traits.cpp
@@ -3,9 +3,9 @@
 #include <CGAL/use.h>
 
 #include <boost/numeric/conversion/cast.hpp>
-#include <boost/unordered_set.hpp>
+#include <unordered_set>
 
-typedef boost::unordered_set<std::size_t>                        id_map;
+typedef std::unordered_set<std::size_t>                        id_map;
 
 template <typename Graph>
 void test_isolated_vertex()

--- a/CGAL_ImageIO/include/CGAL/Image_3.h
+++ b/CGAL_ImageIO/include/CGAL/Image_3.h
@@ -21,7 +21,6 @@
 
 #include <memory>
 #include <boost/format.hpp>
-#include <boost/unordered_set.hpp>
 #include <CGAL/ImageIO.h>
 #include <CGAL/function_objects.h>
 

--- a/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/common-libraries.hpp
+++ b/Classification/include/CGAL/Classification/ETHZ/internal/random-forest/common-libraries.hpp
@@ -47,7 +47,7 @@
 #include <boost/scoped_ptr.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/make_shared.hpp>
-#include <boost/unordered_set.hpp>
+#include <unordered_set>
 #include <iostream>
 #include <cstdio>
 
@@ -63,7 +63,7 @@ inline void init_feature_class_data(FeatureClassDataFloat& /*data*/, int /*n_cla
 {
 //    data.resize(n_samples);
 }
-typedef boost::unordered_set<int> FeatureSet;
+typedef std::unordered_set<int> FeatureSet;
 
 #if BOOST_VERSION >= 104700
 typedef boost::random::uniform_int_distribution<> UniformIntDist;

--- a/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_3.h
@@ -29,7 +29,7 @@
 #include <CGAL/Convex_hull_3/dual/halfspace_intersection_interior_point_3.h>
 #include <CGAL/Number_types/internal/Exact_type_selector.h>
 
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #include <boost/type_traits/is_floating_point.hpp>
 #include <deque>
 
@@ -72,7 +72,7 @@ namespace CGAL
                                                        Plane_3 > > result_inter;
 
 
-              boost::unordered_map <Facet_const_handle, vertex_descriptor> primal_vertices;
+              std::unordered_map <Facet_const_handle, vertex_descriptor> primal_vertices;
               size_t n = 0;
 
               // First, computing the primal vertices

--- a/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_with_constructions_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_with_constructions_3.h
@@ -26,7 +26,7 @@
 #include <CGAL/Convex_hull_3/dual/halfspace_intersection_interior_point_3.h>
 #include <CGAL/Number_types/internal/Exact_type_selector.h>
 
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #include <list>
 #include <vector>
 
@@ -51,7 +51,7 @@ namespace CGAL
         typename boost::property_map<Polyhedron, vertex_point_t>::type vpm_dual = get(CGAL::vertex_point, dual);
         // compute coordinates of extreme vertices in the dual polyhedron
         // from primal faces
-        boost::unordered_map<face_descriptor, vertex_descriptor> extreme_points;
+        std::unordered_map<face_descriptor, vertex_descriptor> extreme_points;
 
         for(face_descriptor fd : faces( primal)){
           halfedge_descriptor h = halfedge(fd,primal);

--- a/Generalized_map/include/CGAL/Generalized_map.h
+++ b/Generalized_map/include/CGAL/Generalized_map.h
@@ -33,8 +33,9 @@
 #include <deque>
 #include <tuple>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/unordered_map.hpp>
 #include <CGAL/config.h>
+
+#include <unordered_map>
 
 #if defined( __INTEL_COMPILER )
 // Workarounf for warning in function basic_link_beta_0

--- a/Heat_method_3/examples/Heat_method_3/heat_method_polyhedron.cpp
+++ b/Heat_method_3/examples/Heat_method_3/heat_method_polyhedron.cpp
@@ -2,8 +2,7 @@
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h>
 
-#include <boost/unordered_map.hpp>
-
+#include <unordered_map>
 #include <fstream>
 #include <iostream>
 
@@ -23,7 +22,7 @@ int main(int argc, char* argv[])
     return 1;
   }
   // map for the distance values to the source set
-  boost::unordered_map<vertex_descriptor, double> vertex_distance;
+  std::unordered_map<vertex_descriptor, double> vertex_distance;
 
   vertex_descriptor source = *(vertices(tm).first);
 

--- a/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
@@ -32,8 +32,8 @@
 
 
 #include <boost/iterator/transform_iterator.hpp>
-#include <boost/unordered_map.hpp>
 
+#include <unordered_map>
 #include <set>
 #include <stack>
 #include <cmath>
@@ -485,7 +485,7 @@ private:
   std::vector<int> mark_edges;
 public:
 
-  boost::unordered_map<vertex_descriptor,vertex_descriptor> v2v, vtov;
+  std::unordered_map<vertex_descriptor,vertex_descriptor> v2v, vtov;
 };
 
 } // namespace Heat_method_3

--- a/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
@@ -37,6 +37,7 @@
 #include <set>
 #include <stack>
 #include <cmath>
+#include <list>
 
 #ifndef DOXYGEN_RUNNING
 

--- a/Linear_cell_complex/include/CGAL/boost/graph/graph_traits_Linear_cell_complex_for_combinatorial_map.h
+++ b/Linear_cell_complex/include/CGAL/boost/graph/graph_traits_Linear_cell_complex_for_combinatorial_map.h
@@ -605,6 +605,31 @@ void set_halfedge(typename boost::graph_traits<CGAL_LCC_TYPE>::face_descriptor f
 
 } // namespace CGAL
 
+namespace std {
+
+#if defined(BOOST_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable:4099) // For VC10 it is class hash
+#endif
+
+#ifndef CGAL_CFG_NO_STD_HASH
+
+template <class Dart_handle>
+struct hash<CGAL::internal::EdgeHandle<Dart_handle>>
+{
+  std::size_t operator()(const CGAL::internal::EdgeHandle<Dart_handle>& edge) const
+  {
+    return hash_value(edge);
+  }
+};
+#endif // CGAL_CFG_NO_STD_HASH
+
+#if defined(BOOST_MSVC)
+#  pragma warning(pop)
+#endif
+
+} // std namespace
+
 #undef CGAL_LCC_TEMPLATE_ARGS
 #undef CGAL_LCC_TYPE
 

--- a/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_by_reduced_convolution_2.h
+++ b/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_by_reduced_convolution_2.h
@@ -20,10 +20,10 @@
 #include <CGAL/Arr_segment_traits_2.h>
 
 #include <CGAL/Minkowski_sum_2/AABB_collision_detector_2.h>
+#include <boost/functional/hash.hpp>
 
 #include <queue>
-#include <boost/unordered_set.hpp>
-#include <boost/unordered_map.hpp>
+#include <unordered_set>
 
 namespace CGAL {
 
@@ -240,7 +240,7 @@ private:
     std::vector<Direction_2> p2_dirs = directions_of_polygon(p2_vertices);
 
     // Contains states that were already visited
-    boost::unordered_set<State> visited_states;
+    std::unordered_set<State, boost::hash<State>> visited_states;
 
     // Init the queue with vertices from the first column
     std::queue<State> state_queue;

--- a/Nef_3/include/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
+++ b/Nef_3/include/CGAL/boost/graph/convert_nef_polyhedron_to_polygon_mesh.h
@@ -20,13 +20,13 @@
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
 #include <CGAL/circulator.h>
 #include <CGAL/Cartesian_converter.h>
-#include <boost/unordered_map.hpp>
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>
 #include <CGAL/Projection_traits_3.h>
 #include <CGAL/Triangulation_vertex_base_with_info_2.h>
 #include <CGAL/Triangulation_face_base_with_info_2.h>
 #include <CGAL/Kernel/global_functions_3.h>
 
+#include <unordered_map>
 
 namespace CGAL{
 
@@ -36,7 +36,7 @@ namespace nef_to_pm{
 template<class Nef_polyhedron, class PointRange, class Converter>
 struct Shell_vertex_index_visitor
 {
-  typedef boost::unordered_map<
+  typedef std::unordered_map<
     typename Nef_polyhedron::Vertex_const_handle, std::size_t> Vertex_index_map;
   typedef typename PointRange::value_type Point_3;
   PointRange& points;
@@ -76,7 +76,7 @@ struct FaceInfo2
 template <class Nef_polyhedron, typename PolygonRange>
 struct Shell_polygons_visitor
 {
-  typedef boost::unordered_map<typename Nef_polyhedron::Vertex_const_handle, std::size_t> Vertex_index_map;
+  typedef std::unordered_map<typename Nef_polyhedron::Vertex_const_handle, std::size_t> Vertex_index_map;
   typedef typename PolygonRange::value_type Polygon;
   Vertex_index_map& vertex_indices;
   PolygonRange& polygons;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_split_visitor_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_split_visitor_example.cpp
@@ -4,9 +4,7 @@
 #include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
 #include <CGAL/boost/graph/copy_face_graph.h>
 
-#include <boost/foreach.hpp>
-#include <boost/unordered_map.hpp>
-
+#include <unordered_map>
 #include <fstream>
 #include <map>
 
@@ -19,7 +17,7 @@ typedef boost::graph_traits<Surface_mesh>::face_descriptor face_descriptor;
 
 class Insert_iterator
 {
-  typedef boost::unordered_map<face_descriptor,face_descriptor> Container;
+  typedef std::unordered_map<face_descriptor,face_descriptor> Container;
   Container& container;
 public:
 
@@ -44,7 +42,7 @@ public:
 
 struct Visitor
 {
-   typedef boost::unordered_map<face_descriptor,face_descriptor> Container;
+   typedef std::unordered_map<face_descriptor,face_descriptor> Container;
 
   Container& container;
   face_descriptor qfd;
@@ -86,7 +84,7 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  boost::unordered_map<face_descriptor,face_descriptor> t2q;
+  std::unordered_map<face_descriptor,face_descriptor> t2q;
 
   Surface_mesh copy;
 
@@ -97,7 +95,7 @@ int main(int argc, char* argv[])
                                                    CGAL::parameters::visitor(v));
 
 
-  for(boost::unordered_map<face_descriptor,face_descriptor>::iterator it = t2q.begin(); it != t2q.end(); ++it){
+  for(std::unordered_map<face_descriptor,face_descriptor>::iterator it = t2q.begin(); it != t2q.end(); ++it){
     std::cout << it->first << "  "  << it->second << std::endl;
   }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/border.h
@@ -23,8 +23,8 @@
 
 #include <boost/graph/graph_traits.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/unordered_set.hpp>
 
+#include <unordered_set>
 #include <set>
 
 namespace CGAL{
@@ -217,7 +217,7 @@ std::size_t border_size(typename boost::graph_traits<PolygonMesh>::halfedge_desc
     typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor halfedge_descriptor;
 
     unsigned int border_counter = 0;
-    boost::unordered_set<halfedge_descriptor> visited;
+    std::unordered_set<halfedge_descriptor> visited;
     for(halfedge_descriptor h : halfedges(pmesh)){
       if(visited.find(h)== visited.end()){
         if(is_border(h,pmesh)){
@@ -250,7 +250,7 @@ std::size_t border_size(typename boost::graph_traits<PolygonMesh>::halfedge_desc
   {
     typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor halfedge_descriptor;
 
-    boost::unordered_set<halfedge_descriptor> hedge_handled;
+    std::unordered_set<halfedge_descriptor> hedge_handled;
     for(halfedge_descriptor h : halfedges(pm))
     {
       if(is_border(h, pm) && hedge_handled.insert(h).second)

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -44,9 +44,9 @@
 #include <atomic>
 #endif // CGAL_LINKED_WITH_TBB
 
-#include <boost/unordered_set.hpp>
 #include <boost/any.hpp>
 
+#include <unordered_set>
 #include <algorithm>
 #include <array>
 #include <cmath>
@@ -345,8 +345,8 @@ sample_triangles(const FaceRange& triangles,
   typedef typename GT::face_descriptor face_descriptor;
   typedef typename GT::halfedge_descriptor halfedge_descriptor;
 
-  boost::unordered_set<typename GT::edge_descriptor> sampled_edges;
-  boost::unordered_set<typename GT::vertex_descriptor> endpoints;
+  std::unordered_set<typename GT::edge_descriptor> sampled_edges;
+  std::unordered_set<typename GT::vertex_descriptor> endpoints;
 
   for(face_descriptor fd : triangles)
   {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -157,7 +157,7 @@ class Face_graph_output_builder
 // Internal typedefs
   typedef std::size_t                                          Node_id;
   typedef std::pair<Node_id,Node_id>                      Node_id_pair;
-  typedef boost::unordered_set<edge_descriptor>  Intersection_edge_map;
+  typedef std::unordered_set<edge_descriptor>  Intersection_edge_map;
   // to maintain a halfedge on each polyline per TriangleMesh + pair<bool,size_t>
   // with first = "is the key (pair<Node_id,Node_id>) was reversed?" and
   // second is the number of edges -1 in the polyline
@@ -167,9 +167,9 @@ class Face_graph_output_builder
                                std::pair<bool,std::size_t> > >
                                               An_edge_per_polyline_map;
 
-  typedef boost::unordered_map<vertex_descriptor, Node_id> Node_id_map;
-  typedef boost::unordered_map<edge_descriptor,
-                               edge_descriptor>               Edge_map;
+  typedef std::unordered_map<vertex_descriptor, Node_id>   Node_id_map;
+  typedef std::unordered_map<edge_descriptor,
+                             edge_descriptor>                 Edge_map;
 //Data members
   TriangleMesh &tm1, &tm2;
   // property maps of input meshes
@@ -556,8 +556,8 @@ public:
     typename An_edge_per_polyline_map::iterator
       epp_it=input_have_coplanar_faces ? an_edge_per_polyline.begin()
                                        : epp_it_end;
-    boost::unordered_set<edge_descriptor> inter_edges_to_remove1,
-                                          inter_edges_to_remove2;
+    std::unordered_set<edge_descriptor> inter_edges_to_remove1,
+                                        inter_edges_to_remove2;
 
     // Each vector contains a subset of coplanar faces. More particularly only
     // the coplanar faces incident to an intersection edge. Note
@@ -1576,7 +1576,7 @@ public:
     typedef Patch_container<TriangleMesh, FaceIdMap1, Intersection_edge_map> Patches1;
     typedef Patch_container<TriangleMesh, FaceIdMap2, Intersection_edge_map> Patches2;
 
-    boost::unordered_set<vertex_descriptor> border_nm_vertices; // only used if used_to_clip_a_surface == true
+    std::unordered_set<vertex_descriptor> border_nm_vertices; // only used if used_to_clip_a_surface == true
     if (used_to_clip_a_surface)
     {
       if (!is_tm1_closed)
@@ -1960,7 +1960,7 @@ public:
           for(vertex_descriptor vd : border_nm_vertices)
           {
             // first check if at least one incident patch will be kept
-            boost::unordered_set<std::size_t> id_p_rm;
+            std::unordered_set<std::size_t> id_p_rm;
             bool all_removed=true;
             for(halfedge_descriptor h : halfedges_around_target(vd, tm1))
             {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Generic_clip_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Generic_clip_output_builder.h
@@ -70,9 +70,9 @@ class Generic_clip_output_builder
                                std::pair<bool,std::size_t> > >
                                               An_edge_per_polyline_map;
 
-  typedef boost::unordered_map<vertex_descriptor, Node_id> Node_id_map;
-  typedef boost::unordered_map<edge_descriptor,
-                               edge_descriptor>               Edge_map;
+  typedef std::unordered_map<vertex_descriptor, Node_id>   Node_id_map;
+  typedef std::unordered_map<edge_descriptor,
+                             edge_descriptor>                 Edge_map;
 //Data members
   TriangleMesh &tm1, &tm2;
   // property maps of input meshes

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
@@ -90,10 +90,10 @@ class Output_builder_for_autorefinement
 
   // to maintain the two halfedges on each polyline
   typedef std::map< Node_id_pair, Shared_halfedges >   An_edge_per_polyline_map;
-  typedef boost::unordered_map<vertex_descriptor, Node_id> Node_id_map;
-  // typedef boost::unordered_map<edge_descriptor,
-  //                              edge_descriptor>               Edge_map;
-  typedef boost::unordered_map<Node_id_pair, Shared_halfedges> All_intersection_edges_map;
+  typedef std::unordered_map<vertex_descriptor, Node_id> Node_id_map;
+  // typedef std::unordered_map<edge_descriptor,
+  //                            edge_descriptor>               Edge_map;
+  typedef std::unordered_map<Node_id_pair, Shared_halfedges, boost::hash<Node_id_pair>> All_intersection_edges_map;
 //Data members
   TriangleMesh &tm;
   // property maps of input mesh
@@ -215,7 +215,7 @@ public:
   {
     // first build an unordered_map mapping a vertex to its node id + a set
     // of all intersection edges
-    typedef boost::unordered_set<edge_descriptor> Intersection_edge_map;
+    typedef std::unordered_set<edge_descriptor> Intersection_edge_map;
     Intersection_edge_map intersection_edges;
 
     typedef std::pair<const Node_id_pair, Shared_halfedges> Pair_type;
@@ -256,7 +256,7 @@ public:
     typename An_edge_per_polyline_map::iterator
       epp_it=input_have_coplanar_faces ? an_edge_per_polyline.begin()
                                        : epp_it_end;
-    boost::unordered_set<edge_descriptor> inter_edges_to_remove;
+    std::unordered_set<edge_descriptor> inter_edges_to_remove;
     for (;epp_it!=epp_it_end;)
     {
       halfedge_descriptor h1  = epp_it->second.h1;
@@ -347,7 +347,7 @@ public:
     // component limited by intersection edges of the surface they are.
     // ... for tm
     std::vector<std::size_t> patch_ids( num_faces(tm),NID );
-    Boolean_property_map< boost::unordered_set<edge_descriptor> >
+    Boolean_property_map< std::unordered_set<edge_descriptor> >
       is_intersection(intersection_edges);
     std::size_t nb_patches =
       PMP::connected_components(tm,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -373,8 +373,8 @@ private:
   typedef typename Graph_traits::vertex_descriptor            vertex_descriptor;
   typedef typename Graph_traits::halfedge_descriptor        halfedge_descriptor;
    typedef std::vector<Node_id>                                        Node_ids;
-   typedef boost::unordered_map<face_descriptor,Node_ids>           On_face_map;
-   typedef boost::unordered_map<edge_descriptor,Node_ids>           On_edge_map;
+   typedef std::unordered_map<face_descriptor,Node_ids>             On_face_map;
+   typedef std::unordered_map<edge_descriptor,Node_ids>             On_edge_map;
    //to keep the correspondance between node_id and vertex_handle in each mesh
    typedef std::vector<vertex_descriptor>                     Node_id_to_vertex;
    typedef std::map<const TriangleMesh*, Node_id_to_vertex >         Mesh_to_map_node;
@@ -382,7 +382,7 @@ private:
    typedef std::multimap<Node_id,halfedge_descriptor>    Node_to_target_of_hedge_map;
    typedef std::map<TriangleMesh*,Node_to_target_of_hedge_map>
                                            Mesh_to_vertices_on_intersection_map;
-   typedef boost::unordered_map<vertex_descriptor,Node_id>    Vertex_to_node_id;
+   typedef std::unordered_map<vertex_descriptor,Node_id>      Vertex_to_node_id;
    typedef std::map<TriangleMesh*, Vertex_to_node_id> Mesh_to_vertex_to_node_id;
    typedef Non_manifold_feature_map<TriangleMesh>               NM_features_map;
 // typedef for the CDT
@@ -828,7 +828,7 @@ public:
 
   };
 
-  typedef boost::unordered_map<face_descriptor,Face_boundary>  Face_boundaries;
+  typedef std::unordered_map<face_descriptor,Face_boundary>  Face_boundaries;
 
   //update the id of input mesh vertex that are also a node
   void update_face_indices(
@@ -837,7 +837,7 @@ public:
     Vertex_to_node_id& vertex_to_node_id)
   {
     for (int k=0;k<3;++k){
-      typename boost::unordered_map<vertex_descriptor,Node_id>::iterator it =
+      typename std::unordered_map<vertex_descriptor,Node_id>::iterator it =
         vertex_to_node_id.find(f_vertices[k]);
       if (it!=vertex_to_node_id.end())
         f_indices[k]=it->second;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -602,7 +602,7 @@ class Border_edge_map {
   typedef boost::graph_traits<PolygonMesh> GT;
   typedef typename GT::halfedge_descriptor halfedge_descriptor;
   typedef typename GT::edge_descriptor edge_descriptor;
-  typedef boost::unordered_set<edge_descriptor> Intersection_edge_map;
+  typedef std::unordered_set<edge_descriptor> Intersection_edge_map;
   const Intersection_edge_map* intersection_edges;
   const PolygonMesh* tm;
 public:
@@ -979,7 +979,7 @@ struct Triangle_mesh_extension_helper<TriangleMesh, true>
   typedef typename GT::edge_descriptor edge_descriptor;
   typedef typename GT::face_descriptor face_descriptor;
 
-  typedef boost::unordered_map< edge_descriptor, edge_descriptor> Edge_map;
+  typedef std::unordered_map< edge_descriptor, edge_descriptor> Edge_map;
   Edge_map& tm_to_output_edges;
   const TriangleMesh& tm;
   TriangleMesh& output;
@@ -1020,7 +1020,7 @@ struct Triangle_mesh_extension_helper<TriangleMesh, false>
   typedef typename GT::edge_descriptor edge_descriptor;
   typedef typename GT::face_descriptor face_descriptor;
 
-  typedef boost::unordered_map< edge_descriptor, edge_descriptor> Edge_map;
+  typedef std::unordered_map< edge_descriptor, edge_descriptor> Edge_map;
   Edge_map& tm_to_output_edges;
   const TriangleMesh& tm;
   TriangleMesh& output;
@@ -1070,7 +1070,7 @@ void append_patches_to_triangle_mesh(
   const VertexPointMap& vpm_tm,
   EdgeMarkMapOut& edge_mark_map_out,
   const EdgeMarkMapIn& edge_mark_map_in,
-  boost::unordered_map<
+  std::unordered_map<
     typename boost::graph_traits<TriangleMesh>::edge_descriptor,
     typename boost::graph_traits<TriangleMesh>::edge_descriptor
   >& tm_to_output_edges,
@@ -1333,8 +1333,8 @@ void fill_new_triangle_mesh(
 
   //add a polyline inside O for each intersection polyline
   std::size_t nb_polylines = polylines.lengths.size();
-  boost::unordered_map<vertex_descriptor, vertex_descriptor> tm1_to_output_vertices;
-  boost::unordered_map<edge_descriptor, edge_descriptor> tm1_to_output_edges,
+  std::unordered_map<vertex_descriptor, vertex_descriptor> tm1_to_output_vertices;
+  std::unordered_map<edge_descriptor, edge_descriptor> tm1_to_output_edges,
                                                          tm2_to_output_edges;
 
   for (std::size_t i=0; i < nb_polylines; ++i)
@@ -1423,7 +1423,7 @@ void disconnect_patches(
     // start the duplicate step
     std::size_t nb_shared_edges = patch.shared_edges.size();
     new_patch_border.reserve( nb_shared_edges );
-    boost::unordered_map<halfedge_descriptor, halfedge_descriptor> old_to_new;
+    std::unordered_map<halfedge_descriptor, halfedge_descriptor> old_to_new;
 
     // save faces inside the patch and set the halfedge
     // to be duplicated on the boundary
@@ -1580,7 +1580,7 @@ void compute_inplace_operation_delay_removal_and_insideout(
   typedef boost::graph_traits<TriangleMesh> GT;
   typedef typename GT::edge_descriptor edge_descriptor;
   typedef typename GT::halfedge_descriptor halfedge_descriptor;
-  typedef boost::unordered_map<edge_descriptor, edge_descriptor> Edge_map;
+  typedef std::unordered_map<edge_descriptor, edge_descriptor> Edge_map;
 
   Edge_map tm2_edge_to_tm1_edge, tm1_edge_to_tm2_edge;
   //maps intersection edges from tm2 to tm1
@@ -1734,13 +1734,13 @@ void compute_inplace_operation(
         EdgeMarkMapIn1& edge_mark_map_in1,
   const EdgeMarkMapIn2& edge_mark_map_in2,
         EdgeMarkMapOut1& edge_mark_map_out1,
-  boost::unordered_map<
+  std::unordered_map<
     typename boost::graph_traits<TriangleMesh>::edge_descriptor,
     typename boost::graph_traits<TriangleMesh>::edge_descriptor
   >& tm2_edge_to_tm1_edge,
   UserVisitor& user_visitor)
 {
-  typedef boost::unordered_map<
+  typedef std::unordered_map<
       typename boost::graph_traits<TriangleMesh>::edge_descriptor,
       typename boost::graph_traits<TriangleMesh>::edge_descriptor> EdgeMap;
   //clean up patches not kept
@@ -1848,7 +1848,7 @@ void compute_inplace_operation(
   typedef boost::graph_traits<TriangleMesh> GT;
   typedef typename GT::edge_descriptor edge_descriptor;
 
-  boost::unordered_map<edge_descriptor, edge_descriptor> tm2_edge_to_tm1_edge;
+  std::unordered_map<edge_descriptor, edge_descriptor> tm2_edge_to_tm1_edge;
 
   //maps intersection edges from tm2 to the equivalent in tm1
   compute_border_edge_map(tm1, tm2,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -26,12 +26,13 @@
 #include <CGAL/Polygon_mesh_processing/Non_manifold_feature_map.h>
 #include <CGAL/utility.h>
 
-#include <boost/unordered_map.hpp>
-#include <boost/unordered_set.hpp>
 #include <boost/dynamic_bitset.hpp>
 #include <boost/container/flat_set.hpp>
+#include <boost/functional/hash.hpp>
 
 #include <stdexcept>
+#include <unordered_map>
+#include <unordered_set>
 
 namespace CGAL{
 namespace Polygon_mesh_processing {
@@ -194,8 +195,8 @@ class Intersection_of_triangle_meshes
   typedef CGAL::Box_intersection_d::ID_FROM_BOX_ADDRESS Box_policy;
   typedef CGAL::Box_intersection_d::Box_with_info_d<double, 3, halfedge_descriptor, Box_policy> Box;
 
-  typedef boost::unordered_set<face_descriptor> Face_set;
-  typedef boost::unordered_map<edge_descriptor, Face_set> Edge_to_faces;
+  typedef std::unordered_set<face_descriptor> Face_set;
+  typedef std::unordered_map<edge_descriptor, Face_set> Edge_to_faces;
 
   static const bool Predicates_on_constructions_needed =
     Node_visitor::Predicates_on_constructions_needed;
@@ -208,7 +209,7 @@ class Intersection_of_triangle_meshes
   // we use Face_pair_and_int and not Face_pair to handle coplanar case.
   // Indeed the boundary of the intersection of two coplanar triangles
   // may contain several segments.
-  typedef boost::unordered_map< Face_pair, Node_id_set >    Faces_to_nodes_map;
+  typedef std::unordered_map< Face_pair, Node_id_set, boost::hash<Face_pair> >    Faces_to_nodes_map;
   typedef Intersection_nodes<TriangleMesh,
                              VertexPointMap1, VertexPointMap2,
                              Predicates_on_constructions_needed>    Node_vector;
@@ -1114,8 +1115,8 @@ class Intersection_of_triangle_meshes
                                          const VPM& vpm,
                                          Node_id& current_node)
   {
-    boost::unordered_map<face_descriptor,
-                         std::vector<face_descriptor> > face_intersections;
+    std::unordered_map<face_descriptor,
+                       std::vector<face_descriptor> > face_intersections;
     for (typename Faces_to_nodes_map::iterator it=f_to_node.begin();
                                                it!=f_to_node.end();
                                                ++it)

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -31,6 +31,7 @@
 #include <boost/functional/hash.hpp>
 
 #include <stdexcept>
+#include <boost/unordered_map.hpp>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -196,7 +197,7 @@ class Intersection_of_triangle_meshes
   typedef CGAL::Box_intersection_d::Box_with_info_d<double, 3, halfedge_descriptor, Box_policy> Box;
 
   typedef std::unordered_set<face_descriptor> Face_set;
-  typedef std::unordered_map<edge_descriptor, Face_set> Edge_to_faces;
+  typedef boost::unordered_map<edge_descriptor, Face_set> Edge_to_faces;
 
   static const bool Predicates_on_constructions_needed =
     Node_visitor::Predicates_on_constructions_needed;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -31,7 +31,6 @@
 #include <boost/functional/hash.hpp>
 
 #include <stdexcept>
-#include <boost/unordered_map.hpp>
 #include <unordered_map>
 #include <unordered_set>
 
@@ -197,7 +196,7 @@ class Intersection_of_triangle_meshes
   typedef CGAL::Box_intersection_d::Box_with_info_d<double, 3, halfedge_descriptor, Box_policy> Box;
 
   typedef std::unordered_set<face_descriptor> Face_set;
-  typedef boost::unordered_map<edge_descriptor, Face_set> Edge_to_faces;
+  typedef std::unordered_map<edge_descriptor, Face_set> Edge_to_faces;
 
   static const bool Predicates_on_constructions_needed =
     Node_visitor::Predicates_on_constructions_needed;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/experimental/experimental_code.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/experimental/experimental_code.h
@@ -121,7 +121,7 @@ triangulate_hole_polyline_incomplete(InputIterator pbegin, InputIterator pend,
   typedef Weight_incomplete<Weight_min_max_dihedral_and_area>      Weight;
   typedef Weight_calculator<Weight, Is_valid_degenerate_triangle>  WC;
 
-  typedef std::vector<boost::tuple<int, int, int> >                   Facet_vector; /* deliberately not OutputIteratorValueType*/
+  typedef std::vector<std::tuple<int, int, int> >                     Facet_vector; /* deliberately not OutputIteratorValueType*/
   typedef std::back_insert_iterator<Facet_vector>                     OutIt;
   typedef Tracer_polyline_incomplete<Facet_vector::value_type, OutIt> Tracer;
   typedef std::pair<int, int> Range;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -40,8 +40,6 @@
 #include <boost/bimap/set_of.hpp>
 #include <boost/range.hpp>
 #include <boost/range/join.hpp>
-#include <boost/unordered_map.hpp>
-#include <boost/unordered_set.hpp>
 #include <memory>
 #include <boost/container/flat_set.hpp>
 #include <boost/optional.hpp>
@@ -52,6 +50,8 @@
 #include <iterator>
 #include <fstream>
 #include <tuple>
+#include <unordered_map>
+#include <unordered_set>
 
 #ifdef CGAL_PMP_REMESHING_DEBUG
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
@@ -1698,7 +1698,7 @@ private:
     {
       CGAL_assertion_code(std::size_t nb_done = 0);
 
-      boost::unordered_set<halfedge_descriptor> degenerate_faces;
+      std::unordered_set<halfedge_descriptor> degenerate_faces;
       for(halfedge_descriptor h :
           halfedges_around_target(halfedge(v, mesh_), mesh_))
       {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/repair_extra.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/repair_extra.h
@@ -20,7 +20,7 @@
 #include <CGAL/box_intersection_d.h>
 #include <CGAL/Union_find.h>
 
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 
 #ifndef DOXYGEN_RUNNING
 
@@ -107,7 +107,7 @@ void collect_close_stitchable_boundary_edges(PM& pm,
   typedef typename boost::graph_traits<PM>::edge_descriptor edge_descriptor;
   typedef typename boost::graph_traits<PM>::vertex_descriptor vertex_descriptor;
 
-  typedef boost::unordered_map<halfedge_descriptor, int> Halfedge_multiplicity;
+  typedef std::unordered_map<halfedge_descriptor, int> Halfedge_multiplicity;
   typedef std::vector<std::pair<halfedge_descriptor, halfedge_descriptor> > Halfedge_pairs;
 
   typedef CGAL::Box_intersection_d::ID_FROM_BOX_ADDRESS Box_policy;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/intersection.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/intersection.h
@@ -1045,15 +1045,15 @@ void get_one_point_per_cc(TriangleMesh& tm,
                           std::vector<typename GT::Point_3>& points_of_interest)
 {
   typedef typename boost::graph_traits<TriangleMesh>::face_descriptor face_descriptor;
-  boost::unordered_map<face_descriptor, int> fid_map;
+  std::unordered_map<face_descriptor, int> fid_map;
   int id = 0;
   for(face_descriptor fd : faces(tm))
   {
     fid_map.insert(std::make_pair(fd,id++));
   }
-  boost::associative_property_map< boost::unordered_map<face_descriptor, int> >
+  boost::associative_property_map< std::unordered_map<face_descriptor, int> >
       fid_pmap(fid_map);
-  boost::unordered_map<face_descriptor, int> fcc_map;
+  std::unordered_map<face_descriptor, int> fcc_map;
 
   int nb_cc = Polygon_mesh_processing::connected_components(tm,
                                                             boost::make_assoc_property_map(fcc_map),

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -28,12 +28,12 @@
 #include <CGAL/Lazy.h> // needed for CGAL::exact(FT)/CGAL::exact(Lazy_exact_nt<T>)
 
 #include <boost/container/small_vector.hpp>
-#include <boost/unordered_set.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/dynamic_bitset.hpp>
 
 #include <utility>
 #include <algorithm>
+#include <unordered_set>
 
 namespace CGAL {
 
@@ -326,7 +326,7 @@ longest_border(const PolygonMesh& pmesh,
             typename property_map_value<PolygonMesh, CGAL::vertex_point_t>::type>::Kernel::FT  FT;
   typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor                       halfedge_descriptor;
 
-  boost::unordered_set<halfedge_descriptor> visited;
+  std::unordered_set<halfedge_descriptor> visited;
   halfedge_descriptor result_halfedge = boost::graph_traits<PolygonMesh>::null_halfedge();
   FT result_len = 0;
   for(halfedge_descriptor h : halfedges(pmesh))

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
@@ -30,10 +30,10 @@
 #include <CGAL/boost/graph/iterator.h>
 #include <CGAL/utility.h>
 
-#include <boost/unordered_set.hpp>
 #include <boost/dynamic_bitset.hpp>
 #include <boost/ref.hpp>
 
+#include <unordered_set>
 #include <functional>
 namespace CGAL {
 
@@ -300,7 +300,7 @@ void reverse_face_orientations_of_mesh_with_polylines(PolygonMesh& pmesh)
     reverse_orientation(halfedge(fd,pmesh),pmesh);
 
   //extract all border cycles
-  boost::unordered_set<halfedge_descriptor> already_seen;
+  std::unordered_set<halfedge_descriptor> already_seen;
   std::vector<halfedge_descriptor> border_cycles;
   for(halfedge_descriptor h : halfedges(pmesh))
     if ( is_border(h,pmesh) && already_seen.insert(h).second )

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -34,6 +34,7 @@
 
 #include <boost/range.hpp>
 #include <boost/utility/enable_if.hpp>
+#include <boost/functional/hash.hpp>
 
 #include <iostream>
 #include <iterator>
@@ -690,8 +691,10 @@ filter_stitchable_pairs(PolygonMesh& pmesh,
   // We look for vertex to be stitched and collect all incident edges with another endpoint
   // to be stitched (that is not an edge scheduled for stitching). That way we can detect
   // if more that one edge will share the same two "master" endpoints.
-  typedef boost::unordered_map<std::pair<vertex_descriptor, vertex_descriptor>,
-                               std::vector<halfedge_descriptor> >           Halfedges_after_stitching;
+  typedef std::pair<vertex_descriptor, vertex_descriptor> Vertex_pair;
+  typedef std::unordered_map<Vertex_pair,
+                             std::vector<halfedge_descriptor>,
+                             boost::hash<Vertex_pair>>           Halfedges_after_stitching;
   Halfedges_after_stitching halfedges_after_stitching;
 
   typedef std::pair<const vertex_descriptor, typename Uf_vertices::handle> Pair_type;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
@@ -27,7 +27,7 @@
 
 #include <CGAL/boost/graph/helpers.h>
 
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 
 #include <vector>
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_polyline_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_polyline_test.cpp
@@ -5,7 +5,7 @@
 #include <cassert>
 #include <vector>
 #include <fstream>
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 
 #include <CGAL/Polyhedron_incremental_builder_3.h>
 #include <CGAL/Polyhedron_3.h>
@@ -20,7 +20,7 @@ template<class HDS, class K>
 class Polyhedron_builder : public CGAL::Modifier_base<HDS> {
   typedef typename K::Point_3 Point_3;
 public:
-  Polyhedron_builder(std::vector<boost::tuple<int, int, int> >* triangles,
+  Polyhedron_builder(std::vector<std::tuple<int, int, int> >* triangles,
     std::vector<Point_3>* polyline)
     : triangles(triangles), polyline(polyline)
   { }
@@ -34,12 +34,12 @@ public:
         B.add_vertex(*it);
     }
 
-    for(typename std::vector<boost::tuple<int, int, int> >::iterator it = triangles->begin();
+    for(typename std::vector<std::tuple<int, int, int> >::iterator it = triangles->begin();
       it != triangles->end(); ++it) {
         B.begin_facet();
-        B.add_vertex_to_facet(it->get<0>());
-        B.add_vertex_to_facet(it->get<1>());
-        B.add_vertex_to_facet(it->get<2>());
+        B.add_vertex_to_facet(std::get<0>(*it));
+        B.add_vertex_to_facet(std::get<1>(*it));
+        B.add_vertex_to_facet(std::get<2>(*it));
         B.end_facet();
     }
 
@@ -47,7 +47,7 @@ public:
   }
 
 private:
-  std::vector<boost::tuple<int, int, int> >* triangles;
+  std::vector<std::tuple<int, int, int> >* triangles;
   std::vector<Point_3>* polyline;
 };
 
@@ -92,25 +92,25 @@ void read_polyline_with_extra_points(
   }
 }
 
-void check_triangles(std::vector<Point_3>& points, std::vector<boost::tuple<int, int, int> >& tris) {
+void check_triangles(std::vector<Point_3>& points, std::vector<std::tuple<int, int, int> >& tris) {
   if(points.size() - 3 != tris.size()) {
     std::cerr << "  Error: there should be n-2 triangles in generated patch." << std::endl;
     assert(false);
   }
 
   const int max_index = static_cast<int>(points.size())-1;
-  for(std::vector<boost::tuple<int, int, int> >::iterator it = tris.begin(); it != tris.end(); ++it) {
-    if(it->get<0>() == it->get<1>() ||
-      it->get<0>() == it->get<2>() ||
-      it->get<1>() == it->get<2>() )
+  for(std::vector<std::tuple<int, int, int> >::iterator it = tris.begin(); it != tris.end(); ++it) {
+    if(std::get<0>(*it) == std::get<1>(*it) ||
+      std::get<0>(*it) == std::get<2>(*it) ||
+      std::get<1>(*it) == std::get<2>(*it) )
     {
       std::cerr << "Error: indices of triangles should be all different." << std::endl;
       assert(false);
     }
 
-    if(it->get<0>() >= max_index ||
-      it->get<1>() >= max_index ||
-      it->get<2>() >= max_index )
+    if(std::get<0>(*it) >= max_index ||
+      std::get<1>(*it) >= max_index ||
+      std::get<2>(*it) >= max_index )
     {
       std::cerr << "  Error: max possible index check failed." << std::endl;
       assert(false);
@@ -119,7 +119,7 @@ void check_triangles(std::vector<Point_3>& points, std::vector<boost::tuple<int,
 }
 
 void check_constructed_polyhedron(const char* file_name,
-  std::vector<boost::tuple<int, int, int> >* triangles,
+  std::vector<std::tuple<int, int, int> >* triangles,
   std::vector<Point_3>* polyline,
   const bool save_poly)
 {
@@ -147,7 +147,7 @@ void test_1(const char* file_name, bool use_DT, bool save_output) {
   std::vector<Point_3> points; // this will contain n and +1 repeated point
   read_polyline_one_line(file_name, points);
 
-  std::vector<boost::tuple<int, int, int> > tris;
+  std::vector<std::tuple<int, int, int> > tris;
   CGAL::Polygon_mesh_processing::triangulate_hole_polyline(
     points, std::back_inserter(tris),
     CGAL::parameters::use_delaunay_triangulation(use_DT)
@@ -166,7 +166,7 @@ void test_2(const char* file_name, bool use_DT, bool save_output) {
   std::vector<Point_3> extras;
   read_polyline_with_extra_points(file_name, points, extras);
 
-  std::vector<boost::tuple<int, int, int> > tris;
+  std::vector<std::tuple<int, int, int> > tris;
   CGAL::Polygon_mesh_processing::triangulate_hole_polyline(
     points, extras, std::back_inserter(tris),
     CGAL::parameters::use_delaunay_triangulation(use_DT)
@@ -184,7 +184,7 @@ void test_should_be_no_output(const char* file_name, bool use_DT) {
   std::vector<Point_3> points; // this will contain n and +1 repeated point
   read_polyline_one_line(file_name, points);
 
-  std::vector<boost::tuple<int, int, int> > tris;
+  std::vector<std::tuple<int, int, int> > tris;
   CGAL::Polygon_mesh_processing::triangulate_hole_polyline(
     points, std::back_inserter(tris),
     CGAL::parameters::use_delaunay_triangulation(use_DT)

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
@@ -22,7 +22,6 @@
 #include "Scene_surface_mesh_item.h"
 #include "Color_ramp.h"
 #include "Color_map.h"
-#include <boost/unordered_map.hpp>
 #include "ui_Display_property.h"
 #include "id_printing.h"
 #include "Scene.h"
@@ -1223,7 +1222,7 @@ private Q_SLOTS:
         scene->addItem(source_points);
         connect(source_points, &Scene_points_with_normal_item::aboutToBeDestroyed,
                 [this](){
-          boost::unordered_map<Scene_surface_mesh_item*, Scene_points_with_normal_item*>::iterator it;
+          std::unordered_map<Scene_surface_mesh_item*, Scene_points_with_normal_item*>::iterator it;
           for(it = mesh_sources_map.begin();
               it != mesh_sources_map.end();
               ++it)
@@ -1432,12 +1431,12 @@ private:
   double bm;
   double bM;
   double bI;
-  boost::unordered_map<Scene_surface_mesh_item*, std::pair<double, SMesh::Face_index> > jacobian_min;
-  boost::unordered_map<Scene_surface_mesh_item*, std::pair<double, SMesh::Face_index> > jacobian_max;
+  std::unordered_map<Scene_surface_mesh_item*, std::pair<double, SMesh::Face_index> > jacobian_min;
+  std::unordered_map<Scene_surface_mesh_item*, std::pair<double, SMesh::Face_index> > jacobian_max;
 
-  boost::unordered_map<Scene_surface_mesh_item*, std::pair<double, SMesh::Face_index> > angles_min;
-  boost::unordered_map<Scene_surface_mesh_item*, std::pair<double, SMesh::Face_index> > angles_max;
-  boost::unordered_map<Scene_surface_mesh_item*, Vertex_source_map> is_source;
+  std::unordered_map<Scene_surface_mesh_item*, std::pair<double, SMesh::Face_index> > angles_min;
+  std::unordered_map<Scene_surface_mesh_item*, std::pair<double, SMesh::Face_index> > angles_max;
+  std::unordered_map<Scene_surface_mesh_item*, Vertex_source_map> is_source;
 
 
   double minBox;
@@ -1446,11 +1445,11 @@ private:
 
   Scene_surface_mesh_item* current_item;
   Scene_points_with_normal_item* source_points;
-  boost::unordered_map<Scene_surface_mesh_item*, Scene_points_with_normal_item*> mesh_sources_map;
-  boost::unordered_map<Scene_surface_mesh_item*, Scene_heat_item*> mesh_heat_item_map;
+  std::unordered_map<Scene_surface_mesh_item*, Scene_points_with_normal_item*> mesh_sources_map;
+  std::unordered_map<Scene_surface_mesh_item*, Scene_heat_item*> mesh_heat_item_map;
 
-  boost::unordered_map<Scene_surface_mesh_item*, Heat_method*> mesh_heat_method_map;
-  boost::unordered_map<Scene_surface_mesh_item*, Heat_method_idt*> mesh_heat_method_idt_map;
+  std::unordered_map<Scene_surface_mesh_item*, Heat_method*> mesh_heat_method_map;
+  std::unordered_map<Scene_surface_mesh_item*, Heat_method_idt*> mesh_heat_method_idt_map;
 
   template<typename, typename, typename> friend class PropertyDisplayer;
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/VTK_io_plugin.cpp
@@ -31,7 +31,7 @@
 #include <fstream>
 
 #include <boost/graph/graph_traits.hpp>
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 
 #include <CGAL/boost/graph/properties.h>
 #include <CGAL/boost/graph/Euler_operations.h>

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Engrave_text_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Engrave_text_plugin.cpp
@@ -52,8 +52,8 @@ halfedge_descriptor      halfedge_descriptor;
 typedef boost::graph_traits<SMesh>::
 vertex_descriptor        vertex_descriptor;
 
-typedef boost::unordered_set<boost::graph_traits<SMesh>::
-face_descriptor>                                         Component;
+typedef std::unordered_set<boost::graph_traits<SMesh>::
+                           face_descriptor>             Component;
 
 struct FaceInfo2
 {
@@ -492,8 +492,8 @@ public Q_SLOTS:
           sm->add_property_map<SMesh::Vertex_index, EPICK::Point_2>("v:uv").first;
 
       // Parameterized bool pmap
-      boost::unordered_set<SMesh::Vertex_index> vs;
-      SMP::internal::Bool_property_map< boost::unordered_set<SMesh::Vertex_index> > vpm(vs);
+      std::unordered_set<SMesh::Vertex_index> vs;
+      SMP::internal::Bool_property_map< std::unordered_set<SMesh::Vertex_index> > vpm(vs);
 
       // Parameterizer
       SMP::ARAP_parameterizer_3<SMesh> parameterizer;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Hole_filling_plugin.cpp
@@ -44,7 +44,7 @@
 #include <CGAL/boost/graph/Euler_operations.h>
 #include "Kernel_type.h"
 
-#include <boost/unordered_set.hpp>
+#include <unordered_set>
 #include <boost/iterator/function_output_iterator.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <QMap>
@@ -240,7 +240,7 @@ private:
 
     Face_graph& poly = *poly_item->polyhedron();
 
-    boost::unordered_set<fg_halfedge_descriptor> visited;
+    std::unordered_set<fg_halfedge_descriptor> visited;
     boost::property_map<Face_graph,CGAL::vertex_point_t>::type vpm = get(CGAL::vertex_point,poly);
 
     for(fg_halfedge_descriptor hd : halfedges(poly)){
@@ -800,7 +800,7 @@ void Polyhedron_demo_hole_filling_plugin::on_Fill_from_selection_button() {
   normalize_border(*poly);
 
   // fill hole
-  boost::unordered_set<fg_halfedge_descriptor> buffer;
+  std::unordered_set<fg_halfedge_descriptor> buffer;
   //check if all selected edges are boder
   //to do check that the seection is closed
   for(fg_edge_descriptor ed : edge_selection->selected_edges)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -18,10 +18,9 @@
 #include <CGAL/boost/graph/properties_Polyhedron_3.h>
 #include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
 #include <CGAL/utility.h>
+#include <CGAL/property_map.h>
 
 #include <boost/graph/graph_traits.hpp>
-#include <boost/unordered_set.hpp>
-#include <CGAL/property_map.h>
 
 #include <QElapsedTimer>
 #include <QAction>
@@ -37,6 +36,7 @@
 #include <queue>
 #include <sstream>
 #include <cmath>
+#include <unordered_set>
 
 #ifdef CGAL_LINKED_WITH_TBB
 #include "tbb/parallel_for.h"
@@ -177,7 +177,7 @@ class Polyhedron_demo_isotropic_remeshing_plugin :
   typedef boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
   typedef boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
 
-  typedef boost::unordered_set<edge_descriptor>    Edge_set;
+  typedef std::unordered_set<edge_descriptor>    Edge_set;
   typedef Scene_polyhedron_selection_item::Is_constrained_map<Edge_set> Edge_constrained_pmap;
 
   struct Visitor

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
@@ -22,7 +22,7 @@
 #include <CGAL/property_map.h>
 
 #include <boost/iterator/function_output_iterator.hpp>
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 #include "Color_map.h"
 
 typedef Scene_surface_mesh_item Scene_facegraph_item;

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -236,7 +236,7 @@ public:
     // the algorithm is only applicable on a mesh
     // that has only one connected component
 
-    boost::unordered_map<boost::graph_traits<Face_graph>::face_descriptor,int> cc(num_faces(*pMesh));
+    std::unordered_map<boost::graph_traits<Face_graph>::face_descriptor,int> cc(num_faces(*pMesh));
     std::size_t num_component = PMP::connected_components(*pMesh, boost::make_assoc_property_map(cc));
 
     if (num_component != 1)

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -394,7 +394,7 @@ public Q_SLOTS:
     if (dialog.exec() != QDialog::Accepted)
       return;
 
-    boost::unordered_map<fg_face_descriptor, bool> is_selected_map;
+    std::unordered_map<fg_face_descriptor, bool> is_selected_map;
     for(fg_face_descriptor fh : faces(*selection_item->polyhedron()))
     {
       if(selection_item->selected_facets.find(fh)
@@ -752,7 +752,7 @@ public Q_SLOTS:
         print_message("Error: Please select a selection item with a selection of faces.");
         return;
       }
-      boost::unordered_map<fg_face_descriptor, bool> is_selected_map;
+      std::unordered_map<fg_face_descriptor, bool> is_selected_map;
       int index = 0;
       for(fg_face_descriptor fh : faces(*selection_item->polyhedron()))
       {
@@ -1171,7 +1171,7 @@ private:
   Ui::Selection ui_widget;
   std::map<QString, int> operations_map;
   std::vector<QString> operations_strings;
-typedef boost::unordered_map<Scene_face_graph_item*, Scene_polyhedron_selection_item*> Selection_item_map;
+  typedef std::unordered_map<Scene_face_graph_item*, Scene_polyhedron_selection_item*> Selection_item_map;
   Selection_item_map selection_item_map;
   int last_mode;
   bool from_plugin;

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
@@ -37,16 +37,14 @@
 #include <CGAL/Surface_mesh_parameterization/Orbifold_Tutte_parameterizer_3.h>
 #include <CGAL/Surface_mesh_parameterization/parameterize.h>
 
-
-#include <boost/unordered_map.hpp>
-#include <boost/unordered_set.hpp>
 #include <boost/container/flat_map.hpp>
 
 #include <algorithm>
 #include <iostream>
 #include <iterator>
 #include <vector>
-
+#include <unordered_map>
+#include <unordered_set>
 
 #include <CGAL/boost/graph/properties.h>
 #include <CGAL/Qt/GraphicsViewNavigation.h>
@@ -63,7 +61,7 @@ typedef EPICK Traits;
 
 namespace SMP = CGAL::Surface_mesh_parameterization;
 
-typedef boost::unordered_set<boost::graph_traits<Base_face_graph>::face_descriptor> Component;
+typedef std::unordered_set<boost::graph_traits<Base_face_graph>::face_descriptor> Component;
 typedef std::vector<Component> Components;
 
 struct Is_selected_property_map{
@@ -209,11 +207,11 @@ typedef boost::graph_traits<Seam_mesh>::face_descriptor             s_face_descr
 
 typedef boost::graph_traits<Seam_mesh>::edges_size_type             s_edges_size_type;
 
-typedef boost::unordered_set<boost::graph_traits<Base_face_graph>::
+typedef std::unordered_set<boost::graph_traits<Base_face_graph>::
 face_descriptor>                                                    Component;
 typedef std::vector<Component>                                      Components;
 
-typedef boost::unordered_set<s_face_descriptor>                       SComponent;
+typedef std::unordered_set<s_face_descriptor>                       SComponent;
 typedef std::vector<SComponent>                                     SComponents;
 
 class UVItem : public QGraphicsItem
@@ -665,7 +663,7 @@ void Polyhedron_demo_parameterization_plugin::parameterize(const Parameterizatio
   }
 
   // map the cones from the selection plugin to the textured polyhedron
-  boost::unordered_set<T_vertex_descriptor> unordered_cones;
+  std::unordered_set<T_vertex_descriptor> unordered_cones;
   if(method == PARAM_OTE) {
     for(P_vertex_descriptor vd : sel_item->selected_vertices) {
       boost::graph_traits<Face_graph>::vertex_descriptor pvd(vd);
@@ -736,7 +734,7 @@ void Polyhedron_demo_parameterization_plugin::parameterize(const Parameterizatio
 
     // find longest border in the connected component
     s_halfedge_descriptor bhd; // a halfedge on the (possibly virtual) border
-    boost::unordered_set<s_halfedge_descriptor> visited;
+    std::unordered_set<s_halfedge_descriptor> visited;
     FT result_len = 0;
     for(s_halfedge_descriptor hd : border)
     {
@@ -877,7 +875,7 @@ void Polyhedron_demo_parameterization_plugin::parameterize(const Parameterizatio
       Parameterizer parameterizer(orb);
 
       // Mark cones in the seam mesh
-      boost::unordered_map<s_vertex_descriptor, SMP::Cone_type> cmap;
+      std::unordered_map<s_vertex_descriptor, SMP::Cone_type> cmap;
       if(!SMP::locate_unordered_cones(sMesh, unordered_cones.begin(), unordered_cones.end(), cmap))
       {
         std::cerr << "Error: invalid cone or seam selection" << std::endl;
@@ -888,7 +886,7 @@ void Polyhedron_demo_parameterization_plugin::parameterize(const Parameterizatio
       QApplication::setOverrideCursor(Qt::WaitCursor);
 
       // Fill the index property map
-      typedef boost::unordered_map<s_vertex_descriptor, int> Indices;
+      typedef std::unordered_map<s_vertex_descriptor, int> Indices;
       Indices indices;
       CGAL::Polygon_mesh_processing::connected_component(
              face(opposite(bhd, sMesh), sMesh),

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -12,8 +12,6 @@
 #include <CGAL/Unique_hash_map.h>
 #include <CGAL/statistics_helpers.h>
 
-#include <boost/unordered_map.hpp>
-#include <boost/unordered_set.hpp>
 #include <boost/range.hpp>
 #include <CGAL/Three/Triangle_container.h>
 #include <CGAL/Three/Edge_container.h>
@@ -27,6 +25,8 @@
 #include <utility>
 #include <vector>
 #include <functional>
+#include <unordered_map>
+#include <unordered_set>
 
 #include "triangulate_primitive.h"
 #include <CGAL/boost/graph/Face_filtered_graph.h>
@@ -77,12 +77,9 @@ public:
 struct Scene_polyhedron_selection_item_priv{
 
   typedef Scene_facegraph_item_k_ring_selection::Active_handle Active_handle;
-  typedef boost::unordered_set<fg_vertex_descriptor
-  , CGAL::Handle_hash_function>    Selection_set_vertex;
-  typedef boost::unordered_set<fg_face_descriptor,
-  CGAL::Handle_hash_function>      Selection_set_facet;
-  typedef boost::unordered_set<fg_edge_descriptor,
-  CGAL::Handle_hash_function>    Selection_set_edge;
+  typedef std::unordered_set<fg_vertex_descriptor>    Selection_set_vertex;
+  typedef std::unordered_set<fg_face_descriptor>      Selection_set_facet;
+  typedef std::unordered_set<fg_edge_descriptor>    Selection_set_edge;
   struct vertex_on_path
   {
     fg_vertex_descriptor vertex;
@@ -322,7 +319,7 @@ void Scene_polyhedron_selection_item_priv::compute_any_elements(std::vector<floa
       return;
 
     VPmap vpm = get(CGAL::vertex_point,*poly);
-    for(Selection_set_facet::iterator
+    for(Selection_set_facet::const_iterator
         it = p_sel_facets.begin(),
         end = p_sel_facets.end();
         it != end; it++)
@@ -396,7 +393,7 @@ void Scene_polyhedron_selection_item_priv::compute_any_elements(std::vector<floa
     //The Lines
     {
 
-        for(Selection_set_edge::iterator it = p_sel_edges.begin(); it != p_sel_edges.end(); ++it) {
+        for(Selection_set_edge::const_iterator it = p_sel_edges.begin(); it != p_sel_edges.end(); ++it) {
           const Point& a = get(vpm, target(halfedge(*it,*poly),*poly));
           const Point& b = get(vpm, target(opposite((halfedge(*it,*poly)),*poly),*poly));
             p_lines.push_back(a.x()+offset.x);
@@ -411,7 +408,7 @@ void Scene_polyhedron_selection_item_priv::compute_any_elements(std::vector<floa
     }
     //The points
     {
-        for(Selection_set_vertex::iterator
+        for(Selection_set_vertex::const_iterator
             it = p_sel_vertices.begin(),
             end = p_sel_vertices.end();
             it != end; ++it)
@@ -1528,7 +1525,7 @@ void Scene_polyhedron_selection_item_priv::computeAndDisplayPath()
   item->temp_selected_edges.clear();
   path.clear();
 
-  typedef boost::unordered_map<fg_vertex_descriptor, fg_vertex_descriptor>     Pred_umap;
+  typedef std::unordered_map<fg_vertex_descriptor, fg_vertex_descriptor>     Pred_umap;
   typedef boost::associative_property_map<Pred_umap>                     Pred_pmap;
 
   Pred_umap predecessor;

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.h
@@ -21,7 +21,7 @@
 #include <CGAL/Three/Viewer_interface.h>
 
 #include <fstream>
-#include <boost/unordered_set.hpp>
+#include <unordered_set>
 #include <boost/property_map/vector_property_map.hpp>
 
 #include <CGAL/boost/graph/selection.h>
@@ -253,9 +253,9 @@ protected:
   void set_is_insert(bool i) { is_insert = i; }
 
 public:
-  typedef boost::unordered_set<fg_vertex_descriptor, CGAL::Handle_hash_function>    Selection_set_vertex;
-  typedef boost::unordered_set<fg_face_descriptor, CGAL::Handle_hash_function>      Selection_set_facet;
-  typedef boost::unordered_set<fg_edge_descriptor, CGAL::Handle_hash_function>    Selection_set_edge;
+  typedef std::unordered_set<fg_vertex_descriptor>    Selection_set_vertex;
+  typedef std::unordered_set<fg_face_descriptor>      Selection_set_facet;
+  typedef std::unordered_set<fg_edge_descriptor>    Selection_set_edge;
 
   Vertex_selection_map vertex_selection_map()
   {

--- a/Property_map/include/CGAL/Dynamic_property_map.h
+++ b/Property_map/include/CGAL/Dynamic_property_map.h
@@ -19,9 +19,10 @@
 #include <CGAL/property_map.h>
 
 #include <memory>
-#include <boost/unordered_map.hpp>
 #include <boost/type_traits/is_same.hpp>
 #include <boost/mpl/if.hpp>
+
+#include <unordered_map>
 
 namespace CGAL {
 
@@ -69,7 +70,7 @@ struct Dynamic_property_map {
   }
 
 
-  typedef boost::unordered_map<K,V> Map;
+  typedef std::unordered_map<K,V> Map;
   std::shared_ptr<Map> map_;
   V default_value_;
 };

--- a/STL_Extension/include/CGAL/utility.h
+++ b/STL_Extension/include/CGAL/utility.h
@@ -325,4 +325,28 @@ inline P make_sorted_pair(T1&& t1, T2&& t2, Compare comp = Compare())
 
 } //namespace CGAL
 
+namespace std {
+
+#if defined(BOOST_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable:4099) // For VC10 it is class hash
+#endif
+
+#ifndef CGAL_CFG_NO_STD_HASH
+template <class T1, class T2, class T3>
+struct hash<CGAL::Triple<T1,T2,T3>>
+{
+  std::size_t operator()(const CGAL::Triple<T1,T2,T3>& t) const
+  {
+    return hash_value(t);
+  }
+};
+#endif // CGAL_CFG_NO_STD_HASH
+
+#if defined(BOOST_MSVC)
+#  pragma warning(pop)
+#endif
+
+} // std namespace
+
 #endif // CGAL_UTILITY_H

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h
@@ -21,8 +21,7 @@
 #include <CGAL/circulator.h>
 #include <CGAL/tags.h>
 
-#include <boost/unordered_map.hpp>
-
+#include <unordered_map>
 #include <iterator>
 #include <list>
 #include <vector>
@@ -80,7 +79,7 @@ void PQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   Point* face_point_buffer = edge_point_buffer + num_e;
 
   int i=0;
-  boost::unordered_map<vertex_descriptor,int> v_index;
+  std::unordered_map<vertex_descriptor,int> v_index;
   for(vertex_descriptor vh : p_vertices){
     v_index[vh]= i++;
   }
@@ -200,7 +199,7 @@ void PTQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   Point* edge_point_buffer = vertex_point_buffer + num_v;
 
   int i=0;
-  boost::unordered_map<vertex_descriptor,int> v_index;
+  std::unordered_map<vertex_descriptor,int> v_index;
   for(vertex_descriptor vh : p_vertices){
     v_index[vh]= i++;
   }

--- a/Subdivision_method_3/test/Subdivision_method_3/test_Subdivision_method_3.cpp
+++ b/Subdivision_method_3/test/Subdivision_method_3/test_Subdivision_method_3.cpp
@@ -328,7 +328,7 @@ void test_Subdivision_surface_3_SM_NP() {
     typedef Kernel::Vector_3                                              Vector;
 
     typedef boost::graph_traits<Polyhedron>::vertex_descriptor            vertex_descriptor;
-    typedef boost::unordered_map<vertex_descriptor, Kernel::Point_3>      Point_pmap;
+    typedef std::unordered_map<vertex_descriptor, Kernel::Point_3>        Point_pmap;
     typedef boost::associative_property_map<Point_pmap>                   APM;
     typedef boost::property_map<Polyhedron, CGAL::vertex_point_t>::type   VPM;
 

--- a/Subdivision_method_3/test/Subdivision_method_3/test_deprecated_Subdivision_method_3.cpp
+++ b/Subdivision_method_3/test/Subdivision_method_3/test_deprecated_Subdivision_method_3.cpp
@@ -329,7 +329,7 @@ void test_Subdivision_surface_3_SM_NP() {
     typedef Kernel::Vector_3                                              Vector;
 
     typedef boost::graph_traits<Polyhedron>::vertex_descriptor            vertex_descriptor;
-    typedef boost::unordered_map<vertex_descriptor, Kernel::Point_3>      Point_pmap;
+    typedef std::unordered_map<vertex_descriptor, Kernel::Point_3>        Point_pmap;
     typedef boost::associative_property_map<Point_pmap>                   APM;
     typedef boost::property_map<Polyhedron, CGAL::vertex_point_t>::type   VPM;
 

--- a/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/L21_metric_plane_proxy.h
+++ b/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/L21_metric_plane_proxy.h
@@ -22,7 +22,8 @@
 
 #include <boost/math/special_functions/fpclassify.hpp>
 #include <boost/graph/graph_traits.hpp>
-#include <boost/unordered_map.hpp>
+
+#include <unordered_map>
 
 namespace CGAL {
 namespace Surface_mesh_approximation {

--- a/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/L2_metric_plane_proxy.h
+++ b/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/L2_metric_plane_proxy.h
@@ -22,7 +22,7 @@
 #include <CGAL/Dynamic_property_map.h>
 
 #include <boost/graph/graph_traits.hpp>
-#include <boost/unordered_map.hpp>
+#include <unordered_map>
 
 #include <list>
 

--- a/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
+++ b/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
@@ -1652,7 +1652,7 @@ private:
     typedef typename SubGraph::vertex_descriptor sg_vertex_descriptor;
     typedef std::vector<sg_vertex_descriptor> VertexVector;
 
-    typedef boost::unordered_map<vertex_descriptor, sg_vertex_descriptor> VertexMap;
+    typedef std::unordered_map<vertex_descriptor, sg_vertex_descriptor> VertexMap;
     typedef boost::associative_property_map<VertexMap> ToSGVertexMap;
     VertexMap vmap;
     ToSGVertexMap to_sgv_map(vmap);

--- a/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/orbifold.cpp
+++ b/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/orbifold.cpp
@@ -11,8 +11,7 @@
 
 #include <CGAL/Timer.h>
 
-#include <boost/unordered_map.hpp>
-
+#include <unordered_map>
 #include <fstream>
 #include <iostream>
 #include <list>
@@ -89,7 +88,7 @@ int main(int argc, char** argv)
   std::cout << mesh.number_of_seam_edges() << " seam edges in input" << std::endl;
 
   // Index map of the seam mesh (assuming a single connected component so far)
-  typedef boost::unordered_map<vertex_descriptor, int> Indices;
+  typedef std::unordered_map<vertex_descriptor, int> Indices;
   Indices indices;
   boost::associative_property_map<Indices> vimap(indices);
   int counter = 0;
@@ -98,7 +97,7 @@ int main(int argc, char** argv)
   }
 
   // Mark the cones in the seam mesh
-  boost::unordered_map<vertex_descriptor, SMP::Cone_type> cmap;
+  std::unordered_map<vertex_descriptor, SMP::Cone_type> cmap;
   SMP::locate_cones(mesh, cone_sm_vds.begin(), cone_sm_vds.end(), cmap);
 
   // The 2D points of the uv parametrisation will be written into this map

--- a/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/square_border_parameterizer.cpp
+++ b/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/square_border_parameterizer.cpp
@@ -11,8 +11,8 @@
 #include <CGAL/Unique_hash_map.h>
 
 #include <boost/array.hpp>
-#include <boost/unordered_set.hpp>
 
+#include <unordered_set>
 #include <cstdlib>
 #include <iostream>
 #include <fstream>
@@ -65,7 +65,7 @@ bool read_vertices(const PolyMesh& mesh,
   std::size_t counter = 0;
   std::istringstream point_line(line);
   std::size_t s;
-  boost::unordered_set<std::size_t> indices;
+  std::unordered_set<std::size_t> indices;
   while(point_line >> s) {
     if(s >= vds.size())
     {

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -84,8 +84,8 @@
 #include <boost/iterator/function_output_iterator.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/unordered_set.hpp>
 
+#include <unordered_set>
 #include <iostream>
 #include <fstream>
 #include <limits>
@@ -223,7 +223,7 @@ private:
   typedef CGAL::Halfedge_around_target_circulator<Triangle_mesh>    halfedge_around_target_circulator;
   typedef CGAL::Halfedge_around_face_circulator<Triangle_mesh>      halfedge_around_face_circulator;
 
-  typedef boost::unordered_set<vertex_descriptor>                   Vertex_set;
+  typedef std::unordered_set<vertex_descriptor>                     Vertex_set;
   typedef std::vector<face_descriptor>                              Faces_vector;
 
   // Traits subtypes:
@@ -378,8 +378,8 @@ private:
     }
 
     // temporary vpmap since we do not need it in the future
-    boost::unordered_set<vertex_descriptor> vs;
-    internal::Bool_property_map<boost::unordered_set<vertex_descriptor> > vpmap(vs);
+    std::unordered_set<vertex_descriptor> vs;
+    internal::Bool_property_map<std::unordered_set<vertex_descriptor> > vpmap(vs);
 
     // According to the paper, MVC is better for single border and LSCM is better
     // when there are multiple borders
@@ -420,7 +420,7 @@ private:
       // A local uvmap (that is then discarded) is passed to avoid changing
       // the values of the real uvmap. Since we can't get VertexUVMap::C,
       // we build a map with the same key and value types
-      typedef boost::unordered_map<typename VertexUVMap::key_type,
+      typedef std::unordered_map<typename VertexUVMap::key_type,
                                    typename VertexUVMap::value_type> Useless_map;
       typedef boost::associative_property_map<Useless_map>           Useless_pmap;
 

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Fixed_border_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Fixed_border_parameterizer_3.h
@@ -33,7 +33,8 @@
 
 #include <boost/iterator/function_output_iterator.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/unordered_set.hpp>
+
+#include <unordered_set>
 
 /// \file Fixed_border_parameterizer_3.h
 
@@ -212,7 +213,7 @@ public:
 
     Error_code status = OK;
 
-    typedef boost::unordered_set<vertex_descriptor> Vertex_set;
+    typedef std::unordered_set<vertex_descriptor> Vertex_set;
     Vertex_set vertices;
 
     internal::Containers_filler<Triangle_mesh> fc(mesh, vertices);
@@ -248,7 +249,7 @@ public:
 
     // Fill the matrix for the inner vertices v_i: compute A's coefficient
     // w_ij for each neighbor j; then w_ii = - sum of w_ijs
-    boost::unordered_set<vertex_descriptor> main_border;
+    std::unordered_set<vertex_descriptor> main_border;
 
     for(vertex_descriptor v : vertices_around_face(bhd,mesh)){
       main_border.insert(v);

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/IO/File_off.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/IO/File_off.h
@@ -25,9 +25,9 @@
 
 #include <boost/iterator/function_output_iterator.hpp>
 #include <boost/property_map/property_map.hpp>
-#include <boost/unordered_map.hpp>
-#include <boost/unordered_set.hpp>
 
+#include <unordered_map>
+#include <unordered_set>
 #include <cstddef>
 #include <fstream>
 #include <sstream>
@@ -96,11 +96,11 @@ void output_uvmap_to_off(const TriangleMesh& mesh,
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor  halfedge_descriptor;
   typedef typename boost::graph_traits<TriangleMesh>::face_descriptor      face_descriptor;
 
-  typedef boost::unordered_map<vertex_descriptor, std::size_t> Vertex_index_map;
+  typedef std::unordered_map<vertex_descriptor, std::size_t> Vertex_index_map;
   Vertex_index_map vium;
   boost::associative_property_map<Vertex_index_map> vimap(vium);
 
-  boost::unordered_set<vertex_descriptor> vertices;
+  std::unordered_set<vertex_descriptor> vertices;
   std::vector<face_descriptor> faces;
 
   internal::Containers_filler<TriangleMesh> fc(mesh, vertices, &faces);

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/LSCM_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/LSCM_parameterizer_3.h
@@ -32,8 +32,8 @@
 #include <CGAL/OpenNL/linear_solver.h>
 
 #include <boost/iterator/function_output_iterator.hpp>
-#include <boost/unordered_set.hpp>
 
+#include <unordered_set>
 #include <vector>
 
 /// \file LSCM_parameterizer_3.h
@@ -201,7 +201,7 @@ public:
     CGAL_precondition(bhd != boost::graph_traits<Triangle_mesh>::null_halfedge() && is_border(bhd, mesh));
 
     // Fill containers
-    boost::unordered_set<vertex_descriptor> ccvertices;
+    std::unordered_set<vertex_descriptor> ccvertices;
     std::vector<face_descriptor> ccfaces;
 
     internal::Containers_filler<Triangle_mesh> fc(mesh, ccvertices, &ccfaces);
@@ -274,7 +274,7 @@ private:
   // \pre At least 2 border vertices must be parameterized.
   template <typename UVmap, typename VertexIndexMap, typename VertexParameterizedMap>
   void initialize_system_from_mesh_border(LeastSquaresSolver& solver,
-                                          const boost::unordered_set<vertex_descriptor>& ccvertices,
+                                          const std::unordered_set<vertex_descriptor>& ccvertices,
                                           UVmap uvmap,
                                           VertexIndexMap vimap,
                                           VertexParameterizedMap vpmap) const

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/MVC_post_processor_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/MVC_post_processor_3.h
@@ -34,8 +34,7 @@
 
 #include <CGAL/Default.h>
 
-#include <boost/unordered_set.hpp>
-
+#include <unordered_set>
 #include <vector>
 #include <fstream>
 #include <iostream>
@@ -117,7 +116,7 @@ private:
   typedef typename boost::graph_traits<Triangle_mesh>::face_iterator        face_iterator;
   typedef typename boost::graph_traits<Triangle_mesh>::vertex_iterator      vertex_iterator;
 
-  typedef boost::unordered_set<vertex_descriptor>       Vertex_set;
+  typedef std::unordered_set<vertex_descriptor>         Vertex_set;
   typedef std::vector<face_descriptor>                  Faces_vector;
 
   // Traits subtypes:
@@ -704,8 +703,8 @@ public:
 
     // Prepare the constrained triangulation: collect exterior faces (faces in
     // the convex hull but not -- geometrically -- in 'mesh').
-    boost::unordered_set<vertex_descriptor> vs;
-    internal::Bool_property_map<boost::unordered_set<vertex_descriptor> > vpmap(vs);
+    std::unordered_set<vertex_descriptor> vs;
+    internal::Bool_property_map<std::unordered_set<vertex_descriptor> > vpmap(vs);
     prepare_CT_for_parameterization(ct, vpmap);
 
     // Run the MVC

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Orbifold_Tutte_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Orbifold_Tutte_parameterizer_3.h
@@ -42,9 +42,9 @@
 #include <boost/array.hpp>
 #include <boost/tuple/tuple.hpp>
 #include <boost/type_traits/is_same.hpp>
-#include <boost/unordered_map.hpp>
-#include <boost/unordered_set.hpp>
 
+#include <unordered_map>
+#include <unordered_set>
 #include <cmath>
 #include <fstream>
 #include <iostream>
@@ -152,7 +152,7 @@ Error_code read_cones(const TriangleMesh& tm, std::ifstream& in, ConeOutputItera
   typedef typename boost::graph_traits<TriangleMesh>::vertex_descriptor TM_vertex_descriptor;
   typedef typename boost::graph_traits<TriangleMesh>::vertex_iterator   TM_vertex_iterator;
 
-  boost::unordered_map<TM_vertex_descriptor, int> m;
+  std::unordered_map<TM_vertex_descriptor, int> m;
   int counter = 0;
 
   TM_vertex_iterator vit, end;

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Two_vertices_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Two_vertices_parameterizer_3.h
@@ -305,7 +305,7 @@ public:
                           VertexParameterizedMap vpmap)
   {
     // Fill containers
-    boost::unordered_set<vertex_descriptor> vertices;
+    std::unordered_set<vertex_descriptor> vertices;
     internal::Containers_filler<Triangle_mesh> fc(mesh, vertices);
     Polygon_mesh_processing::connected_component(
                                       face(opposite(bhd, mesh), mesh),

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/internal/Containers_filler.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/internal/Containers_filler.h
@@ -18,9 +18,9 @@
 #include <CGAL/Polygon_mesh_processing/connected_components.h>
 
 #include <boost/tuple/tuple.hpp>
-#include <boost/unordered_set.hpp>
 #include <boost/graph/graph_traits.hpp>
 
+#include <unordered_set>
 #include <vector>
 
 namespace CGAL {
@@ -32,7 +32,7 @@ namespace internal {
 // Custom output iterator that fills 'faces' and 'vertices' containers from a mesh
 template<typename TriangleMesh,
          typename Vertex_set =
-             boost::unordered_set<typename boost::graph_traits<TriangleMesh>::vertex_descriptor>,
+             std::unordered_set<typename boost::graph_traits<TriangleMesh>::vertex_descriptor>,
          typename Face_vector =
              std::vector<typename boost::graph_traits<TriangleMesh>::face_descriptor> >
 class Containers_filler

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/internal/orbifold_cone_helper.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/internal/orbifold_cone_helper.h
@@ -21,8 +21,8 @@
 #include <CGAL/boost/graph/properties.h>
 
 #include <boost/graph/graph_traits.hpp>
-#include <boost/unordered_set.hpp>
 
+#include <unordered_set>
 #include <fstream>
 #include <set>
 #include <sstream>
@@ -93,7 +93,7 @@ bool are_cones_unique(const Cone_container& cones)
   }
 
   typedef typename Cone_container::value_type   Cone;
-  boost::unordered_set<Cone> unique_cones;
+  std::unordered_set<Cone> unique_cones;
 
   unique_cones.insert(cones.begin(), cones.end());
 
@@ -221,7 +221,7 @@ bool check_cone_validity(const SeamMesh& mesh,
   CGAL_precondition(is_border(bhd, mesh));
 
   // count how many times vertices on a seam appear
-  boost::unordered_map<TM_vertex_descriptor, int> seam_vertices_counter;
+  std::unordered_map<TM_vertex_descriptor, int> seam_vertices_counter;
 
   for(halfedge_descriptor hdaf : halfedges_around_face(bhd, mesh)) {
     CGAL_precondition(mesh.has_on_seam(hdaf));
@@ -229,7 +229,7 @@ bool check_cone_validity(const SeamMesh& mesh,
     TM_vertex_descriptor tm_vdt = target(hdaf, mesh.mesh());
 
     // insert vds
-    std::pair<typename boost::unordered_map<TM_vertex_descriptor, int>::iterator,
+    std::pair<typename std::unordered_map<TM_vertex_descriptor, int>::iterator,
               bool> is_insert_successful =
                       seam_vertices_counter.insert(std::make_pair(tm_vds, 1));
     if(!is_insert_successful.second)
@@ -248,8 +248,8 @@ bool check_cone_validity(const SeamMesh& mesh,
   }
 
   // check for self intersections in the seam
-  typename boost::unordered_map<TM_vertex_descriptor, int>::iterator sit = seam_vertices_counter.begin(),
-                                                                     send = seam_vertices_counter.end();
+  typename std::unordered_map<TM_vertex_descriptor, int>::iterator sit = seam_vertices_counter.begin(),
+                                                                   send = seam_vertices_counter.end();
   for(; sit!=send; ++sit) {
     if(sit->second != 2 && sit->second != 4) {
       std::cerr << sit->second << std::endl;

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/internal/validity.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/internal/validity.h
@@ -52,7 +52,7 @@ bool has_flips(const TriangleMesh& mesh,
   typedef typename Kernel::Vector_3                                   Vector_3;
 
   // Fill containers
-  boost::unordered_set<vertex_descriptor> vertices;
+  std::unordered_set<vertex_descriptor> vertices;
   std::vector<face_descriptor> faces;
 
   internal::Containers_filler<TriangleMesh> fc(mesh, vertices, &faces);
@@ -302,7 +302,7 @@ bool is_one_to_one_mapping(const TriangleMesh& mesh,
   typedef typename boost::graph_traits<TriangleMesh>::vertex_descriptor  vertex_descriptor;
   typedef typename boost::graph_traits<TriangleMesh>::face_descriptor    face_descriptor;
 
-  boost::unordered_set<vertex_descriptor> vertices;
+  std::unordered_set<vertex_descriptor> vertices;
   std::vector<face_descriptor> faces;
 
   internal::Containers_filler<TriangleMesh> fc(mesh, vertices, &faces);

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/orbifold_shortest_path.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/orbifold_shortest_path.h
@@ -20,8 +20,8 @@
 
 #include <boost/graph/dijkstra_shortest_paths.hpp>
 #include <boost/graph/graph_traits.hpp>
-#include <boost/unordered_map.hpp>
 
+#include <unordered_map>
 #include <exception>
 #include <list>
 #include <utility>
@@ -54,7 +54,7 @@ void output_shortest_paths_to_selection_file(const TriangleMesh& mesh,
   typedef typename boost::graph_traits<TriangleMesh>::vertex_descriptor vertex_descriptor;
   typedef typename boost::graph_traits<TriangleMesh>::edge_descriptor   edge_descriptor;
 
-  boost::unordered_map<vertex_descriptor, int> index_map;
+  std::unordered_map<vertex_descriptor, int> index_map;
 
   int counter = 0;
   for(vertex_descriptor vd : vertices(mesh)) {
@@ -133,7 +133,7 @@ void compute_shortest_paths_between_two_cones(const TriangleMesh& mesh,
 
   typedef internal::Stop_at_target_Dijkstra_visitor<TriangleMesh>        Stop_visitor;
 
-  typedef boost::unordered_map<vertex_descriptor, vertex_descriptor>     Pred_umap;
+  typedef std::unordered_map<vertex_descriptor, vertex_descriptor>       Pred_umap;
   typedef boost::associative_property_map<Pred_umap>                     Pred_pmap;
 
   Pred_umap predecessor;

--- a/Surface_mesh_parameterization/test/Surface_mesh_parameterization/extensive_parameterization_test.cpp
+++ b/Surface_mesh_parameterization/test/Surface_mesh_parameterization/extensive_parameterization_test.cpp
@@ -192,7 +192,7 @@ int main(int, char**)
     UV_pmap uvpm = sm.add_property_map<SM_vertex_descriptor, Point_2>("h:uv").first;
 
     // Indices map
-    typedef boost::unordered_map<SM_vertex_descriptor, int> Indices;
+    typedef std::unordered_map<SM_vertex_descriptor, int> Indices;
     Indices indices;
     PMP::connected_component(face(opposite(hd, sm), sm), sm,
                              boost::make_function_output_iterator(
@@ -200,8 +200,8 @@ int main(int, char**)
     boost::associative_property_map<Indices> vipm(indices);
 
     // Vertex parameterized map
-    boost::unordered_set<SM_vertex_descriptor> vs;
-    SMP::internal::Bool_property_map<boost::unordered_set<SM_vertex_descriptor> > vpm(vs);
+    std::unordered_set<SM_vertex_descriptor> vs;
+    SMP::internal::Bool_property_map<std::unordered_set<SM_vertex_descriptor> > vpm(vs);
 
     // Parameterizer
     SMP::Barycentric_mapping_parameterizer_3<SMesh> parameterizer;
@@ -246,7 +246,7 @@ int main(int, char**)
                             boost::hash<SM_vertex_descriptor> > > uv_pm(uvhm);
 
     // Indices map
-    typedef boost::unordered_map<SM_vertex_descriptor, int> Indices;
+    typedef std::unordered_map<SM_vertex_descriptor, int> Indices;
     Indices indices;
     PMP::connected_component(face(opposite(hd, sm), sm), sm,
                              boost::make_function_output_iterator(
@@ -254,8 +254,8 @@ int main(int, char**)
     boost::associative_property_map<Indices> vipm(indices);
 
     // Parameterized bool pmap
-    boost::unordered_set<SM_vertex_descriptor> vs;
-    SMP::internal::Bool_property_map< boost::unordered_set<SM_vertex_descriptor> > vpm(vs);
+    std::unordered_set<SM_vertex_descriptor> vs;
+    SMP::internal::Bool_property_map< std::unordered_set<SM_vertex_descriptor> > vpm(vs);
 
     // Parameterizer
     SMP::ARAP_parameterizer_3<SMesh> parameterizer;
@@ -307,7 +307,7 @@ int main(int, char**)
     PM_SE_halfedge_descriptor hd = PMP::longest_border(mesh).first;
 
     // Indices
-    typedef boost::unordered_map<PM_SE_vertex_descriptor, int> Indices;
+    typedef std::unordered_map<PM_SE_vertex_descriptor, int> Indices;
     Indices indices;
     PMP::connected_component(face(opposite(hd, mesh), mesh), mesh,
                              boost::make_function_output_iterator(
@@ -315,8 +315,8 @@ int main(int, char**)
     boost::associative_property_map<Indices> vipm(indices);
 
     // Parameterized
-    boost::unordered_set<PM_SE_vertex_descriptor> vs;
-    SMP::internal::Bool_property_map<boost::unordered_set<PM_SE_vertex_descriptor> > vpm(vs);
+    std::unordered_set<PM_SE_vertex_descriptor> vs;
+    SMP::internal::Bool_property_map<std::unordered_set<PM_SE_vertex_descriptor> > vpm(vs);
 
     SMP::Discrete_conformal_map_parameterizer_3<PM_Seam_mesh> parameterizer;
 
@@ -372,7 +372,7 @@ int main(int, char**)
     SM_SE_halfedge_descriptor hd = PMP::longest_border(mesh).first;
 
     // Indices
-    typedef boost::unordered_map<SM_SE_vertex_descriptor, int> Indices;
+    typedef std::unordered_map<SM_SE_vertex_descriptor, int> Indices;
     Indices indices;
     PMP::connected_component(face(opposite(hd, mesh), mesh), mesh,
                              boost::make_function_output_iterator(
@@ -380,8 +380,8 @@ int main(int, char**)
     boost::associative_property_map<Indices> vipm(indices);
 
     // Parameterized
-    boost::unordered_set<SM_SE_vertex_descriptor> vs;
-    SMP::internal::Bool_property_map<boost::unordered_set<SM_SE_vertex_descriptor> > vpm(vs);
+    std::unordered_set<SM_SE_vertex_descriptor> vs;
+    SMP::internal::Bool_property_map<std::unordered_set<SM_SE_vertex_descriptor> > vpm(vs);
 
     SMP::Discrete_authalic_parameterizer_3<SM_Seam_mesh> parameterizer;
 
@@ -437,7 +437,7 @@ int main(int, char**)
     }
 
     // Index map of the seam mesh (assuming a single connected component so far)
-    typedef boost::unordered_map<SM_SE_vertex_descriptor, int> Indices;
+    typedef std::unordered_map<SM_SE_vertex_descriptor, int> Indices;
     Indices indices;
     boost::associative_property_map<Indices> vimap(indices);
     int counter = 0;
@@ -446,7 +446,7 @@ int main(int, char**)
     }
 
     // Mark the cones in the seam mesh
-    boost::unordered_map<SM_SE_vertex_descriptor, SMP::Cone_type> cmap;
+    std::unordered_map<SM_SE_vertex_descriptor, SMP::Cone_type> cmap;
     SMP::locate_cones(mesh, cone_sm_vds.begin(), cone_sm_vds.end(), cmap);
 
     // The 2D points of the uv parametrisation will be written into this map
@@ -498,7 +498,7 @@ int main(int, char**)
     UV_pmap uvpm = sm.add_property_map<SM_vertex_descriptor, Point_2>("h:uv").first;
 
     // Indices map
-    typedef boost::unordered_map<SM_vertex_descriptor, int> Indices;
+    typedef std::unordered_map<SM_vertex_descriptor, int> Indices;
     Indices indices;
     PMP::connected_component(face(opposite(hd, sm), sm), sm,
                              boost::make_function_output_iterator(
@@ -506,8 +506,8 @@ int main(int, char**)
     boost::associative_property_map<Indices> vipm(indices);
 
     // Vertex parameterized map
-    boost::unordered_set<SM_vertex_descriptor> vs;
-    SMP::internal::Bool_property_map<boost::unordered_set<SM_vertex_descriptor> > vpm(vs);
+    std::unordered_set<SM_vertex_descriptor> vs;
+    SMP::internal::Bool_property_map<std::unordered_set<SM_vertex_descriptor> > vpm(vs);
 
     // Parameterizer
     SMP::Iterative_authalic_parameterizer_3<SMesh> parameterizer;

--- a/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
+++ b/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
@@ -27,7 +27,6 @@
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/copy.hpp>
-#include <boost/unordered_map.hpp>
 #include <boost/property_map/property_map.hpp>
 
 #include <CGAL/boost/iterator/transform_iterator.hpp>
@@ -68,6 +67,7 @@
 #include <CGAL/Bbox_3.h>
 
 #include <queue>
+#include <unordered_map>
 
 // for default parameters
 #if defined(CGAL_EIGEN3_ENABLED)
@@ -1339,9 +1339,9 @@ private:
   {
     namespace PMP = CGAL::Polygon_mesh_processing;
 
-    boost::unordered_map<face_descriptor, Vector> normals;
+    std::unordered_map<face_descriptor, Vector> normals;
     boost::associative_property_map<
-      boost::unordered_map<face_descriptor, Vector> > normals_pmap(normals);
+      std::unordered_map<face_descriptor, Vector> > normals_pmap(normals);
     PMP::compute_face_normals(m_tmesh, normals_pmap);
 
     m_normals.resize(num_vertices(m_tmesh));

--- a/Surface_mesher/include/CGAL/IO/facets_in_complex_2_to_triangle_mesh.h
+++ b/Surface_mesher/include/CGAL/IO/facets_in_complex_2_to_triangle_mesh.h
@@ -19,6 +19,7 @@
 
 #include <CGAL/boost/graph/Euler_operations.h>
 #include <unordered_map>
+#include <set>
 #include <stack>
 
 namespace CGAL{

--- a/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/tetrahedral_remeshing_generate_input.h
+++ b/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/tetrahedral_remeshing_generate_input.h
@@ -12,7 +12,8 @@
 
 #include <CGAL/Random.h>
 
-#include <boost/unordered_set.hpp>
+#include <unordered_set>
+#include <boost/functional/hash.hpp>
 #include <utility>
 #include <cassert>
 
@@ -74,8 +75,10 @@ namespace Tetrahedral_remeshing
   void add_edge(typename Tr::Vertex_handle v1,
     typename Tr::Vertex_handle v2,
     const Tr& tr,
-    boost::unordered_set<std::pair<typename Tr::Vertex_handle,
-                                   typename Tr::Vertex_handle> >& constraints)
+    std::unordered_set<std::pair<typename Tr::Vertex_handle,
+                                 typename Tr::Vertex_handle>,
+                       boost::hash<std::pair<typename Tr::Vertex_handle,
+                                 typename Tr::Vertex_handle>>>& constraints)
   {
     typename Tr::Cell_handle c;
     int i, j;
@@ -86,8 +89,11 @@ namespace Tetrahedral_remeshing
   template<typename Tr>
   void make_constraints_from_cube_edges(
     Tr& tr,
-    boost::unordered_set<std::pair<typename Tr::Vertex_handle,
-                                   typename Tr::Vertex_handle> >& constraints)
+    std::unordered_set<std::pair<typename Tr::Vertex_handle,
+                                 typename Tr::Vertex_handle>,
+                       boost::hash<std::pair<typename Tr::Vertex_handle,
+                                             typename Tr::Vertex_handle>>
+  >& constraints)
   {
     typedef typename Tr::Point Point;
     typedef typename Tr::Vertex_handle Vertex_handle;
@@ -144,8 +150,10 @@ namespace Tetrahedral_remeshing
   template<typename Tr>
   void generate_input_cube(const std::size_t& n,
     Tr& tr,
-    boost::unordered_set<std::pair<typename Tr::Vertex_handle,
-                                   typename Tr::Vertex_handle> >& constraints)
+    std::unordered_set<std::pair<typename Tr::Vertex_handle,
+                                 typename Tr::Vertex_handle>,
+                       boost::hash<std::pair<typename Tr::Vertex_handle,
+                                             typename Tr::Vertex_handle>>   >& constraints)
   {
     typedef typename Tr::Vertex_handle Vertex_handle;
     typedef typename Tr::Point Point;

--- a/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/tetrahedral_remeshing_with_features.cpp
+++ b/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/tetrahedral_remeshing_with_features.cpp
@@ -5,8 +5,7 @@
 
 #include <CGAL/property_map.h>
 
-#include <boost/unordered_set.hpp>
-
+#include <unordered_set>
 #include <iostream>
 #include <utility>
 #include <cassert>
@@ -31,13 +30,13 @@ public:
   typedef boost::read_write_property_map_tag category;
 
 private:
-  boost::unordered_set<key_type>* m_set_ptr;
+  std::unordered_set<key_type, boost::hash<key_type>>* m_set_ptr;
 
 public:
   Constrained_edges_property_map()
     : m_set_ptr(nullptr)
   {}
-  Constrained_edges_property_map(boost::unordered_set<key_type>* set_)
+  Constrained_edges_property_map(std::unordered_set<key_type, boost::hash<key_type>>* set_)
     : m_set_ptr(set_)
   {}
 
@@ -77,7 +76,8 @@ int main(int argc, char* argv[])
   const int nbv = (argc > 3) ? atoi(argv[3]) : 500;
 
   Remeshing_triangulation t3;
-  boost::unordered_set<std::pair<Vertex_handle, Vertex_handle> > constraints;
+  typedef std::pair<Vertex_handle, Vertex_handle> Vertex_pair;
+  std::unordered_set<Vertex_pair, boost::hash<Vertex_pair>> constraints;
 
   CGAL::Tetrahedral_remeshing::generate_input_cube(nbv, t3, constraints);
   make_constraints_from_cube_edges(t3, constraints);

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/FMLS.h
@@ -562,7 +562,7 @@ void createMLSSurfaces(Subdomain__FMLS& subdomain_FMLS,
   subdomain_FMLS.clear();
   subdomain_FMLS_indices.clear();
 
-  typedef boost::unordered_map<Surface_index, std::size_t> SurfaceIndexMap;
+  typedef std::unordered_map<Surface_index, std::size_t, boost::hash<Surface_index>> SurfaceIndexMap;
 
   SurfaceIndexMap current_subdomain_FMLS_indices;
   SurfaceIndexMap subdomain_sample_numbers;

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
@@ -19,12 +19,13 @@
 #include <boost/bimap/set_of.hpp>
 #include <boost/bimap/multiset_of.hpp>
 #include <boost/array.hpp>
-#include <boost/unordered_set.hpp>
 #include <boost/container/small_vector.hpp>
+#include <boost/functional/hash.hpp>
 
 #include <vector>
 #include <algorithm>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <unordered_set>
 
@@ -157,7 +158,7 @@ public:
         v0_new_pos = vec(point(vh1->point()));
       }
 
-      boost::unordered_set<Cell_handle> invalid_cells;
+      std::unordered_set<Cell_handle> invalid_cells;
 
       typedef typename Tr::Cell_circulator Cell_circulator;
       Cell_circulator circ = triangulation.incident_cells(edge);
@@ -554,12 +555,12 @@ bool collapse_preserves_surface_star(const typename C3t3::Edge& edge,
   typename Tr::Geom_traits::Construct_normal_3
     normal = gt.construct_normal_3_object();
 
-  boost::unordered_set<Facet> facets;
+  std::unordered_set<Facet, boost::hash<Facet>> facets;
   tr.finite_incident_facets(v0, std::inserter(facets, facets.end()));
   tr.finite_incident_facets(v1, std::inserter(facets, facets.end()));
 
 // note : checking a 2nd ring of facets does not change the result
-//  boost::unordered_set<Facet> ring2;
+//  std::unordered_set<Facet, boost::hash<Facet>> ring2;
 //  for (const Facet& f : facets)
 //  {
 //    for (int i = 1; i < 4; ++i)
@@ -671,7 +672,7 @@ bool are_edge_lengths_valid(const typename C3t3::Edge& edge,
   const Vertex_handle v1 = edge.first->vertex(edge.second);
   const Vertex_handle v2 = edge.first->vertex(edge.third);
 
-  boost::unordered_map<Vertex_handle, FT> edges_sqlength_after_collapse;
+  std::unordered_map<Vertex_handle, FT> edges_sqlength_after_collapse;
 
   std::vector<Edge> inc_edges;
   c3t3.triangulation().finite_incident_edges(v1,
@@ -790,7 +791,7 @@ collapse(const typename C3t3::Cell_handle ch,
 
   bool valid = true;
   std::vector<Cell_handle> cells_to_remove;
-  boost::unordered_set<Cell_handle> invalid_cells;
+  std::unordered_set<Cell_handle> invalid_cells;
 
   for(const Cell_handle& c : inc_cells)
   {
@@ -988,7 +989,7 @@ bool is_cells_set_manifold(const C3t3&,
   typedef std::array<Vh, 3> FV;
   typedef std::pair<Vh, Vh> EV;
 
-  boost::unordered_map<FV, int> facets;
+  std::unordered_map<FV, int, boost::hash<FV>> facets;
   for (Cell_handle c : cells)
   {
     for (int i = 0; i < 4; ++i)
@@ -996,7 +997,7 @@ bool is_cells_set_manifold(const C3t3&,
       const FV fvi = make_vertex_array(c->vertex((i + 1) % 4),
         c->vertex((i + 2) % 4),
         c->vertex((i + 3) % 4));
-      typename boost::unordered_map<FV, int>::iterator fit = facets.find(fvi);
+      typename std::unordered_map<FV, int, boost::hash<FV>>::iterator fit = facets.find(fvi);
       if (fit == facets.end())
         facets.insert(std::make_pair(fvi, 1));
       else
@@ -1004,7 +1005,7 @@ bool is_cells_set_manifold(const C3t3&,
     }
   }
 
-  boost::unordered_map<EV, int> edges;
+  std::unordered_map<EV, int, boost::hash<EV>> edges;
   for (const auto& fvv : facets)
   {
     if (fvv.second != 1)
@@ -1013,7 +1014,7 @@ bool is_cells_set_manifold(const C3t3&,
     for (int i = 0; i < 3; ++i)
     {
       const EV evi = make_vertex_pair(fvv.first[i], fvv.first[(i + 1) % 3]);
-      typename boost::unordered_map<EV, int>::iterator eit = edges.find(evi);
+      typename std::unordered_map<EV, int, boost::hash<EV>>::iterator eit = edges.find(evi);
       if (eit == edges.end())
         edges.insert(std::make_pair(evi, 1));
       else

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/compute_c3t3_statistics.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/compute_c3t3_statistics.h
@@ -19,8 +19,7 @@
 #include <vector>
 #include <algorithm>
 #include <fstream>
-
-#include <boost/unordered_set.hpp>
+#include <unordered_set>
 
 #include <CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h>
 
@@ -87,7 +86,7 @@ void compute_statistics(const Triangulation& tr,
     = tr.geom_traits().compute_approximate_dihedral_angle_3_object();
 
   std::size_t nb_tets = 0;
-  boost::unordered_set<Vertex_handle> selected_vertices;
+  std::unordered_set<Vertex_handle> selected_vertices;
   std::vector<Subdomain_index> sub_ids;
   for (Finite_cells_iterator cit = tr.finite_cells_begin();
        cit != tr.finite_cells_end();

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/flip_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/flip_edges.h
@@ -20,11 +20,12 @@
 
 #include <CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h>
 
-#include <boost/unordered_map.hpp>
-#include <boost/unordered_set.hpp>
 #include <boost/container/small_vector.hpp>
 #include <boost/optional.hpp>
+#include <boost/functional/hash.hpp>
 
+#include <unordered_map>
+#include <unordered_set>
 #include <limits>
 #include <queue>
 
@@ -226,8 +227,8 @@ Sliver_removal_result flip_3_to_2(typename C3t3::Edge& edge,
 
   //Keep the facets
   typedef CGAL::Triple<Vertex_handle, Vertex_handle, Vertex_handle> Facet_vvv;
-  typedef boost::unordered_map<Facet_vvv, std::size_t> FaceMapIndex;
-  boost::unordered_set<Facet> outer_mirror_facets;
+  typedef std::unordered_map<Facet_vvv, std::size_t> FaceMapIndex;
+  std::unordered_set<Facet, boost::hash<Facet>> outer_mirror_facets;
 
   FaceMapIndex facet_map_indices;
   std::vector<Facet> mirror_facets;
@@ -782,7 +783,7 @@ Sliver_removal_result flip_n_to_m(C3t3& c3t3,
   boost::container::small_vector<Cell_handle, 20> to_remove;
 
   //Neighbors that will need to be updated after flip
-  boost::unordered_set<Facet> neighbor_facets;
+  std::unordered_set<Facet, boost::hash<Facet>> neighbor_facets;
 
   //Facets that will be used to create new cells
   // i.e. all the facets opposite to vh1 and don't have vh
@@ -895,7 +896,7 @@ Sliver_removal_result flip_n_to_m(C3t3& c3t3,
   }
 
   typedef CGAL::Triple<Vertex_handle, Vertex_handle, Vertex_handle> Facet_vvv;
-  typedef boost::unordered_map<Facet_vvv, std::size_t> FaceMapIndex;
+  typedef std::unordered_map<Facet_vvv, std::size_t> FaceMapIndex;
 
   FaceMapIndex facet_map_indices;
   std::vector<Facet> facets;
@@ -1092,12 +1093,12 @@ Sliver_removal_result find_best_flip(typename C3t3::Edge& edge,
   Facet_circulator done = circ;
 
   //Identify the vertices around this edge
-  boost::unordered_set<Vertex_handle> vertices_around_edge;
+  std::unordered_set<Vertex_handle> vertices_around_edge;
   bool boundary_edge = false;
   bool hull_edge = false;
 
-  boost::unordered_set<Vertex_handle> boundary_vertices;
-//  boost::unordered_set<Vertex_handle> hull_vertices;
+  std::unordered_set<Vertex_handle> boundary_vertices;
+//  std::unordered_set<Vertex_handle> hull_vertices;
   do
   {
     //Get the ids of the opposite vertices
@@ -1242,7 +1243,7 @@ void flip_edges(C3T3& c3t3,
   //compute vertices normals map?
 
   // typedef typename C3T3::Surface_patch_index Surface_patch_index;
-  // typedef boost::unordered_map<Surface_patch_index, unsigned int> Spi_map;
+  // typedef std::unordered_map<Surface_patch_index, unsigned int> Spi_map;
   //if (!protect_boundaries)
   //{
   //  std::cout << "\tBoundary flips" << std::endl;

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/split_long_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/split_long_edges.h
@@ -18,11 +18,12 @@
 #include <boost/bimap.hpp>
 #include <boost/bimap/set_of.hpp>
 #include <boost/bimap/multiset_of.hpp>
-#include <boost/unordered_map.hpp>
 #include <boost/container/small_vector.hpp>
+#include <boost/functional/hash.hpp>
 
 #include <CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h>
 
+#include <unordered_map>
 #include <functional>
 #include <utility>
 
@@ -68,8 +69,8 @@ typename C3t3::Vertex_handle split_edge(const typename C3t3::Edge& e,
   }
   CGAL_assertion(dimension > 0);
 
-  boost::unordered_map<Facet, Subdomain_index> cells_info;
-  boost::unordered_map<Facet, std::pair<Vertex_handle, Surface_patch_index> > facets_info;
+  std::unordered_map<Facet, Subdomain_index, boost::hash<Facet>> cells_info;
+  std::unordered_map<Facet, std::pair<Vertex_handle, Surface_patch_index>, boost::hash<Facet>> facets_info;
 
   // check orientation and collect incident cells to avoid circulating twice
   boost::container::small_vector<Cell_handle, 30> inc_cells;

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -616,7 +616,7 @@ std::size_t nb_incident_subdomains(const typename C3t3::Vertex_handle v,
 {
   typedef typename C3t3::Subdomain_index Subdomain_index;
 
-  boost::unordered_set<Subdomain_index> indices;
+  std::unordered_set<Subdomain_index> indices;
   incident_subdomains(v, c3t3, std::inserter(indices, indices.begin()));
 
   return indices.size();
@@ -628,7 +628,7 @@ std::size_t nb_incident_subdomains(const typename C3t3::Edge& e,
 {
   typedef typename C3t3::Subdomain_index Subdomain_index;
 
-  boost::unordered_set<Subdomain_index> indices;
+  std::unordered_set<Subdomain_index> indices;
   incident_subdomains(e, c3t3, std::inserter(indices, indices.begin()));
 
   return indices.size();
@@ -640,7 +640,7 @@ std::size_t nb_incident_surface_patches(const typename C3t3::Edge& e,
 {
   typedef typename C3t3::Surface_patch_index Surface_patch_index;
 
-  boost::unordered_set<Surface_patch_index> indices;
+  std::unordered_set<Surface_patch_index, boost::hash<Surface_patch_index>> indices;
   incident_surface_patches(e, c3t3, std::inserter(indices, indices.begin()));
 
   return indices.size();
@@ -651,7 +651,7 @@ std::size_t nb_incident_complex_edges(const typename C3t3::Vertex_handle v,
                                       const C3t3& c3t3)
 {
   typedef typename C3t3::Edge Edge;
-  boost::unordered_set<Edge> edges;
+  std::unordered_set<Edge> edges;
   c3t3.triangulation().finite_incident_edges(v, std::inserter(edges, edges.begin()));
 
   std::size_t count = 0;
@@ -1309,7 +1309,7 @@ void dump_cells_off(const CellRange& cells, const Tr& /*tr*/, const char* filena
 
   Bimap_t vertices;
   int index = 0;
-  boost::unordered_set<std::array<Vertex_handle, 3> > facets;
+  std::unordered_set<std::array<Vertex_handle, 3>, boost::hash<std::array<Vertex_handle, 3>> > facets;
 
   for (Cell_handle c : cells)
   {

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -18,6 +18,7 @@
 #include <utility>
 #include <array>
 #include <iterator>
+#include <unordered_set>
 
 #include <CGAL/Point_3.h>
 #include <CGAL/Weighted_point_3.h>

--- a/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_with_features.cpp
+++ b/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_with_features.cpp
@@ -10,8 +10,9 @@
 #include <CGAL/Random.h>
 #include <CGAL/property_map.h>
 
-#include <boost/unordered_set.hpp>
+#include <boost/functional/hash.hpp>
 
+#include <unordered_set>
 #include <iostream>
 #include <fstream>
 #include <vector>
@@ -36,13 +37,13 @@ public:
   typedef boost::read_write_property_map_tag category;
 
 private:
-  boost::unordered_set<key_type>* m_set_ptr;
+  std::unordered_set<key_type, boost::hash<key_type>>* m_set_ptr;
 
 public:
   Constrained_edges_property_map()
     : m_set_ptr(nullptr)
   {}
-  Constrained_edges_property_map(boost::unordered_set<key_type>* set_)
+  Constrained_edges_property_map(std::unordered_set<key_type, boost::hash<key_type>>* set_)
     : m_set_ptr(set_)
   {}
 
@@ -69,7 +70,8 @@ public:
 void add_edge(Vertex_handle v1,
               Vertex_handle v2,
               const Remeshing_triangulation& tr,
-              boost::unordered_set<std::pair<Vertex_handle, Vertex_handle> >& constraints)
+              std::unordered_set<std::pair<Vertex_handle, Vertex_handle>,
+                                 boost::hash<std::pair<Vertex_handle, Vertex_handle>>>& constraints)
 {
   Cell_handle c;
   int i, j;
@@ -79,7 +81,8 @@ void add_edge(Vertex_handle v1,
 
 void generate_input_cube(const std::size_t& n,
               Remeshing_triangulation& tr,
-              boost::unordered_set<std::pair<Vertex_handle, Vertex_handle> >& constraints)
+              std::unordered_set<std::pair<Vertex_handle, Vertex_handle>,
+                                 boost::hash<std::pair<Vertex_handle, Vertex_handle>> >& constraints)
 {
   CGAL::Random rng;
 
@@ -143,7 +146,8 @@ int main(int argc, char* argv[])
   std::cout << "CGAL Random seed = " << CGAL::get_default_random().get_seed() << std::endl;
 
   Remeshing_triangulation tr;
-  boost::unordered_set<std::pair<Vertex_handle, Vertex_handle> > constraints;
+  std::unordered_set<std::pair<Vertex_handle, Vertex_handle>,
+                     boost::hash<std::pair<Vertex_handle, Vertex_handle>>> constraints;
   generate_input_cube(1000, tr, constraints);
 
   const double target_edge_length = (argc > 1) ? atof(argv[1]) : 0.02;

--- a/Visibility_2/include/CGAL/Rotational_sweep_visibility_2.h
+++ b/Visibility_2/include/CGAL/Rotational_sweep_visibility_2.h
@@ -22,7 +22,6 @@
 #include <CGAL/bounding_box.h>
 #include <CGAL/assertions.h>
 #include <CGAL/Kernel/global_functions_2.h>
-#include <boost/unordered_map.hpp>
 #include <iterator>
 
 


### PR DESCRIPTION
I was chasing a warning but then realized that it cannot be fixed but here is some of the changes that still could be interesting to keep.

I wonder if there is anything that prevents us from always using `std::unordered` instead of `boost::unordered`.

**TODO:**
- [x] Understand why 2cc2fa fixes runtime issues. Bug in MSVC's STL? (see https://github.com/CGAL/cgal/pull/6348)
