### PR TITLE
Barycentric_coordinates_2: Unused anchor

### DIFF
--- a/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/segment_coordinates_2.h
+++ b/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/segment_coordinates_2.h
@@ -344,7 +344,6 @@ namespace Barycentric_coordinates {
   };
 
   /*!
-    \anchor seg_coord_global
   * \relates Segment_coordinates_2
   * This is a global function that takes both vertices of a segment and computes segment coordinates at a given query point with respect to these vertices.
 


### PR DESCRIPTION
Removing unused anchor it is defined but never used.
(gives double defined anchor in the "Related Functions" section and "Friends And Related Function Documentation" section.)
