### PR TITLE
PMP repair: Avoid large DAG when using Lazy

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -262,9 +262,6 @@ std::size_t remove_connected_components_of_negligible_size(TriangleMesh& tmesh,
         cc_closeness[face_cc[face(opposite(h, tmesh), tmesh)]] = false;
     }
 
-    typename GT::Compute_volume_3 cv3 = traits.compute_volume_3_object();
-    Point_3 origin(0, 0, 0);
-
     FT total_volume = 0;
     CGAL::Face_filtered_graph<TriangleMesh> fcc(tmesh);
     for (std::size_t i=0; i<num; ++i)

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -272,8 +272,8 @@ std::size_t remove_connected_components_of_negligible_size(TriangleMesh& tmesh,
       if (cc_closeness[i])
       {
         fcc.set_selected_faces(i, face_cc);
-        component_volumes[i] = volume(fcc);
-        total_volume += CGAL::abs(component_volumes[i]);
+        component_volumes[i] = CGAL::abs(volume(fcc));
+        total_volume += component_volumes[i];
       }
     }
 


### PR DESCRIPTION
Avoid issues with EPECK