### PR TITLE
Fixed degenerated case of plane fitting to a linear set of points.

### DIFF
--- a/Principal_component_analysis/include/CGAL/PCA_util.h
+++ b/Principal_component_analysis/include/CGAL/PCA_util.h
@@ -723,7 +723,11 @@ fitting_plane_3(typename DiagonalizeTraits::Covariance_matrix& covariance, // co
                   eigen_vectors[1],
                   eigen_vectors[2]);
     plane = Plane(c,normal);
-    return FT(1) - eigen_values[0] / eigen_values[1];
+
+    if (eigen_values[1] == 0)
+        return FT(0); // line case
+    else
+        return FT(1) - eigen_values[0] / eigen_values[1]; // regular case
   } // end regular case
 }
 


### PR DESCRIPTION
## Summary of Changes

Added a check for degenerated input data in fitting_plane_3 used by linear_least_squares_fitting_3 to avoid NaN as a return value.

## Release Management

* Affected package(s): Principal Component Analysis
* Issue(s) solved (if any): fix #6146

