### PR TITLE
Barycentric coordinates: bug fix: Increment output iterator 

### DIFF
--- a/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/Discrete_harmonic_2.h
+++ b/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/Discrete_harmonic_2.h
@@ -217,6 +217,7 @@ private:
 
         CGAL_precondition( A[n-2] != FT(0) && A[n-1] != FT(0) );
         *output = (r[0]*A[n-2] - r[n-1]*B[n-1] + r[n-2]*A[n-1]) / (A[n-2] * A[n-1]);
+        ++output;
 
         // Return weights.
         return boost::optional<OutputIterator>(output);
@@ -277,6 +278,7 @@ private:
             ++output;
         }
         *output = weight[n-1] * inverted_dh_denominator;
+        ++output;
 
         // Return coordinates.
         return boost::optional<OutputIterator>(output);
@@ -333,6 +335,7 @@ private:
             ++output;
         }
         *output = weight[n-1] * inverted_dh_denominator;
+        ++output;
 
         // Return coordinates.
         return boost::optional<OutputIterator>(output);

--- a/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/Generalized_barycentric_coordinates_2.h
+++ b/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/Generalized_barycentric_coordinates_2.h
@@ -489,6 +489,7 @@ private:
             ++output;
         }
         *output = coordinate[0];
+        ++output;
 
         // Return computed coordinates.
         if(success) return boost::optional<OutputIterator>(output);

--- a/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/Mean_value_2.h
+++ b/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/Mean_value_2.h
@@ -290,6 +290,7 @@ private:
 
         CGAL_precondition( r[n-1] != FT(0) );
         *output = (t[n-2] + t[n-1]) / r[n-1];
+        ++output;
 
         // Return weights.
         return boost::optional<OutputIterator>(output);
@@ -364,6 +365,7 @@ private:
             ++output;
         }
         *output = weight[n-1] * inverted_mv_denominator;
+        ++output;
 
         // Return coordinates.
         return boost::optional<OutputIterator>(output);
@@ -432,6 +434,7 @@ private:
             ++output;
         }
         *output = weight[n-1] * inverted_mv_denominator;
+        ++output;
 
         // Return coordinates.
         return boost::optional<OutputIterator>(output);

--- a/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/Wachspress_2.h
+++ b/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/Wachspress_2.h
@@ -211,6 +211,7 @@ private:
 
         CGAL_precondition( A[n-2] != FT(0) && A[n-1] != FT(0) );
         *output = C[n-1] / (A[n-2] * A[n-1]);
+        ++output;
 
         // Return weights.
         return boost::optional<OutputIterator>(output);
@@ -261,6 +262,7 @@ private:
             ++output;
         }
         *output = weight[n-1] * inverted_wp_denominator;
+        ++output;
 
         // Return coordinates.
         return boost::optional<OutputIterator>(output);
@@ -314,6 +316,7 @@ private:
             ++output;
         }
         *output = weight[n-1] * inverted_wp_denominator;
+        ++output;
 
         // Return coordinates.
         return boost::optional<OutputIterator>(output);

--- a/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/segment_coordinates_2.h
+++ b/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/segment_coordinates_2.h
@@ -337,6 +337,7 @@ namespace Barycentric_coordinates {
       *output = b_first;
       ++output;
       *output = FT(1) - b_first;
+      ++output;
 
       // Output both coordinates.
       return boost::optional<OutputIterator>(output);

--- a/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/triangle_coordinates_2.h
+++ b/Barycentric_coordinates_2/include/CGAL/Barycentric_coordinates_2/triangle_coordinates_2.h
@@ -368,6 +368,7 @@ namespace Barycentric_coordinates {
 
       // Compute the last = third coordinate, using the partition of unity property.
       *output = FT(1) - b_first - b_second;
+      ++output;
 
       // Output all coordinates.
       return boost::optional<OutputIterator>(output);


### PR DESCRIPTION
## Summary of Changes

After the assignment to an output iterator it  must be incremented. 

## Release Management

* Affected package(s): Barycentric_coordinates

