### PR TITLE
Triangulation_2:  Add Example for Starring a Conflict Zone

### DIFF
--- a/Triangulation_2/doc/Triangulation_2/CGAL/Delaunay_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Delaunay_triangulation_2.h
@@ -236,7 +236,7 @@ std::pair<OutputItFaces,OutputItBoundaryEdges>
 get_conflicts_and_boundary(const Point &p,
 OutputItFaces fit,
 OutputItBoundaryEdges eit,
-Face_handle start) const;
+Face_handle start = Face_handle()) const;
 
 /*!
 outputs the faces of the conflict zone of point `p` into an output iterator.
@@ -248,7 +248,7 @@ template <class OutputItFaces>
 OutputItFaces
 get_conflicts (const Point &p,
 OutputItFaces fit,
-Face_handle start) const;
+Face_handle start = Face_handle()) const;
 
 /*!
 outputs the boundary edges of the conflict zone of point `p` into an output iterator.
@@ -266,7 +266,7 @@ template <class OutputItBoundaryEdges>
 OutputItBoundaryEdges
 get_boundary_of_conflicts(const Point &p,
 OutputItBoundaryEdges eit,
-Face_handle start) const;
+Face_handle start = Face_handle()) const;
 
 /// @}
 

--- a/Triangulation_2/doc/Triangulation_2/examples.txt
+++ b/Triangulation_2/doc/Triangulation_2/examples.txt
@@ -22,4 +22,5 @@
 \example Triangulation_2/segment_soup_to_polylines.cpp
 \example Triangulation_2/draw_triangulation_2.cpp
 \example Triangulation_2/low_dimensional.cpp
+\example Triangulation_2/star_conflict_zone.cpp
 */

--- a/Triangulation_2/examples/Triangulation_2/CMakeLists.txt
+++ b/Triangulation_2/examples/Triangulation_2/CMakeLists.txt
@@ -17,6 +17,7 @@ endforeach()
 
 if(CGAL_Qt5_FOUND)
   target_link_libraries(draw_triangulation_2 PUBLIC CGAL::CGAL_Basic_viewer)
+    target_link_libraries(star_conflict_zone PUBLIC CGAL::CGAL_Basic_viewer)
 else()
   message(
     STATUS

--- a/Triangulation_2/examples/Triangulation_2/star_conflict_zone.cpp
+++ b/Triangulation_2/examples/Triangulation_2/star_conflict_zone.cpp
@@ -22,7 +22,7 @@ int main( )
   dt2.insert(Point_2(10,0));
   dt2.insert(Point_2(0,10));
 
-  std::array<Point_2,3> points = { Point_2(2,2), Point_2(1,0), Point_2(9,9) };
+  std::array<Point_2,3> points = { Point_2(2,2), Point_2(1,0), Point_2(2,2) };
 
   CGAL::spatial_sort(points.begin(), points.end());
 
@@ -40,19 +40,22 @@ int main( )
                                    std::back_inserter(edges),
                                    hint);
 
-    // Do something with the faces before the insertion
+    if(faces.empty()){
+      std::cout << "point " << p << " already in the triangulation" << std::endl;
+    }else{
+      // Do something with the faces before the insertion
 
-    Vertex_handle vh = dt2.star_hole(p,
-                                     edges.begin(), edges.end(),
-                                     faces.begin(), faces.end());
-    hint = vh->face(); // we could also take any element of faces
+      Vertex_handle vh = dt2.star_hole(p,
+                                       edges.begin(), edges.end(),
+                                       faces.begin(), faces.end());
+      hint = vh->face(); // we could also take any element of faces
 
-    // Do something with the faces after the insertion
-    Face_circulator fc = dt2.incident_faces(vh), done(fc);
-    do {
+      // Do something with the faces after the insertion
+      Face_circulator fc = dt2.incident_faces(vh), done(fc);
+      do {
         fc++;
-    } while (fc != done);
-
+      } while (fc != done);
+    }
     draw(dt2);
   }
   return 0;

--- a/Triangulation_2/examples/Triangulation_2/star_conflict_zone.cpp
+++ b/Triangulation_2/examples/Triangulation_2/star_conflict_zone.cpp
@@ -1,0 +1,59 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Delaunay_triangulation_2.h>
+#include <CGAL/draw_triangulation_2.h>
+#include <CGAL/spatial_sort.h>
+#include <array>
+#include <vector>
+#include <iostream>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef K::Point_2 Point_2;
+typedef CGAL::Delaunay_triangulation_2<K>  Dt2;
+typedef Dt2::Edge Edge;
+typedef Dt2::Face_handle Face_handle;
+typedef Dt2::Face_circulator Face_circulator;
+typedef Dt2::Vertex_handle Vertex_handle;
+
+int main( )
+{
+  Dt2 dt2;
+
+  dt2.insert(Point_2(0,0));
+  dt2.insert(Point_2(10,0));
+  dt2.insert(Point_2(0,10));
+
+  std::array<Point_2,3> points = { Point_2(2,2), Point_2(1,0), Point_2(9,9) };
+
+  CGAL::spatial_sort(points.begin(), points.end());
+
+  Face_handle hint;
+
+  std::vector<Face_handle> faces;
+  std::vector<Edge> edges;
+
+  assert(dt2.dimension() == 2); // precondition of get_conflicts_and_bounda
+  for(const Point_2 p : points){
+    faces.clear(); // faster than variables in the scope
+    edges.clear();
+    dt2.get_conflicts_and_boundary(p,
+                                   std::back_inserter(faces),
+                                   std::back_inserter(edges),
+                                   hint);
+
+    // Do something with the faces before the insertion
+
+    Vertex_handle vh = dt2.star_hole(p,
+                                     edges.begin(), edges.end(),
+                                     faces.begin(), faces.end());
+    hint = vh->face(); // we could also take any element of faces
+
+    // Do something with the faces after the insertion
+    Face_circulator fc = dt2.incident_faces(vh), done(fc);
+    do {
+        fc++;
+    } while (fc != done);
+
+    draw(dt2);
+  }
+  return 0;
+}

--- a/Triangulation_2/examples/Triangulation_2/star_conflict_zone.cpp
+++ b/Triangulation_2/examples/Triangulation_2/star_conflict_zone.cpp
@@ -31,7 +31,7 @@ int main( )
   std::vector<Face_handle> faces;
   std::vector<Edge> edges;
 
-  assert(dt2.dimension() == 2); // precondition of get_conflicts_and_bounda
+  assert(dt2.dimension() == 2); // precondition of get_conflicts_and_boundary
   for(const Point_2 p : points){
     faces.clear(); // faster than variables in the scope
     edges.clear();


### PR DESCRIPTION
## Summary of Changes

Add an example that computes a conflict zone and then stars it.

Fix at the same time the documentation of  a function, as one parameter has a default.

## Release Management

* Affected package(s): Triangulation_2

