### PR TITLE
Make write_STL (and write_polygon_mesh) compile with sqrt-less kernels

### DIFF
--- a/BGL/include/CGAL/boost/graph/IO/STL.h
+++ b/BGL/include/CGAL/boost/graph/IO/STL.h
@@ -271,9 +271,9 @@ bool write_STL(std::ostream& os,
     for(const face_descriptor f : faces(g))
     {
       const halfedge_descriptor h = halfedge(f, g);
-      const Point_ref p = get(vpm, target(h, g));
-      const Point_ref q = get(vpm, target(next(h, g), g));
-      const Point_ref r = get(vpm, source(h, g));
+      Point_ref p = get(vpm, target(h, g));
+      Point_ref q = get(vpm, target(next(h, g), g));
+      Point_ref r = get(vpm, source(h, g));
 
       const Vector n = internal::construct_normal_of_STL_face(p, q, r, k);
 
@@ -296,9 +296,9 @@ bool write_STL(std::ostream& os,
     for(const face_descriptor f : faces(g))
     {
       const halfedge_descriptor h = halfedge(f, g);
-      const Point_ref p = get(vpm, target(h, g));
-      const Point_ref q = get(vpm, target(next(h, g), g));
-      const Point_ref r = get(vpm, source(h, g));
+      Point_ref p = get(vpm, target(h, g));
+      Point_ref q = get(vpm, target(next(h, g), g));
+      Point_ref r = get(vpm, source(h, g));
       const Vector n = internal::construct_normal_of_STL_face(p, q, r, k);
 
       os << "facet normal " << n << "\nouter loop"<< "\n";

--- a/BGL/include/CGAL/boost/graph/IO/STL.h
+++ b/BGL/include/CGAL/boost/graph/IO/STL.h
@@ -244,7 +244,6 @@ bool write_STL(std::ostream& os,
 
   typedef typename CGAL::GetVertexPointMap<Graph, CGAL_NP_CLASS>::const_type        VPM;
   typedef typename boost::property_traits<VPM>::reference                           Point_ref;
-  typedef typename boost::property_traits<VPM>::value_type                          Point;
 
   typedef typename GetGeomTraits<Graph, CGAL_NP_CLASS>::type                        Kernel;
   typedef typename Kernel::Vector_3                                                 Vector;

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -1811,7 +1811,8 @@ namespace CommonKernelFunctors {
     {
       CGAL_kernel_precondition(! K().collinear_3_object()(p,q,r) );
       Vector_3 res = CGAL::cross_product(q-p, r-p);
-      return res; }
+      return res;
+    }
   };
 
   template <typename K>
@@ -2578,7 +2579,7 @@ namespace CommonKernelFunctors {
       Vector_3 res = CGAL::cross_product(q-p, r-p);
       res = res / CGAL::sqrt(res.squared_length());
       return res;
-        }
+    }
   };
 
   template <typename K>

--- a/Stream_support/include/CGAL/IO/STL.h
+++ b/Stream_support/include/CGAL/IO/STL.h
@@ -236,11 +236,9 @@ typename K::Vector_3 construct_normal_of_STL_face(const typename K::Point_3& p,
   if(k.collinear_3_object()(p, q, r))
     return k.construct_vector_3_object()(1, 0, 0);
 
-  const Vector pq = k.construct_vector_3_object()(p, q);
-  const Vector pr = k.construct_vector_3_object()(p, r);
-  Vector res = k.construct_cross_product_vector_3_object()(pq, pr);
+  Vector res = k.construct_orthogonal_vector_3_object()(p, q, r);
   const FT sql = k.compute_squared_length_3_object()(res);
-  res = k.construct_scaled_vector_3_object()(res, FT(1) / CGAL::approximate_sqrt(sql));
+  res = k.construct_divided_vector_3_object()(res, CGAL::approximate_sqrt(sql));
 
   return res;
 }

--- a/Stream_support/include/CGAL/IO/STL.h
+++ b/Stream_support/include/CGAL/IO/STL.h
@@ -222,6 +222,31 @@ bool read_STL(const std::string& fname,
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 // Write
 
+namespace internal {
+
+template <typename K>
+typename K::Vector_3 construct_normal_of_STL_face(const typename K::Point_3& p,
+                                                  const typename K::Point_3& q,
+                                                  const typename K::Point_3& r,
+                                                  const K& k)
+{
+  typedef typename K::FT FT;
+  typedef typename K::Vector_3 Vector;
+
+  if(k.collinear_3_object()(p, q, r))
+    return k.construct_vector_3_object()(1, 0, 0);
+
+  const Vector pq = k.construct_vector_3_object()(p, q);
+  const Vector pr = k.construct_vector_3_object()(p, r);
+  Vector res = k.construct_cross_product_vector_3_object()(pq, pr);
+  const FT sql = k.compute_squared_length_3_object()(res);
+  res = k.construct_scaled_vector_3_object()(res, FT(1) / CGAL::approximate_sqrt(sql));
+
+  return res;
+}
+
+} // namespace internal
+
 /*!
  * \ingroup PkgStreamSupportIoFuncsSTL
  *
@@ -275,6 +300,8 @@ bool write_STL(std::ostream& os,
   typedef typename CGAL::Kernel_traits<Point>::Kernel                       K;
   typedef typename K::Vector_3                                              Vector_3;
 
+  K k = choose_parameter<K>(get_parameter(np, internal_np::geom_traits));
+
   if(!os.good())
     return false;
 
@@ -313,7 +340,7 @@ bool write_STL(std::ostream& os,
       const Point& q = get(point_map, points[face[1]]);
       const Point& r = get(point_map, points[face[2]]);
 
-      const Vector_3 n = collinear(p,q,r) ? Vector_3(1,0,0) : unit_normal(p,q,r);
+      const Vector_3 n = internal::construct_normal_of_STL_face(p, q, r, k);
       os << "facet normal " << n << "\nouter loop\n";
       os << "vertex " << p << "\n";
       os << "vertex " << q << "\n";


### PR DESCRIPTION
## Summary of Changes

`unit_normal()` is called in STL writing of soup and mesh. Unfortunately, it requires a square root, and will thus not compile with EPECK. This gets especially unpleasant when calling non-STL writing that still requires STL writing compilation e.g., `IO::write_polygon_mesh("out.off", mesh)`.

This PR proposes to use an approximate square root call instead.

## Release Management

* Affected package(s): `Stream_support`, `BGL`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

