### PR TITLE
Make two test programs less verbose

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
@@ -975,7 +975,7 @@ update_mesh(const Moves_vector& moves,
         FT size = std::get<2>(*it);
 
 #ifdef CGAL_MESH_3_OPTIMIZER_VERBOSE
-        std::cout << "Moving #" << it - moves.begin()
+        std::cerr << "Moving #" << it - moves.begin()
                   << " addr: " << &*v
                   << " pt: " << tr_.point(v)
                   << " move: " << move << std::endl;

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
@@ -54,7 +54,7 @@ struct Polyhedron_with_features_tester : public Tester<K>
       const auto str_size= output.size();
       const auto str_begin = output.data();
       const auto str_end = str_begin + str_size;
-      constexpr auto nb = static_cast<decltype(str_size)>(10000);
+      constexpr auto nb = static_cast<std::remove_cv_t<decltype(str_size)>>(10000);
       auto pos1 = str_begin + (std::min)(nb, str_size);
       assert(pos1 <= str_end);
       const auto pos2 = str_end - (std::min)(nb, str_size);

--- a/Voronoi_diagram_2/test/Voronoi_diagram_2/vda_tos2.cpp
+++ b/Voronoi_diagram_2/test/Voronoi_diagram_2/vda_tos2.cpp
@@ -208,7 +208,7 @@ int main(int argc, char** argv)
   const auto str_size = output.size();
   const auto str_begin = output.data();
   const auto str_end = str_begin + str_size;
-  constexpr auto nb = static_cast<decltype(str_size)>(10000);
+  constexpr auto nb = static_cast<std::remove_cv_t<decltype(str_size)>>(10000);
   auto pos1 = str_begin + (std::min)(nb, str_size);
   assert(pos1 <= str_end);
   const auto pos2 = str_end - (std::min)(nb, str_size);

--- a/Voronoi_diagram_2/test/Voronoi_diagram_2/vda_tos2.cpp
+++ b/Voronoi_diagram_2/test/Voronoi_diagram_2/vda_tos2.cpp
@@ -10,6 +10,7 @@
 #include <iostream>
 #include <iterator>
 #include <fstream>
+#include <sstream>
 #include <vector>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
@@ -170,6 +171,10 @@ int main(int argc, char** argv)
   std::cout << vd.number_of_faces() << " faces" << std::endl;
   std::cout << "dimension = " << vd.dual().dimension() << std::endl;
 
+  // redirect std::cout to cout_output
+  std::stringstream cout_output;
+  std::streambuf* old_cout_buf = std::cout.rdbuf(cout_output.rdbuf());
+
   VD::Vertex_iterator vit = vd.vertices_begin(), vend = vd.vertices_end();
   for(; vit!=vend; ++vit)
   {
@@ -196,6 +201,30 @@ int main(int argc, char** argv)
     CGAL_USE(next_h);
     CGAL_USE(opposite_h);
   }
+
+  // now restore std::cout and display the output
+  std::cout.rdbuf(old_cout_buf);
+  const auto output = cout_output.str();
+  const auto str_size = output.size();
+  const auto str_begin = output.data();
+  const auto str_end = str_begin + str_size;
+  constexpr auto nb = static_cast<decltype(str_size)>(10000);
+  auto pos1 = str_begin + (std::min)(nb, str_size);
+  assert(pos1 <= str_end);
+  const auto pos2 = str_end - (std::min)(nb, str_size);
+  assert(pos2 >= str_begin);
+  if (pos2 <= pos1) {
+    pos1 = str_end;
+  }
+  std::cout << "NOW THE FIRST AND LAST 10k CHARACTERS OF THE COUT OUTPUT:\n";
+  std::cout << "-----\n" << std::string(str_begin, pos1) << "\n-----\n";
+  if (pos1 != str_end) {
+    std::cout << "[...]\n-----\n" << std::string(pos2, str_end) << "\n-----\n";
+  }
+  const auto file_name = "vda_tos2_test_output.txt";
+  std::ofstream file_output(file_name);
+  file_output << output;
+  std::cout << "Full log is output to " << file_name << "\n";
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary of Changes

Make two programs less verbose on cerr/cout. Fix #6353.

## Release Management

* Affected package(s): Mesh_3, Voronoi_diagram_2
* Issue(s) solved (if any): fix #6353
* License and copyright ownership: maintenance by GeometryFactory

