### PR TITLE
fix warning 

### DIFF
--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
@@ -19,6 +19,7 @@
 #include <CGAL/boost/graph/Euler_operations.h>
 #include <CGAL/boost/graph/helpers.h>
 #include <CGAL/Modifiable_priority_queue.h>
+#include <CGAL/use.h>
 
 #include <boost/scoped_array.hpp>
 
@@ -311,6 +312,7 @@ private:
     CGAL_assertion(is_primary_edge(h));
     CGAL_expensive_assertion(data.is_in_PQ());
     CGAL_expensive_assertion(mPQ->contains(h));
+    CGAL_USE(data);
 
     mPQ->update(h);
 


### PR DESCRIPTION
Introduced in 5.5

Fix this warning [here](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.4-Ic-137/Surface_mesh_simplification_Examples/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz).