### PR TITLE
Nef_3: Cleanup and performance improvements SNC_intersection

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Plane_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Plane_3.h
@@ -60,6 +60,9 @@ public:
   PlaneC3(const Point_3 &p, const Vector_3 &v)
   { *this = plane_from_point_direction<R>(p, v.direction()); }
 
+  PlaneC3(Origin o, const Vector_3 &v)
+  { *this = plane_from_point_direction<R>(o, v.direction()); }
+
   PlaneC3(const FT &a, const FT &b, const FT &c, const FT &d)
     : base(CGAL::make_array(a, b, c, d)) {}
 

--- a/Cartesian_kernel/include/CGAL/Cartesian/plane_constructions_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/plane_constructions_3.h
@@ -53,6 +53,15 @@ plane_from_point_direction(const typename R::Point_3 &p,
   return PlaneC3<R>(A, B, C, D);
 }
 
+  template <class R>
+CGAL_KERNEL_LARGE_INLINE
+PlaneC3<R>
+plane_from_point_direction(Origin o,
+                           const typename R::Direction_3 &d)
+{
+  return PlaneC3<R>(d.dx(), d.dy(), d.dz(), 0);
+}
+
 } //namespace CGAL
 
 #endif // CGAL_CARTESIAN_PLANE_CONSTRUCTIONS_3_H

--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Ray_hit_generator.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Ray_hit_generator.h
@@ -81,7 +81,6 @@ class Ray_hit_generator : public Modifier_base<typename Nef_::SNC_and_PL> {
     }
 
     Point_3 ip;
-    SNC_intersection I;
     SNC_constructor C(*sncp);
 
     Halfedge_handle e;
@@ -89,7 +88,7 @@ class Ray_hit_generator : public Modifier_base<typename Nef_::SNC_and_PL> {
       CGAL_NEF_TRACEN( "Found edge " << e->source()->point()
                 << "->" << e->twin()->source()->point() );
       Segment_3 seg(e->source()->point(), e->twin()->source()->point());
-      I.does_intersect_internally(r, seg, ip);
+      SNC_intersection::does_intersect_internally(r, seg, ip);
       ip = normalized(ip);
       v = C.create_from_edge(e,ip);
       pl->add_vertex(v);
@@ -135,7 +134,7 @@ class Ray_hit_generator : public Modifier_base<typename Nef_::SNC_and_PL> {
     Halffacet_handle f;
     if(assign(f, o)) {
       CGAL_NEF_TRACEN( "Found facet " );
-      I.does_intersect_internally(r, f, ip);
+      SNC_intersection::does_intersect_internally(r, f, ip);
       ip = normalized(ip);
       v = C.create_from_facet(f,ip);
       pl->add_vertex(v);

--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Ray_hit_generator2.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/Ray_hit_generator2.h
@@ -87,7 +87,6 @@ class Ray_hit_generator2 : public Modifier_base<typename Nef_::SNC_and_PL> {
     }
 
     Point_3 ip;
-    SNC_intersection I;
     SNC_constructor C(*sncp);
 
     Halfedge_handle e;
@@ -95,7 +94,7 @@ class Ray_hit_generator2 : public Modifier_base<typename Nef_::SNC_and_PL> {
        CGAL_NEF_TRACEN("Found edge " << e->source()->point()
                        << "->" << e->twin()->source()->point());
       Segment_3 seg(e->source()->point(), e->twin()->source()->point());
-      I.does_intersect_internally(r, seg, ip);
+      SNC_intersection::does_intersect_internally(r, seg, ip);
       ip = normalized(ip);
       v = C.create_from_edge(e,ip);
       pl->add_vertex(v);
@@ -147,7 +146,7 @@ class Ray_hit_generator2 : public Modifier_base<typename Nef_::SNC_and_PL> {
     Halffacet_handle f;
     if(assign(f, o)) {
       CGAL_NEF_TRACEN("Found facet ");
-      I.does_intersect_internally(r, f, ip);
+      SNC_intersection::does_intersect_internally(r, f, ip);
       ip = normalized(ip);
       v = C.create_from_facet(f,ip);
       pl->add_vertex(v);

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/PlaneH3.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/PlaneH3.h
@@ -58,6 +58,7 @@ public:
     PlaneH3(const Ray_3&, const Point_3& );
     PlaneH3(const Point_3&, const Direction_3& );
     PlaneH3(const Point_3&, const Vector_3& );
+    PlaneH3(Origin, const Vector_3& );
     PlaneH3(const Point_3&, const Direction_3&, const Direction_3& );
 
     const RT & a() const;
@@ -237,6 +238,17 @@ PlaneH3<R>::PlaneH3(const typename PlaneH3<R>::Point_3& p,
            ov.hy()*p.hw(),
            ov.hz()*p.hw(),
           -(ov.hx()*p.hx() + ov.hy()*p.hy() + ov.hz()*p.hz() ) );
+}
+
+template < class R >
+CGAL_KERNEL_INLINE
+PlaneH3<R>::PlaneH3(Origin,
+                    const typename PlaneH3<R>::Vector_3& ov)
+{
+  new_rep( ov.hx(),
+           ov.hy(),
+           ov.hz(),
+           RT(0) );
 }
 
 template < class R >

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -2047,6 +2047,10 @@ namespace CommonKernelFunctors {
     { return Rep(p, v); }
 
     Rep // Plane_3
+    operator()(Return_base_tag, Origin o, const Vector_3& v) const
+    { return Rep(o, v); }
+
+    Rep // Plane_3
     operator()(Return_base_tag, const Line_3& l, const Point_3& p) const
     { return Rep(l, p); }
 

--- a/Kernel_23/include/CGAL/Plane_3.h
+++ b/Kernel_23/include/CGAL/Plane_3.h
@@ -78,6 +78,9 @@ public:
   Plane_3(const Point_3& p, const Vector_3& v)
     : Rep(typename R::Construct_plane_3()(Return_base_tag(), p, v)) {}
 
+  Plane_3(Origin o, const Vector_3& v)
+    : Rep(typename R::Construct_plane_3()(Return_base_tag(), o, v)) {}
+
   Plane_3(const RT& a, const RT& b, const RT& c, const RT& d)
     : Rep(typename R::Construct_plane_3()(Return_base_tag(), a, b, c, d)) {}
 

--- a/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
@@ -901,9 +901,8 @@ public:
     ++t2;
     if(t2 == segs2.end()) t2=segs2.begin();
 
-    SNC_intersection is;
     Point_3 ip;
-    bool flag=is.does_intersect_internally(Segment_3(*s1,*t1),Segment_3(*s2,*t2),ip);
+    bool flag = SNC_intersection::does_intersect_internally(Segment_3(*s1,*t1),Segment_3(*s2,*t2),ip);
     if(!flag) {
       if(*s1 == *s2) return normalized(*s1);
       else if(*s1 == *t2) return normalized(*s1);

--- a/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
@@ -93,24 +93,35 @@ class SNC_intersection {
   static bool does_intersect_internally(const Ray_3& s1,
                                         const Segment_3& s2,
                                         Point_3& p) {
-    if(!coplanar(s1.source(), s1.point(1), s2.source(), s2.target()))
+    if (!coplanar( s1.source(), s1.point(1), s2.source(), s2.target()))
+      // the segments doesn't define a plane
       return false;
-    if(s1.has_on(s2.source()) || s1.has_on(s2.target()) ||
-       s2.has_on(s1.source()))
+    if ( s1.has_on(s2.source()) || s1.has_on(s2.target()) ||
+         s2.has_on(s1.source()))
+      // the segments does intersect at one endpoint
       return false;
-
+    Line_3 ls1(s1), ls2(s2);
+    if ( ls1.direction() ==  ls2.direction() ||
+         ls1.direction() == -ls2.direction() )
+      // the segments are parallel
+      return false;
     Vector_3 vs1(s1.to_vector()), vs2(s2.to_vector()),
       vt(cross_product( vs1, vs2)),
       ws1(cross_product( vt, vs1));
     Plane_3 hs1( s1.source(), ws1);
-    Object o = intersection(hs1, s2);
-    if(!CGAL::assign( p ,o))
-      return false;
+    Object o = intersection(hs1, ls2);
+    CGAL_assertion(CGAL::assign( p, o));
+    // since line(s1) and line(s2) are not parallel they intersects in only
+    //   one point
+    CGAL::assign( p ,o);
     Plane_3 pl(s1.source(), vs1);
     if(pl.oriented_side(p) != CGAL::POSITIVE)
       return false;
-
-    return true;
+    pl = Plane_3(s2.source(), vs2);
+    if(pl.oriented_side(p) != CGAL::POSITIVE)
+      return false;
+    pl = Plane_3(s2.target(), vs2);
+    return (pl.oriented_side(p) == CGAL::NEGATIVE);
   }
 
   static bool does_intersect_internally(const Ray_3& ray,

--- a/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
@@ -72,12 +72,8 @@ class SNC_intersection : public SNC_const_decorator<SNC_structure_> {
   SNC_intersection() : Base() {}
   SNC_intersection(const SNC_structure& W) : Base(W) {}
 
-  bool does_contain_internally(const Segment_3& s, const Point_3& p) const {
-    if(!are_strictly_ordered_along_line (s.source(), p, s.target()))
-      return false;
-    if(!s.supporting_line().has_on(p))
-      return false;
-    return true;
+  bool does_contain_internally(const Point_3& s, const Point_3& t, const Point_3& p) const {
+    return are_strictly_ordered_along_line (s, p, t);
   }
 
   bool does_contain_internally( Halffacet_const_handle f,

--- a/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
@@ -71,17 +71,17 @@ class SNC_intersection {
     return are_strictly_ordered_along_line (s, p, t);
   }
 
-  static bool does_contain_internally( Halffacet_const_handle f,
-                                const Point_3& p,
-                                bool check_has_on = true) {
+  static bool does_contain_internally(Halffacet_const_handle f,
+                                      const Point_3& p,
+                                      bool check_has_on = true) {
     if(check_has_on && !f->plane().has_on(p))
       return false;
     return (locate_point_in_halffacet( p, f) == CGAL::ON_BOUNDED_SIDE);
   }
 
-  static bool does_intersect_internally( const Segment_3& s1,
-                                  const Segment_3& s2,
-                                  Point_3& p) {
+  static bool does_intersect_internally(const Segment_3& s1,
+                                        const Segment_3& s2,
+                                        Point_3& p) {
     if(s2.has_on(s1.target()))
       return false;
     Ray_3 r(s1.source(), s1.target());
@@ -91,9 +91,9 @@ class SNC_intersection {
     return (pl.oriented_side(p) == CGAL::NEGATIVE);
   }
 
-  static bool does_intersect_internally( const Ray_3& s1,
-                                  const Segment_3& s2,
-                                  Point_3& p) {
+  static bool does_intersect_internally(const Ray_3& s1,
+                                        const Segment_3& s2,
+                                        Point_3& p) {
     CGAL_NEF_TRACEN("does intersect internally without  LINE3_LINE3_INTERSECTION");
     CGAL_assertion(!s1.is_degenerate());
     CGAL_assertion(!s2.is_degenerate());
@@ -129,10 +129,10 @@ class SNC_intersection {
     return (pl.oriented_side(p) == CGAL::NEGATIVE);
   }
 
-  static bool does_intersect_internally( const Ray_3& ray,
-                                  Halffacet_const_handle f,
-                                  Point_3& p,
-                                  bool check_has_on = true) {
+  static bool does_intersect_internally(const Ray_3& ray,
+                                        Halffacet_const_handle f,
+                                        Point_3& p,
+                                        bool check_has_on = true) {
     CGAL_NEF_TRACEN("-> Intersection facet - ray");
     Plane_3 h( f->plane());
     CGAL_NEF_TRACEN("-> facet's plane: " << h);
@@ -152,9 +152,9 @@ class SNC_intersection {
     return does_contain_internally( f, p, false);
   }
 
-  static bool does_intersect_internally( const Segment_3& seg,
-                                  Halffacet_const_handle f,
-                                  Point_3& p) {
+  static bool does_intersect_internally(const Segment_3& seg,
+                                        Halffacet_const_handle f,
+                                        Point_3& p) {
     CGAL_NEF_TRACEN("-> Intersection facet - segment");
     Plane_3 h( f->plane());
     CGAL_NEF_TRACEN("-> facet's plane: " << h);
@@ -168,8 +168,8 @@ class SNC_intersection {
   }
 
   static bool does_intersect(const Segment_3& seg,
-                      Halffacet_const_handle f,
-                      Point_3& p) {
+                             Halffacet_const_handle f,
+                             Point_3& p) {
     Plane_3 h( f->plane());
     Object o = intersection( h, seg);
     if( !CGAL::assign( p, o))
@@ -179,8 +179,8 @@ class SNC_intersection {
     return( does_contain_internally( f, p, false));
   }
 
-  static Bounded_side locate_point_in_halffacet( const Point_3& p,
-                                          Halffacet_const_handle f) {
+  static Bounded_side locate_point_in_halffacet(const Point_3& p,
+                                                Halffacet_const_handle f) {
     CGAL_NEF_TRACEN("locate point in halffacet " << p << ", " << f->plane());
     typedef Project_shalfedge_point
       < SHalfedge, const Point_3> Project;

--- a/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
@@ -81,6 +81,8 @@ class SNC_intersection {
   static bool does_intersect_internally(const Segment_3& s1,
                                         const Segment_3& s2,
                                         Point_3& p) {
+    if(!coplanar(s1.source(), s1.target(), s2.source(), s2.target()))
+      return false;
     if(s1.has_on(s2.source()) || s1.has_on(s2.target()) ||
        s2.has_on(s1.source()) || s2.has_on(s1.target()))
       return false;
@@ -91,6 +93,8 @@ class SNC_intersection {
   static bool does_intersect_internally(const Ray_3& s1,
                                         const Segment_3& s2,
                                         Point_3& p) {
+    if(!coplanar(s1.source(), s1.point(1), s2.source(), s2.target()))
+      return false;
     if(s1.has_on(s2.source()) || s1.has_on(s2.target()) ||
        s2.has_on(s1.source()))
       return false;

--- a/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
@@ -72,9 +72,8 @@ class SNC_intersection {
   }
 
   static bool does_contain_internally(Halffacet_const_handle f,
-                                      const Point_3& p,
-                                      bool check_has_on = true) {
-    if(check_has_on && !f->plane().has_on(p))
+                                      const Point_3& p) {
+    if(!f->plane().has_on(p))
       return false;
     return point_in_facet_interior( p, f);
   }
@@ -101,19 +100,15 @@ class SNC_intersection {
 
   static bool does_intersect_internally(const Ray_3& ray,
                                         Halffacet_const_handle f,
-                                        Point_3& p,
-                                        bool check_has_on = true) {
+                                        Point_3& p) {
     CGAL_NEF_TRACEN("-> Intersection facet - ray");
     Plane_3 h( f->plane());
     CGAL_NEF_TRACEN("-> facet's plane: " << h);
     CGAL_NEF_TRACEN("-> a point on the plane: " << h.point());
     CGAL_NEF_TRACEN("-> ray: " << ray);
     CGAL_assertion(!ray.is_degenerate());
-    if(check_has_on) {
-      if(h.has_on(ray.source()))
-        return false;
-    } else
-      CGAL_assertion(!h.has_on(ray.source()));
+    if(h.has_on(ray.source()))
+      return false;
     Object o = intersection( h, ray);
     if( !CGAL::assign( p, o))
       return false;

--- a/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
@@ -76,7 +76,7 @@ class SNC_intersection {
                                       bool check_has_on = true) {
     if(check_has_on && !f->plane().has_on(p))
       return false;
-    return (locate_point_in_halffacet( p, f) == CGAL::ON_BOUNDED_SIDE);
+    return point_in_facet_interior( p, f);
   }
 
   static bool does_intersect_internally(const Segment_3& s1,
@@ -118,8 +118,8 @@ class SNC_intersection {
     if( !CGAL::assign( p, o))
       return false;
     CGAL_NEF_TRACEN( "-> intersection point: " << p );
-    CGAL_NEF_TRACEN( "-> point in facet interior? "<<does_contain_internally( f, p));
-    return does_contain_internally( f, p, false);
+    CGAL_NEF_TRACEN( "-> point in facet interior? "<<point_in_facet_interior( f, p));
+    return point_in_facet_interior( p, f);
   }
 
   static bool does_intersect_internally(const Segment_3& seg,
@@ -138,11 +138,16 @@ class SNC_intersection {
     if( !CGAL::assign( p, o))
       return false;
     CGAL_NEF_TRACEN( "-> intersection point: " << p );
-    CGAL_NEF_TRACEN( "-> point in facet interior? "<<does_contain_internally( f, p));
-    return( does_contain_internally( f, p, false));
+    CGAL_NEF_TRACEN( "-> point in facet interior? "<<point_in_facet_interior( f, p));
+    return point_in_facet_interior( p, f);
   }
 
  private:
+
+  static bool point_in_facet_interior(const Point_3& p,
+                                      Halffacet_const_handle f) {
+    return (locate_point_in_halffacet( p, f) == CGAL::ON_BOUNDED_SIDE);
+  }
 
   static Bounded_side locate_point_in_halffacet(const Point_3& p,
                                                 Halffacet_const_handle f) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
@@ -132,14 +132,14 @@ class SNC_intersection {
   static bool does_intersect_internally( const Ray_3& ray,
                                   Halffacet_const_handle f,
                                   Point_3& p,
-                                  bool checkHasOn = true) {
+                                  bool check_has_on = true) {
     CGAL_NEF_TRACEN("-> Intersection facet - ray");
     Plane_3 h( f->plane());
     CGAL_NEF_TRACEN("-> facet's plane: " << h);
     CGAL_NEF_TRACEN("-> a point on the plane: " << h.point());
     CGAL_NEF_TRACEN("-> ray: " << ray);
     CGAL_assertion(!ray.is_degenerate());
-    if(checkHasOn) {
+    if(check_has_on) {
       if(h.has_on(ray.source()))
         return false;
     } else

--- a/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
@@ -82,51 +82,21 @@ class SNC_intersection {
   static bool does_intersect_internally(const Segment_3& s1,
                                         const Segment_3& s2,
                                         Point_3& p) {
-    if(s2.has_on(s1.target()))
+    if(s1.has_on(s2.source()) || s1.has_on(s2.target()) ||
+       s2.has_on(s1.source()) || s2.has_on(s1.target()))
       return false;
-    Ray_3 r(s1.source(), s1.target());
-    if(!does_intersect_internally(r, s2, p))
-      return false;
-    Plane_3 pl(s1.target(), r.to_vector());
-    return (pl.oriented_side(p) == CGAL::NEGATIVE);
+    Object o = intersection(s1, s2);
+    return CGAL::assign(p,o);
   }
 
   static bool does_intersect_internally(const Ray_3& s1,
                                         const Segment_3& s2,
                                         Point_3& p) {
-    CGAL_NEF_TRACEN("does intersect internally without  LINE3_LINE3_INTERSECTION");
-    CGAL_assertion(!s1.is_degenerate());
-    CGAL_assertion(!s2.is_degenerate());
-    if ( orientation( s1.source(), s1.point(1), s2.source(), s2.target())
-         != COPLANAR)
-      // the segments doesn't define a plane
+    if(s1.has_on(s2.source()) || s1.has_on(s2.target()) ||
+       s2.has_on(s1.source()))
       return false;
-    if ( s1.has_on(s2.source()) || s1.has_on(s2.target()) ||
-         s2.has_on(s1.source()))
-      // the segments does intersect at one endpoint
-      return false;
-    Line_3 ls1(s1), ls2(s2);
-    if ( ls1.direction() ==  ls2.direction() ||
-         ls1.direction() == -ls2.direction() )
-      // the segments are parallel
-      return false;
-    Vector_3 vs1(s1.to_vector()), vs2(s2.to_vector()),
-      vt(cross_product( vs1, vs2)),
-      ws1(cross_product( vt, vs1)); // , ws2(cross_product( vt, vs2));
-    Plane_3 hs1( s1.source(), ws1);
-    Object o = intersection(hs1, ls2);
-    CGAL_assertion(CGAL::assign( p, o));
-    // since line(s1) and line(s2) are not parallel they intersects in only
-    //   one point
-    CGAL::assign( p ,o);
-    Plane_3 pl(s1.source(), vs1);
-    if(pl.oriented_side(p) != CGAL::POSITIVE)
-      return false;
-    pl = Plane_3(s2.source(), vs2);
-    if(pl.oriented_side(p) != CGAL::POSITIVE)
-      return false;
-    pl = Plane_3(s2.target(), vs2);
-    return (pl.oriented_side(p) == CGAL::NEGATIVE);
+    Object o = intersection(s1, s2);
+    return CGAL::assign(p,o);
   }
 
   static bool does_intersect_internally(const Ray_3& ray,
@@ -178,6 +148,8 @@ class SNC_intersection {
     CGAL_NEF_TRACEN( "-> point in facet interior? "<<does_contain_internally( f, p));
     return( does_contain_internally( f, p, false));
   }
+
+ private:
 
   static Bounded_side locate_point_in_halffacet(const Point_3& p,
                                                 Halffacet_const_handle f) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
@@ -134,13 +134,6 @@ class SNC_intersection {
     if( h.has_on( seg.source()) || h.has_on(seg.target()))
       /* no possible internal intersection */
       return false;
-    return does_intersect(seg, f, p);
-  }
-
-  static bool does_intersect(const Segment_3& seg,
-                             Halffacet_const_handle f,
-                             Point_3& p) {
-    Plane_3 h( f->plane());
     Object o = intersection( h, seg);
     if( !CGAL::assign( p, o))
       return false;

--- a/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
@@ -98,8 +98,19 @@ class SNC_intersection {
     if(s1.has_on(s2.source()) || s1.has_on(s2.target()) ||
        s2.has_on(s1.source()))
       return false;
-    Object o = intersection(s1, s2);
-    return CGAL::assign(p,o);
+
+    Vector_3 vs1(s1.to_vector()), vs2(s2.to_vector()),
+      vt(cross_product( vs1, vs2)),
+      ws1(cross_product( vt, vs1));
+    Plane_3 hs1( s1.source(), ws1);
+    Object o = intersection(hs1, s2);
+    if(!CGAL::assign( p ,o))
+      return false;
+    Plane_3 pl(s1.source(), vs1);
+    if(pl.oriented_side(p) != CGAL::POSITIVE)
+      return false;
+
+    return true;
   }
 
   static bool does_intersect_internally(const Ray_3& ray,

--- a/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_intersection.h
@@ -81,13 +81,13 @@ class SNC_intersection {
   static bool does_intersect_internally(const Segment_3& s1,
                                         const Segment_3& s2,
                                         Point_3& p) {
-    if(!coplanar(s1.source(), s1.target(), s2.source(), s2.target()))
+    if(s2.has_on(s1.target()))
       return false;
-    if(s1.has_on(s2.source()) || s1.has_on(s2.target()) ||
-       s2.has_on(s1.source()) || s2.has_on(s1.target()))
+    Ray_3 r(s1.source(), s1.target());
+    if(!does_intersect_internally(r, s2, p))
       return false;
-    Object o = intersection(s1, s2);
-    return CGAL::assign(p,o);
+    Plane_3 pl(s1.target(), r.to_vector());
+    return (pl.oriented_side(p) == CGAL::NEGATIVE);
   }
 
   static bool does_intersect_internally(const Ray_3& s1,

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -319,7 +319,7 @@ public:
         }
       }
       else if( CGAL::assign( e, *o)) {
-        if ( is.does_contain_internally(Segment_3(e->source()->point(),e->twin()->source()->point()), p) ) {
+        if ( is.does_contain_internally(e->source()->point(), e->twin()->source()->point(), p) ) {
           _CGAL_NEF_TRACEN("found on edge "<<Segment_3(e->source()->point(),e->twin()->source()->point()));
           result = make_object(e);
           found = true;
@@ -417,7 +417,7 @@ public:
         //           (e->source() == v  || e->twin()->source() == v)) continue;
         Segment_3 ss(e->source()->point(),e->twin()->source()->point());
         CGAL_NEF_TRACEN("test edge " << e->source()->point() << "->" << e->twin()->source()->point());
-        if (is.does_contain_internally(ss, p)) {
+        if (is.does_contain_internally(e->source()->point(), e->twin()->source()->point(), p)) {
         _CGAL_NEF_TRACEN("found on edge "<< ss);
           return make_object(e);
         }
@@ -484,8 +484,7 @@ public:
 
       //CGAL_warning("altered code in SNC_point_locator");
       SM_point_locator L(&*v);
-      //      Object_handle so = L.locate(s.source()-s.target(), true);
-      Object_handle so = L.locate(s.source()-s.target());
+      Object_handle so = L.locate(s.source()-s.target(), true);
       SFace_handle sf;
       if(CGAL::assign(sf,so))
         return make_object(sf->volume());

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -272,7 +272,7 @@ public:
           Point_3 q;
           _CGAL_NEF_TRACEN("trying facet with on plane "<<f->plane()<<
                   " with point on "<<f->plane().point());
-          if( is.does_intersect_internally( ray, f, q, true) ) {
+          if( is.does_intersect_internally( ray, f, q) ) {
             _CGAL_NEF_TRACEN("ray intersects facet on "<<q);
             _CGAL_NEF_TRACEN("prev. intersection? "<<hit);
             if( hit) { _CGAL_NEF_TRACEN("prev. intersection on "<<eor); }

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -250,8 +250,8 @@ public:
         else if( CGAL::assign( e, *o) && ((mask&2) != 0)) {
           Point_3 q;
           _CGAL_NEF_TRACEN("trying edge on "<< Segment_3(e->source()->point(),e->twin()->source()->point()));
-          if( is.does_intersect_internally( ray, Segment_3(e->source()->point(),
-                                                           e->twin()->source()->point()), q)) {
+          if( SNC_intersection::does_intersect_internally( ray, Segment_3(e->source()->point(),
+                                                                          e->twin()->source()->point()), q)) {
             _CGAL_NEF_TRACEN("ray intersects edge on "<<q);
             _CGAL_NEF_TRACEN("prev. intersection? "<<hit);
             CGAL_assertion_code
@@ -272,7 +272,7 @@ public:
           Point_3 q;
           _CGAL_NEF_TRACEN("trying facet with on plane "<<f->plane()<<
                   " with point on "<<f->plane().point());
-          if( is.does_intersect_internally( ray, f, q) ) {
+          if( SNC_intersection::does_intersect_internally( ray, f, q) ) {
             _CGAL_NEF_TRACEN("ray intersects facet on "<<q);
             _CGAL_NEF_TRACEN("prev. intersection? "<<hit);
             if( hit) { _CGAL_NEF_TRACEN("prev. intersection on "<<eor); }
@@ -319,14 +319,14 @@ public:
         }
       }
       else if( CGAL::assign( e, *o)) {
-        if ( is.does_contain_internally(e->source()->point(), e->twin()->source()->point(), p) ) {
+        if ( SNC_intersection::does_contain_internally(e->source()->point(), e->twin()->source()->point(), p) ) {
           _CGAL_NEF_TRACEN("found on edge "<<Segment_3(e->source()->point(),e->twin()->source()->point()));
           result = make_object(e);
           found = true;
         }
       }
       else if( CGAL::assign( f, *o)) {
-        if (is.does_contain_internally( f, p) ) {
+        if (SNC_intersection::does_contain_internally( f, p) ) {
           _CGAL_NEF_TRACEN("found on facet...");
           result = make_object(f);
           found = true;
@@ -417,11 +417,11 @@ public:
         //           (e->source() == v  || e->twin()->source() == v)) continue;
         Segment_3 ss(e->source()->point(),e->twin()->source()->point());
         CGAL_NEF_TRACEN("test edge " << e->source()->point() << "->" << e->twin()->source()->point());
-        if (is.does_contain_internally(e->source()->point(), e->twin()->source()->point(), p)) {
+        if (SNC_intersection::does_contain_internally(e->source()->point(), e->twin()->source()->point(), p)) {
         _CGAL_NEF_TRACEN("found on edge "<< ss);
           return make_object(e);
         }
-        if((e->source() != v)  && (e->twin()->source() != v) && is.does_intersect_internally(s, ss, ip)) {
+        if((e->source() != v)  && (e->twin()->source() != v) && SNC_intersection::does_intersect_internally(s, ss, ip)) {
           // first = false;
           s = Segment_3(p, normalized(ip));
           result = make_object(e);
@@ -430,7 +430,7 @@ public:
       } else
       if( CGAL::assign( f, *o)) {
         CGAL_NEF_TRACEN("test facet " << f->plane());
-        if (is.does_contain_internally(f,p) ) {
+        if (SNC_intersection::does_contain_internally(f,p) ) {
           _CGAL_NEF_TRACEN("found on facet...");
           return make_object(f);
         }
@@ -451,7 +451,7 @@ public:
         }
 
 
-        if( (! v_vertex_of_f) &&  is.does_intersect_internally(s,f,ip) ) {
+        if( (! v_vertex_of_f) &&  SNC_intersection::does_intersect_internally(s,f,ip) ) {
           s = Segment_3(p, normalized(ip));
           result = make_object(f);
         }
@@ -463,13 +463,13 @@ public:
     /*
       Halffacet_iterator fc;
       CGAL_forall_facets(fc, *this->sncp()) {
-        CGAL_assertion(!is.does_intersect_internally(s,f,ip));
+        CGAL_assertion(!SNC_intersection::does_intersect_internally(s,f,ip));
       }
 
       Halfedge_iterator ec;
       CGAL_forall_edges(ec, *this->sncp()) {
         Segment_3 ss(ec->source()->point(), ec->twin()->source()->point());
-        CGAL_assertion(!is.does_intersect_internally(s,ss,ip));
+        CGAL_assertion(!SNC_intersection::does_intersect_internally(s,ss,ip));
       }
 
       Vertex_iterator vc;
@@ -497,7 +497,7 @@ public:
       for(;ox!=candidates.end();++ox) {
         if(!CGAL::assign(e,*ox)) continue;
         CGAL_NEF_TRACEN("test edge " << e->source()->point() << "->" << e->twin()->source()->point());
-        if(is.does_intersect_internally(s,Segment_3(e->source()->point(),e->twin()->source()->point()),ip)) {
+        if(SNC_intersection::does_intersect_internally(s,Segment_3(e->source()->point(),e->twin()->source()->point()),ip)) {
           s = Segment_3(p, normalized(ip));
           result = make_object(e);
         }
@@ -553,8 +553,8 @@ public:
 #endif
 
         Point_3 q;
-        if( is.does_intersect_internally( s, Segment_3(e->source()->point(),
-                                                       e->twin()->source()->point()), q)) {
+        if( SNC_intersection::does_intersect_internally( s, Segment_3(e->source()->point(),
+                                                                      e->twin()->source()->point()), q)) {
           q = normalized(q);
           call_back( e0, make_object(Halfedge_handle(e)), q);
           _CGAL_NEF_TRACEN("edge intersects edge "<<' '<<&*e<< Segment_3(e->source()->point(),
@@ -567,7 +567,7 @@ public:
 #endif
 
         Point_3 q;
-        if( is.does_intersect_internally( s, f, q) ) {
+        if( SNC_intersection::does_intersect_internally( s, f, q) ) {
           q = normalized(q);
           call_back( e0, make_object(Halffacet_handle(f)), q);
           _CGAL_NEF_TRACEN("edge intersects facet on plane "<<f->plane()<<" on "<<q);
@@ -602,8 +602,8 @@ public:
 #endif
 
         Point_3 q;
-        if( is.does_intersect_internally( s, Segment_3(e->source()->point(),
-                                                       e->twin()->source()->point()), q)) {
+        if( SNC_intersection::does_intersect_internally( s, Segment_3(e->source()->point(),
+                                                                      e->twin()->source()->point()), q)) {
           q = normalized(q);
           call_back( e0, make_object(Halfedge_handle(e)), q);
           _CGAL_NEF_TRACEN("edge intersects edge "<<' '<<&*e<< Segment_3(e->source()->point(),
@@ -645,7 +645,7 @@ public:
 #endif
 
         Point_3 q;
-        if( is.does_intersect_internally( s, f, q) ) {
+        if( SNC_intersection::does_intersect_internally( s, f, q) ) {
           q = normalized(q);
           call_back( e0, make_object(Halffacet_handle(f)), q);
           _CGAL_NEF_TRACEN("edge intersects facet on plane "<<f->plane()<<" on "<<q);
@@ -707,7 +707,6 @@ public:
 private:
   bool initialized;
   SNC_candidate_provider* candidate_provider;
-  SNC_intersection is;
 };
 
 

--- a/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
+++ b/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
@@ -135,7 +135,7 @@ struct binop_intersection_test_segment_tree {
     Halfedge_iterator e0, e1;
     Halffacet_iterator f0, f1;
     std::vector<Nef_box> a, b;
-    SNC_intersection is( sncp );
+    SNC_intersection is;
 
     CGAL_NEF_TRACEN("start edge0 edge1");
     Bop_edge0_edge1_callback<Callback> callback_edge0_edge1( is, cb0 );

--- a/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
+++ b/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
@@ -39,7 +39,6 @@ struct binop_intersection_test_segment_tree {
 
   template<class Callback>
   struct Bop_edge0_face1_callback {
-    SNC_intersection   &is;
     Callback           &cb;
 
     struct Pair_hash_function {
@@ -57,8 +56,8 @@ struct binop_intersection_test_segment_tree {
       }
     };
 
-    Bop_edge0_face1_callback(SNC_intersection &is, Callback &cb)
-    : is(is), cb(cb)
+    Bop_edge0_face1_callback(Callback &cb)
+    : cb(cb)
     {}
 
     void operator()( Nef_box& box0, Nef_box& box1 ) {
@@ -71,7 +70,7 @@ struct binop_intersection_test_segment_tree {
       if( Infi_box::degree( f1->plane().d() ) > 0 )
         return;
       Point_3 ip;
-      if( is.does_intersect_internally( Const_decorator::segment(e0), f1, ip )) {
+      if( SNC_intersection::does_intersect_internally( Const_decorator::segment(e0), f1, ip )) {
         cb(e0,make_object(f1),ip);
       }
     }
@@ -80,11 +79,10 @@ struct binop_intersection_test_segment_tree {
 
   template<class Callback>
   struct Bop_edge1_face0_callback {
-    SNC_intersection &is;
     Callback         &cb;
 
-    Bop_edge1_face0_callback(SNC_intersection &is, Callback &cb)
-    : is(is), cb(cb)
+    Bop_edge1_face0_callback(Callback &cb)
+    : cb(cb)
     {}
 
     void operator()( Nef_box& box0, Nef_box& box1 ) {
@@ -97,19 +95,18 @@ struct binop_intersection_test_segment_tree {
       if( Infi_box::degree( f0->plane().d() ) > 0 )
         return;
       Point_3 ip;
-      if( is.does_intersect_internally( Const_decorator::segment( e1 ),
-                                        f0, ip ) )
+      if( SNC_intersection::does_intersect_internally( Const_decorator::segment( e1 ),
+                                                       f0, ip ) )
         cb(e1,make_object(f0),ip);
     }
   };
 
   template<class Callback>
   struct Bop_edge0_edge1_callback  {
-    SNC_intersection &is;
     Callback         &cb;
 
-    Bop_edge0_edge1_callback(SNC_intersection &is, Callback &cb)
-    : is(is), cb(cb)
+    Bop_edge0_edge1_callback(Callback &cb)
+    : cb(cb)
     {}
 
     void operator()( Nef_box& box0, Nef_box& box1 ) {
@@ -120,8 +117,8 @@ struct binop_intersection_test_segment_tree {
       Halfedge_iterator e0 = box0.get_halfedge();
       Halfedge_iterator e1 = box1.get_halfedge();
       Point_3 ip;
-      if( is.does_intersect_internally( Const_decorator::segment( e0 ),
-                                        Const_decorator::segment( e1 ), ip ))
+      if( SNC_intersection::does_intersect_internally( Const_decorator::segment( e0 ),
+                                                       Const_decorator::segment( e1 ), ip ))
         cb(e0,make_object(e1),ip);
     }
   };
@@ -135,10 +132,9 @@ struct binop_intersection_test_segment_tree {
     Halfedge_iterator e0, e1;
     Halffacet_iterator f0, f1;
     std::vector<Nef_box> a, b;
-    SNC_intersection is;
 
     CGAL_NEF_TRACEN("start edge0 edge1");
-    Bop_edge0_edge1_callback<Callback> callback_edge0_edge1( is, cb0 );
+    Bop_edge0_edge1_callback<Callback> callback_edge0_edge1( cb0 );
     CGAL_forall_edges( e0, sncp)  a.push_back( Nef_box( e0 ) );
     CGAL_forall_edges( e1, snc1i) b.push_back( Nef_box( e1 ) );
 #ifdef CGAL_NEF3_BOX_INTERSECTION_CUTOFF
@@ -153,7 +149,7 @@ struct binop_intersection_test_segment_tree {
     b.clear();
 
     CGAL_NEF_TRACEN("start edge0 face1");
-    Bop_edge0_face1_callback<Callback> callback_edge0_face1( is, cb0 );
+    Bop_edge0_face1_callback<Callback> callback_edge0_face1( cb0 );
     CGAL_forall_edges( e0, sncp ) a.push_back( Nef_box( e0 ) );
     CGAL_forall_facets( f1, snc1i)    b.push_back( Nef_box( f1 ) );
 #ifdef CGAL_NEF3_BOX_INTERSECTION_CUTOFF
@@ -168,7 +164,7 @@ struct binop_intersection_test_segment_tree {
     b.clear();
 
     CGAL_NEF_TRACEN("start edge1 face0");
-    Bop_edge1_face0_callback<Callback> callback_edge1_face0( is, cb1 );
+    Bop_edge1_face0_callback<Callback> callback_edge1_face0( cb1 );
     CGAL_forall_edges( e1, snc1i)  a.push_back( Nef_box( e1 ) );
     CGAL_forall_facets( f0, sncp ) b.push_back( Nef_box( f0 ) );
 #ifdef CGAL_NEF3_BOX_INTERSECTION_CUTOFF

--- a/Nef_3/test/Nef_3/include/CGAL/test_Nef_3.h
+++ b/Nef_3/test/Nef_3/include/CGAL/test_Nef_3.h
@@ -499,112 +499,111 @@ private:
 
     if(Infi_box::standard_kernel()) {
       Nef_polyhedron N = load_nef3("star.nef3.SH");
-      SNC_intersection is;
 
       Point_3 p;
 
-      assert(!is.does_contain_internally(
+      assert(!SNC_intersection::does_contain_internally(
                             Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(0,0,0)));
-      assert(!is.does_contain_internally(
+      assert(!SNC_intersection::does_contain_internally(
                             Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(2,0,0)));
-      assert(!is.does_contain_internally(
+      assert(!SNC_intersection::does_contain_internally(
                             Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(3,0,0)));
-      assert(!is.does_contain_internally(
+      assert(!SNC_intersection::does_contain_internally(
                             Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(-1,0,0)));
-      assert(!is.does_contain_internally(
+      assert(!SNC_intersection::does_contain_internally(
                             Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(1,1,0)));
-      assert(!is.does_contain_internally(
+      assert(!SNC_intersection::does_contain_internally(
                             Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(7,25,11)));
-      assert(is.does_contain_internally(
+      assert(SNC_intersection::does_contain_internally(
                            Point_3(0,0,0), Point_3(2,0,0),
                            Point_3(1,0,0)));
 
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,-1,0)),
                                   Segment_3(Point_3(0,0,0), Point_3(-1,0,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,-1,0)),
                                   Segment_3(Point_3(1,0,0), Point_3(0,0,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,-1,1)),
                                   Segment_3(Point_3(1,0,0), Point_3(-1,0,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,-1,0)),
                                   Segment_3(Point_3(0,2,0), Point_3(0,0,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,-1,0)),
                                   Segment_3(Point_3(0,3,0), Point_3(0,1,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,-1,0)),
                                   Segment_3(Point_3(0,4,0), Point_3(0,2,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,-1,0)),
                                   Segment_3(Point_3(1,5,0), Point_3(1,7,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,-1,0)),
                                   Segment_3(Point_3(1,7,0), Point_3(1,5,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,-1,0)),
                                   Segment_3(Point_3(3,0,0), Point_3(1,0,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,-1,0)),
                                   Segment_3(Point_3(1,0,0), Point_3(3,0,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,3,0), Point_3(0,1,0)),
                                   Segment_3(Point_3(1,0,0), Point_3(-1,0,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,3,0)),
                                   Segment_3(Point_3(1,0,0), Point_3(-1,0,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,3,0), Point_3(0,1,0)),
                                   Segment_3(Point_3(1,0,0), Point_3(3,0,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,3,0)),
                                   Segment_3(Point_3(1,0,0), Point_3(3,0,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,3,0), Point_3(0,1,0)),
                                   Segment_3(Point_3(3,0,0), Point_3(1,0,0)), p));
-      assert(!is.does_intersect_internally(
+      assert(!SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,3,0)),
                                   Segment_3(Point_3(3,0,0), Point_3(1,0,0)), p));
-      assert(is.does_intersect_internally(
+      assert(SNC_intersection::does_intersect_internally(
                            Segment_3(Point_3(0,1,0), Point_3(0,-1,0)),
                                   Segment_3(Point_3(1,0,0), Point_3(-1,0,0)), p));
       assert(p == Point_3(0,0,0));
 
       Halffacet_const_iterator hf;
 
-      assert(!is.does_contain_internally(
+      assert(!SNC_intersection::does_contain_internally(
                             N.halffacets_begin(), Point_3(0,0,0)));
       CGAL_forall_halffacets(hf, N)
-        assert(!is.does_intersect_internally(
+        assert(!SNC_intersection::does_intersect_internally(
                             Segment_3(Point_3(-31,15,0),Point_3(-31,15,1)),hf,p));
       CGAL_forall_halffacets(hf, N)
-        assert(!is.does_intersect_internally(
+        assert(!SNC_intersection::does_intersect_internally(
                             Segment_3(Point_3(-31,15,-1),Point_3(-31,15,0)),hf,p));
       CGAL_forall_halffacets(hf, N)
-        assert(!is.does_intersect_internally(
+        assert(!SNC_intersection::does_intersect_internally(
                             Segment_3(Point_3(-31,15,0),Point_3(-30,15,0)),hf,p));
       CGAL_forall_halffacets(hf, N)
-        assert(!is.does_intersect_internally(
+        assert(!SNC_intersection::does_intersect_internally(
                             Segment_3(Point_3(-32,15,-1),Point_3(-32,15,0)),hf,p));
       CGAL_forall_halffacets(hf, N)
-        assert(!is.does_intersect_internally(
+        assert(!SNC_intersection::does_intersect_internally(
                             Segment_3(Point_3(-16,8,-1),Point_3(-16,8,0)),hf,p));
       CGAL_forall_halffacets(hf, N)
-        assert(!is.does_intersect_internally(
+        assert(!SNC_intersection::does_intersect_internally(
                             Segment_3(Point_3(0,0,-1),Point_3(0,0,1)),hf,p));
 
       int i=0;
       CGAL_forall_halffacets(hf, N) {
         bool b = (i == 13 || i == 15);
-        assert( b == is.does_intersect_internally(
+        assert( b == SNC_intersection::does_intersect_internally(
                                   Segment_3(Point_3(-31,15,-1),Point_3(-31,15,1)),
                                   hf, p));
         if(b) assert(p == Point_3(-31,15,0));
@@ -614,7 +613,7 @@ private:
       i=0;
       CGAL_forall_halffacets(hf, N) {
         bool b = (i == 14 || i == 16);
-        assert( b == is.does_intersect_internally(
+        assert( b == SNC_intersection::does_intersect_internally(
                                    Segment_3(Point_3(-15,7,-1), Point_3(-15,7,1)),
                                    hf, p));
         if(b) assert(p == Point_3(-15,7,0));

--- a/Nef_3/test/Nef_3/include/CGAL/test_Nef_3.h
+++ b/Nef_3/test/Nef_3/include/CGAL/test_Nef_3.h
@@ -504,25 +504,25 @@ private:
       Point_3 p;
 
       assert(!is.does_contain_internally(
-                            Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                            Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(0,0,0)));
       assert(!is.does_contain_internally(
-                            Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                            Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(2,0,0)));
       assert(!is.does_contain_internally(
-                            Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                            Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(3,0,0)));
       assert(!is.does_contain_internally(
-                            Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                            Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(-1,0,0)));
       assert(!is.does_contain_internally(
-                            Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                            Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(1,1,0)));
       assert(!is.does_contain_internally(
-                            Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                            Point_3(0,0,0), Point_3(2,0,0),
                             Point_3(7,25,11)));
       assert(is.does_contain_internally(
-                           Segment_3(Point_3(0,0,0), Point_3(2,0,0)),
+                           Point_3(0,0,0), Point_3(2,0,0),
                            Point_3(1,0,0)));
 
       assert(!is.does_intersect_internally(

--- a/Nef_3/test/Nef_3/include/CGAL/test_Nef_3.h
+++ b/Nef_3/test/Nef_3/include/CGAL/test_Nef_3.h
@@ -499,7 +499,7 @@ private:
 
     if(Infi_box::standard_kernel()) {
       Nef_polyhedron N = load_nef3("star.nef3.SH");
-      SNC_intersection is(*N.sncp());
+      SNC_intersection is;
 
       Point_3 p;
 

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_segment.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_segment.h
@@ -43,7 +43,7 @@ Sphere_segment_rep(const Point& p1, const Point& p2,
   CGAL_warning(p1 != p2.antipode());
   CGAL_assertion(p1 != p2.antipode());
   if ( p1 == p2 ) {
-    Plane_3 h(Point_3(CGAL::ORIGIN),(p1-CGAL::ORIGIN));
+    Plane_3 h(CGAL::ORIGIN, (p1-CGAL::ORIGIN));
     c_ = Sphere_circle<R_>(Plane_3(Point_3(CGAL::ORIGIN),h.base1()));
   }
   if (!shorter_arc) c_ = c_.opposite();


### PR DESCRIPTION
## Summary of Changes

After looking at #6422 I noticed that all of SNC_intersection.h is static methods. So it doesn't need to inherit from SNC_decorator, nor need a constructor. In fact it could just be a namespace. However the rest of the code passes instances of it around so the methods can just be made static for now. Warnings about calling a static method on a variable had to be resolved, and removed some methods are not used (which I confirmed by grepping in case the calls are hidden in an #ifdef )

A performance tweak is under consideration to simplify the overcomplicated code, used for segment-segment, and segment-ray intersections

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): cleaning
* License and copyright ownership: Returned to CGAL authors.

