### PR TITLE
Dediamondize Garland-Heckbert policy stack

### DIFF
--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_plane_policies.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_plane_policies.h
@@ -82,24 +82,15 @@ public:
 
 template<typename TriangleMesh, typename GeomTraits>
 class GarlandHeckbert_plane_policies
-  : public internal::GarlandHeckbert_placement_base<
-             internal::Plane_quadric_calculator<TriangleMesh, GeomTraits>, TriangleMesh, GeomTraits>,
-    public internal::GarlandHeckbert_cost_base<
+  : public internal::GarlandHeckbert_cost_and_placement<
              internal::Plane_quadric_calculator<TriangleMesh, GeomTraits>, TriangleMesh, GeomTraits>
 {
 public:
   typedef internal::Plane_quadric_calculator<TriangleMesh, GeomTraits>         Quadric_calculator;
 
 private:
-  typedef internal::GarlandHeckbert_placement_base<
-            Quadric_calculator, TriangleMesh, GeomTraits>                      Placement_base;
-  typedef internal::GarlandHeckbert_cost_base<
-            Quadric_calculator, TriangleMesh, GeomTraits>                      Cost_base;
-
-  // Diamond base
-  typedef internal::GarlandHeckbert_quadrics_storage<
-            Quadric_calculator, TriangleMesh, GeomTraits>                      Quadrics_storage;
-
+  typedef internal::GarlandHeckbert_cost_and_placement<
+            Quadric_calculator, TriangleMesh, GeomTraits>                      Base;
   typedef GarlandHeckbert_plane_policies<TriangleMesh, GeomTraits>             Self;
 
 public:
@@ -111,15 +102,14 @@ public:
 public:
   GarlandHeckbert_plane_policies(TriangleMesh& tmesh,
                                  const FT dm = FT(100))
-    : Quadrics_storage(tmesh), Placement_base(), Cost_base(dm)
+    : Base(tmesh, Quadric_calculator(), dm)
   { }
 
 public:
   const Get_cost& get_cost() const { return *this; }
   const Get_placement& get_placement() const { return *this; }
 
-  using Cost_base::operator();
-  using Placement_base::operator();
+  using Base::operator();
 };
 
 } // namespace Surface_mesh_simplification

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_probabilistic_plane_policies.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_probabilistic_plane_policies.h
@@ -56,7 +56,7 @@ private:
   Face_variance_map m_face_variance_map;
 
 public:
-  Probabilistic_plane_quadric_calculator() { CGAL_assertion(false); } // compilation only
+  Probabilistic_plane_quadric_calculator() = delete;
 
   template <typename FVM>
   Probabilistic_plane_quadric_calculator(const FVM fvm)
@@ -129,10 +129,7 @@ template<typename TriangleMesh,
          typename GeomTraits,
          typename FaceVarianceMap = CGAL::Default>
 class GarlandHeckbert_probabilistic_plane_policies
-  : public internal::GarlandHeckbert_placement_base<
-             internal::Probabilistic_plane_quadric_calculator<TriangleMesh, GeomTraits, FaceVarianceMap>,
-             TriangleMesh, GeomTraits>,
-    public internal::GarlandHeckbert_cost_base<
+  : public internal::GarlandHeckbert_cost_and_placement<
              internal::Probabilistic_plane_quadric_calculator<TriangleMesh, GeomTraits, FaceVarianceMap>,
              TriangleMesh, GeomTraits>
 {
@@ -141,16 +138,8 @@ public:
             TriangleMesh, GeomTraits, FaceVarianceMap>                         Quadric_calculator;
 
 private:
-  typedef internal::GarlandHeckbert_placement_base<
-            Quadric_calculator, TriangleMesh, GeomTraits>                      Placement_base;
-
-  typedef internal::GarlandHeckbert_cost_base<
-            Quadric_calculator, TriangleMesh, GeomTraits>                      Cost_base;
-
-  // Diamond base
-  typedef internal::GarlandHeckbert_quadrics_storage<
-            Quadric_calculator, TriangleMesh, GeomTraits>                      Quadrics_storage;
-
+  typedef internal::GarlandHeckbert_cost_and_placement<
+            Quadric_calculator, TriangleMesh, GeomTraits>                      Base;
   typedef GarlandHeckbert_probabilistic_plane_policies<
             TriangleMesh, GeomTraits>                                          Self;
 
@@ -164,22 +153,21 @@ public:
   // Only available if the quadric calculator is using the default (constant) variance property map
   GarlandHeckbert_probabilistic_plane_policies(TriangleMesh& tmesh,
                                                const FT dm = FT(100))
-    : Quadrics_storage(tmesh, Quadric_calculator(tmesh)), Placement_base(), Cost_base(dm)
+    : Base(tmesh, Quadric_calculator(tmesh), dm)
   { }
 
   template <typename FVM>
   GarlandHeckbert_probabilistic_plane_policies(TriangleMesh& tmesh,
                                                const FT dm,
                                                const FVM fvm)
-    : Quadrics_storage(tmesh, Quadric_calculator(fvm)), Placement_base(), Cost_base(dm)
+    : Base(tmesh, Quadric_calculator(fvm), dm)
   { }
 
 public:
   const Get_cost& get_cost() const { return *this; }
   const Get_placement& get_placement() const { return *this; }
 
-  using Cost_base::operator();
-  using Placement_base::operator();
+  using Base::operator();
 };
 
 } // namespace Surface_mesh_simplification

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_probabilistic_triangle_policies.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_probabilistic_triangle_policies.h
@@ -53,7 +53,7 @@ private:
   Face_variance_map m_face_variance_map;
 
 public:
-  Probabilistic_triangle_quadric_calculator() { CGAL_assertion(false); } // compilation only
+  Probabilistic_triangle_quadric_calculator() = delete;
 
   template <typename FVM>
   Probabilistic_triangle_quadric_calculator(const FVM fvm)
@@ -119,10 +119,7 @@ template<typename TriangleMesh,
          typename GeomTraits,
          typename FaceVarianceMap = CGAL::Default>
 class GarlandHeckbert_probabilistic_triangle_policies
-  : public internal::GarlandHeckbert_placement_base<
-             internal::Probabilistic_triangle_quadric_calculator<TriangleMesh, GeomTraits, FaceVarianceMap>,
-             TriangleMesh, GeomTraits>,
-    public internal::GarlandHeckbert_cost_base<
+  : public internal::GarlandHeckbert_cost_and_placement<
              internal::Probabilistic_triangle_quadric_calculator<TriangleMesh, GeomTraits, FaceVarianceMap>,
              TriangleMesh, GeomTraits>
 {
@@ -131,15 +128,8 @@ public:
             TriangleMesh, GeomTraits, FaceVarianceMap>                         Quadric_calculator;
 
 private:
-  typedef internal::GarlandHeckbert_placement_base<
-            Quadric_calculator, TriangleMesh, GeomTraits>                      Placement_base;
-
-  typedef internal::GarlandHeckbert_cost_base<
-            Quadric_calculator, TriangleMesh, GeomTraits>                      Cost_base;
-
-  typedef internal::GarlandHeckbert_quadrics_storage<
-            Quadric_calculator, TriangleMesh, GeomTraits>                      Quadrics_storage;
-
+  typedef internal::GarlandHeckbert_cost_and_placement<
+            Quadric_calculator, TriangleMesh, GeomTraits>                      Base;
   typedef GarlandHeckbert_probabilistic_triangle_policies<
             TriangleMesh, GeomTraits>                                          Self;
 
@@ -153,22 +143,21 @@ public:
   // Only available if the quadric calculator is using the default (constant) variance property map
   GarlandHeckbert_probabilistic_triangle_policies(TriangleMesh& tmesh,
                                                   const FT dm = FT(100))
-    : Quadrics_storage(tmesh, Quadric_calculator(tmesh)), Placement_base(), Cost_base(dm)
+    : Base(tmesh, Quadric_calculator(tmesh), dm)
   { }
 
   template <typename FVM>
   GarlandHeckbert_probabilistic_triangle_policies(TriangleMesh& tmesh,
                                                   const FT dm,
                                                   const FVM fvm)
-    : Quadrics_storage(tmesh, Quadric_calculator(fvm)), Placement_base(), Cost_base(dm)
+    : Base(tmesh, Quadric_calculator(fvm), dm)
   { }
 
 public:
   const Get_cost& get_cost() const { return *this; }
   const Get_placement& get_placement() const { return *this; }
 
-  using Cost_base::operator();
-  using Placement_base::operator();
+  using Base::operator();
 };
 
 } // namespace Surface_mesh_simplification

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_triangle_policies.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_triangle_policies.h
@@ -67,24 +67,15 @@ public:
 // implements classic triangle policies
 template<typename TriangleMesh, typename GeomTraits>
 class GarlandHeckbert_triangle_policies
-  : public internal::GarlandHeckbert_placement_base<
-             internal::Triangle_quadric_calculator<TriangleMesh, GeomTraits>, TriangleMesh, GeomTraits>,
-    public internal::GarlandHeckbert_cost_base<
+  : public internal::GarlandHeckbert_cost_and_placement<
              internal::Triangle_quadric_calculator<TriangleMesh, GeomTraits>, TriangleMesh, GeomTraits>
 {
 public:
   typedef internal::Triangle_quadric_calculator<TriangleMesh, GeomTraits>      Quadric_calculator;
 
 private:
-  typedef internal::GarlandHeckbert_placement_base<
-            Quadric_calculator, TriangleMesh, GeomTraits>                      Placement_base;
-  typedef internal::GarlandHeckbert_cost_base<
-            Quadric_calculator, TriangleMesh, GeomTraits>                      Cost_base;
-
-  // Diamond base
-  typedef internal::GarlandHeckbert_quadrics_storage<
-            Quadric_calculator, TriangleMesh, GeomTraits>                      Quadrics_storage;
-
+  typedef internal::GarlandHeckbert_cost_and_placement<
+            Quadric_calculator, TriangleMesh, GeomTraits>                      Base;
   typedef GarlandHeckbert_triangle_policies<TriangleMesh, GeomTraits>          Self;
 
 public:
@@ -96,15 +87,14 @@ public:
 public:
   GarlandHeckbert_triangle_policies(TriangleMesh& tmesh,
                                     const FT dm = FT(100))
-    : Quadrics_storage(tmesh), Placement_base(), Cost_base(dm)
+    : Base(tmesh, Quadric_calculator(), dm)
   { }
 
 public:
   const Get_cost& get_cost() const { return *this; }
   const Get_placement& get_placement() const { return *this; }
 
-  using Cost_base::operator();
-  using Placement_base::operator();
+  using Base::operator();
 };
 
 } // namespace Surface_mesh_simplification

--- a/Surface_mesh_simplification/test/Surface_mesh_simplification/edge_collapse_garland_heckbert_variations.cpp
+++ b/Surface_mesh_simplification/test/Surface_mesh_simplification/edge_collapse_garland_heckbert_variations.cpp
@@ -52,7 +52,7 @@ bool read_from_file(const std::string& filename,
   // make sure the mesh is empty and ready for the next set of data
   clear(mesh);
 
-  if(!CGAL::IO::read_polygon_mesh(filename, mesh))
+  if(!PMP::IO::read_polygon_mesh(filename, mesh))
   {
     std::cerr << "Error: failed to read input: " << filename << std::endl;
     return false;


### PR DESCRIPTION
## Summary of Changes

Four variations of Garland-Heckbert were introduced with https://github.com/CGAL/cgal/pull/6190. In GH methods, the cost and the placement oracles share quadrics. In the PR, this was implemented using diamond inheritance and a virtual base for the quadric storage class.

This is all fine, until cost and placement adapter come into play: some of these adapters inherit the placement oracle, and thus the initialization becomes messed up because the adapter does not initialize the virtual base and so default construction is performed (see https://godbolt.org/z/91qesjrsM for an illustration), yielding broken quadrics storage.

The test with the `Bounded_normal_change_placement` adapter was not affected by this problem because it does not inherit the base placement (like `Constrained_placement` does), but has a "m_placement" member instead...

## Release Management

* Affected package(s): `Surface_mesh_simplification`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

