### PR TITLE
Merge parameters::Is_default and parameters::is_default_parameter 

### DIFF
--- a/BGL/include/CGAL/boost/graph/IO/Generic_facegraph_builder.h
+++ b/BGL/include/CGAL/boost/graph/IO/Generic_facegraph_builder.h
@@ -76,10 +76,10 @@ public:
     using parameters::is_default_parameter;
     using parameters::get_parameter;
 
-    const bool is_vnm_requested = !(is_default_parameter<NamedParameters, internal_np::vertex_normal_map_t>());
-    const bool is_vcm_requested = !(is_default_parameter<NamedParameters, internal_np::vertex_color_map_t>());
-    const bool is_vtm_requested = !(is_default_parameter<NamedParameters, internal_np::vertex_texture_map_t>());
-    const bool is_fcm_requested = !(is_default_parameter<NamedParameters, internal_np::face_color_map_t>());
+    const bool is_vnm_requested = !(is_default_parameter<NamedParameters, internal_np::vertex_normal_map_t>::value);
+    const bool is_vcm_requested = !(is_default_parameter<NamedParameters, internal_np::vertex_color_map_t>::value);
+    const bool is_vtm_requested = !(is_default_parameter<NamedParameters, internal_np::vertex_texture_map_t>::value);
+    const bool is_fcm_requested = !(is_default_parameter<NamedParameters, internal_np::face_color_map_t>::value);
 
     std::vector<Vertex_normal> vertex_normals;
     std::vector<Vertex_color> vertex_colors;

--- a/BGL/include/CGAL/boost/graph/IO/Generic_facegraph_printer.h
+++ b/BGL/include/CGAL/boost/graph/IO/Generic_facegraph_printer.h
@@ -122,10 +122,10 @@ public:
     VPM vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                                get_const_property_map(CGAL::vertex_point, g));
 
-    const bool has_vertex_normals = !(is_default_parameter<NamedParameters, internal_np::vertex_normal_map_t>());
-    const bool has_vertex_colors = !(is_default_parameter<NamedParameters, internal_np::vertex_color_map_t>());
-    const bool has_vertex_textures = !(is_default_parameter<NamedParameters, internal_np::vertex_texture_map_t>());
-    const bool has_face_colors = !(is_default_parameter<NamedParameters, internal_np::face_color_map_t>());
+    const bool has_vertex_normals = !(is_default_parameter<NamedParameters, internal_np::vertex_normal_map_t>::value);
+    const bool has_vertex_colors = !(is_default_parameter<NamedParameters, internal_np::vertex_color_map_t>::value);
+    const bool has_vertex_textures = !(is_default_parameter<NamedParameters, internal_np::vertex_texture_map_t>::value);
+    const bool has_face_colors = !(is_default_parameter<NamedParameters, internal_np::face_color_map_t>::value);
 
     VNM vnm = get_parameter(np, internal_np::vertex_normal_map);
     VTM vtm = get_parameter(np, internal_np::vertex_texture_map);

--- a/BGL/include/CGAL/boost/graph/IO/PLY.h
+++ b/BGL/include/CGAL/boost/graph/IO/PLY.h
@@ -326,8 +326,8 @@ bool write_PLY(std::ostream& os,
   VCM vcm = choose_parameter(get_parameter(np, internal_np::vertex_color_map), VCM());
   FCM fcm = choose_parameter(get_parameter(np, internal_np::face_color_map), FCM());
 
-  bool has_vcolor = !is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>();
-  bool has_fcolor = !is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>();
+  bool has_vcolor = !is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>::value;
+  bool has_fcolor = !is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>::value;
   VIMap vim = CGAL::get_initialized_vertex_index_map(g, np);
   Vpm vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                              get_const_property_map(boost::vertex_point, g));

--- a/BGL/include/CGAL/boost/graph/named_params_helper.h
+++ b/BGL/include/CGAL/boost/graph/named_params_helper.h
@@ -10,175 +10,171 @@
 #define CGAL_BOOST_GRAPH_NAMED_PARAMETERS_HELPERS_H
 
 #include <CGAL/boost/graph/internal/initialized_index_maps_helpers.h>
-#include <CGAL/Named_function_parameters.h>
 #include <CGAL/boost/graph/properties.h>
 #include <CGAL/Dynamic_property_map.h>
+#include <CGAL/iterator.h>
 #include <CGAL/Kernel_traits.h>
 #include <CGAL/Origin.h>
-#include <CGAL/iterator.h>
-
+#include <CGAL/Named_function_parameters.h>
 #include <CGAL/property_map.h>
 
 #include <boost/mpl/if.hpp>
 #include <boost/mpl/has_xxx.hpp>
 #include <boost/type_traits/is_same.hpp>
 
+#include <fstream>
+#include <iterator>
 #include <type_traits>
 
 namespace CGAL {
+namespace parameters {
 
-  namespace parameters
+template <class Parameter, class NamedParameters>
+struct Is_default
+{
+  typedef typename internal_np::Lookup_named_param_def<Parameter,
+                                                       NamedParameters,
+                                                       internal_np::Param_not_found>::type NP_type;
+
+  static const bool value = boost::is_same<NP_type, internal_np::Param_not_found>::value;
+
+  typedef CGAL::Boolean_tag<value> type;
+};
+
+} // namespace parameters
+
+// forward declarations to avoid dependency to Solver_interface
+template <typename FT, unsigned int dim>
+class Default_diagonalize_traits;
+class Eigen_svd;
+class Lapack_svd;
+struct Alpha_expansion_boost_adjacency_list_tag;
+//
+
+//helper classes
+template<typename PolygonMesh, typename PropertyTag>
+class property_map_selector
+{
+public:
+  typedef typename graph_has_property<PolygonMesh, PropertyTag>::type Has_internal_pmap;
+  typedef typename boost::mpl::if_c<Has_internal_pmap::value,
+                                    typename boost::property_map<PolygonMesh, PropertyTag>::type,
+                                    typename boost::cgal_no_property::type
+                                    >::type type;
+  typedef typename boost::mpl::if_c<Has_internal_pmap::value,
+                                    typename boost::property_map<PolygonMesh, PropertyTag>::const_type,
+                                    typename boost::cgal_no_property::const_type
+                                    >::type const_type;
+
+  type get_pmap(const PropertyTag& p, PolygonMesh& pmesh)
   {
-    template <class Parameter, class NamedParameters>
-    struct Is_default
-    {
-      typedef typename internal_np::Lookup_named_param_def <
-        Parameter,
-        NamedParameters,
-        internal_np::Param_not_found > ::type NP_type;
-      static const bool value = boost::is_same<NP_type, internal_np::Param_not_found>::value;
-      typedef CGAL::Boolean_tag<value> type;
-    };
-  } // end of parameters namespace
-
-  // forward declarations to avoid dependency to Solver_interface
-  template <typename FT, unsigned int dim>
-  class Default_diagonalize_traits;
-  class Eigen_svd;
-  class Lapack_svd;
-  struct Alpha_expansion_boost_adjacency_list_tag;
-  //
-
-
-  //helper classes
-  template<typename PolygonMesh, typename PropertyTag>
-  class property_map_selector
-  {
-  public:
-    typedef typename graph_has_property<PolygonMesh, PropertyTag>::type Has_internal_pmap;
-    typedef typename boost::mpl::if_c< Has_internal_pmap::value
-                                       , typename boost::property_map<PolygonMesh, PropertyTag>::type
-                                       , typename boost::cgal_no_property::type
-                                       >::type type;
-    typedef typename boost::mpl::if_c< Has_internal_pmap::value
-                                       , typename boost::property_map<PolygonMesh, PropertyTag>::const_type
-                                       , typename boost::cgal_no_property::const_type
-                                       >::type const_type;
-
-    type get_pmap(const PropertyTag& p, PolygonMesh& pmesh)
-    {
-      return get_impl(p, pmesh, Has_internal_pmap());
-    }
-
-    const_type get_const_pmap(const PropertyTag& p, const PolygonMesh& pmesh)
-    {
-      return get_const_pmap_impl(p, pmesh, Has_internal_pmap());
-    }
-
-  private:
-    type get_impl(const PropertyTag&, PolygonMesh&, CGAL::Tag_false)
-    {
-      return type(); //boost::cgal_no_property::type
-    }
-    type get_impl(const PropertyTag& p, PolygonMesh& pmesh, CGAL::Tag_true)
-    {
-      return get(p, pmesh);
-    }
-
-    const_type get_const_pmap_impl(const PropertyTag&
-                                   , const PolygonMesh&, CGAL::Tag_false)
-    {
-      return const_type(); //boost::cgal_no_property::type
-    }
-    const_type get_const_pmap_impl(const PropertyTag& p
-                                   , const PolygonMesh& pmesh, CGAL::Tag_true)
-    {
-      return get(p, pmesh);
-    }
-  };
-
-  template<typename PolygonMesh, typename PropertyTag>
-  typename property_map_selector<PolygonMesh, PropertyTag>::type
-  get_property_map(const PropertyTag& p, PolygonMesh& pmesh)
-  {
-    property_map_selector<PolygonMesh, PropertyTag> pms;
-    return pms.get_pmap(p, pmesh);
+    return get_impl(p, pmesh, Has_internal_pmap());
   }
 
-  template<typename PolygonMesh, typename PropertyTag>
-  typename property_map_selector<PolygonMesh, PropertyTag>::const_type
-  get_const_property_map(const PropertyTag& p, const PolygonMesh& pmesh)
+  const_type get_const_pmap(const PropertyTag& p, const PolygonMesh& pmesh)
   {
-    property_map_selector<PolygonMesh, PropertyTag> pms;
-    return pms.get_const_pmap(p, pmesh);
+    return get_const_pmap_impl(p, pmesh, Has_internal_pmap());
   }
 
-  // Shortcut for accessing the value type of the property map
-  template <class Graph, class Property>
-  class property_map_value {
-    typedef typename boost::property_map<Graph, Property>::const_type PMap;
-  public:
-    typedef typename boost::property_traits<PMap>::value_type type;
-  };
-
-  template<typename PolygonMesh,
-           typename NamedParameters = parameters::Default_named_parameters >
-  class GetVertexPointMap
+private:
+  type get_impl(const PropertyTag&, PolygonMesh&, CGAL::Tag_false)
   {
-    typedef typename property_map_selector<PolygonMesh, boost::vertex_point_t>::const_type
-    DefaultVPMap_const;
-    typedef typename property_map_selector<PolygonMesh, boost::vertex_point_t>::type
-    DefaultVPMap;
-  public:
-    typedef typename internal_np::Lookup_named_param_def<
-    internal_np::vertex_point_t,
-    NamedParameters,
-    DefaultVPMap
-    > ::type  type;
-    typedef typename internal_np::Lookup_named_param_def<
-      internal_np::vertex_point_t,
-      NamedParameters,
-      DefaultVPMap_const
-      > ::type  const_type;
-  };
-
-  template<typename PolygonMesh, typename NamedParameters>
-  class GetK
+    return type(); //boost::cgal_no_property::type
+  }
+  type get_impl(const PropertyTag& p, PolygonMesh& pmesh, CGAL::Tag_true)
   {
-    typedef typename boost::property_traits<
-      typename GetVertexPointMap<PolygonMesh, NamedParameters>::type
-      >::value_type Point;
-  public:
-    typedef typename CGAL::Kernel_traits<Point>::Kernel Kernel;
-  };
+    return get(p, pmesh);
+  }
 
-  template<typename PolygonMesh,
-           typename NamedParametersGT = parameters::Default_named_parameters,
-           typename NamedParametersVPM = NamedParametersGT >
-  class GetGeomTraits
+  const_type get_const_pmap_impl(const PropertyTag&
+                                 , const PolygonMesh&, CGAL::Tag_false)
   {
-    typedef typename CGAL::graph_has_property<PolygonMesh, boost::vertex_point_t>::type
-      Has_internal_pmap;
+    return const_type(); //boost::cgal_no_property::type
+  }
+  const_type get_const_pmap_impl(const PropertyTag& p
+                                 , const PolygonMesh& pmesh, CGAL::Tag_true)
+  {
+    return get(p, pmesh);
+  }
+};
 
-    typedef typename internal_np::Lookup_named_param_def <
-      internal_np::vertex_point_t,
-      NamedParametersVPM,
-      internal_np::Param_not_found
-    > ::type  NP_vpm;
+template<typename PolygonMesh, typename PropertyTag>
+typename property_map_selector<PolygonMesh, PropertyTag>::type
+get_property_map(const PropertyTag& p, PolygonMesh& pmesh)
+{
+  property_map_selector<PolygonMesh, PropertyTag> pms;
+  return pms.get_pmap(p, pmesh);
+}
 
-    struct Fake_GT {};//to be used if there is no internal vertex_point_map in PolygonMesh
+template<typename PolygonMesh, typename PropertyTag>
+typename property_map_selector<PolygonMesh, PropertyTag>::const_type
+get_const_property_map(const PropertyTag& p, const PolygonMesh& pmesh)
+{
+  property_map_selector<PolygonMesh, PropertyTag> pms;
+  return pms.get_const_pmap(p, pmesh);
+}
 
-    typedef typename boost::mpl::if_c<Has_internal_pmap::value || !boost::is_same<internal_np::Param_not_found, NP_vpm>::value,
-                                     typename GetK<PolygonMesh, NamedParametersVPM>::Kernel,
-                                     Fake_GT>::type DefaultKernel;
+// Shortcut for accessing the value type of the property map
+template <class Graph, class Property>
+class property_map_value
+{
+  typedef typename boost::property_map<Graph, Property>::const_type PMap;
 
-  public:
-    typedef typename internal_np::Lookup_named_param_def <
-      internal_np::geom_traits_t,
-      NamedParametersGT,
-      DefaultKernel
-    > ::type  type;
-  };
+public:
+  typedef typename boost::property_traits<PMap>::value_type type;
+};
+
+template <typename PolygonMesh,
+          typename NamedParameters = parameters::Default_named_parameters>
+class GetVertexPointMap
+{
+  typedef typename property_map_selector<PolygonMesh, boost::vertex_point_t>::const_type
+  DefaultVPMap_const;
+  typedef typename property_map_selector<PolygonMesh, boost::vertex_point_t>::type
+  DefaultVPMap;
+
+public:
+  typedef typename internal_np::Lookup_named_param_def<internal_np::vertex_point_t,
+                                                       NamedParameters,
+                                                       DefaultVPMap>::type type;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::vertex_point_t,
+                                                       NamedParameters,
+                                                       DefaultVPMap_const>::type const_type;
+};
+
+template<typename PolygonMesh, typename NamedParameters>
+class GetK
+{
+  typedef typename boost::property_traits<
+    typename GetVertexPointMap<PolygonMesh, NamedParameters>::type>::value_type Point;
+
+public:
+  typedef typename CGAL::Kernel_traits<Point>::Kernel Kernel;
+};
+
+template <typename PolygonMesh,
+          typename NamedParametersGT = parameters::Default_named_parameters,
+          typename NamedParametersVPM = NamedParametersGT>
+class GetGeomTraits
+{
+  typedef typename CGAL::graph_has_property<PolygonMesh, boost::vertex_point_t>::type Has_internal_pmap;
+
+  typedef typename internal_np::Lookup_named_param_def<internal_np::vertex_point_t,
+                                                       NamedParametersVPM,
+                                                       internal_np::Param_not_found>::type NP_vpm;
+
+  struct Fake_GT {}; // to be used if there is no internal vertex_point_map in PolygonMesh
+
+  typedef typename boost::mpl::if_c<Has_internal_pmap::value ||
+                                    !boost::is_same<internal_np::Param_not_found, NP_vpm>::value,
+                                    typename GetK<PolygonMesh, NamedParametersVPM>::Kernel,
+                                    Fake_GT>::type DefaultKernel;
+
+public:
+  typedef typename internal_np::Lookup_named_param_def<internal_np::geom_traits_t,
+                                                       NamedParametersGT,
+                                                       DefaultKernel>::type type;
+};
 
 // Define the following structs:
 //
@@ -189,7 +185,7 @@ namespace CGAL {
 
 #define CGAL_DEF_GET_INDEX_TYPE(CTYPE, DTYPE, STYPE)                                               \
 template <typename Graph,                                                                          \
-          typename NamedParameters = parameters::Default_named_parameters>                                    \
+        typename NamedParameters = parameters::Default_named_parameters>                           \
 struct GetInitialized##CTYPE##IndexMap                                                             \
   : public BGL::internal::GetInitializedIndexMap<internal_np::DTYPE##_index_t,                     \
                                                  boost::DTYPE##_index_t,                           \
@@ -224,7 +220,7 @@ typename BGL::internal::GetInitializedIndexMap<CGAL::internal_np::DTYPE##_index_
                                                CGAL::dynamic_##DTYPE##_property_t<STYPE>,          \
                                                Graph, NamedParameters>::const_type                 \
 get_initialized_##DTYPE##_index_map(const Graph& g,                                                \
-                                    const NamedParameters& np = parameters::default_values())  \
+                                    const NamedParameters& np = parameters::default_values())      \
 {                                                                                                  \
   typedef BGL::internal::GetInitializedIndexMap<CGAL::internal_np::DTYPE##_index_t,                \
                                                 boost::DTYPE##_index_t,                            \
@@ -234,7 +230,7 @@ get_initialized_##DTYPE##_index_map(const Graph& g,                             
 }                                                                                                  \
 /* same as above, non-const version*/                                                              \
 template <typename Graph,                                                                          \
-          typename NamedParameters = parameters::Default_named_parameters,                                                                \
+          typename NamedParameters = parameters::Default_named_parameters,                         \
           /*otherwise compilers will try to use 'Graph := const PM' and things will go badly*/     \
           std::enable_if_t<                                                                        \
             !std::is_const<typename std::remove_reference<Graph>::type>::value, int> = 0>          \
@@ -243,7 +239,7 @@ typename BGL::internal::GetInitializedIndexMap<CGAL::internal_np::DTYPE##_index_
                                                CGAL::dynamic_##DTYPE##_property_t<STYPE>,          \
                                                Graph, NamedParameters>::type                       \
 get_initialized_##DTYPE##_index_map(Graph& g,                                                      \
-                                    const NamedParameters& np = parameters::default_values())  \
+                                    const NamedParameters& np = parameters::default_values())      \
 {                                                                                                  \
   typedef BGL::internal::GetInitializedIndexMap<CGAL::internal_np::DTYPE##_index_t,                \
                                                 boost::DTYPE##_index_t,                            \
@@ -259,263 +255,244 @@ CGAL_DEF_GET_INITIALIZED_INDEX_MAP(face, typename boost::graph_traits<Graph>::fa
 
 #undef CGAL_DEF_GET_INITIALIZED_INDEX_MAP
 
-  namespace internal {
-    BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(Has_nested_type_iterator, iterator, false)
+namespace internal {
+
+BOOST_MPL_HAS_XXX_TRAIT_NAMED_DEF(Has_nested_type_iterator, iterator, false)
+
+} // namespace internal
+
+template<typename PointRange,
+         typename NamedParameters = parameters::Default_named_parameters,
+         bool has_nested_iterator = internal::Has_nested_type_iterator<PointRange>::value,
+         typename NP_TAG = internal_np::point_t>
+class GetPointMap
+{
+  typedef typename std::iterator_traits<typename PointRange::iterator>::value_type Point;
+  typedef typename CGAL::Identity_property_map<Point> DefaultPMap;
+  typedef typename CGAL::Identity_property_map<const Point> DefaultConstPMap;
+
+public:
+  typedef typename internal_np::Lookup_named_param_def<NP_TAG,
+                                                       NamedParameters,
+                                                       DefaultPMap>::type type;
+
+  typedef typename internal_np::Lookup_named_param_def<NP_TAG,
+                                                       NamedParameters,
+                                                       DefaultConstPMap>::type const_type;
+};
+
+// to please compiler instantiating non valid overloads
+template<typename PointRange, typename NamedParameters>
+class GetPointMap<PointRange, NamedParameters, false>
+{
+  struct Dummy_point{};
+
+public:
+  typedef typename CGAL::Identity_property_map<Dummy_point> type;
+  typedef typename CGAL::Identity_property_map<const Dummy_point> const_type;
+};
+
+template <class PointRange, class NamedParameters, typename NP_TAG = internal_np::point_t>
+struct Point_set_processing_3_np_helper
+{
+  typedef typename std::iterator_traits<typename PointRange::iterator>::value_type Value_type;
+  typedef CGAL::Identity_property_map<Value_type> DefaultPMap;
+  typedef CGAL::Identity_property_map<const Value_type> DefaultConstPMap;
+
+  typedef typename internal_np::Lookup_named_param_def<NP_TAG,
+                                                       NamedParameters,
+                                                       DefaultPMap>::type Point_map;
+  typedef typename internal_np::Lookup_named_param_def<NP_TAG,
+                                                       NamedParameters,
+                                                       DefaultConstPMap>::type Const_point_map;
+
+  typedef typename boost::property_traits<Point_map>::value_type Point;
+  typedef typename Kernel_traits<Point>::Kernel Default_geom_traits;
+
+  typedef typename internal_np::Lookup_named_param_def<internal_np::geom_traits_t,
+                                                       NamedParameters,
+                                                       Default_geom_traits>::type Geom_traits;
+
+  typedef typename Geom_traits::FT FT;
+
+  typedef Constant_property_map<Value_type, typename Geom_traits::Vector_3> DummyNormalMap;
+
+  typedef typename internal_np::Lookup_named_param_def<internal_np::normal_t,
+                                                       NamedParameters,
+                                                       DummyNormalMap>::type Normal_map;
+
+  static Point_map get_point_map(PointRange&, const NamedParameters& np)
+  {
+    return parameters::choose_parameter<Point_map>(parameters::get_parameter(np, internal_np::point_map));
   }
 
-  template<typename PointRange,
-           typename NamedParameters = parameters::Default_named_parameters,
-           bool has_nested_iterator = internal::Has_nested_type_iterator<PointRange>::value,
-           typename NP_TAG = internal_np::point_t
-  >
-  class GetPointMap
+  static Point_map get_point_map(const NamedParameters& np)
   {
-    typedef typename std::iterator_traits<typename PointRange::iterator>::value_type Point;
-    typedef typename CGAL::Identity_property_map<Point> DefaultPMap;
-    typedef typename CGAL::Identity_property_map<const Point> DefaultConstPMap;
+    return parameters::choose_parameter<Point_map>(parameters::get_parameter(np, internal_np::point_map));
+  }
 
-  public:
-    typedef typename internal_np::Lookup_named_param_def<
-    NP_TAG,
-    NamedParameters,
-    DefaultPMap
-    > ::type  type;
+  static Const_point_map get_const_point_map(const PointRange&, const NamedParameters& np)
+  {
+    return parameters::choose_parameter<Const_point_map>(parameters::get_parameter(np, internal_np::point_map));
+  }
 
-    typedef typename internal_np::Lookup_named_param_def<
-    NP_TAG,
-    NamedParameters,
-    DefaultConstPMap
-    > ::type  const_type;
+  static Normal_map get_normal_map(const PointRange&, const NamedParameters& np)
+  {
+    return parameters::choose_parameter<Normal_map>(parameters::get_parameter(np, internal_np::normal_map));
+  }
+
+  static Normal_map get_normal_map(const NamedParameters& np)
+  {
+    return parameters::choose_parameter<Normal_map>(parameters::get_parameter(np, internal_np::normal_map));
+  }
+
+  static Geom_traits get_geom_traits(const PointRange&, const NamedParameters& np)
+  {
+    return parameters::choose_parameter<Geom_traits>(parameters::get_parameter(np, internal_np::geom_traits));
+  }
+
+  static constexpr bool has_normal_map()
+  {
+    return !boost::is_same< typename internal_np::Get_param<typename NamedParameters::base, internal_np::normal_t>::type,
+                            internal_np::Param_not_found> ::value;
+  }
+};
+
+namespace Point_set_processing_3 {
+
+template <typename ValueType>
+struct Fake_point_range
+{
+  struct iterator
+  {
+    typedef ValueType value_type;
+    typedef std::ptrdiff_t difference_type;
+    typedef ValueType* pointer;
+    typedef ValueType reference;
+    typedef std::random_access_iterator_tag iterator_category;
+  };
+};
+
+template<typename PlaneRange, typename NamedParameters>
+class GetPlaneMap
+{
+  typedef typename PlaneRange::iterator::value_type Plane;
+  typedef typename CGAL::Identity_property_map<Plane> DefaultPMap;
+  typedef typename CGAL::Identity_property_map<const Plane> DefaultConstPMap;
+
+public:
+  typedef typename internal_np::Lookup_named_param_def<internal_np::plane_t,
+                                                       NamedParameters,
+                                                       DefaultPMap>::type type;
+
+  typedef typename internal_np::Lookup_named_param_def<internal_np::plane_t,
+                                                       NamedParameters,
+                                                       DefaultConstPMap>::type const_type;
+};
+
+template<typename NamedParameters>
+class GetPlaneIndexMap
+{
+  typedef Constant_property_map<std::size_t, int> DummyPlaneIndexMap;
+
+public:
+  typedef typename internal_np::Lookup_named_param_def<internal_np::plane_index_t,
+                                                       NamedParameters,
+                                                       DummyPlaneIndexMap>::type type;
+};
+
+template<typename PointRange, typename NamedParameters>
+class GetIsConstrainedMap
+{
+  typedef Static_boolean_property_map<
+    typename std::iterator_traits<typename PointRange::iterator>::value_type, false> Default_map;
+
+public:
+  typedef typename internal_np::Lookup_named_param_def<internal_np::point_is_constrained_t,
+                                                       NamedParameters,
+                                                       Default_map>::type type;
+};
+
+template<typename PointRange, typename NamedParameters>
+class GetAdjacencies
+{
+public:
+  typedef Emptyset_iterator Empty;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::adjacencies_t,
+                                                       NamedParameters,
+                                                       Empty>::type type;
+};
+
+} // namespace Point_set_processing_3
+
+template<typename NamedParameters, typename DefaultSolver>
+class GetSolver
+{
+public:
+  typedef typename internal_np::Lookup_named_param_def<internal_np::sparse_linear_solver_t,
+                                                       NamedParameters,
+                                                       DefaultSolver>::type type;
+};
+
+template<typename NamedParameters, typename FT, unsigned int dim = 3>
+class GetDiagonalizeTraits
+{
+public:
+  typedef typename internal_np::Lookup_named_param_def<internal_np::diagonalize_traits_t,
+                                                       NamedParameters,
+                                                       Default_diagonalize_traits<FT, dim> >::type type;
+};
+
+template<typename NamedParameters>
+class GetSvdTraits
+{
+  struct DummySvdTraits
+  {
+    typedef double FT;
+    typedef int Vector;
+    typedef int Matrix;
+    static FT solve (const Matrix&, Vector&) { return 0.; }
   };
 
-  // to please compiler instantiating non valid overloads
-  template<typename PointRange, typename NamedParameters>
-  class GetPointMap<PointRange, NamedParameters, false>
-  {
-    struct Dummy_point{};
-  public:
-    typedef typename CGAL::Identity_property_map<Dummy_point> type;
-    typedef typename CGAL::Identity_property_map<const Dummy_point> const_type;
-  };
+public:
+  typedef DummySvdTraits NoTraits;
 
-  template <class PointRange, class NamedParameters, typename NP_TAG = internal_np::point_t>
-  struct Point_set_processing_3_np_helper
-  {
-    typedef typename std::iterator_traits<typename PointRange::iterator>::value_type Value_type;
-    typedef CGAL::Identity_property_map<Value_type> DefaultPMap;
-    typedef CGAL::Identity_property_map<const Value_type> DefaultConstPMap;
-
-    typedef typename internal_np::Lookup_named_param_def<NP_TAG,
-      NamedParameters,DefaultPMap> ::type  Point_map; // public
-    typedef typename internal_np::Lookup_named_param_def<NP_TAG,
-      NamedParameters,DefaultConstPMap> ::type  Const_point_map; // public
-
-    typedef typename boost::property_traits<Point_map>::value_type Point;
-    typedef typename Kernel_traits<Point>::Kernel Default_geom_traits;
-
-    typedef typename internal_np::Lookup_named_param_def <
-        internal_np::geom_traits_t,
-        NamedParameters,
-        Default_geom_traits
-      > ::type  Geom_traits; // public
-
-    typedef typename Geom_traits::FT FT; // public
-
-    typedef Constant_property_map<Value_type, typename Geom_traits::Vector_3> DummyNormalMap;
-
-    typedef typename internal_np::Lookup_named_param_def<
-      internal_np::normal_t,
-      NamedParameters,
-      DummyNormalMap
-      > ::type  Normal_map; // public
-
-    static Point_map get_point_map(PointRange&, const NamedParameters& np)
-    {
-      return parameters::choose_parameter<Point_map>(parameters::get_parameter(np, internal_np::point_map));
-    }
-
-    static Point_map get_point_map(const NamedParameters& np)
-    {
-      return parameters::choose_parameter<Point_map>(parameters::get_parameter(np, internal_np::point_map));
-    }
-
-    static Const_point_map get_const_point_map(const PointRange&, const NamedParameters& np)
-    {
-      return parameters::choose_parameter<Const_point_map>(parameters::get_parameter(np, internal_np::point_map));
-    }
-
-    static Normal_map get_normal_map(const PointRange&, const NamedParameters& np)
-    {
-      return parameters::choose_parameter<Normal_map>(parameters::get_parameter(np, internal_np::normal_map));
-    }
-
-    static Normal_map get_normal_map(const NamedParameters& np)
-    {
-      return parameters::choose_parameter<Normal_map>(parameters::get_parameter(np, internal_np::normal_map));
-    }
-
-    static Geom_traits get_geom_traits(const PointRange&, const NamedParameters& np)
-    {
-      return parameters::choose_parameter<Geom_traits>(parameters::get_parameter(np, internal_np::geom_traits));
-    }
-
-    static constexpr bool has_normal_map()
-    {
-      return !boost::is_same< typename internal_np::Get_param<typename NamedParameters::base, internal_np::normal_t>::type,
-                              internal_np::Param_not_found> ::value;
-    }
-  };
-
-  namespace Point_set_processing_3 {
-    template <typename ValueType>
-    struct Fake_point_range
-    {
-      struct iterator
-      {
-        typedef ValueType value_type;
-        typedef std::ptrdiff_t difference_type;
-        typedef ValueType* pointer;
-        typedef ValueType reference;
-        typedef std::random_access_iterator_tag iterator_category;
-      };
-    };
-
-    template<typename PlaneRange, typename NamedParameters>
-    class GetPlaneMap
-    {
-      typedef typename PlaneRange::iterator::value_type Plane;
-      typedef typename CGAL::Identity_property_map<Plane> DefaultPMap;
-      typedef typename CGAL::Identity_property_map<const Plane> DefaultConstPMap;
-
-    public:
-      typedef typename internal_np::Lookup_named_param_def<
-      internal_np::plane_t,
-      NamedParameters,
-      DefaultPMap
-      > ::type  type;
-
-      typedef typename internal_np::Lookup_named_param_def<
-      internal_np::plane_t,
-      NamedParameters,
-      DefaultConstPMap
-      > ::type  const_type;
-    };
-
-    template<typename NamedParameters>
-    class GetPlaneIndexMap
-    {
-      typedef Constant_property_map<std::size_t, int> DummyPlaneIndexMap;
-    public:
-      typedef typename internal_np::Lookup_named_param_def <
-        internal_np::plane_index_t,
-        NamedParameters,
-        DummyPlaneIndexMap//default
-        > ::type  type;
-    };
-
-    template<typename PointRange, typename NamedParameters>
-    class GetIsConstrainedMap
-    {
-      typedef Static_boolean_property_map<
-        typename std::iterator_traits<typename PointRange::iterator>::value_type,
-        false>   Default_map;
-    public:
-      typedef typename internal_np::Lookup_named_param_def <
-        internal_np::point_is_constrained_t,
-        NamedParameters,
-        Default_map //default
-        > ::type  type;
-    };
-
-    template<typename PointRange, typename NamedParameters>
-    class GetAdjacencies
-    {
-    public:
-      typedef Emptyset_iterator Empty;
-      typedef typename internal_np::Lookup_named_param_def <
-        internal_np::adjacencies_t,
-        NamedParameters,
-        Empty//default
-        > ::type  type;
-    };
-
-  } // namespace Point_set_processing_3
-
-  template<typename NamedParameters, typename DefaultSolver>
-  class GetSolver
-  {
-  public:
-    typedef typename internal_np::Lookup_named_param_def <
-    internal_np::sparse_linear_solver_t,
-    NamedParameters,
-    DefaultSolver
-    > ::type type;
-  };
-
-  template<typename NamedParameters, typename FT, unsigned int dim = 3>
-  class GetDiagonalizeTraits
-  {
-  public:
-    typedef typename internal_np::Lookup_named_param_def <
-    internal_np::diagonalize_traits_t,
-    NamedParameters,
-    Default_diagonalize_traits<FT, dim>
-    > ::type type;
-  };
-
-  template<typename NamedParameters>
-  class GetSvdTraits
-  {
-    struct DummySvdTraits
-    {
-      typedef double FT;
-      typedef int Vector;
-      typedef int Matrix;
-      static FT solve (const Matrix&, Vector&) { return 0.; }
-    };
-
-  public:
-    typedef DummySvdTraits NoTraits;
-
-    typedef typename internal_np::Lookup_named_param_def <
-    internal_np::svd_traits_t,
-    NamedParameters,
+  typedef typename internal_np::Lookup_named_param_def<internal_np::svd_traits_t,
+                                                       NamedParameters,
 #if defined(CGAL_EIGEN3_ENABLED)
-    Eigen_svd
+                                                       Eigen_svd
 #elif defined(CGAL_LAPACK_ENABLED)
-    Lapack_svd
+                                                       Lapack_svd
 #else
-    NoTraits
+                                                       NoTraits
 #endif
-    > ::type type;
-  };
+                                                       >::type type;
+};
 
-  template<typename NamedParameters>
-  class GetImplementationTag
+template<typename NamedParameters>
+class GetImplementationTag
+{
+public:
+  typedef typename internal_np::Lookup_named_param_def<internal_np::implementation_tag_t,
+                                                       NamedParameters,
+                                                       Alpha_expansion_boost_adjacency_list_tag>::type type;
+};
+
+template<typename NP>
+void set_stream_precision_from_NP(std::ostream& os, const NP& np)
+{
+  using parameters::get_parameter;
+  using parameters::choose_parameter;
+  using parameters::is_default_parameter;
+
+  if(!is_default_parameter<NP, internal_np::stream_precision_t>())
   {
-  public:
-    typedef typename internal_np::Lookup_named_param_def <
-    internal_np::implementation_tag_t,
-    NamedParameters,
-    Alpha_expansion_boost_adjacency_list_tag
-    >::type type;
-  };
-
-  template<typename NP>
-  void set_stream_precision_from_NP(std::ostream& os, const NP& np)
-  {
-    using parameters::get_parameter;
-    using parameters::choose_parameter;
-    using parameters::is_default_parameter;
-
-    if(!is_default_parameter<NP, internal_np::stream_precision_t>())
-    {
-      const int precision = choose_parameter<int>(get_parameter(np,
-                              internal_np::stream_precision));
-      os.precision(precision);
-    }
+    const int precision = choose_parameter<int>(get_parameter(np,
+                            internal_np::stream_precision));
+    os.precision(precision);
   }
-} //namespace CGAL
+}
 
+} // namespace CGAL
 
 #endif // CGAL_BOOST_GRAPH_NAMED_PARAMETERS_HELPERS_H

--- a/BGL/include/CGAL/boost/graph/named_params_helper.h
+++ b/BGL/include/CGAL/boost/graph/named_params_helper.h
@@ -27,21 +27,6 @@
 #include <type_traits>
 
 namespace CGAL {
-namespace parameters {
-
-template <class Parameter, class NamedParameters>
-struct Is_default
-{
-  typedef typename internal_np::Lookup_named_param_def<Parameter,
-                                                       NamedParameters,
-                                                       internal_np::Param_not_found>::type NP_type;
-
-  static const bool value = boost::is_same<NP_type, internal_np::Param_not_found>::value;
-
-  typedef CGAL::Boolean_tag<value> type;
-};
-
-} // namespace parameters
 
 // forward declarations to avoid dependency to Solver_interface
 template <typename FT, unsigned int dim>
@@ -485,7 +470,7 @@ void set_stream_precision_from_NP(std::ostream& os, const NP& np)
   using parameters::choose_parameter;
   using parameters::is_default_parameter;
 
-  if(!is_default_parameter<NP, internal_np::stream_precision_t>())
+  if(!is_default_parameter<NP, internal_np::stream_precision_t>::value)
   {
     const int precision = choose_parameter<int>(get_parameter(np,
                             internal_np::stream_precision));

--- a/Optimal_bounding_box/include/CGAL/Optimal_bounding_box/oriented_bounding_box.h
+++ b/Optimal_bounding_box/include/CGAL/Optimal_bounding_box/oriented_bounding_box.h
@@ -351,7 +351,7 @@ void oriented_bounding_box(const PointRange& points,
   const unsigned int seed = choose_parameter(get_parameter(np, internal_np::random_seed), -1); // undocumented
 
   CGAL::Random fixed_seed_rng(seed);
-  CGAL::Random& rng = is_default_parameter<NamedParameters,internal_np::random_seed_t>() ?
+  CGAL::Random& rng = is_default_parameter<NamedParameters, internal_np::random_seed_t>::value ?
                         CGAL::get_default_random() : fixed_seed_rng;
 
 #ifdef CGAL_OPTIMAL_BOUNDING_BOX_DEBUG

--- a/Point_set_processing_3/include/CGAL/IO/write_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_off_points.h
@@ -39,8 +39,6 @@ bool write_OFF_PSP(std::ostream& os,
                    const PointRange& points,
                    const CGAL_NP_CLASS& np = CGAL::parameters::default_values())
 {
-  using CGAL::parameters::choose_parameter;
-  using CGAL::parameters::get_parameter;
   using CGAL::parameters::is_default_parameter;
 
   // basic geometric types
@@ -48,7 +46,7 @@ bool write_OFF_PSP(std::ostream& os,
   typedef typename NP_helper::Const_point_map PointMap;
   typedef typename NP_helper::Normal_map NormalMap;
 
-  const bool has_normals = !(is_default_parameter<CGAL_NP_CLASS, internal_np::normal_t>());
+  const bool has_normals = !(is_default_parameter<CGAL_NP_CLASS, internal_np::normal_t>::value);
 
   PointMap point_map = NP_helper::get_const_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/mst_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/mst_orient_normals.h
@@ -665,7 +665,7 @@ mst_orient_normals(
     //   or vertex j is in the k-neighborhood of vertex i.
     Riemannian_graph riemannian_graph;
 
-    if (is_default_parameter<NamedParameters, internal_np::point_is_constrained_t>())
+    if (is_default_parameter<NamedParameters, internal_np::point_is_constrained_t>::value)
       riemannian_graph = create_riemannian_graph(points,
                                                  point_map, normal_map, index_map,
                                                  Default_constrained_map<typename PointRange::iterator>

--- a/Point_set_processing_3/include/CGAL/structure_point_set.h
+++ b/Point_set_processing_3/include/CGAL/structure_point_set.h
@@ -235,7 +235,7 @@ public:
     typedef typename Point_set_processing_3::GetPlaneIndexMap<NamedParameters>::type PlaneIndexMap;
 
     CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
-    CGAL_static_assertion_msg((!is_default_parameter<NamedParameters, internal_np::plane_index_t>()),
+    CGAL_static_assertion_msg((!is_default_parameter<NamedParameters, internal_np::plane_index_t>::value),
                               "Error: no plane index map");
 
     PointMap point_map = NP_helper::get_const_point_map(points, np);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -685,7 +685,7 @@ compute_vertex_normal(typename boost::graph_traits<PolygonMesh>::vertex_descript
   Face_vector_map default_fvmap;
   Face_normal_map face_normals = choose_parameter(get_parameter(np, internal_np::face_normal),
                                                   Default_map(default_fvmap));
-  const bool must_compute_face_normals = is_default_parameter<NamedParameters, internal_np::face_normal_t>();
+  const bool must_compute_face_normals = is_default_parameter<NamedParameters, internal_np::face_normal_t>::value;
 
 #ifdef CGAL_PMP_COMPUTE_NORMAL_DEBUG_PP
   std::cout << "<----- compute vertex normal at " << get(vpmap, v)
@@ -802,7 +802,7 @@ void compute_vertex_normals(const PolygonMesh& pmesh,
                                                        Face_normal_dmap>::type   Face_normal_map;
   Face_normal_map face_normals = choose_parameter(get_parameter(np, internal_np::face_normal),
                                                   get(Face_normal_tag(), pmesh));
-  const bool must_compute_face_normals = is_default_parameter<NamedParameters, internal_np::face_normal_t>();
+  const bool must_compute_face_normals = is_default_parameter<NamedParameters, internal_np::face_normal_t>::value;
 
   if(must_compute_face_normals)
     compute_face_normals(pmesh, face_normals, np);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
@@ -731,7 +731,7 @@ void keep_or_remove_connected_components(PolygonMesh& pmesh
   for(vertex_descriptor v: vertices(pmesh))
     if (!keep_vertex[v])
       vertices_to_remove.push_back(v);
-  if ( is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_is_constrained_t>() )
+  if ( is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_is_constrained_t>::value )
     for (vertex_descriptor v : vertices_to_remove)
       remove_vertex(v, pmesh);
   else
@@ -1014,7 +1014,7 @@ void split_connected_components_impl(FIMap fim,
                                 get(CGAL::dynamic_face_property_t<faces_size_type>(), tm));
 
   faces_size_type nb_patches = 0;
-  if(is_default_parameter<NamedParameters, internal_np::face_patch_t>())
+  if(is_default_parameter<NamedParameters, internal_np::face_patch_t>::value)
   {
     nb_patches = CGAL::Polygon_mesh_processing::connected_components(
           tm, pidmap, CGAL::parameters::face_index_map(fim)

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
@@ -737,8 +737,8 @@ corefine(      TriangleMesh& tm1,
   User_visitor uv(choose_parameter<User_visitor>(get_parameter(np1, internal_np::visitor)));
 
   static const bool handle_non_manifold_features =
-    !parameters::is_default_parameter<internal_np::non_manifold_feature_map_t, NamedParameters1>::value ||
-    !parameters::is_default_parameter<internal_np::non_manifold_feature_map_t, NamedParameters2>::value;
+    !parameters::is_default_parameter<NamedParameters1, internal_np::non_manifold_feature_map_t>::value ||
+    !parameters::is_default_parameter<NamedParameters2, internal_np::non_manifold_feature_map_t>::value;
 
 // surface intersection algorithm call
   typedef Corefinement::No_extra_output_from_corefinement<TriangleMesh> Ob;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/corefinement.h
@@ -737,8 +737,8 @@ corefine(      TriangleMesh& tm1,
   User_visitor uv(choose_parameter<User_visitor>(get_parameter(np1, internal_np::visitor)));
 
   static const bool handle_non_manifold_features =
-    !parameters::Is_default<internal_np::non_manifold_feature_map_t, NamedParameters1>::value ||
-    !parameters::Is_default<internal_np::non_manifold_feature_map_t, NamedParameters2>::value;
+    !parameters::is_default_parameter<internal_np::non_manifold_feature_map_t, NamedParameters1>::value ||
+    !parameters::is_default_parameter<internal_np::non_manifold_feature_map_t, NamedParameters2>::value;
 
 // surface intersection algorithm call
   typedef Corefinement::No_extra_output_from_corefinement<TriangleMesh> Ob;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -230,7 +230,7 @@ struct Triangle_structure_sampler_base
 
     if(use_gs || use_ms)
     {
-      if(is_default_parameter<NamedParameters, internal_np::random_uniform_sampling_t>())
+      if(is_default_parameter<NamedParameters, internal_np::random_uniform_sampling_t>::value)
         use_rs = false;
     }
 
@@ -463,7 +463,7 @@ struct Triangle_structure_sampler_for_triangle_mesh
     pmap = choose_parameter(get_parameter(np, internal_np::vertex_point),
                             get_const_property_map(vertex_point, tm));
 
-    if(!(is_default_parameter<NamedParameters, internal_np::random_seed_t>()))
+    if(!(is_default_parameter<NamedParameters, internal_np::random_seed_t>::value))
       rnd = CGAL::Random(choose_parameter(get_parameter(np, internal_np::random_seed),0));
 
     min_sq_edge_length = (std::numeric_limits<double>::max)();
@@ -644,7 +644,7 @@ struct Triangle_structure_sampler_for_triangle_soup
     using parameters::is_default_parameter;
 
     min_sq_edge_length = (std::numeric_limits<double>::max)();
-    if(!(is_default_parameter<NamedParameters, internal_np::random_seed_t>()))
+    if(!(is_default_parameter<NamedParameters, internal_np::random_seed_t>::value))
       rnd = CGAL::Random(choose_parameter(get_parameter(np, internal_np::random_seed),0));
   }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -218,7 +218,7 @@ void isotropic_remeshing(const FaceRange& faces
 #endif
 
   static const bool need_aabb_tree =
-    parameters::is_default_parameter<NamedParameters, internal_np::projection_functor_t>();
+    parameters::is_default_parameter<NamedParameters, internal_np::projection_functor_t>::value;
 
   typedef typename GetGeomTraits<PM, NamedParameters>::type GT;
   GT gt = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
@@ -255,7 +255,7 @@ void isotropic_remeshing(const FaceRange& faces
   FPMap fpmap = choose_parameter(
     get_parameter(np, internal_np::face_patch),
     internal::Connected_components_pmap<PM, FIMap>(faces, pmesh, ecmap, fimap,
-      parameters::is_default_parameter<NamedParameters, internal_np::face_patch_t>() && (need_aabb_tree
+      parameters::is_default_parameter<NamedParameters, internal_np::face_patch_t>::value && (need_aabb_tree
 #if !defined(CGAL_NO_PRECONDITIONS)
       || protect // face patch map is used to identify patch border edges to check protected edges are short enough
 #endif

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -177,8 +177,8 @@ std::size_t remove_connected_components_of_negligible_size(TriangleMesh& tmesh,
   FT volume_threshold = choose_parameter(get_parameter(np, internal_np::volume_threshold), FT(-1));
 
   // If no threshold is provided, compute it as a % of the bbox
-  const bool is_default_area_threshold = is_default_parameter<NamedParameters, internal_np::area_threshold_t>();
-  const bool is_default_volume_threshold = is_default_parameter<NamedParameters, internal_np::volume_threshold_t>();
+  const bool is_default_area_threshold = is_default_parameter<NamedParameters, internal_np::area_threshold_t>::value;
+  const bool is_default_volume_threshold = is_default_parameter<NamedParameters, internal_np::volume_threshold_t>::value;
 
   const bool dry_run = choose_parameter(get_parameter(np, internal_np::dry_run), false);
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -249,7 +249,7 @@ self_intersections_impl(const FaceRange& face_range,
   VPM vpmap = choose_parameter(get_parameter(np, internal_np::vertex_point),
                                get_const_property_map(boost::vertex_point, tmesh));
 
-  const bool do_limit = !(is_default_parameter<NamedParameters, internal_np::maximum_number_t>());
+  const bool do_limit = !(is_default_parameter<NamedParameters, internal_np::maximum_number_t>::value);
   const unsigned int maximum_number = choose_parameter(get_parameter(np, internal_np::maximum_number), 0);
   if(do_limit && maximum_number == 0)
   {

--- a/Polygon_mesh_processing/include/CGAL/Polyhedral_envelope.h
+++ b/Polygon_mesh_processing/include/CGAL/Polyhedral_envelope.h
@@ -404,7 +404,7 @@ public:
       else
         deg_faces.insert(f);
     }
-    if (is_default_parameter<NamedParameters, internal_np::face_epsilon_map_t>())
+    if (is_default_parameter<NamedParameters, internal_np::face_epsilon_map_t>::value)
       init(epsilon);
     else
     {
@@ -513,7 +513,7 @@ public:
         deg_faces.insert(f);
     }
 
-    if (is_default_parameter<NamedParameters, internal_np::face_epsilon_map_t>())
+    if (is_default_parameter<NamedParameters, internal_np::face_epsilon_map_t>::value)
       init(epsilon);
     else
     {
@@ -597,8 +597,10 @@ public:
       env_faces.emplace_back(face);
     }
 
-    if (is_default_parameter<NamedParameters, internal_np::face_epsilon_map_t>())
+    if (is_default_parameter<NamedParameters, internal_np::face_epsilon_map_t>::value)
+    {
       init(epsilon);
+    }
     else
     {
       std::vector<double> epsilon_values;

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_np_function.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_np_function.cpp
@@ -45,7 +45,7 @@ void my_function_with_named_parameters(PolygonMesh& mesh, const NamedParameters&
   bool do_project = choose_parameter(get_parameter(np, internal_np::do_project), false);
 
   // check is a parameter has been given by the user
-  constexpr bool do_project_is_default = is_default_parameter<NamedParameters, internal_np::do_project_t>();
+  constexpr bool do_project_is_default = is_default_parameter<NamedParameters, internal_np::do_project_t>::value;
 
   VCM vcm_np = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained), Default_VCM());
 

--- a/Polyhedron/include/CGAL/IO/Polyhedron_OFF_iostream.h
+++ b/Polyhedron/include/CGAL/IO/Polyhedron_OFF_iostream.h
@@ -66,17 +66,17 @@ bool read_OFF(std::istream& in,
 
   const bool verbose = choose_parameter(get_parameter(np, internal_np::verbose), true);
 
-  if(!(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>()) ||
-     !(is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>()) ||
-     !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_normal_map_t>()) ||
-     !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_texture_map_t>()))
+  if(!(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>::value) ||
+     !(is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>::value) ||
+     !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_normal_map_t>::value) ||
+     !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_texture_map_t>::value))
   {
     return CGAL::IO::internal::read_OFF_BGL(in, P, np);
   }
 
   CGAL::scan_OFF(in, P, verbose);
 
-  if(!parameters::is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_point_t>())
+  if(!parameters::is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_point_t>::value)
   {
     Def_VPM def_vpm = get_property_map(CGAL::vertex_point, P);
     VPM vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
@@ -132,10 +132,10 @@ bool write_OFF(std::ostream& out,
   using parameters::get_parameter;
   using parameters::is_default_parameter;
 
-  if(!(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>()) ||
-     !(is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>()) ||
-     !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_normal_map_t>()) ||
-     !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_texture_map_t>()))
+  if(!(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>::value) ||
+     !(is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>::value) ||
+     !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_normal_map_t>::value) ||
+     !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_texture_map_t>::value))
   {
     return CGAL::IO::internal::write_OFF_BGL(out, P, np);
   }

--- a/STL_Extension/include/CGAL/Named_function_parameters.h
+++ b/STL_Extension/include/CGAL/Named_function_parameters.h
@@ -16,8 +16,11 @@
 #include <CGAL/basic.h>
 #endif
 
+#include <CGAL/tags.h>
+
 #include <boost/type_traits/is_same.hpp>
 #include <boost/mpl/if.hpp>
+
 #include <type_traits>
 #include <utility>
 
@@ -356,12 +359,17 @@ const T& choose_parameter(const T& t)
   return t;
 }
 
-template <class NP, class TAG>
-constexpr bool is_default_parameter()
+template <class NamedParameters, class Parameter>
+struct is_default_parameter
 {
-  return std::is_same< typename internal_np::Get_param<typename NP::base, TAG>::type,
-                       internal_np::Param_not_found> ::value;
-}
+  typedef typename internal_np::Lookup_named_param_def<Parameter,
+                                                       NamedParameters,
+                                                       internal_np::Param_not_found>::type NP_type;
+
+  static const bool value = boost::is_same<NP_type, internal_np::Param_not_found>::value;
+
+  typedef CGAL::Boolean_tag<value> type;
+};
 
 } // end of parameters namespace
 

--- a/Scripts/developer_scripts/test_merge_of_branch
+++ b/Scripts/developer_scripts/test_merge_of_branch
@@ -201,7 +201,7 @@ for i in `echo $nps`; do
   echo "  CGAL::parameters::${i}(A()).${i}(A());" >> main.cpp
 done
 echo "}" >> main.cpp
-if ! g++ -DCGAL_NO_STATIC_ASSERTION_TESTS -I$git_dir/STL_Extension/include main.cpp; then
+if ! g++ -DCGAL_NO_STATIC_ASSERTION_TESTS -I$git_dir/STL_Extension/include -I$git_dir/Stream_support/include main.cpp; then
   echo "ERROR: At least one documented named parameter does not exist"
   cd -
   rm -r $tmp_dir

--- a/Scripts/developer_scripts/test_merge_of_branch
+++ b/Scripts/developer_scripts/test_merge_of_branch
@@ -201,7 +201,7 @@ for i in `echo $nps`; do
   echo "  CGAL::parameters::${i}(A()).${i}(A());" >> main.cpp
 done
 echo "}" >> main.cpp
-if ! g++ -DCGAL_NO_STATIC_ASSERTION_TESTS -I$git_dir/STL_Extension/include -I$git_dir/Stream_support/include main.cpp; then
+if ! g++ -DCGAL_NO_STATIC_ASSERTION_TESTS -I$git_dir/STL_Extension/include -I$git_dir/Stream_support/include -I$git_dir/Installation/include main.cpp; then
   echo "ERROR: At least one documented named parameter does not exist"
   cd -
   rm -r $tmp_dir

--- a/Shape_regularization/include/CGAL/Shape_regularization/regularize_planes.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/regularize_planes.h
@@ -293,10 +293,10 @@ namespace Planes {
     using parameters::get_parameter;
     using parameters::choose_parameter;
     using parameters::is_default_parameter;
-    using PlaneIndexMap = typename CGAL::Point_set_processing_3::
-      GetPlaneIndexMap<NamedParameters>::type;
 
-    CGAL_static_assertion_msg((!is_default_parameter<NamedParameters, internal_np::plane_index_t>()),
+    using PlaneIndexMap = typename CGAL::Point_set_processing_3::GetPlaneIndexMap<NamedParameters>::type;
+
+    CGAL_static_assertion_msg((!is_default_parameter<NamedParameters, internal_np::plane_index_t>::value),
                               "Error: no plane index map");
 
     const PlaneIndexMap index_map =

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/OFF.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/OFF.h
@@ -53,13 +53,13 @@ template<typename PolygonMesh,
 class GetVertexColorMap
 {
   typedef typename PolygonMesh::template Property_map<typename PolygonMesh::Vertex_index,
-                                                      CGAL::IO::Color>                              DefaultMap;
+                                                      CGAL::IO::Color>                          DefaultMap;
   typedef DefaultMap                                                                            DefaultMap_const;
 public:
   typedef typename internal_np::Lookup_named_param_def<internal_np::vertex_color_map_t,
-                                                       NamedParameters, DefaultMap>::type        type;
+                                                       NamedParameters, DefaultMap>::type       type;
   typedef typename internal_np::Lookup_named_param_def<internal_np::vertex_color_map_t,
-                                                       NamedParameters, DefaultMap_const>::type  const_type;
+                                                       NamedParameters, DefaultMap_const>::type const_type;
 };
 
 template<typename PolygonMesh, typename K,
@@ -67,8 +67,8 @@ template<typename PolygonMesh, typename K,
 class GetVertexTextureMap
 {
   typedef typename PolygonMesh::template Property_map<typename PolygonMesh::Vertex_index,
-                                                      typename K::Point_2>                      DefaultMap;
-  typedef DefaultMap                                                                            DefaultMap_const;
+                                                      typename K::Point_2>                     DefaultMap;
+  typedef DefaultMap                                                                           DefaultMap_const;
 
 public:
   typedef typename internal_np::Lookup_named_param_def<internal_np::vertex_texture_map_t,
@@ -82,7 +82,7 @@ template<typename PolygonMesh,
 class GetFaceColorMap
 {
   typedef typename PolygonMesh::template Property_map<typename PolygonMesh::Face_index,
-                                                      CGAL::IO::Color>                              DefaultMap;
+                                                      CGAL::IO::Color>                          DefaultMap;
   typedef DefaultMap                                                                            DefaultMap_const;
 
 public:
@@ -100,9 +100,9 @@ bool read_OFF_with_or_without_fcolors(std::istream& is,
 {
   typedef Surface_mesh<Point>                                                             Mesh;
   typedef typename Mesh::Face_index                                                       Face_index;
-  typedef CGAL::IO::Color                                                                     Color;
+  typedef CGAL::IO::Color                                                                 Color;
 
-  typedef typename GetFaceColorMap<Mesh, CGAL_NP_CLASS>::type     FCM;
+  typedef typename GetFaceColorMap<Mesh, CGAL_NP_CLASS>::type                             FCM;
 
   using parameters::choose_parameter;
   using parameters::is_default_parameter;
@@ -110,7 +110,7 @@ bool read_OFF_with_or_without_fcolors(std::istream& is,
 
   typename Mesh::template Property_map<Face_index, Color> fcm;
 
-  bool is_fcm_requested = !(is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>());
+  bool is_fcm_requested = !(is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>::value);
   if(!is_fcm_requested && scanner.has_colors())
   {
     bool created;
@@ -139,7 +139,7 @@ bool read_OFF_with_or_without_vtextures(std::istream& is,
   typedef Surface_mesh<Point>                                                                Mesh;
   typedef typename Mesh::Vertex_index                                                        Vertex_index;
 
-  typedef typename GetK<Surface_mesh<Point>, CGAL_NP_CLASS>::Kernel                      K;
+  typedef typename GetK<Surface_mesh<Point>, CGAL_NP_CLASS>::Kernel                          K;
   typedef typename K::Point_2                                                                Texture;
   typedef typename GetVertexTextureMap<Mesh, K, CGAL_NP_CLASS>::type VTM;
 
@@ -149,7 +149,7 @@ bool read_OFF_with_or_without_vtextures(std::istream& is,
 
   typename Mesh::template Property_map<Vertex_index, Texture> vtm;
 
-  bool is_vtm_requested = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_texture_map_t>());
+  bool is_vtm_requested = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_texture_map_t>::value);
   if(!is_vtm_requested && scanner.has_textures())
   {
     bool created;
@@ -187,7 +187,7 @@ bool read_OFF_with_or_without_vcolors(std::istream& is,
 
   typename Mesh::template Property_map<Vertex_index, Color> vcm;
 
-  bool is_vcm_requested = !(is_default_parameter<CGAL_NP_CLASS,  internal_np::vertex_color_map_t>());
+  bool is_vcm_requested = !(is_default_parameter<CGAL_NP_CLASS,  internal_np::vertex_color_map_t>::value);
   if(!is_vcm_requested && scanner.has_colors())
   {
     bool created;
@@ -226,7 +226,7 @@ bool read_OFF_with_or_without_vnormals(std::istream& is,
 
   typename Mesh::template Property_map<Vertex_index, Normal> vnm;
 
-  bool is_vnm_requested = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_normal_map_t>());
+  bool is_vnm_requested = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_normal_map_t>::value);
   if(!is_vnm_requested && scanner.has_normals())
   {
     bool created;
@@ -324,10 +324,6 @@ bool read_OFF(std::istream& is,
               Surface_mesh<Point>& sm,
               const CGAL_NP_CLASS& np = parameters::default_values())
 {
-  using parameters::choose_parameter;
-  using parameters::get_parameter;
-  using parameters::is_default_parameter;
-
   std::streampos pos = is.tellg();
   CGAL::File_scanner_OFF scanner(is, false);
   is.seekg(pos);
@@ -388,13 +384,11 @@ bool write_OFF_with_or_without_fcolors(std::ostream& os,
 {
   typedef Surface_mesh<Point>                                            Mesh;
   typedef typename Mesh::Face_index                                      Face_index;
-  typedef CGAL::IO::Color                                                    Color;
+  typedef CGAL::IO::Color                                                Color;
 
-  using parameters::choose_parameter;
   using parameters::is_default_parameter;
-  using parameters::get_parameter;
 
-  const bool has_fcolors = !(is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>());
+  const bool has_fcolors = !(is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>::value);
 
   typename Mesh::template Property_map<Face_index, Color> fcolors;
   bool has_internal_fcolors;
@@ -414,14 +408,12 @@ bool write_OFF_with_or_without_vtextures(std::ostream& os,
   typedef Surface_mesh<Point>                                            Mesh;
   typedef typename Mesh::Vertex_index                                    Vertex_index;
 
-  typedef typename GetK<Surface_mesh<Point>, CGAL_NP_CLASS>::Kernel  K;
+  typedef typename GetK<Surface_mesh<Point>, CGAL_NP_CLASS>::Kernel      K;
   typedef typename K::Point_2                                            Texture;
 
-  using parameters::choose_parameter;
   using parameters::is_default_parameter;
-  using parameters::get_parameter;
 
-  const bool has_vtextures = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_texture_map_t>());
+  const bool has_vtextures = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_texture_map_t>::value);
 
   typename Mesh::template Property_map<Vertex_index, Texture> vtextures;
   bool has_internal_vtextures;
@@ -440,13 +432,11 @@ bool write_OFF_with_or_without_vcolors(std::ostream& os,
 {
   typedef Surface_mesh<Point>                                            Mesh;
   typedef typename Mesh::Vertex_index                                    Vertex_index;
-  typedef CGAL::IO::Color                                                    Color;
+  typedef CGAL::IO::Color                                                Color;
 
-  using parameters::choose_parameter;
   using parameters::is_default_parameter;
-  using parameters::get_parameter;
 
-  const bool has_vcolors = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>());
+  const bool has_vcolors = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>::value);
 
   typename Mesh::template Property_map<Vertex_index, Color> vcolors;
   bool has_internal_vcolors;
@@ -466,14 +456,12 @@ bool write_OFF_with_or_without_vnormals(std::ostream& os,
   typedef Surface_mesh<Point>                                            Mesh;
   typedef typename Mesh::Vertex_index                                    Vertex_index;
 
-  typedef typename GetK<Surface_mesh<Point>, CGAL_NP_CLASS>::Kernel  K;
+  typedef typename GetK<Surface_mesh<Point>, CGAL_NP_CLASS>::Kernel      K;
   typedef typename K::Vector_3                                           Normal;
 
-  using parameters::choose_parameter;
   using parameters::is_default_parameter;
-  using parameters::get_parameter;
 
-  const bool has_vnormals = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_normal_map_t>());
+  const bool has_vnormals = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_normal_map_t>::value);
 
   typename Mesh::template Property_map<Vertex_index, Normal> vnormals;
   bool has_internal_vnormals;
@@ -559,11 +547,9 @@ bool write_OFF(std::ostream& os,
                const Surface_mesh<Point>& sm,
                const CGAL_NP_CLASS& np = parameters::default_values())
 {
-  using parameters::choose_parameter;
   using parameters::is_default_parameter;
-  using parameters::get_parameter;
 
-  const bool has_vpoints = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_point_t>());
+  const bool has_vpoints = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_point_t>::value);
   if(has_vpoints)
     return internal::write_OFF_with_or_without_vnormals(os, sm, np);
 

--- a/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/approximate_triangle_mesh.h
+++ b/Surface_mesh_approximation/include/CGAL/Surface_mesh_approximation/approximate_triangle_mesh.h
@@ -247,21 +247,21 @@ bool approximate_triangle_mesh(const TriangleMesh &tm, const NamedParameters &np
   // get proxy map
   approx.proxy_map( get_parameter(np, internal_np::face_proxy_map) );
 
-  if (!parameters::is_default_parameter<NamedParameters, internal_np::face_proxy_map_t>()
-    && (vl == MAIN_STEPS || vl == VERBOSE))
+  if (!parameters::is_default_parameter<NamedParameters, internal_np::face_proxy_map_t>::value &&
+      (vl == MAIN_STEPS || vl == VERBOSE))
     std::cout << "Filling face proxy map done." << std::endl;
 
   // get proxies
   approx.proxies( get_parameter(np, internal_np::proxies) );
 
-  if (!is_default_parameter<NamedParameters,internal_np::proxies_t>()
-    && (vl == MAIN_STEPS || vl == VERBOSE))
+  if (!is_default_parameter<NamedParameters, internal_np::proxies_t>::value &&
+      (vl == MAIN_STEPS || vl == VERBOSE))
     std::cout << "Get proxies done." << std::endl;
 
   // meshing
   bool is_manifold = false;
-  if (!is_default_parameter<NamedParameters, internal_np::anchors_t>()
-    || !is_default_parameter<NamedParameters,internal_np::triangles_t>())
+  if (!is_default_parameter<NamedParameters, internal_np::anchors_t>::value ||
+      !is_default_parameter<NamedParameters, internal_np::triangles_t>::value)
   {
     if (vl == VERBOSE) {
       const FT subdivision_ratio = choose_parameter(get_parameter(np, internal_np::subdivision_ratio), FT(5.0));
@@ -287,15 +287,15 @@ bool approximate_triangle_mesh(const TriangleMesh &tm, const NamedParameters &np
   // get anchor points
   approx.anchor_points( get_parameter(np, internal_np::anchors) );
 
-  if (!is_default_parameter<NamedParameters,internal_np::anchors_t>()
-    && (vl == MAIN_STEPS || vl == VERBOSE))
+  if (!is_default_parameter<NamedParameters,internal_np::anchors_t>::value &&
+      (vl == MAIN_STEPS || vl == VERBOSE))
     std::cout << "Get anchors done." << std::endl;
 
   // get indexed triangles
   approx.indexed_triangles( get_parameter(np, internal_np::triangles) );
 
-  if (!is_default_parameter<NamedParameters,internal_np::triangles_t>()
-    && (vl == MAIN_STEPS || vl == VERBOSE))
+  if (!is_default_parameter<NamedParameters,internal_np::triangles_t>::value &&
+      (vl == MAIN_STEPS || vl == VERBOSE))
     std::cout << "Get indexed triangles done." << std::endl;
 
   return is_manifold;


### PR DESCRIPTION
## Summary of Changes

In `named_param_helpers.h` there was `Is_default<NP, P>` (defining `value` + `type`), and in `Named_function_parameters.h` there was `is_default_parameter` but with usage `if(is_default_parameter<NP, P>())`, which isn't really the style of e.g. `std::is_same<T1, T2>`.

This PR merges both into `is_default_parameter<NP, NP`, with usage `if(is_default_parameter<NP, P>::value)`.

Re-indent `named_param_helpers.h` while there (diff without whitespace: https://github.com/CGAL/cgal/pull/6499/files?w=1).

## Release Management

5.5 would be best since `is_default_parameter` was introduced in 5.5.

* Affected package(s): BGL, STL_Extension + usages
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change
