### PR TITLE
Remove redundant HTML type of anchor

### DIFF
--- a/Convex_hull_2/doc/Convex_hull_2/CGAL/convexity_check_2.h
+++ b/Convex_hull_2/doc/Convex_hull_2/CGAL/convexity_check_2.h
@@ -58,7 +58,6 @@ It returns `true`, iff the point elements in
 form a clockwise-oriented strongly convex polygon.
 
 A set of points is said to be strongly convex
-<A NAME="Index_anchor_76"></A>
 if it consists of only extreme points
 (<I>i.e.</I>, vertices of the convex hull).
 


### PR DESCRIPTION
Remove redundant HTML type of anchor, the anchor is not used and night give problems in the future (especially with https://github.com/doxygen/doxygen/pull/9204)
