### PR TITLE
Remove some wide 'PMP' namespace declarations

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/clip.h
@@ -702,10 +702,12 @@ bool clip(TriangleMesh& tm,
 #endif
           const NamedParameters& np = parameters::default_values())
 {
-  using parameters::get_parameter;
-  using parameters::choose_parameter;
   namespace PMP = CGAL::Polygon_mesh_processing;
   namespace params = CGAL::parameters;
+
+  using params::get_parameter;
+  using params::choose_parameter;
+
   if(boost::begin(faces(tm))==boost::end(faces(tm))) return true;
 
   CGAL::Bbox_3 bbox = ::CGAL::Polygon_mesh_processing::bbox(tm);
@@ -805,10 +807,11 @@ bool clip(TriangleMesh& tm,
 #endif
           const NamedParameters& np = parameters::default_values())
 {
-  using parameters::get_parameter;
-  using parameters::choose_parameter;
   namespace PMP = CGAL::Polygon_mesh_processing;
   namespace params = CGAL::parameters;
+
+  using params::get_parameter;
+  using params::choose_parameter;
 
   if(boost::begin(faces(tm))==boost::end(faces(tm))) return true;
   TriangleMesh clipper;
@@ -973,10 +976,11 @@ void split(TriangleMesh& tm,
 #endif
            const NamedParameters& np = parameters::default_values())
 {
-  using parameters::get_parameter;
-  using parameters::choose_parameter;
   namespace PMP = CGAL::Polygon_mesh_processing;
   namespace params = CGAL::parameters;
+
+  using params::get_parameter;
+  using params::choose_parameter;
 
   // create a splitter mesh for the splitting plane using an internal CGAL function
   CGAL::Bbox_3 bbox = ::CGAL::Polygon_mesh_processing::bbox(tm, np);
@@ -987,11 +991,10 @@ void split(TriangleMesh& tm,
                       bbox.xmax()+xd, bbox.ymax()+yd, bbox.zmax()+zd);
 
   TriangleMesh splitter;
-  CGAL::Oriented_side os = PMP::internal::clip_to_bbox(plane, bbox, splitter, CGAL::parameters::default_values());
+  CGAL::Oriented_side os = PMP::internal::clip_to_bbox(plane, bbox, splitter, params::default_values());
 
   if(os == CGAL::ON_ORIENTED_BOUNDARY)
   {
-
     const bool do_not_modify = choose_parameter(get_parameter(np, internal_np::allow_self_intersections), false);
     return split(tm, splitter, np, params::do_not_modify(do_not_modify));
   }
@@ -1076,10 +1079,12 @@ void split(TriangleMesh& tm,
            #endif
            const NamedParameters& np = parameters::default_values())
 {
-  using parameters::get_parameter;
-  using parameters::choose_parameter;
   namespace PMP = CGAL::Polygon_mesh_processing;
   namespace params = CGAL::parameters;
+
+  using params::get_parameter;
+  using params::choose_parameter;
+
   TriangleMesh splitter;
 
   make_hexahedron(iso_cuboid[0], iso_cuboid[1], iso_cuboid[2], iso_cuboid[3],

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -55,8 +55,6 @@ namespace Corefinement {
 enum Boolean_operation_type {UNION = 0, INTERSECTION,
                              TM1_MINUS_TM2, TM2_MINUS_TM1, NONE };
 
-namespace PMP=Polygon_mesh_processing;
-
 // extra functions for handling non-documented functions for user visitors
 // with no extra functions
 BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(Has_extra_functions,
@@ -427,8 +425,8 @@ public:
     , requested_output(requested_output)
     , is_tm1_closed( is_closed(tm1))
     , is_tm2_closed( is_closed(tm2))
-    , is_tm1_inside_out( is_tm1_closed && !PMP::is_outward_oriented(tm1, parameters::vertex_point_map(vpm1)) )
-    , is_tm2_inside_out( is_tm2_closed && !PMP::is_outward_oriented(tm2, parameters::vertex_point_map(vpm2)) )
+    , is_tm1_inside_out( is_tm1_closed && !is_outward_oriented(tm1, parameters::vertex_point_map(vpm1)) )
+    , is_tm2_inside_out( is_tm2_closed && !is_outward_oriented(tm2, parameters::vertex_point_map(vpm2)) )
     , NID((std::numeric_limits<Node_id>::max)())
     , mesh_to_intersection_edges(tm1, tm2)
     , used_to_clip_a_surface(false)
@@ -706,10 +704,10 @@ public:
     std::vector<std::size_t> tm1_patch_ids( num_faces(tm1),NID );
     Border_edge_map<TriangleMesh> is_marked_1(intersection_edges1, tm1);
     std::size_t nb_patches_tm1 =
-      PMP::connected_components(tm1,
-                                bind_property_maps(fids1,make_property_map(&tm1_patch_ids[0])),
-                                parameters::edge_is_constrained_map(is_marked_1)
-                                           .face_index_map(fids1));
+      connected_components(tm1,
+                           bind_property_maps(fids1,make_property_map(&tm1_patch_ids[0])),
+                           parameters::edge_is_constrained_map(is_marked_1)
+                                      .face_index_map(fids1));
 
     std::vector <std::size_t> tm1_patch_sizes(nb_patches_tm1, 0);
     for(std::size_t i : tm1_patch_ids)
@@ -719,10 +717,10 @@ public:
     std::vector<std::size_t> tm2_patch_ids( num_faces(tm2),NID );
     Border_edge_map<TriangleMesh> is_marked_2(intersection_edges2, tm2);
     std::size_t nb_patches_tm2 =
-      PMP::connected_components(tm2,
-                                bind_property_maps(fids2,make_property_map(&tm2_patch_ids[0])),
-                                parameters::edge_is_constrained_map(is_marked_2)
-                                           .face_index_map(fids2));
+      connected_components(tm2,
+                           bind_property_maps(fids2,make_property_map(&tm2_patch_ids[0])),
+                           parameters::edge_is_constrained_map(is_marked_2)
+                                      .face_index_map(fids2));
 
     std::vector <std::size_t> tm2_patch_sizes(nb_patches_tm2, 0);
     for(Node_id i : tm2_patch_ids)

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Generic_clip_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Generic_clip_output_builder.h
@@ -28,13 +28,9 @@
 
 #include <boost/dynamic_bitset.hpp>
 
-
 namespace CGAL {
 namespace Polygon_mesh_processing {
 namespace Corefinement {
-
-
-namespace PMP=Polygon_mesh_processing;
 
 template <class TriangleMesh,
           class VertexPointMap1,
@@ -115,7 +111,7 @@ public:
     , ecm1(ecm1)
     , fids1(fids1)
     , use_compact_clipper(use_compact_clipper)
-    , is_tm2_inside_out( !PMP::is_outward_oriented(tm2, parameters::vertex_point_map(vpm2)) )
+    , is_tm2_inside_out( !is_outward_oriented(tm2, parameters::vertex_point_map(vpm2)) )
     , NID((std::numeric_limits<Node_id>::max)())
   {}
 
@@ -151,10 +147,10 @@ public:
     std::vector<std::size_t> tm1_patch_ids( num_faces(tm1),NID );
 
     std::size_t nb_patches_tm1 =
-      PMP::connected_components(tm1,
-                                bind_property_maps(fids1,make_property_map(&tm1_patch_ids[0])),
-                                parameters::edge_is_constrained_map(ecm1)
-                                           .face_index_map(fids1));
+      connected_components(tm1,
+                           bind_property_maps(fids1,make_property_map(&tm1_patch_ids[0])),
+                           parameters::edge_is_constrained_map(ecm1)
+                                      .face_index_map(fids1));
 
     std::vector <std::size_t> tm1_patch_sizes(nb_patches_tm1, 0);
     for(std::size_t i : tm1_patch_ids)
@@ -232,7 +228,7 @@ public:
       }
     }
 
-    PMP::keep_connected_components(tm1, cc_to_keep, bind_property_maps(fids1,make_property_map(&tm1_patch_ids[0])));
+    keep_connected_components(tm1, cc_to_keep, bind_property_maps(fids1,make_property_map(&tm1_patch_ids[0])));
   }
 };
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
@@ -34,8 +34,6 @@ namespace CGAL {
 namespace Polygon_mesh_processing {
 namespace Corefinement {
 
-namespace PMP=Polygon_mesh_processing;
-
 template <class TriangleMesh,
           class VertexPointMap,
           class FaceIdMap,
@@ -160,7 +158,7 @@ public:
     , fids(fids)
     , ecm(ecm)
     , is_tm_closed( is_closed(tm))
-    , is_tm_inside_out( is_tm_closed && !PMP::is_outward_oriented(tm) )
+    , is_tm_inside_out( is_tm_closed && !is_outward_oriented(tm) )
     , NID((std::numeric_limits<Node_id>::max)())
     , all_fixed(true)
   {}
@@ -350,10 +348,10 @@ public:
     Boolean_property_map< boost::unordered_set<edge_descriptor> >
       is_intersection(intersection_edges);
     std::size_t nb_patches =
-      PMP::connected_components(tm,
-                                bind_property_maps(fids,make_property_map(patch_ids)),
-                                parameters::edge_is_constrained_map(is_intersection)
-                                           .face_index_map(fids));
+      connected_components(tm,
+                           bind_property_maps(fids,make_property_map(patch_ids)),
+                           parameters::edge_is_constrained_map(is_intersection)
+                                      .face_index_map(fids));
 
     // (2-a) Use the orientation around an edge to classify a patch
     boost::dynamic_bitset<> patches_to_keep(nb_patches);
@@ -1179,12 +1177,13 @@ public:
     //remove the extra patch
     remove_patches(tm, ~patches_to_keep,patches, ecm);
 
-    PMP::stitch_borders(tm, hedge_pairs_to_stitch, parameters::vertex_point_map(vpm));
+    stitch_borders(tm, hedge_pairs_to_stitch, parameters::vertex_point_map(vpm));
   }
 };
 
-
-} } } // CGAL::Corefinement
+} // namespace Corefinement
+} // namespace Polygon_mesh_processing
+} // namespace CGAL
 
 #include <CGAL/enable_warnings.h>
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -68,11 +68,7 @@
 #define CGAL_PMP_REMESHING_VERBOSE
 #endif
 
-
 namespace CGAL {
-
-namespace PMP = Polygon_mesh_processing;
-
 namespace Polygon_mesh_processing {
 namespace internal {
 
@@ -114,8 +110,7 @@ namespace internal {
       , pmesh_ptr_(&pmesh)
     {
       std::vector<halfedge_descriptor> border;
-      PMP::border_halfedges(faces, *pmesh_ptr_, std::back_inserter(border)
-        , parameters::face_index_map(fimap));
+      border_halfedges(faces, *pmesh_ptr_, std::back_inserter(border), parameters::face_index_map(fimap));
 
       for(halfedge_descriptor h : border)
         border_edges_ptr->insert(edge(h, *pmesh_ptr_));
@@ -193,22 +188,19 @@ namespace internal {
         if ( same_range(face_range, (faces(pmesh))) )
         {
           // applied on the whole mesh
-          nb_cc
-            = PMP::connected_components(pmesh,
-                                        patch_ids_map,
-                                        parameters::edge_is_constrained_map(ecmap)
-                                                   .face_index_map(fimap));
+          nb_cc = connected_components(pmesh, patch_ids_map,
+                                       parameters::edge_is_constrained_map(ecmap)
+                                                  .face_index_map(fimap));
         }
         else
         {
           // applied on a subset of the mesh
-          nb_cc
-            = PMP::connected_components(pmesh,
-                                        patch_ids_map,
-                                        parameters::edge_is_constrained_map(
-                                          make_OR_property_map(ecmap
-                                          , internal::Border_constraint_pmap<PM, FIMap>(pmesh, face_range, fimap) ) )
-                                       .face_index_map(fimap));
+          nb_cc = connected_components(
+                    pmesh, patch_ids_map,
+                    parameters::edge_is_constrained_map(
+                                  make_OR_property_map(ecmap,
+                                                       internal::Border_constraint_pmap<PM, FIMap>(pmesh, face_range, fimap)))
+                               .face_index_map(fimap));
         }
       }
       else
@@ -812,9 +804,7 @@ namespace internal {
 #ifdef CGAL_PMP_REMESHING_DEBUG
       debug_status_map();
       debug_self_intersections();
-      CGAL_assertion(PMP::remove_degenerate_faces(mesh_,
-                            parameters::vertex_point_map(vpmap_)
-                           .geom_traits(gt_)));
+      CGAL_assertion(remove_degenerate_faces(mesh_, parameters::vertex_point_map(vpmap_).geom_traits(gt_)));
 #endif
     }
 
@@ -850,18 +840,19 @@ namespace internal {
         if (!is_flip_allowed(e))
           continue;
         //add geometric test to avoid axe cuts
-        if (!PMP::internal::should_flip(e, mesh_, vpmap_, gt_))
+        if (!internal::should_flip(e, mesh_, vpmap_, gt_))
           continue;
 
         halfedge_descriptor he = halfedge(e, mesh_);
 
-        std::array<halfedge_descriptor, 2> r1 = PMP::internal::is_badly_shaped(
+        std::array<halfedge_descriptor, 2> r1 = internal::is_badly_shaped(
             face(he, mesh_),
             mesh_, vpmap_, vcmap_, ecmap_, gt_,
             cap_threshold, // bound on the angle: above 160 deg => cap
             4, // bound on shortest/longest edge above 4 => needle
             0);// collapse length threshold : not needed here
-        std::array<halfedge_descriptor, 2> r2 = PMP::internal::is_badly_shaped(
+
+        std::array<halfedge_descriptor, 2> r2 = internal::is_badly_shaped(
             face(opposite(he, mesh_), mesh_),
             mesh_, vpmap_, vcmap_, ecmap_, gt_, cap_threshold, 4, 0);
 
@@ -976,9 +967,7 @@ namespace internal {
 
 #ifdef CGAL_PMP_REMESHING_DEBUG
       debug_status_map();
-      CGAL_assertion(PMP::remove_degenerate_faces(mesh_,
-                             parameters::vertex_point_map(vpmap_)
-                            .geom_traits(gt_)));
+      CGAL_assertion(remove_degenerate_faces(mesh_, parameters::vertex_point_map(vpmap_).geom_traits(gt_)));
       debug_self_intersections();
 #endif
 
@@ -1016,9 +1005,7 @@ namespace internal {
 
           else if (is_on_patch(v))
           {
-            Vector_3 vn = PMP::compute_vertex_normal(v, mesh_,
-                                                     parameters::vertex_point_map(vpmap_)
-                                                                .geom_traits(gt_));
+            Vector_3 vn = compute_vertex_normal(v, mesh_, parameters::vertex_point_map(vpmap_).geom_traits(gt_));
             Vector_3 move = CGAL::NULL_VECTOR;
             unsigned int star_size = 0;
             for(halfedge_descriptor h : halfedges_around_target(v, mesh_))
@@ -1547,8 +1534,7 @@ private:
       if (f == boost::graph_traits<PM>::null_face())
         return CGAL::NULL_VECTOR;
 
-      return PMP::compute_face_normal(f, mesh_, parameters::vertex_point_map(vpmap_)
-                                                           .geom_traits(gt_));
+      return compute_face_normal(f, mesh_, parameters::vertex_point_map(vpmap_).geom_traits(gt_));
     }
 
     template<typename FaceRange>
@@ -1959,10 +1945,8 @@ private:
     {
       std::cout << "Test self intersections...";
       std::vector<std::pair<face_descriptor, face_descriptor> > facets;
-      PMP::self_intersections(mesh_,
-                              std::back_inserter(facets),
-                              parameters::vertex_point_map(vpmap_)
-                                         .geom_traits(gt_));
+      self_intersections(mesh_, std::back_inserter(facets),
+                         parameters::vertex_point_map(vpmap_).geom_traits(gt_));
       //CGAL_assertion(facets.empty());
       std::cout << "done ("<< facets.size() <<" facets)." << std::endl;
     }
@@ -1971,11 +1955,8 @@ private:
     {
       std::cout << "Test self intersections...";
       std::vector<std::pair<face_descriptor, face_descriptor> > facets;
-      PMP::self_intersections(faces_around_target(halfedge(v, mesh_), mesh_),
-                              mesh_,
-                              std::back_inserter(facets),
-                              parameters::vertex_point_map(vpmap_)
-                                         .geom_traits(gt_));
+      self_intersections(faces_around_target(halfedge(v, mesh_), mesh_), mesh_, std::back_inserter(facets),
+                         parameters::vertex_point_map(vpmap_).geom_traits(gt_));
       //CGAL_assertion(facets.empty());
       std::cout << "done ("<< facets.size() <<" facets)." << std::endl;
     }


### PR DESCRIPTION
## Summary of Changes

There are a few `namespace PMP =` living at namespace level within the headers of package `Polygon_mesh_processing` (`CGAL::PMP` from isotropic remeshing for example). It's never within the global namespace so it's not particularly dangerous, but from time to time I wonder how did my compiler recognize the `PMP` I forgot to declare. It's also quite specific to this package to have these aliases.

I also removed those in `CGAL::Polygon_mesh_processing::Corefinement::PMP` for the same reason. Look-up can find the function without even putting the namespace, but I can put an alias within the function.

If these aliases are ok to most people, I can just cancel the PR.

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

