### PR TITLE
Convex_hull_3: Use K::Boolean and not bool

### DIFF
--- a/Convex_hull_3/include/CGAL/Convex_hull_3/dual/predicates.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/dual/predicates.h
@@ -70,7 +70,7 @@ namespace CGAL
                 typedef typename K::RT        RT;
                 typedef typename K::Plane_3   Plane_3;
                 typedef typename K::Point_3   Point_3;
-                typedef bool                  result_type;
+                typedef typename K::Boolean   result_type;
 
                 Equal_3_dual_point (Point_3 const& o = Point_3(0, 0, 0)) :
                     origin(o)
@@ -104,7 +104,7 @@ namespace CGAL
                 typedef typename K::RT        RT;
                 typedef typename K::Plane_3   Plane_3;
                 typedef typename K::Point_3   Point_3;
-                typedef bool                  result_type;
+                typedef typename K::Boolean   result_type;
 
                 Collinear_3_dual_point (Point_3 const& o = Point_3(0, 0, 0)) :
                     origin(o)
@@ -151,7 +151,7 @@ namespace CGAL
                 typedef typename K::RT        RT;
                 typedef typename K::Plane_3   Plane_3;
                 typedef typename K::Point_3   Point_3;
-                typedef bool                  result_type;
+                typedef typename K::Boolean   result_type;
 
                 Coplanar_3_dual_point (Point_3 const& o = Point_3(0, 0, 0)) :
                     origin(o)
@@ -200,8 +200,8 @@ namespace CGAL
             {
                 typedef typename K::RT         RT;
                 typedef typename K::Plane_3    Plane_3;
-                typedef typename K::Point_3   Point_3;
-                typedef bool                   result_type;
+                typedef typename K::Point_3    Point_3;
+                typedef typename K::Boolean    result_type;
 
                 Has_on_positive_side_3_dual_point (Point_3 const& o =
                                                    Point_3(0, 0, 0)) :
@@ -263,7 +263,7 @@ namespace CGAL
                 typedef typename K::RT        RT;
                 typedef typename K::Plane_3   Plane_3;
                 typedef typename K::Point_3   Point_3;
-                typedef bool                  result_type;
+                typedef typename K::Boolean   result_type;
 
                 Less_distance_to_point_3_dual_point (Point_3 const& o =
                                                      Point_3(0, 0, 0)) :
@@ -312,8 +312,8 @@ namespace CGAL
             {
                 typedef typename K::RT         RT;
                 typedef typename K::Plane_3    Plane_3;
-                typedef typename K::Point_3   Point_3;
-                typedef bool                   result_type;
+                typedef typename K::Point_3    Point_3;
+                typedef typename K::Boolean    result_type;
 
                 Less_signed_distance_to_plane_3_dual_point (Point_3 const& o =
                                                             Point_3(0, 0, 0)) :
@@ -377,7 +377,7 @@ namespace CGAL
             {
                 typedef typename K::RT         RT;
                 typedef typename K::Plane_3    Plane_3;
-                typedef typename K::Point_3   Point_3;
+                typedef typename K::Point_3    Point_3;
                 typedef CGAL::Oriented_side    result_type;
 
                 Oriented_side_3_dual_point (Point_3 const& o =
@@ -449,4 +449,3 @@ namespace CGAL
 } // namespace CGAL
 
 #endif // CGAL_CH3_DUAL_PREDICATES_H
-

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -3323,8 +3323,8 @@ namespace CommonKernelFunctors {
       return c.rep().has_on_bounded_side(p);
     }
 
-    bool operator()(const Sphere_3& s1, const Sphere_3& s2,
-                    const Point_3& a, const Point_3& b) const
+    result_type operator()(const Sphere_3& s1, const Sphere_3& s2,
+                           const Point_3& a, const Point_3& b) const
     {
       typedef typename K::Circle_3  Circle_3;
       typedef typename K::Point_3   Point_3;


### PR DESCRIPTION
## Summary of Changes

As the predicates are used with a kernel that may return an `Uncertain`  we must use `K::Boolean` instead of `bool`.
This fixes the 'N' we can see in the VC2015 [Convex_hull_3 ](https://cgal.geometryfactory.com/CGAL/testsuite/results-5.5-I-79.shtml#Convex_hull_3) testsuite. 

## Release Management

* Affected package(s): Convex_hull_3

