### PR TITLE
Nef_3: Avoid needless tests

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Plane_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Plane_3.h
@@ -60,6 +60,9 @@ public:
   PlaneC3(const Point_3 &p, const Vector_3 &v)
   { *this = plane_from_point_direction<R>(p, v.direction()); }
 
+  PlaneC3(Origin o, const Vector_3 &v)
+  { *this = plane_from_point_direction<R>(o, v.direction()); }
+
   PlaneC3(const FT &a, const FT &b, const FT &c, const FT &d)
     : base(CGAL::make_array(a, b, c, d)) {}
 

--- a/Cartesian_kernel/include/CGAL/Cartesian/plane_constructions_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/plane_constructions_3.h
@@ -53,6 +53,15 @@ plane_from_point_direction(const typename R::Point_3 &p,
   return PlaneC3<R>(A, B, C, D);
 }
 
+  template <class R>
+CGAL_KERNEL_LARGE_INLINE
+PlaneC3<R>
+plane_from_point_direction(Origin o,
+                           const typename R::Direction_3 &d)
+{
+  return PlaneC3<R>(d.dx(), d.dy(), d.dz(), 0);
+}
+
 } //namespace CGAL
 
 #endif // CGAL_CARTESIAN_PLANE_CONSTRUCTIONS_3_H

--- a/Cartesian_kernel/include/CGAL/Cartesian/plane_constructions_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/plane_constructions_3.h
@@ -56,7 +56,7 @@ plane_from_point_direction(const typename R::Point_3 &p,
   template <class R>
 CGAL_KERNEL_LARGE_INLINE
 PlaneC3<R>
-plane_from_point_direction(Origin o,
+plane_from_point_direction(Origin,
                            const typename R::Direction_3 &d)
 {
   return PlaneC3<R>(d.dx(), d.dy(), d.dz(), 0);

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/PlaneH3.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/PlaneH3.h
@@ -58,6 +58,7 @@ public:
     PlaneH3(const Ray_3&, const Point_3& );
     PlaneH3(const Point_3&, const Direction_3& );
     PlaneH3(const Point_3&, const Vector_3& );
+    PlaneH3(Origin, const Vector_3& );
     PlaneH3(const Point_3&, const Direction_3&, const Direction_3& );
 
     const RT & a() const;
@@ -237,6 +238,17 @@ PlaneH3<R>::PlaneH3(const typename PlaneH3<R>::Point_3& p,
            ov.hy()*p.hw(),
            ov.hz()*p.hw(),
           -(ov.hx()*p.hx() + ov.hy()*p.hy() + ov.hz()*p.hz() ) );
+}
+
+template < class R >
+CGAL_KERNEL_INLINE
+PlaneH3<R>::PlaneH3(Origin,
+                    const typename PlaneH3<R>::Vector_3& ov)
+{
+  new_rep( ov.hx(),
+           ov.hy(),
+           ov.hz(),
+           RT(0) );
 }
 
 template < class R >

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -2047,6 +2047,10 @@ namespace CommonKernelFunctors {
     { return Rep(p, v); }
 
     Rep // Plane_3
+    operator()(Return_base_tag, Origin o, const Vector_3& v) const
+    { return Rep(o, v); }
+
+    Rep // Plane_3
     operator()(Return_base_tag, const Line_3& l, const Point_3& p) const
     { return Rep(l, p); }
 

--- a/Kernel_23/include/CGAL/Plane_3.h
+++ b/Kernel_23/include/CGAL/Plane_3.h
@@ -78,6 +78,9 @@ public:
   Plane_3(const Point_3& p, const Vector_3& v)
     : Rep(typename R::Construct_plane_3()(Return_base_tag(), p, v)) {}
 
+  Plane_3(Origin o, const Vector_3& v)
+    : Rep(typename R::Construct_plane_3()(Return_base_tag(), o, v)) {}
+
   Plane_3(const RT& a, const RT& b, const RT& c, const RT& d)
     : Rep(typename R::Construct_plane_3()(Return_base_tag(), a, b, c, d)) {}
 

--- a/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
@@ -72,12 +72,8 @@ class SNC_intersection : public SNC_const_decorator<SNC_structure_> {
   SNC_intersection() : Base() {}
   SNC_intersection(const SNC_structure& W) : Base(W) {}
 
-  bool does_contain_internally(const Segment_3& s, const Point_3& p) const {
-    if(!are_strictly_ordered_along_line (s.source(), p, s.target()))
-      return false;
-    if(!s.supporting_line().has_on(p))
-      return false;
-    return true;
+  bool does_contain_internally(const Point_3& s, const Point_3& t, const Point_3& p) const {
+    return are_strictly_ordered_along_line (s, p, t);
   }
 
   bool does_contain_internally( Halffacet_const_handle f,

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -319,7 +319,7 @@ public:
         }
       }
       else if( CGAL::assign( e, *o)) {
-        if ( is.does_contain_internally(Segment_3(e->source()->point(),e->twin()->source()->point()), p) ) {
+        if ( is.does_contain_internally(e->source()->point(), e->twin()->source()->point(), p) ) {
           _CGAL_NEF_TRACEN("found on edge "<<Segment_3(e->source()->point(),e->twin()->source()->point()));
           result = make_object(e);
           found = true;
@@ -417,7 +417,7 @@ public:
         //           (e->source() == v  || e->twin()->source() == v)) continue;
         Segment_3 ss(e->source()->point(),e->twin()->source()->point());
         CGAL_NEF_TRACEN("test edge " << e->source()->point() << "->" << e->twin()->source()->point());
-        if (is.does_contain_internally(ss, p)) {
+        if (is.does_contain_internally(e->source()->point(), e->twin()->source()->point(), p)) {
         _CGAL_NEF_TRACEN("found on edge "<< ss);
           return make_object(e);
         }

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -484,8 +484,7 @@ public:
 
       //CGAL_warning("altered code in SNC_point_locator");
       SM_point_locator L(&*v);
-      //      Object_handle so = L.locate(s.source()-s.target(), true);
-      Object_handle so = L.locate(s.source()-s.target());
+      Object_handle so = L.locate(s.source()-s.target(), true);
       SFace_handle sf;
       if(CGAL::assign(sf,so))
         return make_object(sf->volume());

--- a/Nef_3/test/Nef_3/include/CGAL/test_Nef_3.h
+++ b/Nef_3/test/Nef_3/include/CGAL/test_Nef_3.h
@@ -504,25 +504,25 @@ private:
       Point_3 p;
 
       assert(!is.does_contain_internally(
-                            Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                            Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(0,0,0)));
       assert(!is.does_contain_internally(
-                            Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                            Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(2,0,0)));
       assert(!is.does_contain_internally(
-                            Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                            Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(3,0,0)));
       assert(!is.does_contain_internally(
-                            Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                            Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(-1,0,0)));
       assert(!is.does_contain_internally(
-                            Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                            Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(1,1,0)));
       assert(!is.does_contain_internally(
-                            Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                            Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(7,25,11)));
       assert(is.does_contain_internally(
-                           Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                           Point_3(0,0,0), Point_3(2,0,0),
                            Point_3(1,0,0)));
 
       assert(!is.does_intersect_internally(

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_segment.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_segment.h
@@ -43,7 +43,7 @@ Sphere_segment_rep(const Point& p1, const Point& p2,
   CGAL_warning(p1 != p2.antipode());
   CGAL_assertion(p1 != p2.antipode());
   if ( p1 == p2 ) {
-    Plane_3 h(Point_3(CGAL::ORIGIN),(p1-CGAL::ORIGIN));
+    Plane_3 h(CGAL::ORIGIN, (p1-CGAL::ORIGIN));
     c_ = Sphere_circle<R_>(Plane_3(Point_3(CGAL::ORIGIN),h.base1()));
   }
   if (!shorter_arc) c_ = c_.opposite();


### PR DESCRIPTION
## Summary of Changes

Deactivate the test of vertices and edges.  Note that there was a line that did exactly that but it is commented.
I argue that we can skip [these tests](https://github.com/CGAL/cgal/blob/master/Nef_S2/include/CGAL/Nef_S2/SM_point_locator.h#L193) as they do not return the [expected type](https://github.com/CGAL/cgal/blob/master/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h#L490) in the `Object`.
@GilesBathgate can you please check that this makes sense.

## Release Management

* Affected package(s): Nef_3

