### PR TITLE
Nef_3: Avoid more filter failures in ray shoot

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -897,8 +897,7 @@ public:
       if ( f->volume() != Volume_handle() )
         continue;
       CGAL_NEF_TRACEN( "Outer shell #" << ShellSf[f] << " volume?");
-      Volume_handle c = determine_volume( MinimalSFace[ShellSf[f]],
-                                          MinimalSFace, ShellSf );
+      Volume_handle c = determine_volume( f, MinimalSFace, ShellSf );
       c->mark() = f->mark();
       link_as_outer_shell( f, c );
     }


### PR DESCRIPTION
## Summary of Changes

Whilst looking at #6431 I notices the same optimisation can be made for facets, (which is already done in locate). The code was moved into a static function to avoid duplication.

In addition, the call to shoot, via `determine_volume` passes in `MinimalSFace[ShellSf[f]]`, where `determine_volume` already does: `MinimalSFace[ShellSf[sf]]` , making the compound operation equivalent to `MinimalSFace[ShellSf[MinimalSFace[ShellSf[f]]]]` which is redundant.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): performance
* License and copyright ownership: Returned to CGAL authors.

