### PR TITLE
Kernel_23: Add Orientation_3::operator()(Origin,Point_3,Point_3,Point_3)

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -3033,7 +3033,7 @@ namespace CartesianKernelFunctors {
     }
 
     Vector_3
-    operator()( Origin o , const Point_3& q, const Point_3& r ) const
+    operator()( Origin, const Point_3& q, const Point_3& r ) const
     {
       // Cross product oq * or
       FT vx = q.y()*r.z() - r.y()*q.z();
@@ -4320,7 +4320,7 @@ namespace CartesianKernelFunctors {
     }
 
     result_type
-    operator()( Origin o, const Point_3& u,
+    operator()( Origin, const Point_3& u,
                 const Point_3& v, const Point_3& w) const
     {
       return orientationC3(u.x(), u.y(), u.z(),

--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -3035,16 +3035,10 @@ namespace CartesianKernelFunctors {
     Vector_3
     operator()( Origin o , const Point_3& q, const Point_3& r ) const
     {
-      FT orx = r.x();
-      FT ory = r.y();
-      FT orz = r.z();
-      FT oqx = q.x();
-      FT oqy = q.y();
-      FT oqz = q.z();
       // Cross product oq * or
-      FT vx = oqy*orz - oqz*ory;
-      FT vy = oqz*orx - oqx*orz;
-      FT vz = oqx*ory - oqy*orx;
+      FT vx = q.y()*r.z() - r.y()*q.z();
+      FT vy = q.z()*r.x() - r.z()*q.x();
+      FT vz = q.x()*r.y() - r.x()*q.y();
       typename K::Construct_vector_3 construct_vector;
 
       return construct_vector(vx, vy, vz);

--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -3031,6 +3031,24 @@ namespace CartesianKernelFunctors {
 
       return construct_vector(vx, vy, vz);
     }
+
+    Vector_3
+    operator()( Origin o , const Point_3& q, const Point_3& r ) const
+    {
+      FT orx = r.x();
+      FT ory = r.y();
+      FT orz = r.z();
+      FT oqx = q.x();
+      FT oqy = q.y();
+      FT oqz = q.z();
+      // Cross product oq * or
+      FT vx = oqy*orz - oqz*ory;
+      FT vy = oqz*orx - oqx*orz;
+      FT vz = oqx*ory - oqy*orx;
+      typename K::Construct_vector_3 construct_vector;
+
+      return construct_vector(vx, vy, vz);
+    }
   };
 
   template <typename K>

--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -4308,6 +4308,15 @@ namespace CartesianKernelFunctors {
     }
 
     result_type
+    operator()( Origin o, const Point_3& u,
+                const Point_3& v, const Point_3& w) const
+    {
+      return orientationC3(u.x(), u.y(), u.z(),
+                           v.x(), v.y(), v.z(),
+                           w.x(), w.y(), w.z());
+    }
+
+    result_type
     operator()( const Tetrahedron_3& t) const
     {
       return t.rep().orientation();

--- a/Filtered_kernel/include/CGAL/Epic_converter.h
+++ b/Filtered_kernel/include/CGAL/Epic_converter.h
@@ -54,6 +54,11 @@ public:
     return std::make_pair(o, true);
   }
 
+  std::pair<Null_vector, bool> operator()(Null_vector n) const
+  {
+    return std::make_pair(n, true);
+  }
+
   std::pair<double,bool> operator()(const typename IK::FT n) const
   {
     double d;

--- a/Filtered_kernel/include/CGAL/Epic_converter.h
+++ b/Filtered_kernel/include/CGAL/Epic_converter.h
@@ -49,7 +49,10 @@ class Epic_converter {
   typedef typename IK::FT IK_FT;
 public:
 
-
+  std::pair<Origin, bool> operator()(Origin o) const
+  {
+    return std::make_pair(o, true);
+  }
 
   std::pair<double,bool> operator()(const typename IK::FT n) const
   {

--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -799,7 +799,7 @@ struct Approx_converter
   template < typename T >
   decltype(auto)
   operator()(const T&t) const
-  { return t.approx(); }
+  { return approx(t); }
 
   const Null_vector&
   operator()(const Null_vector& n) const
@@ -824,7 +824,7 @@ struct Exact_converter
   template < typename T >
   decltype(auto)
   operator()(const T&t) const
-  { return t.exact(); }
+  { return exact(t); }
 
   const Null_vector&
   operator()(const Null_vector& n) const

--- a/Filtered_kernel/include/CGAL/Static_filtered_predicate.h
+++ b/Filtered_kernel/include/CGAL/Static_filtered_predicate.h
@@ -28,9 +28,7 @@ public:
   result_type operator()(const A1& a1) const
   {
     CGAL::Epic_converter<AK> convert;
-    typedef typename Kernel_traits<A1>::type EK;
-    typedef typename Type_mapper<A1,EK,Exact_predicates_inexact_constructions_kernel>::type T1;
-    std::pair<T1,bool> aa1 = convert(a1.approx());
+    auto aa1 = convert(approx(a1));
     if(! aa1.second){
       return fp(a1);
     }
@@ -42,9 +40,7 @@ public:
   result_type operator()(const A1& a1, const Null_vector& v) const
   {
     CGAL::Epic_converter<AK> convert;
-    typedef typename Kernel_traits<A1>::type EK;
-    typedef typename Type_mapper<A1,EK,Exact_predicates_inexact_constructions_kernel>::type T1;
-    std::pair<T1,bool> aa1 = convert(a1.approx());
+    auto aa1 = convert(approx(a1));
     if(! aa1.second){
       return fp(a1, v);
     }
@@ -56,14 +52,11 @@ public:
   result_type operator()(const A1& a1, const A2& a2) const
   {
     CGAL::Epic_converter<AK> convert;
-    typedef typename Kernel_traits<A1>::type EK;
-    typedef typename Type_mapper<A1,EK, Exact_predicates_inexact_constructions_kernel>::type T1;
-    std::pair<T1,bool> aa1 = convert(approx(a1));
+    auto aa1 = convert(approx(a1));
     if(! aa1.second){
       return fp(a1, a2);
     }
-    typedef typename Type_mapper<A2,EK, Exact_predicates_inexact_constructions_kernel>::type T2;
-    std::pair<T2,bool> aa2 = convert(approx(a2));
+    auto aa2 = convert(approx(a2));
     if(! aa2.second){
       return fp(a1, a2);
     }
@@ -76,9 +69,7 @@ public:
   result_type operator()(const Bbox_2& bb, const A2& a2) const
   {
     CGAL::Epic_converter<AK> convert;
-    typedef typename Kernel_traits<A2>::type EK;
-    typedef typename Type_mapper<A2,EK, Exact_predicates_inexact_constructions_kernel>::type T2;
-    std::pair<T2,bool> aa2 = convert(approx(a2));
+    auto aa2 = convert(approx(a2));
     if(! aa2.second){
       return fp(bb, a2);
     }
@@ -89,9 +80,7 @@ public:
   result_type operator()(const Bbox_3& bb, const A2& a2) const
   {
     CGAL::Epic_converter<AK> convert;
-    typedef typename Kernel_traits<A2>::type EK;
-    typedef typename Type_mapper<A2,EK, Exact_predicates_inexact_constructions_kernel>::type T2;
-    std::pair<T2,bool> aa2 = convert(approx(a2));
+    auto aa2 = convert(approx(a2));
     if(! aa2.second){
       return fp(bb, a2);
     }
@@ -102,19 +91,15 @@ public:
   result_type operator()(const A1& a1, const A2& a2, const A3& a3) const
   {
     CGAL::Epic_converter<AK> convert;
-    typedef typename Kernel_traits<A1>::type EK;
-    typedef typename Type_mapper<A1,EK, Exact_predicates_inexact_constructions_kernel>::type T1;
-    std::pair<T1,bool> aa1 = convert(a1.approx());
+    auto aa1 = convert(approx(a1));
     if(! aa1.second){
       return fp(a1, a2, a3);
     }
-    typedef typename Type_mapper<A2, EK, Exact_predicates_inexact_constructions_kernel>::type T2;
-    std::pair<T2,bool> aa2 = convert(a2.approx());
+    auto aa2 = convert(approx(a2));
     if(! aa2.second){
       return fp(a1, a2, a3);
     }
-    typedef typename Type_mapper<A3,EK, Exact_predicates_inexact_constructions_kernel>::type T3;
-    std::pair<T3,bool> aa3 = convert(a3.approx());
+    auto aa3 = convert(approx(a3));
     if(! aa3.second){
       return fp(a1, a2, a3);
     }
@@ -126,30 +111,22 @@ public:
   result_type operator()(const A1& a1, const A2& a2, const A3& a3, const A4& a4) const
   {
     CGAL::Epic_converter<AK> convert;
-    typedef typename Kernel_traits<A1>::type EK1;
-    typedef typename Type_mapper<A1,EK1,Exact_predicates_inexact_constructions_kernel>::type T1;
-    std::pair<T1,bool> aa1 = convert(a1.approx());
+    auto aa1 = convert(approx(a1));
     if(! aa1.second){
       return fp(a1, a2, a3, a4);
     }
 
-    typedef typename Kernel_traits<A2>::type EK2;
-    typedef typename Type_mapper<A2,EK2,Exact_predicates_inexact_constructions_kernel>::type T2;
-    std::pair<T2,bool> aa2 = convert(a2.approx());
+    auto aa2 = convert(approx(a2));
     if(! aa2.second){
       return fp(a1, a2, a3, a4);
     }
 
-    typedef typename Kernel_traits<A3>::type EK3;
-    typedef typename Type_mapper<A3,EK3,Exact_predicates_inexact_constructions_kernel>::type T3;
-    std::pair<T3,bool> aa3 = convert(a3.approx());
+    auto aa3 = convert(approx(a3));
     if(! aa3.second){
       return fp(a1, a2, a3, a4);
     }
 
-    typedef typename Kernel_traits<A4>::type EK4;
-    typedef typename Type_mapper<A4,EK4,Exact_predicates_inexact_constructions_kernel>::type T4;
-    std::pair<T4,bool> aa4 = convert(a4.approx());
+    auto aa4 = convert(approx(a4));
     if(! aa4.second){
       return fp(a1, a2, a3, a4);
     }
@@ -160,29 +137,23 @@ public:
   result_type operator()(const A1& a1, const A2& a2, const A3& a3, const A4& a4, const A5& a5) const
   {
     CGAL::Epic_converter<AK> convert;
-    typedef typename Kernel_traits<A1>::type EK;
-    typedef typename Type_mapper<A1,EK,Exact_predicates_inexact_constructions_kernel>::type T1;
-    std::pair<T1,bool> aa1 = convert(a1.approx());
+    auto aa1 = convert(approx(a1));
     if(! aa1.second){
       return fp(a1, a2, a3, a4, a5);
     }
-    typedef typename Type_mapper<A2,EK,Exact_predicates_inexact_constructions_kernel>::type T2;
-    std::pair<T2,bool> aa2 = convert(a2.approx());
+    auto aa2 = convert(approx(a2));
     if(! aa2.second){
       return fp(a1, a2, a3, a4, a5);
     }
-    typedef typename Type_mapper<A3,EK,Exact_predicates_inexact_constructions_kernel>::type T3;
-    std::pair<T3,bool> aa3 = convert(a3.approx());
+    auto aa3 = convert(approx(a3));
     if(! aa3.second){
       return fp(a1, a2, a3, a4, a5);
     }
-    typedef typename Type_mapper<A4,EK,Exact_predicates_inexact_constructions_kernel>::type T4;
-    std::pair<T4,bool> aa4 = convert(a4.approx());
+    auto aa4 = convert(approx(a4));
     if(! aa4.second){
       return fp(a1, a2, a3, a4, a5);
     }
-    typedef typename Type_mapper<A5,EK,Exact_predicates_inexact_constructions_kernel>::type T5;
-    std::pair<T5,bool> aa5 = convert(a5.approx());
+    auto aa5 = convert(approx(a5));
     if(! aa5.second){
       return fp(a1, a2, a3, a4, a5);
     }
@@ -193,34 +164,27 @@ public:
   result_type operator()(const A1& a1, const A2& a2, const A3& a3, const A4& a4, const A5& a5, const A6& a6) const
   {
     CGAL::Epic_converter<AK> convert;
-    typedef typename Kernel_traits<A1>::type EK;
-    typedef typename Type_mapper<A1,EK,Exact_predicates_inexact_constructions_kernel>::type T1;
-    std::pair<T1,bool> aa1 = convert(a1.approx());
+    auto aa1 = convert(approx(a1));
     if(! aa1.second){
       return fp(a1, a2, a3, a4, a5, a6);
     }
-    typedef typename Type_mapper<A2,EK,Exact_predicates_inexact_constructions_kernel>::type T2;
-    std::pair<T2,bool> aa2 = convert(a2.approx());
+    auto aa2 = convert(approx(a2));
     if(! aa2.second){
       return fp(a1, a2, a3, a4, a5, a6);
     }
-    typedef typename Type_mapper<A3,EK,Exact_predicates_inexact_constructions_kernel>::type T3;
-    std::pair<T3,bool> aa3 = convert(a3.approx());
+    auto aa3 = convert(approx(a3));
     if(! aa3.second){
       return fp(a1, a2, a3, a4, a5, a6);
     }
-    typedef typename Type_mapper<A4,EK,Exact_predicates_inexact_constructions_kernel>::type T4;
-    std::pair<T4,bool> aa4 = convert(a4.approx());
+    auto aa4 = convert(approx(a4));
     if(! aa4.second){
       return fp(a1, a2, a3, a4, a5, a6);
     }
-    typedef typename Type_mapper<A5,EK,Exact_predicates_inexact_constructions_kernel>::type T5;
-    std::pair<T5,bool> aa5 = convert(a5.approx());
+    auto aa5 = convert(approx(a5));
     if(! aa5.second){
       return fp(a1, a2, a3, a4, a5, a6);
     }
-    typedef typename Type_mapper<A6,EK,Exact_predicates_inexact_constructions_kernel>::type T6;
-    std::pair<T6,bool> aa6 = convert(a6.approx());
+    auto aa6 = convert(approx(a6));
     if(! aa6.second){
       return fp(a1, a2, a3, a4, a5, a6);
     }
@@ -231,39 +195,31 @@ public:
   result_type operator()(const A1& a1, const A2& a2, const A3& a3, const A4& a4, const A5& a5, const A6& a6, const A6& a7) const
   {
     CGAL::Epic_converter<AK> convert;
-    typedef typename Kernel_traits<A1>::type EK;
-    typedef typename Type_mapper<A1,EK,Exact_predicates_inexact_constructions_kernel>::type T1;
-    std::pair<T1,bool> aa1 = convert(a1.approx());
+    auto aa1 = convert(approx(a1));
     if(! aa1.second){
       return fp(a1, a2, a3, a4, a5, a6, a7);
     }
-    typedef typename Type_mapper<A2,EK,Exact_predicates_inexact_constructions_kernel>::type T2;
-    std::pair<T2,bool> aa2 = convert(a2.approx());
+    auto aa2 = convert(approx(a2));
     if(! aa2.second){
       return fp(a1, a2, a3, a4, a5, a6, a7);
     }
-    typedef typename Type_mapper<A3,EK,Exact_predicates_inexact_constructions_kernel>::type T3;
-    std::pair<T3,bool> aa3 = convert(a3.approx());
+    auto aa3 = convert(approx(a3));
     if(! aa3.second){
       return fp(a1, a2, a3, a4, a5, a6, a7);
     }
-    typedef typename Type_mapper<A4,EK,Exact_predicates_inexact_constructions_kernel>::type T4;
-    std::pair<T4,bool> aa4 = convert(a4.approx());
+    auto aa4 = convert(approx(a4));
     if(! aa4.second){
       return fp(a1, a2, a3, a4, a5, a6, a7);
     }
-    typedef typename Type_mapper<A5,EK,Exact_predicates_inexact_constructions_kernel>::type T5;
-    std::pair<T5,bool> aa5 = convert(a5.approx());
+    auto aa5 = convert(approx(a5));
     if(! aa5.second){
       return fp(a1, a2, a3, a4, a5, a6, a7);
     }
-    typedef typename Type_mapper<A6,EK,Exact_predicates_inexact_constructions_kernel>::type T6;
-    std::pair<T6,bool> aa6 = convert(a6.approx());
+    auto aa6 = convert(approx(a6));
     if(! aa6.second){
       return fp(a1, a2, a3, a4, a5, a6, a7);
     }
-    typedef typename Type_mapper<A7,EK,Exact_predicates_inexact_constructions_kernel>::type T7;
-    std::pair<T7,bool> aa7 = convert(a7.approx());
+    auto aa7 = convert(approx(a7));
     if(! aa7.second){
       return fp(a1, a2, a3, a4, a5, a6, a7);
     }
@@ -275,44 +231,35 @@ public:
   result_type operator()(const A1& a1, const A2& a2, const A3& a3, const A4& a4, const A5& a5, const A6& a6, const A7& a7, const A8& a8) const
   {
     CGAL::Epic_converter<AK> convert;
-    typedef typename Kernel_traits<A1>::type EK;
-    typedef typename Type_mapper<A1,EK,Exact_predicates_inexact_constructions_kernel>::type T1;
-    std::pair<T1,bool> aa1 = convert(a1.approx());
+    auto aa1 = convert(approx(a1));
     if(! aa1.second){
       return fp(a1, a2, a3, a4, a5, a6, a7, a8);
     }
-    typedef typename Type_mapper<A2,EK,Exact_predicates_inexact_constructions_kernel>::type T2;
-    std::pair<T2,bool> aa2 = convert(a2.approx());
+    auto aa2 = convert(approx(a2));
     if(! aa2.second){
       return fp(a1, a2, a3, a4, a5, a6, a7, a8);
     }
-    typedef typename Type_mapper<A3,EK,Exact_predicates_inexact_constructions_kernel>::type T3;
-    std::pair<T3,bool> aa3 = convert(a3.approx());
+    auto aa3 = convert(approx(a3));
     if(! aa3.second){
       return fp(a1, a2, a3, a4, a5, a6, a7, a8);
     }
-    typedef typename Type_mapper<A4,EK,Exact_predicates_inexact_constructions_kernel>::type T4;
-    std::pair<T4,bool> aa4 = convert(a4.approx());
+    auto aa4 = convert(approx(a4));
     if(! aa4.second){
       return fp(a1, a2, a3, a4, a5, a6, a7, a8);
     }
-    typedef typename Type_mapper<A5,EK,Exact_predicates_inexact_constructions_kernel>::type T5;
-    std::pair<T5,bool> aa5 = convert(a5.approx());
+    auto aa5 = convert(approx(a5));
     if(! aa5.second){
       return fp(a1, a2, a3, a4, a5, a6, a7, a8);
     }
-    typedef typename Type_mapper<A6,EK,Exact_predicates_inexact_constructions_kernel>::type T6;
-    std::pair<T6,bool> aa6 = convert(a6.approx());
+    auto aa6 = convert(approx(a6));
     if(! aa6.second){
       return fp(a1, a2, a3, a5, a5, a6, a7, a8);
     }
-    typedef typename Type_mapper<A7,EK,Exact_predicates_inexact_constructions_kernel>::type T7;
-    std::pair<T7,bool> aa7 = convert(a7.approx());
+    auto aa7 = convert(approx(a7));
     if(! aa7.second){
       return fp(a1, a2, a3, a5, a5, a6, a7, a8);
     }
-    typedef typename Type_mapper<A8,EK,Exact_predicates_inexact_constructions_kernel>::type T8;
-    std::pair<T8,bool> aa8 = convert(a8.approx());
+    auto aa8 = convert(approx(a8));
     if(! aa8.second){
       return fp(a1, a2, a3, a4, a5, a6, a7, a8);
     }

--- a/Filtered_kernel/include/CGAL/Static_filtered_predicate.h
+++ b/Filtered_kernel/include/CGAL/Static_filtered_predicate.h
@@ -36,17 +36,6 @@ public:
     return epicp(aa1.first);
   }
 
-  template <typename A1>
-  result_type operator()(const A1& a1, const Null_vector& v) const
-  {
-    CGAL::Epic_converter<AK> convert;
-    auto aa1 = convert(approx(a1));
-    if(! aa1.second){
-      return fp(a1, v);
-    }
-
-    return epicp(aa1.first, v);
-  }
 
   template <typename A1, typename A2>
   result_type operator()(const A1& a1, const A2& a2) const

--- a/Filtered_kernel/include/CGAL/Static_filtered_predicate.h
+++ b/Filtered_kernel/include/CGAL/Static_filtered_predicate.h
@@ -7,7 +7,6 @@
 // $Id$
 // SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
 //
-//
 // Author(s)     : Andreas Fabri, Laurent Rineau
 
 #ifndef CGAL_STATIC_FILTERED_PREDICATE_H
@@ -127,23 +126,29 @@ public:
   result_type operator()(const A1& a1, const A2& a2, const A3& a3, const A4& a4) const
   {
     CGAL::Epic_converter<AK> convert;
-    typedef typename Kernel_traits<A1>::type EK;
-    typedef typename Type_mapper<A1,EK,Exact_predicates_inexact_constructions_kernel>::type T1;
+    typedef typename Kernel_traits<A1>::type EK1;
+    typedef typename Type_mapper<A1,EK1,Exact_predicates_inexact_constructions_kernel>::type T1;
     std::pair<T1,bool> aa1 = convert(a1.approx());
     if(! aa1.second){
       return fp(a1, a2, a3, a4);
     }
-    typedef typename Type_mapper<A2,EK,Exact_predicates_inexact_constructions_kernel>::type T2;
+
+    typedef typename Kernel_traits<A2>::type EK2;
+    typedef typename Type_mapper<A2,EK2,Exact_predicates_inexact_constructions_kernel>::type T2;
     std::pair<T2,bool> aa2 = convert(a2.approx());
     if(! aa2.second){
       return fp(a1, a2, a3, a4);
     }
-    typedef typename Type_mapper<A3,EK,Exact_predicates_inexact_constructions_kernel>::type T3;
+
+    typedef typename Kernel_traits<A3>::type EK3;
+    typedef typename Type_mapper<A3,EK3,Exact_predicates_inexact_constructions_kernel>::type T3;
     std::pair<T3,bool> aa3 = convert(a3.approx());
     if(! aa3.second){
       return fp(a1, a2, a3, a4);
     }
-    typedef typename Type_mapper<A4,EK,Exact_predicates_inexact_constructions_kernel>::type T4;
+
+    typedef typename Kernel_traits<A4>::type EK4;
+    typedef typename Type_mapper<A4,EK4,Exact_predicates_inexact_constructions_kernel>::type T4;
     std::pair<T4,bool> aa4 = convert(a4.approx());
     if(! aa4.second){
       return fp(a1, a2, a3, a4);

--- a/Filtered_kernel/include/CGAL/Static_filtered_predicate.h
+++ b/Filtered_kernel/include/CGAL/Static_filtered_predicate.h
@@ -63,29 +63,6 @@ public:
     return epicp(aa1.first, aa2.first);
   }
 
-    // We need these two specializations as in general we determine
-    // the kernel for the template argument A1, and this does not work for Bbox_2 and Bbox_3
-  template <typename A2>
-  result_type operator()(const Bbox_2& bb, const A2& a2) const
-  {
-    CGAL::Epic_converter<AK> convert;
-    auto aa2 = convert(approx(a2));
-    if(! aa2.second){
-      return fp(bb, a2);
-    }
-    return epicp(bb, aa2.first);
-  }
-
-  template <typename A2>
-  result_type operator()(const Bbox_3& bb, const A2& a2) const
-  {
-    CGAL::Epic_converter<AK> convert;
-    auto aa2 = convert(approx(a2));
-    if(! aa2.second){
-      return fp(bb, a2);
-    }
-    return epicp(bb, aa2.first);
-  }
 
   template <typename A1, typename A2, typename A3>
   result_type operator()(const A1& a1, const A2& a2, const A3& a3) const

--- a/Kernel_23/include/CGAL/Origin.h
+++ b/Kernel_23/include/CGAL/Origin.h
@@ -23,7 +23,18 @@
 namespace CGAL {
 
 class Origin
-{};
+{
+public:
+  const Origin& approx() const
+  {
+    return *this;
+  }
+
+  const Origin& exact() const
+  {
+    return *this;
+  }
+};
 
 class Null_vector
 {};

--- a/Kernel_23/include/CGAL/Origin.h
+++ b/Kernel_23/include/CGAL/Origin.h
@@ -23,18 +23,7 @@
 namespace CGAL {
 
 class Origin
-{
-public:
-  const Origin& approx() const
-  {
-    return *this;
-  }
-
-  const Origin& exact() const
-  {
-    return *this;
-  }
-};
+{};
 
 class Null_vector
 {};

--- a/Kernel_23/test/Kernel_23/origin_3.cpp
+++ b/Kernel_23/test/Kernel_23/origin_3.cpp
@@ -1,0 +1,57 @@
+//#define CGAL_PROFILE
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Timer.h>
+#include <vector>
+#include <iostream>
+typedef CGAL::Exact_predicates_exact_constructions_kernel K;
+typedef K::Point_3 Point_3;
+typedef CGAL::Timer Timer;
+
+int main(int argc, char* argv[] )
+{
+  std::ifstream ifs((argc>1)? argv[1]:CGAL::data_file_path("points/cube.xyz"));
+
+  std::vector<Point_3> points;
+  Point_3 p;
+
+  while(ifs >> p){
+    points.push_back(p);
+  }
+
+  const int N = points.size()-3;
+
+  const K::Orientation_3 orientation = K().orientation_3_object();
+
+  int positive = 0;
+  Timer t;
+  t.start();
+  {
+
+    for(int k = 0; k < 100; ++k)
+    for(int i = 0; i < N; ++i){
+       Point_3 o(CGAL::ORIGIN);
+      if(orientation(o, points[i], points[i+1], points[i+2]) == CGAL::POSITIVE){
+        ++positive;
+      }
+    }
+  }
+  t.stop();
+
+  std::cout << t.time() << " sec." << std::endl;
+
+  t.reset();
+  t.start();
+  {
+      for (int k = 0; k < 100; ++k)
+    for(int i = 0; i < N; ++i){
+      if(orientation(CGAL::ORIGIN, points[i], points[i+1], points[i+2]) == CGAL::POSITIVE){
+        --positive;
+     }
+    }
+  }
+  t.stop();
+
+  assert(positive == 0);
+  std::cout << t.time() << " sec." << std::endl;
+  return 0;
+}

--- a/Kernel_23/test/Kernel_23/origin_3.cpp
+++ b/Kernel_23/test/Kernel_23/origin_3.cpp
@@ -10,7 +10,7 @@ typedef CGAL::Timer Timer;
 
 int main(int argc, char* argv[] )
 {
-  std::ifstream ifs((argc>1)? argv[1]:CGAL::data_file_path("points/cube.xyz"));
+  std::ifstream ifs((argc>1)? argv[1]:CGAL::data_file_path("points_3/cube.xyz"));
 
   std::vector<Point_3> points;
   Point_3 p;
@@ -57,7 +57,7 @@ int main(int argc, char* argv[] )
   t.stop();
 
 
-  if(positive =! 0){
+  if(positive != 0){
     std::cout << "Not the same results for Orientation_3"<< std::endl;
     assert(false);
   }
@@ -97,7 +97,7 @@ int main(int argc, char* argv[] )
 
   t.stop();
 
-  if(sumx1 == sumx2){
+  if(sumx1 != sumx2){
     std::cout << "Not the same results for Construct_orthogonal_vector" << std::endl;
     assert(false);
   }

--- a/Kernel_23/test/Kernel_23/origin_3.cpp
+++ b/Kernel_23/test/Kernel_23/origin_3.cpp
@@ -22,7 +22,7 @@ int main(int argc, char* argv[] )
   std::cout << "Orientation_3" << std::endl;
   Timer t;
 
-  const int N = points.size()-3;
+  const std::size_t N = points.size()-3;
 
   const K::Orientation_3 orientation = K().orientation_3_object();
 
@@ -31,8 +31,8 @@ int main(int argc, char* argv[] )
   t.start();
   {
     std::cout << "overload with 4 points" << std::endl;
-    for(int k = 0; k < 100; ++k)
-    for(int i = 0; i < N; ++i){
+    for(std::size_t k = 0; k < 100; ++k)
+      for(std::size_t i = 0; i < N; ++i){
        Point_3 o(CGAL::ORIGIN);
       if(orientation(o, points[i], points[i+1], points[i+2]) == CGAL::POSITIVE){
         ++positive;
@@ -47,8 +47,8 @@ int main(int argc, char* argv[] )
   t.start();
   {
     std::cout << "overload with origin and 3 points" << std::endl;
-    for (int k = 0; k < 100; ++k)
-    for(int i = 0; i < N; ++i){
+    for (std::size_t k = 0; k < 100; ++k)
+      for(std::size_t i = 0; i < N; ++i){
       if(orientation(CGAL::ORIGIN, points[i], points[i+1], points[i+2]) == CGAL::POSITIVE){
         --positive;
      }
@@ -73,8 +73,8 @@ int main(int argc, char* argv[] )
  t.start();
   {
     std::cout << "overload with 3 points" << std::endl;
-    for(int k = 0; k < 100; ++k)
-      for(int i = 0; i < N; ++i){
+    for(std::size_t k = 0; k < 100; ++k)
+      for(std::size_t i = 0; i < N; ++i){
         Point_3 o(CGAL::ORIGIN);
         Vector_3 v = construct_orthogonal_vector(o, points[i], points[i+1]);
         sumx1 += CGAL::to_double(v.approx().x());
@@ -88,8 +88,8 @@ int main(int argc, char* argv[] )
   t.start();
   {
     std::cout << "overload with origin and 2 points" << std::endl;
-    for (int k = 0; k < 100; ++k)
-      for(int i = 0; i < N; ++i){
+    for (std::size_t k = 0; k < 100; ++k)
+      for(std::size_t i = 0; i < N; ++i){
         Vector_3 v = construct_orthogonal_vector(CGAL::ORIGIN, points[i], points[i+1]);
         sumx2 += CGAL::to_double(v.approx().x());
       }

--- a/Kernel_23/test/Kernel_23/origin_3.cpp
+++ b/Kernel_23/test/Kernel_23/origin_3.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 typedef CGAL::Exact_predicates_exact_constructions_kernel K;
 typedef K::Point_3 Point_3;
+typedef K::Vector_3 Vector_3;
 typedef CGAL::Timer Timer;
 
 int main(int argc, char* argv[] )
@@ -18,15 +19,18 @@ int main(int argc, char* argv[] )
     points.push_back(p);
   }
 
+  std::cout << "Orientation_3" << std::endl;
+  Timer t;
+
   const int N = points.size()-3;
 
   const K::Orientation_3 orientation = K().orientation_3_object();
 
   int positive = 0;
-  Timer t;
+
   t.start();
   {
-
+    std::cout << "overload with 4 points" << std::endl;
     for(int k = 0; k < 100; ++k)
     for(int i = 0; i < N; ++i){
        Point_3 o(CGAL::ORIGIN);
@@ -42,7 +46,8 @@ int main(int argc, char* argv[] )
   t.reset();
   t.start();
   {
-      for (int k = 0; k < 100; ++k)
+    std::cout << "overload with origin and 3 points" << std::endl;
+    for (int k = 0; k < 100; ++k)
     for(int i = 0; i < N; ++i){
       if(orientation(CGAL::ORIGIN, points[i], points[i+1], points[i+2]) == CGAL::POSITIVE){
         --positive;
@@ -51,7 +56,53 @@ int main(int argc, char* argv[] )
   }
   t.stop();
 
-  assert(positive == 0);
+
+  if(positive =! 0){
+    std::cout << "Not the same results for Orientation_3"<< std::endl;
+    assert(false);
+  }
   std::cout << t.time() << " sec." << std::endl;
+
+
+  std::cout << "Construct_orthogonal_vector_3" << std::endl;
+
+  const K::Construct_orthogonal_vector_3 construct_orthogonal_vector = K().construct_orthogonal_vector_3_object();
+
+  double sumx1 = 0, sumx2 = 0;
+
+ t.start();
+  {
+    std::cout << "overload with 3 points" << std::endl;
+    for(int k = 0; k < 100; ++k)
+      for(int i = 0; i < N; ++i){
+        Point_3 o(CGAL::ORIGIN);
+        Vector_3 v = construct_orthogonal_vector(o, points[i], points[i+1]);
+        sumx1 += CGAL::to_double(v.approx().x());
+      }
+  }
+  t.stop();
+
+  std::cout << t.time() << " sec." << std::endl;
+
+  t.reset();
+  t.start();
+  {
+    std::cout << "overload with origin and 2 points" << std::endl;
+    for (int k = 0; k < 100; ++k)
+      for(int i = 0; i < N; ++i){
+        Vector_3 v = construct_orthogonal_vector(CGAL::ORIGIN, points[i], points[i+1]);
+        sumx2 += CGAL::to_double(v.approx().x());
+      }
+  }
+
+  t.stop();
+
+  if(sumx1 == sumx2){
+    std::cout << "Not the same results for Construct_orthogonal_vector" << std::endl;
+    assert(false);
+  }
+  std::cout << t.time() << " sec." << std::endl;
+
+
   return 0;
 }


### PR DESCRIPTION
## Summary of Changes

Adding the operator in `CGAL/Cartesian/function_objects.h` required some additions in converters, and in Origin itself. 
I did not add an overload for the homogeneous kernel and I did not add it for the global function. 

The added test case can also be used for benchmarking. For example with ` data/points/sphere_20k.xyz`. 
The main interest is for the exact constructions kernel.

This PR is triggered by a discussion in #6378, and @GilesBathgate might be interested to merge it. 

## Release Management

* Affected package(s): Kernel_23


