### PR TITLE
PMP:  Avoid link in documentation with a %

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
@@ -38,7 +38,7 @@ namespace Polygon_mesh_processing {
 namespace Corefinement
 {
 /** \ingroup PMP_corefinement_grp
- *  Default new-face visitor model of `PMPCorefinementVisitor`.
+ *  %Default new-face visitor model of `PMPCorefinementVisitor`.
  *  All of its functions have an empty body. This class can be used as a
  *  base class if only some of the functions of the concept require to be
  *  overridden.


### PR DESCRIPTION

Put a` %` so that we don't get a link for the word _Default_  [here](https://doc.cgal.org/latest/Polygon_mesh_processing/structCGAL_1_1Polygon__mesh__processing_1_1Corefinement_1_1Default__visitor.html).