### PR TITLE
Hash_map:  Fix warning in test case

### DIFF
--- a/Hash_map/test/Hash_map/Hash.cpp
+++ b/Hash_map/test/Hash_map/Hash.cpp
@@ -129,7 +129,7 @@ int main()
   fct<Arrangement_2, boost::graph_traits<Arrangement_2>::vertex_descriptor>(A);
   fct<Arrangement_2, boost::graph_traits<Arrangement_2>::edge_descriptor>(A);
 
-  Kernel::Point_3 p3;
+  Kernel::Point_3 p3(CGAL::ORIGIN);
   Polyhedron P;
   CGAL::make_triangle(p3,p3,p3,P);
   fct4(P);
@@ -155,5 +155,3 @@ int main()
 
   return 0;
 }
-
-


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes

Initialize the point to avoid a warning in a [test program](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.4-Ic-141/Hash_map/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz)

## Release Management

* Affected package(s): Hash_map


