### PR TITLE
Surface_mesh_shortest_path: Make data member a copy

### DIFF
--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_path_with_locate.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_path_with_locate.cpp
@@ -7,8 +7,6 @@
 #include <CGAL/AABB_traits.h>
 #include <CGAL/AABB_tree.h>
 
-#include <boost/lexical_cast.hpp>
-
 #include <cstdlib>
 #include <iostream>
 #include <fstream>

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_multiple_sources.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_multiple_sources.cpp
@@ -4,6 +4,9 @@
 #include <CGAL/Random.h>
 #include <CGAL/Surface_mesh_shortest_path.h>
 
+#include <boost/lexical_cast.hpp>
+
+#include <cstdlib>
 #include <cstdlib>
 #include <iostream>
 #include <fstream>

--- a/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
+++ b/Surface_mesh_shortest_path/include/CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h
@@ -331,7 +331,7 @@ private:
   };
 
 private:
-  const Traits& m_traits;
+  const Traits m_traits;
   const Triangle_mesh& m_graph;
 
   Vertex_index_map m_vertexIndexMap;

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_1.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_1.cpp
@@ -4,7 +4,6 @@
 
 #include <CGAL/Random.h>
 
-#include <CGAL/Simple_cartesian.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Polyhedron_3.h>

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_2.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_2.cpp
@@ -18,7 +18,6 @@
 #include <CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h>
 #include <CGAL/Surface_mesh_shortest_path/function_objects.h>
 #include <CGAL/Surface_mesh_shortest_path/barycentric.h>
-#include <CGAL/Surface_mesh_shortest_path/internal/misc_functions.h>
 
 #include <CGAL/test_util.h>
 #include "check.h"
@@ -269,5 +268,3 @@ int main(int argc, char* argv[])
 
   return 0;
 }
-
-

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_3.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_3.cpp
@@ -5,6 +5,7 @@
 
 #include <CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path_traits.h>
 #include <CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h>
+#include <CGAL/Surface_mesh_shortest_path/internal/misc_functions.h>
 
 #include <CGAL/boost/graph/iterator.h>
 
@@ -104,6 +105,3 @@ int main(int argc, char* argv[])
 
   return 0;
 }
-
-
-

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_4.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_4.cpp
@@ -5,6 +5,7 @@
 
 #include <CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path_traits.h>
 #include <CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h>
+#include <CGAL/Surface_mesh_shortest_path/internal/misc_functions.h>
 
 #include <CGAL/boost/graph/iterator.h>
 
@@ -152,5 +153,3 @@ int main(int argc, char* argv[])
 
   return 0;
 }
-
-

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_5.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_test_5.cpp
@@ -5,7 +5,6 @@
 
 #include <CGAL/Random.h>
 
-#include <CGAL/Simple_cartesian.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Polyhedron_3.h>
@@ -17,7 +16,6 @@
 #include <CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path.h>
 #include <CGAL/Surface_mesh_shortest_path/function_objects.h>
 #include <CGAL/Surface_mesh_shortest_path/barycentric.h>
-#include <CGAL/Surface_mesh_shortest_path/internal/misc_functions.h>
 
 #include <CGAL/test_util.h>
 #include "check.h"
@@ -188,6 +186,3 @@ int main(int argc, char* argv[])
   }
    return 0;
 }
-
-
-

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_traits_test.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/Surface_mesh_shortest_path_traits_test.cpp
@@ -1,4 +1,3 @@
-#include <CGAL/Simple_cartesian.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Polyhedron_3.h>
@@ -6,7 +5,6 @@
 #include <CGAL/Surface_mesh_shortest_path/Surface_mesh_shortest_path_traits.h>
 #include <CGAL/Surface_mesh_shortest_path/function_objects.h>
 #include <CGAL/Surface_mesh_shortest_path/barycentric.h>
-#include <CGAL/Surface_mesh_shortest_path/internal/misc_functions.h>
 
 #include <CGAL/boost/graph/iterator.h>
 


### PR DESCRIPTION


_Please use the following template to help us managing pull requests._

## Summary of Changes

As reported in #Issue #6333 we may have a dangling reference.  Thank you for pointing out @seb-tourneux.

## Release Management

* Affected package(s): Surface_mesh_shortest_path
* Issue(s) solved (if any): fix #6333


