### PR TITLE
Algebraic_kernel_d: Use CGAL_assertion_code

### DIFF
--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/refine_zero_against.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/refine_zero_against.h
@@ -100,7 +100,7 @@ bool refine_zero_against(Field& low, Field& high, Polynomial p, Polynomial q) {
     if (CGAL::degree(q) == 0) return false;
 
     CGAL::Sign sign_p_low  = p.sign_at(low);
-    CGAL::Sign sign_p_high = p.sign_at(high);
+    CGAL::assertion_code(CGAL::Sign sign_p_high = p.sign_at(high));
     CGAL_precondition(sign_p_low  != CGAL::ZERO);
     CGAL_precondition(sign_p_high != CGAL::ZERO);
     CGAL_precondition(sign_p_high != sign_p_low);
@@ -148,9 +148,9 @@ bool refine_zero_against(Field& low, Field& high, Polynomial p, Polynomial q) {
             low = mid;
             sign_p_low = s;
         } else {
-            CGAL_postcondition(s == sign_p_high);
+            CGAL_assertion(s == sign_p_high);
             high = mid;
-            sign_p_high = s;
+            CGAL_assertion_code(sign_p_high = s);
         }
     }
 }


### PR DESCRIPTION
## Summary of Changes

Address warning in [this ](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.5-I-39/Arrangement_on_surface_2/TestReport_gimeno_ArchLinux-clang-Release.gz)Arrangement testsuite.

## Release Management

* Affected package(s): Arrangement_2
