### PR TITLE
Stream_support: clean up the examples for WKT

### DIFF
--- a/Stream_support/examples/Stream_support/Linestring_WKT.cpp
+++ b/Stream_support/examples/Stream_support/Linestring_WKT.cpp
@@ -1,16 +1,10 @@
-#include <CGAL/Simple_cartesian.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-
-#include <boost/config.hpp>
-#include <boost/version.hpp>
+#include <CGAL/IO/WKT.h>
 
 #include <iostream>
 #include <fstream>
 #include <vector>
 
-#include <CGAL/IO/WKT.h>
-
-//typedef CGAL::Simple_cartesian<CGAL::Gmpq> Kernel;
 typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel;
 
 int main(int argc, char* argv[])

--- a/Stream_support/examples/Stream_support/Point_WKT.cpp
+++ b/Stream_support/examples/Stream_support/Point_WKT.cpp
@@ -1,15 +1,10 @@
-#include <CGAL/Simple_cartesian.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-
-#include <boost/config.hpp>
-#include <boost/version.hpp>
+#include <CGAL/IO/WKT.h>
 
 #include <iostream>
 #include <fstream>
 #include <vector>
-#include <CGAL/IO/WKT.h>
 
-//typedef CGAL::Simple_cartesian<CGAL::Gmpq> Kernel;
 typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel;
 
 int main(int argc, char* argv[])

--- a/Stream_support/examples/Stream_support/Polygon_WKT.cpp
+++ b/Stream_support/examples/Stream_support/Polygon_WKT.cpp
@@ -1,17 +1,10 @@
-#include <CGAL/Simple_cartesian.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-
-#include <boost/config.hpp>
-#include <boost/version.hpp>
+#include <CGAL/IO/WKT.h>
 
 #include <iostream>
 #include <fstream>
-#include <vector>
 #include <deque>
 
-#include <CGAL/IO/WKT.h>
-
-//typedef CGAL::Simple_cartesian<CGAL::Gmpq> Kernel;
 typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel;
 
 int main(int argc, char* argv[])

--- a/Stream_support/examples/Stream_support/read_WKT.cpp
+++ b/Stream_support/examples/Stream_support/read_WKT.cpp
@@ -1,16 +1,12 @@
-#include <CGAL/Simple_cartesian.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-
-#include <boost/config.hpp>
-#include <boost/version.hpp>
+#include <CGAL/IO/WKT.h>
 
 #include <iostream>
 #include <fstream>
 #include <vector>
-#include <CGAL/IO/WKT.h>
-//typedef CGAL::Simple_cartesian<CGAL::Gmpq> Kernel;
 
 typedef CGAL::Exact_predicates_exact_constructions_kernel Kernel;
+
 int main(int argc, char* argv[])
 {
   typedef CGAL::Point_2<Kernel> Point;

--- a/Stream_support/test/Stream_support/test_WKT.cpp
+++ b/Stream_support/test/Stream_support/test_WKT.cpp
@@ -4,9 +4,6 @@
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
-#include <boost/config.hpp>
-#include <boost/version.hpp>
-
 #include <fstream>
 #include <vector>
 #include <cassert>


### PR DESCRIPTION
## Summary of Changes

Remove some `#include" and `typedef` in some WKT example files.
## Release Management

* Affected package(s):  Stream_support


