### PR TITLE
Fix squared_distance(Point_3, Triangle_3)

### DIFF
--- a/Distance_3/include/CGAL/Distance_3/Point_3_Triangle_3.h
+++ b/Distance_3/include/CGAL/Distance_3/Point_3_Triangle_3.h
@@ -68,8 +68,8 @@ squared_distance_to_triangle_RT(const typename K::Point_3& pt,
 
   if(normal == NULL_VECTOR)
   {
-    // The case normal==NULL_VECTOR covers the case when the triangle
-    // is colinear, or even more degenerate. In that case, we can
+    // The case normal == NULL_VECTOR covers the case when the triangle
+    // is collinear, or even more degenerate. In that case, we can
     // simply take also the distance to the three segments.
     squared_distance_RT(pt, segment(t2, t0), num, den, k);
 
@@ -161,7 +161,7 @@ squared_distance_to_triangle(const typename K::Point_3& pt,
   if(normal == NULL_VECTOR)
   {
     // The case normal == NULL_VECTOR covers the case when the triangle
-    // is colinear, or even more degenerate. In that case, we can
+    // is collinear, or even more degenerate. In that case, we can
     // simply take also the distance to the three segments.
     //
     // Note that in the degenerate case, at most 2 edges cover the full triangle,

--- a/Distance_3/include/CGAL/Distance_3/Point_3_Triangle_3.h
+++ b/Distance_3/include/CGAL/Distance_3/Point_3_Triangle_3.h
@@ -158,9 +158,9 @@ squared_distance_to_triangle(const typename K::Point_3& pt,
     // Note that in the degenerate case, at most 2 edges cover the full triangle,
     // and only two distances could be used, but leaving 3 for the case of
     // inexact constructions as it might improve the accuracy.
-    typename K::FT d1 = internal::squared_distance(pt, segment(t2, t0), k);
-    typename K::FT d2 = internal::squared_distance(pt, segment(t1, t2), k);
-    typename K::FT d3 = internal::squared_distance(pt, segment(t0, t1), k);
+    typename K::FT d1 = sq_dist(pt, segment(t2, t0));
+    typename K::FT d2 = sq_dist(pt, segment(t1, t2));
+    typename K::FT d3 = sq_dist(pt, segment(t0, t1));
 
     return (std::min)((std::min)(d1, d2), d3);
   }

--- a/Distance_3/include/CGAL/Distance_3/Point_3_Triangle_3.h
+++ b/Distance_3/include/CGAL/Distance_3/Point_3_Triangle_3.h
@@ -66,7 +66,16 @@ squared_distance_to_triangle_RT(const typename K::Point_3& pt,
   const Vector_3 oe3 = vector(t0, t2);
   const Vector_3 normal = wcross(e1, oe3, k);
 
-  if(normal == NULL_VECTOR)
+  if(normal != NULL_VECTOR &&
+     on_left_of_triangle_edge(pt, normal, t0, t1, k) &&
+     on_left_of_triangle_edge(pt, normal, t1, t2, k) &&
+     on_left_of_triangle_edge(pt, normal, t2, t0, k))
+  {
+    // The projection of pt is inside the triangle
+    inside = true;
+    squared_distance_to_plane_RT(normal, vector(t0, pt), num, den, k);
+  }
+  else
   {
     // The case normal == NULL_VECTOR covers the case when the triangle
     // is collinear, or even more degenerate. In that case, we can
@@ -89,34 +98,7 @@ squared_distance_to_triangle_RT(const typename K::Point_3& pt,
       num = num2;
       den = den2;
     }
-
-    return;
   }
-
-  const bool b01 = on_left_of_triangle_edge(pt, normal, t0, t1, k);
-  if(!b01)
-  {
-    squared_distance_RT(pt, segment(t0, t1), num, den, k);
-    return;
-  }
-
-  const bool b12 = on_left_of_triangle_edge(pt, normal, t1, t2, k);
-  if(!b12)
-  {
-    squared_distance_RT(pt, segment(t1, t2), num, den, k);
-    return;
-  }
-
-  const bool b20 = on_left_of_triangle_edge(pt, normal, t2, t0, k);
-  if(!b20)
-  {
-    squared_distance_RT(pt, segment(t2, t0), num, den, k);
-    return;
-  }
-
-  // The projection of pt is inside the triangle
-  inside = true;
-  squared_distance_to_plane_RT(normal, vector(t0, pt), num, den, k);
 }
 
 template <class K>
@@ -158,7 +140,16 @@ squared_distance_to_triangle(const typename K::Point_3& pt,
   const Vector_3 oe3 = vector(t0, t2);
   const Vector_3 normal = wcross(e1, oe3, k);
 
-  if(normal == NULL_VECTOR)
+  if(normal != NULL_VECTOR &&
+     on_left_of_triangle_edge(pt, normal, t0, t1, k) &&
+     on_left_of_triangle_edge(pt, normal, t1, t2, k) &&
+     on_left_of_triangle_edge(pt, normal, t2, t0, k))
+  {
+    // the projection of pt is inside the triangle
+    inside = true;
+    return squared_distance_to_plane(normal, vector(t0, pt), k);
+  }
+  else
   {
     // The case normal == NULL_VECTOR covers the case when the triangle
     // is collinear, or even more degenerate. In that case, we can
@@ -167,28 +158,12 @@ squared_distance_to_triangle(const typename K::Point_3& pt,
     // Note that in the degenerate case, at most 2 edges cover the full triangle,
     // and only two distances could be used, but leaving 3 for the case of
     // inexact constructions as it might improve the accuracy.
-    typename K::FT d1 = sq_dist(pt, segment(t2, t0));
-    typename K::FT d2 = sq_dist(pt, segment(t1, t2));
-    typename K::FT d3 = sq_dist(pt, segment(t0, t1));
+    typename K::FT d1 = internal::squared_distance(pt, segment(t2, t0), k);
+    typename K::FT d2 = internal::squared_distance(pt, segment(t1, t2), k);
+    typename K::FT d3 = internal::squared_distance(pt, segment(t0, t1), k);
 
     return (std::min)((std::min)(d1, d2), d3);
   }
-
-  const bool b01 = on_left_of_triangle_edge(pt, normal, t0, t1, k);
-  if(!b01)
-    return sq_dist(pt, segment(t0, t1));
-
-  const bool b12 = on_left_of_triangle_edge(pt, normal, t1, t2, k);
-  if(!b12)
-    return sq_dist(pt, segment(t1, t2));
-
-  const bool b20 = on_left_of_triangle_edge(pt, normal, t2, t0, k);
-  if(!b20)
-    return sq_dist(pt, segment(t2, t0));
-
-  // The projection of pt is inside the triangle
-  inside = true;
-  return squared_distance_to_plane(normal, vector(t0, pt), k);
 }
 
 template <class K>

--- a/Distance_3/test/Distance_3/test_distance_3.cpp
+++ b/Distance_3/test/Distance_3/test_distance_3.cpp
@@ -208,6 +208,36 @@ private:
     check_squared_distance (p(1, 1, 1), t, 1);
     check_squared_distance (p(1, 0, 1), t, 1);
     check_squared_distance (p(0, 0, 1), t, 1);
+
+    // Degenerate
+    check_squared_distance (p(1, 2, 3), T(p(4,3,2), p(4,3,2), p(4,3,2)), squared_distance(p(1, 2, 3), p(4,3,2)));
+    check_squared_distance (p(1, 2, 3), T(p(4,3,2), p(10,12,3), p(4,3,2)), squared_distance(p(1, 2, 3), p(4,3,2)));
+    check_squared_distance (p(0, 0, 0), T(p(4,3,2), p(4,-3,-2), p(4,3,2)), squared_distance(p(0, 0, 0), p(4,0,0)));
+
+    // On the triangle
+    check_squared_distance (p(7, 1, -5), T(p(2,9,8), p(-4,-3,-5), p(7, 1, -5)), 0); // vertex
+    check_squared_distance (p(7, 1, -5), T(p(14,2,-10), p(-7,-1,5), p(8, 3, -1)), 0); // edge
+    check_squared_distance (p(1, 4, -3), T(p(0,-8,-3), p(-5,14,-3), p(10, 1, -3)), 0); // face
+
+    // General
+    check_squared_distance (p(-15, 1, 0), T(p(-10, 1, 0), p(0,0,0), p(10,0,0)), 25);
+    check_squared_distance (p(-5, 0, 0), T(p(-10, 1, 0), p(0,0,0), p(10,0,0)), squared_distance(p(-5, 0, 0), S(p(-10, 1, 0), p(0,0,0))));
+    check_squared_distance (p(0, -3, 0), T(p(-10, 1, 0), p(0,0,0), p(10,0,0)), 9);
+    check_squared_distance (p(3, -3, 0), T(p(-10, 1, 0), p(0,0,0), p(10,0,0)), squared_distance(p(3, -3, 0), S(p(0,0,0), p(10,0,0))));
+    check_squared_distance (p(16, 1, 1), T(p(-10, 1, 0), p(0,0,0), p(10,0,0)), 38);
+    check_squared_distance (p(5, 5, 2), T(p(-10, 1, 0), p(0,0,0), p(10,0,0)), squared_distance(p(5, 5, 2), S(p(10,0,0), p(-10,1,0))));
+
+    for(int i=0; i<N; ++i)
+    {
+      P p0 = random_point();
+      P p1 = random_point();
+      P p2 = random_point();
+      P q = random_point();
+
+      check_squared_distance_with_bound(q, T(p0, p1, p2), squared_distance(q, S(p0, p1)));
+      check_squared_distance_with_bound(q, T(p0, p1, p2), squared_distance(q, S(p1, p2)));
+      check_squared_distance_with_bound(q, T(p0, p1, p2), squared_distance(q, S(p2, p0)));
+    }
   }
 
   void P_Tet()

--- a/Triangulation_on_sphere_2/test/Triangulation_on_sphere_2/test_dtos_traits.cpp
+++ b/Triangulation_on_sphere_2/test/Triangulation_on_sphere_2/test_dtos_traits.cpp
@@ -74,7 +74,7 @@ int main(int, char**)
 //  result = traits.power_test_2_object()(P2, P1, P10);
 //  assert(result == CGAL::ON_NEGATIVE_SIDE);
 
-  // power_test_2(p,q) where p, q, and the center of the sphere are colinear
+  // power_test_2(p,q) where p, q, and the center of the sphere are collinear
 //  result = traits.power_test_2_object()(P1, P7);
 //  assert(result == CGAL::ON_POSITIVE_SIDE);
 //  result = traits.power_test_2_object()(P1, P1);
@@ -101,7 +101,7 @@ int main(int, char**)
 //  result = traits_6.power_test_2_object()(P14, P1, P11);
 //  assert(result == CGAL::ON_NEGATIVE_SIDE);
 
-  // power_test_2(p,q) where p, q and sphere are colinear
+  // power_test_2(p,q) where p, q and sphere are collinear
 //  result = traits_6.power_test_2_object()(P13, P0);
 //  assert(result == CGAL::ON_POSITIVE_SIDE);
 //  result = traits_6.power_test_2_object()(P13, P13);


### PR DESCRIPTION
## Summary of Changes

I blundered in commit https://github.com/CGAL/cgal/pull/5527/commits/b95c60fc9fe671eb42a6811e137ab48167657db2: one orientation is of course not sufficient to determine which segment realizes the min.

I'm a little perplexed that nothing exploded, but I think it's because e.g. during an AABB Tree computation, if the computation is wrong for an edge, it still gave the correct result for the same edge seen from the neighboring face.

Reverting to the previous implementation.

## Release Management

* Affected package(s): `Distance_3`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

