### PR TITLE
Incorrect reference to demo zip file

### DIFF
--- a/Shape_regularization/doc/Shape_regularization/PackageDescription.txt
+++ b/Shape_regularization/doc/Shape_regularization/PackageDescription.txt
@@ -47,7 +47,7 @@ to the user-specified conditions.}
 \cgalPkgDependsOn{\ref PkgSolverInterface}
 \cgalPkgBib{cgal:asgbl-sr}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo, polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 
 \cgalPkgDescriptionEnd

--- a/Weights/doc/Weights/PackageDescription.txt
+++ b/Weights/doc/Weights/PackageDescription.txt
@@ -525,7 +525,7 @@ weights, and weighting regions. All weights are available both in 2D and 3D.}
 \cgalPkgSince{5.4}
 \cgalPkgBib{cgal:a-wi}
 \cgalPkgLicense{\ref licensesLGPL "LGPL"}
-\cgalPkgDemo{Polyhedron demo, polyhedron_3.zip}
+\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
 \cgalPkgShortInfoEnd
 
 \cgalPkgDescriptionEnd


### PR DESCRIPTION
Due to the fact that an `ALIASES` is used the space will also be part of the file name and thus the link will, incorrectly be `https://www.cgal.org/demo/5.5/%20polyhedron_3.zip` instead of `https://www.cgal.org/demo/5.5/polyhedron_3.zip`
