### PR TITLE
better reference Kernel intersection functions

### DIFF
--- a/Boolean_set_operations_2/doc/Boolean_set_operations_2/CGAL/Boolean_set_operations_2.h
+++ b/Boolean_set_operations_2/doc/Boolean_set_operations_2/CGAL/Boolean_set_operations_2.h
@@ -650,7 +650,7 @@ OutputIterator difference(const General_polygon_with_holes_2<Polygon>& pgn1,
 // CGAL/Boolean_set_operations_2/do_intersect.h
 namespace CGAL {
 
-/*! \addtogroup boolean_do_intersect Intersection Testing Functions
+/*! \addtogroup boolean_do_intersect Polygon Intersection Testing Functions
  * \ingroup PkgBooleanSetOperations2Ref
  * \anchor ref_bso_do_intersect
  *
@@ -1160,7 +1160,7 @@ bool do_intersect(InputIterator1 begin1, InputIterator1 end1,
 // CGAL/Boolean_set_operations_2/intersection.h
 namespace CGAL {
 
-/*! \addtogroup boolean_intersection Intersection Functions
+/*! \addtogroup boolean_intersection Polygon Intersection Functions
  * \ingroup PkgBooleanSetOperations2Ref
  * \anchor ref_bso_intersection
  *

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -1800,7 +1800,7 @@ const CGAL::Vector_3<Kernel>& w);
 // This is there to keep the global functions in alphabetical order
 // instead of processing order.
 
-/// \defgroup do_intersect_grp CGAL::do_intersect()
+/// \defgroup do_intersect_grp Intersection Testing Functions - CGAL::do_intersect()
 /// \ingroup kernel_global_function
 /// \defgroup do_intersect_linear_grp CGAL::do_intersect() (2D/3D Linear Kernel)
 /// \ingroup do_intersect_grp
@@ -2056,7 +2056,7 @@ const CGAL::Point_3<Kernel>& t);
 
 // Same reason as in defgroup do_intersect.
 
-/// \defgroup intersection_grp CGAL::intersection()
+/// \defgroup intersection_grp Intersection Computation Functions - CGAL::intersection()
 /// \ingroup kernel_global_function
 /// \defgroup intersection_linear_grp CGAL::intersection() (2D/3D Linear Kernel)
 /// \ingroup intersection_grp


### PR DESCRIPTION
When searching "intersection" in the search bar one has a hard time to find the function in the 2D Linear Kernel as we have functions and documentation groups in Boolean Set Operations as well as in Polygon Mesh Processing.

This PR tries to improve the situation.