### PR TITLE
Added missing copy constructor && assignment

### DIFF
--- a/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Decomposition_strategy_adapter.h
+++ b/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Decomposition_strategy_adapter.h
@@ -51,11 +51,33 @@ protected:
   bool m_own_traits;      // inidicates whether the kernel should be freed up.
 
 public:
+  // The pointer to the traits and the flag that indicate ownership should be
+  // replaced with a smart pointer. Meanwhile, the copy constructor and
+  // copy assignment prevent double delition. Notice that once a copy
+  // constructor (assignment) is present, the move constructor (assignment)
+  // is implicitly not generated anyway.
+
   /*! Default constructor. */
   Polygon_decomposition_strategy_adapter() :
     m_traits(nullptr),
     m_own_traits(false)
   { init(); }
+
+  /*! Copy constructor. */
+  Polygon_decomposition_strategy_adapter
+  (const Polygon_decomposition_strategy_adapter& other) :
+    m_traits((other.m_own_traits) ? new Traits_2 : other.m_traits),
+    m_own_traits(other.m_own_traits)
+  { init(); }
+
+  /*! Copy assignment. */
+  Polygon_decomposition_strategy_adapter&
+  operator=(const Polygon_decomposition_strategy_adapter& other) {
+    m_traits = (other.m_own_traits) ? new Traits_2 : other.m_traits;
+    m_own_traits = other.m_own_traits;
+    init();
+    return *this;
+  }
 
   /*! Constructor. */
   Polygon_decomposition_strategy_adapter(const Traits_2& traits) :

--- a/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_conv_2.h
+++ b/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_conv_2.h
@@ -117,11 +117,33 @@ private:
   Ccw_in_between_2        f_ccw_in_between;
 
 public:
+  // The pointer to the kernel and the flag that indicate ownership should be
+  // replaced with a smart pointer. Meanwhile, the copy constructor and
+  // copy assignment prevent double delition. Notice that once a copy
+  // constructor (assignment) is present, the move constructor (assignment)
+  // is implicitly not generated anyway.
+
   /*! Default constructor. */
   Minkowski_sum_by_convolution_2() :
     m_kernel(new Kernel),
     m_own_kernel(true)
   { init(); }
+
+  /*! Copy constructor. */
+  Minkowski_sum_by_convolution_2
+  (const Minkowski_sum_by_convolution_2& other) :
+    m_kernel((other.m_own_kernel) ? new Kernel : other.m_kernel),
+    m_own_kernel(other.m_own_kernel)
+  { init(); }
+
+  /*! Copy assignment. */
+  Minkowski_sum_by_convolution_2&
+  operator=(const Minkowski_sum_by_convolution_2& other) {
+    m_kernel = (other.m_own_kernel) ? new Kernel : other.m_kernel;
+    m_own_kernel = other.m_own_kernel;
+    init();
+    return *this;
+  }
 
   /*! Constructor. */
   Minkowski_sum_by_convolution_2(const Kernel& kernel) :

--- a/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_decomp_2.h
+++ b/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_decomp_2.h
@@ -90,6 +90,12 @@ private:
   Compare_xy_2            f_compare_xy;
 
 public:
+  // The pointers and the corresponding flags that indicate ownerships should
+  // be replaced with smart pointers. Meanwhile, the copy constructor and
+  // copy assignment prevent double delition. Notice that once a copy
+  // constructor (assignment) is present, the move constructor (assignment)
+  // is implicitly not generated anyway.
+
   //! Default constructor.
   Minkowski_sum_by_decomposition_2() :
     m_decomposition_strategy1(nullptr),
@@ -99,6 +105,36 @@ public:
     m_traits(nullptr),
     m_own_traits(false)
   { init(); }
+
+  //! Copy constructor.
+  Minkowski_sum_by_decomposition_2
+  (const Minkowski_sum_by_decomposition_2& other) :
+    m_decomposition_strategy1((other.m_own_strategy1) ?
+                              new Decomposition_strategy1 :
+                              other.m_decomposition_strategy1),
+    m_decomposition_strategy2((other.m_own_strategy2) ?
+                              new Decomposition_strategy2 :
+                              other.m_decomposition_strategy2),
+    m_own_strategy1(other.m_own_strategy1),
+    m_own_strategy2(other.m_own_strategy2),
+    m_traits((other.m_own_traits) ? new Traits_2 : other.m_traits),
+    m_own_traits(other.m_own_traits)
+  { init(); }
+
+  //! Copy assignment.
+  Minkowski_sum_by_decomposition_2&
+  operator=(const Minkowski_sum_by_decomposition_2& other) {
+    m_decomposition_strategy1 = (other.m_own_strategy1) ?
+      new Decomposition_strategy1 : other.m_decomposition_strategy1;
+    m_decomposition_strategy2 = (other.m_own_strategy2) ?
+      new Decomposition_strategy2 : other.m_decomposition_strategy2;
+    m_own_strategy1 = other.m_own_strategy1;
+    m_own_strategy2 = other.m_own_strategy2;
+    m_traits = (other.m_own_traits) ? new Traits_2 : other.m_traits;
+    m_own_traits = other.m_own_traits;
+    init();
+    return *this;
+  }
 
   //! Constructor.
   Minkowski_sum_by_decomposition_2(const Decomposition_strategy1& strategy1,

--- a/Minkowski_sum_2/include/CGAL/Polygon_vertical_decomposition_2.h
+++ b/Minkowski_sum_2/include/CGAL/Polygon_vertical_decomposition_2.h
@@ -100,11 +100,33 @@ private:
   Equal_2     f_equal;
 
 public:
+  // The pointer to the traits and the flag that indicate ownership should be
+  // replaced with a smart pointer. Meanwhile, the copy constructor and
+  // copy assignment prevent double delition. Notice that once a copy
+  // constructor (assignment) is present, the move constructor (assignment)
+  // is implicitly not generated anyway.
+
   /*! Default constructor. */
   Polygon_vertical_decomposition_2() :
     m_traits(nullptr),
     m_own_traits(false)
   { init(); }
+
+  /*! Copy constructor. */
+  Polygon_vertical_decomposition_2
+  (const Polygon_vertical_decomposition_2& other) :
+    m_traits((other.m_own_traits) ? new Traits_2 : other.m_traits),
+    m_own_traits(other.m_own_traits)
+  { init(); }
+
+  /*! Copy assignment. */
+  Polygon_vertical_decomposition_2&
+  operator=(const Polygon_vertical_decomposition_2& other) {
+    m_traits = (other.m_own_traits) ? new Traits_2 : other.m_traits;
+    m_own_traits = other.m_own_traits;
+    init();
+    return *this;
+  }
 
   /*! Constructor */
   Polygon_vertical_decomposition_2(const Traits_2& traits) :

--- a/Minkowski_sum_2/include/CGAL/Small_side_angle_bisector_decomposition_2.h
+++ b/Minkowski_sum_2/include/CGAL/Small_side_angle_bisector_decomposition_2.h
@@ -106,11 +106,33 @@ private:
   Ccw_in_between_2        f_ccw_in_between;
 
 public:
+  // The pointer to the kernel and the flag that indicate ownership should be
+  // replaced with a smart pointer. Meanwhile, the copy constructor and
+  // copy assignment prevent double delition. Notice that once a copy
+  // constructor (assignment) is present, the move constructor (assignment)
+  // is implicitly not generated anyway.
+
   /*! Default constructor. */
   Small_side_angle_bisector_decomposition_2() :
     m_kernel(new Kernel),
     m_own_kernel(true)
   { init(); }
+
+  /*! Copy constructor. */
+  Small_side_angle_bisector_decomposition_2
+  (const Small_side_angle_bisector_decomposition_2& other) :
+    m_kernel((other.m_own_kernel) ? new Kernel : other.m_kernel),
+    m_own_kernel(other.m_own_kernel)
+  { init(); }
+
+  /*! Copy assignment. */
+  Small_side_angle_bisector_decomposition_2&
+  operator=(const Small_side_angle_bisector_decomposition_2& other) {
+    m_kernel = (other.m_own_kernel) ? new Kernel : other.m_kernel;
+    m_own_kernel = other.m_own_kernel;
+    init();
+    return *this;
+  }
 
   /*! Constructor. */
   Small_side_angle_bisector_decomposition_2(const Kernel& kernel) :


### PR DESCRIPTION
## Summary of Changes

Added missing copy constructors and copy assignments to several classes that store pointers to objects that are either passed in via user-defined constructors or allocated. The default implementations caused segmentation faults.

The pointers and the corresponding flags that indicate ownerships should be eventually replaced with a smart pointers. Meanwhile, the copy constructors and copy assignments prevent double deletion. Notice that once a copy constructor (assignment) is present, the move constructor (assignment) is implicitly not generated anyway.

## Release Management

* Affected package(s): Minkowski_sum_2
* Issue(s) solved (if any): 
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature)
* License and copyright ownership: TAU

