### PR TITLE
P2T2: Seed default random to reproduce error in the testsuite

### DIFF
--- a/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/p2t2_hierarchy.cpp
+++ b/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/p2t2_hierarchy.cpp
@@ -28,6 +28,7 @@ typedef CGAL::Creator_uniform_2<double, Point>                      Creator;
 
 int main( )
 {
+  CGAL::get_default_random() = CGAL::Random(1650953440);
   std::cout << "insertion of 1000 random points" << std::endl;
   Triangulation t(Iso_rectangle(-1,-1, 1,1));
   CGAL::Random_points_in_square_2<Point, Creator> g(1.);


### PR DESCRIPTION
## Summary of Changes

Setting the seed as it was in [this testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.5-Ic-70/Periodic_2_triangulation_2_Examples/TestReport_lrineau_Ubuntu-latest-GCC6.gz)   I can reproduce the assertion.

This is not a fix.

## Release Management

* Affected package(s): Periodic_2_triangulation_2

