### PR TITLE
Fix snap visitor get_parameter_reference usage

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Snapping/snap.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Snapping/snap.h
@@ -1107,7 +1107,7 @@ std::size_t snap_non_conformal(HalfedgeRange& halfedge_range_A,
   const bool is_second_mesh_fixed = choose_parameter(get_parameter(np_B, internal_np::do_lock_mesh), false);
 
   internal::Snapping_default_visitor<TriangleMesh> default_visitor;
-  Visitor& visitor = choose_parameter(get_parameter_reference(np_A, internal_np::visitor), default_visitor);
+  Visitor visitor = choose_parameter(get_parameter_reference(np_A, internal_np::visitor), default_visitor);
 
   if(visitor.stop())
     return 0;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Snapping/snap_vertices.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Snapping/snap_vertices.h
@@ -738,7 +738,7 @@ std::size_t snap_vertices_two_way(const HalfedgeRange_A& halfedge_range_A,
                                  get_property_map(vertex_point, tm_B));
 
   internal::Snapping_default_visitor<PolygonMesh> default_visitor;
-  Visitor& visitor = choose_parameter(get_parameter_reference(np_A, internal_np::visitor), default_visitor);
+  Visitor visitor = choose_parameter(get_parameter_reference(np_A, internal_np::visitor), default_visitor);
 
   visitor.start_vertex_vertex_phase();
   if(visitor.stop())


### PR DESCRIPTION
## Summary of Changes

If `Visitor` is not a reference, the previous code might have been taking a (non-const) ref to a temporary.

## Release Management

* Affected package(s): `PMP`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

