### PR TITLE
Fast Box Intersection:  Add progress tracking

### DIFF
--- a/Box_intersection_d/doc/Box_intersection_d/examples.txt
+++ b/Box_intersection_d/doc/Box_intersection_d/examples.txt
@@ -2,6 +2,7 @@
 \example Box_intersection_d/box_grid.cpp
 \example Box_intersection_d/custom_box_grid.cpp
 \example Box_intersection_d/minimal.cpp
+\example Box_intersection_d/progress.cpp
 \example Box_intersection_d/minimal_self.cpp
 \example Box_intersection_d/proximity_custom_box_traits.cpp
 \example Box_intersection_d/triangle_self_intersect.cpp

--- a/Box_intersection_d/examples/Box_intersection_d/progress.cpp
+++ b/Box_intersection_d/examples/Box_intersection_d/progress.cpp
@@ -1,0 +1,101 @@
+#include <CGAL/box_intersection_d.h>
+#include <CGAL/Bbox_2.h>
+#include <CGAL/Timer.h>
+#include <iostream>
+#include<cstdlib>
+
+typedef CGAL::Box_intersection_d::Box_d<double,2> Box;
+typedef CGAL::Bbox_2                              Bbox;
+
+
+void fill(std::vector<Box>& b, int xbl, int ybl, int n)
+{
+  b.reserve(n * n);
+  n = 2 * n;
+  for(int i = 0; i < n; i += 2){
+    for(int j = 0; j < n; j += 2){
+      b.push_back(Bbox(xbl + i, ybl + j,
+                       xbl + i + 2, ybl + j + 2));
+    }
+  }
+}
+
+
+struct Callback_rep{
+
+  Callback_rep(double normalize)
+    : normalize(normalize)
+  {
+    t.start();
+  }
+
+  void progress(double d)
+   {
+    d /= normalize;
+    total += d;
+    if(total > bound){
+      std::cout << std::setprecision(3) << total*100 << " %   in " << std::setprecision(5) << t.time() << " sec." << std::endl;
+      bound += 0.1;
+    }
+  }
+
+  double normalize;
+  double bound = 0.1;
+  double total = 0;
+  int count = 0;
+  CGAL::Timer t;
+};
+
+struct Callback {
+
+  std::shared_ptr<Callback_rep> sptr;
+
+  Callback(double normalize = 1.0)
+    : sptr(std::make_shared<Callback_rep>(normalize))
+  {}
+
+
+  void operator()( const Box& a, const Box& b ) {
+    ++(sptr->count);
+    // std::cout << "box " << a.id() << " intersects box " << b.id() << std::endl;
+  }
+
+
+  bool report(int dim)
+  {
+    return (dim == Box::dimension() - 1);
+  }
+
+
+  void progress(double d)
+  {
+    sptr->progress(d);
+  }
+
+  int count() const
+  {
+      return sptr->count;
+  }
+
+};
+
+int main(int argc, char* argv[]) {
+
+  int n = (argc>1)?std::atoi(argv[1]): 100;
+  int blx = (argc>2)?std::atoi(argv[2]): 1;
+  int bly = (argc>2)?std::atoi(argv[3]): 1;
+
+  std::vector<Box> boxes, queries;
+  fill(boxes, 0, 0, n);
+  fill(queries, blx, bly, n);
+
+  std::ptrdiff_t cutoff = 1;
+
+  Callback callback(2.);  // because we call segment_tree twice
+
+  CGAL::box_intersection_d( boxes.begin(), boxes.end(), queries.begin(), queries.end(), callback);
+
+  std::cout << callback.count() << " callback" << std::endl;
+
+  return 0;
+}

--- a/Box_intersection_d/examples/Box_intersection_d/progress.cpp
+++ b/Box_intersection_d/examples/Box_intersection_d/progress.cpp
@@ -57,7 +57,7 @@ struct Callback {
 
   void operator()( const Box& a, const Box& b ) {
     ++(sptr->count);
-    // std::cout << "box " << a.id() << " intersects box " << b.id() << std::endl;
+    std::cout << "box " << a.id() << " intersects box " << b.id() << std::endl;
   }
 
 
@@ -81,15 +81,13 @@ struct Callback {
 
 int main(int argc, char* argv[]) {
 
-  int n = (argc>1)?std::atoi(argv[1]): 100;
+  int n = (argc>1)?std::atoi(argv[1]): 5;
   int blx = (argc>2)?std::atoi(argv[2]): 1;
   int bly = (argc>2)?std::atoi(argv[3]): 1;
 
   std::vector<Box> boxes, queries;
   fill(boxes, 0, 0, n);
   fill(queries, blx, bly, n);
-
-  std::ptrdiff_t cutoff = 1;
 
   Callback callback(2.);  // because we call segment_tree twice
 

--- a/Box_intersection_d/include/CGAL/Box_intersection_d/segment_tree.h
+++ b/Box_intersection_d/include/CGAL/Box_intersection_d/segment_tree.h
@@ -325,9 +325,12 @@ public:
   static const bool value = (sizeof(f<T>(0)) == sizeof(char));
 };
 
+template <class T>
+CGAL_CPP17_INLINE constexpr bool Has_member_report_v = Has_member_report<T>::value;
+
 template <typename Callback>
 inline
-std::enable_if_t<Has_member_report<Callback>::value, bool>
+std::enable_if_t<Has_member_report_v<Callback>, bool>
 report_impl(Callback callback, int dim)
 {
   return callback.report(dim);
@@ -335,7 +338,7 @@ report_impl(Callback callback, int dim)
 
 template <typename Callback>
 inline
-std::enable_if_t<!Has_member_report<Callback>::value, bool>
+std::enable_if_t<!Has_member_report_v<Callback>, bool>
 report_impl(const Callback&, int)
 {
   return false;
@@ -343,7 +346,7 @@ report_impl(const Callback&, int)
 
 template <typename Callback>
 inline
-std::enable_if_t<Has_member_report<Callback>::value, void>
+std::enable_if_t<Has_member_report_v<Callback>, void>
 progress_impl(Callback callback, double d)
 {
   callback.progress(d);
@@ -351,7 +354,7 @@ progress_impl(Callback callback, double d)
 
 template <typename Callback>
 inline
-std::enable_if_t<!Has_member_report<Callback>::value, void>
+std::enable_if_t<!Has_member_report_v<Callback>, void>
 progress_impl(const Callback&, double)
 {}
 

--- a/Box_intersection_d/include/CGAL/Box_intersection_d/segment_tree.h
+++ b/Box_intersection_d/include/CGAL/Box_intersection_d/segment_tree.h
@@ -317,7 +317,7 @@ private:
   class check {};
 
   template<class C>
-  static char f(check<bool(C::*)(int), &C::report>*);
+  static auto f(int) -> decltype(std::declval<C>().report(0) == true, char());
 
   template<class C>
   static int f(...);

--- a/Box_intersection_d/include/CGAL/Box_intersection_d/segment_tree.h
+++ b/Box_intersection_d/include/CGAL/Box_intersection_d/segment_tree.h
@@ -308,6 +308,56 @@ void dump_box_numbers( ForwardIter begin, ForwardIter end, Traits /* traits */ )
     std::cout << std::endl;
 }
 
+
+template<class T>
+class Has_member_report
+{
+private:
+  template<class U, U>
+  class check {};
+
+  template<class C>
+  static char f(check<bool(C::*)(int), &C::report>*);
+
+  template<class C>
+  static int f(...);
+public:
+  static const bool value = (sizeof(f<T>(0)) == sizeof(char));
+};
+
+template <typename Callback>
+inline
+std::enable_if_t<Has_member_report<Callback>::value, bool>
+report_impl(Callback callback, int dim)
+{
+  return callback.report(dim);
+}
+
+template <typename Callback>
+inline
+std::enable_if_t<!Has_member_report<Callback>::value, bool>
+report_impl(const Callback&, int)
+{
+  return false;
+}
+
+template <typename Callback>
+inline
+std::enable_if_t<Has_member_report<Callback>::value, void>
+progress_impl(Callback callback, double d)
+{
+  callback.progress(d);
+}
+
+template <typename Callback>
+inline
+std::enable_if_t<!Has_member_report<Callback>::value, void>
+progress_impl(const Callback&, double)
+{}
+
+
+
+
 template< class T >
 struct Counter {
    T& value;
@@ -330,9 +380,11 @@ void segment_tree( RandomAccessIter1 p_begin, RandomAccessIter1 p_end,
     const T inf = box_limits< T >::inf();
     const T sup = box_limits< T >::sup();
 
-#if CGAL_BOX_INTERSECTION_DEBUG
-  CGAL_STATIC_THREAD_LOCAL_VARIABLE(int, level, -1);
+
+    CGAL_STATIC_THREAD_LOCAL_VARIABLE(int, level, -1);
     Counter<int> bla( level );
+
+    #if CGAL_BOX_INTERSECTION_DEBUG
     CGAL_BOX_INTERSECTION_DUMP("range: [" << lo << "," << hi << ") dim "
                                           << dim << std::endl )
     CGAL_BOX_INTERSECTION_DUMP("intervals: " )
@@ -356,13 +408,20 @@ void segment_tree( RandomAccessIter1 p_begin, RandomAccessIter1 p_end,
     }
 #endif
 
-    if( p_begin == p_end || i_begin == i_end || lo >= hi )
+    if( p_begin == p_end || i_begin == i_end || lo >= hi ){
+      if(report_impl(callback, dim)){
+          progress_impl(callback, 1.0 / (1 << level));
+        }
         return;
+    }
 
     if( dim == 0 )  {
         CGAL_BOX_INTERSECTION_DUMP( "dim = 0. scanning ... " << std::endl )
         one_way_scan( p_begin, p_end, i_begin, i_end,
                       callback, traits, dim, in_order );
+        if(report_impl(callback,dim)){
+          progress_impl(callback, 1.0 / (1 << level));
+        }
         return;
     }
 
@@ -372,6 +431,9 @@ void segment_tree( RandomAccessIter1 p_begin, RandomAccessIter1 p_end,
         CGAL_BOX_INTERSECTION_DUMP( "scanning ... " << std::endl )
         modified_two_way_scan( p_begin, p_end, i_begin, i_end,
                                callback, traits, dim, in_order );
+        if(report_impl(callback,dim)){
+          progress_impl(callback, 1.0 / (1 << level));
+        }
         return;
     }
 
@@ -398,6 +460,9 @@ void segment_tree( RandomAccessIter1 p_begin, RandomAccessIter1 p_end,
                                      << std::endl )
         modified_two_way_scan( p_begin, p_end, i_span_end, i_end,
                                callback, traits, dim, in_order );
+        if(report_impl(callback,dim)){
+          progress_impl(callback, 1.0 / (1 << level));
+        }
         return;
     }
 

--- a/Box_intersection_d/test/Box_intersection_d/CMakeLists.txt
+++ b/Box_intersection_d/test/Box_intersection_d/CMakeLists.txt
@@ -13,6 +13,7 @@ create_single_source_cgal_program("automated_test.cpp")
 create_single_source_cgal_program("benchmark_box_intersection.cpp")
 create_single_source_cgal_program("random_set_test.cpp")
 create_single_source_cgal_program("test_box_grid.cpp")
+create_single_source_cgal_program("test_Has_member_report.cpp")
 
 if(TARGET CGAL::TBB_support)
   target_link_libraries(test_box_grid PUBLIC CGAL::TBB_support)

--- a/Box_intersection_d/test/Box_intersection_d/test_Has_member_report.cpp
+++ b/Box_intersection_d/test/Box_intersection_d/test_Has_member_report.cpp
@@ -1,0 +1,25 @@
+#include <CGAL/assertions.h>
+#include <CGAL/Box_intersection_d/segment_tree.h>
+#include <cstddef>
+
+struct S {
+  void report(int);
+  bool report();
+};
+
+struct With_report {
+  bool report(int);
+  bool report(int) const;
+};
+
+struct With_report_as_a_template_member_function {
+  template <typename T> bool report(T);
+};
+
+int main() {
+  using CGAL::Box_intersection_d::Has_member_report;
+  CGAL_static_assertion(!Has_member_report<S>::value);
+  CGAL_static_assertion(Has_member_report<With_report>::value);
+  CGAL_static_assertion(Has_member_report<With_report_as_a_template_member_function>::value);
+  return EXIT_SUCCESS;
+}

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -499,6 +499,12 @@ namespace cpp11{
 #  define CGAL_FALLTHROUGH while(false){}
 #endif
 
+#if CGAL_CXX17
+#  define CGAL_CPP17_INLINE inline
+#else
+#  define CGAL_CPP17_INLINE
+#endif
+
 #ifndef CGAL_NO_ASSERTIONS
 #  define CGAL_NO_ASSERTIONS_BOOL false
 #else

--- a/Number_types/include/CGAL/double.h
+++ b/Number_types/include/CGAL/double.h
@@ -125,7 +125,7 @@ inline double sse2fabs(double a)
   static CGAL_ALIGN_16 const union{
     __int64 i[2];
     __m128d m;
-  } absMask = {0x7fffffffffffffff, 0x7fffffffffffffff};
+  } absMask = { {0x7fffffffffffffff, 0x7fffffffffffffff} };
 
   __m128d temp = _mm_set1_pd(a);
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
@@ -121,18 +121,18 @@ public:
 /// @name Functions used by corefine() for progress tracking
 /// @{
   /// called before starting to detect intersections between faces from a mesh and edges of the other
-  void start_filter_intersections();
+  void start_filtering_intersections();
   /// called during detection of intersections between faces from a mesh and edges of the other.
   /// `d` is a double value in `[0,1]` that is increasing with the number of calls. The closer
   /// to `1` you are the closer the intersection detection is complete.
-  void progress_filter_intersection(double d);
+  void progress_filtering_intersection(double d);
   /// called after detection of intersections between faces from a mesh and edges of the other
-  void end_filter_intersections();
+  void end_filtering_intersections();
 
   /// called before processing intersections between the `n` pairs of coplanar faces
   void start_handling_intersection_of_coplanar_faces(std::size_t n);
   /// called each time a pair of coplanar face is processed
-  void coplanar_faces_step() const;
+  void intersection_of_coplanar_faces_step() const;
   /// called after processing all intersections between coplanar faces
   void end_handling_intersection_of_coplanar_faces() const;
 
@@ -140,24 +140,24 @@ public:
   /// `n` is the number of edges possibilly intersecting faces that should be processed.
   void start_handling_edge_face_intersections(std::size_t n);
   /// called each time an edge is processed
-  void intersection_points_step();
+  void edge_face_intersections_step();
   /// called after having processed edge-face intersection between two meshes
   void end_handling_edge_face_intersections();
 
   /// called before triangulating the `n` splitted faces
-  void start_triangulation(std::size_t n);
-  /// called when triangulating `i`'th face
-  void face_triangulation(std::size_t i);
+  void start_triangulating_faces(std::size_t n);
+  /// called when triangulating one splitted face
+  void triangulating_faces_step();
   /// called after the triangulation of the splitted faces
-  void end_triangulation();
+  void end_triangulating_faces();
 /// @}
 
 /// @name Functions used by Boolean operations functions using corefinement for progress tracking.
 /// These functions are not needed if you only call `corefine()`.
   /// called before computing Boolean operations output after corefinement
-  void start_build_output();
+  void start_building_output();
   /// called when output of Boolean operations are computed
-  void end_build_output();
+  void end_building_output();
   /// called before filtering intersection edges between interior to a set of coplanar faces
   void filter_coplanar_edges() const {}
   /// called before segmenting input meshes in patches defined by connected components seperated by intersection edges

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
@@ -85,7 +85,7 @@ public:
 /// @name Functions used by Boolean operations functions using corefinement.
 /// These functions are not needed if only `corefine()` is called.
 /// @{
-  /// called before importing the face `f_src` of `tm_src` in `tm_tgt`
+  /// called before importing the face `f_src` of `tm_src` in `tm_tgt`.
   void before_face_copy(face_descriptor f_src, const Triangle_mesh& tm_src, const Triangle_mesh& tm_tgt);
   /// called after importing the face `f_src` of `tm_src` in `tm_tgt`. The new face is `f_tgt`.
   /// Note that the call is placed just after a call to `add_face()` so the halfedge pointer is not set yet.
@@ -106,7 +106,7 @@ public:
                              halfedge_descriptor h_new, const Triangle_mesh& tm);
   /// called when an intersection edge (represented in input meshes `tm_src1` and `tm_src2` by `h_src1` and `h_src2`,
   /// respectively) is imported in `tm_tgt` as `h_tgt`. There is only one call per edge.
-  /// (Called only when an out-of-place operation is requested)
+  /// (Called only when an out-of-place operation is requested).
   void intersection_edge_copy(halfedge_descriptor h_src1, const Triangle_mesh& tm_src1,
                               halfedge_descriptor h_src2, const Triangle_mesh& tm_src2,
                               halfedge_descriptor h_tgt,  const Triangle_mesh& tm_tgt);
@@ -120,58 +120,58 @@ public:
 
 /// @name Functions used by corefine() for progress tracking
 /// @{
-  /// called before starting to detect intersections between faces of one mesh and edges of the other
+  /// called before starting to detect intersections between faces of one mesh and edges of the other.
   void start_filtering_intersections();
   /// called during detection of intersections between faces of one mesh and edges of the other.
   /// `d` is a double value in `[0,1]` that is increasing with the number of calls. The closer
   /// `d`is to `1`, the closer the intersection detection is to completion.
   void progress_filtering_intersections(double d);
-  /// called after detection of intersections between faces of one mesh and edges of the other
+  /// called after detection of intersections between faces of one mesh and edges of the other.
   void end_filtering_intersections();
 
-  /// called before processing intersections between the `n` pairs of coplanar faces
+  /// called before processing intersections between the `n` pairs of coplanar faces.
   void start_handling_intersection_of_coplanar_faces(std::size_t n);
-  /// called each time a pair of coplanar faces is processed
+  /// called each time a pair of coplanar faces is processed.
   void intersection_of_coplanar_faces_step() const;
-  /// called after processing all intersections between coplanar faces
+  /// called after processing all intersections between coplanar faces.
   void end_handling_intersection_of_coplanar_faces() const;
 
   /// called before processing intersections between edges and faces of two meshes (called twice).
   /// `n` is the number of edges possibly intersecting faces that will be processed.
   void start_handling_edge_face_intersections(std::size_t n);
-  /// called each time an edge is processed
+  /// called each time an edge is processed.
   void edge_face_intersections_step();
-  /// called after having processed edge-face intersections between two meshes
+  /// called after having processed edge-face intersections between two meshes.
   void end_handling_edge_face_intersections();
 
-  /// called before triangulating the `n` split faces
+  /// called before triangulating the `n` split faces.
   void start_triangulating_faces(std::size_t n);
-  /// called when triangulating one split face
+  /// called when triangulating one split face.
   void triangulating_faces_step();
-  /// called after the triangulation of the split faces
+  /// called after the triangulation of the split faces.
   void end_triangulating_faces();
 /// @}
 
 /// @name Functions used by Boolean operations functions using corefinement for progress tracking.
 /// These functions are not needed if only `corefine()` is called.
-/// called before computing the output of the Boolean operations after corefinement
+/// called before computing the output of the Boolean operations after corefinement.
 /// @{
   void start_building_output();
-  /// called when the outputs of the Boolean operations is computed
+  /// called when the output of the Boolean operations is computed.
   void end_building_output();
-  /// called before filtering intersection edges in the interior of a set of coplanar faces
-  void filter_coplanar_edges() const {}
-  /// called before segmenting input meshes in patches defined by connected components seperated by intersection edges
-  void detect_patches() const {}
-  /// called before classifying which patches contribute to each Boolean operation
-  void classify_patches() const {}
-  /// called before classifying patches of `tm` that are free from intersection with the other mesh
-  void classify_intersection_free_patches(const TriangleMesh& tm) const {}
+  /// called before filtering intersection edges in the interior of a set of coplanar faces.
+  void filter_coplanar_edges();
+  /// called before segmenting input meshes in patches defined by connected components seperated by intersection edges.
+  void detect_patches();
+  /// called before classifying which patches contribute to each Boolean operation.
+  void classify_patches();
+  /// called before classifying patches of `tm` that are free from intersection with the other mesh.
+  void classify_intersection_free_patches(const TriangleMesh& tm);
   /// called before creating a new mesh for a Boolean operation of type `t`.
-  void out_of_place_operation(Boolean_operation_type t) const {}
+  void out_of_place_operation(Boolean_operation_type t);
   /// called before updating an input mesh to store the Boolean operation of type `t`.
-  void in_place_operation(Boolean_operation_type t) const {}
+  void in_place_operation(Boolean_operation_type t);
   /// called before updating both input meshes to store the Boolean operations of type `t1` and `t2`.
-  void in_place_operations(Boolean_operation_type t1,Boolean_operation_type t2) const {}
+  void in_place_operations(Boolean_operation_type t1,Boolean_operation_type t2);
 /// @}
 };

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
@@ -83,7 +83,7 @@ public:
 /// @}
 
 /// @name Functions used by Boolean operations functions using corefinement.
-/// These functions are not needed if you only call `corefine()`.
+/// These functions are not needed if only call `corefine()` is called.
 /// @{
   /// called before importing the face `f_src` of `tm_src` in `tm_tgt`
   void before_face_copy(face_descriptor f_src, const Triangle_mesh& tm_src, const Triangle_mesh& tm_tgt);
@@ -124,8 +124,8 @@ public:
   void start_filtering_intersections();
   /// called during detection of intersections between faces from a mesh and edges of the other.
   /// `d` is a double value in `[0,1]` that is increasing with the number of calls. The closer
-  /// to `1` you are the closer the intersection detection is complete.
-  void progress_filtering_intersection(double d);
+  /// to `1` is `d`, the closer the intersection detection is complete.
+  void progress_filtering_intersections(double d);
   /// called after detection of intersections between faces from a mesh and edges of the other
   void end_filtering_intersections();
 
@@ -137,7 +137,7 @@ public:
   void end_handling_intersection_of_coplanar_faces() const;
 
   /// called before processing intersections between edges and faces of two meshes (called twice).
-  /// `n` is the number of edges possibilly intersecting faces that should be processed.
+  /// `n` is the number of edges possibly intersecting faces that will be processed.
   void start_handling_edge_face_intersections(std::size_t n);
   /// called each time an edge is processed
   void edge_face_intersections_step();
@@ -153,16 +153,16 @@ public:
 /// @}
 
 /// @name Functions used by Boolean operations functions using corefinement for progress tracking.
-/// These functions are not needed if you only call `corefine()`.
-  /// called before computing Boolean operations output after corefinement
+/// These functions are not needed if only call `corefine()` is called.
+  /// called before computing the output of the Boolean operations after corefinement
   void start_building_output();
-  /// called when output of Boolean operations are computed
+  /// called when the outputs of the Boolean operations is computed
   void end_building_output();
-  /// called before filtering intersection edges between interior to a set of coplanar faces
+  /// called before filtering intersection edges in the interior of a set of coplanar faces
   void filter_coplanar_edges() const {}
   /// called before segmenting input meshes in patches defined by connected components seperated by intersection edges
   void detect_patches() const {}
-  /// called before classifying which patches contributes to each Boolean operation
+  /// called before classifying which patches contribute to each Boolean operation
   void classify_patches() const {}
   /// called before classifying patches of `tm` that are free from intersection with the other mesh
   void classify_intersection_free_patches(const TriangleMesh& tm) const {}

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
@@ -154,7 +154,8 @@ public:
 
 /// @name Functions used by Boolean operations functions using corefinement for progress tracking.
 /// These functions are not needed if only `corefine()` is called.
-  /// called before computing the output of the Boolean operations after corefinement
+/// called before computing the output of the Boolean operations after corefinement
+/// @{
   void start_building_output();
   /// called when the outputs of the Boolean operations is computed
   void end_building_output();

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
@@ -83,12 +83,12 @@ public:
 /// @}
 
 /// @name Functions used by Boolean operations functions using corefinement.
-/// These functions are not needed if only call `corefine()` is called.
+/// These functions are not needed if only `corefine()` is called.
 /// @{
   /// called before importing the face `f_src` of `tm_src` in `tm_tgt`
   void before_face_copy(face_descriptor f_src, const Triangle_mesh& tm_src, const Triangle_mesh& tm_tgt);
   /// called after importing the face `f_src` of `tm_src` in `tm_tgt`. The new face is `f_tgt`.
-  /// Note that the call is placed just after a call of `add_face()` so the halfedge pointer is not set yet.
+  /// Note that the call is placed just after a call to `add_face()` so the halfedge pointer is not set yet.
   void after_face_copy(face_descriptor  f_src, const Triangle_mesh& tm_src,
                        face_descriptor  f_tgt, const Triangle_mesh& tm_tgt);
   /// called before importing the edge of `h_src` of `tm_src` in `tm_tgt`. There is one call per edge.
@@ -120,18 +120,18 @@ public:
 
 /// @name Functions used by corefine() for progress tracking
 /// @{
-  /// called before starting to detect intersections between faces from a mesh and edges of the other
+  /// called before starting to detect intersections between faces of one mesh and edges of the other
   void start_filtering_intersections();
-  /// called during detection of intersections between faces from a mesh and edges of the other.
+  /// called during detection of intersections between faces of one mesh and edges of the other.
   /// `d` is a double value in `[0,1]` that is increasing with the number of calls. The closer
   /// `d`is to `1`, the closer the intersection detection is to completion.
   void progress_filtering_intersections(double d);
-  /// called after detection of intersections between faces from a mesh and edges of the other
+  /// called after detection of intersections between faces of one mesh and edges of the other
   void end_filtering_intersections();
 
   /// called before processing intersections between the `n` pairs of coplanar faces
   void start_handling_intersection_of_coplanar_faces(std::size_t n);
-  /// called each time a pair of coplanar face is processed
+  /// called each time a pair of coplanar faces is processed
   void intersection_of_coplanar_faces_step() const;
   /// called after processing all intersections between coplanar faces
   void end_handling_intersection_of_coplanar_faces() const;

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
@@ -88,7 +88,7 @@ public:
   /// called before importing the face `f_src` of `tm_src` in `tm_tgt`
   void before_face_copy(face_descriptor f_src, const Triangle_mesh& tm_src, const Triangle_mesh& tm_tgt);
   /// called after importing the face `f_src` of `tm_src` in `tm_tgt`. The new face is `f_tgt`.
-  /// Note that the call is placed just after a call to `add_face()` so the halfedge pointer is not set yet.
+  /// Note that the call is placed just after a call of `add_face()` so the halfedge pointer is not set yet.
   void after_face_copy(face_descriptor  f_src, const Triangle_mesh& tm_src,
                        face_descriptor  f_tgt, const Triangle_mesh& tm_tgt);
   /// called before importing the edge of `h_src` of `tm_src` in `tm_tgt`. There is one call per edge.
@@ -124,7 +124,7 @@ public:
   void start_filtering_intersections();
   /// called during detection of intersections between faces from a mesh and edges of the other.
   /// `d` is a double value in `[0,1]` that is increasing with the number of calls. The closer
-  /// to `1` is `d`, the closer the intersection detection is complete.
+  /// `d`is to `1`, the closer the intersection detection is to completion.
   void progress_filtering_intersections(double d);
   /// called after detection of intersections between faces from a mesh and edges of the other
   void end_filtering_intersections();
@@ -141,19 +141,19 @@ public:
   void start_handling_edge_face_intersections(std::size_t n);
   /// called each time an edge is processed
   void edge_face_intersections_step();
-  /// called after having processed edge-face intersection between two meshes
+  /// called after having processed edge-face intersections between two meshes
   void end_handling_edge_face_intersections();
 
-  /// called before triangulating the `n` splitted faces
+  /// called before triangulating the `n` split faces
   void start_triangulating_faces(std::size_t n);
-  /// called when triangulating one splitted face
+  /// called when triangulating one split face
   void triangulating_faces_step();
-  /// called after the triangulation of the splitted faces
+  /// called after the triangulation of the split faces
   void end_triangulating_faces();
 /// @}
 
 /// @name Functions used by Boolean operations functions using corefinement for progress tracking.
-/// These functions are not needed if only call `corefine()` is called.
+/// These functions are not needed if only `corefine()` is called.
   /// called before computing the output of the Boolean operations after corefinement
   void start_building_output();
   /// called when the outputs of the Boolean operations is computed

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
@@ -10,12 +10,12 @@
 
 class PMPCorefinementVisitor{
 public:
-/// Mesh type
-typedef unspecified_type Triangle_mesh;
-/// Face descriptor type
-typedef unspecified_type face_descriptor;
-/// Halfedge descriptor type
-typedef unspecified_type halfedge_descriptor;
+  /// Mesh type
+  typedef unspecified_type Triangle_mesh;
+  /// Face descriptor type
+  typedef unspecified_type face_descriptor;
+  /// Halfedge descriptor type
+  typedef unspecified_type halfedge_descriptor;
 
 /// @name Functions used by corefine() when faces are split
 /// @{
@@ -116,5 +116,61 @@ typedef unspecified_type halfedge_descriptor;
   /// The point has already been put in the vertex point map.
   void after_vertex_copy(vertex_descriptor v_src, const Triangle_mesh& tm_src,
                          vertex_descriptor v_tgt, const Triangle_mesh& tm_tgt);
+/// @}
+
+/// @name Functions used by corefine() for progress tracking
+/// @{
+  /// called before starting to detect intersections between faces from a mesh and edges of the other
+  void start_filter_intersections();
+  /// called during detection of intersections between faces from a mesh and edges of the other.
+  /// `d` is a double value in `[0,1]` that is increasing with the number of calls. The closer
+  /// to `1` you are the closer the intersection detection is complete.
+  void progress_filter_intersection(double d);
+  /// called after detection of intersections between faces from a mesh and edges of the other
+  void end_filter_intersections();
+
+  /// called before processing intersections between the `n` pairs of coplanar faces
+  void start_handling_intersection_of_coplanar_faces(std::size_t n);
+  /// called each time a pair of coplanar face is processed
+  void coplanar_faces_step() const;
+  /// called after processing all intersections between coplanar faces
+  void end_handling_intersection_of_coplanar_faces() const;
+
+  /// called before processing intersections between edges and faces of two meshes (called twice).
+  /// `n` is the number of edges possibilly intersecting faces that should be processed.
+  void start_handling_edge_face_intersections(std::size_t n);
+  /// called each time an edge is processed
+  void intersection_points_step();
+  /// called after having processed edge-face intersection between two meshes
+  void end_handling_edge_face_intersections();
+
+  /// called before triangulating the `n` splitted faces
+  void start_triangulation(std::size_t n);
+  /// called when triangulating `i`'th face
+  void face_triangulation(std::size_t i);
+  /// called after the triangulation of the splitted faces
+  void end_triangulation();
+/// @}
+
+/// @name Functions used by Boolean operations functions using corefinement for progress tracking.
+/// These functions are not needed if you only call `corefine()`.
+  /// called before computing Boolean operations output after corefinement
+  void start_build_output();
+  /// called when output of Boolean operations are computed
+  void end_build_output();
+  /// called before filtering intersection edges between interior to a set of coplanar faces
+  void filter_coplanar_edges() const {}
+  /// called before segmenting input meshes in patches defined by connected components seperated by intersection edges
+  void detect_patches() const {}
+  /// called before classifying which patches contributes to each Boolean operation
+  void classify_patches() const {}
+  /// called before classifying patches of `tm` that are free from intersection with the other mesh
+  void classify_intersection_free_patches(const TriangleMesh& tm) const {}
+  /// called before creating a new mesh for a Boolean operation of type `t`.
+  void out_of_place_operation(Boolean_operation_type t) const {}
+  /// called before updating an input mesh to store the Boolean operation of type `t`.
+  void in_place_operation(Boolean_operation_type t) const {}
+  /// called before updating both input meshes to store the Boolean operations of type `t1` and `t2`.
+  void in_place_operations(Boolean_operation_type t1,Boolean_operation_type t2) const {}
 /// @}
 };

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/examples.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/examples.txt
@@ -23,6 +23,7 @@
 \example Poisson_surface_reconstruction_3/poisson_reconstruction_example.cpp
 \example Polygon_mesh_processing/corefinement_difference_remeshed.cpp
 \example Polygon_mesh_processing/corefinement_mesh_union.cpp
+\example Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
 \example Polygon_mesh_processing/corefinement_OM_union.cpp
 \example Polygon_mesh_processing/corefinement_mesh_union_and_intersection.cpp
 \example Polygon_mesh_processing/corefinement_consecutive_bool_op.cpp

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
@@ -78,6 +78,7 @@ create_single_source_cgal_program("corefinement_SM.cpp")
 create_single_source_cgal_program("corefinement_consecutive_bool_op.cpp")
 create_single_source_cgal_program("corefinement_difference_remeshed.cpp")
 create_single_source_cgal_program("corefinement_mesh_union.cpp")
+create_single_source_cgal_program("corefinement_mesh_union_progress.cpp")
 create_single_source_cgal_program(
   "corefinement_mesh_union_and_intersection.cpp")
 create_single_source_cgal_program("corefinement_mesh_union_with_attributes.cpp")

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union.cpp
@@ -43,6 +43,40 @@ struct Visitor_rep{
     }
   }
 
+  void start_coplanar_faces(int tc)
+  {
+    std::cout << "Visitor::start_coplanar_faces() at " << t.time() << " sec." << std::endl;
+    tcoplanar= tc;
+    count_coplanar = 0;
+    bound_coplanar = tcoplanar/10;
+  }
+
+  void coplanar_faces_step()
+  {
+    ++count_coplanar;
+    if(count_coplanar> bound_coplanar){
+      std::cout << "Visitor::coplanar_faces: " << double(count_coplanar)/double(tcoplanar) * 100  << " % " << std::endl;
+      bound_coplanar += tcoplanar/10;
+    }
+  }
+
+  void start_intersection_points(int ti)
+  {
+    std::cout << "Visitor::start_intersection_points() at " << t.time() << " sec." << std::endl;
+    tintersection= ti;
+    count_intersection = 0;
+    bound_intersection = tintersection/10;
+  }
+
+  void intersection_points_step()
+  {
+    ++count_intersection;
+    if(count_intersection> bound_intersection){
+      std::cout << "Visitor::intersection_points: " << double(count_intersection)/double(tintersection) * 100  << " % " << std::endl;
+      bound_intersection += tintersection/10;
+    }
+  }
+
   double time() const
   {
     return t.time();
@@ -55,6 +89,14 @@ struct Visitor_rep{
 
   int bound_faces = 0;
   int tfaces = 0;
+
+  int bound_coplanar = 0;
+  int tcoplanar = 0;
+  int count_coplanar = 0;
+
+  int bound_intersection = 0;
+  int tintersection = 0;
+  int count_intersection = 0;
   CGAL::Timer t;
 };
 
@@ -75,16 +117,16 @@ struct Visitor :
 
   void start_filter_intersections() const
   {
-    std::cout << "Visitor::start_filter_intersections() at " << sptr->time() << std::endl;
+    std::cout << "Visitor::start_filter_intersections() at " << sptr->time() << " sec." << std::endl;
   }
   void end_filter_intersections() const
   {
-    std::cout << "Visitor::end_filter_intersections() at " << sptr->time()  << std::endl;
+    std::cout << "Visitor::end_filter_intersections() at " << sptr->time() << " sec."  << std::endl;
   }
 
   void start_triangulation(int tf)const
   {
-    std::cout << "Visitor::start_triangulation() with " << tf << " faces at " << sptr->time()  << std::endl;
+    std::cout << "Visitor::start_triangulation() with " << tf << " faces at " << sptr->time() << " sec."  << std::endl;
     sptr->start_triangulation(tf);
   }
 
@@ -95,37 +137,52 @@ struct Visitor :
 
   void end_triangulation()const
   {
-    std::cout << "Visitor::end_triangulation() at " << sptr->time()  << std::endl;
+    std::cout << "Visitor::end_triangulation() at " << sptr->time() << " sec."  << std::endl;
   }
 
-  void start_coplanar_faces(int) const
+  void start_coplanar_faces(int i) const
   {
-    std::cout << "Visitor::start_coplanar_faces() at " << sptr->time() << std::endl;
+    sptr->start_coplanar_faces(i);
   }
 
   void coplanar_faces_step() const
   {
-    std::cout << "Visitor::coplanar_faces_step() at " << sptr->time() << std::endl;
+    sptr->coplanar_faces_step();
   }
 
   void end_coplanar_faces() const
   {
-    std::cout << "Visitor::end_coplanar_faces() at " << sptr->time() << std::endl;
+    std::cout << "Visitor::end_coplanar_faces() at " << sptr->time() << " sec." << std::endl;
+  }
+
+  void start_intersection_points(int i) const
+  {
+    sptr->start_intersection_points(i);
+  }
+
+  void intersection_points_step() const
+  {
+    sptr->intersection_points_step();
+  }
+
+  void end_intersection_points() const
+  {
+    std::cout << "Visitor::end_intersection_points() at " << sptr->time() << " sec." << std::endl;
   }
 
   void start_build_output() const
   {
-    std::cout << "Visitor::start_build_output() at " << sptr->time() << std::endl;
+    std::cout << "Visitor::start_build_output() at " << sptr->time()  << " sec."<< std::endl;
   }
 
   void build_output_step() const
   {
-    std::cout << "Visitor::build_output_step() at " << sptr->time() << std::endl;
+    std::cout << "Visitor::build_output_step() at " << sptr->time() << " sec." << std::endl;
   }
 
   void end_build_output() const
   {
-    std::cout << "Visitor::end_build_output() at " << sptr->time() << std::endl;
+    std::cout << "Visitor::end_build_output() at " << sptr->time() << " sec." << std::endl;
   }
 };
 
@@ -146,10 +203,10 @@ int main(int argc, char* argv[])
   t.start();
   Mesh out;
   Visitor visitor;
-  // PMP::corefine(mesh1,mesh2, CGAL::parameters::visitor(visitor));
+
   bool valid_union = PMP::corefine_and_compute_union (mesh1,mesh2, out, CGAL::parameters::visitor(visitor));
 
-  std::cout << "total time = " << t.time() << std::endl;
+  std::cout << "Global timer = " << t.time() << " sec." << std::endl;
 
 
   if(valid_union)

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union.cpp
@@ -97,6 +97,36 @@ struct Visitor :
   {
     std::cout << "Visitor::end_triangulation() at " << sptr->time()  << std::endl;
   }
+
+  void start_coplanar_faces(int) const
+  {
+    std::cout << "Visitor::start_coplanar_faces() at " << sptr->time() << std::endl;
+  }
+
+  void coplanar_faces_step() const
+  {
+    std::cout << "Visitor::coplanar_faces_step() at " << sptr->time() << std::endl;
+  }
+
+  void end_coplanar_faces() const
+  {
+    std::cout << "Visitor::end_coplanar_faces() at " << sptr->time() << std::endl;
+  }
+
+  void start_build_output() const
+  {
+    std::cout << "Visitor::start_build_output() at " << sptr->time() << std::endl;
+  }
+
+  void build_output_step() const
+  {
+    std::cout << "Visitor::build_output_step() at " << sptr->time() << std::endl;
+  }
+
+  void end_build_output() const
+  {
+    std::cout << "Visitor::end_build_output() at " << sptr->time() << std::endl;
+  }
 };
 
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union.cpp
@@ -4,188 +4,13 @@
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
 #include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
 
-#include <fstream>
+#include <iostream>
+#include <string>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel   K;
 typedef CGAL::Surface_mesh<K::Point_3>                        Mesh;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
-
-struct Visitor_rep{
-
-  Visitor_rep(double normalize = 4)
-    : normalize(normalize)
-  {
-    t.start();
-  }
-
-  void progress_filter_intersection(double d)
-   {
-    d /= normalize;
-    total += d;
-    if(total > bound){
-      std::cout << std::setprecision(3) << total*100 << " %   in " << std::setprecision(5) << t.time() << " sec." << std::endl;
-      bound += 0.1;
-    }
-  }
-
-  void start_triangulation(int tf)
-  {
-    tfaces = tf;
-    bound_faces = tf/10;
-  }
-
-  void progress_triangulation(int i)
-  {
-    if(i> bound_faces){
-      std::cout << double(i)/double(tfaces) * 100  << " %" << std::endl;
-      bound_faces += tfaces/10;
-    }
-  }
-
-  void start_coplanar_faces(int tc)
-  {
-    std::cout << "Visitor::start_coplanar_faces() at " << t.time() << " sec." << std::endl;
-    tcoplanar= tc;
-    count_coplanar = 0;
-    bound_coplanar = tcoplanar/10;
-  }
-
-  void coplanar_faces_step()
-  {
-    ++count_coplanar;
-    if(count_coplanar> bound_coplanar){
-      std::cout << "Visitor::coplanar_faces: " << double(count_coplanar)/double(tcoplanar) * 100  << " % " << std::endl;
-      bound_coplanar += tcoplanar/10;
-    }
-  }
-
-  void start_intersection_points(int ti)
-  {
-    std::cout << "Visitor::start_intersection_points() at " << t.time() << " sec." << std::endl;
-    tintersection= ti;
-    count_intersection = 0;
-    bound_intersection = tintersection/10;
-  }
-
-  void intersection_points_step()
-  {
-    ++count_intersection;
-    if(count_intersection> bound_intersection){
-      std::cout << "Visitor::intersection_points: " << double(count_intersection)/double(tintersection) * 100  << " % " << std::endl;
-      bound_intersection += tintersection/10;
-    }
-  }
-
-  double time() const
-  {
-    return t.time();
-  }
-
-  double normalize;
-  double bound = 0.1;
-  double total = 0;
-  int count = 0;
-
-  int bound_faces = 0;
-  int tfaces = 0;
-
-  int bound_coplanar = 0;
-  int tcoplanar = 0;
-  int count_coplanar = 0;
-
-  int bound_intersection = 0;
-  int tintersection = 0;
-  int count_intersection = 0;
-  CGAL::Timer t;
-};
-
-
-struct Visitor :
-  public PMP::Corefinement::Default_visitor<Mesh>
-{
-  std::shared_ptr<Visitor_rep> sptr;
-
-  Visitor()
-    : sptr(std::make_shared<Visitor_rep>())
-  {}
-
-  void progress_filter_intersection(double d)
-  {
-    sptr->progress_filter_intersection(d);
-  }
-
-  void start_filter_intersections() const
-  {
-    std::cout << "Visitor::start_filter_intersections() at " << sptr->time() << " sec." << std::endl;
-  }
-  void end_filter_intersections() const
-  {
-    std::cout << "Visitor::end_filter_intersections() at " << sptr->time() << " sec."  << std::endl;
-  }
-
-  void start_triangulation(int tf)const
-  {
-    std::cout << "Visitor::start_triangulation() with " << tf << " faces at " << sptr->time() << " sec."  << std::endl;
-    sptr->start_triangulation(tf);
-  }
-
-  void progress_triangulation(int i) const
-  {
-    sptr->progress_triangulation(i);
-  }
-
-  void end_triangulation()const
-  {
-    std::cout << "Visitor::end_triangulation() at " << sptr->time() << " sec."  << std::endl;
-  }
-
-  void start_coplanar_faces(int i) const
-  {
-    sptr->start_coplanar_faces(i);
-  }
-
-  void coplanar_faces_step() const
-  {
-    sptr->coplanar_faces_step();
-  }
-
-  void end_coplanar_faces() const
-  {
-    std::cout << "Visitor::end_coplanar_faces() at " << sptr->time() << " sec." << std::endl;
-  }
-
-  void start_intersection_points(int i) const
-  {
-    sptr->start_intersection_points(i);
-  }
-
-  void intersection_points_step() const
-  {
-    sptr->intersection_points_step();
-  }
-
-  void end_intersection_points() const
-  {
-    std::cout << "Visitor::end_intersection_points() at " << sptr->time() << " sec." << std::endl;
-  }
-
-  void start_build_output() const
-  {
-    std::cout << "Visitor::start_build_output() at " << sptr->time()  << " sec."<< std::endl;
-  }
-
-  void build_output_step() const
-  {
-    std::cout << "Visitor::build_output_step() at " << sptr->time() << " sec." << std::endl;
-  }
-
-  void end_build_output() const
-  {
-    std::cout << "Visitor::end_build_output() at " << sptr->time() << " sec." << std::endl;
-  }
-};
-
 
 int main(int argc, char* argv[])
 {
@@ -193,21 +18,14 @@ int main(int argc, char* argv[])
   const std::string filename2 = (argc > 2) ? argv[2] : CGAL::data_file_path("meshes/eight.off");
 
   Mesh mesh1, mesh2;
-  if(!CGAL::IO::read_polygon_mesh(filename1, mesh1) || !CGAL::IO::read_polygon_mesh(filename2, mesh2))
+  if(!PMP::IO::read_polygon_mesh(filename1, mesh1) || !PMP::IO::read_polygon_mesh(filename2, mesh2))
   {
     std::cerr << "Invalid input." << std::endl;
     return 1;
   }
 
-  CGAL::Timer t;
-  t.start();
   Mesh out;
-  Visitor visitor;
-
-  bool valid_union = PMP::corefine_and_compute_union (mesh1,mesh2, out, CGAL::parameters::visitor(visitor));
-
-  std::cout << "Global timer = " << t.time() << " sec." << std::endl;
-
+  bool valid_union = PMP::corefine_and_compute_union(mesh1,mesh2, out);
 
   if(valid_union)
   {

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
@@ -29,13 +29,13 @@ struct Visitor_rep{
     }
   }
 
-  void start_triangulation(std::size_t tf)
+  void start_face_triangulations(std::size_t tf)
   {
     tfaces = tf;
     bound_faces = tf/10;
   }
 
-  void progress_triangulation(std::size_t i)
+  void face_triangulation(std::size_t i)
   {
     if(i> bound_faces){
       std::cout << double(i)/double(tfaces) * 100  << " %" << std::endl;
@@ -124,20 +124,20 @@ struct Visitor :
     std::cout << "Visitor::end_filter_intersections() at " << sptr->time() << " sec."  << std::endl;
   }
 
-  void start_triangulation(std::size_t tf)const
+  void start_face_triangulations(std::size_t tf)const
   {
     std::cout << "Visitor::start_triangulation() with " << tf << " faces at " << sptr->time() << " sec."  << std::endl;
-    sptr->start_triangulation(tf);
+    sptr->start_face_triangulations(tf);
   }
 
-  void progress_triangulation(std::size_t i) const
+  void face_triangulation(std::size_t i) const
   {
-    sptr->progress_triangulation(i);
+    sptr->face_triangulation(i);
   }
 
-  void end_triangulation()const
+  void end_face_triangulations()const
   {
-    std::cout << "Visitor::end_triangulation() at " << sptr->time() << " sec."  << std::endl;
+    std::cout << "Visitor::end_face_triangulations() at " << sptr->time() << " sec."  << std::endl;
   }
 
   void start_coplanar_faces(std::size_t i) const

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
@@ -175,11 +175,6 @@ struct Visitor :
     std::cout << "Visitor::start_build_output() at " << sptr->time()  << " sec."<< std::endl;
   }
 
-  void build_output_step() const
-  {
-    std::cout << "Visitor::build_output_step() at " << sptr->time() << " sec." << std::endl;
-  }
-
   void end_build_output() const
   {
     std::cout << "Visitor::end_build_output() at " << sptr->time() << " sec." << std::endl;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
@@ -29,13 +29,13 @@ struct Visitor_rep{
     }
   }
 
-  void start_triangulation(int tf)
+  void start_triangulation(std::size_t tf)
   {
     tfaces = tf;
     bound_faces = tf/10;
   }
 
-  void progress_triangulation(int i)
+  void progress_triangulation(std::size_t i)
   {
     if(i> bound_faces){
       std::cout << double(i)/double(tfaces) * 100  << " %" << std::endl;
@@ -85,18 +85,18 @@ struct Visitor_rep{
   double normalize;
   double bound = 0.1;
   double total = 0;
-  int count = 0;
+  std::size_t count = 0;
 
-  int bound_faces = 0;
-  int tfaces = 0;
+  std::size_t bound_faces = 0;
+  std::size_t tfaces = 0;
 
-  int bound_coplanar = 0;
-  int tcoplanar = 0;
-  int count_coplanar = 0;
+  std::size_t bound_coplanar = 0;
+  std::size_t tcoplanar = 0;
+  std::size_t count_coplanar = 0;
 
-  int bound_intersection = 0;
-  int tintersection = 0;
-  int count_intersection = 0;
+  std::size_t bound_intersection = 0;
+  std::size_t tintersection = 0;
+  std::size_t count_intersection = 0;
   CGAL::Timer t;
 };
 
@@ -130,7 +130,7 @@ struct Visitor :
     sptr->start_triangulation(tf);
   }
 
-  void progress_triangulation(int i) const
+  void progress_triangulation(std::size_t i) const
   {
     sptr->progress_triangulation(i);
   }
@@ -140,7 +140,7 @@ struct Visitor :
     std::cout << "Visitor::end_triangulation() at " << sptr->time() << " sec."  << std::endl;
   }
 
-  void start_coplanar_faces(int i) const
+  void start_coplanar_faces(std::size_t i) const
   {
     sptr->start_coplanar_faces(i);
   }
@@ -155,7 +155,7 @@ struct Visitor :
     std::cout << "Visitor::end_coplanar_faces() at " << sptr->time() << " sec." << std::endl;
   }
 
-  void start_intersection_points(int i) const
+  void start_intersection_points(std::size_t i) const
   {
     sptr->start_intersection_points(i);
   }

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
@@ -19,7 +19,7 @@ struct Visitor_rep{
     t.start();
   }
 
-  void progress_filter_intersection(double d)
+  void progress_filtering_intersection(double d)
    {
     d /= normalize;
     total += d;
@@ -29,7 +29,7 @@ struct Visitor_rep{
     }
   }
 
-  void start_face_triangulations(std::size_t tf)
+  void start_triangulating_faces(std::size_t tf)
   {
     tfaces = tf;
     bound_faces = tf/10;
@@ -51,7 +51,7 @@ struct Visitor_rep{
     bound_coplanar = tcoplanar/10;
   }
 
-  void coplanar_faces_step()
+  void intersection_of_coplanar_faces_step()
   {
     ++count_coplanar;
     if(count_coplanar> bound_coplanar){
@@ -68,7 +68,7 @@ struct Visitor_rep{
     bound_intersection = tintersection/10;
   }
 
-  void intersection_points_step()
+  void edge_face_intersections_step()
   {
     ++count_intersection;
     if(count_intersection> bound_intersection){
@@ -110,24 +110,24 @@ struct Visitor :
     : sptr(std::make_shared<Visitor_rep>())
   {}
 
-  void progress_filter_intersection(double d)
+  void progress_filtering_intersection(double d)
   {
-    sptr->progress_filter_intersection(d);
+    sptr->progress_filtering_intersection(d);
   }
 
-  void start_filter_intersections() const
+  void start_filtering_intersections() const
   {
-    std::cout << "Visitor::start_filter_intersections() at " << sptr->time() << " sec." << std::endl;
+    std::cout << "Visitor::start_filtering_intersections() at " << sptr->time() << " sec." << std::endl;
   }
-  void end_filter_intersections() const
+  void end_filtering_intersections() const
   {
-    std::cout << "Visitor::end_filter_intersections() at " << sptr->time() << " sec."  << std::endl;
+    std::cout << "Visitor::end_filtering_intersections() at " << sptr->time() << " sec."  << std::endl;
   }
 
-  void start_face_triangulations(std::size_t tf)const
+  void start_triangulating_faces(std::size_t tf)const
   {
     std::cout << "Visitor::start_triangulation() with " << tf << " faces at " << sptr->time() << " sec."  << std::endl;
-    sptr->start_face_triangulations(tf);
+    sptr->start_triangulating_faces(tf);
   }
 
   void face_triangulation(std::size_t i) const
@@ -135,9 +135,9 @@ struct Visitor :
     sptr->face_triangulation(i);
   }
 
-  void end_face_triangulations()const
+  void end_triangulating_faces()const
   {
-    std::cout << "Visitor::end_face_triangulations() at " << sptr->time() << " sec."  << std::endl;
+    std::cout << "Visitor::end_triangulating_faces() at " << sptr->time() << " sec."  << std::endl;
   }
 
   void start_coplanar_faces(std::size_t i) const
@@ -145,9 +145,9 @@ struct Visitor :
     sptr->start_coplanar_faces(i);
   }
 
-  void coplanar_faces_step() const
+  void intersection_of_coplanar_faces_step() const
   {
-    sptr->coplanar_faces_step();
+    sptr->intersection_of_coplanar_faces_step();
   }
 
   void end_coplanar_faces() const
@@ -160,9 +160,9 @@ struct Visitor :
     sptr->start_intersection_points(i);
   }
 
-  void intersection_points_step() const
+  void edge_face_intersections_step() const
   {
-    sptr->intersection_points_step();
+    sptr->edge_face_intersections_step();
   }
 
   void end_intersection_points() const
@@ -170,14 +170,14 @@ struct Visitor :
     std::cout << "Visitor::end_intersection_points() at " << sptr->time() << " sec." << std::endl;
   }
 
-  void start_build_output() const
+  void start_building_output() const
   {
-    std::cout << "Visitor::start_build_output() at " << sptr->time()  << " sec."<< std::endl;
+    std::cout << "Visitor::start_building_output() at " << sptr->time()  << " sec."<< std::endl;
   }
 
-  void end_build_output() const
+  void end_building_output() const
   {
-    std::cout << "Visitor::end_build_output() at " << sptr->time() << " sec." << std::endl;
+    std::cout << "Visitor::end_building_output() at " << sptr->time() << " sec." << std::endl;
   }
 };
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
@@ -1,0 +1,222 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Polygon_mesh_processing/corefinement.h>
+#include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
+
+#include <fstream>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel   K;
+typedef CGAL::Surface_mesh<K::Point_3>                        Mesh;
+
+namespace PMP = CGAL::Polygon_mesh_processing;
+
+struct Visitor_rep{
+
+  Visitor_rep(double normalize = 4)
+    : normalize(normalize)
+  {
+    t.start();
+  }
+
+  void progress_filter_intersection(double d)
+   {
+    d /= normalize;
+    total += d;
+    if(total > bound){
+      std::cout << std::setprecision(3) << total*100 << " %   in " << std::setprecision(5) << t.time() << " sec." << std::endl;
+      bound += 0.1;
+    }
+  }
+
+  void start_triangulation(int tf)
+  {
+    tfaces = tf;
+    bound_faces = tf/10;
+  }
+
+  void progress_triangulation(int i)
+  {
+    if(i> bound_faces){
+      std::cout << double(i)/double(tfaces) * 100  << " %" << std::endl;
+      bound_faces += tfaces/10;
+    }
+  }
+
+  void start_coplanar_faces(int tc)
+  {
+    std::cout << "Visitor::start_coplanar_faces() at " << t.time() << " sec." << std::endl;
+    tcoplanar= tc;
+    count_coplanar = 0;
+    bound_coplanar = tcoplanar/10;
+  }
+
+  void coplanar_faces_step()
+  {
+    ++count_coplanar;
+    if(count_coplanar> bound_coplanar){
+      std::cout << "Visitor::coplanar_faces: " << double(count_coplanar)/double(tcoplanar) * 100  << " % " << std::endl;
+      bound_coplanar += tcoplanar/10;
+    }
+  }
+
+  void start_intersection_points(int ti)
+  {
+    std::cout << "Visitor::start_intersection_points() at " << t.time() << " sec." << std::endl;
+    tintersection= ti;
+    count_intersection = 0;
+    bound_intersection = tintersection/10;
+  }
+
+  void intersection_points_step()
+  {
+    ++count_intersection;
+    if(count_intersection> bound_intersection){
+      std::cout << "Visitor::intersection_points: " << double(count_intersection)/double(tintersection) * 100  << " % " << std::endl;
+      bound_intersection += tintersection/10;
+    }
+  }
+
+  double time() const
+  {
+    return t.time();
+  }
+
+  double normalize;
+  double bound = 0.1;
+  double total = 0;
+  int count = 0;
+
+  int bound_faces = 0;
+  int tfaces = 0;
+
+  int bound_coplanar = 0;
+  int tcoplanar = 0;
+  int count_coplanar = 0;
+
+  int bound_intersection = 0;
+  int tintersection = 0;
+  int count_intersection = 0;
+  CGAL::Timer t;
+};
+
+
+struct Visitor :
+  public PMP::Corefinement::Default_visitor<Mesh>
+{
+  std::shared_ptr<Visitor_rep> sptr;
+
+  Visitor()
+    : sptr(std::make_shared<Visitor_rep>())
+  {}
+
+  void progress_filter_intersection(double d)
+  {
+    sptr->progress_filter_intersection(d);
+  }
+
+  void start_filter_intersections() const
+  {
+    std::cout << "Visitor::start_filter_intersections() at " << sptr->time() << " sec." << std::endl;
+  }
+  void end_filter_intersections() const
+  {
+    std::cout << "Visitor::end_filter_intersections() at " << sptr->time() << " sec."  << std::endl;
+  }
+
+  void start_triangulation(int tf)const
+  {
+    std::cout << "Visitor::start_triangulation() with " << tf << " faces at " << sptr->time() << " sec."  << std::endl;
+    sptr->start_triangulation(tf);
+  }
+
+  void progress_triangulation(int i) const
+  {
+    sptr->progress_triangulation(i);
+  }
+
+  void end_triangulation()const
+  {
+    std::cout << "Visitor::end_triangulation() at " << sptr->time() << " sec."  << std::endl;
+  }
+
+  void start_coplanar_faces(int i) const
+  {
+    sptr->start_coplanar_faces(i);
+  }
+
+  void coplanar_faces_step() const
+  {
+    sptr->coplanar_faces_step();
+  }
+
+  void end_coplanar_faces() const
+  {
+    std::cout << "Visitor::end_coplanar_faces() at " << sptr->time() << " sec." << std::endl;
+  }
+
+  void start_intersection_points(int i) const
+  {
+    sptr->start_intersection_points(i);
+  }
+
+  void intersection_points_step() const
+  {
+    sptr->intersection_points_step();
+  }
+
+  void end_intersection_points() const
+  {
+    std::cout << "Visitor::end_intersection_points() at " << sptr->time() << " sec." << std::endl;
+  }
+
+  void start_build_output() const
+  {
+    std::cout << "Visitor::start_build_output() at " << sptr->time()  << " sec."<< std::endl;
+  }
+
+  void build_output_step() const
+  {
+    std::cout << "Visitor::build_output_step() at " << sptr->time() << " sec." << std::endl;
+  }
+
+  void end_build_output() const
+  {
+    std::cout << "Visitor::end_build_output() at " << sptr->time() << " sec." << std::endl;
+  }
+};
+
+
+int main(int argc, char* argv[])
+{
+  const std::string filename1 = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/blobby.off");
+  const std::string filename2 = (argc > 2) ? argv[2] : CGAL::data_file_path("meshes/eight.off");
+
+  Mesh mesh1, mesh2;
+  if(!CGAL::IO::read_polygon_mesh(filename1, mesh1) || !CGAL::IO::read_polygon_mesh(filename2, mesh2))
+  {
+    std::cerr << "Invalid input." << std::endl;
+    return 1;
+  }
+
+  CGAL::Timer t;
+  t.start();
+  Mesh out;
+  Visitor visitor;
+
+  bool valid_union = PMP::corefine_and_compute_union (mesh1,mesh2, out, CGAL::parameters::visitor(visitor));
+
+  std::cout << "Global timer = " << t.time() << " sec." << std::endl;
+
+
+  if(valid_union)
+  {
+    std::cout << "Union was successfully computed\n";
+    CGAL::IO::write_polygon_mesh("union.off", out, CGAL::parameters::stream_precision(17));
+    return 0;
+  }
+
+  std::cout << "Union could not be computed\n";
+
+  return 1;
+}

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
@@ -19,7 +19,7 @@ struct Visitor_rep{
     t.start();
   }
 
-  void progress_filtering_intersection(double d)
+  void progress_filtering_intersections(double d)
    {
     d /= normalize;
     total += d;
@@ -110,9 +110,9 @@ struct Visitor :
     : sptr(std::make_shared<Visitor_rep>())
   {}
 
-  void progress_filtering_intersection(double d)
+  void progress_filtering_intersections(double d)
   {
-    sptr->progress_filtering_intersection(d);
+    sptr->progress_filtering_intersections(d);
   }
 
   void start_filtering_intersections() const

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
@@ -43,7 +43,7 @@ struct Visitor_rep{
     }
   }
 
-  void start_coplanar_faces(int tc)
+  void start_coplanar_faces(std::size_t tc)
   {
     std::cout << "Visitor::start_coplanar_faces() at " << t.time() << " sec." << std::endl;
     tcoplanar= tc;
@@ -60,7 +60,7 @@ struct Visitor_rep{
     }
   }
 
-  void start_intersection_points(int ti)
+  void start_intersection_points(std::size_t ti)
   {
     std::cout << "Visitor::start_intersection_points() at " << t.time() << " sec." << std::endl;
     tintersection= ti;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_mesh_union_progress.cpp
@@ -124,7 +124,7 @@ struct Visitor :
     std::cout << "Visitor::end_filter_intersections() at " << sptr->time() << " sec."  << std::endl;
   }
 
-  void start_triangulation(int tf)const
+  void start_triangulation(std::size_t tf)const
   {
     std::cout << "Visitor::start_triangulation() with " << tf << " faces at " << sptr->time() << " sec."  << std::endl;
     sptr->start_triangulation(tf);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -570,9 +570,9 @@ public:
   }
 
 
-  void start_intersection_points(std::size_t i) const
+  void start_handling_edge_face_intersections(std::size_t i) const
   {
-    user_visitor.start_intersection_points(i);
+    user_visitor.start_handling_edge_face_intersections(i);
   }
 
   void intersection_points_step() const
@@ -580,14 +580,14 @@ public:
     user_visitor.intersection_points_step();
   }
 
-  void end_intersection_points() const
+  void end_handling_edge_face_intersections() const
   {
-    user_visitor.end_intersection_points();
+    user_visitor.end_handling_edge_face_intersections();
   }
 
-  void start_coplanar_faces(std::size_t i) const
+  void start_handling_intersection_of_coplanar_faces(std::size_t i) const
   {
-    user_visitor.start_coplanar_faces(i);
+    user_visitor.start_handling_intersection_of_coplanar_faces(i);
   }
 
   void coplanar_faces_step() const
@@ -595,9 +595,9 @@ public:
     user_visitor.coplanar_faces_step();
   }
 
-  void end_coplanar_faces() const
+  void end_handling_intersection_of_coplanar_faces() const
   {
-    user_visitor.end_coplanar_faces();
+    user_visitor.end_handling_intersection_of_coplanar_faces();
   }
 
   void start_build_output() const
@@ -1208,7 +1208,7 @@ public:
     for (typename On_face_map::iterator it=on_face_map.begin();
           it!=on_face_map.end();++it)
     {
-      user_visitor.progress_triangulation(i++);
+      user_visitor.face_triangulation(i++);
       face_descriptor f = it->first; //the face to be triangulated
       Node_ids& node_ids  = it->second; // ids of nodes in the interior of f
       typename Face_boundaries::iterator it_fb=face_boundaries.find(f);
@@ -1566,7 +1566,7 @@ public:
                                                   : on_face.find(tm1_ptr)->second.size() +
                                                     on_face.find(tm2_ptr)->second.size();
 
-    user_visitor.start_triangulation(total_size);
+    user_visitor.start_face_triangulations(total_size);
 
     for (typename std::map<TriangleMesh*,On_face_map>::iterator
            it=on_face.begin(); it!=on_face.end(); ++it)
@@ -1577,7 +1577,7 @@ public:
         triangulate_intersected_faces(it, vpm2, nodes, mesh_to_face_boundaries);
     }
 
-    user_visitor.end_triangulation();
+    user_visitor.end_face_triangulations();
 
     nodes.finalize(mesh_to_node_id_to_vertex);
     user_visitor.start_build_output();

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -559,9 +559,9 @@ public:
   }
 
 
-  void progress_filtering_intersection(double d) const
+  void progress_filtering_intersections(double d) const
   {
-    user_visitor.progress_filtering_intersection(d);
+    user_visitor.progress_filtering_intersections(d);
   }
 
   void end_filtering_intersections() const

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -1559,11 +1559,12 @@ public:
 
     //2)triangulation of the triangle faces containing intersection point in their interior
     //  and also those with intersection points only on the boundary.
-
-
-    std::size_t total_size = doing_autorefinement ? on_face.find(tm1_ptr)->second.size()
-                                                  : on_face.find(tm1_ptr)->second.size() +
-                                                    on_face.find(tm2_ptr)->second.size();
+    std::size_t total_size = 0;
+    for (typename std::map<TriangleMesh*,On_face_map>::iterator
+           it=on_face.begin(); it!=on_face.end(); ++it)
+    {
+      total_size += it->second.size();
+    }
 
     user_visitor.start_triangulating_faces(total_size);
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -1562,12 +1562,10 @@ public:
     //  and also those with intersection points only on the boundary.
 
 
-    std::size_t total_size = 0;
-    for (typename std::map<TriangleMesh*,On_face_map>::iterator
-           it=on_face.begin(); it!=on_face.end(); ++it)
-    {
-      total_size += it->second.size();
-    }
+    std::size_t total_size = doing_autorefinement ? on_face.find(tm1_ptr)->second.size()
+                                                  : on_face.find(tm1_ptr)->second.size() +
+                                                    on_face.find(tm2_ptr)->second.size();
+
     user_visitor.start_triangulation(total_size);
 
     for (typename std::map<TriangleMesh*,On_face_map>::iterator

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -570,6 +570,36 @@ public:
   }
 
 
+  void start_build_output() const
+  {
+    user_visitor.start_build_output();
+  }
+
+  void build_output_step() const
+  {
+    user_visitor.build_output_step();
+  }
+
+  void end_build_output() const
+  {
+    user_visitor.end_build_output();
+  }
+
+  void start_coplanar_faces(int i) const
+  {
+    user_visitor.start_coplanar_faces(i);
+  }
+
+  void coplanar_faces_step() const
+  {
+    user_visitor.coplanar_faces_step();
+  }
+
+  void end_coplanar_faces() const
+  {
+    user_visitor.end_coplanar_faces();
+  }
+
   void
   set_non_manifold_feature_map(
     const TriangleMesh& tm,
@@ -1537,12 +1567,14 @@ public:
     user_visitor.end_triangulation();
 
     nodes.finalize(mesh_to_node_id_to_vertex);
-
+    user_visitor.start_build_output();
     // additional operations
     output_builder(nodes,
                    input_with_coplanar_faces,
                    is_node_of_degree_one,
                    mesh_to_node_id_to_vertex);
+
+    user_visitor.end_build_output();
   }
 };
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -570,19 +570,19 @@ public:
   }
 
 
-  void start_build_output() const
+  void start_intersection_points(int i) const
   {
-    user_visitor.start_build_output();
+    user_visitor.start_intersection_points(i);
   }
 
-  void build_output_step() const
+  void intersection_points_step() const
   {
-    user_visitor.build_output_step();
+    user_visitor.intersection_points_step();
   }
 
-  void end_build_output() const
+  void end_intersection_points() const
   {
-    user_visitor.end_build_output();
+    user_visitor.end_intersection_points();
   }
 
   void start_coplanar_faces(int i) const
@@ -598,6 +598,21 @@ public:
   void end_coplanar_faces() const
   {
     user_visitor.end_coplanar_faces();
+  }
+
+  void start_build_output() const
+  {
+    user_visitor.start_build_output();
+  }
+
+  void build_output_step() const
+  {
+    user_visitor.build_output_step();
+  }
+
+  void end_build_output() const
+  {
+    user_visitor.end_build_output();
   }
 
   void

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -553,20 +553,20 @@ public:
   {}
 
 
-  void start_filter_intersections() const
+  void start_filtering_intersections() const
   {
-    user_visitor.start_filter_intersections();
+    user_visitor.start_filtering_intersections();
   }
 
 
-  void progress_filter_intersection(double d) const
+  void progress_filtering_intersection(double d) const
   {
-    user_visitor.progress_filter_intersection(d);
+    user_visitor.progress_filtering_intersection(d);
   }
 
-  void end_filter_intersections() const
+  void end_filtering_intersections() const
   {
-    user_visitor.end_filter_intersections();
+    user_visitor.end_filtering_intersections();
   }
 
 
@@ -575,9 +575,9 @@ public:
     user_visitor.start_handling_edge_face_intersections(i);
   }
 
-  void intersection_points_step() const
+  void edge_face_intersections_step() const
   {
-    user_visitor.intersection_points_step();
+    user_visitor.edge_face_intersections_step();
   }
 
   void end_handling_edge_face_intersections() const
@@ -590,9 +590,9 @@ public:
     user_visitor.start_handling_intersection_of_coplanar_faces(i);
   }
 
-  void coplanar_faces_step() const
+  void intersection_of_coplanar_faces_step() const
   {
-    user_visitor.coplanar_faces_step();
+    user_visitor.intersection_of_coplanar_faces_step();
   }
 
   void end_handling_intersection_of_coplanar_faces() const
@@ -600,9 +600,9 @@ public:
     user_visitor.end_handling_intersection_of_coplanar_faces();
   }
 
-  void start_build_output() const
+  void start_building_output() const
   {
-    user_visitor.start_build_output();
+    user_visitor.start_building_output();
   }
 
   void build_output_step() const
@@ -610,9 +610,9 @@ public:
     user_visitor.build_output_step();
   }
 
-  void end_build_output() const
+  void end_building_output() const
   {
-    user_visitor.end_build_output();
+    user_visitor.end_building_output();
   }
 
   void
@@ -1204,11 +1204,10 @@ public:
 
     const Node_id nb_nodes = nodes.size();
 
-    std::size_t i = 0;
     for (typename On_face_map::iterator it=on_face_map.begin();
           it!=on_face_map.end();++it)
     {
-      user_visitor.face_triangulation(i++);
+      user_visitor.triangulating_faces_step();
       face_descriptor f = it->first; //the face to be triangulated
       Node_ids& node_ids  = it->second; // ids of nodes in the interior of f
       typename Face_boundaries::iterator it_fb=face_boundaries.find(f);
@@ -1566,7 +1565,7 @@ public:
                                                   : on_face.find(tm1_ptr)->second.size() +
                                                     on_face.find(tm2_ptr)->second.size();
 
-    user_visitor.start_face_triangulations(total_size);
+    user_visitor.start_triangulating_faces(total_size);
 
     for (typename std::map<TriangleMesh*,On_face_map>::iterator
            it=on_face.begin(); it!=on_face.end(); ++it)
@@ -1577,17 +1576,17 @@ public:
         triangulate_intersected_faces(it, vpm2, nodes, mesh_to_face_boundaries);
     }
 
-    user_visitor.end_face_triangulations();
+    user_visitor.end_triangulating_faces();
 
     nodes.finalize(mesh_to_node_id_to_vertex);
-    user_visitor.start_build_output();
+    user_visitor.start_building_output();
     // additional operations
     output_builder(nodes,
                    input_with_coplanar_faces,
                    is_node_of_degree_one,
                    mesh_to_node_id_to_vertex);
 
-    user_visitor.end_build_output();
+    user_visitor.end_building_output();
   }
 };
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -1159,9 +1159,11 @@ public:
 
     const Node_id nb_nodes = nodes.size();
 
+    int i = 0;
     for (typename On_face_map::iterator it=on_face_map.begin();
           it!=on_face_map.end();++it)
     {
+      user_visitor.progress_triangulation(i++);
       face_descriptor f = it->first; //the face to be triangulated
       Node_ids& node_ids  = it->second; // ids of nodes in the interior of f
       typename Face_boundaries::iterator it_fb=face_boundaries.find(f);
@@ -1513,14 +1515,26 @@ public:
 
     //2)triangulation of the triangle faces containing intersection point in their interior
     //  and also those with intersection points only on the boundary.
+
+
+    int total_size = 0;
     for (typename std::map<TriangleMesh*,On_face_map>::iterator
-      it=on_face.begin(); it!=on_face.end(); ++it)
+           it=on_face.begin(); it!=on_face.end(); ++it)
+    {
+      total_size += it->second.size();
+    }
+    user_visitor.start_triangulation(total_size);
+
+    for (typename std::map<TriangleMesh*,On_face_map>::iterator
+           it=on_face.begin(); it!=on_face.end(); ++it)
     {
       if(it->first == tm1_ptr)
         triangulate_intersected_faces(it, vpm1, nodes, mesh_to_face_boundaries);
       else
         triangulate_intersected_faces(it, vpm2, nodes, mesh_to_face_boundaries);
     }
+
+    user_visitor.end_triangulation();
 
     nodes.finalize(mesh_to_node_id_to_vertex);
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -570,7 +570,7 @@ public:
   }
 
 
-  void start_intersection_points(int i) const
+  void start_intersection_points(std::size_t i) const
   {
     user_visitor.start_intersection_points(i);
   }
@@ -585,7 +585,7 @@ public:
     user_visitor.end_intersection_points();
   }
 
-  void start_coplanar_faces(int i) const
+  void start_coplanar_faces(std::size_t i) const
   {
     user_visitor.start_coplanar_faces(i);
   }
@@ -1204,7 +1204,7 @@ public:
 
     const Node_id nb_nodes = nodes.size();
 
-    int i = 0;
+    std::size_t i = 0;
     for (typename On_face_map::iterator it=on_face_map.begin();
           it!=on_face_map.end();++it)
     {
@@ -1562,7 +1562,7 @@ public:
     //  and also those with intersection points only on the boundary.
 
 
-    int total_size = 0;
+    std::size_t total_size = 0;
     for (typename std::map<TriangleMesh*,On_face_map>::iterator
            it=on_face.begin(); it!=on_face.end(); ++it)
     {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -540,7 +540,6 @@ private:
   {
     return get(ecm, ed);
   }
-
 // visitor public functions
 public:
   Surface_intersection_visitor_for_corefinement(
@@ -552,6 +551,24 @@ public:
     , input_with_coplanar_faces(false)
     , const_mesh_ptr(const_mesh_ptr)
   {}
+
+
+  void start_filter_intersections() const
+  {
+    user_visitor.start_filter_intersections();
+  }
+
+
+  void progress_filter_intersection(double d) const
+  {
+    user_visitor.progress_filter_intersection(d);
+  }
+
+  void end_filter_intersections() const
+  {
+    user_visitor.end_filter_intersections();
+  }
+
 
   void
   set_non_manifold_feature_map(

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -465,24 +465,24 @@ struct Default_visitor{
                          vertex_descriptor /* v_tgt */, TriangleMesh& /*tm_tgt*/){}
 
   // progress tracking
-  void start_filter_intersections() const {}
-  void progress_filter_intersection(double ) const {}
-  void end_filter_intersections() const {}
+  void start_filtering_intersections() const {}
+  void progress_filtering_intersection(double ) const {}
+  void end_filtering_intersections() const {}
 
-  void start_face_triangulations(std::size_t) const {}
-  void face_triangulation(std::size_t) const {}
-  void end_face_triangulations() const {}
+  void start_triangulating_faces(std::size_t) const {}
+  void triangulating_faces_step() const {}
+  void end_triangulating_faces() const {}
 
   void start_handling_intersection_of_coplanar_faces(std::size_t) const {}
-  void coplanar_faces_step() const {}
+  void intersection_of_coplanar_faces_step() const {}
   void end_handling_intersection_of_coplanar_faces() const {}
 
   void start_handling_edge_face_intersections(std::size_t) const {}
-  void intersection_points_step() const {}
+  void edge_face_intersections_step() const {}
   void end_handling_edge_face_intersections() const {}
 
-  void start_build_output() const {}
-  void end_build_output() const {}
+  void start_building_output() const {}
+  void end_building_output() const {}
 
 // Required by Face_graph_output_builder
   void filter_coplanar_edges() const {}

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -469,17 +469,17 @@ struct Default_visitor{
   void progress_filter_intersection(double ) const {}
   void end_filter_intersections() const {}
 
-  void start_triangulation(std::size_t) const {}
-  void progress_triangulation(std::size_t) const {}
-  void end_triangulation() const {}
+  void start_face_triangulations(std::size_t) const {}
+  void face_triangulation(std::size_t) const {}
+  void end_face_triangulations() const {}
 
-  void start_coplanar_faces(std::size_t) const {}
+  void start_handling_intersection_of_coplanar_faces(std::size_t) const {}
   void coplanar_faces_step() const {}
-  void end_coplanar_faces() const {}
+  void end_handling_intersection_of_coplanar_faces() const {}
 
-  void start_intersection_points(std::size_t) const {}
+  void start_handling_edge_face_intersections(std::size_t) const {}
   void intersection_points_step() const {}
-  void end_intersection_points() const {}
+  void end_handling_edge_face_intersections() const {}
 
   void start_build_output() const {}
   void end_build_output() const {}

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -466,15 +466,15 @@ struct Default_visitor{
   void progress_filter_intersection(double ) const {}
   void end_filter_intersections() const {}
 
-  void start_triangulation(int) const {}
-  void progress_triangulation(int) const {}
+  void start_triangulation(std::size_t) const {}
+  void progress_triangulation(std::size_t) const {}
   void end_triangulation() const {}
 
-  void start_coplanar_faces(int) const {}
+  void start_coplanar_faces(std::size_t) const {}
   void coplanar_faces_step() const {}
   void end_coplanar_faces() const {}
 
-  void start_intersection_points(int) const {}
+  void start_intersection_points(std::size_t) const {}
   void intersection_points_step() const {}
   void end_intersection_points() const {}
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -466,7 +466,7 @@ struct Default_visitor{
 
   // progress tracking
   void start_filtering_intersections() const {}
-  void progress_filtering_intersection(double ) const {}
+  void progress_filtering_intersections(double ) const {}
   void end_filtering_intersections() const {}
 
   void start_triangulating_faces(std::size_t) const {}

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -465,15 +465,23 @@ struct Default_visitor{
   void start_filter_intersections() const {}
   void progress_filter_intersection(double ) const {}
   void end_filter_intersections() const {}
+
   void start_triangulation(int) const {}
   void progress_triangulation(int) const {}
   void end_triangulation() const {}
+
+  void start_coplanar_faces(int) const {}
+  void coplanar_faces_step() const {}
+  void end_coplanar_faces() const {}
+
+  void start_intersection_points(int) const {}
+  void intersection_points_step() const {}
+  void end_intersection_points() const {}
+
   void start_build_output() const {}
   void build_output_step() const {}
   void end_build_output() const {}
-  void start_coplanar_faces() const {}
-  void coplanar_faces_step() const {}
-  void end_coplanar_faces() const {}
+
 
   // calls commented in the code and probably incomplete due to the migration
   // see NODE_VISITOR_TAG

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -468,6 +468,12 @@ struct Default_visitor{
   void start_triangulation(int) const {}
   void progress_triangulation(int) const {}
   void end_triangulation() const {}
+  void start_build_output() const {}
+  void build_output_step() const {}
+  void end_build_output() const {}
+  void start_coplanar_faces() const {}
+  void coplanar_faces_step() const {}
+  void end_coplanar_faces() const {}
 
   // calls commented in the code and probably incomplete due to the migration
   // see NODE_VISITOR_TAG
@@ -1104,6 +1110,8 @@ void append_patches_to_triangle_mesh(
     ids_of_patches_to_append.push_back(i);
   }
 
+  user_visitor.build_output_step();
+
   std::vector<halfedge_descriptor> interior_vertex_halfedges;
   for (std::size_t i : ids_of_patches_to_append)
   {
@@ -1163,6 +1171,8 @@ void append_patches_to_triangle_mesh(
     }
   }
 
+  user_visitor.build_output_step();
+
   for (std::size_t i : ids_of_patches_to_append)
   {
     Patch_description<TriangleMesh>& patch = patches[i];
@@ -1185,6 +1195,8 @@ void append_patches_to_triangle_mesh(
       }
     }
   }
+
+    user_visitor.build_output_step();
 
   // handle interior edges that are on the border of the mesh:
   // they do not have a prev/next pointer set since only the pointers
@@ -1230,6 +1242,8 @@ void append_patches_to_triangle_mesh(
       }
   }
 
+  user_visitor.build_output_step();
+
   // now the step (ii) we look for the candidate halfedge by turning around
   // the vertex in the direction of the interior of the patch
   for(halfedge_descriptor h_out : border_halfedges_target_to_link)
@@ -1243,6 +1257,9 @@ void append_patches_to_triangle_mesh(
     }
     set_next(h_out, candidate, output);
   }
+
+  user_visitor.build_output_step();
+
   for(halfedge_descriptor h_out : border_halfedges_source_to_link)
   {
     halfedge_descriptor candidate =
@@ -1251,6 +1268,8 @@ void append_patches_to_triangle_mesh(
       candidate = opposite(next(candidate, output), output);
     set_next(candidate, h_out, output);
   }
+
+  user_visitor.build_output_step();
 
   // For all interior vertices, update the vertex pointer
   // of all but the vertex halfedge
@@ -1264,6 +1283,8 @@ void append_patches_to_triangle_mesh(
       set_target(next_around_vertex, v, output);
     }while(h_out != next_around_vertex);
   }
+
+  user_visitor.build_output_step();
 
   for (std::size_t i : ids_of_patches_to_append)
   {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -465,6 +465,9 @@ struct Default_visitor{
   void start_filter_intersections() const {}
   void progress_filter_intersection(double ) const {}
   void end_filter_intersections() const {}
+  void start_triangulation(int) const {}
+  void progress_triangulation(int) const {}
+  void end_triangulation() const {}
 
   // calls commented in the code and probably incomplete due to the migration
   // see NODE_VISITOR_TAG

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -460,9 +460,15 @@ struct Default_visitor{
   void before_vertex_copy(vertex_descriptor /*v_src*/, const TriangleMesh& /*tm_src*/, TriangleMesh& /*tm_tgt*/){}
   void after_vertex_copy(vertex_descriptor /*v_src*/, const TriangleMesh& /*tm_src*/,
                          vertex_descriptor /* v_tgt */, TriangleMesh& /*tm_tgt*/){}
-// calls commented in the code and probably incomplete due to the migration
-// see NODE_VISITOR_TAG
-/*
+
+  // progress tracking
+  void start_filter_intersections() const {}
+  void progress_filter_intersection(double ) const {}
+  void end_filter_intersections() const {}
+
+  // calls commented in the code and probably incomplete due to the migration
+  // see NODE_VISITOR_TAG
+  /*
   // autorefinement only
   void new_node_added_triple_face(std::size_t node_id,
                                   face_descriptor f1,
@@ -470,7 +476,7 @@ struct Default_visitor{
                                   face_descriptor f3,
                                   const TriangleMesh& tm)
   {}
-*/
+  */
 };
 
 template < class TriangleMesh,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
@@ -163,7 +163,7 @@ public:
 
   void progress(double d)
   {
-    visitor.progress_filter_intersection(d);
+    visitor.progress_filtering_intersection(d);
   }
 
 };

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
@@ -155,15 +155,9 @@ public:
     operator()(*face_box_ptr, *edge_box_ptr);
   }
 
-   bool report(int dim)
-  {
-    return (dim == Box::dimension() - 1);
-  }
-
-
   void progress(double d)
   {
-    visitor.progress_filtering_intersection(d);
+    visitor.progress_filtering_intersections(d);
   }
 
 };

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
@@ -69,7 +69,8 @@ public:
 template<class TriangleMesh,
          class VertexPointMapF, class VertexPointMapE,
          class EdgeToFaces,
-         class CoplanarFaceSet>
+         class CoplanarFaceSet,
+         class Visitor>
 class Collect_face_bbox_per_edge_bbox_with_coplanar_handling {
 protected:
   const TriangleMesh& tm_faces;
@@ -78,6 +79,7 @@ protected:
   const VertexPointMapE& vpmap_tme;
   EdgeToFaces& edge_to_faces;
   CoplanarFaceSet& coplanar_faces;
+  const Visitor& visitor;
 
   typedef boost::graph_traits<TriangleMesh> Graph_traits;
   typedef typename Graph_traits::face_descriptor face_descriptor;
@@ -95,13 +97,15 @@ public:
     const VertexPointMapF& vpmap_tmf,
     const VertexPointMapE& vpmap_tme,
     EdgeToFaces& edge_to_faces,
-    CoplanarFaceSet& coplanar_faces)
+    CoplanarFaceSet& coplanar_faces,
+    const Visitor& visitor)
   : tm_faces(tm_faces)
   , tm_edges(tm_edges)
   , vpmap_tmf(vpmap_tmf)
   , vpmap_tme(vpmap_tme)
   , edge_to_faces(edge_to_faces)
   , coplanar_faces(coplanar_faces)
+  , visitor(visitor)
   {}
 
   void operator()( const Box& face_box, const Box& edge_box) const {
@@ -150,6 +154,18 @@ public:
   {
     operator()(*face_box_ptr, *edge_box_ptr);
   }
+
+   bool report(int dim)
+  {
+    return (dim == Box::dimension() - 1);
+  }
+
+
+  void progress(double d)
+  {
+    visitor.progress_filter_intersection(d);
+  }
+
 };
 
 template<class TriangleMesh,

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -123,7 +123,7 @@ struct Default_surface_intersection_visitor{
 
   // needed for progress tracking
   void start_filter_intersections() const {}
-  void progress_filter_intersection(double d) const{}
+  void progress_filter_intersection(double) const{}
   void end_filter_intersections() const {}
 
   void start_triangulation(std::size_t) const {}

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -122,24 +122,24 @@ struct Default_surface_intersection_visitor{
   {}
 
   // needed for progress tracking
-  void start_filter_intersections() const {}
-  void progress_filter_intersection(double) const{}
-  void end_filter_intersections() const {}
+  void start_filtering_intersections() const {}
+  void progress_filtering_intersection(double) const{}
+  void end_filtering_intersections() const {}
 
-  void start_face_triangulations(std::size_t) const {}
-  void face_triangulation(std::size_t) const {}
-  void end_face_triangulations() const {}
+  void start_triangulating_faces(std::size_t) const {}
+  void triangulating_faces_step(std::size_t) const {}
+  void end_triangulating_faces() const {}
 
   void start_handling_intersection_of_coplanar_faces(std::size_t) const {}
-  void coplanar_faces_step() const {}
+  void intersection_of_coplanar_faces_step() const {}
   void end_handling_intersection_of_coplanar_faces() const {}
 
   void start_handling_edge_face_intersections(std::size_t) const {}
-  void intersection_points_step() const {}
+  void edge_face_intersections_step() const {}
   void end_handling_edge_face_intersections() const {}
 
-  void start_build_output() const {}
-  void end_build_output() const {}
+  void start_building_output() const {}
+  void end_building_output() const {}
 };
 
 struct Node_id_set {
@@ -725,7 +725,7 @@ class Intersection_of_triangle_meshes
     visitor.start_handling_intersection_of_coplanar_faces(coplanar_faces.size());
     for(const Face_pair& face_pair : coplanar_faces)
     {
-      visitor.coplanar_faces_step();
+      visitor.intersection_of_coplanar_faces_step();
       face_descriptor f1=face_pair.first;
       face_descriptor f2=face_pair.second;
 
@@ -872,7 +872,7 @@ class Intersection_of_triangle_meshes
     for(typename Edge_to_faces::iterator it=tm1_edge_to_tm2_faces.begin();
                                          it!=tm1_edge_to_tm2_faces.end();++it)
     {
-      visitor.intersection_points_step();
+      visitor.edge_face_intersections_step();
       edge_descriptor e_1=it->first;
 
       halfedge_descriptor h_1=halfedge(e_1,tm1);
@@ -1652,10 +1652,10 @@ public:
     std::set<face_descriptor> tm1_faces;
     std::set<face_descriptor> tm2_faces;
 
-    visitor.start_filter_intersections();
+    visitor.start_filtering_intersections();
     filter_intersections(tm1, tm2, vpm1, vpm2, non_manifold_feature_map_2, throw_on_self_intersection, tm1_faces, tm2_faces, false);
     filter_intersections(tm2, tm1, vpm2, vpm1, non_manifold_feature_map_1, throw_on_self_intersection, tm2_faces, tm1_faces, true);
-    visitor.end_filter_intersections();
+    visitor.end_filtering_intersections();
 
     Node_id current_node((std::numeric_limits<Node_id>::max)());
     CGAL_assertion(current_node+1==0);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -854,10 +854,12 @@ class Intersection_of_triangle_meshes
   {
     typedef std::tuple<Intersection_type, halfedge_descriptor, bool,bool>  Inter_type;
 
+    visitor.start_intersection_points(tm1_edge_to_tm2_faces.size());
 
     for(typename Edge_to_faces::iterator it=tm1_edge_to_tm2_faces.begin();
                                          it!=tm1_edge_to_tm2_faces.end();++it)
     {
+      visitor.intersection_points_step();
       edge_descriptor e_1=it->first;
 
       halfedge_descriptor h_1=halfedge(e_1,tm1);
@@ -1076,6 +1078,7 @@ class Intersection_of_triangle_meshes
       } // end loop on all faces that intersect the edge
     } // end loop on all entries (edges) in 'edge_to_face'
     CGAL_assertion(nodes.size()==unsigned(current_node+1));
+    visitor.end_intersection_points();
   }
 
   struct Graph_node{

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -122,11 +122,25 @@ struct Default_surface_intersection_visitor{
   {}
 
   // needed for progress tracking
-  void progress_filter_intersection(double d) const{}
-
   void start_filter_intersections() const {}
-
+  void progress_filter_intersection(double d) const{}
   void end_filter_intersections() const {}
+
+  void start_triangulation(int) const {}
+  void progress_triangulation(int) const {}
+  void end_triangulation() const {}
+
+  void start_coplanar_faces(int) const {}
+  void coplanar_faces_step() const {}
+  void end_coplanar_faces() const {}
+
+  void start_intersection_points(int) const {}
+  void intersection_points_step() const {}
+  void end_intersection_points() const {}
+
+  void start_build_output() const {}
+  void build_output_step() const {}
+  void end_build_output() const {}
 };
 
 struct Node_id_set {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -123,7 +123,7 @@ struct Default_surface_intersection_visitor{
 
   // needed for progress tracking
   void start_filtering_intersections() const {}
-  void progress_filtering_intersection(double) const{}
+  void progress_filtering_intersections(double) const{}
   void end_filtering_intersections() const {}
 
   void start_triangulating_faces(std::size_t) const {}

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -305,9 +305,9 @@ class Intersection_of_triangle_meshes
     Callback callback(tm_f, tm_e, edge_to_faces);
     #else
     typedef Collect_face_bbox_per_edge_bbox_with_coplanar_handling<
-      TriangleMesh, VPMF, VPME, Edge_to_faces, Coplanar_face_set>
+      TriangleMesh, VPMF, VPME, Edge_to_faces, Coplanar_face_set, Node_visitor>
      Callback;
-    Callback  callback(tm_f, tm_e, vpm_f, vpm_e, edge_to_faces, coplanar_faces);
+    Callback  callback(tm_f, tm_e, vpm_f, vpm_e, edge_to_faces, coplanar_faces, visitor);
     #endif
     //using pointers in box_intersection_d is about 10% faster
     if (throw_on_self_intersection){
@@ -1625,8 +1625,11 @@ public:
     // used only if throw_on_self_intersection == true
     std::set<face_descriptor> tm1_faces;
     std::set<face_descriptor> tm2_faces;
+
+    visitor.start_filter_intersections();
     filter_intersections(tm1, tm2, vpm1, vpm2, non_manifold_feature_map_2, throw_on_self_intersection, tm1_faces, tm2_faces, false);
     filter_intersections(tm2, tm1, vpm2, vpm1, non_manifold_feature_map_1, throw_on_self_intersection, tm2_faces, tm1_faces, true);
+    visitor.end_filter_intersections();
 
     Node_id current_node((std::numeric_limits<Node_id>::max)());
     CGAL_assertion(current_node+1==0);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -126,20 +126,19 @@ struct Default_surface_intersection_visitor{
   void progress_filter_intersection(double) const{}
   void end_filter_intersections() const {}
 
-  void start_triangulation(std::size_t) const {}
-  void progress_triangulation(std::size_t) const {}
-  void end_triangulation() const {}
+  void start_face_triangulations(std::size_t) const {}
+  void face_triangulation(std::size_t) const {}
+  void end_face_triangulations() const {}
 
-  void start_coplanar_faces(std::size_t) const {}
+  void start_handling_intersection_of_coplanar_faces(std::size_t) const {}
   void coplanar_faces_step() const {}
-  void end_coplanar_faces() const {}
+  void end_handling_intersection_of_coplanar_faces() const {}
 
-  void start_intersection_points(std::size_t) const {}
+  void start_handling_edge_face_intersections(std::size_t) const {}
   void intersection_points_step() const {}
-  void end_intersection_points() const {}
+  void end_handling_edge_face_intersections() const {}
 
   void start_build_output() const {}
-  void build_output_step() const {}
   void end_build_output() const {}
 };
 
@@ -723,7 +722,7 @@ class Intersection_of_triangle_meshes
     typedef std::map<Key,Node_id> Coplanar_node_map;
     Coplanar_node_map coplanar_node_map;
 
-    visitor.start_coplanar_faces(coplanar_faces.size());
+    visitor.start_handling_intersection_of_coplanar_faces(coplanar_faces.size());
     for(const Face_pair& face_pair : coplanar_faces)
     {
       visitor.coplanar_faces_step();
@@ -830,7 +829,7 @@ class Intersection_of_triangle_meshes
         }
       }
     }
-    visitor.end_coplanar_faces();
+    visitor.end_handling_intersection_of_coplanar_faces();
   }
 
   //add a new node in the final graph.
@@ -868,7 +867,7 @@ class Intersection_of_triangle_meshes
   {
     typedef std::tuple<Intersection_type, halfedge_descriptor, bool,bool>  Inter_type;
 
-    visitor.start_intersection_points(tm1_edge_to_tm2_faces.size());
+    visitor.start_handling_edge_face_intersections(tm1_edge_to_tm2_faces.size());
 
     for(typename Edge_to_faces::iterator it=tm1_edge_to_tm2_faces.begin();
                                          it!=tm1_edge_to_tm2_faces.end();++it)
@@ -1092,7 +1091,7 @@ class Intersection_of_triangle_meshes
       } // end loop on all faces that intersect the edge
     } // end loop on all entries (edges) in 'edge_to_face'
     CGAL_assertion(nodes.size()==unsigned(current_node+1));
-    visitor.end_intersection_points();
+    visitor.end_handling_edge_face_intersections();
   }
 
   struct Graph_node{

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -126,15 +126,15 @@ struct Default_surface_intersection_visitor{
   void progress_filter_intersection(double d) const{}
   void end_filter_intersections() const {}
 
-  void start_triangulation(int) const {}
-  void progress_triangulation(int) const {}
+  void start_triangulation(std::size_t) const {}
+  void progress_triangulation(std::size_t) const {}
   void end_triangulation() const {}
 
-  void start_coplanar_faces(int) const {}
+  void start_coplanar_faces(sd::size_t) const {}
   void coplanar_faces_step() const {}
   void end_coplanar_faces() const {}
 
-  void start_intersection_points(int) const {}
+  void start_intersection_points(std::size_t) const {}
   void intersection_points_step() const {}
   void end_intersection_points() const {}
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -130,7 +130,7 @@ struct Default_surface_intersection_visitor{
   void progress_triangulation(std::size_t) const {}
   void end_triangulation() const {}
 
-  void start_coplanar_faces(sd::size_t) const {}
+  void start_coplanar_faces(std::size_t) const {}
   void coplanar_faces_step() const {}
   void end_coplanar_faces() const {}
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -120,6 +120,13 @@ struct Default_surface_intersection_visitor{
     const TriangleMesh&,
     const Non_manifold_feature_map<TriangleMesh>&)
   {}
+
+  // needed for progress tracking
+  void progress_filter_intersection(double d){}
+
+  void start_filter_intersections() const {}
+
+  void end_filter_intersections() const {}
 };
 
 struct Node_id_set {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -122,7 +122,7 @@ struct Default_surface_intersection_visitor{
   {}
 
   // needed for progress tracking
-  void progress_filter_intersection(double d){}
+  void progress_filter_intersection(double d) const{}
 
   void start_filter_intersections() const {}
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -709,8 +709,10 @@ class Intersection_of_triangle_meshes
     typedef std::map<Key,Node_id> Coplanar_node_map;
     Coplanar_node_map coplanar_node_map;
 
+    visitor.start_coplanar_faces(coplanar_faces.size());
     for(const Face_pair& face_pair : coplanar_faces)
     {
+      visitor.coplanar_faces_step();
       face_descriptor f1=face_pair.first;
       face_descriptor f2=face_pair.second;
 
@@ -814,6 +816,7 @@ class Intersection_of_triangle_meshes
         }
       }
     }
+    visitor.end_coplanar_faces();
   }
 
   //add a new node in the final graph.


### PR DESCRIPTION
## Summary of Changes

Introduce an API for tracking progress.  We report the progress in the traversal of the primary tree, that is we report 50% once we come back from the left subtree of the root of the segment tree.

The API is not yet documented, that is for the moment you have to look at the callback class in the example `progress.cpp`.

This PR also adds progress tracking to the Boolean operations based on corefinement.

## Release Management

* Affected package(s): Box_intersection_d, Polygon_mesh_processing
* Feature/Small Feature (if any):  tbd.
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:  unchanged

