### PR TITLE
Nef_3: Use cross product instead of Plane_Plane intersection

### DIFF
--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_circle.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_circle.h
@@ -173,11 +173,9 @@ Sphere_point<R> intersection(const Sphere_circle<R>& c1,
 |c1| and |c2|. \precond |c1 != c2| as sets.}*/
 {
   CGAL_assertion(!equal_as_sets(c1,c2));
-  typename R::Line_3 lres;
   CGAL_NEF_TRACEN("circle_intersection "<<c1<<" "<<c2);
-  CGAL::Object o = CGAL::intersection(c1.plane(),c2.plane());
-  if ( !CGAL::assign(lres,o) ) CGAL_error();
-  return CGAL::ORIGIN + lres.direction().vector();
+  return R().construct_cross_product_vector_3_object()(
+         c1.orthogonal_vector(), c2.orthogonal_vector());
 }
 
 


### PR DESCRIPTION
## Summary of Changes

Whilst implementing #6378 I noticed another minor optimisation. The Plane_Plane intersection of two sphere circles can be simplified to the cross product of the two planes orthogonal vectors. 

## Release Management

* Affected package(s): Nef_3, Nef_S2
* Issue(s) solved (if any): performance
* License and copyright ownership: Returned to CGAL authors.

