### PR TITLE
Nef_3: SNC_structure cleanup - easier debugging

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SNC_list.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_list.h
@@ -15,86 +15,12 @@
 
 #include <CGAL/license/Nef_3.h>
 
-
 #include <CGAL/Nef_S2/SM_list.h>
 
 namespace CGAL {
 
-template < class Sphere_map>
-class SNC_in_place_list_sm
-    : public Sphere_map,
-      public In_place_list_base<SNC_in_place_list_sm<Sphere_map> > {
-public:
-    typedef SNC_in_place_list_sm<Sphere_map> Self;
-
-    SNC_in_place_list_sm() {}
-    SNC_in_place_list_sm(const Self&)=default;
-    SNC_in_place_list_sm(const Sphere_map& sm)   // down cast
-        : Sphere_map(sm) {}
-    Self& operator=( const Self& sm) {
-        // This self written assignment avoids that assigning vertices will
-        // overwrite the list linking of the target vertex.
-        *((Sphere_map*)this) = ((const Sphere_map&)sm);
-        return *this;
-    }
-};
-
-template < class Halffacet>
-class SNC_in_place_list_halffacet
-    : public Halffacet,
-      public In_place_list_base<SNC_in_place_list_halffacet<Halffacet> > {
-public:
-    typedef SNC_in_place_list_halffacet<Halffacet> Self;
-
-    SNC_in_place_list_halffacet() {}
-    SNC_in_place_list_halffacet(const Halffacet& v)   // down cast
-        : Halffacet(v) {}
-    SNC_in_place_list_halffacet(const Self&)=default;
-    Self& operator=( const Self& v) {
-        // This self written assignment avoids that assigning vertices will
-        // overwrite the list linking of the target vertex.
-        *((Halffacet*)this) = ((const Halffacet&)v);
-        return *this;
-    }
-};
-
-template < class Volume>
-class SNC_in_place_list_volume
-    : public Volume,
-      public In_place_list_base<SNC_in_place_list_volume<Volume> > {
-public:
-    typedef SNC_in_place_list_volume<Volume> Self;
-
-    SNC_in_place_list_volume() {}
-    SNC_in_place_list_volume(const Volume& v)   // down cast
-        : Volume(v) {}
-    SNC_in_place_list_volume(const Self&)=default;
-    Self& operator=( const Self& v) {
-        // This self written assignment avoids that assigning vertices will
-        // overwrite the list linking of the target vertex.
-        *((Volume*)this) = ((const Volume&)v);
-        return *this;
-    }
-};
-
-template < class SHalfloop>
-class SNC_in_place_list_shalfloop
-    : public SHalfloop,
-      public In_place_list_base<SNC_in_place_list_shalfloop<SHalfloop> > {
-public:
-    typedef SNC_in_place_list_shalfloop<SHalfloop> Self;
-
-    SNC_in_place_list_shalfloop() {}
-    SNC_in_place_list_shalfloop(const SHalfloop& v)   // down cast
-        : SHalfloop(v) {}
-    SNC_in_place_list_shalfloop(const Self&)=default;
-    Self& operator=( const Self& v) {
-        // This self written assignment avoids that assigning vertices will
-        // overwrite the list linking of the target vertex.
-        *((SHalfloop*)this) = ((const SHalfloop&)v);
-        return *this;
-    }
-};
+template< typename T>
+using SNC_in_place_list = SM_in_place_list<T>;
 
 } //namespace CGAL
 

--- a/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
@@ -338,12 +338,11 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
 
   SHalfedge_handle new_shalfedge_pair() {
     SHalfedge_iterator se = this->sncp()->new_shalfedge_only();
-    SHalfedge_iterator set = this->sncp()->new_shalfedge_only();
     if(this->shalfedges_begin() == this->sncp()->shalfedges_end()) {
       init_range(se);
-    } else {
-      this->shalfedges_last() = set;
     }
+    SHalfedge_iterator set = this->sncp()->new_shalfedge_only();
+    this->shalfedges_last() = set;
     make_twins(se,set);
     return se;
   }

--- a/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
@@ -312,14 +312,10 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
 
   SVertex_handle new_svertex(const Sphere_point& p,
                            Mark m = Mark()) {
-    SVertex_iterator sv;
+    SVertex_iterator sv = this->sncp()->new_halfedge_only();
     if (this->svertices_begin() == this->sncp()->svertices_end()) {
-      sv = this->sncp()->new_halfedge_only();
       init_range(sv);
-    }
-    else {
-      SVertex_iterator svn = this->svertices_end();
-      sv =  this->sncp()->new_halfedge_only(svn);
+    } else {
       this->svertices_last() = sv;
     }
     sv->point() = p;
@@ -328,53 +324,26 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
     CGAL_NEF_TRACEN("new_svertex "<<&*sv);
     return sv;
   }
-  /*
+
   SFace_handle new_sface() {
-    SFace_iterator sf =  this->sncp()->new_sface_only();
-    if ( this->sfaces_begin() == this->sncp()->sfaces_end()) init_range(sf);
-    else this->sfaces_last() = sf;
-    sf->center_vertex() = Vertex_handle((SNC_in_place_list_sm<Self>*) this);
-    return sf;
-  }
-  */
-  SFace_handle new_sface() {
-    SFace_iterator sf;
+    SFace_iterator sf = this->sncp()->new_sface_only();
     if ( this->sfaces_begin() == this->sncp()->sfaces_end()) {
-      sf =  this->sncp()->new_sface_only();
       init_range(sf);
     } else {
-      SFace_iterator sfn = this->sfaces_end();
-      sf =  this->sncp()->new_sface_only(sfn);
       this->sfaces_last() = sf;
     }
     sf->center_vertex() = Vertex_handle((SNC_in_place_list_sm<Self>*) this);
     return sf;
   }
 
-  /*
   SHalfedge_handle new_shalfedge_pair() {
     SHalfedge_iterator se = this->sncp()->new_shalfedge_only();
     SHalfedge_iterator set = this->sncp()->new_shalfedge_only();
-    if(this->shalfedges_begin() == this->sncp()->shalfedges_end())
-      init_range(se);
-    this->shalfedges_last() = set;
-    make_twins(se,set);
-    return se;
-  }
-  */
-
-  SHalfedge_handle new_shalfedge_pair() {
-    SHalfedge_iterator se, set;
     if(this->shalfedges_begin() == this->sncp()->shalfedges_end()) {
-      se = this->sncp()->new_shalfedge_only();
-      set = this->sncp()->new_shalfedge_only();
       init_range(se);
     } else {
-      SHalfedge_iterator sen = this->shalfedges_end();
-      se = this->sncp()->new_shalfedge_only(sen);
-      set = this->sncp()->new_shalfedge_only(sen);
+      this->shalfedges_last() = set;
     }
-    this->shalfedges_last() = set;
     make_twins(se,set);
     return se;
   }

--- a/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
@@ -24,6 +24,7 @@
 #include <CGAL/Nef_S2/Generic_handle_map.h>
 #include <CGAL/Nef_2/iterator_tools.h>
 #include <CGAL/Nef_3/Infimaximal_box.h>
+#include <CGAL/Nef_3/SNC_list.h>
 #include <CGAL/Nef_S2/Sphere_geometry.h>
 #include <list>
 #undef CGAL_NEF_DEBUG
@@ -78,7 +79,7 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
   typedef Infimaximal_box<typename Is_extended_kernel<Standard_kernel>::value_type, Standard_kernel> No_box;
 
   typedef Self                                              Vertex_base;
-  typedef SNC_in_place_list_sm<Vertex_base>                 Vertex;
+  typedef SNC_in_place_list<Vertex_base>                    Vertex;
   typedef CGAL::In_place_list<Vertex,false>                 Vertex_list;
   typedef CGAL_ALLOCATOR(Vertex)                            Vertex_alloc;
   typedef typename Vertex_list::iterator                    Vertex_handle;
@@ -87,7 +88,7 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
   typedef typename Vertex_list::const_iterator              Vertex_const_iterator;
 
   typedef typename Items::template SVertex<SNC_structure>   SVertex_base;
-  typedef SNC_in_place_list_svertex<SVertex_base>           SVertex;
+  typedef SNC_in_place_list<SVertex_base>                   SVertex;
   typedef CGAL::In_place_list<SVertex,false>                SVertex_list;
   typedef CGAL_ALLOCATOR(SVertex)                           SVertex_alloc;
   typedef typename SVertex_list::iterator                   SVertex_handle;
@@ -96,7 +97,7 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
   typedef typename SVertex_list::const_iterator             SVertex_const_iterator;
 
   typedef typename Items::template SHalfedge<SNC_structure> SHalfedge_base;
-  typedef SNC_in_place_list_shalfedge<SHalfedge_base>       SHalfedge;
+  typedef SNC_in_place_list<SHalfedge_base>                 SHalfedge;
   typedef CGAL::In_place_list<SHalfedge,false>              SHalfedge_list;
   typedef CGAL_ALLOCATOR(SHalfedge)                         SHalfedge_alloc;
   typedef typename SHalfedge_list::iterator                 SHalfedge_handle;
@@ -105,7 +106,7 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
   typedef typename SHalfedge_list::const_iterator           SHalfedge_const_iterator;
 
   typedef typename Items::template SHalfloop<SNC_structure> SHalfloop_base;
-  typedef SNC_in_place_list_shalfloop<SHalfloop_base>       SHalfloop;
+  typedef SNC_in_place_list<SHalfloop_base>                 SHalfloop;
   typedef CGAL::In_place_list<SHalfloop,false>              SHalfloop_list;
   typedef CGAL_ALLOCATOR(SHalfloop)                         SHalfloop_alloc;
   typedef typename SHalfloop_list::iterator                 SHalfloop_handle;
@@ -114,7 +115,7 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
   typedef typename SHalfloop_list::const_iterator           SHalfloop_const_iterator;
 
   typedef typename Items::template SFace<SNC_structure>     SFace_base;
-  typedef SNC_in_place_list_sface<SFace_base>               SFace;
+  typedef SNC_in_place_list<SFace_base>                     SFace;
   typedef CGAL::In_place_list<SFace,false>                  SFace_list;
   typedef CGAL_ALLOCATOR(SFace)                             SFace_alloc;
   typedef typename SFace_list::iterator                     SFace_handle;
@@ -320,7 +321,7 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
     }
     sv->point() = p;
     sv->mark() = m;
-    sv->center_vertex() = Vertex_handle((SNC_in_place_list_sm<Self>*) this);
+    sv->center_vertex() = Vertex_handle((SNC_in_place_list<Self>*) this);
     CGAL_NEF_TRACEN("new_svertex "<<&*sv);
     return sv;
   }
@@ -332,7 +333,7 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
     } else {
       this->sfaces_last() = sf;
     }
-    sf->center_vertex() = Vertex_handle((SNC_in_place_list_sm<Self>*) this);
+    sf->center_vertex() = Vertex_handle((SNC_in_place_list<Self>*) this);
     return sf;
   }
 

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -736,130 +736,73 @@ public:
   }
 
   Vertex_alloc vertex_allocator;
-  Vertex* get_vertex_node( const Vertex& ) {
-    Vertex* p = vertex_allocator.allocate(1);
-    std::allocator_traits<Vertex_alloc>::construct(vertex_allocator, p);
-    return p;
-  }
-  void put_vertex_node( Vertex* p) {
-    std::allocator_traits<Vertex_alloc>::destroy(vertex_allocator,p);
-    vertex_allocator.deallocate( p, 1);
-  }
-
   Halfedge_alloc halfedge_allocator;
-  Halfedge* get_halfedge_node( const Halfedge&) {
-    Halfedge* p = halfedge_allocator.allocate(1);
-    std::allocator_traits<Halfedge_alloc>::construct(halfedge_allocator, p);
-    return p;
-  }
-  void put_halfedge_node( Halfedge* p) {
-    std::allocator_traits<Halfedge_alloc>::destroy(halfedge_allocator,p);
-    halfedge_allocator.deallocate( p, 1);
-  }
-
   Halffacet_alloc halffacet_allocator;
-  Halffacet* get_halffacet_node( const Halffacet& ) {
-    Halffacet* p = halffacet_allocator.allocate(1);
-    std::allocator_traits<Halffacet_alloc>::construct(halffacet_allocator, p);
-    return p;
-  }
-  void put_halffacet_node( Halffacet* p) {
-    std::allocator_traits<Halffacet_alloc>::destroy(halffacet_allocator,p);
-    halffacet_allocator.deallocate( p, 1);
-  }
-
   Volume_alloc volume_allocator;
-  Volume* get_volume_node( const Volume& ) {
-    Volume* p = volume_allocator.allocate(1);
-    std::allocator_traits<Volume_alloc>::construct(volume_allocator, p);
-    return p;
-  }
-  void put_volume_node( Volume* p) {
-    std::allocator_traits<Volume_alloc>::destroy(volume_allocator,p);
-    volume_allocator.deallocate( p, 1);
-  }
-
   SHalfedge_alloc shalfedge_allocator;
-  SHalfedge* get_shalfedge_node( const SHalfedge& ) {
-    SHalfedge* p = shalfedge_allocator.allocate(1);
-    std::allocator_traits<SHalfedge_alloc>::construct(shalfedge_allocator, p);
-    return p;
-  }
-  void put_shalfedge_node( SHalfedge* p) {
-    std::allocator_traits<SHalfedge_alloc>::destroy(shalfedge_allocator,p);
-    shalfedge_allocator.deallocate( p, 1);
-  }
-
   SHalfloop_alloc shalfloop_allocator;
-  SHalfloop* get_shalfloop_node( const SHalfloop& ) {
-    SHalfloop* p = shalfloop_allocator.allocate(1);
-    std::allocator_traits<SHalfloop_alloc>::construct(shalfloop_allocator, p);
-    return p;
-  }
-  void put_shalfloop_node( SHalfloop* p) {
-    std::allocator_traits<SHalfloop_alloc>::destroy(shalfloop_allocator,p);
-    shalfloop_allocator.deallocate( p, 1);
-  }
-
   SFace_alloc sface_allocator;
-  SFace* get_sface_node( const SFace& ) {
-    SFace* p = sface_allocator.allocate(1);
-    std::allocator_traits<SFace_alloc>::construct(sface_allocator, p);
+
+  template <typename Node_alloc, typename Node = typename std::allocator_traits<Node_alloc>::value_type>
+  Node* get_node(Node_alloc& allocator) {
+    Node* p = allocator.allocate(1);
+    std::allocator_traits<Node_alloc>::construct(allocator, p);
     return p;
   }
-  void put_sface_node( SFace* p) {
-    std::allocator_traits<SFace_alloc>::destroy(sface_allocator,p);
-    sface_allocator.deallocate( p, 1);
-  }
 
+  template <typename Node_alloc, typename Node>
+  void put_node(Node_alloc& allocator, Node* p) {
+    std::allocator_traits<Node_alloc>::destroy(allocator,p);
+    allocator.deallocate( p, 1);
+  }
 
   Vertex_handle new_vertex_only() {
-    vertices_.push_back(* get_vertex_node(Vertex()));
+    vertices_.push_back(* get_node(vertex_allocator));
     CGAL_NEF_TRACEN("  new vertex only "<<&*(--vertices_end()));
     return --vertices_end();
   }
   Halfedge_handle new_halfedge_only(Halfedge_handle e)  {
-    Halfedge_handle ne = halfedges_.insert(e, * get_halfedge_node(Halfedge()));
+    Halfedge_handle ne = halfedges_.insert(e, * get_node(halfedge_allocator));
     CGAL_NEF_TRACEN("  after "<<&*e<<" new halfedge only "<<&*ne);
     return ne;
   }
   Halfedge_handle new_halfedge_only()  {
     CGAL_NEF_TRACEN("  new halfedge only "<<&*(--halfedges_end()));
-    halfedges_.push_back( * get_halfedge_node(Halfedge()));
+    halfedges_.push_back( * get_node(halfedge_allocator));
     return --halfedges_end();
   }
   Halffacet_handle new_halffacet_only()  {
-    halffacets_.push_back( * get_halffacet_node(Halffacet()));
+    halffacets_.push_back( * get_node(halffacet_allocator));
     CGAL_NEF_TRACEN("  new halffacet only "<<&*(--halffacets_end()));
     return --halffacets_end();
   }
   Volume_handle new_volume_only()  {
-    volumes_.push_back( * get_volume_node(Volume()));
+    volumes_.push_back( * get_node(volume_allocator));
     CGAL_NEF_TRACEN("  new volume only "<<&*(--volumes_end()));
     return --volumes_end();
   }
   SHalfedge_handle new_shalfedge_only()  {
-    shalfedges_.push_back( * get_shalfedge_node(SHalfedge()));
+    shalfedges_.push_back( * get_node(shalfedge_allocator));
     CGAL_NEF_TRACEN("  new shalfedge only "<<&*(--shalfedges_end()));
     return --shalfedges_end();
   }
   SHalfedge_handle new_shalfedge_only(SHalfedge_handle se) {
-    SHalfedge_handle nse = shalfedges_.insert(se, * get_shalfedge_node(SHalfedge()));
+    SHalfedge_handle nse = shalfedges_.insert(se, * get_node(shalfedge_allocator));
     CGAL_NEF_TRACEN("  after " << &*se << " new shalfedge only " << &*nse);
     return nse;
   }
   SHalfloop_handle new_shalfloop_only()  {
-    shalfloops_.push_back( * get_shalfloop_node(SHalfloop()));
+    shalfloops_.push_back( * get_node(shalfloop_allocator));
     CGAL_NEF_TRACEN("  new shalfloop only "<<&*(--shalfloops_end()));
     return --shalfloops_end();
   }
   SFace_handle new_sface_only() {
-    sfaces_.push_back( * get_sface_node(SFace()));
+    sfaces_.push_back( * get_node(sface_allocator));
     CGAL_NEF_TRACEN("  new sface only "<<&*(--sfaces_end()));
     return --sfaces_end();
   }
   SFace_handle new_sface_only(SFace_handle sf) {
-    SFace_handle nsf = sfaces_.insert(sf, * get_sface_node(SFace()));
+    SFace_handle nsf = sfaces_.insert(sf, * get_node(sface_allocator));
     CGAL_NEF_TRACEN("  after " << &*sf << " new sface only " << &*nsf);
     return nsf;
   }
@@ -867,41 +810,41 @@ public:
   void delete_vertex_only(Vertex_handle h) {
     CGAL_NEF_TRACEN("~ deleting vertex only "<<&*h<<" from "<<&*this);
     vertices_.erase(h);
-    put_vertex_node(&*h);
+    put_node(vertex_allocator,&*h);
   }
   void delete_halfedge_only(Halfedge_handle h) {
     CGAL_NEF_TRACEN("~ deleting halfedge only "<<&*h<<" from "<<&*this);
     CGAL_assertion(!is_sm_boundary_object(h));
     halfedges_.erase(h);
-    put_halfedge_node(&*h);
+    put_node(halfedge_allocator,&*h);
   }
   void delete_halffacet_only(Halffacet_handle h) {
     CGAL_NEF_TRACEN("~ deleting halffacet only "<<&*h<<" from "<<&*this);
     halffacets_.erase(h);
-    put_halffacet_node(&*h);
+    put_node(halffacet_allocator,&*h);
   }
   void delete_volume_only(Volume_handle h) {
     CGAL_NEF_TRACEN("~ deleting volume only "<<&*h<<" from "<<&*this);
     volumes_.erase(h);
-    put_volume_node(&*h);
+    put_node(volume_allocator,&*h);
   }
   void delete_shalfedge_only(SHalfedge_handle h)  {
     CGAL_NEF_TRACEN("~ deleting shalfedge only "<<&*h<<" from "<<&*this);
     CGAL_assertion(!is_sm_boundary_object(h));
     shalfedges_.erase(h);
-    put_shalfedge_node(&*h);
+    put_node(shalfedge_allocator,&*h);
   }
   void delete_shalfloop_only(SHalfloop_handle h)  {
     CGAL_NEF_TRACEN("~ deleting shalfloop only "<<&*h<<" from "<<&*this);
     CGAL_assertion(!is_sm_boundary_object(h));
     shalfloops_.erase(h);
-    put_shalfloop_node(&*h);
+    put_node(shalfloop_allocator,&*h);
   }
   void delete_sface_only(SFace_handle h)  {
     CGAL_NEF_TRACEN("~ deleting sface only "<<&*h<<" from "<<&*this);
     CGAL_assertion(!is_boundary_object(h));
     sfaces_.erase(h);
-    put_sface_node(&*h);
+    put_node(sface_allocator,&*h);
   }
     //SL: in the following function, I guess the sizeof(void*) is related to the void* info that was
     //used together with geninfo to store an arbitrary type. I replaced that with any and did not changed that

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -129,7 +129,7 @@ public:
 
  public:
   typedef Sphere_map                                        Vertex_base;
-  typedef SNC_in_place_list_sm<Vertex_base>                 Vertex;
+  typedef SNC_in_place_list<Vertex_base>                    Vertex;
   typedef CGAL::In_place_list<Vertex,false>                 Vertex_list;
   typedef CGAL_ALLOCATOR(Vertex)                            Vertex_alloc;
   typedef typename Vertex_list::iterator                    Vertex_handle;
@@ -138,7 +138,7 @@ public:
   typedef typename Vertex_list::const_iterator              Vertex_const_iterator;
 
   typedef typename Items::template Halffacet<SNC_structure> Halffacet_base;
-  typedef SNC_in_place_list_halffacet<Halffacet_base>       Halffacet;
+  typedef SNC_in_place_list<Halffacet_base>                 Halffacet;
   typedef CGAL::In_place_list<Halffacet,false>              Halffacet_list;
   typedef CGAL_ALLOCATOR(Halffacet)                         Halffacet_alloc;
   typedef typename Halffacet_list::iterator                 Halffacet_handle;
@@ -147,7 +147,7 @@ public:
   typedef typename Halffacet_list::const_iterator           Halffacet_const_iterator;
 
   typedef typename Items::template Volume<SNC_structure>    Volume_base;
-  typedef SNC_in_place_list_volume<Volume_base>             Volume;
+  typedef SNC_in_place_list<Volume_base>                    Volume;
   typedef CGAL::In_place_list<Volume,false>                 Volume_list;
   typedef CGAL_ALLOCATOR(Volume)                            Volume_alloc;
   typedef typename Volume_list::iterator                    Volume_handle;
@@ -156,7 +156,7 @@ public:
   typedef typename Volume_list::const_iterator              Volume_const_iterator;
 
   typedef typename Items::template SVertex<SNC_structure>   SVertex_base;
-  typedef SNC_in_place_list_svertex<SVertex_base>           SVertex;
+  typedef SNC_in_place_list<SVertex_base>                   SVertex;
   typedef CGAL::In_place_list<SVertex,false>                SVertex_list;
   typedef CGAL_ALLOCATOR(SVertex)                           SVertex_alloc;
   typedef typename SVertex_list::iterator                   SVertex_handle;
@@ -165,7 +165,7 @@ public:
   typedef typename SVertex_list::const_iterator             SVertex_const_iterator;
 
   typedef typename Items::template SVertex<SNC_structure>   Halfedge_base;
-  typedef SNC_in_place_list_svertex<SVertex_base>           Halfedge;
+  typedef SNC_in_place_list<SVertex_base>                   Halfedge;
   typedef CGAL::In_place_list<SVertex,false>                Halfedge_list;
   typedef CGAL_ALLOCATOR(SVertex)                           Halfedge_alloc;
   typedef typename SVertex_list::iterator                   Halfedge_handle;
@@ -174,7 +174,7 @@ public:
   typedef typename SVertex_list::const_iterator             Halfedge_const_iterator;
 
   typedef typename Items::template SHalfedge<SNC_structure> SHalfedge_base;
-  typedef SNC_in_place_list_shalfedge<SHalfedge_base>       SHalfedge;
+  typedef SNC_in_place_list<SHalfedge_base>                 SHalfedge;
   typedef CGAL::In_place_list<SHalfedge,false>              SHalfedge_list;
   typedef CGAL_ALLOCATOR(SHalfedge)                         SHalfedge_alloc;
   typedef typename SHalfedge_list::iterator                 SHalfedge_handle;
@@ -183,7 +183,7 @@ public:
   typedef typename SHalfedge_list::const_iterator           SHalfedge_const_iterator;
 
   typedef typename Items::template SHalfloop<SNC_structure> SHalfloop_base;
-  typedef SNC_in_place_list_shalfloop<SHalfloop_base>       SHalfloop;
+  typedef SNC_in_place_list<SHalfloop_base>                 SHalfloop;
   typedef CGAL::In_place_list<SHalfloop,false>              SHalfloop_list;
   typedef CGAL_ALLOCATOR(SHalfloop)                         SHalfloop_alloc;
   typedef typename SHalfloop_list::iterator                 SHalfloop_handle;
@@ -192,7 +192,7 @@ public:
   typedef typename SHalfloop_list::const_iterator           SHalfloop_const_iterator;
 
   typedef typename Items::template SFace<SNC_structure>     SFace_base;
-  typedef SNC_in_place_list_sface<SFace_base>               SFace;
+  typedef SNC_in_place_list<SFace_base>                     SFace;
   typedef CGAL::In_place_list<SFace,false>                  SFace_list;
   typedef CGAL_ALLOCATOR(SFace)                             SFace_alloc;
   typedef typename SFace_list::iterator                     SFace_handle;

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -761,11 +761,6 @@ public:
     CGAL_NEF_TRACEN("  new vertex only "<<&*(--vertices_end()));
     return --vertices_end();
   }
-  Halfedge_handle new_halfedge_only(Halfedge_handle e)  {
-    Halfedge_handle ne = halfedges_.insert(e, * get_node(halfedge_allocator));
-    CGAL_NEF_TRACEN("  after "<<&*e<<" new halfedge only "<<&*ne);
-    return ne;
-  }
   Halfedge_handle new_halfedge_only()  {
     CGAL_NEF_TRACEN("  new halfedge only "<<&*(--halfedges_end()));
     halfedges_.push_back( * get_node(halfedge_allocator));
@@ -786,11 +781,6 @@ public:
     CGAL_NEF_TRACEN("  new shalfedge only "<<&*(--shalfedges_end()));
     return --shalfedges_end();
   }
-  SHalfedge_handle new_shalfedge_only(SHalfedge_handle se) {
-    SHalfedge_handle nse = shalfedges_.insert(se, * get_node(shalfedge_allocator));
-    CGAL_NEF_TRACEN("  after " << &*se << " new shalfedge only " << &*nse);
-    return nse;
-  }
   SHalfloop_handle new_shalfloop_only()  {
     shalfloops_.push_back( * get_node(shalfloop_allocator));
     CGAL_NEF_TRACEN("  new shalfloop only "<<&*(--shalfloops_end()));
@@ -800,11 +790,6 @@ public:
     sfaces_.push_back( * get_node(sface_allocator));
     CGAL_NEF_TRACEN("  new sface only "<<&*(--sfaces_end()));
     return --sfaces_end();
-  }
-  SFace_handle new_sface_only(SFace_handle sf) {
-    SFace_handle nsf = sfaces_.insert(sf, * get_node(sface_allocator));
-    CGAL_NEF_TRACEN("  after " << &*sf << " new sface only " << &*nsf);
-    return nsf;
   }
 
   void delete_vertex_only(Vertex_handle h) {

--- a/Nef_3/include/CGAL/Nef_3/Vertex.h
+++ b/Nef_3/include/CGAL/Nef_3/Vertex.h
@@ -81,7 +81,7 @@ class Vertex_base {
     shalfedges_begin_(), shalfedges_last_(),
     sfaces_begin_(), sfaces_last_(), shalfloop_(),
     info_()
-    // , sm_(Vertex_handle((SNC_in_place_list_vertex<Vertex_base>*) this))
+    // , sm_(Vertex_handle((SNC_in_place_list<Vertex_base>*) this))
       {}
 
     Vertex_base(const Point_3& p, Mark m) :
@@ -90,11 +90,11 @@ class Vertex_base {
       shalfedges_begin_(), shalfedges_last_(),
       sfaces_begin_(), sfaces_last_(), shalfloop_(),
       info_()
-      //    , sm_(Vertex_handle((SNC_in_place_list_vertex<Vertex_base>*) this))
+      //    , sm_(Vertex_handle((SNC_in_place_list<Vertex_base>*) this))
         {}
 
       Vertex_base(const Vertex_base<Refs>& v)
-      //      : sm_(Vertex_handle((SNC_in_place_list_vertex<Vertex_base>*)this))
+      //      : sm_(Vertex_handle((SNC_in_place_list<Vertex_base>*)this))
         {
           point_at_center_ = v.point_at_center_;
           mark_ = v.mark_;

--- a/Nef_S2/include/CGAL/Nef_S2/SM_list.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_list.h
@@ -15,88 +15,24 @@
 
 #include <CGAL/license/Nef_S2.h>
 
-
 #include <CGAL/In_place_list.h>
-#include <CGAL/Nef_S2/SM_items.h>
-#include <CGAL/Nef_S2/Sphere_geometry.h>
-#include <CGAL/Nef_2/Object_handle.h>
-#include <CGAL/Nef_S2/Generic_handle_map.h>
-#include <CGAL/Nef_2/iterator_tools.h>
-#include <list>
 
 namespace CGAL {
 
-/*
-template <typename HE>
-class move_edge_around_svertex {
+template < class T>
+class SM_in_place_list
+    : public T,
+      public In_place_list_base<SM_in_place_list<T> > {
 public:
-  void forward(HE& e) const  { e = (e->sprev()->twin()); }
-  void backward(HE& e) const { e = (e->twin()->snext()); }
-};
-
-template <typename HE>
-struct move_edge_around_sface {
-  void forward(HE& e)  const { e = (e->snext()); }
-  void backward(HE& e) const { e = (e->sprev()); }
-};
-*/
-
-template < class SVertex>
-class SNC_in_place_list_svertex
-    : public SVertex,
-      public In_place_list_base<SNC_in_place_list_svertex<SVertex> > {
-public:
-    typedef SNC_in_place_list_svertex<SVertex> Self;
-    //    typedef typename SVertex::SVertex_handle       SVertex_handle;
-    //    typedef typename SVertex::SVertex_const_handle SVertex_const_handle;
-    SNC_in_place_list_svertex() {}
-  SNC_in_place_list_svertex(const SNC_in_place_list_svertex& other)=default;
-    SNC_in_place_list_svertex(const SVertex& v)   // down cast
-        : SVertex(v) {}
+    typedef SM_in_place_list<T> Self;
+    SM_in_place_list() {}
+    SM_in_place_list(const SM_in_place_list& other)=default;
+    SM_in_place_list(const T& v)   // down cast
+        : T(v) {}
     Self& operator=( const Self& v) {
         // This self written assignment avoids that assigning vertices will
         // overwrite the list linking of the target vertex.
-        *((SVertex*)this) = ((const SVertex&)v);
-        return *this;
-    }
-};
-
-template < class SHalfedge>
-class SNC_in_place_list_shalfedge
-    : public SHalfedge,
-      public In_place_list_base<SNC_in_place_list_shalfedge<SHalfedge> > {
-public:
-    typedef SNC_in_place_list_shalfedge<SHalfedge> Self;
-    //    typedef typename SHalfedge::SHalfedge_handle       SHalfedge_handle;
-    //    typedef typename SHalfedge::SHalfedge_const_handle SHalfedge_const_handle;
-    SNC_in_place_list_shalfedge() {}
-    SNC_in_place_list_shalfedge(const SNC_in_place_list_shalfedge& other)=default;
-    SNC_in_place_list_shalfedge(const SHalfedge& v)   // down cast
-        : SHalfedge(v) {}
-    Self& operator=( const Self& v) {
-        // This self written assignment avoids that assigning vertices will
-        // overwrite the list linking of the target vertex.
-        *((SHalfedge*)this) = ((const SHalfedge&)v);
-        return *this;
-    }
-};
-
-template < class SFace>
-class SNC_in_place_list_sface
-    : public SFace,
-      public In_place_list_base<SNC_in_place_list_sface<SFace> > {
-public:
-    typedef SNC_in_place_list_sface<SFace> Self;
-    //    typedef typename SFace::SFace_handle       SFace_handle;
-    //    typedef typename SFace::SFace_const_handle SFace_const_handle;
-    SNC_in_place_list_sface() {}
-    SNC_in_place_list_sface(const SNC_in_place_list_sface& other)=default;
-    SNC_in_place_list_sface(const SFace& v)   // down cast
-        : SFace(v) {}
-    Self& operator=( const Self& v) {
-        // This self written assignment avoids that assigning vertices will
-        // overwrite the list linking of the target vertex.
-        *((SFace*)this) = ((const SFace&)v);
+        *((T*)this) = ((const T&)v);
         return *this;
     }
 };

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
@@ -85,7 +85,7 @@ public:
   at most one |SLoop| pair per sphere map.}*/
 
   typedef typename Items::template SVertex<Self>        SVertex_base;
-  typedef SNC_in_place_list_svertex<SVertex_base>       SVertex;
+  typedef SM_in_place_list<SVertex_base>                SVertex;
   typedef CGAL::In_place_list<SVertex,false>            SVertex_list;
   typedef CGAL_ALLOCATOR(SVertex)                       SVertex_alloc;
   typedef typename SVertex_list::iterator               SVertex_handle;
@@ -94,7 +94,7 @@ public:
   typedef typename SVertex_list::const_iterator         SVertex_const_iterator;
 
   typedef typename Items::template SHalfedge<Self>      SHalfedge_base;
-  typedef SNC_in_place_list_shalfedge<SHalfedge_base>   SHalfedge;
+  typedef SM_in_place_list<SHalfedge_base>              SHalfedge;
   typedef CGAL::In_place_list<SHalfedge,false>          SHalfedge_list;
   typedef CGAL_ALLOCATOR(SHalfedge)                     SHalfedge_alloc;
   typedef typename SHalfedge_list::iterator             SHalfedge_handle;
@@ -103,7 +103,7 @@ public:
   typedef typename SHalfedge_list::const_iterator       SHalfedge_const_iterator;
 
   typedef typename Items::template SFace<Self>          SFace_base;
-  typedef SNC_in_place_list_sface<SFace_base>           SFace;
+  typedef SM_in_place_list<SFace_base>                  SFace;
   typedef CGAL::In_place_list<SFace,false>              SFace_list;
   typedef CGAL_ALLOCATOR(SFace)                         SFace_alloc;
   typedef typename SFace_list::iterator                 SFace_handle;


### PR DESCRIPTION
## Summary of Changes

In SNC_structure there is a pattern for creating 'nodes' 

```c++
vertices_.push_back(* get_vertex_node(Vertex()));
```

This is confusing when compiled in debug mode because without optimisations the `Vertex()` gets initialised in the callee but it's just used as a 'tag' parameter, and the allocator in the  `get_vertex_node` function creates the real instance. All of the `get_x_node` functions essentially do the same thing using a different allocator, so they can be simplified to a single template function. The same can be done for the `put_x_node`  functions. Replacing these reduces the amount of 'boilerplate' code.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): cleaning / easier debugging
* License and copyright ownership: Returned to CGAL authors

