### PR TITLE
Mesh_3: Fixes for VC++ with option /permissive-

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
@@ -106,7 +106,16 @@ protected:
   Lock_data_structure *get_lock_data_structure() { return 0; }
   void unlock_all_elements() {}
 
+
+  // Workaround for problem with VC and /permissive
+  // See: https://gist.github.com/afabri/0416bebec1c32fb4efd6632446698972
+  void increment_frozen_points() const
+  {
+    ++nb_frozen_points_;
+  }
+
 protected:
+  mutable unsigned int nb_frozen_points_;
   std::size_t big_moves_size_;
   std::multiset<FT> big_moves_;
 };
@@ -116,6 +125,7 @@ protected:
 template <typename Tr>
 class Mesh_global_optimizer_base<Tr, Parallel_tag>
 {
+
 protected:
   typedef typename Tr::Geom_traits                          Gt;
   typedef typename Gt::FT                                   FT;
@@ -183,9 +193,14 @@ protected:
     m_lock_ds.unlock_all_points_locked_by_this_thread();
   }
 
+  void increment_frozen_points() const
+  {
+    ++nb_frozen_points_;
+  }
 public:
 
 protected:
+  mutable std::atomic<unsigned int> nb_frozen_points_ = 0;
   std::atomic<std::size_t>  big_moves_current_size_;
   std::atomic<FT>           big_moves_smallest_;
   std::size_t               big_moves_size_;
@@ -221,6 +236,8 @@ class Mesh_global_optimizer
   using Base::get_lock_data_structure;
   using Base::big_moves_;
   using Base::big_moves_size_;
+  using Base::nb_frozen_points_;
+  using Base::increment_frozen_points;
 
   typedef typename C3T3::Triangulation  Tr;
   typedef typename Tr::Geom_traits      Gt;
@@ -240,7 +257,6 @@ class Mesh_global_optimizer
   typedef Hash_handles_with_or_without_timestamps                Hash_fct;
   typedef typename boost::unordered_set<Vertex_handle, Hash_fct> Vertex_set;
   typedef typename Base::Moves_vector                            Moves_vector;
-  typedef typename Base::Nb_frozen_points_type                   Nb_frozen_points_type;
 
 #ifdef CGAL_INTRUSIVE_LIST
   typedef Intrusive_list<Cell_handle>   Outdated_cell_set;
@@ -566,7 +582,6 @@ private:
   CGAL::Real_timer running_time_;
 
   bool do_freeze_;
-  mutable Nb_frozen_points_type nb_frozen_points_;
 
 #ifdef CGAL_MESH_3_OPTIMIZER_VERBOSE
   mutable FT sum_moves_;
@@ -602,8 +617,6 @@ Mesh_global_optimizer(C3T3& c3t3,
 , sum_moves_(0)
 #endif // CGAL_MESH_3_OPTIMIZER_VERBOSE
 {
-  nb_frozen_points_ = 0; // We put it here in case it's an "atomic"
-
   // If we're multi-thread
   tr_.set_lock_data_structure(get_lock_data_structure());
 
@@ -906,7 +919,7 @@ compute_move(const Vertex_handle& v)
   // Move point only if the displacement is big enough w.r.t. the local size
   if ( local_move_sq_ratio < sq_freeze_ratio_ )
   {
-    ++nb_frozen_points_;
+    increment_frozen_points();
     return CGAL::NULL_VECTOR;
   }
 

--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
@@ -81,7 +81,7 @@ protected:
   typedef unsigned int                                      Nb_frozen_points_type;
 
   Mesh_global_optimizer_base(const Bbox_3 &, int)
-    : big_moves_size_(0) {}
+    : nb_frozen_points_(0), big_moves_size_(0) {}
 
   void update_big_moves(const FT& new_sq_move)
   {
@@ -136,7 +136,7 @@ protected:
   typedef std::atomic<unsigned int>                         Nb_frozen_points_type ;
 
   Mesh_global_optimizer_base(const Bbox_3 &bbox, int num_grid_cells_per_axis)
-    : big_moves_size_(0)
+    : nb_frozen_points_(0), big_moves_size_(0)
     , m_lock_ds(bbox, num_grid_cells_per_axis)
   {
     big_moves_current_size_ = 0;
@@ -200,7 +200,7 @@ protected:
 public:
 
 protected:
-  mutable std::atomic<unsigned int> nb_frozen_points_ = 0;
+  mutable std::atomic<unsigned int> nb_frozen_points_;
   std::atomic<std::size_t>  big_moves_current_size_;
   std::atomic<FT>           big_moves_smallest_;
   std::size_t               big_moves_size_;


### PR DESCRIPTION
## Summary of Changes

With the option `/permissive-` some of the tests of `Mesh_3` do not compile. 
I could boil it down to this [gist](https://gist.github.com/afabri/0416bebec1c32fb4efd6632446698972).
The fix is to move the counter in the base class and add a function to increment it.

## Release Management

* Affected package(s): Mesh_3

