### PR TITLE
Use sizeof(void*) divisor in Void_handle_hash_function

### DIFF
--- a/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
@@ -22,7 +22,7 @@ namespace CGAL {
 
 struct Void_handle_hash_function {
     std::size_t operator() (void* h) const {
-        return std::size_t(h);
+        return std::size_t(h)/sizeof(void*);
     }
 };
 

--- a/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
@@ -20,6 +20,10 @@
 
 namespace CGAL {
 
+/* Since Void_handle_hash_function should work
+   when the pointee is multiple different handle
+   types the greatest common divisor is the size
+   of a pointer i.e. sizeof(void*) */
 struct Void_handle_hash_function {
     std::size_t operator() (void* h) const {
         return std::size_t(h)/sizeof(void*);


### PR DESCRIPTION
## Summary of Changes

This replaces #6501 . Since no two addresses can be closer than sizeof(void*) apart the address can be divided by at least sizeof(void*), A Handle class that wraps a pointer in the Generic_handle_map is usually this size, but if it's bigger then dividing by a smaller size is ok. It was also suggested to go further and divide the address of the handle by the size of the pointee, which would in theory provide a better distribution in the hashmap, however this doesn't work in practice, because of the way the Unique_hash_map handles collisions.

## Release Management

* Affected package(s): Nef_3, Nef_S2
* Issue(s) solved (if any): performance
* License and copyright ownership: Returned to CGAL authors.

