### PR TITLE
CGAL:   In testcode do not use CGAL_assertion  but assert 

### DIFF
--- a/AABB_tree/test/AABB_tree/aabb_test_all_intersected_primitives_tree.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_all_intersected_primitives_tree.cpp
@@ -1,7 +1,6 @@
 #include <fstream>
 #include <iterator>
-
-#include <CGAL/assertions.h>
+#include <cassert>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
@@ -59,11 +58,11 @@ int main()
   std::list<T_Tree::Primitive::Id> t_primitives;
   std::list<S_Tree::Primitive::Id> s_primitives;
   cube_tree.all_intersected_primitives(tet_tree,std::back_inserter(t_primitives));
-  CGAL_assertion(t_primitives.size() == 6);
+  assert(t_primitives.size() == 6);
   tet_tree.all_intersected_primitives(cube_tree,std::back_inserter(s_primitives));
-  CGAL_assertion(s_primitives.size() == 6);
-  CGAL_assertion(tet_tree.do_intersect(cube_tree));
-  CGAL_assertion(cube_tree.do_intersect(tet_tree));
+  assert(s_primitives.size() == 6);
+  assert(tet_tree.do_intersect(cube_tree));
+  assert(cube_tree.do_intersect(tet_tree));
 
   std::vector<T_Tree::Primitive::Id> all_primitives;
   cube_tree.all_intersected_primitives(tet_tree, std::back_inserter(all_primitives));
@@ -73,7 +72,7 @@ int main()
     if((int)prim.first == 5)
       found_f5 = true;
   }
-  CGAL_assertion(found_f5);
-  CGAL_USE(found_f5);
+  assert(found_f5);
+
   return 0;
 }

--- a/AABB_tree/test/AABB_tree/aabb_test_move_constructor.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_move_constructor.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <list>
 #include <utility>
+#include <cassert>
 
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 #include <CGAL/AABB_halfedge_graph_segment_primitive.h>
@@ -149,12 +150,12 @@ public:
     std::list<S_Tree::Primitive::Id> s_primitives;
     cube_tree.all_intersected_primitives(tet_tree,
                                          std::back_inserter(t_primitives));
-    CGAL_assertion(t_primitives.size() == 6);
+    assert(t_primitives.size() == 6);
     tet_tree.all_intersected_primitives(cube_tree,
                                         std::back_inserter(s_primitives));
-    CGAL_assertion(s_primitives.size() == 6);
-    CGAL_assertion(tet_tree.do_intersect(cube_tree));
-    CGAL_assertion(cube_tree.do_intersect(tet_tree));
+    assert(s_primitives.size() == 6);
+    assert(tet_tree.do_intersect(cube_tree));
+    assert(cube_tree.do_intersect(tet_tree));
 
     std::vector<T_Tree::Primitive::Id> all_primitives;
     cube_tree.all_intersected_primitives(tet_tree,
@@ -164,8 +165,8 @@ public:
       if ((int)prim.first == 5)
         found_f5 = true;
     }
-    CGAL_assertion(found_f5);
-    CGAL_USE(found_f5);
+    assert(found_f5);
+
     return true;
   }
 };

--- a/AABB_tree/test/AABB_tree/aabb_test_multi_mesh.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_multi_mesh.cpp
@@ -5,7 +5,6 @@
 #include <boost/functional/value_factory.hpp>
 #include <boost/array.hpp>
 
-#include <CGAL/assertions.h>
 #include <CGAL/algorithm.h>
 #include <CGAL/point_generators_3.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>

--- a/AABB_tree/test/AABB_tree/aabb_test_ray_intersection.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_test_ray_intersection.cpp
@@ -138,9 +138,8 @@ int main()
   for(std::vector<Ray>::iterator it = rays.begin(); it != rays.end(); ++it) {
     primitives2.push_back(tree.first_intersection(*it));
   }
-  CGAL_assertion_msg(primitives1.size() == primitives2.size(), "Different amount of primitives intersected.");
-  CGAL_assertion_msg(std::equal(primitives1.begin(), primitives1.end(), primitives2.begin()),
-                     "Primitives mismatch.");
+  assert(primitives1.size() == primitives2.size()); //  Different amount of primitives intersected
+  assert(std::equal(primitives1.begin(), primitives1.end(), primitives2.begin())); //  Primitives mismatch
   std::size_t c = primitives1.size() - std::count(primitives1.begin(), primitives1.end(), boost::none);
   std::cout << "Intersected " << c << " primitives with " << NB_RAYS << " rays" << std::endl;
   std::cout << "Primitive method had to sort " << accum/NB_RAYS

--- a/Algebraic_kernel_d/test/Algebraic_kernel_d/include/CGAL/_test_algebraic_kernel_1.h
+++ b/Algebraic_kernel_d/test/Algebraic_kernel_d/include/CGAL/_test_algebraic_kernel_1.h
@@ -409,9 +409,9 @@ void test_algebraic_kernel_1(const AlgebraicKernel_d_1& ak_1){
 #define CGAL_TEST_ALGEBRAIC_REAL_IO(_f)         \
     alg1=_f;                                    \
     ss<<CGAL::IO::oformat(alg1);                \
-    CGAL_assertion(ss.good());                  \
-    ss>>CGAL::IO::iformat(alg2);                    \
-    CGAL_assertion(!ss.fail());                 \
+    assert(ss.good());                          \
+    ss>>CGAL::IO::iformat(alg2);                \
+    assert(!ss.fail());                         \
     ss.clear();                                 \
     assert(alg1==alg2)
     // Note: after the reading ss>>CGAL::IO::iformat(alg2) the state of ss can

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_polycurve_intersection.cpp
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/test_polycurve_intersection.cpp
@@ -6,6 +6,7 @@
 #include <boost/iterator/function_output_iterator.hpp>
 
 #include <array>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel;
 typedef CGAL::Arr_segment_traits_2<Kernel>                Segment_traits_2;
@@ -29,7 +30,7 @@ struct Test_functor
   {
      const X_monotone_polyline* poly
       = CGAL::object_cast<X_monotone_polyline>(&obj);
-    CGAL_assertion_msg (poly != nullptr, "Intersection is not a polyline");
+     assert(poly != nullptr); //  Intersection is not a polyline
 
     typename X_monotone_polyline::Point_const_iterator
       itref = reference->points_begin(),
@@ -38,7 +39,7 @@ struct Test_functor
     for (; itref != reference->points_end()
            && itpoly != poly->points_end();
          ++ itref, ++ itpoly)
-      CGAL_assertion (*itref == *itpoly);
+      assert(*itref == *itpoly);
   }
 };
 

--- a/BGL/test/BGL/test_Euler_operations.cpp
+++ b/BGL/test/BGL/test_Euler_operations.cpp
@@ -480,7 +480,7 @@ test_swap_edges()
       halfedge_descriptor h1 = *std::next(boost::begin(halfedges(g)), i);
       halfedge_descriptor h2 = *std::next(boost::begin(halfedges(g)), j);
       CGAL::internal::swap_edges(h1, h2, g);
-      CGAL_assertion(CGAL::is_valid_polygon_mesh(g));
+      assert(CGAL::is_valid_polygon_mesh(g));
     }
   }
 }

--- a/BGL/test/BGL/test_Face_filtered_graph.cpp
+++ b/BGL/test/BGL/test_Face_filtered_graph.cpp
@@ -423,7 +423,7 @@ void test_mesh(Adapter fga)
   assert(num_halfedges(fga) == 10);
   assert(num_vertices(fga) == 4);
   halfedge_descriptor h = halfedge(*faces(fga).first, fga);
-  CGAL_assertion_code( vertex_descriptor v = source(h, fga));
+  vertex_descriptor v = source(h, fga);
   //check that next() works inside the patch
   assert(next(next(next(h, fga), fga), fga) == h);
   //check that next() works on bordure of the patch

--- a/BGL/test/BGL/test_Face_filtered_graph.cpp
+++ b/BGL/test/BGL/test_Face_filtered_graph.cpp
@@ -13,6 +13,7 @@
 #include <map>
 #include <memory>
 #include <utility>
+#include <cassert>
 
 typedef boost::unordered_set<std::size_t> id_map;
 
@@ -416,29 +417,29 @@ void test_mesh(Adapter fga)
 {
   CGAL_GRAPH_TRAITS_MEMBERS(Adapter);
   //check that there is the right number of simplices in fga
-  CGAL_assertion(CGAL::is_valid_polygon_mesh(fga));
-  CGAL_assertion(num_faces(fga) == 2);
-  CGAL_assertion(num_edges(fga) == 5);
-  CGAL_assertion(num_halfedges(fga) == 10);
-  CGAL_assertion(num_vertices(fga) == 4);
+  assert(CGAL::is_valid_polygon_mesh(fga));
+  assert(num_faces(fga) == 2);
+  assert(num_edges(fga) == 5);
+  assert(num_halfedges(fga) == 10);
+  assert(num_vertices(fga) == 4);
   halfedge_descriptor h = halfedge(*faces(fga).first, fga);
   CGAL_assertion_code( vertex_descriptor v = source(h, fga));
   //check that next() works inside the patch
-  CGAL_assertion(next(next(next(h, fga), fga), fga) == h);
+  assert(next(next(next(h, fga), fga), fga) == h);
   //check that next() works on bordure of the patch
   h = opposite(h, fga);
-  CGAL_assertion(next(next(next(next(h, fga), fga), fga), fga) == h);
+  assert(next(next(next(next(h, fga), fga), fga), fga) == h);
   //check that prev() works inside the patch
   h = halfedge(*faces(fga).first, fga);
-  CGAL_assertion(prev(prev(prev(h, fga), fga), fga) == h);
+  assert(prev(prev(prev(h, fga), fga), fga) == h);
   //check that prev() works on bordure of the patch
   h = opposite(h, fga);
-  CGAL_assertion(prev(prev(prev(prev(h, fga), fga), fga), fga) == h);
+  assert(prev(prev(prev(prev(h, fga), fga), fga), fga) == h);
   //check degree
-  CGAL_assertion(degree(v, fga) == 3);
+  assert(degree(v, fga) == 3);
   //check in_edges and out_edges
-  CGAL_assertion(std::distance(in_edges(v, fga).first ,in_edges(v, fga).second) == 3);
-  CGAL_assertion(std::distance(out_edges(v, fga).first ,out_edges(v, fga).second) == 3);
+  assert(std::distance(in_edges(v, fga).first ,in_edges(v, fga).second) == 3);
+  assert(std::distance(out_edges(v, fga).first ,out_edges(v, fga).second) == 3);
 
   Mesh copy;
   CGAL::copy_face_graph(fga, copy);

--- a/Combinatorial_map/test/Combinatorial_map/Combinatorial_map_copy_test.cpp
+++ b/Combinatorial_map/test/Combinatorial_map/Combinatorial_map_copy_test.cpp
@@ -12,6 +12,7 @@
 #include <iostream>
 #include <fstream>
 #include <cstdlib>
+#include <cassert>
 
 using namespace std;
 
@@ -291,7 +292,7 @@ void create2Dmap(Map& map)
   CreateAttributes<Map,0>::run(map);
   CreateAttributes<Map,1>::run(map);
   CreateAttributes<Map,2>::run(map);
-  CGAL_assertion ( map.is_valid() );
+  assert( map.is_valid() );
 }
 template<typename Map>
 void create3Dmap(Map& map)
@@ -342,7 +343,7 @@ void create4Dmap(Map& map)
   CreateAttributes<Map,2>::run(map);
   CreateAttributes<Map,3>::run(map);
   CreateAttributes<Map,4>::run(map);
-  CGAL_assertion ( map.is_valid() );
+  assert( map.is_valid() );
 }
 
 bool testCopy()

--- a/Convex_hull_3/test/Convex_hull_3/ch3_4points.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/ch3_4points.cpp
@@ -2,6 +2,7 @@
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/convex_hull_3.h>
 #include <CGAL/Polygon_mesh_processing/orientation.h>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef K::Point_3 Point_3;
@@ -12,9 +13,9 @@ int main()
   Point_3 points[] = { Point_3(1.0, 0.0, 0.0), Point_3(0.0, 1.0, 0.0), Point_3(0.0, 0.0, 1.0), Point_3(0.0, 0.0, 0.0) };
   Gm_polyhedron P1;
   CGAL::convex_hull_3(points, &points[4], P1);
-  CGAL_assertion( CGAL::Polygon_mesh_processing::is_outward_oriented(P1) );
+  assert( CGAL::Polygon_mesh_processing::is_outward_oriented(P1) );
 
   Point_3 points_bis[] = { Point_3(0.0, 1.0, 0.0), Point_3(1.0, 0.0, 0.0), Point_3(0.0, 0.0, 1.0), Point_3(0.0, 0.0, 0.0) };
   CGAL::convex_hull_3(points_bis, &points_bis[4], P1);
-  CGAL_assertion( CGAL::Polygon_mesh_processing::is_outward_oriented(P1) );
+  assert( CGAL::Polygon_mesh_processing::is_outward_oriented(P1) );
 }

--- a/Kernel_23/test/Kernel_23/test_Has_conversion.cpp
+++ b/Kernel_23/test/Kernel_23/test_Has_conversion.cpp
@@ -10,6 +10,8 @@
 //
 // Author(s)     : Mael Rouxel-Labbé
 
+#include <cassert>
+
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Simple_homogeneous.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel_with_kth_root.h>
@@ -42,26 +44,26 @@ int main()
   CGAL_USE_TYPE(FSH);
   CGAL_USE_TYPE(EPECK);
 
-  CGAL_assertion((CGAL::Has_conversion<SC, SC, SC::Point_2, SC::Point_2>::value));
-  CGAL_assertion((CGAL::Has_conversion<SC, SC, SC::Object_2, SC::Object_2>::value));
+  assert((CGAL::Has_conversion<SC, SC, SC::Point_2, SC::Point_2>::value));
+  assert((CGAL::Has_conversion<SC, SC, SC::Object_2, SC::Object_2>::value));
 
-  CGAL_assertion(!(CGAL::Has_conversion<SC, SC, SC::Point_2, SC::Point_3>::value));
-  CGAL_assertion(!(CGAL::Has_conversion<SC, SC, SC::Iso_cuboid_3, SC::Circle_2>::value));
+  assert(!(CGAL::Has_conversion<SC, SC, SC::Point_2, SC::Point_3>::value));
+  assert(!(CGAL::Has_conversion<SC, SC, SC::Iso_cuboid_3, SC::Circle_2>::value));
 
-  CGAL_assertion((CGAL::Has_conversion<SC, FSC, SC::Vector_2, FSC::Vector_2>::value));
-  CGAL_assertion((CGAL::Has_conversion<FSC, SC, FSC::Vector_3, SC::Vector_3>::value));
-  CGAL_assertion((CGAL::Has_conversion<SH, FSH, SH::Vector_3, FSH::Vector_3>::value));
+  assert((CGAL::Has_conversion<SC, FSC, SC::Vector_2, FSC::Vector_2>::value));
+  assert((CGAL::Has_conversion<FSC, SC, FSC::Vector_3, SC::Vector_3>::value));
+  assert((CGAL::Has_conversion<SH, FSH, SH::Vector_3, FSH::Vector_3>::value));
 
-  CGAL_assertion((CGAL::Has_conversion<SC, ASC, SC::Sphere_3, ASC::Sphere_3>::value));
-  CGAL_assertion((CGAL::Has_conversion<SC, EPECK, SC::Triangle_2, EPECK::Triangle_2>::value));
-  CGAL_assertion((CGAL::Has_conversion<EPECK, SC, EPECK::Circle_3, SC::Circle_3>::value));
+  assert((CGAL::Has_conversion<SC, ASC, SC::Sphere_3, ASC::Sphere_3>::value));
+  assert((CGAL::Has_conversion<SC, EPECK, SC::Triangle_2, EPECK::Triangle_2>::value));
+  assert((CGAL::Has_conversion<EPECK, SC, EPECK::Circle_3, SC::Circle_3>::value));
 
-  CGAL_assertion(!(CGAL::Has_conversion<SC, EPECK, SC::Weighted_point_2, EPECK::Weighted_point_3>::value));
-  CGAL_assertion(!(CGAL::Has_conversion<SC, ASC, SC::Point_2, ASC::Weighted_point_2>::value));
+  assert(!(CGAL::Has_conversion<SC, EPECK, SC::Weighted_point_2, EPECK::Weighted_point_3>::value));
+  assert(!(CGAL::Has_conversion<SC, ASC, SC::Point_2, ASC::Weighted_point_2>::value));
 
   // below will produce static assert failures
-//  CGAL_assertion((CGAL::Has_conversion<SC, SH, SC::Point_2, SH::Point_2>::value));
-//  CGAL_assertion((CGAL::Has_conversion<FSH, EPECK, FSH::Point_3, EPECK::Point_2>::value));
+//  assert((CGAL::Has_conversion<SC, SH, SC::Point_2, SH::Point_2>::value));
+//  assert((CGAL::Has_conversion<FSH, EPECK, FSH::Point_3, EPECK::Point_2>::value));
 
 
 }

--- a/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_copy_test.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_copy_test.cpp
@@ -6,6 +6,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <cassert>
 
 using namespace std;
 
@@ -188,7 +189,7 @@ struct Converter_map9_points_into_map5_points
   (const CMap9& map1, CMap5& map2, CMap9::Dart_const_handle dh1,
    CMap5::Dart_handle dh2) const
   {
-    CGAL_assertion( map1.attribute<0>(dh1)!=map1.null_handle );
+    assert( map1.attribute<0>(dh1)!=map1.null_handle );
 
     CMap5::Attribute_handle<0>::type res = map2.attribute<0>(dh2);
     if ( res==map2.null_handle )
@@ -245,7 +246,7 @@ struct Converter_gmap9_points_into_gmap5_points
   (const GMap9& map1, GMap5& map2, GMap9::Dart_const_handle dh1,
    GMap5::Dart_handle dh2) const
   {
-    CGAL_assertion( map1.attribute<0>(dh1)!=map1.null_handle );
+    assert( map1.attribute<0>(dh1)!=map1.null_handle );
 
     GMap5::Attribute_handle<0>::type res = map2.attribute<0>(dh2);
     if ( res==map2.null_handle )
@@ -502,7 +503,7 @@ void create2Dmap(Map& map)
   CreateAttributes<Map,0>::run(map);
   CreateAttributes<Map,1>::run(map);
   CreateAttributes<Map,2>::run(map);
-  CGAL_assertion ( map.is_valid() );
+  assert( map.is_valid() );
 }
 template<typename Map>
 void create3Dmap(Map& map)
@@ -526,7 +527,7 @@ void create3Dmap(Map& map)
   CreateAttributes<Map,1>::run(map);
   CreateAttributes<Map,2>::run(map);
   CreateAttributes<Map,3>::run(map);
-  CGAL_assertion ( map.is_valid() );
+  assert( map.is_valid() );
 }
 
 template<typename LCC>
@@ -572,7 +573,7 @@ void create4Dmap(Map& map)
   CreateAttributes<Map,2>::run(map);
   CreateAttributes<Map,3>::run(map);
   CreateAttributes<Map,4>::run(map);
-  CGAL_assertion ( map.is_valid() );
+  assert( map.is_valid() );
 }
 
 template<typename Map1,

--- a/Mesh_2/test/Mesh_2/test_lipschitz.cpp
+++ b/Mesh_2/test/Mesh_2/test_lipschitz.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include "test_dependencies.h"
 
 // and additionally
@@ -28,6 +29,6 @@ int main()
 
   CGAL::Lipschitz_sizing_field_2<CDT> lip_size(cdt);
   lip_size.set_K(2.);
-  CGAL_assertion(lip_size.get_K() == 2.);
+  assert(lip_size.get_K() == 2.);
 
 }

--- a/Mesh_2/test/Mesh_2/test_lloyd.cpp
+++ b/Mesh_2/test/Mesh_2/test_lloyd.cpp
@@ -40,7 +40,7 @@ struct Lloyd_tester
     std::cerr << "Reading fish-and-rectangle.poly...";
     std::ifstream poly_file("fish-and-rectangle.poly");
     CGAL::IO::read_triangle_poly_file(cdt, poly_file, std::back_inserter(seeds));
-    CGAL_assertion( cdt.is_valid() );
+    assert( cdt.is_valid() );
 
     std::cerr << " done.\nNumber of vertices: " << cdt.number_of_vertices()
               << "\nNumber of seeds: " << seeds.size() << "\n\n";
@@ -50,8 +50,8 @@ struct Lloyd_tester
                                  seeds.begin(), seeds.end(),
                                  Criteria(0.125, 0.1));
     std::cerr << " done.\nNumber of vertices: " << cdt.number_of_vertices() << "\n\n";
-    CGAL_assertion( cdt.is_valid() );
-    CGAL_assertion( 580 <= cdt.number_of_vertices() &&
+    assert( cdt.is_valid() );
+    assert( 580 <= cdt.number_of_vertices() &&
                     cdt.number_of_vertices() <= 640 );
 
     CGAL_assertion_code(
@@ -70,9 +70,9 @@ struct Lloyd_tester
     std::cerr << " done (return code = "<< rc <<").\n";
     std::cerr << "Number of vertices: " << number_of_vertices2 << "\n\n";
 
-    CGAL_assertion( cdt.is_valid() );
-    CGAL_assertion( number_of_vertices1 == number_of_vertices2 );
-    CGAL_assertion( number_of_constraints == number_of_constrained_edges(cdt));
+    assert( cdt.is_valid() );
+    assert( number_of_vertices1 == number_of_vertices2 );
+    assert( number_of_constraints == number_of_constrained_edges(cdt));
   }
 };
 

--- a/Mesh_2/test/Mesh_2/test_lloyd.cpp
+++ b/Mesh_2/test/Mesh_2/test_lloyd.cpp
@@ -54,10 +54,9 @@ struct Lloyd_tester
     assert( 580 <= cdt.number_of_vertices() &&
                     cdt.number_of_vertices() <= 640 );
 
-    CGAL_assertion_code(
-      const size_type number_of_constraints = number_of_constrained_edges(cdt));
-    CGAL_assertion_code(
-      const size_type number_of_vertices1 = cdt.number_of_vertices());
+
+    const size_type number_of_constraints = number_of_constrained_edges(cdt);
+    const size_type number_of_vertices1 = cdt.number_of_vertices();
 
     CGAL::Mesh_optimization_return_code rc
       = CGAL::lloyd_optimize_mesh_2(cdt,

--- a/Mesh_3/test/Mesh_3/test_c3t3_into_facegraph.cpp
+++ b/Mesh_3/test/Mesh_3/test_c3t3_into_facegraph.cpp
@@ -12,6 +12,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <cassert>
 
 int main (int argc, char** argv){
   typedef CGAL::Exact_predicates_inexact_constructions_kernel                 K;
@@ -49,7 +50,7 @@ int main (int argc, char** argv){
          cit != c3t3.triangulation().finite_cells_end();
          ++cit)
     {
-      CGAL_assertion(cit->subdomain_index() >= 0);
+      assert(cit->subdomain_index() >= 0);
       c3t3.add_to_complex(cit, cit->subdomain_index());
       for(int i=0; i < 4; ++i)
       {
@@ -89,6 +90,6 @@ int main (int argc, char** argv){
   std::ofstream out("graph.off");
   out << poly;
 
-  CGAL_assertion(is_valid(poly));
+  assert(is_valid(poly));
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_mesh_cell_base_3.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_cell_base_3.cpp
@@ -13,6 +13,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <cassert>
 
 int main (int argc, char** argv){
   typedef CGAL::Exact_predicates_inexact_constructions_kernel                 K;
@@ -55,7 +56,7 @@ int main (int argc, char** argv){
          cit != c3t3.triangulation().finite_cells_end();
          ++cit)
     {
-      CGAL_assertion(cit->subdomain_index() >= 0);
+      assert(cit->subdomain_index() >= 0);
       c3t3.add_to_complex(cit, cit->subdomain_index());
       for(int i=0; i < 4; ++i)
       {
@@ -95,6 +96,6 @@ int main (int argc, char** argv){
   std::ofstream out("graph.off");
   out << poly;
 
-  CGAL_assertion(is_valid(poly));
+  assert(is_valid(poly));
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_determinism.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_determinism.cpp
@@ -11,6 +11,7 @@
 #include <CGAL/exude_mesh_3.h>
 #include <CGAL/facets_in_complex_3_to_triangle_mesh.h>
 
+#include <cassert>
 #include <fstream>
 #include <sstream>
 #include <cstring>
@@ -137,12 +138,12 @@ void test()
       if(0 != output_c3t3[5*(i-1)+j].compare(output_c3t3[5*i+j]))
       {
         std::cerr << "Meshing operation " << j << " is not deterministic.\n";
-        CGAL_assertion(false);
+        assert(false);
       }
       if (0 != output_surfaces[5 * (i - 1) + j].compare(output_surfaces[5 * i + j]))
       {
         std::cerr << "Output surface after operation " << j << " is not deterministic.\n";
-        CGAL_assertion(false);
+        assert(false);
       }
     }
   }

--- a/Nef_3/test/Nef_3/test_nef_to_soup.cpp
+++ b/Nef_3/test/Nef_3/test_nef_to_soup.cpp
@@ -7,6 +7,7 @@
 #include <CGAL/IO/Nef_polyhedron_iostream_3.h>
 
 #include <fstream>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_exact_constructions_kernel EPEC;
 typedef CGAL::Exact_predicates_inexact_constructions_kernel EPIC;
@@ -39,8 +40,8 @@ int main()
   PolygonRange polygons;
     std::cout << "    convert...\n";
   CGAL::convert_nef_polyhedron_to_polygon_soup(nef, points, polygons);
-  CGAL_assertion(points.size() == 4);
-  CGAL_assertion(polygons.size() == 4);
+  assert(points.size() == 4);
+  assert(polygons.size() == 4);
   PolygonMesh pm;
   CGAL::convert_nef_polyhedron_to_polygon_mesh<
       Nef_polyhedron,

--- a/Number_types/test/Number_types/CORE_Expr.cpp
+++ b/Number_types/test/Number_types/CORE_Expr.cpp
@@ -3,7 +3,9 @@
 #ifdef CGAL_USE_CORE
 #include <sstream>
 #include <list>
+#include <cassert>
 #include <cstdlib>
+
 #include <CGAL/CORE_Expr.h>
 #include <CGAL/Gmpq.h>
 #include <CGAL/Test/_test_algebraic_structure.h>
@@ -30,7 +32,7 @@ void precision_bug()
     sqrtD1D2.approx(53,1075); //force evaluation of sqrtD1D2
     uz.approx(53,1075);
 
-    CGAL_assertion(!uz.isZero());
+    assert(!uz.isZero());
   }
   //computation without forced evaluation of sqrtD1D2
   {
@@ -47,7 +49,7 @@ void precision_bug()
     FT a1a2b1b2 = a1 * a2 + b1 * b2;
     FT uz =  sqrtD1D2 -  a1a2b1b2 ;
 
-    CGAL_assertion(!uz.isZero());
+    assert(!uz.isZero());
   }
   std::cout << "precision bug OK\n";
 }
@@ -667,4 +669,3 @@ int main(){
 int main() { return 0; }
 #endif // CGAL_USE_CORE
 //EOF
-

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/include/interface_test.h
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/include/interface_test.h
@@ -16,30 +16,30 @@ void test_constructor()
 
   T t;
   T t2(t);
-  CGAL_assertion(t == t2);
+  assert(t == t2);
   T t3 = t2;
-  CGAL_assertion(t == t3);
+  assert(t == t3);
   T t4(Iso_rectangle(0, 0, 2, 2));
   T t5(Iso_rectangle(0, 0, 2, 2), Geom_traits());
   t5.clear();
 
   t.insert(Point(0.5, 0.5));
-  CGAL_assertion(t != t2);
-  CGAL_assertion(t != t3);
+  assert(t != t2);
+  assert(t != t3);
 
   T t6(t);
-  CGAL_assertion(t == t6);
+  assert(t == t6);
   T t7 = t6;
-  CGAL_assertion(t == t7);
+  assert(t == t7);
 
   t.clear();
-  CGAL_assertion(t != t6);
-  CGAL_assertion(t != t7);
+  assert(t != t6);
+  assert(t != t7);
 
   t.swap(t7);
-  CGAL_assertion(t7.empty());
-  CGAL_assertion(!t.empty());
-  CGAL_assertion(t != t7);
+  assert(t7.empty());
+  assert(!t.empty());
+  assert(t != t7);
 }
 
 template <class T>
@@ -58,28 +58,28 @@ void test_global_access()
   t_const.dimension();
 
   size_t number_of_vertices = t_const.number_of_vertices();
-  CGAL_USE(number_of_vertices);
-  CGAL_assertion(number_of_vertices == t.number_of_vertices());
+
+  assert(number_of_vertices == t.number_of_vertices());
   size_t number_of_faces = t_const.number_of_faces();
-  CGAL_USE(number_of_faces);
-  CGAL_assertion(number_of_faces == t.number_of_faces());
+
+  assert(number_of_faces == t.number_of_faces());
   size_t number_of_stored_vertices = t_const.number_of_stored_vertices();
-  CGAL_USE(number_of_stored_vertices);
-  CGAL_assertion(number_of_stored_vertices == t.number_of_stored_vertices());
+
+  assert(number_of_stored_vertices == t.number_of_stored_vertices());
   size_t number_of_stored_faces = t_const.number_of_stored_faces();
-  CGAL_USE(number_of_stored_faces);
-  CGAL_assertion(number_of_stored_faces == t.number_of_stored_faces());
+
+  assert(number_of_stored_faces == t.number_of_stored_faces());
 
   size_t number_of_edges = t_const.number_of_edges();
-  CGAL_USE(number_of_edges);
-  CGAL_assertion(number_of_edges == t.number_of_edges());
+
+  assert(number_of_edges == t.number_of_edges());
   size_t number_of_stored_edges = t_const.number_of_stored_edges();
-  CGAL_USE(number_of_stored_edges);
-  CGAL_assertion(number_of_stored_edges == t.number_of_stored_edges());
+
+  assert(number_of_stored_edges == t.number_of_stored_edges());
 
   bool is_triang1 = t_const.is_triangulation_in_1_sheet();
-  CGAL_USE(is_triang1);
-  CGAL_assertion(is_triang1 == t.is_triangulation_in_1_sheet());
+
+  assert(is_triang1 == t.is_triangulation_in_1_sheet());
   t.convert_to_1_sheeted_covering();
   t.convert_to_9_sheeted_covering();
 }
@@ -91,11 +91,11 @@ void test_delaunay_global_access()
   const T &t_const = t;
 
   bool ext1 = t_const.is_extensible_triangulation_in_1_sheet_h1();
-  CGAL_USE(ext1);
-  CGAL_assertion(ext1 == t.is_extensible_triangulation_in_1_sheet_h1());
+
+  assert(ext1 == t.is_extensible_triangulation_in_1_sheet_h1());
   bool ext2 = t_const.is_extensible_triangulation_in_1_sheet_h2();
-  CGAL_USE(ext2);
-  CGAL_assertion(ext2 == t.is_extensible_triangulation_in_1_sheet_h2());
+
+  assert(ext2 == t.is_extensible_triangulation_in_1_sheet_h2());
 }
 
 template <class T>
@@ -215,21 +215,21 @@ void test_iterators()
     {
       ++size;
     }
-  CGAL_assertion(size == t_const.number_of_stored_vertices());
+  assert(size == t_const.number_of_stored_vertices());
   size = 0;
   for (typename T::Unique_vertex_iterator uvit = t_const.unique_vertices_begin();
        uvit != t_const.unique_vertices_end(); ++uvit)
     {
       ++size;
     }
-  CGAL_assertion(size == t_const.number_of_vertices());
+  assert(size == t_const.number_of_vertices());
   size = 0;
   for (typename T::Vertex_iterator vit = t_const.all_vertices_begin();
        vit != t_const.all_vertices_end(); ++vit)
     {
       ++size;
     }
-  CGAL_assertion(size == t_const.number_of_stored_vertices());
+  assert(size == t_const.number_of_stored_vertices());
 
   // edges
   size = 0;
@@ -238,14 +238,14 @@ void test_iterators()
     {
       ++size;
     }
-  CGAL_assertion(size == t_const.number_of_stored_edges());
+  assert(size == t_const.number_of_stored_edges());
   size = 0;
   for (typename T::Edge_iterator eit = t_const.all_edges_begin();
        eit != t_const.all_edges_end(); ++eit)
     {
       ++size;
     }
-  CGAL_assertion(size == t_const.number_of_stored_edges());
+  assert(size == t_const.number_of_stored_edges());
 
   // faces
   size = 0;
@@ -254,14 +254,14 @@ void test_iterators()
     {
       ++size;
     }
-  CGAL_assertion(size == t_const.number_of_stored_faces());
+  assert(size == t_const.number_of_stored_faces());
   size = 0;
   for (typename T::All_faces_iterator fit = t_const.all_faces_begin();
        fit != t_const.all_faces_end(); ++fit)
     {
       ++size;
     }
-  CGAL_assertion(size == t_const.number_of_stored_faces());
+  assert(size == t_const.number_of_stored_faces());
 
   /// Geometric iterators
   for (typename T::Periodic_point_iterator ppit = t_const.periodic_points_begin();
@@ -422,10 +422,10 @@ void test_modifiers()
   vh0 = t.insert_first(p0);
 
   fh = t_const.locate(p1, lt, li);
-  CGAL_assertion(lt == T::FACE);
+  assert(lt == T::FACE);
   t.insert_in_face(p1, fh);
   fh = t_const.locate(p2, lt, li);
-  CGAL_assertion(lt == T::EDGE);
+  assert(lt == T::EDGE);
   t.insert_in_edge(p2, fh, li);
 
   for (typename T::Vertex_iterator vit = t_const.vertices_begin();
@@ -465,9 +465,8 @@ void test_miscellaneous()
   t.set_domain(typename T::Iso_rectangle(0, 0, 2, 2));
   int i = t.ccw(0);
   int j = t.cw(0);
-  CGAL_USE(i);
-  CGAL_USE(j);
-  CGAL_assertion(i + j == 3);
+
+  assert(i + j == 3);
 
   t = T();
   vh0 = t.insert(p0);
@@ -551,7 +550,7 @@ void test_io(bool exact)
   for (int x = 0; x < 5; ++x)
     for (int y = 0; y < 5; ++y)
       t.insert(Point(x / 5.0, y / 5.0));
-  CGAL_assertion(t.number_of_vertices() == 25);
+  assert(t.number_of_vertices() == 25);
   test_io(t, exact);
 
   std::cout << __FILE__ << ", " << __LINE__ << std::endl;
@@ -613,18 +612,18 @@ void test_nearest()
   Vertex_handle vh0, vh1, vh2;
 
   T t;
-  CGAL_assertion(t.nearest_vertex(p0) == Vertex_handle());
+  assert(t.nearest_vertex(p0) == Vertex_handle());
 
   vh0 = t.insert(p0);
-  CGAL_assertion(t.get_original_vertex(t.nearest_vertex(p0)) == vh0);
-  CGAL_assertion(t.get_original_vertex(t.nearest_vertex(p1)) == vh0);
-  CGAL_assertion(t.get_original_vertex(t.nearest_vertex(p2)) == vh0);
+  assert(t.get_original_vertex(t.nearest_vertex(p0)) == vh0);
+  assert(t.get_original_vertex(t.nearest_vertex(p1)) == vh0);
+  assert(t.get_original_vertex(t.nearest_vertex(p2)) == vh0);
 
   vh1 = t.insert(p1);
   vh2 = t.insert(p2);
-  CGAL_assertion(t.get_original_vertex(t.nearest_vertex(p0)) == vh0);
-  CGAL_assertion(t.get_original_vertex(t.nearest_vertex(p1)) == vh1);
-  CGAL_assertion(t.get_original_vertex(t.nearest_vertex(p2)) == vh2);
+  assert(t.get_original_vertex(t.nearest_vertex(p0)) == vh0);
+  assert(t.get_original_vertex(t.nearest_vertex(p1)) == vh1);
+  assert(t.get_original_vertex(t.nearest_vertex(p2)) == vh2);
 }
 
 template <class T>
@@ -651,7 +650,7 @@ void test_locally_delaunay()
     {
       for (int i = 0; i < 3; ++i)
         {
-          CGAL_assertion(t.locally_Delaunay(fit, i, fit->neighbor(i)));
+          assert(t.locally_Delaunay(fit, i, fit->neighbor(i)));
         }
     }
 
@@ -662,7 +661,7 @@ void test_locally_delaunay()
     {
       for (int i = 0; i < 3; ++i)
         {
-          CGAL_assertion(t.locally_Delaunay(fit, i, fit->neighbor(i)));
+          assert(t.locally_Delaunay(fit, i, fit->neighbor(i)));
         }
     }
 

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_delaunay_insert_degenerate.cpp
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_delaunay_insert_degenerate.cpp
@@ -21,20 +21,20 @@ void test_insertion()
     }
 
   Triangulation pt(pts_rnd1000.begin(), pts_rnd1000.end());
-  CGAL_assertion(pt.is_valid());
-  CGAL_assertion(pt.number_of_vertices() == 1000);
+  assert(pt.is_valid());
+  assert(pt.number_of_vertices() == 1000);
   pt.clear();
-  CGAL_assertion(pt.is_valid());
-  CGAL_assertion(pt.empty());
-  CGAL_assertion(pt.number_of_vertices() == 0);
+  assert(pt.is_valid());
+  assert(pt.empty());
+  assert(pt.number_of_vertices() == 0);
 
   pt.insert(pts_rnd1000.begin(), pts_rnd1000.end());
-  CGAL_assertion(pt.is_valid());
-  CGAL_assertion(pt.number_of_vertices() == 1000);
+  assert(pt.is_valid());
+  assert(pt.number_of_vertices() == 1000);
   pt.clear();
-  CGAL_assertion(pt.is_valid());
-  CGAL_assertion(pt.empty());
-  CGAL_assertion(pt.number_of_vertices() == 0);
+  assert(pt.is_valid());
+  assert(pt.empty());
+  assert(pt.number_of_vertices() == 0);
 
   // Center of the circle around the origin
   pts_rnd1000.clear();
@@ -45,12 +45,12 @@ void test_insertion()
     }
 
   pt.insert(pts_rnd1000.begin(), pts_rnd1000.end());
-  CGAL_assertion(pt.is_valid());
-  CGAL_assertion(pt.number_of_vertices() == 1000);
+  assert(pt.is_valid());
+  assert(pt.number_of_vertices() == 1000);
   pt.clear();
-  CGAL_assertion(pt.is_valid());
-  CGAL_assertion(pt.empty());
-  CGAL_assertion(pt.number_of_vertices() == 0);
+  assert(pt.is_valid());
+  assert(pt.empty());
+  assert(pt.number_of_vertices() == 0);
 }
 
 int main()

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_delaunay_remove.cpp
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_delaunay_remove.cpp
@@ -16,13 +16,13 @@ int main()
   Triangulation::Locate_type lt;
   int i;
   fh = t.locate(Point(0, 0) + midpoint, lt, i);
-  CGAL_assertion(lt == Triangulation::EMPTY);
+  assert(lt == Triangulation::EMPTY);
 
   Vertex_handle vh_midpoint = t.insert(Point(0, 0) + midpoint);
   fh = t.locate(Point(0, 0) + midpoint, lt, i);
-  CGAL_assertion(lt == Triangulation::VERTEX && fh->vertex(i) == vh_midpoint);
+  assert(lt == Triangulation::VERTEX && fh->vertex(i) == vh_midpoint);
   t.remove(vh_midpoint);
-  CGAL_assertion(t.empty());
+  assert(t.empty());
 
   // High degree vertex
   for (int n = 3; n < 8; ++n)
@@ -33,11 +33,11 @@ int main()
           t.insert(Point(0.3 * sin(i * 1.0 / n * 2 * M_PI), 0.3 * cos(i * 1.0 / n * 2 * M_PI)) + midpoint);
         }
       t.remove(vh_midpoint);
-      CGAL_assertion(t.is_valid(true));
+      assert(t.is_valid(true));
       while (!t.empty())
         {
           t.remove(t.vertices_begin());
-          CGAL_assertion(t.is_valid(true));
+          assert(t.is_valid(true));
         }
     }
 
@@ -45,14 +45,14 @@ int main()
   std::cout << "Seed: " << random.get_seed () << std::endl;
   Random_points_in_square g(0.495, random);
 
-  CGAL_assertion(t.is_valid());
+  assert(t.is_valid());
 
   std::cout << "Removing first point" << std::endl;
   Vertex_handle vh0 = t.insert(Point(0.5, 0.5));
-  CGAL_assertion(t.is_valid());
+  assert(t.is_valid());
   t.remove(vh0);
-  CGAL_assertion(t.is_valid());
-  CGAL_assertion(t.empty());
+  assert(t.is_valid());
+  assert(t.empty());
 
   {
     Random random(1284141159);
@@ -62,14 +62,14 @@ int main()
     Vector midpoint(0.5, 0.5);
 
     Triangulation t;
-    CGAL_assertion(t.is_valid());
+    assert(t.is_valid());
 
     std::cout << "Removing first point" << std::endl;
     Vertex_handle vh0 = t.insert(Point(0.5, 0.5));
-    CGAL_assertion(t.is_valid());
+    assert(t.is_valid());
     t.remove(vh0);
-    CGAL_assertion(t.is_valid());
-    CGAL_assertion(t.empty());
+    assert(t.is_valid());
+    assert(t.empty());
 
     std::cout << "Inserting random points and removing them." << std::endl;
 
@@ -77,7 +77,7 @@ int main()
       {
         t.insert(*(++g) + midpoint);
       }
-    CGAL_assertion(t.is_valid());
+    assert(t.is_valid());
 
     for (int i = 0; i < N_PTS; ++i)
       {
@@ -85,7 +85,7 @@ int main()
         Vertex_handle vh = t.locate(*(++g) + midpoint)->vertex(0);
         vh = t.get_original_vertex(vh);
         t.remove(vh);
-        CGAL_assertion(t.is_valid());
+        assert(t.is_valid());
       }
   }
   return 0;

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_performance_test.cpp
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_performance_test.cpp
@@ -112,7 +112,7 @@ int main()
                         << periodic_insert_time <<  ", \t" << periodic_insert_time << std::endl;
             }
         }
-      CGAL_assertion(t.is_valid());
+      assert(t.is_valid());
 
       std::cout << std::endl;
     }

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_test_semi_static_predicates.cpp
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_test_semi_static_predicates.cpp
@@ -18,37 +18,37 @@ void test_orientation()
   Point p1(0.5 + (0.4999 / N) * 4, 0.5 + (0.4999 / N) * -4);
   Point p2(0.5 + (0.4999 / N) * 6, 0.5 + (0.4999 / N) * -3);
 
-  CGAL_assertion(traits.orientation_2_object()(p0, p1, p2) == 1);
-  CGAL_assertion(traits.orientation_2_object()(p2, p0, p1) == 1);
-  CGAL_assertion(traits.orientation_2_object()(p1, p2, p0) == 1);
-  CGAL_assertion(traits.orientation_2_object()(p0, p2, p1) == -1);
-  CGAL_assertion(traits.orientation_2_object()(p1, p0, p2) == -1);
-  CGAL_assertion(traits.orientation_2_object()(p2, p1, p0) == -1);
+  assert(traits.orientation_2_object()(p0, p1, p2) == 1);
+  assert(traits.orientation_2_object()(p2, p0, p1) == 1);
+  assert(traits.orientation_2_object()(p1, p2, p0) == 1);
+  assert(traits.orientation_2_object()(p0, p2, p1) == -1);
+  assert(traits.orientation_2_object()(p1, p0, p2) == -1);
+  assert(traits.orientation_2_object()(p2, p1, p0) == -1);
 
-  CGAL_assertion(traits.orientation_2_object()(p0, p1, p2) ==
+  assert(traits.orientation_2_object()(p0, p1, p2) ==
                  traits.orientation_2_object()(p0, p1, p2, o0, o0, o0));
-  CGAL_assertion(traits.orientation_2_object()(p2, p0, p1) ==
+  assert(traits.orientation_2_object()(p2, p0, p1) ==
                  traits.orientation_2_object()(p2, p0, p1, o0, o0, o0));
-  CGAL_assertion(traits.orientation_2_object()(p1, p2, p0) ==
+  assert(traits.orientation_2_object()(p1, p2, p0) ==
                  traits.orientation_2_object()(p1, p2, p0, o0, o0, o0));
-  CGAL_assertion(traits.orientation_2_object()(p0, p2, p1) ==
+  assert(traits.orientation_2_object()(p0, p2, p1) ==
                  traits.orientation_2_object()(p0, p2, p1, o0, o0, o0));
-  CGAL_assertion(traits.orientation_2_object()(p1, p0, p2) ==
+  assert(traits.orientation_2_object()(p1, p0, p2) ==
                  traits.orientation_2_object()(p1, p0, p2, o0, o0, o0));
-  CGAL_assertion(traits.orientation_2_object()(p2, p1, p0) ==
+  assert(traits.orientation_2_object()(p2, p1, p0) ==
                  traits.orientation_2_object()(p2, p1, p0, o0, o0, o0));
 
-  CGAL_assertion(traits.orientation_2_object()(p0, p1, p2) ==
+  assert(traits.orientation_2_object()(p0, p1, p2) ==
                  traits.orientation_2_object()(p0, p1, p2, o1, o1, o1));
-  CGAL_assertion(traits.orientation_2_object()(p2, p0, p1) ==
+  assert(traits.orientation_2_object()(p2, p0, p1) ==
                  traits.orientation_2_object()(p2, p0, p1, o1, o1, o1));
-  CGAL_assertion(traits.orientation_2_object()(p1, p2, p0) ==
+  assert(traits.orientation_2_object()(p1, p2, p0) ==
                  traits.orientation_2_object()(p1, p2, p0, o1, o1, o1));
-  CGAL_assertion(traits.orientation_2_object()(p0, p2, p1) ==
+  assert(traits.orientation_2_object()(p0, p2, p1) ==
                  traits.orientation_2_object()(p0, p2, p1, o1, o1, o1));
-  CGAL_assertion(traits.orientation_2_object()(p1, p0, p2) ==
+  assert(traits.orientation_2_object()(p1, p0, p2) ==
                  traits.orientation_2_object()(p1, p0, p2, o1, o1, o1));
-  CGAL_assertion(traits.orientation_2_object()(p2, p1, p0) ==
+  assert(traits.orientation_2_object()(p2, p1, p0) ==
                  traits.orientation_2_object()(p2, p1, p0, o1, o1, o1));
 }
 
@@ -67,37 +67,37 @@ void test_in_circle()
   Point p2(-4 - 0.4999,  3 - 0.4999);
   Point p3( 4 - 0.4999, -3 - 0.4999);
 
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p0, p1, p2, p3) == 1);
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p2, p0, p1, p3) == 1);
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p1, p2, p0, p3) == 1);
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p0, p2, p1, p3) == -1);
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p1, p0, p2, p3) == -1);
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p2, p1, p0, p3) == -1);
+  assert(traits.side_of_oriented_circle_2_object()(p0, p1, p2, p3) == 1);
+  assert(traits.side_of_oriented_circle_2_object()(p2, p0, p1, p3) == 1);
+  assert(traits.side_of_oriented_circle_2_object()(p1, p2, p0, p3) == 1);
+  assert(traits.side_of_oriented_circle_2_object()(p0, p2, p1, p3) == -1);
+  assert(traits.side_of_oriented_circle_2_object()(p1, p0, p2, p3) == -1);
+  assert(traits.side_of_oriented_circle_2_object()(p2, p1, p0, p3) == -1);
 
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p0, p1, p2, p3) ==
+  assert(traits.side_of_oriented_circle_2_object()(p0, p1, p2, p3) ==
                  traits.side_of_oriented_circle_2_object()(p0, p1, p2, p3, o0, o0, o0, o0));
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p2, p0, p1, p3) ==
+  assert(traits.side_of_oriented_circle_2_object()(p2, p0, p1, p3) ==
                  traits.side_of_oriented_circle_2_object()(p2, p0, p1, p3, o0, o0, o0, o0));
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p1, p2, p0, p3) ==
+  assert(traits.side_of_oriented_circle_2_object()(p1, p2, p0, p3) ==
                  traits.side_of_oriented_circle_2_object()(p1, p2, p0, p3, o0, o0, o0, o0));
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p0, p2, p1, p3) ==
+  assert(traits.side_of_oriented_circle_2_object()(p0, p2, p1, p3) ==
                  traits.side_of_oriented_circle_2_object()(p0, p2, p1, p3, o0, o0, o0, o0));
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p1, p0, p2, p3) ==
+  assert(traits.side_of_oriented_circle_2_object()(p1, p0, p2, p3) ==
                  traits.side_of_oriented_circle_2_object()(p1, p0, p2, p3, o0, o0, o0, o0));
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p2, p1, p0, p3) ==
+  assert(traits.side_of_oriented_circle_2_object()(p2, p1, p0, p3) ==
                  traits.side_of_oriented_circle_2_object()(p2, p1, p0, p3, o0, o0, o0, o0));
 
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p0, p1, p2, p3) ==
+  assert(traits.side_of_oriented_circle_2_object()(p0, p1, p2, p3) ==
                  traits.side_of_oriented_circle_2_object()(p0, p1, p2, p3, o1, o1, o1, o1));
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p2, p0, p1, p3) ==
+  assert(traits.side_of_oriented_circle_2_object()(p2, p0, p1, p3) ==
                  traits.side_of_oriented_circle_2_object()(p2, p0, p1, p3, o1, o1, o1, o1));
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p1, p2, p0, p3) ==
+  assert(traits.side_of_oriented_circle_2_object()(p1, p2, p0, p3) ==
                  traits.side_of_oriented_circle_2_object()(p1, p2, p0, p3, o1, o1, o1, o1));
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p0, p2, p1, p3) ==
+  assert(traits.side_of_oriented_circle_2_object()(p0, p2, p1, p3) ==
                  traits.side_of_oriented_circle_2_object()(p0, p2, p1, p3, o1, o1, o1, o1));
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p1, p0, p2, p3) ==
+  assert(traits.side_of_oriented_circle_2_object()(p1, p0, p2, p3) ==
                  traits.side_of_oriented_circle_2_object()(p1, p0, p2, p3, o1, o1, o1, o1));
-  CGAL_assertion(traits.side_of_oriented_circle_2_object()(p2, p1, p0, p3) ==
+  assert(traits.side_of_oriented_circle_2_object()(p2, p1, p0, p3) ==
                  traits.side_of_oriented_circle_2_object()(p2, p1, p0, p3, o1, o1, o1, o1));
 }
 

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_triangulation_flip.cpp
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_triangulation_flip.cpp
@@ -65,7 +65,7 @@ int main()
 
   greedy_flip_long_edges(t);
   greedy_flip_long_edges(t);
-  CGAL_assertion(t.is_valid());
+  assert(t.is_valid());
 
   size_t n_vertices = t.number_of_vertices();
   size_t n_faces = t.number_of_faces();
@@ -75,26 +75,26 @@ int main()
   std::cout << "Converting to 1 cover" << std::endl;
   t.convert_to_1_sheeted_covering();
   std::cout << "... done" << std::endl;
-  CGAL_assertion(t.is_1_cover());
-  CGAL_assertion(t.is_valid());
-  CGAL_assertion(t.number_of_vertices() == n_vertices);
-  CGAL_assertion(t.number_of_faces() == n_faces);
+  assert(t.is_1_cover());
+  assert(t.is_valid());
+  assert(t.number_of_vertices() == n_vertices);
+  assert(t.number_of_faces() == n_faces);
 
   std::cout << "Converting to 9 cover" << std::endl;
   t.convert_to_9_sheeted_covering();
   std::cout << "... done" << std::endl;
-  CGAL_assertion(!t.is_1_cover());
-  CGAL_assertion(t.is_valid());
-  CGAL_assertion(t.number_of_vertices() == n_vertices);
-  CGAL_assertion(t.number_of_faces() == n_faces);
+  assert(!t.is_1_cover());
+  assert(t.is_valid());
+  assert(t.number_of_vertices() == n_vertices);
+  assert(t.number_of_faces() == n_faces);
 
   std::cout << "Converting to 1 cover" << std::endl;
   t.convert_to_1_sheeted_covering();
   std::cout << "... done" << std::endl;
-  CGAL_assertion(t.is_1_cover());
-  CGAL_assertion(t.is_valid());
-  CGAL_assertion(t.number_of_vertices() == n_vertices);
-  CGAL_assertion(t.number_of_faces() == n_faces);
+  assert(t.is_1_cover());
+  assert(t.is_valid());
+  assert(t.number_of_vertices() == n_vertices);
+  assert(t.number_of_faces() == n_faces);
 
   return 0;
 }

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_triangulation_insert_edge.cpp
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_triangulation_insert_edge.cpp
@@ -8,9 +8,9 @@ void insert_in_edge(Triangulation &t, const Point &p)
   int li;
 
   Face_handle fh = t.locate(p, lt, li);
-  CGAL_assertion(lt == Triangulation::EDGE);
+  assert(lt == Triangulation::EDGE);
   t.insert(p, fh);
-  CGAL_assertion(t.is_valid());
+  assert(t.is_valid());
 }
 
 int main()

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_triangulation_insert_grid.cpp
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_triangulation_insert_grid.cpp
@@ -21,7 +21,7 @@ void test_insertion_xy(int x_order, int y_order)
           t.insert(p);
         }
     }
-  CGAL_assertion(t.is_valid());
+  assert(t.is_valid());
 }
 
 void test_insertion_yx(int x_order, int y_order)
@@ -38,7 +38,7 @@ void test_insertion_yx(int x_order, int y_order)
           t.insert(p);
         }
     }
-  CGAL_assertion(t.is_valid());
+  assert(t.is_valid());
 }
 
 int main()

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_triangulation_insert_vertex.cpp
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_triangulation_insert_vertex.cpp
@@ -7,47 +7,43 @@ int main()
   Point p;
   Triangulation t;
 
-  CGAL_assertion(t.is_valid());
+  assert(t.is_valid());
 
   Point p0(0.5, 0.5);
-  CGAL_assertion_code(Vertex_handle vh0 = )
-  t.insert(p0);
-  CGAL_assertion(t.is_valid());
+  Vertex_handle vh0 = t.insert(p0);
+  assert(t.is_valid());
 
-  CGAL_assertion(t.number_of_vertices() == 1);
-  CGAL_assertion(vh0 == t.insert(p0));
-  CGAL_assertion(t.is_valid());
+  assert(t.number_of_vertices() == 1);
+  assert(vh0 == t.insert(p0));
+  assert(t.is_valid());
 
   Point p1(0.6, 0.5);
-  CGAL_assertion_code(Vertex_handle vh1 = )
-  t.insert(p1);
-  CGAL_assertion(t.is_valid());
-  CGAL_assertion(t.number_of_vertices() == 2);
-  CGAL_assertion(vh0 != vh1);
-  CGAL_assertion(vh0 == t.insert(p0));
-  CGAL_assertion(vh1 == t.insert(p1));
-  CGAL_assertion(t.is_valid());
+  Vertex_handle vh1 = t.insert(p1);
+  assert(t.is_valid());
+  assert(t.number_of_vertices() == 2);
+  assert(vh0 != vh1);
+  assert(vh0 == t.insert(p0));
+  assert(vh1 == t.insert(p1));
+  assert(t.is_valid());
 
   Point p2(0.5, 0.7);
-  CGAL_assertion_code(Vertex_handle vh2 = )
-  t.insert(p2);
-  CGAL_assertion(t.is_valid());
-  CGAL_assertion(t.number_of_vertices() == 3);
-  CGAL_assertion(vh0 == t.insert(p0));
-  CGAL_assertion(vh1 == t.insert(p1));
-  CGAL_assertion(vh2 == t.insert(p2));
-  CGAL_assertion(t.is_valid());
+  Vertex_handle vh2 = t.insert(p2);
+  assert(t.is_valid());
+  assert(t.number_of_vertices() == 3);
+  assert(vh0 == t.insert(p0));
+  assert(vh1 == t.insert(p1));
+  assert(vh2 == t.insert(p2));
+  assert(t.is_valid());
 
   Point p3(0.3, 0.4);
-  CGAL_assertion_code(Vertex_handle vh3 = )
-  t.insert(p3);
-  CGAL_assertion(t.is_valid());
-  CGAL_assertion(t.number_of_vertices() == 4);
-  CGAL_assertion(vh0 == t.insert(p0));
-  CGAL_assertion(vh1 == t.insert(p1));
-  CGAL_assertion(vh2 == t.insert(p2));
-  CGAL_assertion(vh3 == t.insert(p3));
-  CGAL_assertion(t.is_valid());
+  Vertex_handle vh3 = t.insert(p3);
+  assert(t.is_valid());
+  assert(t.number_of_vertices() == 4);
+  assert(vh0 == t.insert(p0));
+  assert(vh1 == t.insert(p1));
+  assert(vh2 == t.insert(p2));
+  assert(vh3 == t.insert(p3));
+  assert(t.is_valid());
 
   return 0;
 }

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_triangulation_point_location.cpp
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_triangulation_point_location.cpp
@@ -13,9 +13,9 @@ Face_handle test_point_location(const Triangulation &t,
   CGAL::Oriented_side os;
 
   fh = t.locate(query, lt, li);
-  CGAL_assertion(lt == lt_in);
+  assert(lt == lt_in);
   if (lt_in == Triangulation::EMPTY) {
-    CGAL_assertion(fh == Face_handle());
+    assert(fh == Face_handle());
     return fh;
   }
 
@@ -24,31 +24,31 @@ Face_handle test_point_location(const Triangulation &t,
   CGAL_USE(bs);
   CGAL_USE(os);
 
-  CGAL_assertion(lt2 == lt_in);
+  assert(lt2 == lt_in);
 
   switch (lt_in)
   {
     case Triangulation::VERTEX:
     case Triangulation::EDGE:
     {
-      CGAL_assertion(fh != Face_handle());
-      CGAL_assertion(bs == CGAL::ON_BOUNDARY);
-      CGAL_assertion(os == CGAL::ON_ORIENTED_BOUNDARY);
+      assert(fh != Face_handle());
+      assert(bs == CGAL::ON_BOUNDARY);
+      assert(os == CGAL::ON_ORIENTED_BOUNDARY);
 
-      CGAL_assertion(li == li2);
+      assert(li == li2);
       break;
     }
     case Triangulation::FACE:
     {
-      CGAL_assertion(fh != Face_handle());
-      CGAL_assertion(bs == CGAL::ON_BOUNDED_SIDE);
-      CGAL_assertion(os == CGAL::ON_POSITIVE_SIDE);
+      assert(fh != Face_handle());
+      assert(bs == CGAL::ON_BOUNDED_SIDE);
+      assert(os == CGAL::ON_POSITIVE_SIDE);
       break;
     }
     default:
     {
       // Handled above
-      CGAL_assertion(false);
+      assert(false);
       break;
     }
   }
@@ -63,76 +63,76 @@ int main()
 
   // Check the empty triangulation
   fh = test_point_location(t, Point(0.5, 0.5), Triangulation::EMPTY);
-  CGAL_assertion(fh == Face_handle());
+  assert(fh == Face_handle());
 
   // Insert the first point
   Point p0(0.5, 0.5);
   Vertex_handle vh0 = t.insert(p0);
-  CGAL_assertion(t.is_valid(true));
+  assert(t.is_valid(true));
   CGAL_USE(vh0);
 
   fh = test_point_location(t, p0, Triangulation::VERTEX);
-  CGAL_assertion(fh->has_vertex(vh0));
+  assert(fh->has_vertex(vh0));
 
   fh = test_point_location(t, p0 + Vector(0.1, 0.1), Triangulation::EDGE);
-  CGAL_assertion(fh->has_vertex(vh0));
+  assert(fh->has_vertex(vh0));
 
   fh = test_point_location(t, p0 + Vector(-0.1, -0.1), Triangulation::EDGE);
-  CGAL_assertion(fh->has_vertex(vh0));
+  assert(fh->has_vertex(vh0));
 
   fh = test_point_location(t, p0 + Vector(-0.2, -0.3), Triangulation::FACE);
-  CGAL_assertion(fh->has_vertex(vh0));
+  assert(fh->has_vertex(vh0));
 
-  CGAL_assertion(t.is_valid(true));
+  assert(t.is_valid(true));
 
   // Insert the second point on an edge
   Point p1(0.7, 0.7);
   Vertex_handle vh1 = t.insert(p1);
   CGAL_USE(vh1);
-  CGAL_assertion(t.is_valid(true));
+  assert(t.is_valid(true));
 
   fh = test_point_location(t, p0, Triangulation::VERTEX);
-  CGAL_assertion(fh->has_vertex(vh0));
+  assert(fh->has_vertex(vh0));
 
   fh = test_point_location(t, p1, Triangulation::VERTEX);
-  CGAL_assertion(fh->has_vertex(vh1));
+  assert(fh->has_vertex(vh1));
 
   fh = test_point_location(t, p0 + Vector(0.1, 0.1), Triangulation::EDGE);
-  CGAL_assertion(fh->has_vertex(vh0));
-  CGAL_assertion(fh->has_vertex(vh1));
+  assert(fh->has_vertex(vh0));
+  assert(fh->has_vertex(vh1));
 
   fh = test_point_location(t, p0 + Vector(-0.1, -0.1), Triangulation::EDGE);
-  CGAL_assertion(fh->has_vertex(vh0));
-  CGAL_assertion(!fh->has_vertex(vh1));
+  assert(fh->has_vertex(vh0));
+  assert(!fh->has_vertex(vh1));
 
   fh = test_point_location(t, p1 + Vector(0.1, 0.1), Triangulation::EDGE);
-  CGAL_assertion(!fh->has_vertex(vh0));
-  CGAL_assertion(fh->has_vertex(vh1));
+  assert(!fh->has_vertex(vh0));
+  assert(fh->has_vertex(vh1));
 
   fh = test_point_location(t, p0 + Vector(-0.02, -0.03), Triangulation::FACE);
-  CGAL_assertion(fh->has_vertex(vh0));
+  assert(fh->has_vertex(vh0));
 
   fh = test_point_location(t, p1 + Vector(-0.02, -0.03), Triangulation::FACE);
-  CGAL_assertion(fh->has_vertex(vh1));
+  assert(fh->has_vertex(vh1));
 
-  CGAL_assertion(t.is_valid(true));
+  assert(t.is_valid(true));
 
   // Insert the third point in a face
   Point p2(0.8, 0.6);
   Vertex_handle vh2 = t.insert(p2);
   CGAL_USE(vh2);
-  CGAL_assertion(t.is_valid(true));
+  assert(t.is_valid(true));
 
   fh = test_point_location(t, p0, Triangulation::VERTEX);
-  CGAL_assertion(fh->has_vertex(vh0));
+  assert(fh->has_vertex(vh0));
   fh = test_point_location(t, p1, Triangulation::VERTEX);
-  CGAL_assertion(fh->has_vertex(vh1));
+  assert(fh->has_vertex(vh1));
   fh = test_point_location(t, p2, Triangulation::VERTEX);
-  CGAL_assertion(fh->has_vertex(vh2));
+  assert(fh->has_vertex(vh2));
 
   fh = test_point_location(t, Point(0.6, 0.6), Triangulation::EDGE);
-  CGAL_assertion(fh->has_vertex(vh0));
-  CGAL_assertion(fh->has_vertex(vh1));
+  assert(fh->has_vertex(vh0));
+  assert(fh->has_vertex(vh1));
 
   test_point_location(t, Point(0.7, 0.6), Triangulation::FACE);
   test_point_location(t, p0 + Vector(-0.02, -0.03), Triangulation::FACE);

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_triangulation_prog1.cpp
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_triangulation_prog1.cpp
@@ -21,7 +21,7 @@ typedef Triangulation::Periodic_triangle_iterator   Periodic_triangle_iterator;
 
 void test_point_location_in_a_triangulation_with_a_single_point(Triangulation &t)
 {
-  CGAL_assertion(t.number_of_vertices() == 1);
+  assert(t.number_of_vertices() == 1);
 
   Point &p = t.vertices_begin()->point();
   Triangulation::Locate_type lt;
@@ -47,7 +47,7 @@ void test_point_location_in_a_triangulation_with_a_single_point(Triangulation &t
                   CGAL::Bounded_side side = t.side_of_face(p, offset, triang_it.get_face(), lt, li);
                   if (side != CGAL::ON_UNBOUNDED_SIDE)
                     {
-                      CGAL_assertion(lt == Triangulation::VERTEX);
+                      assert(lt == Triangulation::VERTEX);
                     }
                   on_boundary += (side == CGAL::ON_BOUNDARY ? 1 : 0);
                   on_inside += (side == CGAL::ON_BOUNDED_SIDE ? 1 : 0);
@@ -55,8 +55,8 @@ void test_point_location_in_a_triangulation_with_a_single_point(Triangulation &t
                   triangle.vertex(0); // Avoid warning
                   ++triang_it;
                 }
-              CGAL_assertion(on_boundary == 6);
-              CGAL_assertion(on_inside == 0);
+              assert(on_boundary == 6);
+              assert(on_inside == 0);
             }
             {
               // Locate point on an edge
@@ -68,7 +68,7 @@ void test_point_location_in_a_triangulation_with_a_single_point(Triangulation &t
                   CGAL::Bounded_side side = t.side_of_face(p + Vector(0.0, 0.1), offset, triang_it.get_face(), lt, li);
                   if (side != CGAL::ON_UNBOUNDED_SIDE)
                     {
-                      CGAL_assertion(lt == Triangulation::EDGE);
+                      assert(lt == Triangulation::EDGE);
                     }
                   on_boundary += (side == CGAL::ON_BOUNDARY ? 1 : 0);
                   on_inside += (side == CGAL::ON_BOUNDED_SIDE ? 1 : 0);
@@ -76,8 +76,8 @@ void test_point_location_in_a_triangulation_with_a_single_point(Triangulation &t
                   triangle.vertex(0); // Avoid warning
                   ++triang_it;
                 }
-              CGAL_assertion(on_boundary == 2);
-              CGAL_assertion(on_inside == 0);
+              assert(on_boundary == 2);
+              assert(on_inside == 0);
             }
             {
               // Locate point inside a face
@@ -89,7 +89,7 @@ void test_point_location_in_a_triangulation_with_a_single_point(Triangulation &t
                   CGAL::Bounded_side side = t.side_of_face(p + Vector(0.1, 0.2), offset, triang_it.get_face(), lt, li);
                   if (side != CGAL::ON_UNBOUNDED_SIDE)
                     {
-                      CGAL_assertion(lt == Triangulation::FACE);
+                      assert(lt == Triangulation::FACE);
                     }
                   on_boundary += (side == CGAL::ON_BOUNDARY ? 1 : 0);
                   on_inside += (side == CGAL::ON_BOUNDED_SIDE ? 1 : 0);
@@ -97,8 +97,8 @@ void test_point_location_in_a_triangulation_with_a_single_point(Triangulation &t
                   triangle.vertex(0); // Avoid warning
                   ++triang_it;
                 }
-              CGAL_assertion(on_boundary == 0);
-              CGAL_assertion(on_inside == 1);
+              assert(on_boundary == 0);
+              assert(on_inside == 1);
             }
           }
           {
@@ -116,14 +116,14 @@ void test_point_location_in_a_triangulation_with_a_single_point(Triangulation &t
                   CGAL::Bounded_side side = t.side_of_face(p, offset, face_it, lt, li);
                   if (side != CGAL::ON_UNBOUNDED_SIDE)
                     {
-                      CGAL_assertion(lt == Triangulation::VERTEX);
+                      assert(lt == Triangulation::VERTEX);
                     }
                   on_boundary += (side == CGAL::ON_BOUNDARY ? 1 : 0);
                   on_inside += (side == CGAL::ON_BOUNDED_SIDE ? 1 : 0);
                   ++face_it;
                 }
-              CGAL_assertion(on_boundary == 6);
-              CGAL_assertion(on_inside == 0);
+              assert(on_boundary == 6);
+              assert(on_inside == 0);
             }
             {
               // Locate point on an edge
@@ -135,14 +135,14 @@ void test_point_location_in_a_triangulation_with_a_single_point(Triangulation &t
                   CGAL::Bounded_side side = t.side_of_face(p + Vector(0.1, 0.0), offset, face_it, lt, li);
                   if (side != CGAL::ON_UNBOUNDED_SIDE)
                     {
-                      CGAL_assertion(lt == Triangulation::EDGE);
+                      assert(lt == Triangulation::EDGE);
                     }
                   on_boundary += (side == CGAL::ON_BOUNDARY ? 1 : 0);
                   on_inside += (side == CGAL::ON_BOUNDED_SIDE ? 1 : 0);
                   ++face_it;
                 }
-              CGAL_assertion(on_boundary == 2);
-              CGAL_assertion(on_inside == 0);
+              assert(on_boundary == 2);
+              assert(on_inside == 0);
             }
             {
               // Locate point inside a face
@@ -154,14 +154,14 @@ void test_point_location_in_a_triangulation_with_a_single_point(Triangulation &t
                   CGAL::Bounded_side side = t.side_of_face(p + Vector(0.1, 0.2), offset, face_it, lt, li);
                   if (side != CGAL::ON_UNBOUNDED_SIDE)
                     {
-                      CGAL_assertion(lt == Triangulation::FACE);
+                      assert(lt == Triangulation::FACE);
                     }
                   on_boundary += (side == CGAL::ON_BOUNDARY ? 1 : 0);
                   on_inside += (side == CGAL::ON_BOUNDED_SIDE ? 1 : 0);
                   ++face_it;
                 }
-              CGAL_assertion(on_boundary == 0);
-              CGAL_assertion(on_inside == 1);
+              assert(on_boundary == 0);
+              assert(on_inside == 1);
             }
           }
         }
@@ -175,13 +175,13 @@ int main()
   // Insert the first point
   Point first_point(0.5, 0.5);
   t.insert(first_point);
-  CGAL_assertion(t.is_valid(true));
+  assert(t.is_valid(true));
 
   {
     // Testing the point iterator
     Periodic_point_iterator it = t.periodic_points_begin();
     Periodic_point_iterator beyond = t.periodic_points_end();
-    CGAL_assertion(std::distance(it, beyond) == 9);
+    assert(std::distance(it, beyond) == 9);
     while(it != beyond)
       {
         Point p = t.point(*it);
@@ -193,7 +193,7 @@ int main()
     // Testing the segment iterator
     Periodic_segment_iterator it = t.periodic_segments_begin();
     Periodic_segment_iterator beyond = t.periodic_segments_end();
-    CGAL_assertion(std::distance(it, beyond) == 27);
+    assert(std::distance(it, beyond) == 27);
     while(it != beyond)
       {
         Segment s = t.segment(*it);
@@ -205,7 +205,7 @@ int main()
     // Testing the triangle iterator
     Periodic_triangle_iterator it = t.periodic_triangles_begin();
     Periodic_triangle_iterator beyond = t.periodic_triangles_end();
-    CGAL_assertion(std::distance(it, beyond) == 18);
+    assert(std::distance(it, beyond) == 18);
     while(it != beyond)
       {
         Triangle triangle = t.triangle(*it);

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_versus_rt3.cpp
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/test_p3rt3_versus_rt3.cpp
@@ -112,7 +112,7 @@ int main (int, char**)
 
   std::cout << unique_vertices_from_rt3.size() << " unique vertices (rt3)" << std::endl;
   std::cout << p3rt3.number_of_vertices() << " unique vertices (p3rt3)" << std::endl;
-  CGAL_assertion(unique_vertices_from_rt3.size() == p3rt3.number_of_vertices());
+  assert(unique_vertices_from_rt3.size() == p3rt3.number_of_vertices());
 
   // compare cells
   std::set<std::set<int> > unique_cells_from_rt3;
@@ -138,7 +138,7 @@ int main (int, char**)
 
   std::cout << unique_cells_from_rt3.size() << " unique cells (rt3)" << std::endl;
   std::cout << p3rt3.number_of_cells() << " unique cells (p3rt3)" << std::endl;
-  CGAL_assertion(unique_cells_from_rt3.size() == p3rt3.number_of_cells());
+  assert(unique_cells_from_rt3.size() == p3rt3.number_of_cells());
 
   std::cout << t.time() << " sec." << std::endl;
   std::cout << "EXIT SUCCESS" << std::endl;

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/polygon_mesh_slicer_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/polygon_mesh_slicer_test.cpp
@@ -14,9 +14,9 @@
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 #include <CGAL/Polygon_2.h>
-#include <CGAL/use.h>
 
 #include <fstream>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Epic;
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Epec;
@@ -118,24 +118,24 @@ int test_slicer()
   slicer(typename K::Plane_3(0,1,0,0.5), std::back_inserter(polylines));
   assert(polylines.size()==2); // two polylines
   int closed_id = polylines.front().front()==polylines.front().back() ? 0 : 1;
-  CGAL_USE(closed_id);
-  CGAL_assertion( is_ccw<K>(0, 2 , polylines[closed_id]) );
+
+  assert( is_ccw<K>(0, 2 , polylines[closed_id]) );
 
   polylines.clear();
   slicer(typename K::Plane_3(0,-1,0,-0.5), std::back_inserter(polylines));
   assert(polylines.size()==2); // two polylines
   closed_id = polylines.front().front()==polylines.front().back() ? 0 : 1;
-  CGAL_assertion( !is_ccw<K>(0, 2, polylines[closed_id]) );
+  assert( !is_ccw<K>(0, 2, polylines[closed_id]) );
 
   polylines.clear();
   slicer(typename K::Plane_3(0,0,1,1), std::back_inserter(polylines));
   assert(polylines.size()==1); // one polyline
-  CGAL_assertion( is_ccw<K>(0, 1 , polylines[0]) );
+  assert( is_ccw<K>(0, 1 , polylines[0]) );
 
   polylines.clear();
   slicer(typename K::Plane_3(0,0,-1,-1), std::back_inserter(polylines));
   assert(polylines.size()==1); // one polyline
-  CGAL_assertion( !is_ccw<K>(0, 1 , polylines[0]) );
+  assert( !is_ccw<K>(0, 1 , polylines[0]) );
 
   // reverse face orientation (no need to rebuild the tree)
   CGAL::Polygon_mesh_processing::reverse_face_orientations(m);
@@ -143,23 +143,23 @@ int test_slicer()
   slicer(typename K::Plane_3(0,1,0,0.5), std::back_inserter(polylines));
   assert(polylines.size()==2); // two polylines
   closed_id = polylines.front().front()==polylines.front().back() ? 0 : 1;
-  CGAL_assertion( !is_ccw<K>(0, 2 , polylines[closed_id]) );
+  assert( !is_ccw<K>(0, 2 , polylines[closed_id]) );
 
   polylines.clear();
   slicer(typename K::Plane_3(0,-1,0,-0.5), std::back_inserter(polylines));
   assert(polylines.size()==2); // two polylines
   closed_id = polylines.front().front()==polylines.front().back() ? 0 : 1;
-  CGAL_assertion( is_ccw<K>(0, 2, polylines[closed_id]) );
+  assert( is_ccw<K>(0, 2, polylines[closed_id]) );
 
   polylines.clear();
   slicer(typename K::Plane_3(0,0,1,1), std::back_inserter(polylines));
   assert(polylines.size()==1); // one polyline
-  CGAL_assertion( !is_ccw<K>(0, 1 , polylines[0]) );
+  assert( !is_ccw<K>(0, 1 , polylines[0]) );
 
   polylines.clear();
   slicer(typename K::Plane_3(0,0,-1,-1), std::back_inserter(polylines));
   assert(polylines.size()==1); // one polyline
-  CGAL_assertion( is_ccw<K>(0, 1 , polylines[0]) );
+  assert( is_ccw<K>(0, 1 , polylines[0]) );
 
 
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
@@ -22,6 +22,7 @@
 #include <vector>
 #include <cstdlib>
 #include <cstring>
+#include <cassert>
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -101,7 +102,7 @@ void test_precondition(const char* filename,
   {
     exception_caught = true;
   }
-  CGAL_assertion(exception_caught);
+  assert(exception_caught);
 #endif
 }
 
@@ -137,13 +138,13 @@ public:
 
   friend value_type get(const Constraints_pmap& map, const key_type& e)
   {
-    CGAL_assertion(map.set_ptr_ != nullptr);
+    assert(map.set_ptr_ != nullptr);
     return !map.set_ptr_->empty()
          && map.set_ptr_->count(e);
   }
   friend void put(Constraints_pmap& map, const key_type& e, const value_type is)
   {
-    CGAL_assertion(map.set_ptr_ != nullptr);
+    assert(map.set_ptr_ != nullptr);
     if (is)                map.set_ptr_->insert(e);
     else if(get(map, e))   map.set_ptr_->erase(e);
   }

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_remove_border_edge.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_remove_border_edge.cpp
@@ -4,6 +4,7 @@
 #include <CGAL/Polygon_mesh_processing/repair.h>
 
 #include <fstream>
+#include <cassert>
 
 typedef CGAL::Simple_cartesian<double> K;
 typedef K::Point_3 Point;
@@ -30,11 +31,11 @@ void test_middle_edge()
       break;
     }
   }
-  CGAL_assertion( h!=GT::null_halfedge() );
+  assert( h!=GT::null_halfedge() );
   CGAL::Polygon_mesh_processing::remove_a_border_edge(edge(h,tm), tm);
 
-  CGAL_assertion(is_valid_polygon_mesh(tm));
-  CGAL_assertion(is_triangle_mesh(tm));
+  assert(is_valid_polygon_mesh(tm));
+  assert(is_triangle_mesh(tm));
   std::ofstream out("edge_middle_out.off");
   out << tm;
 }
@@ -59,11 +60,11 @@ void test_edge_border_case1()
       break;
     }
   }
-  CGAL_assertion( h!=GT::null_halfedge() );
+  assert( h!=GT::null_halfedge() );
   CGAL::Polygon_mesh_processing::remove_a_border_edge(edge(h,tm), tm);
 
-  CGAL_assertion(is_valid_polygon_mesh(tm));
-  CGAL_assertion(is_triangle_mesh(tm));
+  assert(is_valid_polygon_mesh(tm));
+  assert(is_triangle_mesh(tm));
   std::ofstream out("edge_border_case1_out.off");
   out << tm;
 }
@@ -88,11 +89,11 @@ void test_edge_border_case2()
       break;
     }
   }
-  CGAL_assertion( h!=GT::null_halfedge() );
+  assert( h!=GT::null_halfedge() );
   CGAL::Polygon_mesh_processing::remove_a_border_edge(edge(h,tm), tm);
 
-  CGAL_assertion(is_valid_polygon_mesh(tm));
-  CGAL_assertion(is_triangle_mesh(tm));
+  assert(is_valid_polygon_mesh(tm));
+  assert(is_triangle_mesh(tm));
   std::ofstream out("edge_border_case2_out.off");
   out << tm;
 }

--- a/Principal_component_analysis/test/Principal_component_analysis/test_validity.cpp
+++ b/Principal_component_analysis/test/Principal_component_analysis/test_validity.cpp
@@ -30,6 +30,7 @@
 #include <CGAL/Random.h>
 
 #include <fstream>
+#include <cassert>
 
 typedef CGAL::Simple_cartesian<double> Kernel;
 typedef Kernel::Point_3 Point_3;
@@ -224,9 +225,9 @@ void assert_quality (const std::vector<Point_3>& points, const Fitted& fitted)
 
   std::cerr << "mean distance = " << mean_dist << std::endl;
 
-  CGAL_assertion_code
-    (double limit = 1e-5 * std::sqrt (CGAL::squared_distance (points.front(), points.back())));
-  CGAL_assertion (mean_dist < limit);
+
+  double limit = 1e-5 * std::sqrt (CGAL::squared_distance (points.front(), points.back()));
+  assert (mean_dist < limit);
 }
 
 /*

--- a/Property_map/test/Property_map/kernel_converter_properties_test.cpp
+++ b/Property_map/test/Property_map/kernel_converter_properties_test.cpp
@@ -6,6 +6,8 @@
 #include <CGAL/Cartesian_converter.h>
 #include <CGAL/property_map.h>
 
+#include <cassert>
+
 typedef CGAL::Simple_cartesian<double> K1;
 typedef CGAL::Simple_cartesian<CGAL::Quotient<CGAL::MP_Float> >  K2;
 typedef K1::Point_3 Point_3;
@@ -21,9 +23,9 @@ test()
   VPMap vmap = get(CGAL::vertex_point, m);
 
   CGAL::Cartesian_converter_property_map<K2::Point_3, VPMap> kcmap =CGAL::make_cartesian_converter_property_map<K2::Point_3>(vmap);
-  CGAL_assertion(get(kcmap, *vertices(m).begin()) == CGAL::Point_3<K2>(2,0,0));
+  assert(get(kcmap, *vertices(m).begin()) == CGAL::Point_3<K2>(2,0,0));
   put(kcmap, *vertices(m).begin(), CGAL::Point_3<K2>(0,2,3));
-  CGAL_assertion(get(kcmap, *vertices(m).begin()) == CGAL::Point_3<K2>(0,2,3));
+  assert(get(kcmap, *vertices(m).begin()) == CGAL::Point_3<K2>(0,2,3));
 
 }
 
@@ -34,4 +36,3 @@ int main()
   test<SM>();
   return 0;
 }
-

--- a/STL_Extension/test/STL_Extension/test_Object.cpp
+++ b/STL_Extension/test/STL_Extension/test_Object.cpp
@@ -2,40 +2,40 @@
 
 #include <CGAL/Object.h>
 #include <CGAL/assertions.h>
-#include <CGAL/use.h>
 
 #include <boost/variant.hpp>
 #include <boost/optional.hpp>
+#include <cassert>
 
 void from_opt_var() {
   int i = 0;
   double j = 0.0;
-  CGAL_USE(i);   CGAL_USE(j);
+
   boost::optional< boost::variant<int, char, double> > v(23);
   CGAL::Object o = v;
-  CGAL_assertion(!o.empty());
-  CGAL_assertion(CGAL::assign(i, o));
-  CGAL_assertion(i == 23);
+  assert(!o.empty());
+  assert(CGAL::assign(i, o));
+  assert(i == 23);
   //reassign the variant and assign it again
   v = 2.0;
   o = v;
-  CGAL_assertion(!CGAL::assign(i, o));
-  CGAL_assertion(CGAL::assign(j, o));
-  CGAL_assertion(j == 2.0);
+  assert(!CGAL::assign(i, o));
+  assert(CGAL::assign(j, o));
+  assert(j == 2.0);
   //empty optional
   boost::optional< boost::variant<int, char, double> > v2;
   CGAL::Object o2 = v2;
-  CGAL_assertion(o2.empty());
+  assert(o2.empty());
 }
 
 void from_var() {
   int i = 0;
-  CGAL_USE(i);
+
   boost::variant<int, char, double> v(23);
   CGAL::Object o = v;
-  CGAL_assertion(!o.empty());
-  CGAL_assertion(CGAL::assign(i, o));
-  CGAL_assertion(i == 23);
+  assert(!o.empty());
+  assert(CGAL::assign(i, o));
+  assert(i == 23);
 }
 
 struct Foo {
@@ -43,19 +43,19 @@ struct Foo {
 
 void make_object_and_assign() {
   int i = 23, j = 0;
-  CGAL_USE(j);
+
   CGAL::Object o = CGAL::make_object(i);
-  CGAL_assertion(CGAL::assign(j, o));
-  CGAL_assertion(j == i);
-  CGAL_assertion(CGAL::object_cast<Foo>(&o) == nullptr);
-  CGAL_assertion(CGAL::object_cast<int>(&o) != nullptr);
+  assert(CGAL::assign(j, o));
+  assert(j == i);
+  assert(CGAL::object_cast<Foo>(&o) == nullptr);
+  assert(CGAL::object_cast<int>(&o) != nullptr);
 }
 
 void safe_bool() {
   CGAL::Object o;
-  CGAL_assertion(!o);
+  assert(!o);
   CGAL::Object o2 = CGAL::make_object(23);
-  CGAL_assertion(o2);
+  assert(o2);
 
   // dummy code, we want to bork on this
   // if(o == o2) ;

--- a/Stream_support/test/Stream_support/test_WKT.cpp
+++ b/Stream_support/test/Stream_support/test_WKT.cpp
@@ -9,6 +9,7 @@
 
 #include <fstream>
 #include <vector>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel           Kernel;
 
@@ -30,42 +31,42 @@ bool test_read_WKT()
     std::ifstream in("data/point.wkt");
     if(!CGAL::IO::read_point_WKT(in, p))
       return false;
-    CGAL_assertion(p == Point(2,3));
+    assert(p == Point(2,3));
   }
   {
     std::ifstream in("data/linestring.wkt");
     Linestring ls;
     if(!CGAL::IO::read_linestring_WKT(in, ls))
       return false;
-    CGAL_assertion(ls.size() == 3);
+    assert(ls.size() == 3);
   }
   {
     Poly poly;
     std::ifstream in("data/polygon.wkt");
     if(!CGAL::IO::read_polygon_WKT(in, poly))
       return false;
-    CGAL_assertion(poly.outer_boundary().size() == 3);
+    assert(poly.outer_boundary().size() == 3);
   }
   {
     MultiPoint pees;
     std::ifstream in("data/multipoint.wkt");
     if(!CGAL::IO::read_multi_point_WKT(in, pees))
       return false;
-    CGAL_assertion(pees.size() == 4);
+    assert(pees.size() == 4);
   }
   {
     std::ifstream in("data/multilinestring.wkt");
     MultiLinestring mls;
     if(!CGAL::IO::read_multi_linestring_WKT(in, mls))
       return false;
-    CGAL_assertion(mls.size() == 2);
+    assert(mls.size() == 2);
   }
   {
     MultiPolygon polies;
     std::ifstream in("data/multipolygon.wkt");
     if(!CGAL::IO::read_multi_polygon_WKT(in, polies))
       return false;
-    CGAL_assertion(polies.size() == 2);
+    assert(polies.size() == 2);
   }
 
   std::cout << "WKT reading test passed." << std::endl;
@@ -184,7 +185,7 @@ bool test_write_WKT()
     CGAL::IO::read_point_WKT(is, test_p);
     is.close();
   }
-  CGAL_assertion(p == test_p);
+  assert(p == test_p);
 
   Linestring ls = generate_linestring();
   {
@@ -199,7 +200,7 @@ bool test_write_WKT()
     CGAL::IO::read_linestring_WKT(is, test_ls);
     is.close();
   }
-  CGAL_assertion(ls == test_ls);
+  assert(ls == test_ls);
 
   Poly poly = generate_polygon();
   {
@@ -215,7 +216,7 @@ bool test_write_WKT()
     is.close();
   }
 
-  CGAL_assertion(poly == test_poly);
+  assert(poly == test_poly);
 
   MultiPoint pees = generate_multipoint();
   {
@@ -230,7 +231,7 @@ bool test_write_WKT()
     CGAL::IO::read_multi_point_WKT(is, test_pees);
     is.close();
   }
-  CGAL_assertion(pees== test_pees);
+  assert(pees== test_pees);
 
   MultiLinestring mls = generate_multilinestring();
   {
@@ -248,7 +249,7 @@ bool test_write_WKT()
   bool ok = true;
   for(size_t i=0; i<mls.size(); ++i)
     ok &= mls[i] == test_mls[i];
-  CGAL_assertion(ok);
+  assert(ok);
 
   MultiPolygon polies = generate_multipolygon();
   {
@@ -263,7 +264,7 @@ bool test_write_WKT()
     CGAL::IO::read_multi_polygon_WKT(is, test_polies);
     is.close();
   }
-  CGAL_assertion(polies == test_polies);
+  assert(polies == test_polies);
 
   std::cout << "WKT writing test passed." << std::endl;
   return true;
@@ -278,4 +279,3 @@ int main()
 
   return EXIT_SUCCESS;
 }
-

--- a/Surface_mesh/test/Surface_mesh/sm_open_colored_off.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_open_colored_off.cpp
@@ -3,6 +3,8 @@
 #include <cstring>
 #include <iostream>
 #include <fstream>
+#include <cassert>
+
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 typedef Kernel::Point_3 Point;
 typedef CGAL::Surface_mesh<Point> SMesh;
@@ -28,7 +30,7 @@ void OpenOFF(int i)
   std::ifstream in(path.c_str());
   SMesh surface_mesh;
   in >> surface_mesh;
-  CGAL_assertion(in && !surface_mesh.is_empty());
+  assert(in && !surface_mesh.is_empty());
 
 
   SMesh::Property_map<face_descriptor, CGAL::IO::Color> fcolors =
@@ -37,14 +39,14 @@ void OpenOFF(int i)
   SMesh::Property_map<vertex_descriptor, CGAL::IO::Color> vcolors =
     surface_mesh.property_map<vertex_descriptor, CGAL::IO::Color >("v:color").first;
   CGAL::IO::Color c = fcolors[*(surface_mesh.faces().begin())];
-  CGAL_assertion(c== CGAL::IO::Color(229,0,0));
+  assert(c== CGAL::IO::Color(229,0,0));
   c = fcolors[*(--surface_mesh.faces().end())];
-  CGAL_assertion(c== CGAL::IO::Color(0,0,229));
+  assert(c== CGAL::IO::Color(0,0,229));
 
   c = vcolors[*(surface_mesh.vertices().begin())];
-  CGAL_assertion((c== CGAL::IO::Color(229,0,0)));
+  assert((c== CGAL::IO::Color(229,0,0)));
   c = vcolors[*(--surface_mesh.vertices().end())];
-  CGAL_assertion((c== CGAL::IO::Color(0,0,229)));
+  assert((c== CGAL::IO::Color(0,0,229)));
 }
 
 

--- a/Surface_mesh_segmentation/test/Surface_mesh_segmentation/K_means_clustering_test_2.cpp
+++ b/Surface_mesh_segmentation/test/Surface_mesh_segmentation/K_means_clustering_test_2.cpp
@@ -1,5 +1,7 @@
+#include <cassert>
 #include <iostream>
 #include <string>
+
 #include <CGAL/Surface_mesh_segmentation/internal/K_means_clustering.h>
 typedef CGAL::internal::K_means_clustering K_means;
 /**
@@ -34,7 +36,7 @@ int main(void)
           std::string init_type_s = init_type_enum == K_means::RANDOM_INITIALIZATION ? "Random " :
                                                                                        "Plus plus ";
           std::cerr << "Init type: " << init_type_s << "center size: "  << center_size << std::endl;
-          CGAL_assertion(false);
+          assert(false);
         }
       }
     }

--- a/Surface_mesh_topology/test/Surface_mesh_topology/fundamental_group_of_the_circle.cpp
+++ b/Surface_mesh_topology/test/Surface_mesh_topology/fundamental_group_of_the_circle.cpp
@@ -17,6 +17,8 @@ Then it verify that
 #include <CGAL/Curves_on_surface_topology.h>
 #include <CGAL/Path_on_surface.h>
 
+#include <cassert>
+
 // If you want to use a viewer, you can use qglviewer.
 #ifdef CGAL_USE_BASIC_VIEWER
 #include <CGAL/draw_face_graph_with_paths.h>
@@ -36,12 +38,12 @@ void create_positive_loop_88(Path_on_surface<SM>& p, unsigned int n)
   if (n==0)
   {
     p.push_back_by_index(88, true, true);
-    CGAL_assertion(p.is_closed());
+    assert(p.is_closed());
   }
   else
   {
     p.extend_straight_positive(10*n-1);
-    CGAL_assertion(p.is_closed());
+    assert(p.is_closed());
   }
 }
 ///////////////////////////////////////////////////////////////////////////////
@@ -52,12 +54,12 @@ void create_negative_loop_88(Path_on_surface<SM>& p, unsigned int n)
   if (n==0)
   {
     p.push_back_by_index(88, false, true);
-    CGAL_assertion(p.is_closed());
+    assert(p.is_closed());
   }
   else
   {
     p.extend_straight_positive(10*n-1);
-    CGAL_assertion(p.is_closed());
+    assert(p.is_closed());
   }
 }
 ///////////////////////////////////////////////////////////////////////////////
@@ -68,7 +70,7 @@ void create_positive_loop_24(Path_on_surface<SM>& p, unsigned int n)
   if (n==0)
   {
     p.push_back_by_index(24, true, true);
-    CGAL_assertion(p.is_closed());
+    assert(p.is_closed());
   }
   else
   {
@@ -80,7 +82,7 @@ void create_positive_loop_24(Path_on_surface<SM>& p, unsigned int n)
   CGAL::draw(p.get_mesh(), v, "Title"); */
 #endif // CGAL_USE_BASIC_VIEWER
 
-    CGAL_assertion(p.is_closed());
+    assert(p.is_closed());
   }
 }
 ///////////////////////////////////////////////////////////////////////////////
@@ -91,12 +93,12 @@ void create_negative_loop_24(Path_on_surface<SM>& p, unsigned int n)
   if (n==0)
   {
     p.push_back_by_index(24, false, true);
-    CGAL_assertion(p.is_closed());
+    assert(p.is_closed());
   }
   else
   {
     p.extend_straight_negative((10*n)-1);
-    CGAL_assertion(p.is_closed());
+    assert(p.is_closed());
   }
 }
 ///////////////////////////////////////////////////////////////////////////////

--- a/Surface_mesh_topology/test/Surface_mesh_topology/path_with_rle_deformation_tests.cpp
+++ b/Surface_mesh_topology/test/Surface_mesh_topology/path_with_rle_deformation_tests.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <sstream>
 #include <tuple>
+#include <cassert>
 
 #include "Creation_of_test_cases_for_paths.h"
 
@@ -120,7 +121,7 @@ void transform_path(Path_on_surface<LCC_3_cmap>& path, Transformation t,
 #endif // CGAL_USE_BASIC_VIEWER
 
   path.swap(prevp);
-  CGAL_assertion(path.is_valid(true));
+  assert(path.is_valid(true));
 }
 ///////////////////////////////////////////////////////////////////////////////
 bool unit_test(Path_on_surface<LCC_3_cmap>& path, Transformation t,

--- a/Surface_mesh_topology/test/Surface_mesh_topology/test_homotopy_with_polygonal_schema.cpp
+++ b/Surface_mesh_topology/test/Surface_mesh_topology/test_homotopy_with_polygonal_schema.cpp
@@ -4,6 +4,7 @@
 #include <iostream>
 #include <ctime>
 #include <cstdlib>
+#include <cassert>
 
 typedef CGAL::Surface_mesh_topology::Polygonal_schema_with_combinatorial_map<> PS;
 typedef typename PS::Dart_handle  Dart_handle;
@@ -20,7 +21,7 @@ bool test_two_random_paths(const PS& ps,
                            int lmin=5,
                            int lmax=20)
 {
-  CGAL_assertion(lmin>0 && lmin<lmax);
+  assert(lmin>0 && lmin<lmax);
   CGAL::Random random(seed++);
   Path_on_surface<PS> p1(ps), p2(ps);
   internal::generate_random_closed_path

--- a/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing.cpp
+++ b/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 
@@ -38,7 +39,7 @@ void generate_input_one_subdomain(const std::size_t nbv, T3& tr)
   for (typename T3::Cell_handle c : tr.finite_cell_handles())
     c->set_subdomain_index(1);
 
-  CGAL_assertion(tr.is_valid(true));
+  assert(tr.is_valid(true));
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_GENERATE_INPUT_FILES
   std::ofstream out("data/triangulation_one_subdomain.binary.cgal",

--- a/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_io.cpp
+++ b/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_io.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <string>
 #include <vector>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 

--- a/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_of_one_subdomain.cpp
+++ b/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_of_one_subdomain.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <fstream>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 
@@ -37,7 +38,7 @@ void generate_input_two_subdomains(const std::size_t nbv, Remeshing_triangulatio
     else
       c->set_subdomain_index(2);
   }
-  CGAL_assertion(tr.is_valid(true));
+  assert(tr.is_valid(true));
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_GENERATE_INPUT_FILES
   std::ofstream os("data/triangulation_two_subdomains.binary.cgal",
@@ -78,4 +79,3 @@ int main(int argc, char* argv[])
 
   return EXIT_SUCCESS;
 }
-

--- a/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_with_features.cpp
+++ b/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_with_features.cpp
@@ -16,6 +16,7 @@
 #include <fstream>
 #include <vector>
 #include <utility>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 
@@ -50,8 +51,8 @@ public:
                   const key_type& k,
                   const value_type b)
   {
-    CGAL_assertion(map.m_set_ptr != nullptr);
-    CGAL_assertion(k.first < k.second);
+    assert(map.m_set_ptr != nullptr);
+    assert(k.first < k.second);
     if (b)  map.m_set_ptr->insert(k);
     else    map.m_set_ptr->erase(k);
   }
@@ -59,8 +60,8 @@ public:
   friend value_type get(const Constrained_edges_property_map& map,
                         const key_type& k)
   {
-    CGAL_assertion(map.m_set_ptr != nullptr);
-    CGAL_assertion(k.first < k.second);
+    assert(map.m_set_ptr != nullptr);
+    assert(k.first < k.second);
     return map.m_set_ptr->count(k) > 0;
   }
 };
@@ -101,7 +102,7 @@ void generate_input_cube(const std::size_t& n,
   Vertex_handle v6 = tr.insert(Point( 2.,  2., -2.));
   Vertex_handle v7 = tr.insert(Point( 2.,  2.,  2.));
 
-  CGAL_assertion(tr.is_valid(true));
+  assert(tr.is_valid(true));
 
   // writing file output
 #ifdef CGAL_TETRAHEDRAL_REMESHING_GENERATE_INPUT_FILES
@@ -127,7 +128,7 @@ void generate_input_cube(const std::size_t& n,
   add_edge(v2, v6, tr, constraints);
   add_edge(v3, v7, tr, constraints);
 
-  CGAL_assertion(tr.is_valid(true));
+  assert(tr.is_valid(true));
 }
 
 void set_subdomain(Remeshing_triangulation& tr, const int index)
@@ -158,4 +159,3 @@ int main(int argc, char* argv[])
 
   return EXIT_SUCCESS;
 }
-

--- a/Triangulation/test/Triangulation/test_delaunay.cpp
+++ b/Triangulation/test/Triangulation/test_delaunay.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <cstdlib>
 #include <algorithm>
+#include <cassert>
 
 using namespace std;
 
@@ -58,7 +59,7 @@ void test(const int d, const string & type, const int N)
     cerr << nbis << " = " << (nbis+nbfs)
     << " = " << dt.number_of_full_cells();
     cerr << "\nThe triangulation has current dimension " << dt.current_dimension();
-    CGAL_assertion( dt.number_of_full_cells() == nbis+nbfs);
+    assert( dt.number_of_full_cells() == nbis+nbfs);
 
     cerr << "\nTraversing finite vertices... ";
     size_t nbfv(0);

--- a/Triangulation/test/Triangulation/test_regular.cpp
+++ b/Triangulation/test/Triangulation/test_regular.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <cstdlib>
 #include <algorithm>
+#include <cassert>
 
 using namespace std;
 
@@ -54,7 +55,7 @@ void test(const int d, const string & type, const int N)
   cerr << nbis << " = " << (nbis+nbfs)
   << " = " << rt.number_of_full_cells();
   cerr << "\nThe triangulation has current dimension " << rt.current_dimension();
-  CGAL_assertion( rt.number_of_full_cells() == nbis+nbfs);
+  assert( rt.number_of_full_cells() == nbis+nbfs);
 
   cerr << "\nTraversing finite vertices... ";
   size_t nbfv(0);

--- a/Triangulation_2/test/Triangulation_2/test_constrained_triangulation_with_info_2.cpp
+++ b/Triangulation_2/test/Triangulation_2/test_constrained_triangulation_with_info_2.cpp
@@ -2,6 +2,7 @@
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>
 #include <CGAL/Triangulation_vertex_base_with_info_2.h>
 #include <vector>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 
@@ -27,7 +28,7 @@ int main()
     CDT T;
     T.insert( points.begin(),points.end() );
 
-    CGAL_assertion( T.number_of_vertices() == 6 );
+    assert( T.number_of_vertices() == 6 );
 
     // check that the info was correctly set.
     CDT::Finite_vertices_iterator vit;
@@ -63,7 +64,7 @@ int main()
     T.insert( boost::make_zip_iterator(boost::make_tuple( points.begin(),indices.begin() )),
               boost::make_zip_iterator(boost::make_tuple( points.end(),indices.end() ) )  );
 
-    CGAL_assertion( T.number_of_vertices() == 6 );
+    assert( T.number_of_vertices() == 6 );
 
 
     // check that the info was correctly set.

--- a/Triangulation_2/test/Triangulation_2/test_triangulation_with_zip_iterator_2.cpp
+++ b/Triangulation_2/test/Triangulation_2/test_triangulation_with_zip_iterator_2.cpp
@@ -3,6 +3,7 @@
 #include <CGAL/Triangulation_vertex_base_with_info_2.h>
 #include <boost/iterator/zip_iterator.hpp>
 #include <vector>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel         K;
 typedef CGAL::Triangulation_vertex_base_with_info_2<unsigned, K>    Vb;
@@ -34,7 +35,7 @@ int main()
   Triangulation T( boost::make_zip_iterator(boost::make_tuple( points.begin(),indices.begin() )),
                    boost::make_zip_iterator(boost::make_tuple( points.end(),indices.end() ) )  );
 
-  CGAL_assertion( T.number_of_vertices() == 6 );
+  assert( T.number_of_vertices() == 6 );
 
 
   // check that the info was correctly set.

--- a/Triangulation_3/test/Triangulation_3/test_Triangulation_with_transform_iterator.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_Triangulation_with_transform_iterator.cpp
@@ -5,6 +5,7 @@
 #include <CGAL/boost/iterator/transform_iterator.hpp>
 
 #include <vector>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel         K;
 typedef CGAL::Triangulation_vertex_base_with_info_3<unsigned, K>    Vb;
@@ -37,7 +38,7 @@ int main()
   Triangulation T( boost::make_transform_iterator(points.begin(),Auto_count()),
                    boost::make_transform_iterator(points.end(),  Auto_count() )  );
 
-  CGAL_assertion( T.number_of_vertices() == 6 );
+  assert( T.number_of_vertices() == 6 );
 
   // check that the info was correctly set.
   Triangulation::Finite_vertices_iterator vit;

--- a/Triangulation_3/test/Triangulation_3/test_Triangulation_with_zip_iterator.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_Triangulation_with_zip_iterator.cpp
@@ -7,6 +7,7 @@
 
 #include <iostream>
 #include <vector>
+#include <cassert>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel         K;
 typedef CGAL::Triangulation_vertex_base_with_info_3<unsigned, K>    Vb;
@@ -36,7 +37,7 @@ int main()
   Triangulation T(boost::make_zip_iterator(boost::make_tuple( points.begin(),indices.begin() )),
                   boost::make_zip_iterator(boost::make_tuple( points.end(),indices.end() ) )  );
 
-  CGAL_assertion( T.number_of_vertices() == 6 );
+  assert( T.number_of_vertices() == 6 );
 
   // check that the info was correctly set.
   Triangulation::Finite_vertices_iterator vit;

--- a/Weights/test/Weights/include/utils.h
+++ b/Weights/test/Weights/include/utils.h
@@ -124,20 +124,20 @@ bool test_query(
 
   const auto a2 = wrapper.weight_a(t2, r2, p2, q2);
   const auto b2 = wrapper.weight_b(t2, r2, p2, q2);
-  CGAL_assertion(a2 >= FT(0) && b2 >= FT(0));
+  assert(a2 >= FT(0) && b2 >= FT(0));
   if (a2 < FT(0) || b2 < FT(0)) return false;
-  CGAL_assertion(CGAL::abs(a2 - b2) < tol);
+  assert(CGAL::abs(a2 - b2) < tol);
   if (CGAL::abs(a2 - b2) >= tol) return false;
 
   if (wrapper.supports_3d()) {
     const auto a3 = wrapper.weight_a(t3, r3, p3, q3);
     const auto b3 = wrapper.weight_b(t3, r3, p3, q3);
-    CGAL_assertion(a3 >= FT(0) && b3 >= FT(0));
+    assert(a3 >= FT(0) && b3 >= FT(0));
     if (a3 < FT(0) || b3 < FT(0)) return false;
-    CGAL_assertion(CGAL::abs(a3 - b3) < tol);
+    assert(CGAL::abs(a3 - b3) < tol);
     if (CGAL::abs(a3 - b3) >= tol) return false;
-    CGAL_assertion(CGAL::abs(a2 - a3) < tol);
-    CGAL_assertion(CGAL::abs(b2 - b3) < tol);
+    assert(CGAL::abs(a2 - a3) < tol);
+    assert(CGAL::abs(b2 - b3) < tol);
     if (CGAL::abs(a2 - a3) >= tol) return false;
     if (CGAL::abs(b2 - b3) >= tol) return false;
   }
@@ -169,20 +169,20 @@ bool test_symmetry_x(
 
   const auto a2 = wrapper.weight_a(t2, r2, p2, Point_2(-x, 0));
   const auto b2 = wrapper.weight_a(t2, r2, p2, Point_2(+x, 0));
-  CGAL_assertion(a2 >= FT(0) && b2 >= FT(0));
+  assert(a2 >= FT(0) && b2 >= FT(0));
   if (a2 < FT(0) || b2 < FT(0)) return false;
-  CGAL_assertion(CGAL::abs(a2 - b2) < tol);
+  assert(CGAL::abs(a2 - b2) < tol);
   if (CGAL::abs(a2 - b2) >= tol) return false;
 
   if (wrapper.supports_3d()) {
     const auto a3 = wrapper.weight_a(t3, r3, p3, Point_3(-x, 0, 1));
     const auto b3 = wrapper.weight_a(t3, r3, p3, Point_3(+x, 0, 1));
-    CGAL_assertion(a3 >= FT(0) && b3 >= FT(0));
+    assert(a3 >= FT(0) && b3 >= FT(0));
     if (a3 < FT(0) || b3 < FT(0)) return false;
-    CGAL_assertion(CGAL::abs(a3 - b3) < tol);
+    assert(CGAL::abs(a3 - b3) < tol);
     if (CGAL::abs(a3 - b3) >= tol) return false;
-    CGAL_assertion(CGAL::abs(a2 - a3) < tol);
-    CGAL_assertion(CGAL::abs(b2 - b3) < tol);
+    assert(CGAL::abs(a2 - a3) < tol);
+    assert(CGAL::abs(b2 - b3) < tol);
     if (CGAL::abs(a2 - a3) >= tol) return false;
     if (CGAL::abs(b2 - b3) >= tol) return false;
   }
@@ -218,17 +218,17 @@ bool test_compare(
 
   const auto a2 = wrapper1.weight_a(t2, r2, p2, q2);
   const auto b2 = wrapper2.weight_a(t2, r2, p2, q2);
-  CGAL_assertion(a2 >= FT(0) && b2 >= FT(0));
+  assert(a2 >= FT(0) && b2 >= FT(0));
   if (a2 < FT(0) || b2 < FT(0)) return false;
-  CGAL_assertion(CGAL::abs(a2 - b2) < tol);
+  assert(CGAL::abs(a2 - b2) < tol);
   if (CGAL::abs(a2 - b2) >= tol) return false;
 
   if (wrapper1.supports_3d() && wrapper2.supports_3d()) {
     const auto a3 = wrapper1.weight_a(t3, r3, p3, q3);
     const auto b3 = wrapper2.weight_a(t3, r3, p3, q3);
-    CGAL_assertion(a3 >= FT(0) && b3 >= FT(0));
+    assert(a3 >= FT(0) && b3 >= FT(0));
     if (a3 < FT(0) || b3 < FT(0)) return false;
-    CGAL_assertion(CGAL::abs(a3 - b3) < tol);
+    assert(CGAL::abs(a3 - b3) < tol);
     if (CGAL::abs(a3 - b3) >= tol) return false;
   }
   return true;
@@ -258,9 +258,9 @@ bool test_neighbors(
 
   const auto a2 = wrapper.weight(p2, q2, r2);
   const auto a3 = wrapper.weight(p3, q3, r3);
-  CGAL_assertion(a2 >= FT(0) && a3 >= FT(0));
+  assert(a2 >= FT(0) && a3 >= FT(0));
   if (a2 < FT(0) || a3 < FT(0)) return false;
-  CGAL_assertion(CGAL::abs(a2 - a3) < tol);
+  assert(CGAL::abs(a2 - a3) < tol);
   if (CGAL::abs(a2 - a3) >= tol) return false;
   return true;
 }
@@ -288,12 +288,12 @@ bool test_area(
 
   const auto a2 = wrapper.weight(p2, q2, r2);
   const auto a3 = wrapper.weight(p3, q3, r3);
-  CGAL_assertion(a2 <= CGAL::Weights::area(p2, q2, r2));
-  CGAL_assertion(a3 <= CGAL::Weights::area(p3, q3, r3));
+  assert(a2 <= CGAL::Weights::area(p2, q2, r2));
+  assert(a3 <= CGAL::Weights::area(p3, q3, r3));
   if (a2 > CGAL::Weights::area(p2, q2, r2)) return false;
   if (a3 > CGAL::Weights::area(p3, q3, r3)) return false;
-  CGAL_assertion(a2 >= FT(0));
-  CGAL_assertion(a3 >= FT(0));
+  assert(a2 >= FT(0));
+  assert(a3 >= FT(0));
   if (a2 < FT(0)) return false;
   if (a3 < FT(0)) return false;
   return true;
@@ -305,7 +305,7 @@ bool test_coordinates(
   const std::vector<Point>& polygon,
   const std::vector<FT>& weights) {
 
-  CGAL_assertion(weights.size() > 0);
+  assert(weights.size() > 0);
   if (weights.size() == 0) return false;
 
   // Compute the sum of weights.
@@ -314,7 +314,7 @@ bool test_coordinates(
   for (const FT& weight : weights) {
     sum += weight;
   }
-  CGAL_assertion(sum >= tol);
+  assert(sum >= tol);
   if (sum < tol) return false;
 
   // Compute coordinates.
@@ -323,7 +323,7 @@ bool test_coordinates(
   for (const FT& weight : weights) {
     coordinates.push_back(weight / sum);
   }
-  CGAL_assertion(coordinates.size() == weights.size());
+  assert(coordinates.size() == weights.size());
   if (coordinates.size() != weights.size()) return false;
 
   // Test partition of unity.
@@ -331,7 +331,7 @@ bool test_coordinates(
   for (const FT& coordinate : coordinates) {
     sum += coordinate;
   }
-  CGAL_assertion(CGAL::abs(FT(1) - sum) < tol);
+  assert(CGAL::abs(FT(1) - sum) < tol);
   if (CGAL::abs(FT(1) - sum) >= tol) return false;
 
   // Test linear precision.
@@ -340,8 +340,8 @@ bool test_coordinates(
     x += coordinates[i] * polygon[i].x();
     y += coordinates[i] * polygon[i].y();
   }
-  CGAL_assertion(CGAL::abs(query.x() - x) < tol);
-  CGAL_assertion(CGAL::abs(query.y() - y) < tol);
+  assert(CGAL::abs(query.x() - x) < tol);
+  assert(CGAL::abs(query.y() - y) < tol);
   if (CGAL::abs(query.x() - x) >= tol) return false;
   if (CGAL::abs(query.y() - y) >= tol) return false;
   return true;
@@ -357,7 +357,7 @@ bool test_on_polygon(
 
   // Get weights.
   using FT = typename Kernel::FT;
-  CGAL_assertion(polygon_2.size() >= 3);
+  assert(polygon_2.size() >= 3);
   if (polygon_2.size() < 3) return false;
 
   // 2D version.
@@ -365,7 +365,7 @@ bool test_on_polygon(
   weights_2.reserve(polygon_2.size());
   wrapper.compute_on_polygon(
     polygon_2, query_2, Kernel(), std::back_inserter(weights_2));
-  CGAL_assertion(weights_2.size() == polygon_2.size());
+  assert(weights_2.size() == polygon_2.size());
   if (weights_2.size() != polygon_2.size()) return false;
   if (!test_coordinates(query_2, polygon_2, weights_2)) return false;
 
@@ -377,7 +377,7 @@ bool test_on_polygon(
   for (const auto& vertex_2 : polygon_2) {
     polygon_3.push_back(Point_3(vertex_2.x(), vertex_2.y(), 1));
   }
-  CGAL_assertion(polygon_3.size() == polygon_2.size());
+  assert(polygon_3.size() == polygon_2.size());
   if (polygon_3.size() != polygon_2.size()) return false;
   const CGAL::Projection_traits_xy_3<Kernel> ptraits;
 
@@ -385,7 +385,7 @@ bool test_on_polygon(
   weights_3.reserve(polygon_3.size());
   wrapper.compute_on_polygon(
     polygon_3, query_3, ptraits, std::back_inserter(weights_3));
-  CGAL_assertion(weights_3.size() == polygon_3.size());
+  assert(weights_3.size() == polygon_3.size());
   if (weights_3.size() != polygon_3.size()) return false;
   if (!test_coordinates(query_3, polygon_3, weights_3)) return false;
   return true;
@@ -402,7 +402,7 @@ bool test_barycentric_properties(
   // Get weights.
   using FT = typename Kernel::FT;
   const std::size_t n = polygon.size();
-  CGAL_assertion(n >= 3);
+  assert(n >= 3);
   if (n < 3) return false;
 
   // Check properties.
@@ -418,7 +418,7 @@ bool test_barycentric_properties(
     const FT weight = wrapper.weight_a(t, r, p, q);
     weights.push_back(weight);
   }
-  CGAL_assertion(weights.size() == n);
+  assert(weights.size() == n);
   if (weights.size() != n) return false;
   if (!test_coordinates(query, polygon, weights)) return false;
   return true;


### PR DESCRIPTION

## Summary of Changes

We must use CGAL_assertion only inside CGAL code and not in the test code itself.  I fix it for 2D Periodic Triangulations but I think we have to fix it in other places (e.g. P3T3 @MaelRL )

## Release Management

* Affected package(s): P2T2
* Issue(s) solved (if any):    See this [warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.4-Ic-141/Periodic_2_triangulation_2/TestReport_gimeno_ArchLinux-clang-CXX17-Release.gz)


