### PR TITLE
CGAL::Mesh_3::polylines_to_protect with angle bound - bug fix

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
+++ b/Mesh_3/include/CGAL/Mesh_3/polylines_to_protect.h
@@ -304,14 +304,14 @@ struct Polyline_visitor
 template <typename Kernel>
 struct Angle_tester
 {
-  const double m_angle_sq_cosine;// squared cosine of `std:min(90, angle_deg)`
+  const double m_angle_sq_cosine;// squared cosine of `std:max(90, angle_deg)`
 
   Angle_tester()
     : m_angle_sq_cosine(0)
   {}
 
   Angle_tester(const double angle_deg)//angle given in degrees for readability
-    : m_angle_sq_cosine(CGAL::square(std::cos((std::min)(90.,angle_deg) * CGAL_PI / 180.)))
+    : m_angle_sq_cosine(CGAL::square(std::cos((std::max)(90.,angle_deg) * CGAL_PI / 180.)))
   {}
 
   template <typename vertex_descriptor, typename Graph>


### PR DESCRIPTION
## Summary of Changes

`min(90, angle_bound)` should be `max(90, angle_bound)`.
90 is a conservative lower bound. This means that each vertex corresponding to an angle smaller than 90 should be set as terminal by `CGAL::Mesh_3::polylines_to_protect()`, even if `angle_bound < 90`.
If `angle_bound > 90`, we keep `angle_bound` and collect/set more terminal vertices.

This PR fixes PR #6402

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

