### PR TITLE
Tetrahedral remeshing - avoid useless dumps

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -272,6 +272,8 @@ void tetrahedral_isotropic_remeshing(
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
   std::cout << "done." << std::endl;
+#endif
+#ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
   Tetrahedral_remeshing::internal::compute_statistics(
     remesher.tr(), cell_select, "statistics_begin.txt");
 #endif
@@ -280,7 +282,7 @@ void tetrahedral_isotropic_remeshing(
   std::size_t nb_extra_iterations = 3;
   remesher.remesh(max_it, nb_extra_iterations);
 
-#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
+#ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
   const double angle_bound = 5.0;
   Tetrahedral_remeshing::debug::dump_cells_with_small_dihedral_angle(tr,
     angle_bound, cell_select, "bad_cells.mesh");


### PR DESCRIPTION
## Summary of Changes

Protect the dump of statistics and bad cells with the _DEBUG macro instead of the _VERBOSE macro (which is used in the demo)

## Release Management

* Affected package(s): Tetrahedral remeshing
