### PR TITLE
Aos 2 fixes efif

### DIFF
--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
@@ -2213,11 +2213,9 @@ vertex and the remaining one is vertical.
 \cgalFigureBegin{aos_fig-bounded_vd,bounded_vertical_decomposition.png}
 An arrangement of four line segments and its vertical decomposition
 into pseudo trapezoids, as constructed in \ref
-Arrangement_on_surface_2/bounded_vertical_decomposition.cpp.  The
-segments of \f$\mathcal{S}_1\f$ are drawn in solid lines and the
-segments of \f$\mathcal{S}_2\f$ are drawn in dark dashed lines. Note
-that the segment \f$ s\f$ (light dashed line) overlaps one of the
-segments in \f$\mathcal{S}_1\f$.
+Arrangement_on_surface_2/bounded_vertical_decomposition.cpp. The
+segments of the arrangement are drawn in solid blue lines and the
+segments of the vertical decomposition are drawn in dark dotted lines.
 \cgalFigureEnd
 <!-- ------------------------------------------------------------------------- -->
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_spherical_gaussian_map_3/Arr_spherical_gaussian_map_3.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_spherical_gaussian_map_3/Arr_spherical_gaussian_map_3.h
@@ -134,8 +134,7 @@ public:
                                  OutputIterator oi)
   {
     const Geometry_traits_2* traits = this->m_sgm.geometry_traits();
-    typename Traits::Construct_point_2 ctr_point =
-      traits->construct_point_2_object();
+    auto ctr_point = traits->construct_point_2_object();
     Curve_2 cv =
       traits->construct_curve_2_object()(ctr_point(normal1.direction()),
                                          ctr_point(normal2.direction()));


### PR DESCRIPTION
## Two small fixes:

1. A small fix in the Gaussian-map code: Changed an erroneous type to 'auto'. The Gaussian-map code is not exposed (yet), but I have some code that uses it; others may as well, and I'm working on the feature that exposes it.
2. Fixed the caption of the vertical-decomposition figure. (Some of the text was irrelevant.)

## Release Management

* Affected package(s): Arrangement_on_surface_2
* Issue(s) solved (if any): 
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: TAU

