### PR TITLE
Workaround warnings

### DIFF
--- a/HalfedgeDS/examples/HalfedgeDS/hds_prog_compact2.cpp
+++ b/HalfedgeDS/examples/HalfedgeDS/hds_prog_compact2.cpp
@@ -37,14 +37,14 @@ public:
         // pointer arithmetic, then convert pointer back to handle again.
         Halfedge_handle h = HDS::halfedge_handle(this); // proper handle
         if ( nxt & 1)
-            return HDS::halfedge_handle( &* h + 1);
-        return HDS::halfedge_handle( &* h - 1);
+            return HDS::halfedge_handle( std::next(&*h) );
+        return HDS::halfedge_handle( std::prev(&*h));
     }
     Halfedge_const_handle opposite() const { // same as above
         Halfedge_const_handle h = HDS::halfedge_handle(this); // proper handle
         if ( nxt & 1)
-            return HDS::halfedge_handle( &* h + 1);
-        return HDS::halfedge_handle( &* h - 1);
+            return HDS::halfedge_handle( std::next(&*h));
+        return HDS::halfedge_handle( std::prev(&*h));
     }
     Halfedge_handle next() {
         return HDS::halfedge_handle((Halfedge*)(nxt & (~ std::ptrdiff_t(1))));
@@ -54,9 +54,9 @@ public:
                                                  (~ std::ptrdiff_t(1))));
     }
     void  set_opposite( Halfedge_handle h) {
-        CGAL_precondition(( &* h - 1 == &* HDS::halfedge_handle(this)) ||
-                          ( &* h + 1 == &* HDS::halfedge_handle(this)));
-        if ( &* h - 1 == &* HDS::halfedge_handle(this))
+        CGAL_precondition(( std::prev(&*h) == &* HDS::halfedge_handle(this)) ||
+                          ( std::next(&*h)== &* HDS::halfedge_handle(this)));
+        if ( std::prev(&*h) == &* HDS::halfedge_handle(this))
             nxt |= 1;
         else
             nxt &= (~ std::ptrdiff_t(1));


### PR DESCRIPTION
Try to workaround this [warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.5-Ic-10/HalfedgeDS_Examples/TestReport_lrineau_Fedora-with-LEDA.gz)

```
/home/cgal_tester/build/src/cmake/platforms/Fedora-with-LEDA/test/HalfedgeDS_Examples/hds_prog_compact2.cpp:42:36: warning: array subscript -1 is outside array bounds of ‘std::pair<CGAL::HalfedgeDS_in_place_list_halfedge<My_halfedge<CGAL::HalfedgeDS_list_types<Traits, My_items, std::allocator<int> > > >, CGAL::HalfedgeDS_in_place_list_halfedge<My_halfedge<CGAL::HalfedgeDS_list_types<Traits, My_items, std::allocator<int> > > > > [1]’ [-Warray-bounds]
   42 |         return HDS::halfedge_handle( &* h - 1);
      |                ~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
```