### PR TITLE
Nef_3: Proof of concept for no-hashmap approach.

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/Halfedge.h
+++ b/Nef_3/include/CGAL/Nef_3/Halfedge.h
@@ -64,52 +64,55 @@ class Halfedge_base
   SFace_handle       incident_sface_;
   GenPtr             info_;
   Sphere_point       point_;
+  mutable bool       visited_;
 
  public:
 
-  Halfedge_base() : center_vertex_(), mark_(), twin_(),
-    out_sedge_(), incident_sface_(),
-    info_(), point_() {}
+      Halfedge_base() : center_vertex_(), mark_(), twin_(),
+        out_sedge_(), incident_sface_(),
+        info_(), point_(), visited_() {}
 
-    Halfedge_base(Mark m) :  center_vertex_(), mark_(m), twin_(),
-      out_sedge_(), incident_sface_(),
-      info_(), point_() {}
+      Halfedge_base(Mark m) :  center_vertex_(), mark_(m), twin_(),
+        out_sedge_(), incident_sface_(),
+        info_(), point_(), visited_() {}
 
       ~Halfedge_base() {
         CGAL_NEF_TRACEN("  destroying Halfedge item "<<&*this);
       }
 
-      Halfedge_base(const Halfedge_base<Refs>& e)
-        { center_vertex_ = e.center_vertex_;
-          point_ = e.point_;
-          mark_ = e.mark_;
-          twin_ = e.twin_;
-          out_sedge_ = e.out_sedge_;
-          incident_sface_ = e.incident_sface_;
-          info_ = 0;
-        }
+      Halfedge_base(const Halfedge_base<Refs>& e) :
+        center_vertex_(e.center_vertex_),
+        point_(e.point_),
+        mark_(e.mark_),
+        twin_(e.twin_),
+        out_sedge_(e.out_sedge_),
+        incident_sface_(e.incident_sface_),
+        info_(0),
+        visited_(false) {}
 
       Halfedge_base<Refs>& operator=(const Halfedge_base<Refs>& e)
-        { center_vertex_ = e.center_vertex_;
-          point_ = e.point_;
-          mark_ = e.mark_;
-          twin_ = e.twin_;
-          out_sedge_ = e.out_sedge_;
-          incident_sface_ = e.incident_sface_;
-          info_ = 0;
-          return *this;
-        }
+      { center_vertex_ = e.center_vertex_;
+        point_ = e.point_;
+        mark_ = e.mark_;
+        twin_ = e.twin_;
+        out_sedge_ = e.out_sedge_;
+        incident_sface_ = e.incident_sface_;
+        info_ = 0;
+        visited_ = false;
+        return *this;
+      }
 
       Halfedge_base<Refs>& operator=(Halfedge_base<Refs>&& e) noexcept
-        { center_vertex_ = std::move(e.center_vertex_);
-          point_ = std::move(e.point_);
-          mark_ = std::move(e.mark_);
-          twin_ = std::move(e.twin_);
-          out_sedge_ = std::move(e.out_sedge_);
-          incident_sface_ = std::move(e.incident_sface_);
-          info_ = 0;
-          return *this;
-        }
+      { center_vertex_ = std::move(e.center_vertex_);
+        point_ = std::move(e.point_);
+        mark_ = std::move(e.mark_);
+        twin_ = std::move(e.twin_);
+        out_sedge_ = std::move(e.out_sedge_);
+        incident_sface_ = std::move(e.incident_sface_);
+        info_ = 0;
+        visited_ = false;
+        return *this;
+      }
 
       Vertex_handle& center_vertex() { return center_vertex_; }
       Vertex_const_handle center_vertex() const { return center_vertex_; }
@@ -122,6 +125,8 @@ class Halfedge_base
 
       Mark& mark() { return mark_; }
       const Mark& mark() const { return mark_; }
+
+      bool& visited() const { return visited_; }
 
       Vector_3 vector() const { return (point_ - CGAL::ORIGIN); }
       Sphere_point& point(){ return point_; }

--- a/Nef_3/include/CGAL/Nef_3/Halfedge.h
+++ b/Nef_3/include/CGAL/Nef_3/Halfedge.h
@@ -70,11 +70,11 @@ class Halfedge_base
 
       Halfedge_base() : center_vertex_(), mark_(), twin_(),
         out_sedge_(), incident_sface_(),
-        info_(), point_(), visited_() {}
+        info_(), point_(), visited_(false) {}
 
       Halfedge_base(Mark m) :  center_vertex_(), mark_(m), twin_(),
         out_sedge_(), incident_sface_(),
-        info_(), point_(), visited_() {}
+        info_(), point_(), visited_(false) {}
 
       ~Halfedge_base() {
         CGAL_NEF_TRACEN("  destroying Halfedge item "<<&*this);

--- a/Nef_3/include/CGAL/Nef_3/Halffacet.h
+++ b/Nef_3/include/CGAL/Nef_3/Halffacet.h
@@ -27,12 +27,20 @@
 #undef CGAL_NEF_DEBUG
 #define CGAL_NEF_DEBUG 83
 #include <CGAL/Nef_2/debug.h>
+#ifndef CGAL_I_DO_WANT_TO_USE_GENINFO
+#include <boost/any.hpp>
+#endif
 
 namespace CGAL {
 
 template <typename Refs>
 class Halffacet_base  {
 
+  #ifdef CGAL_I_DO_WANT_TO_USE_GENINFO
+  typedef void* GenPtr;
+  #else
+  typedef boost::any GenPtr;
+  #endif
   typedef typename Refs::Mark  Mark;
   typedef typename Refs::Plane_3   Plane_3;
   typedef typename Refs::Halffacet_handle         Halffacet_handle;
@@ -49,6 +57,7 @@ class Halffacet_base  {
   Mark                 mark_;
   Halffacet_handle     twin_;
   Volume_handle        volume_;
+  GenPtr               info_;
   Object_list          boundary_entry_objects_; // SEdges, SLoops
 
  public:
@@ -96,6 +105,9 @@ class Halffacet_base  {
 
       Object_list& boundary_entry_objects() { return boundary_entry_objects_; }
       const Object_list& boundary_entry_objects() const { return boundary_entry_objects_; }
+
+      GenPtr& info() { return info_; }
+      const GenPtr& info() const { return info_; }
 
       Halffacet_cycle_iterator facet_cycles_begin()
       { return boundary_entry_objects_.begin(); }

--- a/Nef_3/include/CGAL/Nef_3/Halffacet.h
+++ b/Nef_3/include/CGAL/Nef_3/Halffacet.h
@@ -59,37 +59,43 @@ class Halffacet_base  {
   Volume_handle        volume_;
   GenPtr               info_;
   Object_list          boundary_entry_objects_; // SEdges, SLoops
+  mutable bool         visited_;
 
  public:
 
-  Halffacet_base() : supporting_plane_(), mark_() {}
+      Halffacet_base() : supporting_plane_(), mark_(), visited_() {}
 
-    Halffacet_base(const Plane_3& h, Mark m) :
-      supporting_plane_(h), mark_(m) {}
+      Halffacet_base(const Plane_3& h, Mark m) :
+        supporting_plane_(h), mark_(m), visited_() {}
 
       ~Halffacet_base() {
         CGAL_NEF_TRACEN("  destroying Halffacet_base item "<<&*this);
       }
 
-      Halffacet_base(const Halffacet_base<Refs>& f)
-        { supporting_plane_ = f.supporting_plane_;
-          mark_ = f.mark_;
-          twin_ = f.twin_;
-          CGAL_NEF_TRACEN("VOLUME const");
-          volume_ = f.volume_;
-          boundary_entry_objects_ = f.boundary_entry_objects_;
-        }
+      Halffacet_base(const Halffacet_base<Refs>& f) :
+        supporting_plane_(f.supporting_plane_),
+        mark_(f.mark_),
+        twin_(f.twin_),
+        volume_(f.volume_),
+        info_(0),
+        boundary_entry_objects_(f.boundary_entry_objects_),
+        visited_(false)
+      {
+        CGAL_NEF_TRACEN("VOLUME const");
+      }
 
       Halffacet_base<Refs>& operator=(const Halffacet_base<Refs>& f)
-        { if (this == &f) return *this;
-          supporting_plane_ = f.supporting_plane_;
-          mark_ = f.mark_;
-          twin_ = f.twin_;
-          CGAL_NEF_TRACEN("VOLUME op=");
-          volume_ = f.volume_;
-          boundary_entry_objects_ = f.boundary_entry_objects_;
-          return *this;
-        }
+      { if (this == &f) return *this;
+        supporting_plane_ = f.supporting_plane_;
+        mark_ = f.mark_;
+        twin_ = f.twin_;
+        CGAL_NEF_TRACEN("VOLUME op=");
+        volume_ = f.volume_;
+        info_ = 0;
+        boundary_entry_objects_ = f.boundary_entry_objects_;
+        visited_ = false;
+        return *this;
+      }
 
       Mark& mark() { return mark_; }
       const Mark& mark() const { return mark_; }
@@ -108,6 +114,8 @@ class Halffacet_base  {
 
       GenPtr& info() { return info_; }
       const GenPtr& info() const { return info_; }
+
+      bool& visited() const { return visited_; }
 
       Halffacet_cycle_iterator facet_cycles_begin()
       { return boundary_entry_objects_.begin(); }

--- a/Nef_3/include/CGAL/Nef_3/Halffacet.h
+++ b/Nef_3/include/CGAL/Nef_3/Halffacet.h
@@ -63,10 +63,10 @@ class Halffacet_base  {
 
  public:
 
-      Halffacet_base() : supporting_plane_(), mark_(), visited_() {}
+      Halffacet_base() : supporting_plane_(), mark_(), visited_(false) {}
 
       Halffacet_base(const Plane_3& h, Mark m) :
-        supporting_plane_(h), mark_(m), visited_() {}
+        supporting_plane_(h), mark_(m), visited_(false) {}
 
       ~Halffacet_base() {
         CGAL_NEF_TRACEN("  destroying Halffacet_base item "<<&*this);

--- a/Nef_3/include/CGAL/Nef_3/SFace.h
+++ b/Nef_3/include/CGAL/Nef_3/SFace.h
@@ -58,32 +58,34 @@ class SFace_base {
   GenPtr         info_;
   // temporary needed:
   Mark           mark_;
+  mutable bool   visited_;
 
  public:
 
-  SFace_base() : center_vertex_(), volume_(), info_(), mark_() {}
+    SFace_base() : center_vertex_(), volume_(), info_(), mark_(), visited_() {}
 
     ~SFace_base() {
       CGAL_NEF_TRACEN("  destroying SFace_base item "<<&*this);
     }
 
-    SFace_base(const SFace_base<Refs>& f)
-      { center_vertex_ = f.center_vertex_;
-        volume_ = f.volume_;
-        boundary_entry_objects_ = f.boundary_entry_objects_;
-        info_ = 0;
-        mark_ = f.mark_;
-      }
+    SFace_base(const SFace_base<Refs>& f) :
+      center_vertex_(f.center_vertex_),
+      volume_(f.volume_),
+      boundary_entry_objects_(f.boundary_entry_objects_),
+      info_(0),
+      mark_(f.mark_),
+      visited_(false) {}
 
     SFace_base<Refs>& operator=(const SFace_base<Refs>& f)
-      { if (this == &f) return *this;
-        center_vertex_ = f.center_vertex_;
-        volume_ = f.volume_;
-        boundary_entry_objects_ = f.boundary_entry_objects_;
-        info_ = 0;
-        mark_ = f.mark_;
-        return *this;
-      }
+    { if (this == &f) return *this;
+      center_vertex_ = f.center_vertex_;
+      volume_ = f.volume_;
+      boundary_entry_objects_ = f.boundary_entry_objects_;
+      info_ = 0;
+      mark_ = f.mark_;
+      visited_ = false;
+      return *this;
+    }
 
     SFace_cycle_iterator sface_cycles_begin()
     { return boundary_entry_objects_.begin(); }
@@ -96,6 +98,8 @@ class SFace_base {
 
     Mark& mark() { return mark_; }
     const Mark& mark() const { return mark_; }
+
+    bool& visited() const { return visited_; }
 
     Vertex_handle& center_vertex() { return center_vertex_; }
     Vertex_const_handle center_vertex() const { return center_vertex_; }

--- a/Nef_3/include/CGAL/Nef_3/SFace.h
+++ b/Nef_3/include/CGAL/Nef_3/SFace.h
@@ -62,7 +62,7 @@ class SFace_base {
 
  public:
 
-    SFace_base() : center_vertex_(), volume_(), info_(), mark_(), visited_() {}
+    SFace_base() : center_vertex_(), volume_(), info_(), mark_(), visited_(false) {}
 
     ~SFace_base() {
       CGAL_NEF_TRACEN("  destroying SFace_base item "<<&*this);

--- a/Nef_3/include/CGAL/Nef_3/Vertex.h
+++ b/Nef_3/include/CGAL/Nef_3/Vertex.h
@@ -73,56 +73,59 @@ class Vertex_base {
   SFace_iterator     sfaces_begin_, sfaces_last_;
   SHalfloop_iterator shalfloop_;
   GenPtr             info_;
+  mutable bool       visited_;
 
  public:
 
-  Vertex_base() : point_at_center_(), mark_(), sncp_(),
-    svertices_begin_(), svertices_last_(),
-    shalfedges_begin_(), shalfedges_last_(),
-    sfaces_begin_(), sfaces_last_(), shalfloop_(),
-    info_()
-    // , sm_(Vertex_handle((SNC_in_place_list_vertex<Vertex_base>*) this))
-      {}
+      Vertex_base() : point_at_center_(), mark_(), sncp_(),
+        svertices_begin_(), svertices_last_(),
+        shalfedges_begin_(), shalfedges_last_(),
+        sfaces_begin_(), sfaces_last_(), shalfloop_(),
+        info_(), visited_()
+        // , sm_(Vertex_handle((SNC_in_place_list_vertex<Vertex_base>*) this))
+          {}
 
-    Vertex_base(const Point_3& p, Mark m) :
-      point_at_center_(p), mark_(m), sncp_(),
-      svertices_begin_(), svertices_last_(),
-      shalfedges_begin_(), shalfedges_last_(),
-      sfaces_begin_(), sfaces_last_(), shalfloop_(),
-      info_()
-      //    , sm_(Vertex_handle((SNC_in_place_list_vertex<Vertex_base>*) this))
+      Vertex_base(const Point_3& p, Mark m) :
+        point_at_center_(p), mark_(m), sncp_(),
+        svertices_begin_(), svertices_last_(),
+        shalfedges_begin_(), shalfedges_last_(),
+        sfaces_begin_(), sfaces_last_(), shalfloop_(),
+        info_(), visited_()
+        //    , sm_(Vertex_handle((SNC_in_place_list_vertex<Vertex_base>*) this))
         {}
 
-      Vertex_base(const Vertex_base<Refs>& v)
+      Vertex_base(const Vertex_base<Refs>& v) :
       //      : sm_(Vertex_handle((SNC_in_place_list_vertex<Vertex_base>*)this))
-        {
-          point_at_center_ = v.point_at_center_;
-          mark_ = v.mark_;
-          sncp_ = v.sncp_;
-          svertices_begin_ = v.svertices_begin_;
-          svertices_last_ = v.svertices_last_;
-          shalfedges_begin_ = v.shalfedges_begin_;
-          shalfedges_last_ = v.shalfedges_last_;
-          sfaces_begin_ = v.sfaces_begin_;
-          sfaces_last_ = v.sfaces_last_;
-          shalfloop_ = v.shalfloop_;
-          info_ = 0;
-        }
+
+        point_at_center_(v.point_at_center_),
+        mark_(v.mark_),
+        sncp_(v.sncp_),
+        svertices_begin_(v.svertices_begin_),
+        svertices_last_(v.svertices_last_),
+        shalfedges_begin_(v.shalfedges_begin_),
+        shalfedges_last_(v.shalfedges_last_),
+        sfaces_begin_(v.sfaces_begin_),
+        sfaces_last_(v.sfaces_last_),
+        shalfloop_(v.shalfloop_),
+        info_(0),
+        visited_(false) {}
 
       Vertex_base<Refs>& operator=(const Vertex_base<Refs>& v)
-        { if (this == &v) return *this;
-          point_at_center_ = v.point_at_center_;
-          mark_ = v.mark_;
-          sncp_ = v.sncp_;
-          svertices_begin_ = v.svertices_begin_;
-          svertices_last_ = v.svertices_last_;
-          shalfedges_begin_ = v.shalfedges_begin_;
-          shalfedges_last_ = v.shalfedges_last_;
-          sfaces_begin_ = v.sfaces_begin_;
-          sfaces_last_ = v.sfaces_last_;
-          shalfloop_ = v.shalfloop_;
-          return *this;
-        }
+      { if (this == &v) return *this;
+        point_at_center_ = v.point_at_center_;
+        mark_ = v.mark_;
+        sncp_ = v.sncp_;
+        svertices_begin_ = v.svertices_begin_;
+        svertices_last_ = v.svertices_last_;
+        shalfedges_begin_ = v.shalfedges_begin_;
+        shalfedges_last_ = v.shalfedges_last_;
+        sfaces_begin_ = v.sfaces_begin_;
+        sfaces_last_ = v.sfaces_last_;
+        shalfloop_ = v.shalfloop_;
+        info_ = 0;
+        visited_ = false;
+        return *this;
+      }
 
       Refs* sncp() const { return sncp_; }
       Refs*& sncp() { return sncp_; }
@@ -295,6 +298,8 @@ class Vertex_base {
       const Mark& mark() const { return mark_;}
       GenPtr& info() { return info_; }
       const GenPtr& info() const { return info_; }
+
+      bool& visited() const { return visited_; }
 
       ~Vertex_base() {
         CGAL_NEF_TRACEN("  destroying Vertex item "<<&*this);

--- a/Nef_3/include/CGAL/Nef_3/Vertex.h
+++ b/Nef_3/include/CGAL/Nef_3/Vertex.h
@@ -81,7 +81,7 @@ class Vertex_base {
         svertices_begin_(), svertices_last_(),
         shalfedges_begin_(), shalfedges_last_(),
         sfaces_begin_(), sfaces_last_(), shalfloop_(),
-        info_(), visited_()
+        info_(), visited_(false)
         // , sm_(Vertex_handle((SNC_in_place_list_vertex<Vertex_base>*) this))
           {}
 
@@ -90,7 +90,7 @@ class Vertex_base {
         svertices_begin_(), svertices_last_(),
         shalfedges_begin_(), shalfedges_last_(),
         sfaces_begin_(), sfaces_last_(), shalfloop_(),
-        info_(), visited_()
+        info_(), visited_(false)
         //    , sm_(Vertex_handle((SNC_in_place_list_vertex<Vertex_base>*) this))
         {}
 


### PR DESCRIPTION
## Summary of Changes

In Nef_3 hashmaps are used to associate information with objects at runtime, for example, to flag that a HalfEdge has been visited there might be a `Unique_hash_map<Halfedge_handle,bool> visited;`. If the class HalfEdge had a member variable called `visited` this could be used instead to indicate whether the edge had been visited (although it would have to be reset afterwards) However this would mean adding lots of extraneous data to the classes depending on the method or algorithm that is processing the list of objects.

There is a generalised `info` container on all the classes which could be used. However, a mechanism is needed to make sure that the existing info isn't overwritten, and is restored to whatever it was before the processing was done.


## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): draft/discussion only
* License and copyright ownership: Returned to CGAL authors.

