### PR TITLE
Mesh_3: Suppress a clang warning

### DIFF
--- a/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
@@ -372,6 +372,13 @@ public:
 #  pragma warning(push)
 #  pragma warning(disable: 4003)
 #endif
+
+  // see <CGAL/config.h>
+CGAL_PRAGMA_DIAG_PUSH
+// see <CGAL/boost/parameter.h>
+CGAL_IGNORE_BOOST_PARAMETER_NAME_WARNINGS
+
+
   BOOST_PARAMETER_MEMBER_FUNCTION(
                                   (Labeled_mesh_domain_3),
                                   static create_gray_image_mesh_domain,
@@ -493,6 +500,8 @@ public:
        p::construct_surface_patch_index =
          create_construct_surface_patch_index(construct_surface_patch_index_));
   }
+
+CGAL_PRAGMA_DIAG_POP
 
 #if defined(BOOST_MSVC)
 #  pragma warning(pop)


### PR DESCRIPTION
## Summary of Changes

Address this [warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.5-I-69/Mesh_3/TestReport_cgaltester_x86-64_Darwin-18.5_Apple-clang-default_Release.gz).  Just comparing the code with other header files in Mesh_3 I think we just forgot one place where the warning must be suppressed.  

## Release Management

* Affected package(s): Mesh_3
