### PR TITLE
Fix warnings

### DIFF
--- a/Stream_support/include/CGAL/IO/OFF/File_scanner_OFF.h
+++ b/Stream_support/include/CGAL/IO/OFF/File_scanner_OFF.h
@@ -742,6 +742,7 @@ public:
         m_in.clear(std::ios::badbit);
         if(verbose())
           std::cerr<<"error while reading facet. Missing index."<<std::endl;
+        index=0;
         return;
       }
       index = static_cast<std::size_t>(entries[current_entry]);
@@ -757,7 +758,7 @@ public:
                      "cannot read OFF file beyond facet "
                   << current_facet << "." << std::endl;
       }
-
+      index=0;
       set_off_header(false);
       return;
     }
@@ -777,7 +778,7 @@ public:
                   << index + index_offset() << ": is out of range."
                   << std::endl;
       }
-
+      index = 0;
       set_off_header(false);
       return;
     }


### PR DESCRIPTION
Try to fix this warning [here](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.4-I-134/Nef_3_Examples/TestReport_lrineau_ArchLinux-CXX17-Release.gz)

```
/mnt/testsuite/include/CGAL/IO/OFF/Scanner_OFF.h:169:39: warning: ‘no’ may be used uninitialized in this function [-Wmaybe-uninitialized]
  169 |             for (std::size_t i = 0; i < no; ++i) {
      |                                     ~~^~~~
/mnt/testsuite/include/CGAL/IO/OFF/Scanner_OFF.h:163:25: note: ‘no’ was declared here
  163 |             std::size_t no;
```