### PR TITLE
Nef_3: Performance std::map -> std::unordered_map

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/Binary_operation.h
+++ b/Nef_3/include/CGAL/Nef_3/Binary_operation.h
@@ -319,6 +319,9 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
     CGAL_NEF_TRACEN("=> for all v0 in snc1, qualify v0 with respect snc2");
     //    int i=2;
     Association A;
+    A.reserve(snc1.number_of_shalfedges() + snc1.number_of_shalfloops() +
+              snc2.number_of_shalfedges() + snc2.number_of_shalfloops());
+
     SHalfedge_const_iterator sei;
     CGAL_forall_shalfedges(sei, snc1)
       A.initialize_hash(sei);

--- a/Nef_3/include/CGAL/Nef_3/ID_support_handler.h
+++ b/Nef_3/include/CGAL/Nef_3/ID_support_handler.h
@@ -56,10 +56,14 @@ class ID_support_handler<SNC_indexed_items, Decorator> {
     }
   };
   std::unordered_map<Halffacet_pair, int, Handle_pair_hash_function> f2m;
-  std::map<int, int> hash;
+  std::unordered_map<int, int> hash;
 
  public:
   ID_support_handler() {}
+
+  void reserve(std::size_t n) {
+    hash.reserve(n);
+  }
 
   int get_hash(int i) {
     int root(i);
@@ -78,12 +82,13 @@ class ID_support_handler<SNC_indexed_items, Decorator> {
     hash[get_hash(i)] = parent;
   }
 
+  void initialize_hash(int i) {
+    hash[i] = i;
+  }
+
   template<typename Handle>
   void initialize_hash(Handle h) {
-    hash[h->get_index()] = h->get_index();
-  }
-  void initialize_hash(int i) {
-        hash[i] = i;
+    initialize_hash(h->get_index());
   }
 
   void hash_facet_pair(SVertex_handle sv,

--- a/Nef_3/include/CGAL/Nef_3/ID_support_handler.h
+++ b/Nef_3/include/CGAL/Nef_3/ID_support_handler.h
@@ -65,16 +65,18 @@ class ID_support_handler<SNC_indexed_items, Decorator> {
     hash.reserve(n);
   }
 
-  // The method get_hash implements a
-  // two-pass union find algorithm
-  //    __    __           _______
-  //   /  \  /  \         /  _____\
-  //  _|__|__|__|_      _/__/__/__|_
-  // | |  v  |  v |    | |  |  |  v |
-  // | O  O  O  O | => | O  O  O  O |
-  // |____|__^____|    |____________|
-  //      |  | root
-  //      \_/
+  /*
+     The method get_hash implements a
+     two-pass union find algorithm
+        __    __           _______
+       /  \  /  \         /  _____\
+      _|__|__|__|_      _/__/__/__|_
+     | |  v  |  v |    | |  |  |  v |
+     | O  O  O  O | => | O  O  O  O |
+     |____|__^____|    |____________|
+          |  | root
+          \_/
+  */
   int get_hash(int i) {
     int root(i);
     while(hash[root] != root)

--- a/Nef_3/include/CGAL/Nef_3/ID_support_handler.h
+++ b/Nef_3/include/CGAL/Nef_3/ID_support_handler.h
@@ -65,6 +65,16 @@ class ID_support_handler<SNC_indexed_items, Decorator> {
     hash.reserve(n);
   }
 
+  // The method get_hash implements a
+  // two-pass union find algorithm
+  //    __    __           _______
+  //   /  \  /  \         /  _____\
+  //  _|__|__|__|_      _/__/__/__|_
+  // | |  v  |  v |    | |  |  |  v |
+  // | O  O  O  O | => | O  O  O  O |
+  // |____|__^____|    |____________|
+  //      |  | root
+  //      \_/
   int get_hash(int i) {
     int root(i);
     while(hash[root] != root)

--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -30,6 +30,7 @@
 #include <CGAL/Nef_3/SNC_simplify.h>
 #include <map>
 #include <list>
+#include <unordered_map>
 
 #undef CGAL_NEF_DEBUG
 #define CGAL_NEF_DEBUG 43

--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -1308,8 +1308,10 @@ public:
      //     O0.print();
     link_shalfedges_to_facet_cycles();
 
-    std::map<int, int> hash;
-    CGAL::Unique_hash_map<SHalfedge_handle, bool> done(false, this->sncp()->number_of_shalfedges());
+    std::size_t num_shalfedges = this->sncp()->number_of_shalfedges();
+    std::unordered_map<int, int> hash;
+    hash.reserve(num_shalfedges);
+    CGAL::Unique_hash_map<SHalfedge_handle, bool> done(false, num_shalfedges);
 
     SHalfedge_iterator sei;
     CGAL_forall_shalfedges(sei, *this->sncp()) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -1309,8 +1309,7 @@ public:
     link_shalfedges_to_facet_cycles();
 
     std::size_t num_shalfedges = this->sncp()->number_of_shalfedges();
-    std::unordered_map<int, int> hash;
-    hash.reserve(num_shalfedges);
+    std::unordered_map<int, int> hash(num_shalfedges);
     CGAL::Unique_hash_map<SHalfedge_handle, bool> done(false, num_shalfedges);
 
     SHalfedge_iterator sei;

--- a/Nef_S2/include/CGAL/Nef_S2/ID_support_handler.h
+++ b/Nef_S2/include/CGAL/Nef_S2/ID_support_handler.h
@@ -38,6 +38,8 @@ class ID_support_handler {
  public:
   ID_support_handler() {}
 
+  void reserve(std::size_t n) {}
+
   int get_hash(int) { return 0; }
   template<typename Handle> void initialize_hash(Handle /*h*/) {}
   void initialize_hash(int /*i*/) {}

--- a/Nef_S2/include/CGAL/Nef_S2/ID_support_handler.h
+++ b/Nef_S2/include/CGAL/Nef_S2/ID_support_handler.h
@@ -38,7 +38,7 @@ class ID_support_handler {
  public:
   ID_support_handler() {}
 
-  void reserve(std::size_t n) {}
+  void reserve(std::size_t) {}
 
   int get_hash(int) { return 0; }
   template<typename Handle> void initialize_hash(Handle /*h*/) {}


### PR DESCRIPTION
## Summary of Changes

There are a couple of places in Nef_3 where `std::map<int, int>` is used even though the order isn't important and the number of elements that will be placed in the map is known ahead of use. `std::unordered_map<int, int>` is a better choice when this is the case.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): performance
* License and copyright ownership: Returned to CGAL authors.

