### PR TITLE
Nef_3: Use separate lists K3_tree node to avoid object casts

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/Binary_operation.h
+++ b/Nef_3/include/CGAL/Nef_3/Binary_operation.h
@@ -180,37 +180,9 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
       snc0(s0), snc1(s1), bop(_bop), result(r),
       inverse_order(invert_order), A(Ain) {}
 
-      void operator()(Halfedge_handle e0, Object_handle o1, const Point_3& ip)
-      const {
-
-#ifdef CGAL_NEF3_DUMP_STATISTICS
-      ++number_of_intersections;
-#endif
-
-      Halfedge_handle e;
-      Halffacet_handle f;
-
-      Point_3 p(normalized(ip));
-#ifdef CGAL_USE_TRACE
-      CGAL_NEF_TRACEN("Intersection_call_back: intersection reported on " << p << " (normalized: " << normalized(p) << " )");
-      CGAL_NEF_TRACEN("edge 0 has source " << e0->source()->point() << " and direction " << e0->vector());
-      if( CGAL::assign( e, o1)) {
-        CGAL_NEF_TRACEN("edge 1 has source " << e->source()->point() << " and direction " << e->vector());
-      }
-      else if( CGAL::assign( f, o1)) {
-        CGAL_NEF_TRACEN("face 1 has plane equation " << f->plane());
-      }
-      else
-              CGAL_error_msg( "wrong handle");
-#endif
-
-#if defined (CGAL_NEF3_TIMER_OVERLAY) || (CGAL_NEF3_TIMER_INTERSECTION)
-      timer_overlay.start();
-#endif
-
-      if( CGAL::assign( e, o1)) {
-        //        std::cerr << "inverse order " << inverse_order << std::endl;
-
+      void operator()(Halfedge_handle e0, Halfedge_handle e, const Point_3& ip) const override
+      {
+        Point_3 p(normalized(ip));
 #ifdef CGAL_NEF_EXPERIMENTAL_CODE
         typename CGAL::Edge_edge_overlay<SNC_structure> eeo(result, e0, e);
         Sphere_map* M0 = eeo.create_edge_edge_overlay(p, bop, inverse_order, A);
@@ -228,7 +200,10 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
         result.delete_vertex(v1);
 #endif
       }
-      else if( CGAL::assign( f, o1)) {
+
+      void operator()(Halfedge_handle e0, Halffacet_handle f, const Point_3& ip) const override
+      {
+        Point_3 p(normalized(ip));
 #ifdef CGAL_NEF3_OVERLAY_BY_HAND_OFF
         Binary_operation D(result);
         Vertex_handle v0, v1;
@@ -246,14 +221,7 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
         O.simplify(A);
 #endif // CGAL_NEF3_OVERLAY_BY_HAND_OFF
       }
-      else
-        CGAL_error_msg( "wrong handle");
 
-#if defined (CGAL_NEF3_TIMER_OVERLAY) || (CGAL_NEF3_TIMER_INTERSECTION)
-      timer_overlay.stop();
-#endif
-
-    }
   private:
     const SNC_structure& snc0;
     const SNC_structure& snc1;

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -394,7 +394,7 @@ public:
     non_efective_splits=0;
     root = build_kdtree(vertices, edges, facets, 0);
   }
-  Node_handle locate_node_containing( const Point_3 p) const {
+  Node_handle locate_node_containing( const Point_3& p) const {
     return locate_node_containing( p, root);
   }
   Node_list nodes_along_ray( const Ray_3& r) const {

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -193,8 +193,8 @@ private:
   Node_handle right_node;
   Plane_3 splitting_plane;
   Vertex_list vertex_list;
-  Halffacet_list facet_list;
   Halfedge_list edge_list;
+  Halffacet_list facet_list;
 };
 
   typedef boost::container::deque<Node> Node_range;

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -402,12 +402,12 @@ public:
     return nodes_around_segment(s);
   }
   Node_list nodes_around_segment( const Segment_3& s) const {
-    Node_list nodes;
+    Node_list result;
     Objects_around_segment objects( *this, s);
     for(typename Objects_around_segment::Iterator oas = objects.begin(); oas != objects.end(); ++oas) {
-      nodes.push_back(oas.get_node());
+      result.push_back(oas.get_node());
     }
-    return nodes;
+    return result;
   }
   bool is_point_in_node( const Point_3& p, const Node_handle target) const {
     return is_point_in_node( p, target, root);

--- a/Nef_3/include/CGAL/Nef_3/K3_tree.h
+++ b/Nef_3/include/CGAL/Nef_3/K3_tree.h
@@ -108,15 +108,8 @@ typedef Smaller_than<
 public:
     typedef Node* Node_handle;
   Node(const Vertex_list& V, const Halfedge_list& E, const Halffacet_list& F) :
-    left_node(nullptr), right_node(nullptr)
+    left_node(nullptr), right_node(nullptr), vertex_list(V), edge_list(E), facet_list(F)
   {
-      object_list.reserve(V.size()+E.size()+F.size());
-      for(Vertex_const_iterator vi=V.begin(); vi!=V.end(); ++vi)
-          object_list.push_back(make_object(*vi));
-      for(Halfedge_const_iterator ei=E.begin(); ei!=E.end(); ++ei)
-          object_list.push_back(make_object(*ei));
-      for(Halffacet_const_iterator fi=F.begin(); fi!=F.end(); ++fi)
-          object_list.push_back(make_object(*fi));
   }
 
   Node(Node_handle l, Node_handle r, const Plane_3& pl) :
@@ -133,20 +126,27 @@ public:
   Node_handle left() const { return left_node; }
   Node_handle right() const { return right_node; }
   const Plane_3& plane() const { return splitting_plane; }
-  const Object_list& objects() const { return object_list; }
+
+  bool empty() { return vertex_list.empty() && edge_list.empty() && facet_list.empty(); }
+  Vertex_const_iterator vertices_begin() { return vertex_list.begin(); }
+  Vertex_const_iterator vertices_end() { return vertex_list.end(); }
+  Halfedge_const_iterator edges_begin() { return edge_list.begin(); }
+  Halfedge_const_iterator edges_end() { return edge_list.end(); }
+  Halffacet_const_iterator facets_begin() { return facet_list.begin(); }
+  Halffacet_const_iterator facets_end() { return facet_list.end(); }
 
   void transform(const Aff_transformation_3& t) {
     if(left_node != nullptr) {
         CGAL_assertion(right_node != nullptr);
         left_node->transform(t);
-         right_node->transform(t);
-          splitting_plane = splitting_plane.transform(t);
+        right_node->transform(t);
+        splitting_plane = splitting_plane.transform(t);
     }
   }
 
   void add_facet(Halffacet_handle f, int depth) {
     if(left_node == nullptr) {
-      object_list.push_back(make_object(f));
+      facet_list.push_back(f);
       return;
     }
 
@@ -160,7 +160,7 @@ public:
 
   void add_edge(Halfedge_handle e, int depth) {
     if(left_node == nullptr) {
-      object_list.push_back(make_object(e));
+      edge_list.push_back(e);
       return;
     }
 
@@ -174,7 +174,7 @@ public:
 
   void add_vertex(Vertex_handle v, int depth) {
     if(left_node == nullptr) {
-      object_list.push_back(make_object(v));
+      vertex_list.push_back(v);
       return;
     }
 
@@ -187,33 +187,19 @@ public:
   }
 
 
-friend std::ostream& operator<<
-  (std::ostream& os, const Node_handle node) {
-  CGAL_assertion( node != nullptr);
-  if( node->is_leaf())
-    os <<  node->objects().size();
-  else {
-    os << " ( ";
-    if( !node->left()) os << '-';
-    else os << node->left();
-    os << " , ";
-    if( !node->right()) os << '-';
-    else os << node->right();
-    os << " ) ";
-  }
-  return os;
-}
-
 private:
 
   Node_handle left_node;
   Node_handle right_node;
   Plane_3 splitting_plane;
-  Object_list object_list;
+  Vertex_list vertex_list;
+  Halffacet_list facet_list;
+  Halfedge_list edge_list;
 };
 
   typedef boost::container::deque<Node> Node_range;
   typedef Node* Node_handle;
+  typedef std::vector<Node_handle> Node_list;
 
 
 public:
@@ -266,10 +252,6 @@ public:
         ++(*this); // place the interator in the first intersected cell
       }
       Iterator( const Self& i) : S(i.S), node(i.node) {}
-      const Object_list& operator*() const {
-        CGAL_assertion( node != nullptr);
-        return node->objects();
-      }
       Self& operator++() {
 
 if( S.empty())
@@ -350,35 +332,6 @@ void divide_segment_by_plane( Segment_3 s, Plane_3 pl,
     };
   };
 
-  class Objects_along_ray : public Objects_around_segment
-  {
-    typedef Objects_around_segment Base;
-  protected:
-    Traits traits;
-  public:
-    Objects_along_ray( const K3_tree& k, const Ray_3& r) {
-      CGAL_NEF_TRACEN("Objects_along_ray: input ray: "<<r);
-      Vector_3 vec(r.to_vector());
-      // First of all, we need to find out wheather we are working over an extended kernel or on a standard kernel. As precondition we have that ray is oriented in the minus x axis direction.  When having an extended kernel, the ray can be subtituted by a segment with the endpoint on the 'intersection' between the ray and the bounding infimaximal box.  In the presence of a standard kernel, the intersection is computed with the bounding box with the vertices of the Nef polyhedron.
-      Point_3 p(r.source()), q;
-      Bounding_box_3 b = k.bounding_box;
-      typename Kernel::Non_zero_coordinate_index_3 non_zero_coordinate_index_3;
-      int c = non_zero_coordinate_index_3(vec);
-
-      Point_3 pt_on_minus_x_plane = vec[c] < 0 ?
-        Point_3(FT(b.min_coord(0)), FT(b.min_coord(1)),FT(b.min_coord(2))) :
-        Point_3(FT(b.max_coord(0)), FT(b.max_coord(1)),FT(b.max_coord(2)));
-      // We compute the intersection between a plane with normal vector in
-      // the minus x direction and located at the minimum point of the bounding box, and the input ray.  When the ray does not intersect the bounding volume, there won't be any object hit, so it is safe to construct a segment that simply lay in the unbounded side of the bounding box.  This approach is taken instead of somehow (efficiently) report that there was no hit object, in order to mantain a clear interface with the Iterator class.
-      Plane_3 pl_on_minus_x = K3_tree::construct_splitting_plane(pt_on_minus_x_plane, c, typename Traits::Kernel::Kernel_tag());
-      Object o = traits.intersect_object()( pl_on_minus_x, r);
-      if( !CGAL::assign( q, o) || pl_on_minus_x.has_on(p))
-        q = r.source() + vec;
-      else
-        q = normalized(q);
-      Base::initialize( k, Segment_3( p, q));
-    }
-  };
 
 private:
 #ifdef CGAL_NEF_EXPLOIT_REFERENCE_COUNTING
@@ -441,53 +394,23 @@ public:
     non_efective_splits=0;
     root = build_kdtree(vertices, edges, facets, 0);
   }
-  const Object_list& objects_around_point( const Point_3& p) const {
-    return locate( p, root);
+  Node_handle locate_node_containing( const Point_3 p) const {
+    return locate_node_containing( p, root);
   }
-  Objects_along_ray objects_along_ray( const Ray_3& r) const {
-    return Objects_along_ray( *this, r);
+  Node_list nodes_along_ray( const Ray_3& r) const {
+    Segment_3 s = ray_to_segment(r);
+    return nodes_around_segment(s);
   }
-  Object_list objects_around_segment( const Segment_3& s) const {
-    Object_list O;
-
+  Node_list nodes_around_segment( const Segment_3& s) const {
+    Node_list nodes;
     Objects_around_segment objects( *this, s);
-    Unique_hash_map< Vertex_handle, bool> v_mark(false);
-    Unique_hash_map< Halfedge_handle, bool> e_mark(false);
-    Unique_hash_map< Halffacet_handle, bool> f_mark(false);
-    for( typename Objects_around_segment::Iterator oar = objects.begin();
-         oar != objects.end(); ++oar) {
-      for( typename Object_list::const_iterator o = (*oar).begin();
-           o != (*oar).end(); ++o) { // TODO: implement operator->(...)
-        Vertex_handle v;
-        Halfedge_handle e;
-        Halffacet_handle f;
-        if( CGAL::assign( v, *o)) {
-          if( !v_mark[v]) {
-            O.push_back(*o);
-            v_mark[v] = true;
-          }
-        }
-        else if( CGAL::assign( e, *o)) {
-          if( !e_mark [e]) {
-            O.push_back(*o);
-            e_mark[e] = true;
-          }
-        }
-        else if( CGAL::assign( f, *o)) {
-          if( !f_mark[f]) {
-            O.push_back(*o);
-            f_mark[f] = true;
-          }
-        }
-        else
-          CGAL_error_msg( "wrong handle");
-      }
+    for(typename Objects_around_segment::Iterator oas = objects.begin(); oas != objects.end(); ++oas) {
+      nodes.push_back(oas.get_node());
     }
-    return O;
+    return nodes;
   }
-
-  bool is_point_on_cell( const Point_3& p, const typename Objects_around_segment::Iterator& target) const {
-    return is_point_on_cell( p, target.get_node(), root);
+  bool is_point_in_node( const Point_3& p, const Node_handle target) const {
+    return is_point_in_node( p, target, root);
   }
 
   void add_facet(Halffacet_handle f) {
@@ -510,12 +433,8 @@ public:
 
     void pre_visit(const Node_handle) {}
     void post_visit(const Node_handle n) {
-      typename Object_list::const_iterator o;
-      for( o = n->objects().begin();
-           o != n->objects().end(); ++o) {
-        Vertex_handle v;
-        if( CGAL::assign( v, *o))
-          b.extend(v->point());
+      for(Vertex_const_iterator vi = n->vertex_list.begin(); vi!=n->vertex_list.end(); ++vi) {
+          b.extend((*vi)->point());
       }
     }
 
@@ -722,7 +641,7 @@ static Node_handle get_child_by_side( const Node_handle node, Oriented_side side
   return node->right();
 }
 
-Node_handle locate_cell_containing( const Point_3& p, const Node_handle node) const {
+Node_handle locate_node_containing( const Point_3& p, const Node_handle node) const {
   CGAL_precondition( node != nullptr);
   if( node->is_leaf())
     return node;
@@ -730,26 +649,57 @@ Node_handle locate_cell_containing( const Point_3& p, const Node_handle node) co
   Oriented_side side = node->plane().oriented_side(p);
   if(side == ON_ORIENTED_BOUNDARY)
     side = ON_NEGATIVE_SIDE;
-  return locate_cell_containing(p, get_child_by_side(node, side));
+  return locate_node_containing(p, get_child_by_side(node, side));
 }
 
-const Object_list& locate( const Point_3& p, const Node_handle node) const {
-  CGAL_precondition( node != nullptr);
-  return locate_cell_containing( p, node)->objects();
-}
 
-bool is_point_on_cell( const Point_3& p, const Node_handle target, const Node_handle current) const {
+bool is_point_in_node( const Point_3& p, const Node_handle target, const Node_handle current) const {
   CGAL_precondition( target != nullptr && current != nullptr);
   if( current->is_leaf())
     return (current == target);
   Oriented_side side = current->plane().oriented_side(p);
   if( side == ON_NEGATIVE_SIDE)
-    return is_point_on_cell( p, target, current->left());
+    return is_point_in_node( p, target, current->left());
   else if( side == ON_POSITIVE_SIDE)
-    return is_point_on_cell( p, target, current->right());
+    return is_point_in_node( p, target, current->right());
   CGAL_assertion( side == ON_ORIENTED_BOUNDARY);
-  return (is_point_on_cell( p, target, current->left()) ||
-          is_point_on_cell( p, target, current->right()));
+  return (is_point_in_node( p, target, current->left()) ||
+          is_point_in_node( p, target, current->right()));
+}
+
+Segment_3 ray_to_segment(const Ray_3& r) const
+{
+  CGAL_NEF_TRACEN("Objects_along_ray: input ray: "<<r);
+  Vector_3 vec(r.to_vector());
+  /* First of all, we need to find out wheather we are working over an extended
+   * kernel or on a standard kernel. As precondition we have that ray is oriented
+   * in the minus x axis direction.  When having an extended kernel, the ray can
+   * be subtituted by a segment with the endpoint on the 'intersection' between
+   * the ray and the bounding infimaximal box.  In the presence of a standard
+   * kernel, the intersection is computed with the bounding box with the vertices
+   * of the Nef polyhedron.*/
+  Point_3 p(r.source()), q;
+  Bounding_box_3 b = bounding_box;
+  typename Kernel::Non_zero_coordinate_index_3 non_zero_coordinate_index_3;
+  int c = non_zero_coordinate_index_3(vec);
+
+  Point_3 pt_on_minus_x_plane = vec[c] < 0 ?
+    Point_3(FT(b.min_coord(0)), FT(b.min_coord(1)),FT(b.min_coord(2))) :
+    Point_3(FT(b.max_coord(0)), FT(b.max_coord(1)),FT(b.max_coord(2)));
+  /* We compute the intersection between a plane with normal vector in the minus x
+   * direction and located at the minimum point of the bounding box, and the input
+   * ray.  When the ray does not intersect the bounding volume, there won't be any
+   * object hit, so it is safe to construct a segment that simply lay in the
+   * unbounded side of the bounding box.  This approach is taken instead of somehow
+   * (efficiently) report that there was no hit object, in order to mantain a clear
+   * interface with the Iterator class.*/
+  Plane_3 pl_on_minus_x = K3_tree::construct_splitting_plane(pt_on_minus_x_plane, c, typename Traits::Kernel::Kernel_tag());
+  Object o = traits.intersect_object()( pl_on_minus_x, r);
+  if( !CGAL::assign( q, o) || pl_on_minus_x.has_on(p))
+    q = r.source() + vec;
+  else
+    q = normalized(q);
+  return Segment_3( p, q);
 }
 
 };

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -328,7 +328,7 @@ public:
       case is_vertex_: return make_object(v_res);
       case is_edge_: return make_object(e_res);
       case is_facet_: return make_object(f_res);
-      case is_none_ : return Object_handle();;
+      case is_none_ : return Object_handle();
     }
   }
 
@@ -371,7 +371,7 @@ public:
 
       CGAL_assertion( initialized);
       _CGAL_NEF_TRACEN( "locate "<<p);
-      SOLUTION solution;
+      SOLUTION solution = is_none_;
 
       Node_handle n = candidate_provider->locate_node_containing(p);
       typename Vertex_list::const_iterator vi = n->vertices_begin();

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -328,8 +328,8 @@ public:
       case is_vertex_: return make_object(v_res);
       case is_edge_: return make_object(e_res);
       case is_facet_: return make_object(f_res);
+      case is_none_ : return Object_handle();;
     }
-    return Object_handle();
   }
 
   virtual Object_handle locate( const Point_3& p) const {

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -93,7 +93,7 @@ public:
     const = 0;
 
   virtual void intersect_with_edges_and_facets( Halfedge_handle edge,
-        const Intersection_call_back& call_back) const = 0;
+                                                const Intersection_call_back& call_back) const = 0;
 
   class Intersection_call_back
   {
@@ -182,8 +182,14 @@ public:
 
   typedef typename SNC_candidate_provider::Object_list Object_list;
   typedef typename Object_list::iterator Object_list_iterator;
-  typedef typename SNC_candidate_provider::Objects_along_ray Objects_along_ray;
-  typedef typename Objects_along_ray::Iterator Objects_along_ray_iterator;
+
+  typedef typename SNC_candidate_provider::Node_handle Node_handle;
+  typedef typename SNC_candidate_provider::Node_list Node_list;
+  typedef typename SNC_candidate_provider::Vertex_list Vertex_list;
+  typedef typename SNC_candidate_provider::Halfedge_list Halfedge_list;
+  typedef typename SNC_candidate_provider::Halffacet_list Halffacet_list;
+  typedef typename SNC_point_locator::Intersection_call_back Intersection_call_back;
+
 
   using Base::get_visible_facet;
 public:
@@ -233,19 +239,21 @@ public:
     Halffacet_handle f;
     bool hit = false;
     Point_3 eor = CGAL::ORIGIN; // 'end of ray', the latest ray's hit point
-    Objects_along_ray objects = candidate_provider->objects_along_ray(ray);
-    Objects_along_ray_iterator objects_iterator = objects.begin();
-    while( !hit && objects_iterator != objects.end()) {
-      Object_list candidates = *objects_iterator;
-      Object_list_iterator o;
-      CGAL_for_each( o, candidates) {
-        if( CGAL::assign( v, *o) && ((mask&1) != 0)) {
+
+    Node_list nodes = candidate_provider->nodes_along_ray(ray);
+    typename Node_list::iterator nodes_iterator = nodes.begin();
+
+    while( !hit && nodes_iterator != nodes.end()) {
+      Node_handle n(*nodes_iterator);
+      if((mask&1)!=0) {
+        for(typename Vertex_list::const_iterator vi=n->vertices_begin(); vi!=n->vertices_end(); ++vi) {
+          Vertex_handle v(*vi);
           _CGAL_NEF_TRACEN("trying vertex on "<<v->point());
           if( (ray.source() != v->point()) && ray.has_on(v->point())) {
             _CGAL_NEF_TRACEN("the ray intersects the vertex");
             _CGAL_NEF_TRACEN("prev. intersection? "<<hit);
             CGAL_assertion_code
-              (if( hit)_CGAL_NEF_TRACEN("prev. intersection on "<<eor));
+                (if( hit)_CGAL_NEF_TRACEN("prev. intersection on "<<eor));
             if( hit && !Segment_3( ray.source(), eor).has_on(v->point()))
               continue;
             eor = v->point();
@@ -254,34 +262,39 @@ public:
             _CGAL_NEF_TRACEN("the vertex becomes the new hit object");
           }
         }
-        else if( CGAL::assign( e, *o) && ((mask&2) != 0)) {
+      }
+      if((mask&2)!=0) {
+        for(typename Halfedge_list::const_iterator ei=n->edges_begin(); ei!=n->edges_end(); ++ei) {
+          Halfedge_handle e(*ei);
           Point_3 q;
           _CGAL_NEF_TRACEN("trying edge on "<< Segment_3(e->source()->point(),e->twin()->source()->point()));
           if ( (ray_source_vertex == Vertex_handle()) || ( (ray_source_vertex != e->source()) && (ray_source_vertex != e->twin()->source())) ) {
-
-              if( SNC_intersection::does_intersect_internally( ray, Segment_3(e->source()->point(),
-                                                                          e->twin()->source()->point()), q)) {
-                  _CGAL_NEF_TRACEN("ray intersects edge on " << q);
-                  _CGAL_NEF_TRACEN("prev. intersection? " << hit);
-                  CGAL_assertion_code
-                  (if (hit) _CGAL_NEF_TRACEN("prev. intersection on " << eor));
-                  if (hit && !has_smaller_distance_to_point(ray.source(), q, eor))
-                      continue;
-                  _CGAL_NEF_TRACEN("is the intersection point on the current cell? " <<
-                      candidate_provider->is_point_on_cell(q, objects_iterator));
-                  if (!candidate_provider->is_point_on_cell(q, objects_iterator))
-                      continue;
-                  eor = q;
-                  result = make_object(e);
-                  hit = true;
-                  _CGAL_NEF_TRACEN("the edge becomes the new hit object");
-              }
+            if( SNC_intersection::does_intersect_internally( ray, Segment_3(e->source()->point(),
+                                                                            e->twin()->source()->point()), q)) {
+              _CGAL_NEF_TRACEN("ray intersects edge on "<<q);
+              _CGAL_NEF_TRACEN("prev. intersection? "<<hit);
+              CGAL_assertion_code
+                  (if( hit) _CGAL_NEF_TRACEN("prev. intersection on "<<eor));
+              if( hit && !has_smaller_distance_to_point( ray.source(), q, eor))
+                continue;
+              _CGAL_NEF_TRACEN("is the intersection point on the current cell? "<<
+                               candidate_provider->is_point_in_node( q, n));
+              if( !candidate_provider->is_point_in_node( q, n))
+                continue;
+              eor = q;
+              result = make_object(e);
+              hit = true;
+              _CGAL_NEF_TRACEN("the edge becomes the new hit object");
+            }
           }
         }
-        else if( CGAL::assign( f, *o) && ((mask&4) != 0)) {
+      }
+      if((mask&4)!=0) {
+        for(typename Halffacet_list::const_iterator fi=n->facets_begin(); fi!=n->facets_end(); ++fi) {
+          Halffacet_handle f(*fi);
           Point_3 q;
           _CGAL_NEF_TRACEN("trying facet with on plane "<<f->plane()<<
-                  " with point on "<<f->plane().point());
+                           " with point on "<<f->plane().point());
           if( SNC_intersection::does_intersect_internally( ray, f, q) ) {
             _CGAL_NEF_TRACEN("ray intersects facet on "<<q);
             _CGAL_NEF_TRACEN("prev. intersection? "<<hit);
@@ -289,8 +302,8 @@ public:
             if( hit && !has_smaller_distance_to_point( ray.source(), q, eor))
               continue;
             _CGAL_NEF_TRACEN("is the intersection point on the current cell? "<<
-                    candidate_provider->is_point_on_cell( q, objects_iterator));
-            if( !candidate_provider->is_point_on_cell( q, objects_iterator))
+                             candidate_provider->is_point_in_node( q, n));
+            if( !candidate_provider->is_point_in_node( q, n))
               continue;
             eor = q;
             result = make_object(f);
@@ -298,145 +311,105 @@ public:
             _CGAL_NEF_TRACEN("the facet becomes the new hit object");
           }
         }
-        else if((mask&15) == 15)
-          CGAL_error_msg( "wrong handle");
       }
       if(!hit)
-        ++objects_iterator;
+        ++nodes_iterator;
     }
+
     CGAL_NEF_TIMER(rs_t.stop());
     return result;
   }
 
   virtual Object_handle locate( const Point_3& p) const {
     if(Infi_box::extended_kernel()) {
-    CGAL_NEF_TIMER(pl_t.start());
-    CGAL_assertion( initialized);
-    _CGAL_NEF_TRACEN( "locate "<<p);
-    Object_handle result;
-    Vertex_handle v;
-    Halfedge_handle e;
-    Halffacet_handle f;
-    Object_list candidates = candidate_provider->objects_around_point(p);
-    Object_list_iterator o = candidates.begin();
-    bool found = false;
-    while( !found && o != candidates.end()) {
-      if( CGAL::assign( v, *o)) {
+      CGAL_NEF_TIMER(pl_t.start());
+      CGAL_assertion( initialized);
+      _CGAL_NEF_TRACEN( "locate "<<p);
+
+      Node_handle n = candidate_provider->locate_node_containing(p);
+      for(typename Vertex_list::const_iterator vi=n->vertices_begin(); vi!=n->vertices_end(); ++vi) {
+        Vertex_handle v(*vi);
         if ( p == v->point()) {
           _CGAL_NEF_TRACEN("found on vertex "<<v->point());
-          result = make_object(v);
-          found = true;
+          return make_object(v);
         }
       }
-      else if( CGAL::assign( e, *o)) {
-        if ( SNC_intersection::does_contain_internally(e->source()->point(), e->twin()->source()->point(), p) ) {
+      for(typename Halfedge_list::const_iterator ei=n->edges_begin(); ei!=n->edges_end(); ++ei) {
+        Halfedge_handle e(*ei);
+        if (SNC_intersection::does_contain_internally(e->source()->point(),e->twin()->source()->point(), p) ) {
           _CGAL_NEF_TRACEN("found on edge "<<Segment_3(e->source()->point(),e->twin()->source()->point()));
-          result = make_object(e);
-          found = true;
+          return make_object(e);
         }
       }
-      else if( CGAL::assign( f, *o)) {
+      for(typename Halffacet_list::const_iterator fi=n->facets_begin(); fi!=n->facets_end(); ++fi) {
+        Halffacet_handle f(*fi);
         if (SNC_intersection::does_contain_internally( f, p) ) {
           _CGAL_NEF_TRACEN("found on facet...");
-          result = make_object(f);
-          found = true;
+          return make_object(f);
         }
       }
-      o++;
-    }
-    if( !found) {
+
       _CGAL_NEF_TRACEN("point not found in 2-skeleton");
       _CGAL_NEF_TRACEN("shooting ray to determine the volume");
       Ray_3 r( p, Vector_3( -1, 0, 0));
-      result = make_object(determine_volume(r));
-    }    CGAL_NEF_TIMER(pl_t.start());
-    CGAL_NEF_TIMER(pl_t.stop());
-    return result;
+      return make_object(determine_volume(r));
+
+    } else {   // standard kernel
 
 
-  } else {   // standard kernel
+      CGAL_assertion( initialized);
+      _CGAL_NEF_TRACEN( "locate "<<p);
+      Object_handle result;
 
+      Node_handle n = candidate_provider->locate_node_containing(p);
+      typename Vertex_list::const_iterator vi = n->vertices_begin();
 
-    CGAL_assertion( initialized);
-    _CGAL_NEF_TRACEN( "locate "<<p);
-    Object_handle result;
-    Vertex_handle v, closest;
-    Halfedge_handle e;
-    Halffacet_handle f;
-    Object_list candidates = candidate_provider->objects_around_point(p);
-    Object_list_iterator o = candidates.begin();
+      if(n->empty())
+        return make_object(Base(*this).volumes_begin());
 
-    if(candidates.empty())
-      return make_object(Base(*this).volumes_begin());
-
-    CGAL::assign(v,*o);
-    CGAL_assertion(CGAL::assign(v,*o));
-    if(p==v->point())
-      return make_object(v);
-
-    closest = v;
-    ++o;
-    while(o!=candidates.end() && CGAL::assign(v,*o)) {
-      if ( p == v->point()) {
-        _CGAL_NEF_TRACEN("found on vertex "<<v->point());
+      Vertex_handle v(*vi),closest;
+      if(p==v->point())
         return make_object(v);
-      }
 
-      if(CGAL::has_smaller_distance_to_point(p, v->point(), closest->point())){
-        closest = v;
-      }
-      ++o;
-    }
-
-    v = closest;
-    result = make_object(v);
-
-    Segment_3 s(p,v->point());
-    // bool first = true;
-    Point_3 ip;
-
-    /*
-    // TODO: das geht effizienter
-    Object_list_iterator of(o);
-    while(of != candidates.end() && assign(e, *of)) ++of;
-
-    typename SNC_structure::SHalfedge_iterator sei;
-    for(sei=v->shalfedges_begin(); sei!=v->shalfedges_end(); ++sei){
-      if(sei->is_twin()) continue;
-      Halffacet_handle fout = sei->facet();
-      if(fout->is_twin()) fout = fout->twin();
-      Object_list_iterator ofc(of);
-      for(;ofc!=candidates.end();++ofc) {
-        if(CGAL::assign(f,*ofc)) {
-          if(f == fout->twin())
-            std::cerr << "shit" << std::endl;
-          if(f == fout) {
-            Object_list_iterator oe(ofc);
-            --ofc;
-            candidates.erase(oe);
-          }
+      closest = v;
+      ++vi;
+      while(vi!=n->vertices_end()) {
+        v = *vi;
+        if ( p == v->point()) {
+          _CGAL_NEF_TRACEN("found on vertex "<<v->point());
+          return make_object(v);
         }
+
+        if(CGAL::has_smaller_distance_to_point(p, v->point(), closest->point())){
+          closest = v;
+        }
+        ++vi;
       }
-    }
-    */
-    for(;o!=candidates.end();++o) {
-      if( CGAL::assign( e, *o)) {
-        //        if(first &&
-        //           (e->source() == v  || e->twin()->source() == v)) continue;
+
+      v = closest;
+      result = make_object(v);
+
+      Segment_3 s(p,v->point());
+      Point_3 ip;
+
+      Halfedge_handle e;
+      for(typename Halfedge_list::const_iterator ei=n->edges_begin(); ei!=n->edges_end(); ++ei) {
+        e = *ei;
         Segment_3 ss(e->source()->point(),e->twin()->source()->point());
         CGAL_NEF_TRACEN("test edge " << e->source()->point() << "->" << e->twin()->source()->point());
         if (SNC_intersection::does_contain_internally(e->source()->point(), e->twin()->source()->point(), p)) {
-        _CGAL_NEF_TRACEN("found on edge "<< ss);
+          _CGAL_NEF_TRACEN("found on edge "<< ss);
           return make_object(e);
         }
         if((e->source() != v)  && (e->twin()->source() != v) && SNC_intersection::does_intersect_internally(s, ss, ip)) {
-          // first = false;
           s = Segment_3(p, normalized(ip));
           result = make_object(e);
         }
+      }
 
-      } else
-      if( CGAL::assign( f, *o)) {
+      Halffacet_handle f;
+      for(typename Halffacet_list::const_iterator fi=n->facets_begin(); fi!=n->facets_end(); ++fi) {
+        f = *fi;
         CGAL_NEF_TRACEN("test facet " << f->plane());
         if (SNC_intersection::does_contain_internally(f,p) ) {
           _CGAL_NEF_TRACEN("found on facet...");
@@ -458,214 +431,118 @@ public:
           }
         }
 
-
-        if( (! v_vertex_of_f) &&  SNC_intersection::does_intersect_internally(s,f,ip) ) {
+        if( (! v_vertex_of_f) && SNC_intersection::does_intersect_internally(s,f,ip) ) {
           s = Segment_3(p, normalized(ip));
           result = make_object(f);
         }
       }
-      else CGAL_error_msg( "wrong handle type");
-    }
 
-    //CGAL_warning("altered code in SNC_point_locator");
-    /*
-      Halffacet_iterator fc;
-      CGAL_forall_facets(fc, *this->sncp()) {
-        CGAL_assertion(!SNC_intersection::does_intersect_internally(s,f,ip));
+      if( CGAL::assign( v, result)) {
+        _CGAL_NEF_TRACEN("vertex hit, obtaining volume..." << v->point());
+
+        //CGAL_warning("altered code in SNC_point_locator");
+        SM_point_locator L(&*v);
+        Object_handle so = L.locate(s.source()-s.target(), true);
+        SFace_handle sf;
+        if(CGAL::assign(sf,so))
+          return make_object(sf->volume());
+        CGAL_error_msg( "wrong handle type");
+        return Object_handle();
+
+      } else if( CGAL::assign( f, result)) {
+        _CGAL_NEF_TRACEN("facet hit, obtaining volume...");
+        if(f->plane().oriented_side(p) == ON_NEGATIVE_SIDE)
+          f = f->twin();
+        return make_object(f->incident_volume());
+      } else if( CGAL::assign(e, result)) {
+        SM_decorator SD(&*e->source());
+        if( SD.is_isolated(e))
+          return make_object(e->incident_sface()->volume());
+        return make_object(get_visible_facet(e,Ray_3(s.source(),s.to_vector()))->incident_volume());
       }
-
-      Halfedge_iterator ec;
-      CGAL_forall_edges(ec, *this->sncp()) {
-        Segment_3 ss(ec->source()->point(), ec->twin()->source()->point());
-        CGAL_assertion(!SNC_intersection::does_intersect_internally(s,ss,ip));
-      }
-
-      Vertex_iterator vc;
-      CGAL_forall_vertices(vc, *this->sncp()) {
-        std::cerr << "test vertex " << vc->point() << std::endl;
-        CGAL_assertion(vc->point() == s.target() || !s.has_on(vc->point()));
-      }
-    */
-
-    if( CGAL::assign( v, result)) {
-      _CGAL_NEF_TRACEN("vertex hit, obtaining volume..." << v->point());
-
-      //CGAL_warning("altered code in SNC_point_locator");
-      SM_point_locator L(&*v);
-      Object_handle so = L.locate(s.source()-s.target(), true);
-      SFace_handle sf;
-      if(CGAL::assign(sf,so))
-        return make_object(sf->volume());
       CGAL_error_msg( "wrong handle type");
       return Object_handle();
-/*
-      SHalfedge_handle se;
-      CGAL_assertion(CGAL::assign(se,so));
-      CGAL_NEF_TRACEN("intersect segment " << s << " with edges");
-      for(;ox!=candidates.end();++ox) {
-        if(!CGAL::assign(e,*ox)) continue;
-        CGAL_NEF_TRACEN("test edge " << e->source()->point() << "->" << e->twin()->source()->point());
-        if(SNC_intersection::does_intersect_internally(s,Segment_3(e->source()->point(),e->twin()->source()->point()),ip)) {
-          s = Segment_3(p, normalized(ip));
-          result = make_object(e);
-        }
-      }
-      CGAL_assertion(CGAL::assign(e,result));
-      CGAL::assign(e,result);
-      f = get_visible_facet(e, Ray_3(p, s.target()));
-      if( f != Halffacet_handle())
-        return f->incident_volume();
-      SM_decorator SD(&*v); // now, the vertex has no incident facets
-      CGAL_assertion( SD.number_of_sfaces() == 1);
-      return SD.sfaces_begin()->volume();
-*/
-    } else if( CGAL::assign( f, result)) {
-      _CGAL_NEF_TRACEN("facet hit, obtaining volume...");
-      if(f->plane().oriented_side(p) == ON_NEGATIVE_SIDE)
-        f = f->twin();
-      return make_object(f->incident_volume());
-    } else if( CGAL::assign(e, result)) {
-      SM_decorator SD(&*e->source());
-      if( SD.is_isolated(e))
-        return make_object(e->incident_sface()->volume());
-      return make_object(get_visible_facet(e,Ray_3(s.source(),s.to_vector()))->incident_volume());
     }
-    CGAL_error_msg( "wrong handle type");
-    return Object_handle();
-  }
   }
 
   virtual void intersect_with_edges_and_facets( Halfedge_handle e0,
-        const typename SNC_point_locator::Intersection_call_back& call_back) const {
-
-    CGAL_NEF_TIMER(it_t.start());
-    CGAL_assertion( initialized);
+                                                const Intersection_call_back& call_back) const {
     _CGAL_NEF_TRACEN( "intersecting edge: "<<&*e0<<' '<<Segment_3(e0->source()->point(),
-                                                         e0->twin()->source()->point()));
-
-
-    Segment_3 s(Segment_3(e0->source()->point(),e0->twin()->source()->point()));
-    Vertex_handle v;
-    Halfedge_handle e;
-    Halffacet_handle f;
-    Object_list_iterator o;
-    Object_list objects = candidate_provider->objects_around_segment(s);
-    CGAL_for_each( o, objects) {
-      if( CGAL::assign( v, *o)) {
-        /* do nothing */
-      }
-      else if( CGAL::assign( e, *o)) {
-
-#ifdef CGAL_NEF3_DUMP_STATISTICS
-      ++number_of_intersection_candidates;
-#endif
-
-        Point_3 q;
-        if( SNC_intersection::does_intersect_internally( s, Segment_3(e->source()->point(),
-                                                                      e->twin()->source()->point()), q)) {
-          q = normalized(q);
-          call_back( e0, make_object(Halfedge_handle(e)), q);
-          _CGAL_NEF_TRACEN("edge intersects edge "<<' '<<&*e<< Segment_3(e->source()->point(),
-                                                                e->twin()->source()->point())<<" on "<<q);
-        }
-      }
-      else if( CGAL::assign( f, *o)) {
-#ifdef CGAL_NEF3_DUMP_STATISTICS
-      ++number_of_intersection_candidates;
-#endif
-
-        Point_3 q;
-        if( SNC_intersection::does_intersect_internally( s, f, q) ) {
-          q = normalized(q);
-          call_back( e0, make_object(Halffacet_handle(f)), q);
-          _CGAL_NEF_TRACEN("edge intersects facet on plane "<<f->plane()<<" on "<<q);
-        }
-      }
-      else
-        CGAL_error_msg( "wrong handle");
-    }
-    CGAL_NEF_TIMER(it_t.stop());
+                                                                  e0->twin()->source()->point()));
+    Segment_3 s(e0->source()->point(),e0->twin()->source()->point());
+    Node_list nodes = candidate_provider->nodes_around_segment(s);
+    intersect_with_edges(e0,call_back,s,nodes);
+    intersect_with_facets(e0,call_back,s,nodes);
   }
 
   virtual void intersect_with_edges( Halfedge_handle e0,
-    const typename SNC_point_locator::Intersection_call_back& call_back) const {
+                                     const Intersection_call_back& call_back) const {
     CGAL_NEF_TIMER(it_t.start());
-    CGAL_assertion( initialized);
     _CGAL_NEF_TRACEN( "intersecting edge: "<<&*e0<<' '<<Segment_3(e0->source()->point(),
-                                                         e0->twin()->source()->point()));
-    Segment_3 s(Segment_3(e0->source()->point(),e0->twin()->source()->point()));
-    Vertex_handle v;
-    Halfedge_handle e;
-    Halffacet_handle f;
-    Object_list_iterator o;
-    Object_list objects = candidate_provider->objects_around_segment(s);
-    CGAL_for_each( o, objects) {
-      if( CGAL::assign( v, *o)) {
-        /* do nothing */
-      }
-      else if( CGAL::assign( e, *o)) {
-
-#ifdef CGAL_NEF3_DUMP_STATISTICS
-      ++number_of_intersection_candidates;
-#endif
-
-        Point_3 q;
-        if( SNC_intersection::does_intersect_internally( s, Segment_3(e->source()->point(),
-                                                                      e->twin()->source()->point()), q)) {
-          q = normalized(q);
-          call_back( e0, make_object(Halfedge_handle(e)), q);
-          _CGAL_NEF_TRACEN("edge intersects edge "<<' '<<&*e<< Segment_3(e->source()->point(),
-                                                                e->twin()->source()->point())<<" on "<<q);
-        }
-      }
-      else if( CGAL::assign( f, *o)) {
-        /* do nothing */
-      }
-      else
-        CGAL_error_msg( "wrong handle");
-    }
-    CGAL_NEF_TIMER(it_t.stop());
+                                                                  e0->twin()->source()->point()));
+    Segment_3 s(e0->source()->point(),e0->twin()->source()->point());
+    Node_list nodes = candidate_provider->nodes_around_segment(s);
+    intersect_with_edges(e0,call_back,s,nodes);
   }
 
   virtual void intersect_with_facets( Halfedge_handle e0,
-    const typename SNC_point_locator::Intersection_call_back& call_back) const {
-    CGAL_NEF_TIMER(it_t.start());
+                                      const Intersection_call_back& call_back) const {
     CGAL_assertion( initialized);
     _CGAL_NEF_TRACEN( "intersecting edge: "<< Segment_3(e0->source()->point(),
-                                               e0->twin()->source()->point()));
-    Segment_3 s(Segment_3(e0->source()->point(),e0->twin()->source()->point()));
-    Vertex_handle v;
-    Halfedge_handle e;
-    Halffacet_handle f;
-    Object_list_iterator o;
-    Object_list objects = candidate_provider->objects_around_segment(s);
-    CGAL_for_each( o, objects) {
-      if( CGAL::assign( v, *o)) {
-        /* do nothing */
-      }
-      else if( CGAL::assign( e, *o)) {
-        /* do nothing */
-      }
-      else if( CGAL::assign( f, *o)) {
-
-#ifdef CGAL_NEF3_DUMP_STATISTICS
-      ++number_of_intersection_candidates;
-#endif
-
-        Point_3 q;
-        if( SNC_intersection::does_intersect_internally( s, f, q) ) {
-          q = normalized(q);
-          call_back( e0, make_object(Halffacet_handle(f)), q);
-          _CGAL_NEF_TRACEN("edge intersects facet on plane "<<f->plane()<<" on "<<q);
-        }
-      }
-      else
-        CGAL_error_msg( "wrong handle");
-    }
-    CGAL_NEF_TIMER(it_t.stop());
+                                                        e0->twin()->source()->point()));
+    Segment_3 s(e0->source()->point(),e0->twin()->source()->point());
+    Node_list nodes = candidate_provider->nodes_around_segment(s);
+    intersect_with_facets(e0,call_back,s,nodes);
   }
 
 private:
+
+  void intersect_with_edges( Halfedge_handle e0,
+                             const Intersection_call_back& call_back, Segment_3& s, Node_list& nodes) const {
+    Unique_hash_map<Halfedge_handle,bool> visited(false);
+    for(typename Node_list::iterator ni = nodes.begin(); ni!=nodes.end(); ++ni) {
+      Node_handle n(*ni);
+      for(typename Halfedge_list::const_iterator e = n->edges_begin(); e!=n->edges_end(); ++e) {
+        if(!visited[*e]) {
+#ifdef CGAL_NEF3_DUMP_STATISTICS
+          ++number_of_intersection_candidates;
+#endif
+          Point_3 q;
+          if(SNC_intersection::does_intersect_internally( s, Segment_3((*e)->source()->point(),
+                                                                       (*e)->twin()->source()->point()), q)) {
+            q = normalized(q);
+            call_back( e0, make_object(Halfedge_handle(*e)), q);
+            _CGAL_NEF_TRACEN("edge intersects edge "<<' '<<&*e<< Segment_3((*e)->source()->point(),
+                                                                           (*e)->twin()->source()->point())<<" on "<<q);
+          }
+          visited[*e] = true;
+        }
+      }
+    }
+  }
+
+  void intersect_with_facets( Halfedge_handle e0,
+                              const Intersection_call_back& call_back,Segment_3& s, Node_list& nodes) const {
+    Unique_hash_map<Halffacet_handle,bool> visited(false);
+    for(typename Node_list::iterator ni = nodes.begin(); ni!=nodes.end(); ++ni) {
+      Node_handle n(*ni);
+      for(typename Halffacet_list::const_iterator f = n->facets_begin(); f!=n->facets_end(); ++f) {
+        if(!visited[*f]) {
+#ifdef CGAL_NEF3_DUMP_STATISTICS
+          ++number_of_intersection_candidates;
+#endif
+          Point_3 q;
+          if(SNC_intersection::does_intersect_internally( s, *f, q) ) {
+            q = normalized(q);
+            call_back( e0, make_object(Halffacet_handle(*f)), q);
+            _CGAL_NEF_TRACEN("edge intersects facet on plane "<<f->plane()<<" on "<<q);
+          }
+          visited[*f] = true;
+        }
+      }
+    }
+  }
+
   Volume_handle determine_volume( const Ray_3& ray) const {
     Halffacet_handle f_below;
     Object_handle o = shoot(ray);

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -230,14 +230,14 @@ public:
     return this->shoot(ray, null_handle, mask);
   }
 
-  enum SOLUTION { is_vertex_, is_edge_, is_facet_ };
+  enum SOLUTION { is_vertex_, is_edge_, is_facet_ , is_none_};
 
   virtual Object_handle shoot(const Ray_3& ray, Vertex_handle ray_source_vertex, int mask=255) const {
     CGAL_NEF_TIMER(rs_t.start());
     CGAL_assertion( initialized);
     _CGAL_NEF_TRACEN( "shooting: "<<ray);
 
-    SOLUTION solution;
+    SOLUTION solution = is_none_;
     Vertex_handle v_res;
     Halfedge_handle e_res;
     Halffacet_handle f_res;

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -328,8 +328,9 @@ public:
       case is_vertex_: return make_object(v_res);
       case is_edge_: return make_object(e_res);
       case is_facet_: return make_object(f_res);
-      case is_none_ : return Object_handle();
+      case is_none_ : break;
     }
+    return Object_handle();
   }
 
   virtual Object_handle locate( const Point_3& p) const {

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -98,9 +98,10 @@ public:
   class Intersection_call_back
   {
   public:
-    virtual void operator()( Halfedge_handle edge, Object_handle object,
+    virtual void operator()( Halfedge_handle edge0, Halfedge_handle edge1,
                              const Point_3& intersection_point) const = 0;
-
+    virtual void operator()( Halfedge_handle edge0, Halffacet_handle facet1,
+                             const Point_3& intersection_point) const = 0;
     virtual ~Intersection_call_back() {}
   };
 
@@ -511,7 +512,7 @@ private:
           if(SNC_intersection::does_intersect_internally( s, Segment_3((*e)->source()->point(),
                                                                        (*e)->twin()->source()->point()), q)) {
             q = normalized(q);
-            call_back( e0, make_object(Halfedge_handle(*e)), q);
+            call_back( e0, *e, q);
             _CGAL_NEF_TRACEN("edge intersects edge "<<' '<<&*e<< Segment_3((*e)->source()->point(),
                                                                            (*e)->twin()->source()->point())<<" on "<<q);
           }
@@ -534,7 +535,7 @@ private:
           Point_3 q;
           if(SNC_intersection::does_intersect_internally( s, *f, q) ) {
             q = normalized(q);
-            call_back( e0, make_object(Halffacet_handle(*f)), q);
+            call_back( e0, *f, q);
             _CGAL_NEF_TRACEN("edge intersects facet on plane "<<f->plane()<<" on "<<q);
           }
           visited[*f] = true;

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -411,13 +411,13 @@ public:
       Halfedge_handle e;
       for(typename Halfedge_list::const_iterator ei=n->edges_begin(); ei!=n->edges_end(); ++ei) {
         e = *ei;
-        Segment_3 ss(e->source()->point(),e->twin()->source()->point());
         CGAL_NEF_TRACEN("test edge " << e->source()->point() << "->" << e->twin()->source()->point());
         if (SNC_intersection::does_contain_internally(e->source()->point(), e->twin()->source()->point(), p)) {
           _CGAL_NEF_TRACEN("found on edge "<< ss);
           return make_object(e);
         }
-        if((e->source() != v)  && (e->twin()->source() != v) && SNC_intersection::does_intersect_internally(s, ss, ip)) {
+        if((e->source() != v)  && (e->twin()->source() != v) &&
+           SNC_intersection::does_intersect_internally(s, Segment_3(e->source()->point(),e->twin()->source()->point()), ip)) {
           s = Segment_3(p, normalized(ip));
           e_res = e;
           solution = is_edge_;

--- a/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
+++ b/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
@@ -71,7 +71,7 @@ struct binop_intersection_test_segment_tree {
         return;
       Point_3 ip;
       if( SNC_intersection::does_intersect_internally( Const_decorator::segment(e0), f1, ip )) {
-        cb(e0,make_object(f1),ip);
+        cb(e0,f1,ip);
       }
     }
   };
@@ -97,7 +97,7 @@ struct binop_intersection_test_segment_tree {
       Point_3 ip;
       if( SNC_intersection::does_intersect_internally( Const_decorator::segment( e1 ),
                                                        f0, ip ) )
-        cb(e1,make_object(f0),ip);
+        cb(e1,f0,ip);
     }
   };
 
@@ -119,7 +119,7 @@ struct binop_intersection_test_segment_tree {
       Point_3 ip;
       if( SNC_intersection::does_intersect_internally( Const_decorator::segment( e0 ),
                                                        Const_decorator::segment( e1 ), ip ))
-        cb(e0,make_object(e1),ip);
+        cb(e0,e1,ip);
     }
   };
 


### PR DESCRIPTION
## Summary of Changes

It is believed that the object casts in K3_tree/SNC_point_locator creates an overhead. This pull request aims to reduce this overhead by keeping lists of vertices, edges and facets separately in the Node.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): performance
* License and copyright ownership: Returned to CGAL authors.