### PR TITLE
Warning when building Periodic_2_triangulation_2 documentation

### DIFF
--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Periodic_2_triangulation_2.txt
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Periodic_2_triangulation_2.txt
@@ -199,7 +199,6 @@ parameters:
   `Periodic_2TriangulationTraits_2` (for `Periodic_2_triangulation_2`)
   and `Periodic_2DelaunayTriangulationTraits_2` (for
   `Periodic_2_Delaunay_triangulation_2`) in the reference manual and
-.
 - the <B>triangulation data structure</B> class, which stores the
   combinatorial structure, described in Section \ref
   P2Triangulation2sectds and in more detail in Chapter \ref

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Periodic_2_triangulation_2.txt
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Periodic_2_triangulation_2.txt
@@ -198,7 +198,7 @@ parameters:
   P2Triangulation2secTraits. The concepts that should be refined are
   `Periodic_2TriangulationTraits_2` (for `Periodic_2_triangulation_2`)
   and `Periodic_2DelaunayTriangulationTraits_2` (for
-  `Periodic_2_Delaunay_triangulation_2`) in the reference manual and
+  `Periodic_2_Delaunay_triangulation_2`).
 - the <B>triangulation data structure</B> class, which stores the
   combinatorial structure, described in Section \ref
   P2Triangulation2sectds and in more detail in Chapter \ref


### PR DESCRIPTION
When building the Periodic_2_triangulation_2 documentation we get the warning:
```
/home/cgal-testsuite/cgal_doc_build/CGAL-5.5-Ic-3/doc/Periodic_2_triangulation_2/Periodic_2_triangulation_2.txt:202: warning: End of list marker found without any preceding list items
```

This has been corrected.
