### PR TITLE
Reserve method for Chained Map / Unique Hash Map 

### DIFF
--- a/Hash_map/include/CGAL/Tools/chained_map.h
+++ b/Hash_map/include/CGAL/Tools/chained_map.h
@@ -83,13 +83,15 @@ private:
    }
 
 public:
+   static constexpr std::size_t min_size = 32;
+   static constexpr std::size_t default_size = 512;
    typedef chained_map_elem<T>*  chained_map_item;
    typedef chained_map_item item;
 
    std::size_t index(chained_map_item it) const { return it->k; }
    T&            inf(chained_map_item it) const { return it->i; }
 
-   chained_map(std::size_t n = 1);
+   chained_map(std::size_t n = default_size);
    chained_map(const chained_map<T, Allocator>& D);
    chained_map& operator=(const chained_map<T, Allocator>& D);
 
@@ -273,8 +275,8 @@ template <typename T, typename Allocator>
 chained_map<T, Allocator>::chained_map(std::size_t n) :
   nullptrKEY(0), NONnullptrKEY(1), old_table(0)
 {
-  if (n < 512)
-    init_table(512);
+  if (n < min_size)
+    init_table(min_size);
   else {
     std::size_t ts = 1;
     while (ts < n) ts <<= 1;
@@ -336,7 +338,7 @@ void chained_map<T, Allocator>::clear()
     destroy(item);
   alloc.deallocate(table, table_end - table);
 
-  init_table(512);
+  init_table(min_size);
 }
 
 template <typename T, typename Allocator>

--- a/Hash_map/include/CGAL/Tools/chained_map.h
+++ b/Hash_map/include/CGAL/Tools/chained_map.h
@@ -95,7 +95,7 @@ public:
    chained_map(const chained_map<T, Allocator>& D);
    chained_map& operator=(const chained_map<T, Allocator>& D);
 
-
+   void reserve(std::size_t n);
    void clear_entries();
    void clear();
    ~chained_map()
@@ -322,6 +322,13 @@ chained_map<T, Allocator>& chained_map<T, Allocator>::operator=(const chained_ma
     }
   }
   return *this;
+}
+
+template <typename T, typename Allocator>
+void chained_map<T, Allocator>::reserve(std::size_t n)
+{
+  CGAL_assertion(!table);
+  reserved_size = n;
 }
 
 template <typename T, typename Allocator>

--- a/Hash_map/include/CGAL/Tools/chained_map.h
+++ b/Hash_map/include/CGAL/Tools/chained_map.h
@@ -118,6 +118,7 @@ public:
    chained_map_item lookup(std::size_t x) const;
    chained_map_item first_item() const;
    chained_map_item next_item(chained_map_item it) const;
+   std::size_t size() const;
    void statistics() const;
 };
 
@@ -384,6 +385,10 @@ chained_map<T, Allocator>::next_item(chained_map_item it) const
   do it++; while (it < table + table_size && it->k == nullptrKEY);
   return (it < free ? it : 0);
 }
+
+template <typename T, typename Allocator>
+std::size_t chained_map<T, Allocator>::size() const
+{ return table_size; }
 
 template <typename T, typename Allocator>
 void chained_map<T, Allocator>::statistics() const

--- a/Hash_map/include/CGAL/Tools/chained_map.h
+++ b/Hash_map/include/CGAL/Tools/chained_map.h
@@ -282,7 +282,7 @@ T& chained_map<T, Allocator>::access(chained_map_item p, std::size_t x)
 
 template <typename T, typename Allocator>
 chained_map<T, Allocator>::chained_map(std::size_t n)
-  : table(nullptr), nullptrKEY(0), NONnullptrKEY(1), old_table(0), reserved_size(n)
+  : nullptrKEY(0), NONnullptrKEY(1), table(nullptr), old_table(0), reserved_size(n)
 {
 }
 

--- a/Hash_map/include/CGAL/Tools/chained_map.h
+++ b/Hash_map/include/CGAL/Tools/chained_map.h
@@ -118,7 +118,6 @@ public:
    chained_map_item lookup(std::size_t x) const;
    chained_map_item first_item() const;
    chained_map_item next_item(chained_map_item it) const;
-   std::size_t size() const;
    void statistics() const;
 };
 
@@ -385,10 +384,6 @@ chained_map<T, Allocator>::next_item(chained_map_item it) const
   do it++; while (it < table + table_size && it->k == nullptrKEY);
   return (it < free ? it : 0);
 }
-
-template <typename T, typename Allocator>
-std::size_t chained_map<T, Allocator>::size() const
-{ return table_size; }
 
 template <typename T, typename Allocator>
 void chained_map<T, Allocator>::statistics() const

--- a/Hash_map/include/CGAL/Unique_hash_map.h
+++ b/Hash_map/include/CGAL/Unique_hash_map.h
@@ -113,6 +113,8 @@ public:
         return first2;
     }
 
+    std::size_t size() const { return m_map.size(); }
+
     void statistics() const { m_map.statistics(); }
 };
 

--- a/Hash_map/include/CGAL/Unique_hash_map.h
+++ b/Hash_map/include/CGAL/Unique_hash_map.h
@@ -57,7 +57,7 @@ public:
 
     Unique_hash_map() { m_map.xdef() = Data(); }
 
-    Unique_hash_map( const Data& deflt, std::size_t table_size = 1)
+    Unique_hash_map( const Data& deflt, std::size_t table_size = Map::default_size)
         : m_map( table_size) { m_map.xdef() = deflt; }
 
     Unique_hash_map( const Data& deflt,

--- a/Hash_map/include/CGAL/Unique_hash_map.h
+++ b/Hash_map/include/CGAL/Unique_hash_map.h
@@ -78,6 +78,9 @@ public:
         insert( first1, beyond1, first2);
     }
 
+    void reserve(std::size_t n)
+    { m_map.reserve(n); }
+
     Data default_value() const { return m_map.cxdef(); }
 
     Hash_function  hash_function() const { return m_hash_function; }

--- a/Hash_map/include/CGAL/Unique_hash_map.h
+++ b/Hash_map/include/CGAL/Unique_hash_map.h
@@ -113,8 +113,6 @@ public:
         return first2;
     }
 
-    std::size_t size() const { return m_map.size(); }
-
     void statistics() const { m_map.statistics(); }
 };
 

--- a/Miscellany/doc/Miscellany/CGAL/Unique_hash_map.h
+++ b/Miscellany/doc/Miscellany/CGAL/Unique_hash_map.h
@@ -127,11 +127,6 @@ sets the table size.
 void reserve(std::size_t table_size);
 
 /*!
-gets the table size.
- */
-std::size_t size();
-
-/*!
 
 resets `*this` to the injective function from `Key` to the
 set of unused variables of type `Data`. The `default_data`

--- a/Miscellany/doc/Miscellany/CGAL/Unique_hash_map.h
+++ b/Miscellany/doc/Miscellany/CGAL/Unique_hash_map.h
@@ -127,6 +127,11 @@ sets the table size.
 void reserve(std::size_t table_size);
 
 /*!
+gets the table size.
+ */
+std::size_t size();
+
+/*!
 
 resets `*this` to the injective function from `Key` to the
 set of unused variables of type `Data`. The `default_data`

--- a/Miscellany/doc/Miscellany/CGAL/Unique_hash_map.h
+++ b/Miscellany/doc/Miscellany/CGAL/Unique_hash_map.h
@@ -120,6 +120,12 @@ been inserted explicitly. Their variables are initialized to
 */
 bool is_defined( const Key& key) const;
 
+
+/*!
+sets the table size.
+ */
+void reserve(std::size_t table_size);
+
 /*!
 
 resets `*this` to the injective function from `Key` to the

--- a/Nef_3/include/CGAL/Nef_3/Binary_operation.h
+++ b/Nef_3/include/CGAL/Nef_3/Binary_operation.h
@@ -306,7 +306,7 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
       number_of_intersection_candidates=0;
 #endif
 
-    Unique_hash_map<Vertex_const_handle, bool> ignore(false);
+    Unique_hash_map<Vertex_const_handle, bool> ignore(false, snc1.number_of_vertices());
     Vertex_const_iterator v0;
 
     //    CGAL_NEF_SETDTHREAD(19*43*131);

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -606,6 +606,7 @@ Node_handle build_kdtree(Vertex_list& V, Halfedge_list& E, Halffacet_list& F,
 #else
   Side_of_plane sop(point_on_plane, coord);
 #endif
+  sop.reserve(V.size());
 
   Vertex_list V1,V2;
   classify_objects(V, sop, V1, V2);

--- a/Nef_3/include/CGAL/Nef_3/SNC_FM_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_FM_decorator.h
@@ -110,14 +110,14 @@ struct Sort_sedges2 {
 template <typename P, typename V, typename E, typename I>
 struct Halffacet_output {
 
-Halffacet_output(CGAL::Unique_hash_map<I,E>& F, std::vector<E>& S)
+Halffacet_output(const CGAL::Unique_hash_map<I,E>& F, std::vector<E>& S)
   : From(F), Support(S) { edge_number=0; Support[0]=E(); }
 
 typedef P         Point;
 typedef V         Vertex_handle;
 typedef unsigned  Halfedge_handle;
 
-CGAL::Unique_hash_map<I,E>& From;
+const CGAL::Unique_hash_map<I,E>& From;
 std::vector<E>& Support;
 unsigned edge_number;
 
@@ -467,12 +467,11 @@ create_facet_objects(const Plane_3& plane_supporting_facet,
   Object_list_iterator start, Object_list_iterator end) const
 { CGAL_NEF_TRACEN(">>>>>create_facet_objects "
                   << normalized(plane_supporting_facet));
-  CGAL::Unique_hash_map<SHalfedge_handle,int> FacetCycle(-1);
+
   std::vector<SHalfedge_handle> MinimalEdge;
   std::list<SHalfedge_handle> SHalfedges;
   std::list<SHalfloop_handle> SHalfloops;
 
-  CGAL::Unique_hash_map<Segment_iterator,SHalfedge_handle>  From;
 
   Segment_list Segments;
   SHalfedge_handle e; SHalfloop_handle l;
@@ -503,6 +502,7 @@ create_facet_objects(const Plane_3& plane_supporting_facet,
       CGAL_error_msg("Damn wrong handle.");
   }
 
+  CGAL::Unique_hash_map<SHalfedge_handle,int> FacetCycle(-1, SHalfedges.size());
   /* We iterate all shalfedges and assign a number for each facet
      cycle.  After that iteration for an edge |e| the number of its
      facet cycle is |FacetCycle[e]| and for a facet cycle |c| we know
@@ -606,6 +606,7 @@ create_facet_objects(const Plane_3& plane_supporting_facet,
   //  Insertion of SHalfedges into Segments is shifted below in order
   //  to guarantee that there are no gaps in the overlay.
 
+  CGAL::Unique_hash_map<Segment_iterator,SHalfedge_handle> From(SHalfedge_handle(), SHalfedges.size());
 
   //  SHalfedges.sort(Sort_sedges2<Point_3,SHalfedge_handle>());
   SHalfedges.sort(Sort_sedges<Vertex_handle,SHalfedge_handle>());

--- a/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
@@ -280,6 +280,7 @@ class SNC_decorator : public SNC_const_decorator<Map> {
     SFace_map linked;
     Shell_volume_setter(const SNCD_& Di)
       : D(Di), linked(false) {}
+    void reserve(Size_type n) { linked.reserve(n); }
     void visit(SFace_handle h) {
       CGAL_NEF_TRACEN(h->center_vertex()->point());
       D.set_volume(h, c);

--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -1386,17 +1386,7 @@ public:
     SNC_simplify simp(*this->sncp());
     simp.vertex_simplificationI();
 
-    //    std::map<int, int> hash;
-    CGAL::Unique_hash_map<SHalfedge_handle, bool>
-      done(false);
 
-    /*
-    SHalfedge_iterator sei;
-    CGAL_forall_shalfedges(sei, *this->sncp()) {
-      hash[sei->get_forward_index()] = sei->get_forward_index();
-      hash[sei->get_backward_index()] = sei->get_backward_index();
-    }
-    */
 
     categorize_facet_cycles_and_create_facets();
     create_volumes();

--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -796,9 +796,11 @@ public:
     //    CGAL_NEF_SETDTHREAD(37*43*503*509);
 
     CGAL_NEF_TRACEN(">>>>>create_volumes");
-    Sface_shell_hash     ShellSf(0);
-    Face_shell_hash      ShellF(0);
-    SFace_visited_hash Done(false);
+    auto face_count = this->sncp()->number_of_halffacets();
+    auto sface_count = this->sncp()->number_of_sfaces();
+    Sface_shell_hash     ShellSf(0, sface_count);
+    Face_shell_hash      ShellF(0, face_count);
+    SFace_visited_hash Done(false, sface_count);
     Shell_explorer V(*this,ShellSf,ShellF,Done);
     std::vector<SFace_handle> MinimalSFace;
     std::vector<SFace_handle> EntrySFace;
@@ -828,11 +830,14 @@ public:
       Closed.push_back(false);
 
     Halffacet_iterator hf;
-    CGAL_forall_facets(hf,*this)
-      if(ShellF[hf] != ShellF[hf->twin()]) {
-        Closed[ShellF[hf]] = true;
-        Closed[ShellF[hf->twin()]] = true;
+    CGAL_forall_facets(hf,*this) {
+      unsigned int shf = ShellF[hf];
+      unsigned int shf_twin = ShellF[hf->twin()];
+      if(shf != shf_twin) {
+        Closed[shf] = true;
+        Closed[shf_twin] = true;
       }
+    }
 
     CGAL_assertion( pl != nullptr);
 
@@ -1304,7 +1309,7 @@ public:
     link_shalfedges_to_facet_cycles();
 
     std::map<int, int> hash;
-    CGAL::Unique_hash_map<SHalfedge_handle, bool> done(false);
+    CGAL::Unique_hash_map<SHalfedge_handle, bool> done(false, this->sncp()->number_of_shalfedges());
 
     SHalfedge_iterator sei;
     CGAL_forall_shalfedges(sei, *this->sncp()) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_k3_tree_traits.h
@@ -85,7 +85,7 @@ public:
 #else
   Side_of_plane(const Point_3& p, int c) : OnSideMap(unknown_side), coord(c), pop(p) {}
 #endif
-
+  void reserve(std::size_t n) { OnSideMap.reserve(n); }
   Oriented_side operator()(Vertex_handle v);
   Oriented_side operator()(Halfedge_handle e);
   Oriented_side operator()(Halffacet_handle f);

--- a/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
@@ -545,7 +545,6 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
       Unique_hash_map< SFace_handle, UFH_sface>& hash,
       Union_find< SFace_handle>& uf ) {
     Unique_hash_map< SHalfedge_handle, bool> linked(false, this->sncp()->number_of_shalfedges());
-    this->sncp()->reserve_sm_boundary_items(this->sncp()->number_of_sfaces());
 
     SNC_decorator D(*this->sncp());
     SHalfedge_iterator e;

--- a/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
@@ -316,9 +316,9 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
     CGAL_NEF_TRACEN(">>> simplifying");
     SNC_decorator D(*this->sncp());
 
-    Unique_hash_map< Volume_handle, UFH_volume> hash_volume;
-    Unique_hash_map< Halffacet_handle, UFH_facet> hash_facet;
-    Unique_hash_map< SFace_handle, UFH_sface> hash_sface;
+    Unique_hash_map< Volume_handle, UFH_volume> hash_volume(UFH_volume(), this->sncp()->number_of_volumes());
+    Unique_hash_map< Halffacet_handle, UFH_facet> hash_facet(UFH_facet(), this->sncp()->number_of_halffacets());
+    Unique_hash_map< SFace_handle, UFH_sface> hash_sface(UFH_sface(), this->sncp()->number_of_sfaces());
     Union_find< Volume_handle> uf_volume;
     Union_find< Halffacet_handle> uf_facet;
     Union_find< SFace_handle> uf_sface;
@@ -544,7 +544,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
   void create_boundary_links_forall_sfaces(
       Unique_hash_map< SFace_handle, UFH_sface>& hash,
       Union_find< SFace_handle>& uf ) {
-    Unique_hash_map< SHalfedge_handle, bool> linked(false);
+    Unique_hash_map< SHalfedge_handle, bool> linked(false, this->sncp()->number_of_shalfedges());
     SNC_decorator D(*this->sncp());
     SHalfedge_iterator e;
     CGAL_forall_shalfedges(e, *this->sncp()) {
@@ -597,7 +597,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
   void create_boundary_links_forall_facets(
       Unique_hash_map< Halffacet_handle, UFH_facet>& hash,
       Union_find< Halffacet_handle>& uf) {
-    Unique_hash_map< SHalfedge_handle, bool> linked(false);
+    Unique_hash_map< SHalfedge_handle, bool> linked(false, this->sncp()->number_of_shalfedges());
     SNC_decorator D(*this->sncp());
     SHalfedge_iterator u;
     CGAL_forall_shalfedges(u, *this->sncp()) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
@@ -545,6 +545,8 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
       Unique_hash_map< SFace_handle, UFH_sface>& hash,
       Union_find< SFace_handle>& uf ) {
     Unique_hash_map< SHalfedge_handle, bool> linked(false, this->sncp()->number_of_shalfedges());
+    this->sncp()->reserve_sm_boundary_items(this->sncp()->number_of_sfaces());
+
     SNC_decorator D(*this->sncp());
     SHalfedge_iterator e;
     CGAL_forall_shalfedges(e, *this->sncp()) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
@@ -651,6 +651,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
 
     SNC_decorator D(*this->sncp());
     Volume_setter setter(D);
+    setter.reserve(this->sncp()->number_of_sfaces());
 
     SFace_iterator sf;
     Volume_handle c;

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -484,10 +484,10 @@ public:
   }
 
   template <typename H>
-  bool is_boundary_object(H h)
+  bool is_boundary_object(H h) const
   { return boundary_item_[h]!=boost::none; }
   template <typename H>
-  bool is_sm_boundary_object(H h)
+  bool is_sm_boundary_object(H h) const
   { return sm_boundary_item_[h]!=boost::none; }
 
   template <typename H>

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -438,7 +438,7 @@ public:
   ~SNC_structure() { CGAL_NEF_TRACEN("~SNC_structure: clearing "<<this); clear(); }
 
   SNC_structure(const Self& D) :
-    boundary_item_(boost::none, D.boundary_item_.size()), sm_boundary_item_(boost::none, D.sm_boundary_item_.size()),
+    boundary_item_(boost::none), sm_boundary_item_(boost::none),
     vertices_(D.vertices_), halfedges_(D.halfedges_),
     halffacets_(D.halffacets_), volumes_(D.volumes_),
     shalfedges_(D.shalfedges_), shalfloops_(D.shalfloops_),
@@ -450,9 +450,7 @@ public:
       return *this;
     clear();
     boundary_item_.clear(boost::none);
-    boundary_item_.reserve(D.boundary_item_.size());
     sm_boundary_item_.clear(boost::none);
-    sm_boundary_item_.reserve(D.sm_boundary_item_.size());
     vertices_ = D.vertices_;
     halfedges_ = D.halfedges_;
     halffacets_ = D.halffacets_;

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -462,6 +462,10 @@ public:
     return *this;
   }
 
+  void reserve_sm_boundary_items(Size_type n) {
+    sm_boundary_item_.reserve(n);
+  }
+
   void clear_boundary() {
     boundary_item_.clear(boost::none);
     sm_boundary_item_.clear(boost::none);

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -438,7 +438,7 @@ public:
   ~SNC_structure() { CGAL_NEF_TRACEN("~SNC_structure: clearing "<<this); clear(); }
 
   SNC_structure(const Self& D) :
-    boundary_item_(boost::none), sm_boundary_item_(boost::none),
+    boundary_item_(boost::none, D.boundary_item_.size()), sm_boundary_item_(boost::none, D.sm_boundary_item_.size()),
     vertices_(D.vertices_), halfedges_(D.halfedges_),
     halffacets_(D.halffacets_), volumes_(D.volumes_),
     shalfedges_(D.shalfedges_), shalfloops_(D.shalfloops_),
@@ -450,7 +450,9 @@ public:
       return *this;
     clear();
     boundary_item_.clear(boost::none);
+    boundary_item_.reserve(D.boundary_item_.size());
     sm_boundary_item_.clear(boost::none);
+    sm_boundary_item_.reserve(D.sm_boundary_item_.size());
     vertices_ = D.vertices_;
     halfedges_ = D.halfedges_;
     halffacets_ = D.halffacets_;
@@ -1103,13 +1105,13 @@ template <typename Kernel, typename Items, typename Mark>
 void SNC_structure<Kernel,Items,Mark>::
 pointer_update(const SNC_structure<Kernel,Items,Mark>& D)
 {
-  CGAL::Unique_hash_map<Vertex_const_handle,Vertex_handle>       VM;
-  CGAL::Unique_hash_map<Halfedge_const_handle,Halfedge_handle>   EM;
-  CGAL::Unique_hash_map<Halffacet_const_handle,Halffacet_handle> FM;
-  CGAL::Unique_hash_map<Volume_const_handle,Volume_handle>       CM;
-  CGAL::Unique_hash_map<SHalfedge_const_handle,SHalfedge_handle> SEM;
-  CGAL::Unique_hash_map<SHalfloop_const_handle,SHalfloop_handle> SLM;
-  CGAL::Unique_hash_map<SFace_const_handle,SFace_handle>         SFM;
+  CGAL::Unique_hash_map<Vertex_const_handle,Vertex_handle>       VM(Vertex_handle(), D.number_of_vertices());
+  CGAL::Unique_hash_map<Halfedge_const_handle,Halfedge_handle>   EM(Halfedge_handle(), D.number_of_halfedges());
+  CGAL::Unique_hash_map<Halffacet_const_handle,Halffacet_handle> FM(Halffacet_handle(), D.number_of_halffacets());
+  CGAL::Unique_hash_map<Volume_const_handle,Volume_handle>       CM(Volume_handle(), D.number_of_volumes());
+  CGAL::Unique_hash_map<SHalfedge_const_handle,SHalfedge_handle> SEM(SHalfedge_handle(), D.number_of_shalfedges());
+  CGAL::Unique_hash_map<SHalfloop_const_handle,SHalfloop_handle> SLM(SHalfloop_handle(), D.number_of_shalfloops());
+  CGAL::Unique_hash_map<SFace_const_handle,SFace_handle>         SFM(SFace_handle(), D.number_of_sfaces());
   Vertex_const_iterator vc = D.vertices_begin();
   Vertex_iterator v = vertices_begin();
   for ( ; vc != D.vertices_end(); ++vc,++v) VM[vc] = v;

--- a/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
@@ -205,7 +205,6 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
   Face_graph_index_adder<typename SNC_structure::Items,
                  PolygonMesh, SNC_structure,HalfedgeIndexMap> index_adder(P,himap);
 
-  S.reserve_sm_boundary_items(num_vertices(P));
   for(vertex_descriptor pv : vertices(P) ) {
 
     typename boost::property_traits<PMap>::reference npv = get(pmap,pv);

--- a/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/polygon_mesh_to_nef_3.h
@@ -205,7 +205,7 @@ void polygon_mesh_to_nef_3(PolygonMesh& P, SNC_structure& S, FaceIndexMap fimap,
   Face_graph_index_adder<typename SNC_structure::Items,
                  PolygonMesh, SNC_structure,HalfedgeIndexMap> index_adder(P,himap);
 
-
+  S.reserve_sm_boundary_items(num_vertices(P));
   for(vertex_descriptor pv : vertices(P) ) {
 
     typename boost::property_traits<PMap>::reference npv = get(pmap,pv);

--- a/Nef_3/include/CGAL/Nef_polyhedron_3.h
+++ b/Nef_3/include/CGAL/Nef_polyhedron_3.h
@@ -355,6 +355,10 @@ protected:
     delegate(mbv, /*compute_external*/ false, /*simplify*/ false);
   }
 
+  void reserve_for_vertices(Size_type n) {
+    snc().reserve_sm_boundary_items(n);
+  }
+
   struct Private_tag {};
   Nef_polyhedron_3(Private_tag) {
     pl() = new SNC_point_locator_default;
@@ -615,6 +619,7 @@ protected:
    : Nef_polyhedron_3(Private_tag{})
  {
     CGAL_NEF_TRACEN("construction from Polyhedron_3");
+    reserve_for_vertices(P.size_of_vertices());
     initialize_infibox_vertices(EMPTY);
     polyhedron_3_to_nef_3
       <CGAL::Polyhedron_3<T1,T2,T3,T4>, SNC_structure>( P, snc());
@@ -628,6 +633,7 @@ protected:
    : Nef_polyhedron_3(Private_tag{})
  {
     CGAL_NEF_TRACEN("construction from PolygonMesh with internal index maps");
+    reserve_for_vertices(num_vertices(pm));
     initialize_infibox_vertices(EMPTY);
     polygon_mesh_to_nef_3<PolygonMesh, SNC_structure>(const_cast<PolygonMesh&>(pm), snc());
     build_external_structure();
@@ -645,6 +651,7 @@ protected:
   ) : Nef_polyhedron_3(Private_tag{})
   {
     CGAL_NEF_TRACEN("construction from PolygonMesh");
+    reserve_for_vertices(num_vertices(pm));
     initialize_infibox_vertices(EMPTY);
     polygon_mesh_to_nef_3<PolygonMesh, SNC_structure>(const_cast<PolygonMesh&>(pm), snc(), fim, him);
     build_external_structure();

--- a/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
@@ -34,6 +34,7 @@ class Generic_handle_map : public
 public:
   Generic_handle_map() : Base() {}
   Generic_handle_map(I i) : Base(i) {}
+  Generic_handle_map(I i, std::size_t n) : Base(i,n) {}
 
   template <class H>
   const I& operator[](H h) const

--- a/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
@@ -34,7 +34,6 @@ class Generic_handle_map : public
 public:
   Generic_handle_map() : Base() {}
   Generic_handle_map(I i) : Base(i) {}
-  Generic_handle_map(I i, std::size_t n) : Base(i,n) {}
 
   template <class H>
   const I& operator[](H h) const

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
@@ -236,7 +236,7 @@ public:
     );
   }
 
-  Sphere_map(const Self& D) : boundary_item_(boost::none, D.boundary_item_.size()),
+  Sphere_map(const Self& D) : boundary_item_(boost::none),
     svertices_(D.svertices_),
     sedges_(D.sedges_),
     sfaces_(D.sfaces_),
@@ -248,7 +248,6 @@ public:
   Self& operator=(const Self& D)
   { if ( this == &D ) return *this;
     clear();
-    boundary_item_.reserve(D.boundary_item_.size());
     svertices_ = D.svertices_;
     sfaces_ = D.sfaces_;
     sedges_ = D.sedges_;

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
@@ -236,7 +236,7 @@ public:
     );
   }
 
-  Sphere_map(const Self& D) : boundary_item_(boost::none),
+  Sphere_map(const Self& D) : boundary_item_(boost::none, D.boundary_item_.size()),
     svertices_(D.svertices_),
     sedges_(D.sedges_),
     sfaces_(D.sfaces_),
@@ -248,6 +248,7 @@ public:
   Self& operator=(const Self& D)
   { if ( this == &D ) return *this;
     clear();
+    boundary_item_.reserve(D.boundary_item_.size());
     svertices_ = D.svertices_;
     sfaces_ = D.sfaces_;
     sedges_ = D.sedges_;
@@ -495,10 +496,10 @@ template <typename K, typename I, typename M>
 void Sphere_map<K, I, M>::
 pointer_update(const Sphere_map<K, I, M>& D)
 {
-  CGAL::Unique_hash_map<SVertex_const_handle,SVertex_handle>     VM;
-  CGAL::Unique_hash_map<SHalfedge_const_handle,SHalfedge_handle> EM;
-  CGAL::Unique_hash_map<SHalfloop_const_handle,SHalfloop_handle> LM;
-  CGAL::Unique_hash_map<SFace_const_handle,SFace_handle>         FM;
+  CGAL::Unique_hash_map<SVertex_const_handle,SVertex_handle>     VM(SVertex_handle(), D.number_of_svertices());
+  CGAL::Unique_hash_map<SHalfedge_const_handle,SHalfedge_handle> EM(SHalfedge_handle(), D.number_of_shalfedges());
+  CGAL::Unique_hash_map<SHalfloop_const_handle,SHalfloop_handle> LM(SHalfloop_handle(), D.number_of_shalfloops());
+  CGAL::Unique_hash_map<SFace_const_handle,SFace_handle>         FM(SFace_handle(), D.number_of_sfaces());
 
   SVertex_const_iterator vc = D.svertices_begin();
   SVertex_iterator v = svertices_begin();


### PR DESCRIPTION
## Summary of Changes

This replaces #5673 and implements just the minimal changes required to add a reserve method and initialise the hash map on first access instead of during construction.

* The table is now initialized on first use instead of at construction
* Keep the `default_size` of 512
* Add a `min_size` of 32
* Passing a table_size value less than 512 in the constructor works.
* Calling `reserve` can set the table_size before (and only before) table first use.

---
Changes among Nef_3 classes.

* Utilise the `reserve` method in places where the hash table is created ahead of knowing how many items it would contain
* Utilise the table_size  parameter in the constructor where the hash table is created and the number of items is known.

## Release Management

* Affected package(s): Nef_3 / Hash_map
* Issue(s) solved (if any): performance / speed
* License and copyright ownership: Returned to CGAL Authors.

