### PR TITLE
Fix deprecation warning

### DIFF
--- a/Shape_regularization/include/CGAL/Shape_regularization/internal/Contour_base_2.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/internal/Contour_base_2.h
@@ -752,7 +752,7 @@ namespace internal {
       const Line_2& line_2,
       Point_2& in_point) const {
 
-      typename std::result_of<Intersect_2(Line_2, Line_2)>::type result
+      typename CGAL::cpp11::result_of<Intersect_2(Line_2, Line_2)>::type result
       = CGAL::intersection(line_1, line_2);
       if (result) {
         if (const Line_2* line = boost::get<Line_2>(&*result)) {


### PR DESCRIPTION
Fix [this warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.5-Ic-77/Shape_regularization/TestReport_Sosno_MSVC-2022-Preview-Release.gz)