### PR TITLE
Triangulation_2: Quiet a warning

### DIFF
--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -1186,7 +1186,8 @@ intersect(Face_handle f, int i,
             << " , #" << vd->time_stamp() << "= " << vd->point()
             << " , Exact_intersections_tag)\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
-  Point pi;
+  Point pi(ORIGIN); // initialize although we are sure that it will be
+                    // set by the intersection, but to quit a warning
   Intersection_tag itag = Intersection_tag();
   CGAL_triangulation_assertion_code( bool ok = )
   intersection(geom_traits(), pa, pb, pc, pd, pi, itag );

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -1187,7 +1187,7 @@ intersect(Face_handle f, int i,
             << " , Exact_intersections_tag)\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   Point pi(ORIGIN); // initialize although we are sure that it will be
-                    // set by the intersection, but to quit a warning
+                    // set by the intersection, but to quiet a warning
   Intersection_tag itag = Intersection_tag();
   CGAL_triangulation_assertion_code( bool ok = )
   intersection(geom_traits(), pa, pb, pc, pd, pi, itag );


### PR DESCRIPTION
## Summary of Changes

We only default initialize a point as we are sure that it will be set by the intersection function before it is used, but the compiler does not know and warns for several test platforms.  So let's just initialize it.

## Release Management

* Affected package(s): Triangulation_2

