### PR TITLE
Stream_support: Fix File_scanner_OFF::scan_facet()

### DIFF
--- a/Stream_support/include/CGAL/IO/OFF/File_scanner_OFF.h
+++ b/Stream_support/include/CGAL/IO/OFF/File_scanner_OFF.h
@@ -710,7 +710,7 @@ public:
       if(entries.empty())
       {
         m_in.clear(std::ios::badbit);
-	size = 0;
+        size = 0;
         return;
       }
       size = static_cast<std::size_t>(entries[0]);

--- a/Stream_support/include/CGAL/IO/OFF/File_scanner_OFF.h
+++ b/Stream_support/include/CGAL/IO/OFF/File_scanner_OFF.h
@@ -710,6 +710,7 @@ public:
       if(entries.empty())
       {
         m_in.clear(std::ios::badbit);
+	size = 0;
         return;
       }
       size = static_cast<std::size_t>(entries[0]);


### PR DESCRIPTION
## Summary of Changes

In  case of a failure the reference parameter ` size`  did not get set to zero. This leads to a warning in [this testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.5-Ic-11/Stream_support_Examples/TestReport_lrineau_ArchLinux-CXX17-Release.gz). 


## Release Management

* Affected package(s): Stream_support

