### PR TITLE
PMP: Add example for extrude_mesh()

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -230,10 +230,11 @@ Once this is done, remeshing is run on all the surface, with protection of const
 \subsubsection ExtrusionExample Extrusion of a Triangle Mesh
 
 The following example extrudes in both directions by projecting points along the vertex normal.
+In case the function `Bottom` was the identity this would have been a one-sided extrusion.
 
 \cgalExample{Polygon_mesh_processing/extrude.cpp}
 
-In case the function `Bottom` was the identity this would have been a one-sided extrusion.
+
 
 
 \section Coref_section Corefinement and Boolean Operations

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -185,6 +185,14 @@ Shape smoothing of the devil model, using the mean curvature flow with a time st
 constraining border vertices (located at the neck, where the mesh is open).
 \cgalFigureCaptionEnd
 
+
+\subsubsection Extrusion
+
+This package provides two functions to extrude a triangle mesh with boundaries. A first one extrudes by offsetting each vertex by a user provided vector.
+A second one is more general: It takes two users provided functors which extrude "up" and "down".  In both cases the boundaries are connected by a triangle strip.
+Note that the extrusion may generate self intersecting surfaces.
+
+
 \subsection MeshingExamples Meshing Examples
 
 \subsubsection MeshingExample_1 Refine and Fair a Region on a Triangle Mesh
@@ -217,6 +225,16 @@ Since the boundary edges will be considered as constrained and protected in this
 Once this is done, remeshing is run on all the surface, with protection of constraints activated, for 3 iterations.
 
 \cgalExample{Polygon_mesh_processing/isotropic_remeshing_example.cpp}
+
+
+\subsubsection ExtrusionExample Extrusion of a Triangle Mesh
+
+The following example extrudes in both directions by projecting points along the vertex normal.
+
+\cgalExample{Polygon_mesh_processing/extrude.cpp}
+
+In case the function `Bottom` was the identity this would have been a one-sided extrusion.
+
 
 \section Coref_section Corefinement and Boolean Operations
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/examples.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/examples.txt
@@ -1,5 +1,6 @@
 /*!
 
+\example Polygon_mesh_processing/extrude.cpp
 \example Polygon_mesh_processing/polyhedral_envelope.cpp
 \example Polygon_mesh_processing/polyhedral_envelope_of_triangle_soup.cpp
 \example Polygon_mesh_processing/polyhedral_envelope_mesh_containment.cpp

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
@@ -54,6 +54,7 @@ if(TARGET CGAL::Eigen3_support)
   target_link_libraries(mesh_smoothing_example PUBLIC CGAL::Eigen3_support)
 endif()
 
+create_single_source_cgal_program( "extrude.cpp" )
 create_single_source_cgal_program( "polyhedral_envelope.cpp" )
 create_single_source_cgal_program( "polyhedral_envelope_of_triangle_soup.cpp" )
 create_single_source_cgal_program( "polyhedral_envelope_mesh_containment.cpp" )

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/extrude.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/extrude.cpp
@@ -1,0 +1,75 @@
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/compute_normal.h>
+#include <CGAL/Polygon_mesh_processing/extrude.h>
+#include <CGAL/boost/graph/IO/polygon_mesh_io.h>
+
+#include <iostream>
+#include <fstream>
+#include <string>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel  Kernel;
+typedef CGAL::Surface_mesh<Kernel::Point_3> SM;
+typedef boost::graph_traits<SM>::vertex_descriptor           vertex_descriptor;
+
+typedef Kernel::Vector_3                                     Vector;
+typedef boost::property_map<SM, CGAL::vertex_point_t>::type  VPMap;
+typedef SM::template Property_map<vertex_descriptor, Vector> VNMap;
+
+struct Bottom
+{
+  Bottom(VPMap pmap, VNMap nmap, double vlen)
+    : pmap(pmap), nmap(nmap), vlen(vlen)
+  {}
+
+
+  void operator()(const vertex_descriptor& vin, const vertex_descriptor vout) const
+  {
+    put(pmap, vout, get(pmap, vout) - vlen* get(nmap, vin));
+  }
+
+  VPMap pmap;
+  VNMap nmap;
+  double vlen;
+};
+
+struct Top
+{
+  Top(VPMap pmap, VNMap nmap, double vlen)
+    : pmap(pmap), nmap(nmap), vlen(vlen)
+  {}
+
+
+  void operator()(const vertex_descriptor& vin, const vertex_descriptor vout) const
+  {
+    put(pmap, vout, get(pmap, vout) + vlen* get(nmap, vin));
+  }
+
+  VPMap pmap;
+  VNMap nmap;
+  double vlen;
+};
+
+int main(int argc, char* argv[])
+{
+  SM in, out;
+
+  std::string filename = (argc > 1) ? std::string(argv[1]) : CGAL::data_file_path("meshes/sphere_selection_facets.off");
+  double vlen = (argc > 2) ? std::stod(argv[2]) : 0.1;
+
+  CGAL::IO::read_polygon_mesh(filename, in);
+
+  VNMap vnormals = in.template add_property_map<vertex_descriptor, Vector>("v:normals", CGAL::NULL_VECTOR).first;
+
+  CGAL::Polygon_mesh_processing::compute_vertex_normals(in, vnormals);
+  Bottom bottom(get(CGAL::vertex_point,out), vnormals, vlen);
+  Top top(get(CGAL::vertex_point,out), vnormals, vlen);
+  CGAL::Polygon_mesh_processing::extrude_mesh(in, out, bottom, top);
+
+
+  filename = filename.substr(filename.find_last_of("/") + 1, filename.length() - 1);
+  filename = filename.substr(0, filename.find_last_of("."));
+  filename = filename + "_" + std::to_string(vlen) + ".off";
+  CGAL::IO::write_polygon_mesh(filename, out, CGAL::parameters::stream_precision(17));
+  return 0;
+}

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/extrude.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/extrude.cpp
@@ -54,7 +54,7 @@ int main(int argc, char* argv[])
 {
   SM in, out;
 
-  std::string filename = (argc > 1) ? std::string(argv[1]) : CGAL::data_file_path("meshes/sphere_selection_facets.off");
+  std::string filename = (argc > 1) ? std::string(argv[1]) : CGAL::data_file_path("meshes/cube-ouvert.off");
   double vlen = (argc > 2) ? std::stod(argv[2]) : 0.1;
 
   CGAL::IO::read_polygon_mesh(filename, in);


### PR DESCRIPTION
## Summary of Changes

Add an example for the function that enables to extrude a mesh.

Text  [subsection ](https://cgal.geometryfactory.com/CGAL/Manual_doxygen_test/CGAL-5.5-Ic-30/output2/Polygon_mesh_processing/index.html#title10 )and example [subsection ](https://cgal.geometryfactory.com/CGAL/Manual_doxygen_test/CGAL-5.5-Ic-30/output2/Polygon_mesh_processing/index.html#title15) in the User Manual.

## Release Management

* Affected package(s): PMP


