### PR TITLE
Add CGAL::Color operator< and return values

### DIFF
--- a/Stream_support/include/CGAL/IO/Color.h
+++ b/Stream_support/include/CGAL/IO/Color.h
@@ -132,6 +132,11 @@ public:
     return !( (*this) == c);
   }
 
+  bool operator<(const Color& c) const
+  {
+      return m_data < c.to_rgba();
+  }
+
   unsigned char r() const { return red(); }
   unsigned char g() const { return green(); }
   unsigned char b() const { return blue(); }
@@ -206,7 +211,7 @@ public:
   /*!
     replaces the rgb values of the colors by the one given as parameters.
   */
-  void set_rgb (unsigned char red,
+  Color& set_rgb (unsigned char red,
                 unsigned char green,
                 unsigned char blue,
                 unsigned char alpha = 255)
@@ -215,13 +220,15 @@ public:
     m_data[1] = green;
     m_data[2] = blue;
     m_data[3] = alpha;
+
+    return *this;
   }
 
   /*!
     replaces the rgb values of the colors by the conversion to rgb of
     the hsv values given as parameters.
   */
-  void set_hsv (double hue,
+  Color& set_hsv (double hue,
                 double saturation,
                 double value,
                 unsigned char alpha = 255)
@@ -275,6 +282,8 @@ public:
     m_data[1] = (unsigned char)g;
     m_data[2] = (unsigned char)b;
     m_data[3] = alpha;
+
+    return *this;
   }
 
   /// @}


### PR DESCRIPTION
## Summary of Changes

This PR add 2 features to the `CGAL::Color` class.  

### 1. Add `CGAL::Color::operator<`

I'm personnaly using `Color` as a key of a `std::map`. The map therefore needs a [comparator](https://en.cppreference.com/w/cpp/named_req/Compare). 
Instead of implementing a comparator separately in my code, I think it might be useful to add the `operator<` in the class.   
To do so, I compared the two `m_data` arrays that call internally the [`std::lexicographical_compare`](https://en.cppreference.com/w/cpp/algorithm/lexicographical_compare).

### 2. Add return value

It could be useful to return the color when calling `set_hsv()` and `set_rgb()`, and not `void`.
For example in my code I'm doing this:
```c++
CGAL::Color newColor;
newColor.set_hsv(angle, 100, 100);
put(colorPm, vertex, newColor);
```
But with a return value I could be written on one line.
```c++
put(colorPm, vertex, CGAL::Color().set_hsv(angle, 100, 100));
```


## Release Management

* Affected package(s): [IO Streams](https://doc.cgal.org/latest/Stream_support/index.html)
* Small Feature
* Link to compiled documentation (obligatory for small feature) [CGAL::IO::Color Class Reference](https://doc.cgal.org/latest/Stream_support/classCGAL_1_1IO_1_1Color.html)

