### PR TITLE
BGL: Suppress warning in boost

### DIFF
--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/bgl_dual_adapter.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/bgl_dual_adapter.cpp
@@ -3,7 +3,15 @@
 
 #include <CGAL/config.h>
 
+#if defined(BOOST_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable:4172) // Address warning inside boost named parameters
+#endif
 #include <boost/graph/breadth_first_search.hpp>
+#if defined(BOOST_MSVC)
+#  pragma warning(pop)
+#endif
+
 #include <boost/graph/visitors.hpp>
 
 #include <CGAL/Arr_extended_dcel.h>

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/bgl_dual_adapter.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/bgl_dual_adapter.cpp
@@ -3,14 +3,7 @@
 
 #include <CGAL/config.h>
 
-#if defined(BOOST_MSVC)
-#  pragma warning(push)
-#  pragma warning(disable:4172) // Address warning inside boost named parameters
-#endif
-#include <boost/graph/breadth_first_search.hpp>
-#if defined(BOOST_MSVC)
-#  pragma warning(pop)
-#endif
+#include <CGAL/boost/graph/breadth_first_search.h>
 
 #include <boost/graph/visitors.hpp>
 

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/bgl_primal_adapter.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/bgl_primal_adapter.cpp
@@ -5,7 +5,7 @@
 
 #include <CGAL/config.h>
 
-#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <CGAL/boost/graph/dijkstra_shortest_paths.h>
 #include <boost/property_map/vector_property_map.hpp>
 
 #include <CGAL/graph_traits_Arrangement_2.h>

--- a/BGL/examples/BGL_LCC/distance_lcc.cpp
+++ b/BGL/examples/BGL_LCC/distance_lcc.cpp
@@ -3,7 +3,7 @@
 #include <CGAL/boost/graph/graph_traits_Linear_cell_complex_for_combinatorial_map.h>
 #include <CGAL/boost/graph/IO/polygon_mesh_io.h>
 
-#include <boost/graph/breadth_first_search.hpp>
+#include <CGAL/boost/graph/breadth_first_search.h> // wrapper to suppress a warning
 
 #include <fstream>
 

--- a/BGL/examples/BGL_LCC/kruskal_lcc.cpp
+++ b/BGL/examples/BGL_LCC/kruskal_lcc.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <list>
 
-#include <boost/graph/kruskal_min_spanning_tree.hpp>
+#include <CGAL/boost/graph/kruskal_min_spanning_tree.h>
 
 typedef CGAL::Simple_cartesian<double>              Kernel;
 typedef Kernel::Point_3                             Point;

--- a/BGL/examples/BGL_arrangement_2/arrangement_dual.cpp
+++ b/BGL/examples/BGL_arrangement_2/arrangement_dual.cpp
@@ -10,7 +10,7 @@
 #include <CGAL/Arr_face_index_map.h>
 
 #include <climits>
-#include <boost/graph/breadth_first_search.hpp>
+#include <CGAL/boost/graph/breadth_first_search.h>
 #include <boost/graph/visitors.hpp>
 
 #include "arr_print.h"

--- a/BGL/examples/BGL_polyhedron_3/distance.cpp
+++ b/BGL/examples/BGL_polyhedron_3/distance.cpp
@@ -2,7 +2,7 @@
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
 
-#include <boost/graph/breadth_first_search.hpp>
+#include <CGAL/boost/graph/breadth_first_search.h>
 
 #include <fstream>
 

--- a/BGL/examples/BGL_polyhedron_3/kruskal.cpp
+++ b/BGL/examples/BGL_polyhedron_3/kruskal.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <list>
 
-#include <boost/graph/kruskal_min_spanning_tree.hpp>
+#include <CGAL/boost/graph/kruskal_min_spanning_tree.h>
 
 
 typedef CGAL::Simple_cartesian<double>                       Kernel;

--- a/BGL/examples/BGL_polyhedron_3/kruskal_with_stored_id.cpp
+++ b/BGL/examples/BGL_polyhedron_3/kruskal_with_stored_id.cpp
@@ -5,7 +5,7 @@
 #include <iostream>
 #include <list>
 
-#include <boost/graph/kruskal_min_spanning_tree.hpp>
+#include <CGAL/boost/graph/kruskal_min_spanning_tree.h>
 
 typedef CGAL::Simple_cartesian<double>                               Kernel;
 typedef Kernel::Point_3                                              Point;

--- a/BGL/examples/BGL_surface_mesh/prim.cpp
+++ b/BGL/examples/BGL_surface_mesh/prim.cpp
@@ -4,7 +4,7 @@
 #include <iostream>
 #include <fstream>
 
-#include <boost/graph/prim_minimum_spanning_tree.hpp>
+#include <CGAL/boost/graph/prim_minimum_spanning_tree.h>
 
 typedef CGAL::Simple_cartesian<double>                       Kernel;
 typedef Kernel::Point_3                                      Point;

--- a/BGL/examples/BGL_triangulation_2/emst.cpp
+++ b/BGL/examples/BGL_triangulation_2/emst.cpp
@@ -3,7 +3,7 @@
 #include <CGAL/Delaunay_triangulation_2.h>
 #include <CGAL/boost/graph/graph_traits_Delaunay_triangulation_2.h>
 
-#include <boost/graph/kruskal_min_spanning_tree.hpp>
+#include <CGAL/boost/graph/kruskal_min_spanning_tree.h>
 
 #include <fstream>
 #include <iostream>

--- a/BGL/examples/BGL_triangulation_2/emst_cdt_plus_hierarchy.cpp
+++ b/BGL/examples/BGL_triangulation_2/emst_cdt_plus_hierarchy.cpp
@@ -9,7 +9,7 @@
 #include <CGAL/boost/graph/graph_traits_Constrained_triangulation_plus_2.h>
 #include <CGAL/boost/graph/graph_traits_Triangulation_hierarchy_2.h>
 
-#include <boost/graph/kruskal_min_spanning_tree.hpp>
+#include <CGAL/boost/graph/kruskal_min_spanning_tree.h>
 
 #include <fstream>
 #include <iostream>

--- a/BGL/examples/BGL_triangulation_2/emst_regular.cpp
+++ b/BGL/examples/BGL_triangulation_2/emst_regular.cpp
@@ -4,7 +4,7 @@
 #include <CGAL/boost/graph/graph_traits_Regular_triangulation_2.h>
 
 #include <boost/property_map/function_property_map.hpp>
-#include <boost/graph/kruskal_min_spanning_tree.hpp>
+#include <CGAL/boost/graph/kruskal_min_spanning_tree.h>
 
 #include <fstream>
 #include <iostream>

--- a/BGL/include/CGAL/boost/graph/alpha_expansion_graphcut.h
+++ b/BGL/include/CGAL/boost/graph/alpha_expansion_graphcut.h
@@ -27,10 +27,19 @@
 
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/compressed_sparse_row_graph.hpp>
+
+#if defined(BOOST_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable:4172) // Address boost_1_67_0\boost\graph\named_function_params.hpp(240): warning C4172: returning address of local variable or temporary
+#endif
+
 #include <boost/graph/boykov_kolmogorov_max_flow.hpp>
 
-#include <vector>
+#if defined(BOOST_MSVC)
+#  pragma warning(pop)
+#endif
 
+#include <vector>
 
 
 

--- a/BGL/include/CGAL/boost/graph/breadth_first_search.h
+++ b/BGL/include/CGAL/boost/graph/breadth_first_search.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014  GeometryFactory (France).  All rights reserved.
+// Copyright (c) 2021  GeometryFactory (France).  All rights reserved.
 //
 // This file is part of CGAL (www.cgal.org)
 //
@@ -9,9 +9,8 @@
 //
 // Author(s)     : Sebastien Loriot
 
-
-#ifndef CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATHS_H
-#define CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATHS_H
+#ifndef CGAL_BOOST_GRAPH_BREADTH_FIRST_SEARCH_H
+#define CGAL_BOOST_GRAPH_BREADTH_FIRST_SEARCH_H
 
 // This will push/pop a VC++ warning
 #include <CGAL/Named_function_parameters.h>
@@ -21,10 +20,10 @@
 #  pragma warning(disable:4172) // Address warning inside boost named parameters
 #endif
 
-#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <boost/graph/breadth_first_search.hpp>
 
 #if defined(BOOST_MSVC)
 #  pragma warning(pop)
 #endif
 
-#endif // CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATHS_H
+#endif // CGAL_BOOST_GRAPH_BREADTH_FIRST_SEARCH_H

--- a/BGL/include/CGAL/boost/graph/dijkstra_shortest_paths.h
+++ b/BGL/include/CGAL/boost/graph/dijkstra_shortest_paths.h
@@ -15,6 +15,16 @@
 
 // This will push/pop a VC15 warning
 #include <CGAL/Named_function_parameters.h>
+
+#if defined(BOOST_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable:4172) // Address warning inside boost named parameters
+#endif
+
 #include <boost/graph/dijkstra_shortest_paths.hpp>
+
+#if defined(BOOST_MSVC)
+#  pragma warning(pop)
+#endif
 
 #endif // CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATHS_H

--- a/BGL/include/CGAL/boost/graph/kruskal_min_spanning_tree.h
+++ b/BGL/include/CGAL/boost/graph/kruskal_min_spanning_tree.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014  GeometryFactory (France).  All rights reserved.
+// Copyright (c) 2021  GeometryFactory (France).  All rights reserved.
 //
 // This file is part of CGAL (www.cgal.org)
 //
@@ -9,9 +9,8 @@
 //
 // Author(s)     : Sebastien Loriot
 
-
-#ifndef CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATHS_H
-#define CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATHS_H
+#ifndef CGAL_BOOST_GRAPH_KRUSKAL_MIN_SPANNING_TREE_H
+#define CGAL_BOOST_GRAPH_KRUSKAL_MIN_SPANNING_TREE_H
 
 // This will push/pop a VC++ warning
 #include <CGAL/Named_function_parameters.h>
@@ -21,10 +20,10 @@
 #  pragma warning(disable:4172) // Address warning inside boost named parameters
 #endif
 
-#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <boost/graph/kruskal_min_spanning_tree.hpp>
 
 #if defined(BOOST_MSVC)
 #  pragma warning(pop)
 #endif
 
-#endif // CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATHS_H
+#endif // CGAL_BOOST_GRAPH_KRUSKAL_MIN_SPANNING_TREE_H

--- a/BGL/include/CGAL/boost/graph/prim_minimum_spanning_tree.h
+++ b/BGL/include/CGAL/boost/graph/prim_minimum_spanning_tree.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2014  GeometryFactory (France).  All rights reserved.
+// Copyright (c) 2021  GeometryFactory (France).  All rights reserved.
 //
 // This file is part of CGAL (www.cgal.org)
 //
@@ -9,9 +9,8 @@
 //
 // Author(s)     : Sebastien Loriot
 
-
-#ifndef CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATHS_H
-#define CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATHS_H
+#ifndef CGAL_BOOST_GRAPH_PRIM_MINIMUM_SPANNING_TREE_H
+#define CGAL_BOOST_GRAPH_PRIM_MINIMUM_SPANNING_TREE_H
 
 // This will push/pop a VC++ warning
 #include <CGAL/Named_function_parameters.h>
@@ -21,10 +20,10 @@
 #  pragma warning(disable:4172) // Address warning inside boost named parameters
 #endif
 
-#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <boost/graph/prim_minimum_spanning_tree.hpp>
 
 #if defined(BOOST_MSVC)
 #  pragma warning(pop)
 #endif
 
-#endif // CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATHS_H
+#endif // CGAL_BOOST_GRAPH_PRIM_MINIMUM_SPANNING_TREE_H

--- a/Point_set_processing_3/include/CGAL/mst_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/mst_orient_normals.h
@@ -32,10 +32,23 @@
 #include <climits>
 #include <math.h>
 
+#if defined(BOOST_MSVC)
+#  pragma warning(push)
+#  pragma warning(disable:4172) // Address warning inside boost named parameters
+#endif
+
 #include <CGAL/property_map.h>
 #include <boost/graph/adjacency_list.hpp>
-#include <CGAL/boost/graph/dijkstra_shortest_paths.h> // work around a bug in boost 1.54
+#include <CGAL/boost/graph/dijkstra_shortest_paths.h> // work around a
+                                                      // bug in boost
+                                                      // 1.54
+
+
 #include <boost/graph/prim_minimum_spanning_tree.hpp>
+
+#if defined(BOOST_MSVC)
+#  pragma warning(pop)
+#endif
 
 namespace CGAL {
 

--- a/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
+++ b/Surface_mesh_approximation/include/CGAL/Variational_shape_approximation.h
@@ -31,7 +31,7 @@
 
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/adjacency_list.hpp>
-#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <CGAL/boost/graph/dijkstra_shortest_paths.h>
 #include <boost/graph/subgraph.hpp>
 #include <boost/optional.hpp>
 

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/orbifold_shortest_path.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/orbifold_shortest_path.h
@@ -18,7 +18,7 @@
 
 #include <CGAL/assertions.h>
 
-#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <CGAL/boost/graph/dijkstra_shortest_paths.h>
 #include <boost/graph/graph_traits.hpp>
 
 #include <unordered_map>


### PR DESCRIPTION
## Summary of Changes

Address a warning in many VC++ testsuites concerning a boost file. For example in the [BGL ](https://cgal.geometryfactory.com/CGAL/testsuite/results-5.5-I-74.shtml#BGL) package.

## Release Management

* Affected package(s): BGL

