### PR TITLE
Installation:  Fix issues for CGAL_WARNING

### DIFF
--- a/Installation/include/CGAL/Installation/internal/enable_third_party_libraries.h
+++ b/Installation/include/CGAL/Installation/internal/enable_third_party_libraries.h
@@ -25,13 +25,13 @@
 #  undef CGAL_USE_GMP
 #endif
 
-#if defined(__has_include)
+#if defined(__has_include) && ( ! defined _MSC_VER || _MSC_VER > 1900)
 #  if CGAL_USE_GMP && ! __has_include(<gmp.h>)
-#    pragma CGAL_WARNING(<gmp.h> cannot be found. Less efficient number types will be used instead. Define CGAL_NO_GMP=1 if that is on purpose.)
+#    pragma CGAL_WARNING("<gmp.h> cannot be found. Less efficient number types will be used instead. Define CGAL_NO_GMP=1 if that is on purpose.")
 #    undef CGAL_USE_GMP
 #    undef CGAL_USE_MPFR
 #  elif CGAL_USE_MPFR && ! __has_include(<mpfr.h>)
-#    pragma CGAL_WARNING(<mpfr.h> cannot be found and the GMP support in CGAL requires it. Less efficient number types will be used instead. Define CGAL_NO_GMP=1 if that is on purpose.)
+#    pragma CGAL_WARNING("<mpfr.h> cannot be found and the GMP support in CGAL requires it. Less efficient number types will be used instead. Define CGAL_NO_GMP=1 if that is on purpose.")
 #    undef CGAL_USE_GMP
 #    undef CGAL_USE_MPFR
 #  endif // CGAL_USE_MPFR and no <mpfr.h>

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -523,7 +523,7 @@ namespace cpp11{
 /// Macro `CGAL_WARNING`.
 /// Must be used with `#pragma`, this way:
 ///
-///     #pragma CGAL_WARNING(This line should trigger a warning)
+///     #pragma CGAL_WARNING("This line should trigger a warning")
 ///
 /// @{
 #ifdef BOOST_MSVC


### PR DESCRIPTION

## Summary of Changes

The warning must be put in quotes.
The check for gmp.h does not work for VC2015 so we have to disable it.

This PR fixes [this warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.4-Ic-141/AABB_tree_Demo/TestReport_Christo_MSVC2015-Release-64bits.gz)

## Release Management

* Affected package(s): Installation   and the warning shows up in AABB Tree


