### PR TITLE
Mesh_3::generate_label_weights - add documentation group

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/generate_label_weights.h
+++ b/Mesh_3/include/CGAL/Mesh_3/generate_label_weights.h
@@ -227,6 +227,7 @@ CGAL::Image_3 generate_label_weights_with_known_word_type(const CGAL::Image_3& i
 /// @endcond
 
 /*!
+* \ingroup PkgMesh3Functions
 * Free function that generates a `CGAL::Image_3` of weights associated to each
 * voxel of `image`, to make the output mesh surfaces smoother.
 * The weights image is generated using the algorithm described by Stalling et al


### PR DESCRIPTION
## Summary of Changes

The function did not appear in the functions list of the documentation. Now it does!

## Release Management

* Affected package(s): Mesh_3 doc
