### PR TITLE
Hash_map: Fix infinite recursion in `del_old_table`

### DIFF
--- a/Hash_map/include/CGAL/Tools/chained_map.h
+++ b/Hash_map/include/CGAL/Tools/chained_map.h
@@ -83,7 +83,7 @@ private:
    }
 
 public:
-   static constexpr std::size_t min_size = 32;
+   static constexpr std::size_t min_size = 8;
    static constexpr std::size_t default_size = 512;
    typedef chained_map_elem<T>*  chained_map_item;
    typedef chained_map_item item;
@@ -233,7 +233,8 @@ void chained_map<T, Allocator>::del_old_table()
 
   old_table = 0;
 
-  T p = access(old_index);
+  chained_map_item old_item = lookup(old_index);
+  T p = old_item ? old_item->i : xdef();
 
   for (chained_map_item item = table ; item != table_end ; ++item)
     destroy(item);


### PR DESCRIPTION
## Summary of Changes

This is my proposed fix for the crash introduced in #6306 (sorry). My analysis of the issue and then debugging code suggests that the problem stems from `del_old_table` calling `access` to get the old item from the old table. However, because the item doesn't exist calling `access` trys to insert a new item into the old table. When it tries to insert it, the old table is found to be full (`free == table_end`), so it calls rehash, calling rehash then overwrites the old_table. This means that the second access in del_old_table (which is intended to put the old item back) then calls del_old_table again and the process enters an infinite recursion.

After a few attempts and trying to hotfix with one-liners that set old_table to null repeatedly, I finally realised that the first call in del_old_table doesn't need to be `access` at all, it only needs to be a `lookup`. Using lookup means that a new item isn't inserted and so rehash will never be called, which solves the problem.

Although I don't fully understand why on Apple min_size had to be 128, and on other platforms, it had to be 32. This change to del_old_table also solves the mystery of why min_size could never be smaller than 32, which I came across during the development of #6306. I always intended min_size to be smaller, So I have done so in this PR.

## Release Management

* Affected package(s): Hash_map
* Issue(s) solved (if any): fix crash
* License and copyright ownership: Returned to CGAL authors.

