### PR TITLE
Advancing Front Surface Reconstruction: allow float

### DIFF
--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -394,7 +394,7 @@ namespace CGAL {
     bool deal_with_2d;
     Priority priority;
     int max_connected_component;
-    double K_init, K_step;
+    coord_type K_init, K_step;
     std::list<Vertex_handle> interior_edges;
     std::list< Incidence_request_elt > incidence_requests;
     typename std::list< Incidence_request_elt >::iterator sentinel;


### PR DESCRIPTION
## Summary of Changes

Compiling `Advancing_front_surface_reconstruction` with `CGAL::Simple_cartesian<float>` currently fails:
```
/CGAL-5.3.1/include/CGAL/Advancing_front_surface_reconstruction.h: In instantiation of ‘void CGAL::Advancing_front_surface_reconstruction<B, C>::extend() [with Dt = CGAL::Delaunay_triangulation_3<Kernel, CGAL::Triangulation_data_structure_3<CGAL::Advancing_front_surface_reconstruction_vertex_base_3<Kernel>, CGAL::Advancin
g_front_surface_reconstruction_cell_base_3<Kernel> >, CGAL::Location_policy<CGAL::Fast> >; P = Priority]’:
/CGAL-5.3.1/include/CGAL/Advancing_front_surface_reconstruction.h:804:21:   required from ‘void CGAL::Advancing_front_surface_reconstruction<B, C>::run(double, double) [with Dt = CGAL::Delaunay_triangulation_3<Kernel, CGAL::Triangulation_data_structure_3<CGAL::Advancing_front_surface_reconstruction_vertex_base_3<Kernel>,
CGAL::Advancing_front_surface_reconstruction_cell_base_3<Kernel> >, CGAL::Location_policy<CGAL::Fast> >; P = Priority]’
/CGAL-5.3.1/include/CGAL/Advancing_front_surface_reconstruction.h:2113:26: error: no matching function for call to ‘max(double&, CGAL::Advancing_front_surface_reconstruction<CGAL::Delaunay_triangulation_3<Kernel, CGAL::Triangulation_data_structure_3<CGAL::Advancing_front_surface_reconstruction_vertex_base_3<Kernel>, CGAL:
:Advancing_front_surface_reconstruction_cell_base_3<Kernel> >, CGAL::Location_policy<CGAL::Fast> >, Priority>::coord_type)’
           K += (std::max)(K_step, min_K - K + eps);
                ~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~
```
This PR fixes the issue.

## Release Management

* Affected package(s): Advancing_front_surface_reconstruction

