### PR TITLE
issue #6440 Periodic_2_triangulation_2: Strange documentation.

### DIFF
--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_2.h
@@ -209,7 +209,8 @@ public:
   \name Handles, Iterators and Circulators
 
   The vertices and faces of the triangulations are accessed through
-  `handles`, `iterators` and `circulators`. The handles are \cgalModels of
+  `handles`, `iterators` and `circulators`. The handles are %CGAL
+  \ref models "models" of
   the concept `Handle` which basically offers the two dereference
   operators and `->`. The iterators and circulators are all
   bidirectional and non-mutable. The circulators and iterators are


### PR DESCRIPTION
Corrected documentation in respect to the miss-use of `\cgalModels`
