### PR TITLE
Surface_mesh_deformation: Incorrect deprecated sections

### DIFF
--- a/Surface_mesh_deformation/doc/Surface_mesh_deformation/Surface_mesh_deformation.txt
+++ b/Surface_mesh_deformation/doc/Surface_mesh_deformation/Surface_mesh_deformation.txt
@@ -102,6 +102,7 @@ The function `Surface_mesh_deformation::preprocess()` returns `true` if the fact
 Rank deficiency is the main reason for failure. Typical failure cases are:
   - All the vertices are in the ROI and no control vertices are set
   - The weighting scheme used to fill the sparse matrix (model of `SurfaceMeshDeformationWeights`) features too many zeros and breaks the connectivity information
+.
 
 \cgalAdvancedBegin
 The choice of the weighting scheme provides a mean to adjust the way the control vertices


### PR DESCRIPTION
In the file  Surface_mesh_deformation/index.html the deprecated section is not properly shown due to the fact that the list is not properly closed.

**Original**
![image](https://user-images.githubusercontent.com/5223533/158234663-efa82d99-afd3-4ac9-b1d5-b85aefb6c4ad.png)

**New**
![image](https://user-images.githubusercontent.com/5223533/158234719-ac84f22c-ab68-488c-aa31-0aed54084b9b.png)
