### PR TITLE
Replaced boost::tuple with std::tuple

### DIFF
--- a/AABB_tree/test/AABB_tree/aabb_any_all_benchmark.cpp
+++ b/AABB_tree/test/AABB_tree/aabb_any_all_benchmark.cpp
@@ -1,7 +1,7 @@
 #include <iostream>
 #include <fstream>
 #include <algorithm>
-#include <boost/tuple/tuple.hpp>
+#include <tuple>
 
 #include <CGAL/Cartesian.h>
 #include <CGAL/Simple_cartesian.h>
@@ -55,7 +55,7 @@ std::size_t intersect(ForwardIterator b, ForwardIterator e, const Tree& tree, lo
 }
 
 template<typename K>
-boost::tuple<std::size_t, std::size_t, std::size_t, long> test(const char* name) {
+std::tuple<std::size_t, std::size_t, std::size_t, long> test(const char* name) {
   typedef typename K::FT FT;
   typedef typename K::Ray_3 Ray;
   typedef typename K::Line_3 Line;
@@ -119,7 +119,7 @@ boost::tuple<std::size_t, std::size_t, std::size_t, long> test(const char* name)
 
   segments.erase(std::remove_if(segments.begin(), segments.end(), p), segments.end());
 
-  boost::tuple<std::size_t, std::size_t, std::size_t, long> tu;
+  std::tuple<std::size_t, std::size_t, std::size_t, long> tu;
 
     {
       CGAL::Timer t;
@@ -128,12 +128,12 @@ boost::tuple<std::size_t, std::size_t, std::size_t, long> test(const char* name)
       for(int i = 0; i < runs; ++i)
       {
         long counter = 0L;
-        tu = boost::make_tuple(intersect(lines.begin(), lines.end(), tree, counter),
+        tu = std::make_tuple(intersect(lines.begin(), lines.end(), tree, counter),
                                intersect(rays.begin(), rays.end(), tree, counter),
                                intersect(segments.begin(), segments.end(), tree, counter),
                                // cant use counter here
                                0);
-        boost::get<3>(tu) = counter;
+        std::get<3>(tu) = counter;
       }
       std::cout << t.time();
     }
@@ -146,41 +146,41 @@ int main()
   const char* filename = "data/finger.off";
 
   std::cout << "| Simple cartesian float kernel | ";
-  boost::tuple<std::size_t, std::size_t, std::size_t, long> t1 = test<CGAL::Simple_cartesian<float> >(filename);
+  std::tuple<std::size_t, std::size_t, std::size_t, long> t1 = test<CGAL::Simple_cartesian<float> >(filename);
   std::cout << " | " << std::endl;
 
   std::cout << "| Cartesian float kernel | ";
-  boost::tuple<std::size_t, std::size_t, std::size_t, long> t2 = test<CGAL::Cartesian<float> >(filename);
+  std::tuple<std::size_t, std::size_t, std::size_t, long> t2 = test<CGAL::Cartesian<float> >(filename);
   std::cout << " | " << std::endl;
 
   std::cout << "| Simple cartesian double kernel |";
-  boost::tuple<std::size_t, std::size_t, std::size_t, long> t3 = test<CGAL::Simple_cartesian<double> >(filename);
+  std::tuple<std::size_t, std::size_t, std::size_t, long> t3 = test<CGAL::Simple_cartesian<double> >(filename);
   std::cout << " | " << std::endl;
 
   std::cout << "| Cartesian double kernel |";
-  boost::tuple<std::size_t, std::size_t, std::size_t, long> t4 = test<CGAL::Cartesian<double> >(filename);
+  std::tuple<std::size_t, std::size_t, std::size_t, long> t4 = test<CGAL::Cartesian<double> >(filename);
   std::cout << " | " << std::endl;
 
   std::cout << "| Epic kernel |";
-  boost::tuple<std::size_t, std::size_t, std::size_t, long> t5 = test<CGAL::Exact_predicates_inexact_constructions_kernel>(filename);
+  std::tuple<std::size_t, std::size_t, std::size_t, long> t5 = test<CGAL::Exact_predicates_inexact_constructions_kernel>(filename);
   std::cout << " | " << std::endl;
 
   std::size_t a, b, c;
   long d;
 
-  boost::tie(a, b, c, d) = t5;
+  std::tie(a, b, c, d) = t5;
   std::cout << a << " " << b << " " << c << " " << d << std::endl;
 
-  boost::tie(a, b, c, d) = t4;
+  std::tie(a, b, c, d) = t4;
   std::cout << a << " " << b << " " << c << " " << d << std::endl;
 
-  boost::tie(a, b, c, d) = t3;
+  std::tie(a, b, c, d) = t3;
   std::cout << a << " " << b << " " << c << " " << d << std::endl;
 
-  boost::tie(a, b, c, d) = t2;
+  std::tie(a, b, c, d) = t2;
   std::cout << a << " " << b << " " << c << " " << d << std::endl;
 
-  boost::tie(a, b, c, d) = t1;
+  std::tie(a, b, c, d) = t1;
   std::cout << a << " " << b << " " << c << " " << d << std::endl;
   return 0;
 }

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
@@ -12,7 +12,7 @@
 #define CGAL_SURFACE_MESH_SIMPLIFICATION_DETAIL_EDGE_COLLAPSE_H
 
 #include <CGAL/license/Surface_mesh_simplification.h>
-
+#include <tuple>
 #include <CGAL/Surface_mesh_simplification/internal/Common.h>
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Edge_profile.h>
 
@@ -265,12 +265,12 @@ private:
   typename boost::property_traits<Vertex_point_map>::reference
   get_point(const vertex_descriptor v) const { return get(m_vpm, v); }
 
-  boost::tuple<vertex_descriptor, vertex_descriptor> get_vertices(const halfedge_descriptor h) const
+  std::tuple<vertex_descriptor, vertex_descriptor> get_vertices(const halfedge_descriptor h) const
   {
     vertex_descriptor p, q;
     p = source(h, m_tm);
     q = target(h, m_tm);
-    return boost::make_tuple(p, q);
+    return std::make_tuple(p, q);
   }
 
   std::string vertex_to_string(const vertex_descriptor v) const
@@ -282,7 +282,7 @@ private:
   std::string edge_to_string(const halfedge_descriptor h) const
   {
     vertex_descriptor p, q;
-    boost::tie(p,q) = get_vertices(h);
+    std::tie(p,q) = get_vertices(h);
     return boost::str(boost::format("{E%1% %2%->%3%}%4%") % get_edge_id(h) % vertex_to_string(p) % vertex_to_string(q) % (is_border(h, m_tm) ? " (BORDER)" : (is_border(opposite(h, m_tm), m_tm) ? " (~BORDER)": "")));
   }
 


### PR DESCRIPTION
## Summary of Changes

Replaced boost::tuple with std::tuple where there is no difference in use of the two.

## Release Management

* Affected package(s): Surface_mesh_simplification, AABB_tree

