### PR TITLE
Intersections_3 :   Use Coercion_traits

### DIFF
--- a/Intersections_3/include/CGAL/Intersections_3/internal/Bbox_3_Segment_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Bbox_3_Segment_3_do_intersect.h
@@ -173,11 +173,11 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
     }
     else
     {
-      tmax = bxmax - px;
+      tmax = CFT(bxmax) - px;
       dmax = qx - px;
     }
 
-    tmin = bxmin - px;
+    tmin = CFT(bxmin) - px;
     dmin = qx - px;
   }
   else
@@ -194,11 +194,11 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
     }
     else
     {
-      tmax = px - bxmin;
+      tmax = px - CFT(bxmin);
       dmax = px - qx;
     }
 
-    tmin = px - bxmax;
+    tmin = px - CFT(bxmax);
     dmin = px - qx;
   }
 
@@ -246,11 +246,11 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
     }
     else
     {
-      tymax = bymax - py;
+      tymax = CFT(bymax) - py;
       dymax = qy - py;
     }
 
-    tymin = bymin - py;
+    tymin = CFT(bymin) - py;
     dymin = qy - py;
   }
   else
@@ -267,11 +267,11 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
     }
     else
     {
-      tymax = py - bymin;
+      tymax = py - CFT(bymin);
       dymax = py - qy;
     }
 
-    tymin = py - bymax;
+    tymin = py - CFT(bymax);
     dymin = py - qy;
   }
 
@@ -317,11 +317,11 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
     }
     else
     {
-      tzmax = bzmax - pz;
+      tzmax = CFT(bzmax) - pz;
       dzmax = qz - pz;
     }
 
-    tzmin = bzmin - pz;
+    tzmin = CFT(bzmin) - pz;
     dzmin = qz - pz;
   }
   else
@@ -338,11 +338,11 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
     }
     else
     {
-      tzmax = pz - bzmin;
+      tzmax = pz - CFT(bzmin);
       dzmax = pz - qz;
     }
 
-    tzmin = pz - bzmax;
+    tzmin = pz - CFT(bzmax);
     dzmin = pz - qz;
   }
 

--- a/Number_types/test/Number_types/CMakeLists.txt
+++ b/Number_types/test/Number_types/CMakeLists.txt
@@ -12,6 +12,7 @@ include(CGAL_VersionUtils)
 
 include_directories(BEFORE include)
 
+create_single_source_cgal_program("Exact_rational.cpp")
 create_single_source_cgal_program("bench_interval.cpp")
 create_single_source_cgal_program("constant.cpp")
 create_single_source_cgal_program("CORE_BigFloat.cpp")

--- a/Number_types/test/Number_types/CMakeLists.txt
+++ b/Number_types/test/Number_types/CMakeLists.txt
@@ -12,7 +12,7 @@ include(CGAL_VersionUtils)
 
 include_directories(BEFORE include)
 
-create_single_source_cgal_program("Exact_rational.cpp")
+
 create_single_source_cgal_program("bench_interval.cpp")
 create_single_source_cgal_program("constant.cpp")
 create_single_source_cgal_program("CORE_BigFloat.cpp")

--- a/Number_types/test/Number_types/Exact_rational.cpp
+++ b/Number_types/test/Number_types/Exact_rational.cpp
@@ -1,0 +1,20 @@
+#include <CGAL/Exact_rational.h>
+#include <iostream>
+
+typedef CGAL::Exact_rational Rational;
+
+int main()
+{
+  std::cout << typeid(Rational).name() << std::endl;
+
+  Rational rat(-0.375);
+  double d = -0.625;
+
+  std::cout << "rat : " << rat << std::endl;
+
+  Rational sub = rat - d;
+  std::cout << "sub : " << sub << std::endl;
+  assert(rat != sub);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary of Changes

This PR fixes a problem with the GMP backend in `boost::multiprecision`. 

The failure of the [Intersections_3 testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.5-Ic-2/Intersections_3/TestReport_Sosno_MSVC-2022-Preview-Release.gz) for VC++ comes from the error in  `operator-()`.    The type `CGAL::Exact_rational` is `boost::multiprecision::number<struct boost::multiprecision::backends::gmp_rational,1>`  on this platform and the boost version is 1_78.       When I use `CGAL::Gmpq` directly or if I use `boost::multiprecision::cpp_rational` there is no problem.  

The `operator-()`  is used [here](https://github.com/CGAL/cgal/blob/master/Intersections_3/include/CGAL/Intersections_3/internal/Bbox_3_Segment_3_do_intersect.h#L197).    

In the intersection code we  now  construct a `CFT` from the `double`  before performing the subtraction. 

I isolated this into a testcase in the  `Number_types` package, but didn't put it into the `CMakeLists.txt` as it would break the testsuite.  I made  a [bug report](https://github.com/boostorg/multiprecision/issues/415) to boost.org. 

## Release Management

* Affected package(s):  Intersections_3
