### PR TITLE
BGL: Add adjacency_iterator for several classes

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/graph_traits_Arrangement_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/graph_traits_Arrangement_2.h
@@ -27,6 +27,7 @@
 #include <CGAL/Named_function_parameters.h>
 
 #include <boost/graph/graph_concepts.hpp>
+#include <CGAL/boost/graph/iterator.h>
 #include <CGAL/boost/iterator/counting_iterator.hpp>
 #include <CGAL/Arrangement_on_surface_2.h>
 #include <CGAL/Arrangement_2.h>
@@ -75,7 +76,8 @@ private:
     public virtual boost::bidirectional_graph_tag,   // This tag refines the
                                                      // incidence_graph_tag.
     public virtual boost::vertex_list_graph_tag,  // Can iterate over vertices.
-    public virtual boost::edge_list_graph_tag     // Can iterate over edges.
+    public virtual boost::edge_list_graph_tag,     // Can iterate over edges.
+    public virtual boost::adjacency_graph_tag
   {};
 
   /*! \class
@@ -232,7 +234,7 @@ public:
   typedef typename Arrangement_on_surface_2::Size       edges_size_type;
 
   // Types not required by any of these concepts:
-  typedef void                                          adjacency_iterator;
+  typedef  CGAL::Vertex_around_target_iterator<Arrangement_on_surface_2> adjacency_iterator;
 
   /*! Constructor. */
   graph_traits (const Arrangement_on_surface_2& arr) :
@@ -409,6 +411,20 @@ out_edges (typename
     gt_arr (arr);
 
   return std::make_pair (gt_arr.out_edges_begin (v), gt_arr.out_edges_end (v));
+}
+
+template <class GeomTraits, class TopTraits>
+Iterator_range< typename
+          boost::graph_traits<CGAL::Arrangement_on_surface_2<GeomTraits,
+                                                             TopTraits> >::
+                                                         adjacency_iterator>
+adjacent_vertices(typename
+           boost::graph_traits<CGAL::Arrangement_on_surface_2<GeomTraits,
+                                                              TopTraits> >::
+                                                          vertex_descriptor v,
+           const CGAL::Arrangement_on_surface_2<GeomTraits, TopTraits>& arr)
+{
+  return CGAL::vertices_around_target(v,arr);
 }
 
 /*!

--- a/BGL/doc/BGL/graph_traits.txt
+++ b/BGL/doc/BGL/graph_traits.txt
@@ -221,17 +221,17 @@ The traits class `boost::graph_traits<OpenMesh::PolyMesh_ArrayKernelT<K> >` prov
 
 | Member                   | Value  | Description |
 | :----------------------- | :----: | :---------- |
-| `vertex_descriptor`      | `OpenMesh::PolyMesh_ArrayKernelT<K>::VertexHandle`     | Identify vertices in the graph. |
+| `vertex_descriptor`      | `OpenMesh::PolyMesh_ArrayKernelT<K>::%VertexHandle`     | Identify vertices in the graph. |
 | `edge_descriptor`        | `unspecified_type`   | Identify edges in the graph. |
-| `halfedge_descriptor`    | `OpenMesh::PolyMesh_ArrayKernelT<K>::HalfedgeHandle`   | Identify halfedges in the graph. |
-| `face_descriptor`        | `OpenMesh::PolyMesh_ArrayKernelT<K>::FaceHandle`       | Identify faces in the graph. |
+| `halfedge_descriptor`    | `OpenMesh::PolyMesh_ArrayKernelT<K>::%HalfedgeHandle`   | Identify halfedges in the graph. |
+| `face_descriptor`        | `OpenMesh::PolyMesh_ArrayKernelT<K>::%FaceHandle`       | Identify faces in the graph. |
 | `adjacency_iterator`     | `CGAL::Vertex_around_target_iterator<OpenMesh::PolyMesh_ArrayKernelT<K> >` | An iterator to traverse through the vertices adjacent to a vertex. Its value type is `vertex_descriptor`. |
 | `out_edge_iterator`      | `CGAL::Out_edge_iterator<OpenMesh::PolyMesh_ArrayKernelT<K> >` | An iterator to traverse through the outgoing edges incident to a vertex. Its value type is `edge_descriptor`. |
 | `in_edge_iterator`       | `CGAL::In_edge_iterator<OpenMesh::PolyMesh_ArrayKernelT<K> >` | An iterator to traverse through the incoming edges incident to a vertex. Its value type is `edge_descriptor`. |
-| `vertex_iterator`        | `OpenMesh::PolyMesh_ArrayKernelT<K>::VertexIter`     | An iterator to traverse through the vertices of the graph. Its value type is `vertex_descriptor`. |
+| `vertex_iterator`        | `OpenMesh::PolyMesh_ArrayKernelT<K>::%VertexIter`     | An iterator to traverse through the vertices of the graph. Its value type is `vertex_descriptor`. |
 | `edge_iterator`          | `unspecified_type`     | An iterator to traverse through the edges of the graph. Its value type is `edge_descriptor`. |
-| `halfedge_iterator`      | `OpenMesh::PolyMesh_ArrayKernelT<K>::HalfedgeIter`     | An iterator to traverse through the halfedges of the graph. Its value type is `halfedge_descriptor`. |
-| `face_iterator`          | `OpenMesh::PolyMesh_ArrayKernelT<K>::FaceIter`         | An iterator to traverse through the faces of the graph. Its value type is `face_descriptor`. |
+| `halfedge_iterator`      | `OpenMesh::PolyMesh_ArrayKernelT<K>::%HalfedgeIter`     | An iterator to traverse through the halfedges of the graph. Its value type is `halfedge_descriptor`. |
+| `face_iterator`          | `OpenMesh::PolyMesh_ArrayKernelT<K>::%FaceIter`         | An iterator to traverse through the faces of the graph. Its value type is `face_descriptor`. |
 | `directed_category`      | `boost::undirected_tag`      | This graph is not directed. |
 | `edge_parallel_category` | `boost::disallow_parallel_edge_tag`   | This graph does not support multiedges. |
 | `traversal_category`     | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`,`boost::edge_list_graph_tag`, and`boost::adjacency_graph_tag`  | The ways in which the vertices in the graph can be traversed. |
@@ -251,17 +251,17 @@ The traits class `boost::graph_traits<OpenMesh::TriMesh_ArrayKernelT<K> >` provi
 
 | Member                   | Value  | Description |
 | :----------------------- | :----: | :---------- |
-| `vertex_descriptor`      | `OpenMesh::TriMesh_ArrayKernelT<K>::VertexHandle`     | Identify vertices in the graph. |
+| `vertex_descriptor`      | `OpenMesh::TriMesh_ArrayKernelT<K>::%VertexHandle`     | Identify vertices in the graph. |
 | `edge_descriptor`        | `unspecified_type`   | Identify edges in the graph. |
-| `halfedge_descriptor`    | `OpenMesh::TriMesh_ArrayKernelT<K>::HalfedgeHandle`   | Identify halfedges in the graph. |
-| `face_descriptor`        | `OpenMesh::TriMesh_ArrayKernelT<K>::FaceHandle`       | Identify faces in the graph. |
+| `halfedge_descriptor`    | `OpenMesh::TriMesh_ArrayKernelT<K>::%HalfedgeHandle`   | Identify halfedges in the graph. |
+| `face_descriptor`        | `OpenMesh::TriMesh_ArrayKernelT<K>::%FaceHandle`       | Identify faces in the graph. |
 | `adjacency_iterator`     | `CGAL::Vertex_around_target_iterator<OpenMesh::TriMesh_ArrayKernelT<K> >` | An iterator to traverse through the vertices adjacent to a vertex. Its value type is `vertex_descriptor`. |
 | `out_edge_iterator`      | `CGAL::Out_edge_iterator<OpenMesh::TriMesh_ArrayKernelT<K> >` | An iterator to traverse through the outgoing edges incident to a vertex. Its value type is `edge_descriptor`. |
 | `in_edge_iterator`       | `CGAL::In_edge_iterator<OpenMesh::TriMesh_ArrayKernelT<K> >` | An iterator to traverse through the incoming edges incident to a vertex. Its value type is `edge_descriptor`. |
-| `vertex_iterator`        | `OpenMesh::PolyMesh_ArrayKernelT<K>::VertexIter`     | An iterator to traverse through the vertices of the graph. Its value type is `vertex_descriptor`. |
+| `vertex_iterator`        | `OpenMesh::PolyMesh_ArrayKernelT<K>::%VertexIter`     | An iterator to traverse through the vertices of the graph. Its value type is `vertex_descriptor`. |
 | `edge_iterator`          | `unspecified_type`     | An iterator to traverse through the edges of the graph. Its value type is `edge_descriptor`. |
-| `halfedge_iterator`      | `OpenMesh::TriMesh_ArrayKernelT<K>::HalfedgeIter`     | An iterator to traverse through the halfedges of the graph. Its value type is `halfedge_descriptor`. |
-| `face_iterator`          | `OpenMesh::TriMesh_ArrayKernelT<K>::FaceIter`         | An iterator to traverse through the faces of the graph. Its value type is `face_descriptor`. |
+| `halfedge_iterator`      | `OpenMesh::TriMesh_ArrayKernelT<K>::%HalfedgeIter`     | An iterator to traverse through the halfedges of the graph. Its value type is `halfedge_descriptor`. |
+| `face_iterator`          | `OpenMesh::TriMesh_ArrayKernelT<K>::%FaceIter`         | An iterator to traverse through the faces of the graph. Its value type is `face_descriptor`. |
 | `directed_category`      | `boost::undirected_tag`      | This graph is not directed. |
 | `edge_parallel_category` | `boost::disallow_parallel_edge_tag`   | This graph does not support multiedges. |
 | `traversal_category`     | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`, `boost::edge_list_graph_tag`, and `boost::adjacency_graph_tag` | The ways in which the vertices in the graph can be traversed. |

--- a/BGL/doc/BGL/graph_traits.txt
+++ b/BGL/doc/BGL/graph_traits.txt
@@ -36,7 +36,7 @@ The traits class `boost::graph_traits< CGAL::Surface_mesh<T> >` provides the fol
 | `face_iterator`          | `Surface_mesh::Face_iterator`         | An iterator to traverse through the faces of the graph. Its value type is `face_descriptor`. |
 | `directed_category`      | `boost::undirected_tag`      | This graph is not directed. |
 | `edge_parallel_category` | `boost::disallow_parallel_edge_tag`   | This graph does not support multiedges. |
-| `traversal_category`     | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`, and `boost::edge_list_graph_tag` | The ways in which the vertices in the graph can be traversed. |
+| `traversal_category`     | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`, `boost::edge_list_graph_tag`, and `boost::adjacency_graph_tag`  | The ways in which the vertices in the graph can be traversed. |
 | `vertices_size_type`     | `Surface_mesh::vertices_size_type` | The size type of the vertex list. |
 | `edges_size_type`        | `Surface_mesh::edges_size_type` | The size type of the edge list. |
 | `degree_size_type`       | `Surface_mesh::degree_size_type` | The size type of the adjacency list. |
@@ -69,7 +69,7 @@ The traits class `boost::graph_traits< CGAL::Polyhedron_3<T> >` provides the fol
 | `face_iterator`          | `unspecified_type`         | An iterator to traverse through the faces of the graph. Its value type is `face_descriptor`. |
 | `directed_category`      | `boost::undirected_tag`      | This graph is not directed. |
 | `edge_parallel_category` | `boost::disallow_parallel_edge_tag`   | This graph does not support multiedges. |
-| `traversal_category`     | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`, and `boost::edge_list_graph_tag` | The ways in which the vertices in the graph can be traversed. |
+| `traversal_category`     | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`, `boost::edge_list_graph_tag`, and`boost::adjacency_graph_tag`  | The ways in which the vertices in the graph can be traversed. |
 | `vertices_size_type`     | `Polyhedron_3::size_type` | The size type of the vertex list. |
 | `edges_size_type`        | `Polyhedron_3::size_type` | The size type of the edge list. |
 | `degree_size_type`       | `Polyhedron_3::size_type` | The size type of the adjacency list. |
@@ -102,7 +102,7 @@ The traits class `boost::graph_traits<LCC>` provides the following types:
 | `edge_iterator`          | `unspecified_type`         | Iterate through the edges of LCC.|
 | `halfedge_iterator`      | `unspecified_type`         | Iterate through the halfedges of LCC.|
 | `face_iterator`          | `unspecified_type`         | Iterate through the faces of LCC.|
-| `directed_category`      | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag` and `boost::edge_list_graph_tag` | |
+| `directed_category`      | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`, `boost::edge_list_graph_tag`, and `boost::adjacency_graph_tag`  | |
 | `edge_parallel_category` | `boost::disallow_parallel_edge_tag`   | Indicates that this graph does not support multiedges |
 | `traversal_category`     | `boost::bidirectional_graph_tag`      | Indicates that this graph is bidirectional |
 | `vertices_size_type`     | `LCC::size_type` | The size type of the vertex list |
@@ -197,14 +197,14 @@ provides the following types:
 | :----------------------- | :----: | :---------- |
 | `vertex_descriptor`      | `Arrangement_2::Vertex_handle`     | Identify vertices in the graph. |
 | `edge_descriptor`        | `Arrangement_2::Halfedge_handle`   | Identify edges in the graph. |
-| `adjacency_iterator`     | Not provided| |
+| `adjacency_iterator`     | `Vertex_around_target_iterator<Arrangement_2>`| An iterator to traverse through the vertices adjacent to a vertex. Its value type is `vertex_descriptor`.|
 | `out_edge_iterator`      | `unspecified_type` | An edge iterator which only iterates over the outgoing halfedges around a vertex. It corresponds to a `Arrangement_2::Halfedge_around_vertex_circulator` with the difference that its value type is an edge descriptor and not `Arrangement_2::Halfedge`|
 | `in_edge_iterator`       | `unspecified_type` | An edge iterator which only iterates over the incoming edges around a vertex. It corresponds to a `Arrangement_2::Halfedge_around_vertex_circulator` with the difference that its value type is an edge descriptor and not `Arrangement_2::Halfedge`|
 | `vertex_iterator`        | `unspecified_type` | An iterator corresponding to `Arrangement_2::Vertex_iterator`, with the difference that its value type is a vertex descriptor and not `Arrangement_2::Vertex`  |
 | `edge_iterator`          | `unspecified_type` | An iterator corresponding to `Arrangement_2::Halfedge_iterator` with the difference that its value type is an edge descriptor and not `Arrangement_2::Halfedge`|
 | `directed_category`      | `boost::directed_tag`      | This graph is directed. |
 | `edge_parallel_category` | `boost::allow_parallel_edge_tag` | This graph supports multiedges. |
-| `traversal_category`     | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`, and `boost::edge_list_graph_tag` | The ways in which the vertices in the graph can be traversed. |
+| `traversal_category`     | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`, `boost::edge_list_graph_tag`, and `boost::adjacency_graph_tag`  | The ways in which the vertices in the graph can be traversed. |
 | `vertices_size_type`     | `Arrangement_2::Size` | The size type of the vertex list. |
 | `edges_size_type`        | `Arrangement_2::Size` | The size type of the edge list. |
 | `degree_size_type`       | `Arrangement_2::Size` | The size type of the adjacency list. |
@@ -221,20 +221,20 @@ The traits class `boost::graph_traits<OpenMesh::PolyMesh_ArrayKernelT<K> >` prov
 
 | Member                   | Value  | Description |
 | :----------------------- | :----: | :---------- |
-| `vertex_descriptor`      | `OpenMesh::PolyMesh_ArrayKernelT::VertexHandle`     | Identify vertices in the graph. |
+| `vertex_descriptor`      | `OpenMesh::PolyMesh_ArrayKernelT<K>::VertexHandle`     | Identify vertices in the graph. |
 | `edge_descriptor`        | `unspecified_type`   | Identify edges in the graph. |
-| `halfedge_descriptor`    | `OpenMesh::PolyMesh_ArrayKernelT::HalfedgeHandle`   | Identify halfedges in the graph. |
-| `face_descriptor`        | `OpenMesh::PolyMesh_ArrayKernelT::FaceHandle`       | Identify faces in the graph. |
-| `adjacency_iterator`     | `unspecified_type` | An iterator to traverse through the vertices adjacent to a vertex. Its value type is `vertex_descriptor`. |
+| `halfedge_descriptor`    | `OpenMesh::PolyMesh_ArrayKernelT<K>::HalfedgeHandle`   | Identify halfedges in the graph. |
+| `face_descriptor`        | `OpenMesh::PolyMesh_ArrayKernelT<K>::FaceHandle`       | Identify faces in the graph. |
+| `adjacency_iterator`     | `CGAL::Vertex_around_target_iterator<OpenMesh::PolyMesh_ArrayKernelT<K> >` | An iterator to traverse through the vertices adjacent to a vertex. Its value type is `vertex_descriptor`. |
 | `out_edge_iterator`      | `CGAL::Out_edge_iterator<OpenMesh::PolyMesh_ArrayKernelT<K> >` | An iterator to traverse through the outgoing edges incident to a vertex. Its value type is `edge_descriptor`. |
 | `in_edge_iterator`       | `CGAL::In_edge_iterator<OpenMesh::PolyMesh_ArrayKernelT<K> >` | An iterator to traverse through the incoming edges incident to a vertex. Its value type is `edge_descriptor`. |
-| `vertex_iterator`        | `OpenMesh::PolyMesh_ArrayKernelT::VertexIter`     | An iterator to traverse through the vertices of the graph. Its value type is `vertex_descriptor`. |
+| `vertex_iterator`        | `OpenMesh::PolyMesh_ArrayKernelT<K>::VertexIter`     | An iterator to traverse through the vertices of the graph. Its value type is `vertex_descriptor`. |
 | `edge_iterator`          | `unspecified_type`     | An iterator to traverse through the edges of the graph. Its value type is `edge_descriptor`. |
-| `halfedge_iterator`      | `OpenMesh::PolyMesh_ArrayKernelT::HalfedgeIter`     | An iterator to traverse through the halfedges of the graph. Its value type is `halfedge_descriptor`. |
-| `face_iterator`          | `OpenMesh::PolyMesh_ArrayKernelT::FaceIter`         | An iterator to traverse through the faces of the graph. Its value type is `face_descriptor`. |
+| `halfedge_iterator`      | `OpenMesh::PolyMesh_ArrayKernelT<K>::HalfedgeIter`     | An iterator to traverse through the halfedges of the graph. Its value type is `halfedge_descriptor`. |
+| `face_iterator`          | `OpenMesh::PolyMesh_ArrayKernelT<K>::FaceIter`         | An iterator to traverse through the faces of the graph. Its value type is `face_descriptor`. |
 | `directed_category`      | `boost::undirected_tag`      | This graph is not directed. |
 | `edge_parallel_category` | `boost::disallow_parallel_edge_tag`   | This graph does not support multiedges. |
-| `traversal_category`     | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`, and `boost::edge_list_graph_tag` | The ways in which the vertices in the graph can be traversed. |
+| `traversal_category`     | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`,`boost::edge_list_graph_tag`, and`boost::adjacency_graph_tag`  | The ways in which the vertices in the graph can be traversed. |
 | `vertices_size_type`     | `unsigned int` | The size type of the vertex list. |
 | `edges_size_type`        | `unsigned int` | The size type of the edge list. |
 | `degree_size_type`       | `unsigned int` | The size type of the adjacency list. |
@@ -251,20 +251,20 @@ The traits class `boost::graph_traits<OpenMesh::TriMesh_ArrayKernelT<K> >` provi
 
 | Member                   | Value  | Description |
 | :----------------------- | :----: | :---------- |
-| `vertex_descriptor`      | `OpenMesh::TriMesh_ArrayKernelT::VertexHandle`     | Identify vertices in the graph. |
+| `vertex_descriptor`      | `OpenMesh::TriMesh_ArrayKernelT<K>::VertexHandle`     | Identify vertices in the graph. |
 | `edge_descriptor`        | `unspecified_type`   | Identify edges in the graph. |
-| `halfedge_descriptor`    | `OpenMesh::TriMesh_ArrayKernelT::HalfedgeHandle`   | Identify halfedges in the graph. |
-| `face_descriptor`        | `OpenMesh::TriMesh_ArrayKernelT::FaceHandle`       | Identify faces in the graph. |
-| `adjacency_iterator`     | `unspecified_type` | An iterator to traverse through the vertices adjacent to a vertex. Its value type is `vertex_descriptor`. |
+| `halfedge_descriptor`    | `OpenMesh::TriMesh_ArrayKernelT<K>::HalfedgeHandle`   | Identify halfedges in the graph. |
+| `face_descriptor`        | `OpenMesh::TriMesh_ArrayKernelT<K>::FaceHandle`       | Identify faces in the graph. |
+| `adjacency_iterator`     | `CGAL::Vertex_around_target_iterator<OpenMesh::TriMesh_ArrayKernelT<K> >` | An iterator to traverse through the vertices adjacent to a vertex. Its value type is `vertex_descriptor`. |
 | `out_edge_iterator`      | `CGAL::Out_edge_iterator<OpenMesh::TriMesh_ArrayKernelT<K> >` | An iterator to traverse through the outgoing edges incident to a vertex. Its value type is `edge_descriptor`. |
 | `in_edge_iterator`       | `CGAL::In_edge_iterator<OpenMesh::TriMesh_ArrayKernelT<K> >` | An iterator to traverse through the incoming edges incident to a vertex. Its value type is `edge_descriptor`. |
-| `vertex_iterator`        | `OpenMesh::PolyMesh_ArrayKernelT::VertexIter`     | An iterator to traverse through the vertices of the graph. Its value type is `vertex_descriptor`. |
+| `vertex_iterator`        | `OpenMesh::PolyMesh_ArrayKernelT<K>::VertexIter`     | An iterator to traverse through the vertices of the graph. Its value type is `vertex_descriptor`. |
 | `edge_iterator`          | `unspecified_type`     | An iterator to traverse through the edges of the graph. Its value type is `edge_descriptor`. |
-| `halfedge_iterator`      | `OpenMesh::TriMesh_ArrayKernelT::HalfedgeIter`     | An iterator to traverse through the halfedges of the graph. Its value type is `halfedge_descriptor`. |
-| `face_iterator`          | `OpenMesh::TriMesh_ArrayKernelT::FaceIter`         | An iterator to traverse through the faces of the graph. Its value type is `face_descriptor`. |
+| `halfedge_iterator`      | `OpenMesh::TriMesh_ArrayKernelT<K>::HalfedgeIter`     | An iterator to traverse through the halfedges of the graph. Its value type is `halfedge_descriptor`. |
+| `face_iterator`          | `OpenMesh::TriMesh_ArrayKernelT<K>::FaceIter`         | An iterator to traverse through the faces of the graph. Its value type is `face_descriptor`. |
 | `directed_category`      | `boost::undirected_tag`      | This graph is not directed. |
 | `edge_parallel_category` | `boost::disallow_parallel_edge_tag`   | This graph does not support multiedges. |
-| `traversal_category`     | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`, and `boost::edge_list_graph_tag` | The ways in which the vertices in the graph can be traversed. |
+| `traversal_category`     | Inherits from `boost::bidirectional_graph_tag`, `boost::vertex_list_graph_tag`, `boost::edge_list_graph_tag`, and `boost::adjacency_graph_tag` | The ways in which the vertices in the graph can be traversed. |
 | `vertices_size_type`     | `unsigned int` | The size type of the vertex list. |
 | `edges_size_type`        | `unsigned int` | The size type of the edge list. |
 | `degree_size_type`       | `unsigned int` | The size type of the adjacency list. |

--- a/BGL/include/CGAL/boost/graph/graph_traits_OpenMesh.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_OpenMesh.h
@@ -16,7 +16,6 @@
 #include <boost/graph/properties.hpp>
 
 #include <CGAL/boost/iterator/transform_iterator.hpp>
-#include <boost/graph/adjacency_iterator.hpp>
 
 #include <CGAL/boost/graph/internal/OM_iterator_from_circulator.h>
 #include <CGAL/boost/graph/iterator.h>
@@ -126,7 +125,7 @@ public:
 
   typedef CGAL::Out_edge_iterator<SM> out_edge_iterator;
 
-  typedef typename boost::adjacency_iterator_generator<SM, vertex_descriptor, out_edge_iterator>::type adjacency_iterator;
+  typedef CGAL::Vertex_around_target_iterator<SM> adjacency_iterator;
 
   // nulls
   static vertex_descriptor   null_vertex() { return vertex_descriptor(); }
@@ -270,12 +269,10 @@ out_edges(typename boost::graph_traits<OPEN_MESH_CLASS >::vertex_descriptor v,
 
 template <typename K>
 CGAL::Iterator_range<typename boost::graph_traits<OPEN_MESH_CLASS >::adjacency_iterator>
-adjacnt_vertices(typename boost::graph_traits<OPEN_MESH_CLASS >::vertex_descriptor v,
+adjaecnt_vertices(typename boost::graph_traits<OPEN_MESH_CLASS >::vertex_descriptor v,
                  const OPEN_MESH_CLASS& sm)
 {
-  typedef typename boost::graph_traits<OPEN_MESH_CLASS >::out_edge_iterator OutEdgeIter;
-  typedef typename boost::graph_traits<OPEN_MESH_CLASS >::adjacency_iterator Iter;
-  return CGAL::make_range(Iter(OutEdgeIter(halfedge(v,sm),sm), &sm), Iter(OutEdgeIter(halfedge(v,sm),sm,1), &sm));
+  return CGAL::vertices_around_target(v,sm);
 }
 
 

--- a/BGL/include/CGAL/boost/graph/graph_traits_OpenMesh.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_OpenMesh.h
@@ -16,6 +16,7 @@
 #include <boost/graph/properties.hpp>
 
 #include <CGAL/boost/iterator/transform_iterator.hpp>
+#include <boost/graph/adjacency_iterator.hpp>
 
 #include <CGAL/boost/graph/internal/OM_iterator_from_circulator.h>
 #include <CGAL/boost/graph/iterator.h>
@@ -81,7 +82,8 @@ private:
 
   struct SM_graph_traversal_category : public virtual boost::bidirectional_graph_tag,
                                        public virtual boost::vertex_list_graph_tag,
-                                       public virtual boost::edge_list_graph_tag
+                                       public virtual boost::edge_list_graph_tag,
+                                       public virtual boost::adjacency_graph_tag
   {};
 
 public:
@@ -124,10 +126,12 @@ public:
 
   typedef CGAL::Out_edge_iterator<SM> out_edge_iterator;
 
+  typedef typename boost::adjacency_iterator_generator<SM, vertex_descriptor, out_edge_iterator>::type adjacency_iterator;
+
   // nulls
   static vertex_descriptor   null_vertex() { return vertex_descriptor(); }
   static face_descriptor     null_face()   { return face_descriptor(); }
-  static halfedge_descriptor     null_halfedge()   { return halfedge_descriptor(); }
+  static halfedge_descriptor null_halfedge()   { return halfedge_descriptor(); }
 };
 
 template<typename K>
@@ -262,6 +266,19 @@ out_edges(typename boost::graph_traits<OPEN_MESH_CLASS >::vertex_descriptor v,
   typedef typename boost::graph_traits<OPEN_MESH_CLASS >::out_edge_iterator Iter;
   return CGAL::make_range(Iter(halfedge(v,sm),sm), Iter(halfedge(v,sm),sm,1));
 }
+
+
+template <typename K>
+CGAL::Iterator_range<typename boost::graph_traits<OPEN_MESH_CLASS >::adjacency_iterator>
+adjacnt_vertices(typename boost::graph_traits<OPEN_MESH_CLASS >::vertex_descriptor v,
+                 const OPEN_MESH_CLASS& sm)
+{
+  typedef typename boost::graph_traits<OPEN_MESH_CLASS >::out_edge_iterator OutEdgeIter;
+  typedef typename boost::graph_traits<OPEN_MESH_CLASS >::adjacency_iterator Iter;
+  return CGAL::make_range(Iter(OutEdgeIter(halfedge(v,sm),sm), &sm), Iter(OutEdgeIter(halfedge(v,sm),sm,1), &sm));
+}
+
+
 
 
 template<typename K>

--- a/BGL/include/CGAL/boost/graph/graph_traits_OpenMesh.h
+++ b/BGL/include/CGAL/boost/graph/graph_traits_OpenMesh.h
@@ -269,7 +269,7 @@ out_edges(typename boost::graph_traits<OPEN_MESH_CLASS >::vertex_descriptor v,
 
 template <typename K>
 CGAL::Iterator_range<typename boost::graph_traits<OPEN_MESH_CLASS >::adjacency_iterator>
-adjaecnt_vertices(typename boost::graph_traits<OPEN_MESH_CLASS >::vertex_descriptor v,
+adjacent_vertices(typename boost::graph_traits<OPEN_MESH_CLASS >::vertex_descriptor v,
                  const OPEN_MESH_CLASS& sm)
 {
   return CGAL::vertices_around_target(v,sm);

--- a/BGL/test/BGL/graph_concept_Linear_cell_complex.cpp
+++ b/BGL/test/BGL/graph_concept_Linear_cell_complex.cpp
@@ -21,6 +21,7 @@ typedef LCC::Traits::Point Point_3;
 template<typename Graph>
 void concept_check_polyhedron() {
   boost::function_requires< boost::GraphConcept<LCC> >();
+  boost::function_requires< boost::AdjacencyGraphConcept<LCC> >();
   boost::function_requires< boost::VertexListGraphConcept<LCC> >();
   boost::function_requires< boost::EdgeListGraphConcept<LCC> >();
   boost::function_requires< boost::IncidenceGraphConcept<LCC> >();

--- a/BGL/test/BGL/graph_concept_OpenMesh.cpp
+++ b/BGL/test/BGL/graph_concept_OpenMesh.cpp
@@ -18,6 +18,7 @@ typedef Traits::face_descriptor           face_descriptor;
 template<typename Graph>
 void concept_check_polyhedron() {
   boost::function_requires< boost::GraphConcept<Sm> >();
+  boost::function_requires< boost::AdjacencyGraphConcept<Sm> >();
 
   // Those have to be disabled due to OpenMesh's broken iterators.
   // boost::function_requires< boost::VertexListGraphConcept<Sm> >();

--- a/BGL/test/BGL/graph_concept_Polyhedron_3.cpp
+++ b/BGL/test/BGL/graph_concept_Polyhedron_3.cpp
@@ -15,6 +15,7 @@ typedef Kernel::Point_3 Point_3;
 template<typename Graph>
 void concept_check_polyhedron() {
   boost::function_requires< boost::GraphConcept<Polyhedron> >();
+  boost::function_requires< boost::AdjacencyGraphConcept<Polyhedron> >();
   boost::function_requires< boost::VertexListGraphConcept<Polyhedron> >();
   boost::function_requires< boost::EdgeListGraphConcept<Polyhedron> >();
   boost::function_requires< boost::IncidenceGraphConcept<Polyhedron> >();

--- a/BGL/test/BGL/graph_concept_Surface_mesh.cpp
+++ b/BGL/test/BGL/graph_concept_Surface_mesh.cpp
@@ -15,6 +15,7 @@ typedef Traits::face_descriptor face_descriptor;
 void concept_check_surface_mesh()
 {
   boost::function_requires< boost::GraphConcept<Surface_mesh> >();
+  boost::function_requires< boost::AdjacencyGraphConcept<Surface_mesh> >();
   boost::function_requires< boost::VertexListGraphConcept<Surface_mesh> >();
   boost::function_requires< boost::EdgeListGraphConcept<Surface_mesh> >();
   boost::function_requires< boost::IncidenceGraphConcept<Surface_mesh> >();

--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS.h
@@ -20,6 +20,7 @@
 #include <boost/config.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <CGAL/boost/iterator/transform_iterator.hpp>
+#include <boost/graph/adjacency_iterator.hpp>
 #include <boost/type_traits/remove_const.hpp>
 
 #include <boost/graph/graph_traits.hpp>
@@ -155,7 +156,8 @@ struct HDS_graph_traits
 private:
   struct HDS_graph_traversal_category : public virtual boost::bidirectional_graph_tag,
                                         public virtual boost::vertex_list_graph_tag,
-                                        public virtual boost::edge_list_graph_tag
+                                        public virtual boost::edge_list_graph_tag,
+                                        public virtual boost::adjacency_graph_tag
   {};
 
 public:
@@ -178,6 +180,8 @@ public:
   typedef Out_edge_iterator<HDS> out_edge_iterator;
 
   typedef In_edge_iterator<HDS> in_edge_iterator;
+
+  typedef typename boost::adjacency_iterator_generator<HDS, vertex_descriptor, out_edge_iterator>::type adjacency_iterator;
 
   typedef boost::undirected_tag             directed_category;
   typedef boost::disallow_parallel_edge_tag edge_parallel_category;

--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS.h
@@ -20,7 +20,6 @@
 #include <boost/config.hpp>
 #include <boost/iterator/iterator_adaptor.hpp>
 #include <CGAL/boost/iterator/transform_iterator.hpp>
-#include <boost/graph/adjacency_iterator.hpp>
 #include <boost/type_traits/remove_const.hpp>
 
 #include <boost/graph/graph_traits.hpp>
@@ -181,7 +180,7 @@ public:
 
   typedef In_edge_iterator<HDS> in_edge_iterator;
 
-  typedef typename boost::adjacency_iterator_generator<HDS, vertex_descriptor, out_edge_iterator>::type adjacency_iterator;
+  typedef Vertex_around_target_iterator<HDS> adjacency_iterator;
 
   typedef boost::undirected_tag             directed_category;
   typedef boost::disallow_parallel_edge_tag edge_parallel_category;

--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
@@ -177,9 +177,7 @@ inline Iterator_range<typename boost::graph_traits< HalfedgeDS_default<T,I,A> co
 adjacent_vertices( typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_descriptor u
                    , const HalfedgeDS_default<T,I,A>& p)
 {
-  typedef typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::out_edge_iterator OutEdgeIter;
-  typedef typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::adjacency_iterator Iter;
-  return make_range(Iter(OutEdgeIter(halfedge(u,p),p),&p), Iter(OutEdgeIter(halfedge(u,p),p,1), &p));
+  return CGAL::vertices_around_target(u,p);
 }
 
 //

--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS_default.h
@@ -172,6 +172,16 @@ out_edges( typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::verte
   return make_range(Iter(halfedge(u,p),p), Iter(halfedge(u,p),p,1));
 }
 
+template<class T, class I, class A>
+inline Iterator_range<typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::adjacency_iterator>
+adjacent_vertices( typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::vertex_descriptor u
+                   , const HalfedgeDS_default<T,I,A>& p)
+{
+  typedef typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::out_edge_iterator OutEdgeIter;
+  typedef typename boost::graph_traits< HalfedgeDS_default<T,I,A> const>::adjacency_iterator Iter;
+  return make_range(Iter(OutEdgeIter(halfedge(u,p),p),&p), Iter(OutEdgeIter(halfedge(u,p),p,1), &p));
+}
+
 //
 // MutableHalfedgeGraph
 //

--- a/Linear_cell_complex/include/CGAL/boost/graph/graph_traits_Linear_cell_complex_for_combinatorial_map.h
+++ b/Linear_cell_complex/include/CGAL/boost/graph/graph_traits_Linear_cell_complex_for_combinatorial_map.h
@@ -18,6 +18,7 @@
 #include <boost/config.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
+#include <boost/graph/adjacency_iterator.hpp>
 #include <CGAL/boost/graph/iterator.h>
 #include <CGAL/boost/graph/properties_Linear_cell_complex_for_combinatorial_map.h>
 #include <CGAL/boost/graph/graph_traits_HalfedgeDS.h>
@@ -178,7 +179,8 @@ struct CMap_Base_graph_traits
 public :
   struct CMap_graph_traversal_category : public virtual boost::bidirectional_graph_tag,
                                          public virtual boost::vertex_list_graph_tag,
-                                         public virtual boost::edge_list_graph_tag
+                                         public virtual boost::edge_list_graph_tag,
+                                         public virtual boost::adjacency_graph_tag
   {};
 
   // Expose types required by the boost::Graph concept.
@@ -205,6 +207,8 @@ public :
 
   typedef CGAL::In_edge_iterator<CMap>  in_edge_iterator;
   typedef CGAL::Out_edge_iterator<CMap> out_edge_iterator;
+
+  typedef typename boost::adjacency_iterator_generator<CMap, vertex_descriptor, out_edge_iterator>::type adjacency_iterator;
 
   // nulls
   static vertex_descriptor   null_vertex()   { return nullptr; }
@@ -389,6 +393,16 @@ out_edges(typename boost::graph_traits<CGAL_LCC_TYPE>::vertex_descriptor v,
 {
   typedef typename boost::graph_traits<CGAL_LCC_TYPE>::out_edge_iterator Iter;
   return make_range(Iter(halfedge(v, lcc), lcc), Iter(halfedge(v, lcc), lcc, 1));
+}
+
+CGAL_LCC_TEMPLATE_ARGS
+CGAL::Iterator_range<typename boost::graph_traits<CGAL_LCC_TYPE>::adjacency_iterator>
+adjacent_vertices(typename boost::graph_traits<CGAL_LCC_TYPE>::vertex_descriptor v,
+                  const CGAL_LCC_TYPE& lcc)
+{
+  typedef typename boost::graph_traits<CGAL_LCC_TYPE>::out_edge_iterator OutEdgeIter;
+  typedef typename boost::graph_traits<CGAL_LCC_TYPE>::adjacency_iterator Iter;
+  return make_range(Iter(OutEdgeIter(halfedge(v, lcc), lcc), &lcc), Iter(OutEdgeIter(halfedge(v, lcc), lcc, 1), &lcc));
 }
 
 //

--- a/Linear_cell_complex/include/CGAL/boost/graph/graph_traits_Linear_cell_complex_for_combinatorial_map.h
+++ b/Linear_cell_complex/include/CGAL/boost/graph/graph_traits_Linear_cell_complex_for_combinatorial_map.h
@@ -208,7 +208,7 @@ public :
   typedef CGAL::In_edge_iterator<CMap>  in_edge_iterator;
   typedef CGAL::Out_edge_iterator<CMap> out_edge_iterator;
 
-  typedef typename boost::adjacency_iterator_generator<CMap, vertex_descriptor, out_edge_iterator>::type adjacency_iterator;
+  typedef CGAL::Vertex_around_target_iterator<CMap> adjacency_iterator;
 
   // nulls
   static vertex_descriptor   null_vertex()   { return nullptr; }
@@ -400,9 +400,7 @@ CGAL::Iterator_range<typename boost::graph_traits<CGAL_LCC_TYPE>::adjacency_iter
 adjacent_vertices(typename boost::graph_traits<CGAL_LCC_TYPE>::vertex_descriptor v,
                   const CGAL_LCC_TYPE& lcc)
 {
-  typedef typename boost::graph_traits<CGAL_LCC_TYPE>::out_edge_iterator OutEdgeIter;
-  typedef typename boost::graph_traits<CGAL_LCC_TYPE>::adjacency_iterator Iter;
-  return make_range(Iter(OutEdgeIter(halfedge(v, lcc), lcc), &lcc), Iter(OutEdgeIter(halfedge(v, lcc), lcc, 1), &lcc));
+  return CGAL::vertices_around_target(v,lcc);
 }
 
 //

--- a/Linear_cell_complex/include/CGAL/boost/graph/graph_traits_Linear_cell_complex_for_combinatorial_map.h
+++ b/Linear_cell_complex/include/CGAL/boost/graph/graph_traits_Linear_cell_complex_for_combinatorial_map.h
@@ -18,7 +18,6 @@
 #include <boost/config.hpp>
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
-#include <boost/graph/adjacency_iterator.hpp>
 #include <CGAL/boost/graph/iterator.h>
 #include <CGAL/boost/graph/properties_Linear_cell_complex_for_combinatorial_map.h>
 #include <CGAL/boost/graph/graph_traits_HalfedgeDS.h>

--- a/Surface_mesh/include/CGAL/boost/graph/graph_traits_Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/boost/graph/graph_traits_Surface_mesh.h
@@ -30,6 +30,7 @@
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/assertions.h>
 
+#include <boost/graph/adjacency_iterator.hpp>
 
 namespace boost {
 
@@ -41,7 +42,8 @@ private:
 
   struct SM_graph_traversal_category : public virtual boost::bidirectional_graph_tag,
                                        public virtual boost::vertex_list_graph_tag,
-                                       public virtual boost::edge_list_graph_tag
+                                       public virtual boost::edge_list_graph_tag,
+                                       public virtual boost::adjacency_graph_tag
   {};
 
 public:
@@ -77,14 +79,18 @@ public:
   typedef typename SM::size_type              degree_size_type;
 
 
+
+
   typedef CGAL::In_edge_iterator<SM> in_edge_iterator;
 
   typedef CGAL::Out_edge_iterator<SM> out_edge_iterator;
 
+  typedef typename boost::adjacency_iterator_generator<SM, vertex_descriptor, out_edge_iterator>::type adjacency_iterator;
+
   // nulls
   static vertex_descriptor   null_vertex() { return vertex_descriptor(); }
   static face_descriptor     null_face()   { return face_descriptor(); }
-  static halfedge_descriptor     null_halfedge()   { return halfedge_descriptor(); }
+  static halfedge_descriptor null_halfedge()   { return halfedge_descriptor(); }
 };
 
 template<typename P>
@@ -217,6 +223,16 @@ out_edges(typename boost::graph_traits<CGAL::Surface_mesh<P> >::vertex_descripto
   return make_range(Iter(halfedge(v,sm),sm), Iter(halfedge(v,sm),sm,1));
 }
 
+template <typename P>
+Iterator_range<typename boost::graph_traits<CGAL::Surface_mesh<P> >::adjacency_iterator>
+adjacent_vertices(typename boost::graph_traits<CGAL::Surface_mesh<P> >::vertex_descriptor v,
+                  const CGAL::Surface_mesh<P>& sm)
+{
+  typedef typename boost::graph_traits<CGAL::Surface_mesh<P> >::out_edge_iterator OutEdgeIter;
+  typedef typename boost::graph_traits<CGAL::Surface_mesh<P> >::adjacency_iterator Iter;
+  return make_range(Iter(OutEdgeIter(halfedge(v,sm),sm), &sm),
+                    Iter(OutEdgeIter(halfedge(v,sm),sm,1), &sm));
+}
 
 template<typename P>
 std::pair<typename boost::graph_traits<CGAL::Surface_mesh<P> >::edge_descriptor,

--- a/Surface_mesh/include/CGAL/boost/graph/graph_traits_Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/boost/graph/graph_traits_Surface_mesh.h
@@ -30,7 +30,6 @@
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/assertions.h>
 
-#include <boost/graph/adjacency_iterator.hpp>
 
 namespace boost {
 
@@ -85,7 +84,7 @@ public:
 
   typedef CGAL::Out_edge_iterator<SM> out_edge_iterator;
 
-  typedef typename boost::adjacency_iterator_generator<SM, vertex_descriptor, out_edge_iterator>::type adjacency_iterator;
+  typedef CGAL::Vertex_around_target_iterator<SM> adjacency_iterator;
 
   // nulls
   static vertex_descriptor   null_vertex() { return vertex_descriptor(); }
@@ -228,10 +227,7 @@ Iterator_range<typename boost::graph_traits<CGAL::Surface_mesh<P> >::adjacency_i
 adjacent_vertices(typename boost::graph_traits<CGAL::Surface_mesh<P> >::vertex_descriptor v,
                   const CGAL::Surface_mesh<P>& sm)
 {
-  typedef typename boost::graph_traits<CGAL::Surface_mesh<P> >::out_edge_iterator OutEdgeIter;
-  typedef typename boost::graph_traits<CGAL::Surface_mesh<P> >::adjacency_iterator Iter;
-  return make_range(Iter(OutEdgeIter(halfedge(v,sm),sm), &sm),
-                    Iter(OutEdgeIter(halfedge(v,sm),sm,1), &sm));
+  return CGAL::vertices_around_target(v,sm);
 }
 
 template<typename P>


### PR DESCRIPTION
## Summary of Changes

Add `adjacency_iterator` to several classes with `typedef`s as defined in the [documentation](https://doc.cgal.org/latest/BGL/group__PkgBGLTraits.html).

Do we want to provide it for `Dual` etc ?

## Release Management

* Affected package(s): Surface_mesh, Polyhedron, LCC
* Issue(s) solved (if any): fix #6531

