### PR TITLE
Fix uninitialised members in Convex_hull_vertex_base_2.h

### DIFF
--- a/Convex_hull_3/include/CGAL/Convex_hull_vertex_base_2.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_vertex_base_2.h
@@ -48,16 +48,16 @@ public:
   };
 
   Convex_hull_vertex_base_2()
-    : Vb() {}
+    : Vb(),_info(),_p() {}
 
   Convex_hull_vertex_base_2(const Point& p)
-    : Vb(), _p(p) {}
+    : Vb(),_info(),_p(p) {}
 
   Convex_hull_vertex_base_2(const Point& p, Face_handle f)
-    : Vb(f), _p(p) {}
+    : Vb(f),_info(),_p(p) {}
 
   Convex_hull_vertex_base_2(Face_handle f)
-    : Vb(f) {}
+    : Vb(f),_info(),_p() {}
 
   void set_point(const Point& p) { _p = p; }
   const Point&  point() const { return _p; }


### PR DESCRIPTION
Fix uninitialized members (_info,_p) in Convex_hull_vertex_base_2.h

## Summary of Changes

This is another one of these 'contentious' uninitialised member issues, thrown by the static analysis for this relatively new class. I've created this pull request just to record the issue and potential fix.

## Release Management

* Affected package(s): Convex_hull
* Issue(s) solved (if any): static analysis
* Feature/Small Feature (if any): small / bugfix
* License and copyright ownership: Returned to CGAL authors.

