### PR TITLE
Polynomial: Workaround for VC bug when cout << double  while rounding up

### DIFF
--- a/Polynomial/test/Polynomial/test_polynomial.h
+++ b/Polynomial/test/Polynomial/test_polynomial.h
@@ -285,6 +285,13 @@ void division(CGAL::Integral_domain_tag) {
 
 template <class NT>
 void io() {
+
+    // https://github.com/CGAL/cgal/issues/6272#issuecomment-1022005703
+    // VCbug:  Setting the rounding mode influences output of double
+    // The rounding mode is set to CGAL_FE_UPWARD in the test ccp files
+    // in order to test Modular Arithmetic
+    // Without this change which is local to the function  p == q will fail
+    CGAL::Protect_FPU_rounding<true> pfr(CGAL_FE_TONEAREST);
     typedef CGAL::Polynomial<NT> POLY;
 
     {


### PR DESCRIPTION
## Summary of Changes

Locally in the IO test function set the  rounding mode to nearest to avoid a known VC++ bug.
So we can keep the intended check that when rounding up the Modular Arithmetic for Polynomials works correctly.

## Release Management

* Affected package(s): Polynomial
* Issue(s) solved (if any): fix #6272
