### PR TITLE
Fix run_testsuite_with_ctest on Cygwin

### DIFF
--- a/Scripts/developer_scripts/run_testsuite_with_ctest
+++ b/Scripts/developer_scripts/run_testsuite_with_ctest
@@ -331,7 +331,11 @@ run_test_on_platform()
   if [ -n "${SCRIPTS_DIR}" ]; then
     touch ../../../../../.scm-branch
   fi
-  python3 ${CGAL_DIR}/${TESTSUITE_DIR}test/parse-ctest-dashboard-xml.py $CGAL_TESTER $PLATFORM
+  # The strange way to run the script is to avoid the error message:
+  # python3: can't open file '/cygdrive/c/CGAL_ROOT/CGAL-5.5-Ic-68/C:/CGAL_ROOT/CGAL-5.5-Ic-68/test/parse-ctest-dashboard-xml.py': [Errno 2] No such file or directory
+  # It seems Python 3.9 from Cygwin cannot understand the Windows paths,
+  # but its `open` function can.
+  python3 -c "exec(open(\"${CGAL_DIR}/${TESTSUITE_DIR}test/parse-ctest-dashboard-xml.py\").read())" $CGAL_TESTER $PLATFORM
 
   for file in $(ls|grep _Tests); do
     mv $file "$(echo "$file" | sed 's/_Tests//g')"
@@ -343,7 +347,7 @@ run_test_on_platform()
   cat "${CGAL_BINARY_DIR}/package_installation.log" >> "Installation/${TEST_REPORT}"
 
   #call the python script to complete the results report.
-  python3 ${CGAL_DIR}/${TESTSUITE_DIR}test/post_process_ctest_results.py Installation/${TEST_REPORT} ${TEST_REPORT} results_${CGAL_TESTER}_${PLATFORM}.txt
+  python3 -c "exec(open(\"${CGAL_DIR}/${TESTSUITE_DIR}test/post_process_ctest_results.py\").read())" Installation/${TEST_REPORT} ${TEST_REPORT} results_${CGAL_TESTER}_${PLATFORM}.txt
   rm -f $OUTPUT_FILE $OUTPUT_FILE.gz
   if [ -n "${SCRIPTS_DIR}" ]; then
     rm ../../../../../.scm-branch


### PR DESCRIPTION
## Summary of Changes

Since I have upgrade Cygwin on `christo`, the testsuite cannot process the results of CTest, with that error message:
```
python3: can't open file '/cygdrive/c/CGAL_ROOT/CGAL-5.5-Ic-68/C:/CGAL_ROOT/CGAL-5.5-Ic-68/test/parse-ctest-dashboard-xml.py': [Errno 2] No such file or directory
```

The version of `/usr/bin/python3` in Cygwin is now:
```
Python 3.9.10 (main, Jan 20 2022, 21:37:52)  
[GCC 11.2.0] 
````

It seems the `os.path` module of that version of Python, under Cygwin, can no longer understand Windows paths, and treat them as relative paths. But the `open` function of Python can still open Windows paths. This PR uses a trick: with `open` and `exec` we have an equivalent of the C++ `#include`.

## Release Management

* Affected package(s): Scripts

