### PR TITLE
Set precision of the ostringstream

### DIFF
--- a/Polynomial/test/Polynomial/test_polynomial.h
+++ b/Polynomial/test/Polynomial/test_polynomial.h
@@ -291,6 +291,7 @@ void io() {
         // successful re-reading of output
         POLY p(NT(-3), NT(5), NT(0), NT(0), NT(-7), NT(9)), q;
         std::ostringstream os;
+        os.precision(17);
         os << p;
         std::istringstream is(os.str());
         is >> q;


### PR DESCRIPTION
## Summary of Changes

Fix  for an assertion in the [Polynomial testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.5-I-4/Polynomial/TestReport_Sosno_MSVC-2019-Community-Release.gz) which is there since ever.

For testing I/O we write to an `ostringstream` and read back from it, but we forgot to call `precision(17)`.   
No idea why we only have this problem with VC++.

## Release Management

* Affected package(s): Polynomial

