### PR TITLE
issue #6515 Solver_interface: Non reachable link to https://osqp.org/docs/interfaces/cc++

### DIFF
--- a/Solver_interface/include/CGAL/OSQP_quadratic_program_traits.h
+++ b/Solver_interface/include/CGAL/OSQP_quadratic_program_traits.h
@@ -46,7 +46,7 @@ namespace CGAL {
   \note The `FT` type is provided for convenience. Internally, this FT type is converted
   to `c_float` type that can be set either to `float` or `double`. By default, the `double`
   type is used. After the optimization is complete, the `c_float` type is converted back to `FT`.
-  See more about `c_float` <a href="https://osqp.org/docs/interfaces/cc++#data-types">here</a>.
+  See more about `c_float` <a href="https://osqp.org/docs/interfaces/C.html#data-types">here</a>.
 
   \cgalModels `QuadraticProgramTraits`
 */


### PR DESCRIPTION
Corrected non existing link.
