### PR TITLE
Hash_map: Implement erase method.

### DIFF
--- a/Hash_map/benchmark/Hash_map/polyhedron.cpp
+++ b/Hash_map/benchmark/Hash_map/polyhedron.cpp
@@ -56,7 +56,7 @@ template <typename Map>
 int fct(int ii, int jj, const Vertex_list& V, const Vertex_list& V2, const VPM& vpm, const std::string& s)
 {
   int x = 0;
-  Timer construct, query, lookups;
+  Timer construct, query, lookups, erase;
   construct.start();
   for(int j=0; j <jj; j++){
     Map sm;
@@ -88,10 +88,18 @@ int fct(int ii, int jj, const Vertex_list& V, const Vertex_list& V2, const VPM& 
     }
   }
   lookups.stop();
+
+  erase.start();
+  for(int j=0; j <jj; j++){
+    for(vertex_descriptor vh : V){
+      sm.erase(vh);
+    }
+  }
+  erase.stop();
   if(y != 0) { std::cout << y << " != 0" << std::endl;}
 
 
-  std::cerr << s << construct.time() << " sec.\t| " << query.time() << " sec.\t| " << lookups.time() << " sec." << std::endl;
+  std::cerr << s << construct.time() << " sec.\t| " << query.time() << " sec.\t| " << lookups.time() << " sec.\t| " << erase.time() << " sec." << std::endl;
 
   return x;
 }
@@ -133,7 +141,7 @@ void  fct(int ii, int jj)
 
 
   std::cerr << std::endl << ii << " items and queries (repeated " << jj << " times)" << std::endl;
-  std::cerr << "Name\t\t\t| Version\t| Construction\t| Queries\t| Lookups" << std::endl;
+  std::cerr << "Name\t\t\t| Version\t| Construction\t| Queries\t| Lookups\t| Erase" << std::endl;
 
   int temp;
   int res = fct<SM>(ii,jj, V1,V2, vpm1, "std::map\t\t|\t\t| " );

--- a/Hash_map/include/CGAL/Hash_map/internal/chained_map.h
+++ b/Hash_map/include/CGAL/Hash_map/internal/chained_map.h
@@ -33,7 +33,7 @@ class chained_map_elem
   std::size_t k; T i;
   chained_map_elem<T>*  succ;
 public:
-  chained_map_elem(const T& _i) : i(_i) {}
+  chained_map_elem(std::size_t _k, const T& _i) : k(_k), i(_i) {}
 };
 
 template <typename T, typename Allocator>
@@ -68,8 +68,8 @@ private:
 
    inline void insert(std::size_t x, T y);
 
-   void construct(chained_map_elem<T>* item, const T& d)
-   { Allocator_type_traits::construct(alloc,item, d); }
+   void construct(chained_map_elem<T>* item, std::size_t k, const T& d)
+   { Allocator_type_traits::construct(alloc,item, k, d); }
 
    void destroy(chained_map_elem<T>* item)
    { Allocator_type_traits::destroy(alloc,item); }
@@ -114,8 +114,7 @@ inline T& chained_map<T, Allocator>::access(std::size_t x)
   }
   else {
     if ( p->k == nullkey ) {
-      p->k = x;
-      construct(p, def);
+      construct(p, x, def);
       return p->i;
     } else
       return access(p,x);
@@ -225,14 +224,12 @@ T& chained_map<T, Allocator>::access(Item p, std::size_t x)
   }
 
   if (p->k == nullkey)
-  { p->k = x;
-    construct(p, def);
+  { construct(p, x, def);
     return p->i;
   }
 
   q = free; free_succ();
-  q->k = x;
-  construct(q, def);
+  construct(q, x, def);
   q->succ = p->succ;
   p->succ = q;
   return q->i;

--- a/Hash_map/include/CGAL/Unique_hash_map.h
+++ b/Hash_map/include/CGAL/Unique_hash_map.h
@@ -102,7 +102,15 @@ public:
         m_map.xdef() = deflt; }
 
     bool is_defined( const Key& key) const {
-        return m_map.lookup( m_hash_function(key)) != 0;
+        return contains(key);
+    }
+
+    bool contains(const Key& key) const {
+        return m_map.lookup( m_hash_function(key)) != nullptr;
+    }
+
+    void erase(const Key& key) {
+        m_map.erase(m_hash_function(key));
     }
 
     const Data& operator[]( const Key& key) const {

--- a/Miscellany/doc/Miscellany/CGAL/Unique_hash_map.h
+++ b/Miscellany/doc/Miscellany/CGAL/Unique_hash_map.h
@@ -7,7 +7,7 @@ namespace CGAL {
 An instance of the class template `Unique_hash_map` is an
 injective mapping from the set of keys of type `Key` to the set of
 variables of type `Data`. New keys can be inserted at any time,
-however keys cannot be individually deleted.
+and can be deleted with the erase method.
 
 An object `hash` of the type `UniqueHashFunction` returns a
 unique integer index `hash(key)` of type `std::size_t` for all

--- a/Miscellany/doc/Miscellany/CGAL/Unique_hash_map.h
+++ b/Miscellany/doc/Miscellany/CGAL/Unique_hash_map.h
@@ -113,13 +113,22 @@ the current hash function.
 Hash_function hash_function() const;
 
 /*!
-returns true if \f$ key\f$ is
-defined in `*this`. Note that there can be keys defined that have not
+returns true if `*this` contains \f$ key\f$.
+Note that there can be keys defined that have not
 been inserted explicitly. Their variables are initialized to
 `default_value`.
 */
+bool contains( const Key& key) const;
+
+/*!
+returns true if `*this` contains \f$ key\f$
+*/
 bool is_defined( const Key& key) const;
 
+/*!
+erases \f$ key\f$ and its value from the `map`
+*/
+void erase(const Key& key);
 
 /*!
 sets the table size.

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -383,13 +383,13 @@ public:
   expensive operation.}*/
 
   SNC_structure() :
-    boundary_item_(boost::none), sm_boundary_item_(boost::none),
+    boundary_item_(), sm_boundary_item_(),
     vertices_(), halfedges_(), halffacets_(), volumes_(),
     shalfedges_(), shalfloops_(), sfaces_() {}
   ~SNC_structure() { CGAL_NEF_TRACEN("~SNC_structure: clearing "<<this); clear(); }
 
   SNC_structure(const Self& D) :
-    boundary_item_(boost::none), sm_boundary_item_(boost::none),
+    boundary_item_(), sm_boundary_item_(),
     vertices_(D.vertices_), halfedges_(D.halfedges_),
     halffacets_(D.halffacets_), volumes_(D.volumes_),
     shalfedges_(D.shalfedges_), shalfloops_(D.shalfloops_),
@@ -400,8 +400,8 @@ public:
     if ( this == &D )
       return *this;
     clear();
-    boundary_item_.clear(boost::none);
-    sm_boundary_item_.clear(boost::none);
+    boundary_item_.clear();
+    sm_boundary_item_.clear();
     vertices_ = D.vertices_;
     halfedges_ = D.halfedges_;
     halffacets_ = D.halffacets_;
@@ -418,17 +418,17 @@ public:
   }
 
   void clear_boundary() {
-    boundary_item_.clear(boost::none);
-    sm_boundary_item_.clear(boost::none);
+    boundary_item_.clear();
+    sm_boundary_item_.clear();
   }
 
   void clear_snc_boundary() {
-    boundary_item_.clear(boost::none);
+    boundary_item_.clear();
   }
 
   void clear() {
-    boundary_item_.clear(boost::none);
-    sm_boundary_item_.clear(boost::none);
+    boundary_item_.clear();
+    sm_boundary_item_.clear();
     vertices_.destroy();
     halfedges_.destroy();
     halffacets_.destroy();
@@ -440,17 +440,17 @@ public:
 
   template <typename H>
   bool is_boundary_object(H h) const
-  { return boundary_item_[h]!=boost::none; }
+  { return boundary_item_.contains(h); }
   template <typename H>
   bool is_sm_boundary_object(H h) const
-  { return sm_boundary_item_[h]!=boost::none; }
+  { return sm_boundary_item_.contains(h); }
 
   template <typename H>
   Object_iterator& boundary_item(H h)
-  { return *boundary_item_[h]; }
+  { return boundary_item_[h]; }
   template <typename H>
   Object_iterator& sm_boundary_item(H h)
-  { return *sm_boundary_item_[h]; }
+  { return sm_boundary_item_[h]; }
 
   template <typename H>
   void store_boundary_item(H h, Object_iterator o)
@@ -461,12 +461,12 @@ public:
 
   template <typename H>
   void undef_boundary_item(H h)
-  { CGAL_assertion(boundary_item_[h]!=boost::none);
-    boundary_item_[h] = boost::none; }
+  { CGAL_assertion(is_boundary_object(h));
+    boundary_item_.erase(h); }
   template <typename H>
   void undef_sm_boundary_item(H h)
-  { CGAL_assertion(sm_boundary_item_[h]!=boost::none);
-    sm_boundary_item_[h] = boost::none; }
+  { CGAL_assertion(is_sm_boundary_object(h));
+    sm_boundary_item_.erase(h); }
 
   void reset_iterator_hash(Object_iterator it)
   { SVertex_handle sv;
@@ -1034,10 +1034,9 @@ public:
 protected:
   void pointer_update(const Self& D);
 
-  typedef boost::optional<Object_iterator> Optional_object_iterator ;
  private:
-  Generic_handle_map<Optional_object_iterator> boundary_item_;
-  Generic_handle_map<Optional_object_iterator> sm_boundary_item_;
+  Generic_handle_map<Object_iterator> boundary_item_;
+  Generic_handle_map<Object_iterator> sm_boundary_item_;
  protected:
   Vertex_list    vertices_;
   Halfedge_list  halfedges_;

--- a/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
@@ -43,6 +43,14 @@ public:
   I& operator[](H h)
   { return Base::operator[]((void*)&*h); }
 
+  template <class H>
+  bool contains(H h) const
+  { return Base::contains((void*)&*h); }
+
+  template <class H>
+  void erase(H h)
+  { Base::erase((void*)&*h); }
+
 };
 
 } //namespace CGAL

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_map.h
@@ -128,8 +128,7 @@ public:
   typedef std::list<Object_handle>                     Object_list;
   typedef typename Object_list::iterator               Object_iterator;
   typedef typename Object_list::const_iterator         Object_const_iterator;
-  typedef boost::optional<Object_iterator>             Optional_object_iterator ;
-  typedef Generic_handle_map<Optional_object_iterator> Handle_to_iterator_map;
+  typedef Generic_handle_map<Object_iterator>          Handle_to_iterator_map;
 
   typedef Sphere_map*       Constructor_parameter;
   typedef const Sphere_map* Constructor_const_parameter;
@@ -226,7 +225,7 @@ public:
   construction means cloning an isomorphic structure and is thus an
   expensive operation.}*/
 
-  Sphere_map(bool = false) : boundary_item_(boost::none),
+  Sphere_map(bool = false) : boundary_item_(),
     svertices_(), sedges_(), sfaces_(), shalfloop_() {}
 
   ~Sphere_map() noexcept(!CGAL_ASSERTIONS_ENABLED)
@@ -236,7 +235,7 @@ public:
     );
   }
 
-  Sphere_map(const Self& D) : boundary_item_(boost::none),
+  Sphere_map(const Self& D) : boundary_item_(),
     svertices_(D.svertices_),
     sedges_(D.sedges_),
     sfaces_(D.sfaces_),
@@ -258,7 +257,7 @@ public:
 
   void clear()
   {
-    boundary_item_.clear(boost::none);
+    boundary_item_.clear();
     svertices_.destroy();
     sfaces_.destroy();
     while ( shalfedges_begin() != shalfedges_end() )
@@ -268,11 +267,11 @@ public:
 
   template <typename H>
   bool is_sm_boundary_object(H h) const
-  { return boundary_item_[h]!=boost::none; }
+  { return boundary_item_.contains(h); }
 
   template <typename H>
   Object_iterator& sm_boundary_item(H h)
-  { return *boundary_item_[h]; }
+  { return boundary_item_[h]; }
 
   template <typename H>
   void store_sm_boundary_item(H h, Object_iterator o)
@@ -280,8 +279,8 @@ public:
 
   template <typename H>
   void undef_sm_boundary_item(H h)
-  { CGAL_assertion(boundary_item_[h]!=boost::none);
-    boundary_item_[h] = boost::none; }
+  { CGAL_assertion(is_sm_boundary_object(h));
+    boundary_item_.erase(h); }
 
   void reset_sm_iterator_hash(Object_iterator it)
   { SVertex_handle sv;


### PR DESCRIPTION
## Summary of Changes

When looking at SNC_structure from the Nef_3 package, I noticed an unusual design that wraps `Object_iterator` in a `boost::optional` I have come to believe that the reason for the design is to work around the fact that Unique_hash_map/chained_map implementation does not support an erase function. Instead of removing the Object_iterator from the hashmap, its optional wrapper is set to `boost::none`. In theory, this design could have a memory leak, as adding and removing boundary items would only add optional items. I am not sure if this is the case in practice.

Either way, I decided to attempt to implement erase for the hashmap. One of the problems that I ran into was managing the so-called `free` pointer since the existing code needs to be able to increment it to move to the next available memory, but the erased element could exist below the free pointer's location. One approach would be to move the erased element to the location of the free pointer and decrement the free pointer, but this was found to be slow, as it required unlinking anything that pointed to the `free` node.

Instead, I had the idea of a "free chain" which builds on the single linked lists of the existing code. I think this idea could be novel, but I am not very well versed in hashmap literature. Essentially the idea is to build a chain of the overflow memory, and instead of incrementing free, an iterator function `free = free->succ` is used. The advantage of this approach is that when memory needs to be returned to the overflow memory via `erase`, it is simply a case of inserting it back into the free chain.

The pull request also adds a `contains` method (wrapper for is_defined) and uses the methods within SNC_structure/Sphere_map. Usage of std::move was added to erase and rehash.

## Testing
* Nef_3 ctest 100% pass
* Nef_S2 ctest 100% pass
* Hash_map ctest 100% pass

## Release Management

* Affected package(s): Hash_map
* Issue(s) solved (if any): cleaning
* License and copyright ownership: Returned to CGAL authors.