### PR TITLE
Algebraic_kernel_d: Incorrect deprectated sections

### DIFF
--- a/Algebraic_kernel_d/doc/Algebraic_kernel_d/CGAL/Algebraic_kernel_d_1.h
+++ b/Algebraic_kernel_d/doc/Algebraic_kernel_d/CGAL/Algebraic_kernel_d_1.h
@@ -10,12 +10,10 @@ The template argument `Coeff` determines the coefficient type of the
 kernel, which is also the coefficient type of the supported polynomials.
 
 Currently, the following coefficient types are supported:
-
 - `Gmpz`, `Gmpq`, (requires configuration with external libraries GMP, MPFR and MPFI)
-
 - `CORE::BigInt`, `CORE::BigRat`, (requires configuration with external library GMP)
-
 - `leda_integer`, `leda_rational`. (requires configuration with external library LEDA)
+.
 
 \cgalAdvancedBegin
 The template argument type can also be set to `Sqrt_extension<NT,ROOT>`, where `NT` is

--- a/Algebraic_kernel_d/doc/Algebraic_kernel_d/CGAL/Algebraic_kernel_d_2.h
+++ b/Algebraic_kernel_d/doc/Algebraic_kernel_d/CGAL/Algebraic_kernel_d_2.h
@@ -35,10 +35,10 @@ The template argument `Coeff` determines the coefficient type of the
 kernel, which is also the innermost coefficient type of the supported polynomials.
 
 Currently, the following coefficient types are supported:
-
 - `Gmpz`, `Gmpq`, (requires configuration with external libraries GMP, MPFR and MPFI)
 - `CORE::BigInt`, `CORE::BigRat`, (requires configuration with external library GMP)
 - `leda_integer`, `leda_rational`. (requires configuration with external library LEDA)
+.
 
 \cgalAdvancedBegin
 The template argument type can also be set to


### PR DESCRIPTION
In the files Algebraic_kernel_d/CGAL/Algebraic_kernel_d_1.h and Algebraic_kernel_d/CGAL/Algebraic_kernel_d_2.h the deprecated section is not properly shown due to the fact that the list is not properly closed.

**Original**
![image](https://user-images.githubusercontent.com/5223533/158232984-cbbbbe21-b522-4846-a15e-e011938152b8.png)

**New**
![image](https://user-images.githubusercontent.com/5223533/158232889-6e1920ba-4b16-435a-8a2f-f42ad7ac7e23.png)

