### PR TITLE
Point_set_processing_3: Missing end command for cgalParam

### DIFF
--- a/Point_set_processing_3/include/CGAL/structure_point_set.h
+++ b/Point_set_processing_3/include/CGAL/structure_point_set.h
@@ -1525,6 +1525,7 @@ private:
                               to the index of plane (`-1` if the point is not assigned to a plane)}
         \cgalParamType{a class model of `ReadablePropertyMap` with `std::size_t` as key type and `int` as value type}
         \cgalParamDefault{There is no default, this parameters is mandatory.}
+      \cgalParamNEnd
 
       \cgalParamNBegin{plane_map}
         \cgalParamDescription{a property map containing the planes associated to the elements of the plane range `planes`}


### PR DESCRIPTION
A `\cgalParamEnd` was missing, resulting in an incorrect sequence of HTML tags (in the output just a small extra white space was shown)

**Original**
![image](https://user-images.githubusercontent.com/5223533/158239003-ee03de62-4adb-4f75-8ea9-25ae173044df.png)

**New**
![image](https://user-images.githubusercontent.com/5223533/158239091-cfc69389-f844-4f9e-91ea-0d14c2014cdc.png)
