### PR TITLE
Correcting permanent redirect to Cbc

### DIFF
--- a/Polygonal_surface_reconstruction/doc/Polygonal_surface_reconstruction/Polygonal_surface_reconstruction.txt
+++ b/Polygonal_surface_reconstruction/doc/Polygonal_surface_reconstruction/Polygonal_surface_reconstruction.txt
@@ -208,7 +208,7 @@ The current implementation incorporates two open source solvers: \ref thirdparty
 (see \ref PkgSolverInterface). It should be noted that GLPK only manages to solve small problems, i.e., objects
 with reasonably simple structure.
 In case you are reconstructing more complex objects, you may need to consider more efficient open source
-solvers (e.g., <a href = "https://projects.coin-or.org/Cbc">CBC</a>) or even commercial solvers (e.g.,
+solvers (e.g., <a href = "https://github.com/coin-or/Cbc">CBC</a>) or even commercial solvers (e.g.,
 <a href = "https://www.gurobi.com/">Gurobi</a>, <a href = "https://www.ibm.com/analytics/cplex-optimizer">CPLEX</a>).
 The following table gives a rough idea of the performance of some solvers.
 

--- a/Solver_interface/include/CGAL/Mixed_integer_program_traits.h
+++ b/Solver_interface/include/CGAL/Mixed_integer_program_traits.h
@@ -273,7 +273,7 @@ namespace CGAL {
         ///       classes, i.e., `CGAL::GLPK_mixed_integer_program_traits` or
         ///                  `CGAL::SCIP_mixed_integer_program_traits`. Alternatively, use
         ///       `CGAL::Mixed_integer_program_traits` as a base to derive a new model
-        ///       (using e.g., <a href = "https://projects.coin-or.org/Cbc"> CBC </a>,
+        ///       (using e.g., <a href = "https://github.com/coin-or/Cbc"> CBC </a>,
         ///       <a href = "https://www.gurobi.com/"> Gurobi </a> for better
         ///       performance).
         ///


### PR DESCRIPTION
It looks like that the https://projects.coin-or.org/Cbc is a permanent redirect to https://github.com/coin-or/Cbc (all https://projects.coin-or.org redirect to github).
