### PR TITLE
Periodic_4_hyperbolic_triangulation_2 and Hyperbolic_triangulation_2: Incorrect enumeration sections

### DIFF
--- a/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/CGAL/Hyperbolic_Delaunay_triangulation_2.h
+++ b/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/CGAL/Hyperbolic_Delaunay_triangulation_2.h
@@ -72,7 +72,7 @@ public:
     typedef Triangulation_data_structure::Vertex_circulator Vertex_circulator;
   /// @}
 
-  /// \name
+  /// \name Enums
   /// The enumeration `Locate_type` is defined to specify which case occurs when locating a
   /// point in the triangulation.
   /// @{

--- a/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/CGAL/Periodic_4_hyperbolic_triangulation_2.h
+++ b/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/CGAL/Periodic_4_hyperbolic_triangulation_2.h
@@ -109,7 +109,7 @@ public:
                 typedef typename Triangulation_data_structure::Vertex_circulator    Vertex_circulator;
         /// @}
 
-        /// \name
+        /// \name Enums
         /// The following enumeration type indicates where a point is located in the triangulation.
         /// @{
         enum Locate_type {


### PR DESCRIPTION
In the files Periodic_4_hyperbolic_triangulation_2/classCGAL_1_1Periodic__4__hyperbolic__triangulation__2.html and Hyperbolic_triangulation_2/classCGAL_1_1Hyperbolic__Delaunay__triangulation__2.html we see that for the enumeration the heading is missing.
Furthermore the resulting HTML code is not valid (we see a `tr` tag outside a `table` tag).

**Original**

![image](https://user-images.githubusercontent.com/5223533/158583957-6ad8c3c4-58cc-44b6-b3a6-67e9a7f8aea0.png)

**New**:

![image](https://user-images.githubusercontent.com/5223533/158583765-b43545da-300b-45bb-909c-4adfff370e7a.png)
