### PR TITLE
prevent remove_self_intersections from emitting a warning 

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/angle_and_area_smoothing.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/angle_and_area_smoothing.h
@@ -189,13 +189,19 @@ void angle_and_area_smoothing(const FaceRange& faces,
   bool use_area_smoothing = choose_parameter(get_parameter(np, internal_np::use_area_smoothing), true);
 
 #ifndef CGAL_PMP_USE_CERES_SOLVER
-  std::cerr << "Area-based smoothing requires the Ceres Library, which is not available." << std::endl;
-  std::cerr << "No such smoothing will be performed!" << std::endl;
-  use_area_smoothing = false;
+  if (use_area_smoothing)
+  {
+    std::cerr << "Area-based smoothing requires the Ceres Library, which is not available." << std::endl;
+    std::cerr << "No such smoothing will be performed!" << std::endl;
+    use_area_smoothing = false;
+  }
 #endif
 
   if(!use_angle_smoothing && !use_area_smoothing)
+  {
     std::cerr << "Called PMP::angle_and_area_smoothing() without any smoothing method selected or available" << std::endl;
+    return;
+  }
 
   unsigned int nb_iterations = choose_parameter(get_parameter(np, internal_np::number_of_iterations), 1);
   const bool do_project = choose_parameter(get_parameter(np, internal_np::do_project), true);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_self_intersections.h
@@ -550,7 +550,11 @@ bool remove_self_intersections_with_smoothing(std::set<typename boost::graph_tra
                                                     local_mesh,
                                                     CP::edge_is_constrained_map(eif)
                                                     .number_of_iterations(100)
-                                                    .use_safety_constraints(false));
+                                                    .use_safety_constraints(false)
+#ifndef CGAL_PMP_USE_CERES_SOLVER
+                                                    .use_area_smoothing(false)
+#endif
+                                                    );
 
 #ifdef CGAL_PMP_REMOVE_SELF_INTERSECTION_OUTPUT
   CGAL::IO::write_polygon_mesh("results/post_smoothing_local_mesh.off", local_mesh, CGAL::parameters::stream_precision(17));


### PR DESCRIPTION
(5.5 only as the refactor is introduced in 5.5)