### PR TITLE
Do not set cxx standard in the final target cmake script

### DIFF
--- a/Barycentric_coordinates_2/benchmark/Barycentric_coordinates_2/CMakeLists.txt
+++ b/Barycentric_coordinates_2/benchmark/Barycentric_coordinates_2/CMakeLists.txt
@@ -4,7 +4,6 @@
 project(Barycentric_coordinates_2_Benchmarks)
 
 cmake_minimum_required(VERSION 3.1...3.15)
-set(CMAKE_CXX_STANDARD 14)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 include(${CGAL_USE_FILE})

--- a/Barycentric_coordinates_2/examples/Barycentric_coordinates_2/CMakeLists.txt
+++ b/Barycentric_coordinates_2/examples/Barycentric_coordinates_2/CMakeLists.txt
@@ -4,7 +4,6 @@
 project(Barycentric_coordinates_2_Examples)
 
 cmake_minimum_required(VERSION 3.1...3.22)
-set(CMAKE_CXX_STANDARD 14)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Barycentric_coordinates_2/test/Barycentric_coordinates_2/CMakeLists.txt
+++ b/Barycentric_coordinates_2/test/Barycentric_coordinates_2/CMakeLists.txt
@@ -4,7 +4,6 @@
 project(Barycentric_coordinates_2_Tests)
 
 cmake_minimum_required(VERSION 3.1...3.22)
-set(CMAKE_CXX_STANDARD 14)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Orthtree/benchmark/Orthtree/CMakeLists.txt
+++ b/Orthtree/benchmark/Orthtree/CMakeLists.txt
@@ -4,9 +4,6 @@
 cmake_minimum_required(VERSION 3.1...3.14)
 project(Orthtree_benchmarks)
 
-# TODO: I shouldn't leave this here
-set(CMAKE_CXX_STANDARD 14)
-
 find_package(CGAL REQUIRED QUIET OPTIONAL_COMPONENTS Core)
 
 create_single_source_cgal_program("construction.cpp")

--- a/Shape_regularization/benchmark/Shape_regularization/CMakeLists.txt
+++ b/Shape_regularization/benchmark/Shape_regularization/CMakeLists.txt
@@ -4,7 +4,6 @@
 project(Shape_regularization_Benchmarks)
 
 cmake_minimum_required(VERSION 3.1...3.15)
-set(CMAKE_CXX_STANDARD 14)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Shape_regularization/examples/Shape_regularization/CMakeLists.txt
+++ b/Shape_regularization/examples/Shape_regularization/CMakeLists.txt
@@ -4,7 +4,6 @@
 project(Shape_regularization_Examples)
 
 cmake_minimum_required(VERSION 3.1...3.22)
-set(CMAKE_CXX_STANDARD 14)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Shape_regularization/test/Shape_regularization/CMakeLists.txt
+++ b/Shape_regularization/test/Shape_regularization/CMakeLists.txt
@@ -4,7 +4,6 @@
 project(Shape_regularization_Tests)
 
 cmake_minimum_required(VERSION 3.1...3.22)
-set(CMAKE_CXX_STANDARD 14)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Weights/examples/Weights/CMakeLists.txt
+++ b/Weights/examples/Weights/CMakeLists.txt
@@ -4,7 +4,6 @@
 project(Weights_Examples)
 
 cmake_minimum_required(VERSION 3.1...3.22)
-set(CMAKE_CXX_STANDARD 14)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Weights/test/Weights/CMakeLists.txt
+++ b/Weights/test/Weights/CMakeLists.txt
@@ -4,7 +4,6 @@
 project(Weights_Tests)
 
 cmake_minimum_required(VERSION 3.1...3.22)
-set(CMAKE_CXX_STANDARD 14)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 


### PR DESCRIPTION
Fix recent errors due to a bug in GCC

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=105436
[error](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.5-Ic-75/Weights/TestReport_lrineau_Ubuntu-GCC_master_CXX20-Release.gz)