### PR TITLE
Polygon_2: Add functions for ranges

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -29,6 +29,10 @@ Release date: June 2022
     [`remove_isolated_vertices()`](https://doc.cgal.org/5.5/Mesh_3/classCGAL_1_1Mesh__complex__3__in__triangulation__3.html#ace57c4e777da457c6e33b4f6e89949ce)
     as a post-processing step for the tetrahedral mesh generation.
 
+### [2D Polygons](https://doc.cgal.org/5.5/Manual/packages.html#PkgPolygon3)
+
+-   Add vertex, edge, and hole ranges.
+
 [Release 5.4](https://github.com/CGAL/cgal/releases/tag/v5.4)
 -----------
 

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -29,7 +29,7 @@ Release date: June 2022
     [`remove_isolated_vertices()`](https://doc.cgal.org/5.5/Mesh_3/classCGAL_1_1Mesh__complex__3__in__triangulation__3.html#ace57c4e777da457c6e33b4f6e89949ce)
     as a post-processing step for the tetrahedral mesh generation.
 
-### [2D Polygons](https://doc.cgal.org/5.5/Manual/packages.html#PkgPolygon3)
+### [2D Polygons](https://doc.cgal.org/5.5/Manual/packages.html#PkgPolygon2)
 
 -   Add vertex, edge, and hole ranges.
 

--- a/Polygon/doc/Polygon/Polygon.txt
+++ b/Polygon/doc/Polygon/Polygon.txt
@@ -75,7 +75,7 @@ and 3D Linear Geometric %Kernel.
 
 The polygon class provides member functions such as `Polygon_2::vertices_begin()` and `Polygon_2::vertices_end()` to iterate over the
 vertices. It additionally provides a member function `Polygon_2::vertices()` that returns a range, mainly to be used with modern
-`for`loops. The same holds for edges and for the holes of the class `Polygon_with_holes_2`.
+`for` loops. The same holds for edges and for the holes of the class `Polygon_with_holes_2`.
 
 \cgalExample{Polygon/ranges.cpp}
 

--- a/Polygon/doc/Polygon/Polygon.txt
+++ b/Polygon/doc/Polygon/Polygon.txt
@@ -70,6 +70,16 @@ and 3D Linear Geometric %Kernel.
 
 \cgalExample{Polygon/projected_polygon.cpp}
 
+
+\subsection subsecPolygonIterate Iterating over Vertices and Edges
+
+The polygon class provides member functions such as `Polygon_2::vertices_begin()` and `Polygon_2::vertices_end()` to iterate over the
+vertices. It additionally provides a member function `Polygon_2::vertices()` that returns a range, mainly to be used with modern
+`for`loops. The same holds for edges and for the holes of the class `Polygon_with_holes_2`.
+
+\cgalExample{Polygon/ranges.cpp}
+
+
 \subsection subsecPolygonDraw Draw a Polygon
 
 A polygon can be visualized by calling the \link  PkgDrawPolygon2 CGAL::draw<P>() \endlink function as shown in the following example. This function opens a new window showing the given polygon. A call to this function is blocking, that is the program continues as soon as the user closes the window (a version exists for polygon with holes, cf. \link PkgDrawPolygonWithHoles2 CGAL::draw<PH>() \endlink).

--- a/Polygon/doc/Polygon/examples.txt
+++ b/Polygon/doc/Polygon/examples.txt
@@ -1,5 +1,6 @@
 /*!
 \example Polygon/Example.cpp
+\example Polygon/ranges.cpp
 \example Polygon/polygon_algorithms.cpp
 \example Polygon/Polygon.cpp
 \example Polygon/projected_polygon.cpp

--- a/Polygon/examples/Polygon/ranges.cpp
+++ b/Polygon/examples/Polygon/ranges.cpp
@@ -1,0 +1,36 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_2.h>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Polygon_2<K>                                  Polygon_2;
+typedef K::Point_2                                          Point_2;
+typedef K::Segment_2                                        Segment_2;
+
+
+int main()
+{
+  // create a polygon and put some points in it
+  Polygon_2 p;
+
+  p.push_back(Point_2(0,0));
+  p.push_back(Point_2(4,0));
+  p.push_back(Point_2(4,4));
+
+
+  for(const Point_2& p : p.vertices()){
+    std::cout << p << std::endl;
+  }
+
+  // As the range is not light weight, we have to use a reference
+  const Polygon_2::Vertices& range = p.vertices();
+
+  for(auto it = range.begin(); it!= range.end(); ++it){
+    std::cout << *it << std::endl;
+  }
+
+  for(const Segment_2& e  : p.edges()){
+    std::cout << e << std::endl;
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -29,6 +29,7 @@
 
 #include <CGAL/algorithm.h>
 #include <CGAL/circulator.h>
+#include <CGAL/Iterator_range.h>
 #include <CGAL/enum.h>
 
 #include <CGAL/Aff_transformation_2.h>
@@ -117,16 +118,25 @@ class Polygon_2 {
     /// vertex iterator type
     typedef typename Container::iterator       Vertex_iterator;
 
+  /// a range type to iterate over the vertices
+    typedef Container Vertices;
 
     //typedef typename Container::const_iterator Vertex_const_iterator; ??
 
 #ifdef DOXYGEN_RUNNING
   /// vertex circulator type
   typedef unspecified_type Vertex_circulator;
-  /// edge circulator type
+
+  /// edge iterator type
   typedef unspecified_type Edge_const_iterator;
+
+  /// a range type to iterate over the vertices
+  typedef unspecified_type Edges;
+
   /// edge circular type
   typedef unspecified_type Edge_const_circulator;
+
+  //
 #else
     typedef Vertex_const_circulator Vertex_circulator;
     typedef Polygon_2_edge_iterator<Traits_P,Container_P> Edge_const_iterator;
@@ -135,6 +145,8 @@ class Polygon_2 {
 
     typedef Polygon_2_edge_iterator<Traits_P,Container_P,
                                     Tag_false> Vertex_pair_iterator;
+
+  typedef Iterator_range<Edge_const_iterator> Edges;
 #endif // DOXYGEN_RUNNING
     /// @}
 
@@ -269,6 +281,11 @@ class Polygon_2 {
     Vertex_const_iterator vertices_end() const
       { return const_cast<Polygon_2&>(*this).d_container.end(); }
 
+    const Vertices& vertices() const
+    {
+      return d_container;
+    }
+
 //    Vertex_const_circulator vertices_circulator() const
 //      { return Vertex_const_circulator(&d_container, d_container.begin()); }
 
@@ -289,6 +306,11 @@ class Polygon_2 {
     /// Returns the corresponding past-the-end iterator.
     Edge_const_iterator edges_end() const
       { return Edge_const_iterator(&d_container, d_container.end()); }
+
+    Edges edges() const
+    {
+      return make_range(edges_begin(),edges_end());
+    }
 
     /// Returns a non-mutable circulator that allows to traverse the
     /// edges of the polygon.

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -281,6 +281,7 @@ class Polygon_2 {
     Vertex_const_iterator vertices_end() const
       { return const_cast<Polygon_2&>(*this).d_container.end(); }
 
+    /// returns the range of vertices.
     const Vertices& vertices() const
     {
       return d_container;
@@ -307,6 +308,7 @@ class Polygon_2 {
     Edge_const_iterator edges_end() const
       { return Edge_const_iterator(&d_container, d_container.end()); }
 
+    /// returns the range of edges.
     Edges edges() const
     {
       return make_range(edges_begin(),edges_end());

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -274,11 +274,11 @@ class Polygon_2 {
 
     /// Returns a constant iterator that allows to traverse the
     /// vertices of the polygon.
-    Vertex_const_iterator vertices_begin() const
+    Vertex_iterator vertices_begin() const
       { return const_cast<Polygon_2&>(*this).d_container.begin(); }
 
     /// Returns the corresponding past-the-end iterator.
-    Vertex_const_iterator vertices_end() const
+    Vertex_iterator vertices_end() const
       { return const_cast<Polygon_2&>(*this).d_container.end(); }
 
     /// returns the range of vertices.
@@ -290,12 +290,12 @@ class Polygon_2 {
 //    Vertex_const_circulator vertices_circulator() const
 //      { return Vertex_const_circulator(&d_container, d_container.begin()); }
 
-    /// Returns a mutable circulator that allows to traverse the
+    /// Returns a constant circulator that allows to traverse the
     /// vertices of the polygon.
-    Vertex_const_circulator vertices_circulator() const
+    Vertex_circulator vertices_circulator() const
       {
         Polygon_2& self = const_cast<Polygon_2&>(*this);
-        return Vertex_const_circulator(&self.d_container,
+        return Vertex_circulator(&self.d_container,
                self.d_container.begin());
       }
 
@@ -404,7 +404,7 @@ class Polygon_2 {
                              self.d_container.end(), traits);
     }
 
-    /// Returns topmost vertex of the polygon with the largest
+    /// Returns the topmost vertex of the polygon with the largest
     /// `y`-coordinate.
     Vertex_const_iterator top_vertex() const
     {


### PR DESCRIPTION
## Summary of Changes

Add functions for returning a range of vertices, edges, and holes to the existing `begin(()/end()` pairs.

## Release Management

* Affected package(s): Polygon


