### PR TITLE
TDS: Initialize the size of Unique_hash_map

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map.h
@@ -3376,7 +3376,7 @@ namespace CGAL {
       CGAL_assertion( is_without_boundary(dimension) );
 
       CGAL::Unique_hash_map< Dart_handle, Dart_handle,
-        typename Self::Hash_function > dual;
+                             typename Self::Hash_function > dual(Dart_handle(), darts().size());
       Dart_handle d, d2, res = amap.null_handle;
 
       // We clear amap. TODO return a new amap ?

--- a/Linear_cell_complex/include/CGAL/boost/graph/properties_Linear_cell_complex_for_combinatorial_map.h
+++ b/Linear_cell_complex/include/CGAL/boost/graph/properties_Linear_cell_complex_for_combinatorial_map.h
@@ -16,7 +16,6 @@
 
 #include <CGAL/boost/graph/properties.h>
 #include <CGAL/Linear_cell_complex_for_combinatorial_map.h>
-#include <CGAL/Unique_hash_map.h>
 #include <CGAL/Dynamic_property_map.h>
 
 

--- a/Periodic_2_triangulation_2/include/CGAL/Periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/Periodic_2_triangulation_2.h
@@ -4164,7 +4164,7 @@ Periodic_2_triangulation_2<Gt, Tds>::save(std::ostream& os) const
     return os;
 
   // write the vertices
-  Unique_hash_map<Vertex_handle, std::size_t > V;
+  Unique_hash_map<Vertex_handle, std::size_t > V(0, number_of_vertices());
   std::size_t i = 0;
   if (is_1_cover())
     {
@@ -4208,7 +4208,7 @@ Periodic_2_triangulation_2<Gt, Tds>::save(std::ostream& os) const
     }
   CGAL_triangulation_postcondition(i == _cover[0]*_cover[1]*n);
 
-  Unique_hash_map<Face_handle, std::size_t> F;
+  Unique_hash_map<Face_handle, std::size_t> F(0,  _tds.number_of_faces());
   int inum = 0;
   // asks the tds for the combinatorial information
   // vertices of the faces

--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_3.h
@@ -3205,7 +3205,7 @@ periodic_remove(Vertex_handle v, PointRemover& remover, CoverManager& cover_mana
   // in Euclidean space and make a map from the vertices in remover.tmp
   // towards the vertices in *this
 
-  Unique_hash_map<VertexE_handle,Vertex_handle> vmap(Vertex_handle(), vertices_size());
+  Unique_hash_map<VertexE_handle,Vertex_handle> vmap(Vertex_handle(), vertices.size());
   CellE_handle ch;
   remover.tmp.clear();
 

--- a/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_3.h
+++ b/Periodic_3_triangulation_3/include/CGAL/Periodic_3_triangulation_3.h
@@ -3205,7 +3205,7 @@ periodic_remove(Vertex_handle v, PointRemover& remover, CoverManager& cover_mana
   // in Euclidean space and make a map from the vertices in remover.tmp
   // towards the vertices in *this
 
-  Unique_hash_map<VertexE_handle,Vertex_handle> vmap;
+  Unique_hash_map<VertexE_handle,Vertex_handle> vmap(Vertex_handle(), vertices_size());
   CellE_handle ch;
   remover.tmp.clear();
 
@@ -4145,7 +4145,7 @@ operator<< (std::ostream& os,const Periodic_3_triangulation_3<GT,TDS>& tr)
     return os;
 
   // write the vertices
-  Unique_hash_map<Vertex_handle, std::size_t > V;
+  Unique_hash_map<Vertex_handle, std::size_t > V(0, tr.number_of_vertices());
   std::size_t i=0;
   if(tr.is_1_cover()) {
     for(Vertex_iterator it=tr.vertices_begin(); it!=tr.vertices_end(); ++it) {

--- a/Skin_surface_3/include/CGAL/triangulate_mixed_complex_3.h
+++ b/Skin_surface_3/include/CGAL/triangulate_mixed_complex_3.h
@@ -15,7 +15,6 @@
 
 #include <CGAL/license/Skin_surface_3.h>
 
-// #include <CGAL/Unique_hash_map.h>
 #include <CGAL/Compute_anchor_3.h>
 
 #include <CGAL/Triangulation_data_structure_3.h>
@@ -254,12 +253,6 @@ private:
   struct Index_c4 { Tmc_Vertex_handle V[4]; };
   struct Index_c6 { Tmc_Vertex_handle V[6]; };
   struct Index_c44 { Tmc_Vertex_handle V[4][4]; };
-  struct Index_v {
-    Unique_hash_map < Rt_Vertex_handle, Tmc_Vertex_handle > V;
-  };
-
-  // index to vertex
-  Unique_hash_map < Rt_Cell_handle, Index_c4 > index_03;
 
   Union_find_anchor                            anchor_del_uf, anchor_vor_uf;
   Simplex_UF_map                               anchor_del_map, anchor_vor_map;

--- a/Skin_surface_3/include/CGAL/triangulate_power_diagram_3.h
+++ b/Skin_surface_3/include/CGAL/triangulate_power_diagram_3.h
@@ -209,12 +209,6 @@ private:
   struct Index_c4 { Tmc_Vertex_handle V[4]; };
   struct Index_c6 { Tmc_Vertex_handle V[6]; };
   struct Index_c44 { Tmc_Vertex_handle V[4][4]; };
-  struct Index_v {
-    Unique_hash_map < Rt_Vertex_handle, Tmc_Vertex_handle > V;
-  };
-
-  // index to vertex
-  Unique_hash_map < Rt_Cell_handle, Index_c4 > index_03;
 
   Union_find_anchor                            anchor_vor_uf;
   Simplex_UF_map                               anchor_vor_map;

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
@@ -15,7 +15,6 @@
 
 #include <CGAL/number_type_config.h>
 #include <CGAL/Real_timer.h>
-#include <CGAL/Unique_hash_map.h>
 
 #include <boost/utility.hpp>
 #include <boost/version.hpp>

--- a/TDS_2/include/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/Triangulation_data_structure_2.h
@@ -2008,9 +2008,10 @@ copy_tds(const TDS_src& tds_src,
   // Number of neighbors to set in each face (dim -1 has a single face)
   const int nn = (std::max)(0, dimension() + 1);
 
+  std::cout << "in copy_tds" << std::endl;
   //initializes maps
-  Unique_hash_map<typename TDS_src::Vertex_handle,Vertex_handle> vmap;
-  Unique_hash_map<typename TDS_src::Face_handle,Face_handle> fmap;
+  Unique_hash_map<typename TDS_src::Vertex_handle,Vertex_handle> vmap(Vertex_handle(), tds_src.number_of_vertices());
+  Unique_hash_map<typename TDS_src::Face_handle,Face_handle> fmap(Face_handle(), tds_src.number_of_faces());
 
   // create vertices
   typename TDS_src::Vertex_iterator vit1 = tds_src.vertices_begin();
@@ -2120,8 +2121,8 @@ file_output( std::ostream& os, Vertex_handle v, bool skip_first) const
   else     os << n << m << dimension();
   if (n==0) return;
 
-  Unique_hash_map<Vertex_handle,int> V;
-  Unique_hash_map<Face_handle,int> F;
+  Unique_hash_map<Vertex_handle,int> V(-1, number_of_vertices());
+  Unique_hash_map<Face_handle,int> F(-1, number_of_faces());
 
 
   // first vertex
@@ -2257,7 +2258,7 @@ vrml_output( std::ostream& os, Vertex_handle v, bool skip_infinite) const
   os << "\t\tcoord Coordinate {" << std::endl;
   os << "\t\t\tpoint [" << std::endl;
 
-  Unique_hash_map<Vertex_handle,int> vmap;
+  Unique_hash_map<Vertex_handle,int> vmap(-1, number_of_vertices());
 
   Vertex_iterator vit;
   Face_iterator fit;

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -2001,7 +2001,7 @@ operator<<(std::ostream& os, const Triangulation_data_structure_3<Vb,Cb,Ct> &tds
   typedef typename Tds::Vertex_iterator         Vertex_iterator;
 
 
-  Unique_hash_map<Vertex_handle, size_type> V;
+  Unique_hash_map<Vertex_handle, size_type> V(0, tds.number_of_vertices());
 
   // outputs dimension and number of vertices
   size_type n = tds.number_of_vertices();
@@ -2589,7 +2589,7 @@ void
 Triangulation_data_structure_3<Vb,Cb,Ct>::
 print_cells(std::ostream& os, const Unique_hash_map<Vertex_handle, std::size_t> &V ) const
 {
-  Unique_hash_map<Cell_handle, std::size_t > C;
+  Unique_hash_map<Cell_handle, std::size_t > C(0, number_of_cells());
   std::size_t i = 0;
 
   switch ( dimension() ) {
@@ -4053,8 +4053,8 @@ copy_tds(const TDS_src& tds,
   const int nn = (std::max)(0, dimension() + 1);
 
   // Initializes maps
-  Unique_hash_map< typename TDS_src::Vertex_handle,Vertex_handle > V;
-  Unique_hash_map< typename TDS_src::Cell_handle,Cell_handle > F;
+  Unique_hash_map< typename TDS_src::Vertex_handle,Vertex_handle > V(Vertex_handle(), tds.number_of_vertices());
+  Unique_hash_map< typename TDS_src::Cell_handle,Cell_handle > F(Cell_handle(), tds.number_of_cells());
 
   // Create the vertices.
   for (typename TDS_src::Vertex_iterator vit = tds.vertices_begin();

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -633,7 +633,7 @@ public:
   file_output(std::ostream& os) const
   {
     os << static_cast<const Tr&>(*this);
-    Unique_hash_map<Vertex_handle,int> V;
+    Unique_hash_map<Vertex_handle,int> V(0, number_of_vertices());
     int inum = 0;
     for(Vertex_iterator vit = vertices_begin(); vit != vertices_end() ; ++vit){
       if(! is_infinite(vit)){


### PR DESCRIPTION
## Summary of Changes

In functions like `copy_tds()`, and hence in the copy constructor of triangulation classes, as well as when writing to a stream we use `Unique_hash_map`.    When we know that all vertices will be inserted in a loop we better construct the map with a table as big as the number of vertices.

I stumbled in this while checking whether there is a drawback to start with table size 512 or 32 as suggested  by @GilesBathgate  in PR #6306.       I opted for an independent PR. 

We have to check more packages for the same improvement to make.

## Release Management

* Affected package(s):  TDS_2/3, Periodic_2/3

