### PR TITLE
Workaround issue with intel compiler

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Point_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Point_2.h
@@ -51,7 +51,7 @@ public:
     : base(hx, hy, hw) {}
 
   friend void swap(Self& a, Self& b)
-#ifdef __cpp_lib_is_swappable
+#if !defined(__INTEL_COMPILER) && defined(__cpp_lib_is_swappable)
     noexcept(std::is_nothrow_swappable_v<Vector_2_>)
 #endif
   {

--- a/Cartesian_kernel/include/CGAL/Cartesian/Point_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Point_3.h
@@ -49,7 +49,7 @@ public:
     : base(x, y, z, w) {}
 
   friend void swap(Self& a, Self& b)
-#ifdef __cpp_lib_is_swappable
+#if !defined(__INTEL_COMPILER) && defined(__cpp_lib_is_swappable)
     noexcept(std::is_nothrow_swappable_v<Vector_3>)
 #endif
   {

--- a/Cartesian_kernel/include/CGAL/Cartesian/Vector_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Vector_2.h
@@ -57,7 +57,7 @@ public:
                         : CGAL::make_array(hx, hy) ) {}
 
   friend void swap(Self& a, Self& b)
-#ifdef __cpp_lib_is_swappable
+#if !defined(__INTEL_COMPILER) && defined(__cpp_lib_is_swappable)
     noexcept(std::is_nothrow_swappable_v<Base>)
 #endif
   {

--- a/Cartesian_kernel/include/CGAL/Cartesian/Vector_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Vector_3.h
@@ -72,7 +72,7 @@ public:
                        : CGAL::make_array(x, y, z) ) {}
 
   friend void swap(Self& a, Self& b)
-#ifdef __cpp_lib_is_swappable
+#if !defined(__INTEL_COMPILER) && defined(__cpp_lib_is_swappable)
     noexcept(std::is_nothrow_swappable_v<Base>)
 #endif
   {

--- a/Kernel_23/include/CGAL/Point_2.h
+++ b/Kernel_23/include/CGAL/Point_2.h
@@ -84,7 +84,7 @@ public:
   {}
 
   friend void swap(Self& a, Self& b)
-#ifdef __cpp_lib_is_swappable
+#if !defined(__INTEL_COMPILER) && defined(__cpp_lib_is_swappable)
     noexcept(std::is_nothrow_swappable_v<Rep>)
 #endif
   {

--- a/Kernel_23/include/CGAL/Point_3.h
+++ b/Kernel_23/include/CGAL/Point_3.h
@@ -82,7 +82,7 @@ public:
   {}
 
   friend void swap(Self& a, Self& b)
-#ifdef __cpp_lib_is_swappable
+#if !defined(__INTEL_COMPILER) && defined(__cpp_lib_is_swappable)
     noexcept(std::is_nothrow_swappable_v<Rep>)
 #endif
   {

--- a/Kernel_23/include/CGAL/Vector_2.h
+++ b/Kernel_23/include/CGAL/Vector_2.h
@@ -93,7 +93,7 @@ public:
       : RVector_2(typename R::Construct_vector_2()(Return_base_tag(), x,y,w)) {}
 
   friend void swap(Self& a, Self& b)
-#ifdef __cpp_lib_is_swappable
+#if !defined(__INTEL_COMPILER) && defined(__cpp_lib_is_swappable)
     noexcept(std::is_nothrow_swappable_v<Rep>)
 #endif
   {

--- a/Kernel_23/include/CGAL/Vector_3.h
+++ b/Kernel_23/include/CGAL/Vector_3.h
@@ -93,7 +93,7 @@ public:
     : Rep(typename R::Construct_vector_3()(Return_base_tag(), x, y, z, w)) {}
 
   friend void swap(Self& a, Self& b)
-#ifdef __cpp_lib_is_swappable
+#if !defined(__INTEL_COMPILER) && defined(__cpp_lib_is_swappable)
     noexcept(std::is_nothrow_swappable_v<Rep>)
 #endif
   {

--- a/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Point_d.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Wrapper/Point_d.h
@@ -102,7 +102,7 @@ public:
     : Rep(CPBase()(std::move(v))) {}
 
   friend void swap(Self& a, Self& b)
-#ifdef __cpp_lib_is_swappable
+#if !defined(__INTEL_COMPILER) && defined(__cpp_lib_is_swappable)
     noexcept(std::is_nothrow_swappable_v<Rep>)
 #endif
     {


### PR DESCRIPTION
Full error message:

```
/home/sloriot/CGAL/git/integration/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h(38): error: incomplete type is not allowed
      Point_3 first;
              ^
          detected during:
            instantiation of class "CGAL::LineC3<R_>::Rep [with R_=CGAL::Simple_cartesian<double>]" at line 46
            instantiation of class "CGAL::LineC3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 30 of "/home/sloriot/CGAL/git/integration/Kernel_23/include/CGAL/Line_3.h"
            instantiation of class "CGAL::Line_3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 901 of "/usr/include/c++/10/type_traits"
            instantiation of class "std::__is_constructible_impl<_Tp, _Args...> [with _Tp=CGAL::VectorC3<CGAL::Simple_cartesian<double>>, _Args=<CGAL::VectorC3<CGAL::Simple_cartesian<double>> &&>]" at line 952 of "/usr/include/c++/10/type_traits"
            instantiation of class "std::__is_move_constructible_impl<_Tp, true> [with _Tp=CGAL::VectorC3<CGAL::Simple_cartesian<double>>]" at line 958 of "/usr/include/c++/10/type_traits"
            [ 4 instantiation contexts not shown ]
            instantiation of class "std::is_nothrow_swappable<_Tp> [with _Tp=CGAL::VectorC3<CGAL::Simple_cartesian<double>>]" at line 2745 of "/usr/include/c++/10/type_traits"
            instantiation of "const bool std::is_nothrow_swappable_v [with _Tp=CGAL::VectorC3<CGAL::Simple_cartesian<double>>]" at line 98 of "/home/sloriot/CGAL/git/integration/Kernel_23/include/CGAL/Vector_3.h"
            instantiation of class "CGAL::Vector_3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 32 of "/home/sloriot/CGAL/git/integration/Cartesian_kernel/include/CGAL/Cartesian/Point_3.h"
            instantiation of class "CGAL::PointC3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 31 of "/home/sloriot/CGAL/git/integration/Kernel_23/include/CGAL/Point_3.h"
            instantiation of class "CGAL::Point_3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 44 of "/tmp/test/main.cpp"

/home/sloriot/CGAL/git/integration/Cartesian_kernel/include/CGAL/Cartesian/Line_3.h(39): error: incomplete type is not allowed
      Vector_3 second;
               ^
          detected during:
            instantiation of class "CGAL::LineC3<R_>::Rep [with R_=CGAL::Simple_cartesian<double>]" at line 46
            instantiation of class "CGAL::LineC3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 30 of "/home/sloriot/CGAL/git/integration/Kernel_23/include/CGAL/Line_3.h"
            instantiation of class "CGAL::Line_3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 901 of "/usr/include/c++/10/type_traits"
            instantiation of class "std::__is_constructible_impl<_Tp, _Args...> [with _Tp=CGAL::VectorC3<CGAL::Simple_cartesian<double>>, _Args=<CGAL::VectorC3<CGAL::Simple_cartesian<double>> &&>]" at line 952 of "/usr/include/c++/10/type_traits"
            instantiation of class "std::__is_move_constructible_impl<_Tp, true> [with _Tp=CGAL::VectorC3<CGAL::Simple_cartesian<double>>]" at line 958 of "/usr/include/c++/10/type_traits"
            [ 4 instantiation contexts not shown ]
            instantiation of class "std::is_nothrow_swappable<_Tp> [with _Tp=CGAL::VectorC3<CGAL::Simple_cartesian<double>>]" at line 2745 of "/usr/include/c++/10/type_traits"
            instantiation of "const bool std::is_nothrow_swappable_v [with _Tp=CGAL::VectorC3<CGAL::Simple_cartesian<double>>]" at line 98 of "/home/sloriot/CGAL/git/integration/Kernel_23/include/CGAL/Vector_3.h"
            instantiation of class "CGAL::Vector_3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 32 of "/home/sloriot/CGAL/git/integration/Cartesian_kernel/include/CGAL/Cartesian/Point_3.h"
            instantiation of class "CGAL::PointC3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 31 of "/home/sloriot/CGAL/git/integration/Kernel_23/include/CGAL/Point_3.h"
            instantiation of class "CGAL::Point_3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 44 of "/tmp/test/main.cpp"

/usr/include/c++/10/array(110): error: incomplete type is not allowed
        typename _AT_Type::_Type                         _M_elems;
                                                         ^
          detected during:
            instantiation of class "std::array<_Tp, _Nm> [with _Tp=CGAL::Point_3<CGAL::Simple_cartesian<double>>, _Nm=2UL]" at line 38 of "/home/sloriot/CGAL/git/integration/Cartesian_kernel/include/CGAL/Cartesian/Ray_3.h"
            instantiation of class "CGAL::RayC3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 31 of "/home/sloriot/CGAL/git/integration/Kernel_23/include/CGAL/Ray_3.h"
            instantiation of class "CGAL::Ray_3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 901 of "/usr/include/c++/10/type_traits"
            instantiation of class "std::__is_constructible_impl<_Tp, _Args...> [with _Tp=CGAL::VectorC3<CGAL::Simple_cartesian<double>>, _Args=<CGAL::VectorC3<CGAL::Simple_cartesian<double>> &&>]" at line 952 of "/usr/include/c++/10/type_traits"
            instantiation of class "std::__is_move_constructible_impl<_Tp, true> [with _Tp=CGAL::VectorC3<CGAL::Simple_cartesian<double>>]" at line 958 of "/usr/include/c++/10/type_traits"
            [ 4 instantiation contexts not shown ]
            instantiation of class "std::is_nothrow_swappable<_Tp> [with _Tp=CGAL::VectorC3<CGAL::Simple_cartesian<double>>]" at line 2745 of "/usr/include/c++/10/type_traits"
            instantiation of "const bool std::is_nothrow_swappable_v [with _Tp=CGAL::VectorC3<CGAL::Simple_cartesian<double>>]" at line 98 of "/home/sloriot/CGAL/git/integration/Kernel_23/include/CGAL/Vector_3.h"
            instantiation of class "CGAL::Vector_3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 32 of "/home/sloriot/CGAL/git/integration/Cartesian_kernel/include/CGAL/Cartesian/Point_3.h"
            instantiation of class "CGAL::PointC3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 31 of "/home/sloriot/CGAL/git/integration/Kernel_23/include/CGAL/Point_3.h"
            instantiation of class "CGAL::Point_3<R_> [with R_=CGAL::Simple_cartesian<double>]" at line 44 of "/tmp/test/main.cpp"

compilation aborted for /tmp/test/main.cpp (code 2)
make[2]: *** [CMakeFiles/main.dir/build.make:82: CMakeFiles/main.dir/main.cpp.o] Error 2
make[1]: *** [CMakeFiles/Makefile2:151: CMakeFiles/main.dir/all] Error 2
make: *** [Makefile:103: all] Error 2
```

Looking at the code I did not see anything forbidden so I suspect it is a bug.