### PR TITLE
Intersection_3: Use Coercion_traits

### DIFF
--- a/Intersections_3/include/CGAL/Intersections_3/internal/Bbox_3_Line_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Bbox_3_Line_3_do_intersect.h
@@ -63,7 +63,7 @@ bbox_line_do_intersect_aux(const LFT px, const LFT py, const LFT pz,
   }
 
   //if px is not in the x-slab
-  if(dmin == FT(0) && (tmin > FT(0) || tmax < FT(0)))
+  if(is_zero(dmin) && (is_positive(tmin) || is_negative(tmax)))
     return false;
 
   FT dmax = dmin;

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Bbox_3_Segment_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Bbox_3_Segment_3_do_intersect.h
@@ -162,9 +162,9 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   CFT dmin, tmin, tmax, dmax;
   if(qx >= px)
   {
-    if(bounded_0 && px > to_CFT(bxmax))
+    if(bounded_0 && compare(px, bxmax) == LARGER)
       return false; // segment on the right of bbox
-    if(bounded_1 && qx < to_CFT(bxmin))
+    if(bounded_1 && compare(qx, bxmin) == SMALLER)
       return false; // segment on the left of bbox
 
     if(bounded_1 && bxmax > qx)
@@ -183,12 +183,12 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   }
   else
   {
-    if(bounded_1 && qx > to_CFT(bxmax))
+    if(bounded_1 && compare(qx, bxmax) == LARGER)
       return false; // segment on the right of bbox
-    if(bounded_0 && px < to_CFT(bxmin))
+    if(bounded_0 && compare(px, bxmin) == SMALLER)
       return false; // segment on the left of bbox
 
-    if(bounded_1 && to_CFT(bxmin) < qx)
+    if(bounded_1 && compare(bxmin, qx) == SMALLER)
     {
       tmax = 1;
       dmax = 1;
@@ -211,7 +211,7 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   if((px == qx) &&  // <=> (dmin == 0)
      (!(bounded_0 && bounded_1))) // do not check for a segment
   {
-    if(px > to_CFT(bxmax) || px < to_CFT(bxmin))
+    if(compare(px, bxmax) == LARGER || compare(px, bxmin) == SMALLER)
       return false;
 
     // Note: for a segment the condition has already been tested by the two
@@ -235,12 +235,12 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   CFT dymin, tymin, tymax, dymax;
   if(qy >= py)
   {
-    if(bounded_0 && py > to_CFT(bymax))
+    if(bounded_0 && compare(py, bymax) == LARGER)
       return false; // segment on the right of bbox
-    if(bounded_1 && qy < to_CFT(bymin))
+    if(bounded_1 && compare(qy, bymin) == SMALLER)
       return false; // segment on the left of bbox
 
-    if(bounded_1 && to_CFT(bymax) > qy)
+    if(bounded_1 && compare(bymax, qy) == LARGER)
     {
       tymax = 1;
       dymax = 1;
@@ -256,12 +256,12 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   }
   else
   {
-    if(bounded_1 && qy > to_CFT(bymax))
+    if(bounded_1 && compare(qy, bymax) == LARGER)
       return false; // segment on the right of bbox
-    if(bounded_0 && py < to_CFT(bymin))
+    if(bounded_0 && compare(py, bymin) == SMALLER)
       return false; // segment on the left of bbox
 
-    if(bounded_1 && to_CFT(bymin) < qy)
+    if(bounded_1 && compare(bymin, qy) == SMALLER)
     {
       tymax = 1;
       dymax = 1;
@@ -284,7 +284,7 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   if((py == qy) &&  // <=> (dmin == 0)
      (! (bounded_0 && bounded_1))) // do not check for a segment
   {
-    if(py > to_CFT(bymax) || py < to_CFT(bymin))
+    if(py > to_CFT(bymax) || compare(py, bymin) == SMALLER)
       return false;
   }
 
@@ -306,12 +306,12 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   CFT dzmin, tzmin, tzmax, dzmax;
   if(qz >= pz)
   {
-    if(bounded_0 && pz > to_CFT(bzmax))
+    if(bounded_0 && compare(pz, bzmax)== LARGER)
       return false; // segment on the right of bbox
-    if(bounded_1 && qz < to_CFT(bzmin))
+    if(bounded_1 && compare(qz, bzmin) == SMALLER)
       return false; // segment on the left of bbox
 
-    if(bounded_1 && to_CFT(bzmax) > qz)
+    if(bounded_1 && compare(bzmax, qz) == LARGER)
     {
       tzmax = 1;
       dzmax = 1;
@@ -327,12 +327,12 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   }
   else
   {
-    if(bounded_1 && qz > to_CFT(bzmax))
+    if(bounded_1 && compare(qz, bzmax) == LARGER)
       return false; // segment on the right of bbox
-    if(bounded_0 && pz < to_CFT(bzmin))
-      return false; // segment on the left of bbox
+    if(bounded_0 && compare(pz, bzmin) == SMALLER)
+    return false; // segment on the left of bbox
 
-    if(bounded_1 && to_CFT(bzmin) < qz)
+    if(bounded_1 && compare(bzmin, qz) == SMALLER)
     {
       tzmax = 1;
       dzmax = 1;
@@ -355,7 +355,7 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   if((pz == qz) &&  // <=> (dmin == 0)
      (! (bounded_0 && bounded_1))) // do not check for a segment
   {
-    if(pz > to_CFT(bzmax) || pz < to_CFT(bzmin))
+    if(compare(pz, bzmax) == LARGER || compare(pz, bzmin) == SMALLER)
       return false;
   }
 

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Bbox_3_Segment_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Bbox_3_Segment_3_do_intersect.h
@@ -157,13 +157,14 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   // -----------------------------------
   // treat x coord
   // -----------------------------------
-  typedef typename Coercion_traits<double,FT>::Type CFT;
+  typedef typename Coercion_traits<FT,BFT>::Type CFT;
+  typename Coercion_traits<FT,BFT>::Cast to_CFT;
   CFT dmin, tmin, tmax, dmax;
   if(qx >= px)
   {
-    if(bounded_0 && px > bxmax)
+    if(bounded_0 && px > to_CFT(bxmax))
       return false; // segment on the right of bbox
-    if(bounded_1 && qx < bxmin)
+    if(bounded_1 && qx < to_CFT(bxmin))
       return false; // segment on the left of bbox
 
     if(bounded_1 && bxmax > qx)
@@ -173,7 +174,7 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
     }
     else
     {
-      tmax = CFT(bxmax) - px;
+      tmax = to_CFT(bxmax) - px;
       dmax = qx - px;
     }
 
@@ -182,23 +183,23 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   }
   else
   {
-    if(bounded_1 && qx > bxmax)
+    if(bounded_1 && qx > to_CFT(bxmax))
       return false; // segment on the right of bbox
-    if(bounded_0 && px < bxmin)
+    if(bounded_0 && px < to_CFT(bxmin))
       return false; // segment on the left of bbox
 
-    if(bounded_1 && bxmin < qx)
+    if(bounded_1 && to_CFT(bxmin) < qx)
     {
       tmax = 1;
       dmax = 1;
     }
     else
     {
-      tmax = px - CFT(bxmin);
+      tmax = px - to_CFT(bxmin);
       dmax = px - qx;
     }
 
-    tmin = px - CFT(bxmax);
+    tmin = px - to_CFT(bxmax);
     dmin = px - qx;
   }
 
@@ -210,7 +211,7 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   if((px == qx) &&  // <=> (dmin == 0)
      (!(bounded_0 && bounded_1))) // do not check for a segment
   {
-    if(px > bxmax || px < bxmin)
+    if(px > to_CFT(bxmax) || px < to_CFT(bxmin))
       return false;
 
     // Note: for a segment the condition has already been tested by the two
@@ -221,11 +222,11 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   // is a NaN. But the case with NaNs is treated as if the interval
   // [t1, t2] was ]-inf, +inf[.
 
-  CGAL_assertion(dmin >= 0);
-  CGAL_assertion(dmax >= 0);
+  CGAL_assertion(! is_negative(dmin));
+  CGAL_assertion(! is_negative(dmax));
   if(bounded_0) {
-    CGAL_assertion(tmin >= 0);
-    CGAL_assertion(tmax >= 0);
+    CGAL_assertion(! is_negative(tmin));
+    CGAL_assertion(! is_negative(tmax));
   }
 
   // -----------------------------------
@@ -234,40 +235,40 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   CFT dymin, tymin, tymax, dymax;
   if(qy >= py)
   {
-    if(bounded_0 && py > bymax)
+    if(bounded_0 && py > to_CFT(bymax))
       return false; // segment on the right of bbox
-    if(bounded_1 && qy < bymin)
+    if(bounded_1 && qy < to_CFT(bymin))
       return false; // segment on the left of bbox
 
-    if(bounded_1 && bymax > qy)
+    if(bounded_1 && to_CFT(bymax) > qy)
     {
       tymax = 1;
       dymax = 1;
     }
     else
     {
-      tymax = CFT(bymax) - py;
+      tymax = to_CFT(bymax) - py;
       dymax = qy - py;
     }
 
-    tymin = CFT(bymin) - py;
+    tymin = to_CFT(bymin) - py;
     dymin = qy - py;
   }
   else
   {
-    if(bounded_1 && qy > bymax)
+    if(bounded_1 && qy > to_CFT(bymax))
       return false; // segment on the right of bbox
-    if(bounded_0 && py < bymin)
+    if(bounded_0 && py < to_CFT(bymin))
       return false; // segment on the left of bbox
 
-    if(bounded_1 && bymin < qy)
+    if(bounded_1 && to_CFT(bymin) < qy)
     {
       tymax = 1;
       dymax = 1;
     }
     else
     {
-      tymax = py - CFT(bymin);
+      tymax = py - to_CFT(bymin);
       dymax = py - qy;
     }
 
@@ -283,7 +284,7 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   if((py == qy) &&  // <=> (dmin == 0)
      (! (bounded_0 && bounded_1))) // do not check for a segment
   {
-    if(py > bymax || py < bymin)
+    if(py > to_CFT(bymax) || py < to_CFT(bymin))
       return false;
   }
 
@@ -291,12 +292,12 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   // is a NaN. But the case with NaNs is treated as if the interval
   // [t1, t2] was ]-inf, +inf[.
 
-  CGAL_assertion(dymin >= 0);
-  CGAL_assertion(dymax >= 0);
+  CGAL_assertion(! is_negative(dymin));
+  CGAL_assertion(! is_negative(dymax));
   if(bounded_0)
   {
-    CGAL_assertion(tymin >= 0);
-    CGAL_assertion(tymax >= 0);
+    CGAL_assertion(! is_negative(tymin));
+    CGAL_assertion(! is_negative(tymax));
   }
 
   // -----------------------------------
@@ -305,44 +306,44 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   CFT dzmin, tzmin, tzmax, dzmax;
   if(qz >= pz)
   {
-    if(bounded_0 && pz > bzmax)
+    if(bounded_0 && pz > to_CFT(bzmax))
       return false; // segment on the right of bbox
-    if(bounded_1 && qz < bzmin)
+    if(bounded_1 && qz < to_CFT(bzmin))
       return false; // segment on the left of bbox
 
-    if(bounded_1 && bzmax > qz)
+    if(bounded_1 && to_CFT(bzmax) > qz)
     {
       tzmax = 1;
       dzmax = 1;
     }
     else
     {
-      tzmax = CFT(bzmax) - pz;
+      tzmax = to_CFT(bzmax) - pz;
       dzmax = qz - pz;
     }
 
-    tzmin = CFT(bzmin) - pz;
+    tzmin = to_CFT(bzmin) - pz;
     dzmin = qz - pz;
   }
   else
   {
-    if(bounded_1 && qz > bzmax)
+    if(bounded_1 && qz > to_CFT(bzmax))
       return false; // segment on the right of bbox
-    if(bounded_0 && pz < bzmin)
+    if(bounded_0 && pz < to_CFT(bzmin))
       return false; // segment on the left of bbox
 
-    if(bounded_1 && bzmin < qz)
+    if(bounded_1 && to_CFT(bzmin) < qz)
     {
       tzmax = 1;
       dzmax = 1;
     }
     else
     {
-      tzmax = pz - CFT(bzmin);
+      tzmax = pz - to_CFT(bzmin);
       dzmax = pz - qz;
     }
 
-    tzmin = pz - CFT(bzmax);
+    tzmin = pz - to_CFT(bzmax);
     dzmin = pz - qz;
   }
 
@@ -354,7 +355,7 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   if((pz == qz) &&  // <=> (dmin == 0)
      (! (bounded_0 && bounded_1))) // do not check for a segment
   {
-    if(pz > bzmax || pz < bzmin)
+    if(pz > to_CFT(bzmax) || pz < to_CFT(bzmin))
       return false;
   }
 
@@ -362,12 +363,12 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   // is a NaN. But the case with NaNs is treated as if the interval
   // [t1, t2] was ]-inf, +inf[.
 
-  CGAL_assertion(dzmin >= 0);
-  CGAL_assertion(dzmax >= 0);
+  CGAL_assertion(! is_negative(dzmin));
+  CGAL_assertion(! is_negative(dzmax));
   if(bounded_0)
   {
-    CGAL_assertion(tzmin >= 0);
-    CGAL_assertion(tzmax >= 0);
+    CGAL_assertion(! is_negative(tzmin));
+    CGAL_assertion(! is_negative(tzmax));
   }
 
   typedef Do_intersect_bbox_segment_aux_is_greater<CFT, bounded_0, use_static_filters> Is_greater;
@@ -421,8 +422,8 @@ do_intersect_bbox_segment_aux(const FT& px, const FT& py, const FT& pz,
   if(is_indeterminate(b))
     return b;
 
-  CGAL_assertion(dmin >= 0);
-  CGAL_assertion(dmax >= 0);
+  CGAL_assertion(! is_negative(dmin));
+  CGAL_assertion(! is_negative(dmax));
 
   // If t1 > tzmax || tzmin > t2, return false.
   if((px != qx || py != qy) &&

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Iso_cuboid_3_Sphere_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Iso_cuboid_3_Sphere_3_do_intersect.h
@@ -28,7 +28,7 @@ bool do_intersect_sphere_box_3(const typename K::Sphere_3& sphere,
                                const K&)
 {
   typedef typename K::FT SFT;
-  typedef typename Coercion_traits<double, SFT>::Type FT;
+  typedef typename Coercion_traits<SFT, BFT>::Type FT;
   typedef typename K::Point_3 Point;
 
   typename Coercion_traits<SFT, BFT>::Cast to_FT;


### PR DESCRIPTION
## Summary of Changes

Use the correct types when mixing double and coordinate types which may be not double.  This was discussed in PR #6261

## Release Management

* Affected package(s): Intersections_3

