### PR TITLE
Kernel_23: Call function objects from CGAL::Segment_3

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Direction_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Direction_3.h
@@ -52,10 +52,10 @@ public:
   { *this = l.rep().direction(); }
 
   explicit DirectionC3(const Ray_3 &r)
-  { *this = r.direction(); }
+  { *this = r.rep().direction(); }
 
   explicit DirectionC3(const Segment_3 &s)
-  { *this = s.direction(); }
+  { *this = s.rep().direction(); }
 
   DirectionC3(const FT &x, const FT &y, const FT &z)
     : base(CGAL::make_array(x, y, z)) {}

--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -3988,7 +3988,7 @@ namespace CartesianKernelFunctors {
 
     result_type
     operator()( const Segment_3& s, const Point_3& p) const
-    { return s.has_on(p); }
+    { return s.rep().has_on(p); }
 
     result_type
     operator()( const Plane_3& pl, const Point_3& p) const

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/DirectionH3.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/DirectionH3.h
@@ -49,16 +49,16 @@ public:
     //: base(p) {}
 
   DirectionH3(const Vector_3 & v )
-  { *this = v.direction(); }
+  { *this = v.rep().direction(); }
 
   DirectionH3(const Line_3 & l )
   { *this = l.rep().direction(); }
 
   DirectionH3(const Ray_3 & r )
-  { *this = r.direction(); }
+  { *this = r.rep().direction(); }
 
   DirectionH3(const Segment_3 & s )
-  { *this = s.direction(); }
+  { *this = s.rep().direction(); }
 
   // the fourth argument is not documented.  Should go away ?
   DirectionH3(const RT& x, const RT& y,

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
@@ -4090,7 +4090,7 @@ namespace HomogeneousKernelFunctors {
 
     result_type
     operator()( const Segment_3& s, const Point_3& p) const
-    { return s.has_on(p); }
+    { return s.rep().has_on(p); }
 
     result_type
     operator()( const Plane_3& pl, const Point_3& p) const

--- a/Kernel_23/include/CGAL/Segment_3.h
+++ b/Kernel_23/include/CGAL/Segment_3.h
@@ -136,10 +136,8 @@ public:
   }
 
   bool has_on(const Point_3 &p) const
-  { // TODO : use one predicate.
-    return R_().are_ordered_along_line_3_object()(source(),
-                                                 p,
-                                                 target());
+  {
+    return R().has_on_3_object()(*this, p);
   }
 
   Segment_3 opposite() const
@@ -149,8 +147,7 @@ public:
 
   Direction_3 direction() const
   {
-    typename R::Construct_vector_3 construct_vector;
-    return Direction_3( construct_vector( source(), target()));
+    return R().construct_direction_3_object()(*this);
   }
 
   bool is_degenerate() const


### PR DESCRIPTION
## Summary of Changes

Member functions like `CGAL::Segment_3<K>::has_on(CGAL::Point_3<K>)` must call the corresponding functor.

This should accelerate the Nef_polyhedron_3 a little bit as there we write  `seg.has_on(p)`  instread of `K().has_on_3_object()(seg,p)`.  To change that in Nef is an orthogonal task.  


## Release Management

* Affected package(s): Kernel_23, Nef_3

