### PR TITLE
Stream_support: Make line a data member and call clear()

### DIFF
--- a/Stream_support/include/CGAL/IO/OFF/File_scanner_OFF.h
+++ b/Stream_support/include/CGAL/IO/OFF/File_scanner_OFF.h
@@ -37,6 +37,7 @@ class File_scanner_OFF
   std::vector<double> entries;
   std::size_t color_entries;
   std::size_t first_color_index;
+  std::string line;
   std::istream& m_in;
   bool normals_read;
 
@@ -78,7 +79,7 @@ public:
     else
     {
       skip_comment();
-      std::string line;
+      line.clear();
       std::getline(m_in, line);
       // First remove the comment if there is one
       std::size_t pos = line.find('#');
@@ -692,7 +693,7 @@ public:
     else
     {
       skip_comment();
-      std::string line;
+      line.clear();
       std::getline(m_in, line);
       // First remove the comment if there is one
       std::size_t pos = line.find('#');


### PR DESCRIPTION
## Summary of Changes

Instead of creating again and again an empty string for a call to   `getline()` we turn the local variable `line` into a data member and call `std::string::clear()`. 

This PR does it for reading OFF files, but it might apply to other readers as well,
It would be good if somebody else could confirm that there is a (small) performance gain.

## Release Management

* Affected package(s): Stream_support

