### PR TITLE
Fix crash during binary I/O of Triangulation_3

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
@@ -50,7 +50,7 @@ set_package_properties(
   DESCRIPTION "A library for image processing."
   PURPOSE "Can be used for I/O (DICOM, VTU, VTP.")
 
-polyhedron_demo_plugin(triangulation_3_io_plugin triangulation_3_io_plugin KEYWORDS IO)
+polyhedron_demo_plugin(triangulation_3_io_plugin triangulation_3_io_plugin KEYWORDS Viewer)
 target_link_libraries(triangulation_3_io_plugin PUBLIC scene_triangulation_3_item)
 
 if(VTK_FOUND)

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -2388,9 +2388,13 @@ std::istream& operator>> (std::istream& is, Triangulation_3<GT, Tds, Lds>& tr)
   if(!is)
     return is;
 
+  std::vector< Vertex_handle > V;
+  if(d > 3 || d < -2 || (n+1) > V.max_size()) {
+    is.setstate(std::ios_base::failbit);
+    return is;
+  }
   tr._tds.set_dimension(d);
-
-  std::vector< Vertex_handle > V(n+1);
+  V.resize(n+1);
   V[0] = tr.infinite_vertex(); // the infinite vertex is numbered 0
 
   for(std::size_t i=1; i <= n; i++)


### PR DESCRIPTION
## Summary of Changes

While loading a mesh binary file with the `triangulation_io_plugin`, I got a crash. This PR turns the crash into a proper error handling.

## Release Management

* Affected package(s): Triangulation_3
* License and copyright ownership: maintenance by GF
