### PR TITLE
Polyhedron_3: Faster split in the demo

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Join_and_split_polyhedra_plugin.cpp
@@ -144,11 +144,11 @@ void Polyhedron_demo_join_and_split_polyhedra_plugin::on_actionSplitPolyhedra_tr
     if(item)
     {
       QApplication::setOverrideCursor(Qt::WaitCursor);
-      std::vector<FaceGraph> new_polyhedra;
+      std::list<FaceGraph> new_polyhedra;
       CGAL::Polygon_mesh_processing::split_connected_components(*item->face_graph(),
                                                                 new_polyhedra);
       //sort polyhedra by number of faces
-      std::sort(new_polyhedra.begin(), new_polyhedra.end(), Compare());
+      new_polyhedra.sort(Compare());
 
 
       if (new_polyhedra.size()==1)


### PR DESCRIPTION
## Summary of Changes
Make the splitting of connected components faster.
First step: do not use a vector but a list, which avoids reallocation and swapping.

There are more copies made that we might want to avoid.    The surface mesh item gets constructed with a reference and makes a copy on the heap.  How to make the split function generate the mesh directly on the heap and then give the pointer to the surface mesh item.  Can one transfer ownership.  Also having a `swap()`  member function for the Surface_mesh would be helpful.

## Release Management

* Affected package(s):  Polyhedron
* Issue(s) solved (if any): improves #6479

