### PR TITLE
Triangulation_2: Fix doc bug

### DIFF
--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -110,6 +110,11 @@ constraint. The value type of this iterator is `Vertex_handle`.
 typedef unspecified_type Vertices_in_constraint_iterator;
 
 /*!
+A range type for iterating over the vertices of the constraint.
+*/
+typedef unspecified_type Vertices_in_constraint;
+
+/*!
 A context enables the access to the vertices of a constraint that pass
 through a subconstraint.
 

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -341,7 +341,7 @@ Constraint_iterator constraints_end() const;
 /*!
 returns a range of constraints.
 */
-Subconstraints constraints() const;
+Constraints constraints() const;
 
 /*!
 returns a `Subconstraint_iterator` pointing at the first


### PR DESCRIPTION
## Summary of Changes

Fix the return type of  `Constrained_triangulation_plus_2::constraints()`.  
Also add the `typdef`  for [`Vertices_in_constraint`](https://cgal.github.io/6372/v1/Triangulation_2/classCGAL_1_1Constrained__triangulation__plus__2.html#ac9e4a6b9d892bd683c36dc64ae0613e4)

## Release Management

* Affected package(s): Triangulation_2

