### PR TITLE
Nef_3:  Avoid Filter Failures

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -914,7 +914,7 @@ public:
     number_of_ray_shooting_queries++;
     timer_ray_shooting.start();
 #endif
-    Object_handle o = pl->shoot(ray);
+    Object_handle o = pl->shoot(ray, vi);
 #ifdef CGAL_NEF3_TIMER_POINT_LOCATION
     timer_ray_shooting.stop();
 #endif

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -234,7 +234,7 @@ public:
       CGAL_for_each( o, candidates) {
         if( CGAL::assign( v, *o) && ((mask&1) != 0)) {
           _CGAL_NEF_TRACEN("trying vertex on "<<v->point());
-          if( ray.source() != v->point() && ray.has_on(v->point())) {
+          if( (ray_source_vertex != v) && (ray.source() != v->point()) && ray.has_on(v->point())) {
             _CGAL_NEF_TRACEN("the ray intersects the vertex");
             _CGAL_NEF_TRACEN("prev. intersection? "<<hit);
             CGAL_assertion_code


### PR DESCRIPTION
## Summary of Changes

Check if the vertex of the ray is a vertex of an edge instead of comparing their points.

There are more filter failures that merit a closer look

## Release Management

* Affected package(s): Nef_3


