### PR TITLE
Mesh_3: correcting gforge address

### DIFF
--- a/Mesh_3/doc/Mesh_3/CGAL/Image_3.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Image_3.h
@@ -4,7 +4,7 @@ namespace CGAL {
 \ingroup PkgMesh3Domains
 
 The class `Image_3` is a C++ wrapper around the <a
-href="http://inrimage.gforge.inria.fr/">InrImage library</a>. It holds a
+href="https://www-pequan.lip6.fr/~bereziat/inrimage/">InrImage library</a>. It holds a
 shared pointer to a 3D image buffer.
 
 */

--- a/Mesh_3/doc/Mesh_3/Mesh_3.txt
+++ b/Mesh_3/doc/Mesh_3/Mesh_3.txt
@@ -714,7 +714,7 @@ where each subdomain corresponds to a specific tissue.
 
 In the following example, the image is read from the file
 `liver.inr.gz` which is encoded in the format of the library Inrimage
-`http://inrimage.gforge.inria.fr/`.
+`https://www-pequan.lip6.fr/~bereziat/inrimage/`.
 The resulting mesh is shown in \cgalFigureRef{figureliver_3d_image_mesh}.
 
 \cgalExample{Mesh_3/mesh_3D_image.cpp}


### PR DESCRIPTION
Replacing the address http://inrimage.gforge.inria.fr/ by https://www-pequan.lip6.fr/~bereziat/inrimage/ as Forge is definitively shutdown.