### PR TITLE
Nef_3 : Fix SFace encapsulation.

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SFace.h
+++ b/Nef_3/include/CGAL/Nef_3/SFace.h
@@ -54,13 +54,12 @@ class SFace_base {
     SFace_cycle_const_iterator;
   Vertex_handle  center_vertex_;
   Volume_handle  volume_;
-  //    Object_list   boundary_entry_objects_; // SEdges, SLoops, SVertices
+  Object_list    boundary_entry_objects_; // SEdges, SLoops, SVertices
   GenPtr         info_;
   // temporary needed:
   Mark           mark_;
 
  public:
-  Object_list   boundary_entry_objects_; // SEdges, SLoops, SVertices
 
   SFace_base() : center_vertex_(), volume_(), info_(), mark_() {}
 

--- a/Nef_3/include/CGAL/Nef_3/Vertex.h
+++ b/Nef_3/include/CGAL/Nef_3/Vertex.h
@@ -261,8 +261,7 @@ class Vertex_base {
           fend = sfaces_end();
         while (fit != fend) {
           SFace_iterator fdel = fit++;
-          CGAL_assertion(&fdel->boundary_entry_objects_ == &fdel->boundary_entry_objects());
-          sncp()->reset_sm_object_list(fdel->boundary_entry_objects_);
+          sncp()->reset_sm_object_list(fdel->boundary_entry_objects());
           sncp()->delete_sface_only(fdel);
         }
         sfaces_begin_ = sfaces_last_ = sncp()->sfaces_end();

--- a/Nef_3/include/CGAL/Nef_3/Vertex.h
+++ b/Nef_3/include/CGAL/Nef_3/Vertex.h
@@ -261,7 +261,7 @@ class Vertex_base {
           fend = sfaces_end();
         while (fit != fend) {
           SFace_iterator fdel = fit++;
-          /* TO VERIFY: next statement needs access to a private attribute */
+          CGAL_assertion(&fdel->boundary_entry_objects_ == &fdel->boundary_entry_objects());
           sncp()->reset_sm_object_list(fdel->boundary_entry_objects_);
           sncp()->delete_sface_only(fdel);
         }


### PR DESCRIPTION
## Summary of Changes

Minor cleanup. SFace `boundary_entry_objects_` was public and should be private.
I used the code f1a3f68fbb6f5f52dd91959fed3e99bdf8c53690:
```c++
CGAL_assertion(&fdel->boundary_entry_objects_ == &fdel->boundary_entry_objects());
```
to verify that the statement in `Vertex.h` does not need access to a private member.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): cleaning
* License and copyright ownership: Returned to CGAL authors.

