### PR TITLE
Nef_3: Cleanup Halffacet_triangle_handle/Halffacet_triangle_const_handle

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SNC_decorator_traits.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_decorator_traits.h
@@ -37,9 +37,6 @@ class SNC_decorator_traits : public CGAL::SM_decorator_traits<Refs_> {
   typedef typename Refs::SHalfloop_handle SHalfloop_handle;
   typedef typename Refs::SFace_handle SFace_handle;
 
-  typedef typename Refs::Halffacet_triangle_handle
-    Halffacet_triangle_handle;
-
   typedef typename Refs::Vertex_iterator Vertex_iterator;
   typedef typename Refs::Halfedge_iterator Halfedge_iterator;
   typedef typename Refs::Halffacet_iterator Halffacet_iterator;
@@ -75,9 +72,6 @@ class SNC_decorator_const_traits {
   typedef typename Refs::SHalfedge_const_handle SHalfedge_handle;
   typedef typename Refs::SHalfloop_const_handle SHalfloop_handle;
   typedef typename Refs::SFace_const_handle SFace_handle;
-
-  typedef typename Refs::Halffacet_triangle_const_handle
-    Halffacet_triangle_handle;
 
   typedef typename Refs::Vertex_const_iterator Vertex_iterator;
   typedef typename Refs::Halfedge_const_iterator Halfedge_iterator;

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -224,6 +224,21 @@ public:
   // Halffacet triangle
 
 #ifdef CGAL_NEF_LIST_OF_TRIANGLES
+  class Halffacet_triangle_const_handle : public Halffacet_const_handle {
+    typedef Halffacet_const_handle Base;
+    Triangle_3* triangle;
+  public:
+    Halffacet_triangle_const_handle() : Base() {}
+    Halffacet_triangle_const_handle( Halffacet_const_handle h, Triangle_3& t) :
+      Base(h), triangle(&t) {}
+    Triangle_3& get_triangle() { return *triangle; }
+    void transform(const Aff_transformation_3& t) {
+      *triangle = Triangle_3((*triangle)[0].transform(t),
+                                  (*triangle)[1].transform(t),
+                              (*triangle)[2].transform(t));
+    }
+  };
+
   class Halffacet_triangle_handle : public Halffacet_handle {
     typedef Halffacet_handle Base;
     Triangle_3* triangle;

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -223,37 +223,6 @@ public:
 
   // Halffacet triangle
 
-#ifdef CGAL_NEF_LIST_OF_TRIANGLES
-  class Halffacet_triangle_const_handle : public Halffacet_const_handle {
-    typedef Halffacet_const_handle Base;
-    Triangle_3* triangle;
-  public:
-    Halffacet_triangle_const_handle() : Base() {}
-    Halffacet_triangle_const_handle( Halffacet_const_handle h, Triangle_3& t) :
-      Base(h), triangle(&t) {}
-    Triangle_3& get_triangle() { return *triangle; }
-    void transform(const Aff_transformation_3& t) {
-      *triangle = Triangle_3((*triangle)[0].transform(t),
-                                  (*triangle)[1].transform(t),
-                              (*triangle)[2].transform(t));
-    }
-  };
-
-  class Halffacet_triangle_handle : public Halffacet_handle {
-    typedef Halffacet_handle Base;
-    Triangle_3* triangle;
-  public:
-    Halffacet_triangle_handle() : Base() {}
-    Halffacet_triangle_handle( Halffacet_handle h, Triangle_3& t) :
-      Base(h), triangle(&t) {}
-    Triangle_3& get_triangle() { return *triangle; }
-    void transform(const Aff_transformation_3& t) {
-      *triangle = Triangle_3((*triangle)[0].transform(t),
-                                  (*triangle)[1].transform(t),
-                              (*triangle)[2].transform(t));
-    }
-  };
-#else
   class Halffacet_triangle_const_handle : public Halffacet_const_handle {
     typedef Halffacet_const_handle Base;
     Triangle_3 triangle;
@@ -283,7 +252,6 @@ public:
                               triangle[2].transform(t));
     }
   };
-#endif
 
   class Halffacet_cycle_iterator : public Object_iterator
   /*{\Mtypemember a generic handle to an object in the boundary

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -221,38 +221,6 @@ public:
   typedef Vertex_handle Constructor_parameter;
   typedef Vertex_const_handle Constructor_const_parameter;
 
-  // Halffacet triangle
-
-  class Halffacet_triangle_const_handle : public Halffacet_const_handle {
-    typedef Halffacet_const_handle Base;
-    Triangle_3 triangle;
-  public:
-    Halffacet_triangle_const_handle() : Base() {}
-    Halffacet_triangle_const_handle( Halffacet_const_handle h, Triangle_3& t) :
-      Base(h), triangle(t) {}
-    Triangle_3 get_triangle() { return triangle; }
-    void transform(const Aff_transformation_3& t) {
-      triangle = Triangle_3(triangle[0].transform(t),
-                                  triangle[1].transform(t),
-                              triangle[2].transform(t));
-    }
-  };
-
-  class Halffacet_triangle_handle : public Halffacet_handle {
-    typedef Halffacet_handle Base;
-    Triangle_3 triangle;
-  public:
-    Halffacet_triangle_handle() : Base() {}
-    Halffacet_triangle_handle( Halffacet_handle h, Triangle_3& t) :
-      Base(h), triangle(t) {}
-    Triangle_3 get_triangle() { return triangle; }
-    void transform(const Aff_transformation_3& t) {
-      triangle = Triangle_3(triangle[0].transform(t),
-                                  triangle[1].transform(t),
-                              triangle[2].transform(t));
-    }
-  };
-
   class Halffacet_cycle_iterator : public Object_iterator
   /*{\Mtypemember a generic handle to an object in the boundary
   of a facet. Convertible to |Object_handle|.}*/


### PR DESCRIPTION
## Summary of Changes

The code doesn't seem to be used or referenced anywhere except as typedefs.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): cleaning
* License and copyright ownership: Returned to CGAL authors

