### PR TITLE
A sidetracked attempt to implement IO for polygon sets

### DIFF
--- a/Boolean_set_operations_2/include/CGAL/General_polygon_2.h
+++ b/Boolean_set_operations_2/include/CGAL/General_polygon_2.h
@@ -169,7 +169,16 @@ template <class Traits>
 std::istream &operator>>(std::istream &is, General_polygon_2<Traits>& p)
 {
   int n; // number of edges
-  is >> n;
+
+  switch(IO::get_mode(is)) {
+    case IO::ASCII :
+      is >> n;
+      break;
+    case IO::BINARY :
+      read(is, n);
+      break;
+  }
+
   typename Traits::X_monotone_curve_2 cv;
 
   if (is) {
@@ -202,7 +211,10 @@ std::ostream
       return os;
 
     case IO::BINARY :
-      os << p.size();
+      {
+          int n = p.size();
+          write(os, n);
+      }
       for (i = p.curves_begin(); i != p.curves_end(); ++i) {
         os << *i;
       }

--- a/Boolean_set_operations_2/include/CGAL/General_polygon_set_2.h
+++ b/Boolean_set_operations_2/include/CGAL/General_polygon_set_2.h
@@ -114,6 +114,109 @@ public:
   //@}
 };
 
+
+
+//-----------------------------------------------------------------------//
+//                          operator<<
+//-----------------------------------------------------------------------//
+/*!
+This operator exports a General_polygon_with_holes_2 to the output stream `out`.
+
+An \ascii and a binary format exist. The format can be selected with
+the \cgal modifiers for streams, `set_ascii_mode(0` and `set_binary_mode()`
+respectively. The modifier `set_pretty_mode()` can be used to allow for (a
+few) structuring comments in the output. Otherwise, the output would
+be free of comments. The default for writing is \ascii without comments.
+
+The number of curves of the outer boundary is exported followed by the
+curves themselves. Then, the number of holes
+is exported, and for each hole, the number of curves on its outer
+boundary is exported followed by the curves themselves.
+
+\relates General_polygon_with_holes_2
+*/
+template <class Traits_, class Dcel_ = Gps_default_dcel<Traits_> >
+std::ostream
+&operator<<(std::ostream &os, const General_polygon_set_2<Traits_, Dcel_>& g)
+{
+  typedef typename General_polygon_set_2<Traits_, Dcel_>::Polygon_with_holes_2 Polygon_with_holes_2;
+  std::vector<Polygon_with_holes_2> v;
+  const unsigned int n = g.number_of_polygons_with_holes();
+
+  v.reserve(n);
+  g.polygons_with_holes(std::back_inserter(v));
+
+  switch(IO::get_mode(os)) {
+    case IO::ASCII :
+      os << n;
+      for (const Polygon_with_holes_2 &H: v) {
+        os << ' ' << H;
+      }
+      return os;
+
+    case IO::BINARY :
+      write(os, n);
+      for (const Polygon_with_holes_2 &H: v) {
+        os << H;
+      }
+      return os;
+
+
+    default:
+      os << "General_polygon_set_2( " << std::endl;
+      os << n << " ";
+      for (const Polygon_with_holes_2 &H: v) {
+        os << H;
+      }
+      return os;
+  }
+}
+
+//-----------------------------------------------------------------------//
+//                          operator>>
+//-----------------------------------------------------------------------//
+
+/*!
+This operator imports a General_polygon_with_holes_2 from the input stream `in`.
+
+Both ASCII and binary formats are supported, and the format is automatically detected.
+
+The format consists of the number of curves of the outer boundary
+followed by the curves themselves, followed
+by the number of holes, and for each hole, the number of curves on its
+outer boundary is followed by the curves themselves.
+
+\relates General_polygon_with_holes_2
+*/
+template <class Traits_, class Dcel_ = Gps_default_dcel<Traits_> >
+std::istream
+&operator>>(std::istream &is, General_polygon_set_2<Traits_, Dcel_>& g)
+{
+  typedef typename General_polygon_set_2<Traits_, Dcel_>::Polygon_with_holes_2 Polygon_with_holes_2;
+
+  g.clear();
+
+  unsigned int n;
+
+  switch(IO::get_mode(is)) {
+    case IO::ASCII :
+      is >> n;
+      break;
+    case IO::BINARY :
+      read(is, n);
+      break;
+  }
+
+  for (unsigned int i = 0; i < n; i++) {
+    Polygon_with_holes_2 pgn_hole;
+    is >> pgn_hole;
+    g.insert(pgn_hole);
+  }
+
+  return is;
+}
+
+
 } //namespace CGAL
 
 #include <CGAL/enable_warnings.h>

--- a/Kernel_23/include/CGAL/Circle_2.h
+++ b/Kernel_23/include/CGAL/Circle_2.h
@@ -231,7 +231,7 @@ insert(std::ostream& os, const Circle_2<R>& c)
         break;
     case IO::BINARY :
         os << c.center();
-        write(os, c.squared_radius());
+        write(os, to_double(c.squared_radius()));
         write(os, static_cast<int>(c.orientation()));
         break;
     default:
@@ -272,10 +272,14 @@ extract(std::istream& is, Circle_2<R>& c)
         is >> center >> IO::iformat(squared_radius) >> o;
         break;
     case IO::BINARY :
+    {
+        double d;
         is >> center;
-        read(is, squared_radius);
+        read(is, d);
+        squared_radius = d;
         is >> o;
         break;
+    }
     default:
         is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;

--- a/Kernel_23/include/CGAL/Point_2.h
+++ b/Kernel_23/include/CGAL/Point_2.h
@@ -194,16 +194,16 @@ template <class R >
 std::ostream&
 insert(std::ostream& os, const Point_2<R>& p,const Cartesian_tag&)
 {
-    switch(IO::get_mode(os)) {
-    case IO::ASCII :
-        return os << p.x() << ' ' << p.y();
-    case IO::BINARY :
-        write(os, p.x());
-        write(os, p.y());
-        return os;
-    default:
-        return os << "PointC2(" << p.x() << ", " << p.y() << ')';
-    }
+  switch(IO::get_mode(os)) {
+  case IO::ASCII :
+      return os << p.x() << ' ' << p.y();
+  case IO::BINARY :
+      write(os, to_double(p.x()));
+      write(os, to_double(p.y()));
+      return os;
+  default:
+      return os << "PointC2(" << p.x() << ", " << p.y() << ')';
+  }
 }
 
 template <class R >
@@ -215,9 +215,9 @@ insert(std::ostream& os, const Point_2<R>& p,const Homogeneous_tag&)
     case IO::ASCII :
         return os << p.hx() << ' ' << p.hy() << ' ' << p.hw();
     case IO::BINARY :
-        write(os, p.hx());
-        write(os, p.hy());
-        write(os, p.hw());
+        write(os, to_double(p.hx()));
+        write(os, to_double(p.hy()));
+        write(os, to_double(p.hw()));
         return os;
     default:
         return os << "PointH2(" << p.hx() << ", "
@@ -244,9 +244,14 @@ extract(std::istream& is, Point_2<R>& p, const Cartesian_tag&)
         is >> IO::iformat(x) >> IO::iformat(y);
         break;
     case IO::BINARY :
-        read(is, x);
-        read(is, y);
+    {
+        double dx, dy;
+        read(is, dx);
+        read(is, dy);
+        x = dx;
+        y = dy;
         break;
+    }
     default:
         is.setstate(std::ios::failbit);
         std::cerr << "" << std::endl;
@@ -270,9 +275,15 @@ extract(std::istream& is, Point_2<R>& p, const Homogeneous_tag&)
         is >> hx >> hy >> hw;
         break;
     case IO::BINARY :
-        read(is, hx);
-        read(is, hy);
-        read(is, hw);
+    {
+        double f, g, h;
+        read(is, f);
+        read(is, g);
+        read(is, h);
+        hx = f;
+        hy = g;
+        hw = h;
+    }
         break;
     default:
         is.setstate(std::ios::failbit);

--- a/Polygon/include/CGAL/General_polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/General_polygon_with_holes_2.h
@@ -192,7 +192,8 @@ std::ostream
       return os;
 
     case IO::BINARY :
-      os << p.outer_boundary()  << p.number_of_holes();
+      write(os, p.outer_boundary());
+      write(os, p.number_of_holes());
       for (hit = p.holes_begin(); hit != p.holes_end(); ++hit) {
         os << *hit;
       }

--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_impl.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_impl.h
@@ -84,7 +84,16 @@ std::istream &
 operator>>(std::istream &is, Polygon_2<Traits_P,Container_P>& p)
 {
   int n = 0; // number of vertices
-  is >> n;
+
+  switch(IO::get_mode(is)) {
+    case IO::ASCII :
+      is >> n;
+      break;
+    case IO::BINARY :
+      read(is, n);
+      break;
+  }
+
   typename Traits_P::Point_2 point;
 
   if (is) {
@@ -121,7 +130,10 @@ operator<<(std::ostream &os, const Polygon_2<Traits_P,Container_P>& p)
       return os;
 
     case IO::BINARY :
-      os << p.size();
+      {
+          int n = p.size();
+          write(os, n);
+      }
       for (i = p.vertices_begin(); i != p.vertices_end(); ++i) {
         os << *i;
       }

--- a/Polygon/include/CGAL/Polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/Polygon_with_holes_2.h
@@ -111,7 +111,11 @@ std::ostream& operator<<(std::ostream &os,
       return os;
 
     case IO::BINARY :
-       os << p.outer_boundary() << p.number_of_holes();
+      os << p.outer_boundary();
+      {
+          unsigned int n = p.number_of_holes();
+          write(os, n);
+      }
       for (i = p.holes_begin(); i != p.holes_end(); ++i) {
         os << *i ;
       }
@@ -163,7 +167,16 @@ std::istream &operator>>(std::istream &is,
   is >> p.outer_boundary();
 
   unsigned int n; // number of holes;
-  is >> n;
+
+  switch(IO::get_mode(is)) {
+    case IO::ASCII :
+      is >> n;
+      break;
+    case IO::BINARY :
+      read(is, n);
+      break;
+  }
+
   if(is)
   {
      for (unsigned int i=0; i<n; i++)


### PR DESCRIPTION
This PR started out as an attempt to implement IO for polygon sets.  In the process, I bumped into the problem described in #6275 and tried to fix that, then noticed that IO doesn't really work for general polygons and set out to implement IO for circle-segment polygons.  I then ran out of steam.

I do not believe the (partial) implementation of this PR is correct, but I submit it anyway, in case it is of any use.  Binary output for the various number types, doesn't seem to be implemented, so I converted coordinates to doubles in order to output them in binary form.  This works for plain polygons, but is of course lossy, which is no the case for ASCII output.  For circle-segment and other polygons, I do not expect it to work at all, since the approximate intersection points will not lie on the supporting curves/lines in the geneal case.

I have gotten ASCII IO for circle-segment polygons to work, at least for the cases I've tried.  See the attached file in #6275 for some test code for the implemented functionality.

If this is, as I suspect of no use, feel free to close the PR.