### PR TITLE
Polygon:  Remove a workaround for an old Sun compiler

### DIFF
--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -157,11 +157,8 @@ class Polygon_2 {
     template <class InputIterator>
     Polygon_2(InputIterator first, InputIterator last,
               Traits p_traits = Traits())
-        : d_container(), traits(p_traits)
-    {
-      // Sun STL switches off member templates for binary backward compat.
-      std::copy(first, last, std::back_inserter(d_container));
-    }
+      : d_container(first,last), traits(p_traits)
+    {}
 
 #ifndef DOXYGEN_RUNNING
   Polygon_2& operator=(const Polygon_2&)=default;


### PR DESCRIPTION
## Summary of Changes

No need to construct an empty container and to call `std::copy()`.  
Additionally I hope that the warning in this [testsuite ](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.5-Ic-11/Polygon_Examples/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz) goes away.

## Release Management

* Affected package(s): Polygon

