### PR TITLE
typo in the intro of 'Scale-Space Surface Reconstruction' and #6220

### DIFF
--- a/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/poisson_surface_reconstruction.h
@@ -40,7 +40,7 @@ namespace CGAL {
 
     This function relies mainly on the size parameter `spacing`. A
     reasonable solution is to use the average spacing of the input
-    point set (using `compute_average_spacing()` for example). Higher
+    point set (using `compute_average_spacing()` for example). Smaller
     values increase the precision of the output mesh at the cost of
     higher computation time.
 

--- a/Scale_space_reconstruction_3/doc/Scale_space_reconstruction_3/PackageDescription.txt
+++ b/Scale_space_reconstruction_3/doc/Scale_space_reconstruction_3/PackageDescription.txt
@@ -13,7 +13,7 @@
 \cgalPkgPicture{knot_thumb.png}
 \cgalPkgSummaryBegin
 \cgalPkgAuthors{Thijs van Lankveld}
-\cgalPkgDesc{This method allows to reconstruct a surface that interpolates a set of 3D points using either and alpha shape or the advancing front surface reconstruction method. The output interpolates the point set (as opposed to approximating the point set). How the surface connects the points depends on a scale variable, which can be estimated semi-automatically.}
+\cgalPkgDesc{This method allows to reconstruct a surface that interpolates a set of 3D points using either an alpha shape or the advancing front surface reconstruction method. The output interpolates the point set (as opposed to approximating the point set). How the surface connects the points depends on a scale variable, which can be estimated semi-automatically.}
 \cgalPkgManuals{Chapter_Scale_space_reconstruction,PkgScaleSpaceReconstruction3Ref}
 \cgalPkgSummaryEnd
 \cgalPkgShortInfoBegin


### PR DESCRIPTION
## Summary of Changes

Fixed a typo in the intro of [Scale-Space Surface Recontruction](https://doc.cgal.org/latest/Manual/packages.html#PkgScaleSpaceReconstruction3) and fixed #6220 
