### PR TITLE
ignore CDT2 if normal is null

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -1277,7 +1277,6 @@ bool is_planar_2(
   }
 
   // Here, avg_squared_distance is a little bit more tolerant than avg_distance^2.
-  CGAL_assertion(avg_normal != typename Traits::Vector_3());
   const Plane_3 plane = Plane_3(centroid, avg_normal);
   FT avg_squared_distance = FT(0);
   for (const Point_3& p : points)
@@ -1367,6 +1366,8 @@ triangulate_hole_polyline_with_cdt(const PointRange& points,
   z /= ft_nn;
   const Vector_3 avg_normal = Vector_3(x, y, z);
   // std::cout << "avg normal: " << avg_normal << std::endl;
+
+  if (avg_normal==NULL_VECTOR) return false;
 
   // Checking the hole planarity.
   if (!is_planar_2(P, avg_normal, max_squared_distance, traits)) {


### PR DESCRIPTION
should also fix [this warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.5-Ic-27/Polygon_mesh_processing_Examples/TestReport_lrineau_ArchLinux-CXX17-Release.gz)