### PR TITLE
PLY: Support writing per-face/vertex property lists

### DIFF
--- a/Point_set_3/include/CGAL/Point_set_3/IO/PLY.h
+++ b/Point_set_3/include/CGAL/Point_set_3/IO/PLY.h
@@ -545,7 +545,7 @@ bool write_PLY(std::ostream& os,
       if(okay)
       {
         os << "property char " << prop[i] << std::endl;
-        printers.push_back(new internal::Char_property_printer<Index,Int8_map>(pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Int8_map>(pmap));
         continue;
       }
     }
@@ -555,7 +555,7 @@ bool write_PLY(std::ostream& os,
       if(okay)
       {
         os << "property uchar " << prop[i] << std::endl;
-        printers.push_back(new internal::Char_property_printer<Index,Uint8_map>(pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Uint8_map>(pmap));
         continue;
       }
     }

--- a/Stream_support/include/CGAL/IO/PLY/PLY_writer.h
+++ b/Stream_support/include/CGAL/IO/PLY/PLY_writer.h
@@ -298,6 +298,42 @@ public:
   }
 };
 
+
+template <typename Index,
+          typename PropertyMap,
+          typename VectorType = typename boost::property_traits<PropertyMap>::value_type,
+          typename ElementType = typename VectorType::value_type>
+class Simple_property_vector_printer
+  : public Abstract_property_printer<Index>
+{
+  PropertyMap m_pmap;
+public:
+  Simple_property_vector_printer(const PropertyMap& pmap) : m_pmap(pmap) { }
+
+  virtual void print(std::ostream& stream, const Index& index)
+  {
+    const VectorType& vec = get(m_pmap, index);
+    if(get_mode(stream) == CGAL::IO::ASCII)
+    {
+      stream << vec.size();
+      for(const ElementType& v : vec)
+      {
+        stream << " " << v;
+      }
+    }
+    else
+    {
+      unsigned char size = (unsigned char)(vec.size());
+      stream.write(reinterpret_cast<char*>(&size), sizeof(size));
+      for(const ElementType& v : vec)
+      {
+        ElementType t = ElementType(v);
+        stream.write(reinterpret_cast<char*>(&t), sizeof(t));
+      }
+    }
+  }
+};
+
 } // namespace internal
 } // namespace IO
 } // namespace CGAL

--- a/Stream_support/include/CGAL/IO/PLY/PLY_writer.h
+++ b/Stream_support/include/CGAL/IO/PLY/PLY_writer.h
@@ -275,30 +275,6 @@ public:
   }
 };
 
-template <typename Index, typename PropertyMap>
-class Char_property_printer
-  : public Abstract_property_printer<Index>
-{
-  typedef typename boost::property_traits<PropertyMap>::value_type Type;
-
-  PropertyMap m_pmap;
-
-public:
-  Char_property_printer(const PropertyMap& pmap) : m_pmap(pmap) { }
-
-  virtual void print(std::ostream& stream, const Index& index)
-  {
-    if(get_mode(stream) == CGAL::IO::ASCII)
-      stream << int(get(m_pmap, index));
-    else
-    {
-      Type t = get(m_pmap, index);
-      stream.write(reinterpret_cast<char*>(&t), sizeof(t));
-    }
-  }
-};
-
-
 template <typename Index,
           typename PropertyMap,
           typename VectorType = typename boost::property_traits<PropertyMap>::value_type,

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -590,6 +590,17 @@ void fill_header(std::ostream& os, const Surface_mesh<Point>& sm,
   typedef typename SMesh::template Property_map<Simplex, boost::uint64_t> Uint64_map;
   typedef typename SMesh::template Property_map<Simplex, float>           Float_map;
   typedef typename SMesh::template Property_map<Simplex, double>          Double_map;
+  // vector types for "property list"s
+  typedef typename SMesh::template Property_map<Simplex, std::vector<boost::int8_t>>   vector_Int8_map;
+  typedef typename SMesh::template Property_map<Simplex, std::vector<boost::uint8_t>>  vector_Uint8_map;
+  typedef typename SMesh::template Property_map<Simplex, std::vector<boost::int16_t>>  vector_Int16_map;
+  typedef typename SMesh::template Property_map<Simplex, std::vector<boost::uint16_t>> vector_Uint16_map;
+  typedef typename SMesh::template Property_map<Simplex, std::vector<boost::int32_t>>  vector_Int32_map;
+  typedef typename SMesh::template Property_map<Simplex, std::vector<boost::uint32_t>> vector_Uint32_map;
+  typedef typename SMesh::template Property_map<Simplex, std::vector<boost::int64_t>>  vector_Int64_map;
+  typedef typename SMesh::template Property_map<Simplex, std::vector<boost::uint64_t>> vector_Uint64_map;
+  typedef typename SMesh::template Property_map<Simplex, std::vector<float>>           vector_Float_map;
+  typedef typename SMesh::template Property_map<Simplex, std::vector<double>>          vector_Double_map;
 
   std::vector<std::string> prop = sm.template properties<Simplex>();
 
@@ -699,6 +710,106 @@ void fill_header(std::ostream& os, const Surface_mesh<Point>& sm,
       {
         os << "property double " << name << std::endl;
         printers.push_back(new internal::Simple_property_printer<Simplex,Double_map>(pmap));
+        continue;
+      }
+    }
+    {
+      vector_Int8_map pmap;
+      boost::tie(pmap, okay) = sm.template property_map<Simplex,std::vector<boost::int8_t>>(prop[i]);
+      if(okay)
+      {
+        os << "property list uchar char " << name << std::endl;
+        printers.push_back(new internal::Simple_property_vector_printer<Simplex,vector_Int8_map>(pmap));
+        continue;
+      }
+    }
+    {
+      vector_Uint8_map pmap;
+      boost::tie(pmap, okay) = sm.template property_map<Simplex,std::vector<boost::uint8_t>>(prop[i]);
+      if(okay)
+      {
+        os << "property list uchar uchar " << name << std::endl;
+        printers.push_back(new internal::Simple_property_vector_printer<Simplex,vector_Uint8_map>(pmap));
+        continue;
+      }
+    }
+    {
+      vector_Int16_map pmap;
+      boost::tie(pmap, okay) = sm.template property_map<Simplex,std::vector<boost::int16_t>>(prop[i]);
+      if(okay)
+      {
+        os << "property list uchar short " << name << std::endl;
+        printers.push_back(new internal::Simple_property_vector_printer<Simplex,vector_Int16_map>(pmap));
+        continue;
+      }
+    }
+    {
+      vector_Uint16_map pmap;
+      boost::tie(pmap, okay) = sm.template property_map<Simplex,std::vector<boost::uint16_t>>(prop[i]);
+      if(okay)
+      {
+        os << "property list uchar ushort " << name << std::endl;
+        printers.push_back(new internal::Simple_property_vector_printer<Simplex,vector_Uint16_map>(pmap));
+        continue;
+      }
+    }
+    {
+      vector_Int32_map pmap;
+      boost::tie(pmap, okay) = sm.template property_map<Simplex,std::vector<boost::int32_t>>(prop[i]);
+      if(okay)
+      {
+        os << "property list uchar int " << name << std::endl;
+        printers.push_back(new internal::Simple_property_vector_printer<Simplex,vector_Int32_map>(pmap));
+        continue;
+      }
+    }
+    {
+      vector_Uint32_map pmap;
+      boost::tie(pmap, okay) = sm.template property_map<Simplex,std::vector<boost::uint32_t>>(prop[i]);
+      if(okay)
+      {
+        os << "property list uchar uint " << name << std::endl;
+        printers.push_back(new internal::Simple_property_vector_printer<Simplex,vector_Uint32_map>(pmap));
+        continue;
+      }
+    }
+    {
+      vector_Int64_map pmap;
+      boost::tie(pmap, okay) = sm.template property_map<Simplex,std::vector<boost::int64_t>>(prop[i]);
+      if(okay)
+      {
+        os << "property list uchar int " << name << std::endl;
+        printers.push_back(new internal::Simple_property_vector_printer<Simplex,vector_Int64_map>(pmap));
+        continue;
+      }
+    }
+    {
+      vector_Uint64_map pmap;
+      boost::tie(pmap, okay) = sm.template property_map<Simplex,std::vector<boost::uint64_t>>(prop[i]);
+      if(okay)
+      {
+        os << "property list uchar uint " << name << std::endl;
+        printers.push_back(new internal::Simple_property_vector_printer<Simplex,vector_Uint64_map>(pmap));
+        continue;
+      }
+    }
+    {
+      vector_Float_map pmap;
+      boost::tie(pmap, okay) = sm.template property_map<Simplex,std::vector<float>>(prop[i]);
+      if(okay)
+      {
+        os << "property list uchar float " << name << std::endl;
+        printers.push_back(new internal::Simple_property_vector_printer<Simplex,vector_Float_map>(pmap));
+        continue;
+      }
+    }
+    {
+      vector_Double_map pmap;
+      boost::tie(pmap, okay) = sm.template property_map<Simplex,std::vector<double>>(prop[i]);
+      if(okay)
+      {
+        os << "property list uchar double " << name << std::endl;
+        printers.push_back(new internal::Simple_property_vector_printer<Simplex,vector_Double_map>(pmap));
         continue;
       }
     }

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -626,7 +626,6 @@ template <typename Point, typename Simplex>
 void fill_header(std::ostream& os, const Surface_mesh<Point>& sm,
                  std::vector<Abstract_property_printer<Simplex>*>& printers)
 {
-  typedef Surface_mesh<Point>                                             SMesh;
   typedef std::tuple<std::int8_t, std::uint8_t,
                      std::int16_t , std::uint16_t,
                      std::int32_t , std::uint32_t,

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -615,7 +615,7 @@ void fill_header_impl(std::tuple<T,TN...>,
 
 template <std::size_t s, class Point, typename Simplex>
 void fill_header_impl(std::tuple<>,
-                      const char* const type_strings[],
+                      const char* const [],
                       const Surface_mesh<Point>&,
                       const std::string&,
                       std::ostream&,

--- a/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
@@ -43,5 +43,92 @@ int main()
 //  CGAL::IO::set_binary_mode(out);
   CGAL::IO::write_PLY(out, mesh);
 
+  // extra test for read/write of properties
+  mesh = SMesh();
+  in.close();
+  in.open(CGAL::data_file_path("meshes/colored_tetra.ply"));
+  CGAL::IO::read_PLY(in, mesh);
+  float fvalue=1001;
+  auto v_uvmap = mesh.add_property_map<SMesh::Vertex_index, std::vector<float>>("v:uv").first;
+  auto v_umap = mesh.add_property_map<SMesh::Vertex_index, float>("v:u").first;
+  auto v_vmap = mesh.add_property_map<SMesh::Vertex_index, float>("v:v").first;
+  for (SMesh::Vertex_index v : vertices(mesh))
+  {
+    v_uvmap[v]={fvalue, -fvalue};
+    v_umap[v]=fvalue;
+    v_vmap[v]=-fvalue;
+    ++fvalue;
+  }
+
+  double dvalue=2001;
+  auto f_uvmap = mesh.add_property_map<SMesh::Face_index, std::vector<double>>("f:uv").first;
+  auto f_umap = mesh.add_property_map<SMesh::Face_index, double>("f:u").first;
+  auto f_vmap = mesh.add_property_map<SMesh::Face_index, double>("f:v").first;
+  for (SMesh::Face_index f : faces(mesh))
+  {
+    f_uvmap[f]={dvalue, -dvalue};
+    f_umap[f]=dvalue;
+    f_vmap[f]=-dvalue;
+    ++dvalue;
+  }
+
+  out.close();
+  out.open("out_ascii.ply");
+  CGAL::IO::write_PLY(out, mesh);
+  out.close();
+  out.open("out_binary.ply");
+  CGAL::IO::set_binary_mode(out);
+  CGAL::IO::write_PLY(out, mesh);
+  out.close();
+  mesh.clear();
+
+  const std::array<std::string,2> fnames = {"out_ascii.ply", "out_binary.ply"};
+  for (std::string fn : fnames)
+  {
+    std::cout << "Reading " << fn << "\n";
+    in.close();
+    in.open(fn);
+    SMesh mesh_bis;
+    CGAL::IO::read_PLY(in, mesh_bis);
+
+    assert((mesh_bis.property_map<SMesh::Vertex_index, float>("v:u").second));
+    assert((mesh_bis.property_map<SMesh::Vertex_index, float>("v:v").second));
+    assert((mesh_bis.property_map<SMesh::Vertex_index, std::vector<float>>("v:uv").second));
+
+    v_uvmap = mesh_bis.property_map<SMesh::Vertex_index, std::vector<float>>("v:uv").first;
+    v_umap = mesh_bis.property_map<SMesh::Vertex_index, float>("v:u").first;
+    v_vmap = mesh_bis.property_map<SMesh::Vertex_index, float>("v:v").first;
+
+    fvalue=1001;
+    for (SMesh::Vertex_index v : vertices(mesh_bis))
+    {
+      assert(v_uvmap[v].size()==2);
+      assert(v_uvmap[v][0]==fvalue);
+      assert(v_uvmap[v][1]==-fvalue);
+      assert(v_umap[v]==fvalue);
+      assert(v_vmap[v]==-fvalue);
+      ++fvalue;
+    }
+
+    assert((mesh_bis.property_map<SMesh::Face_index, double>("f:u").second));
+    assert((mesh_bis.property_map<SMesh::Face_index, double>("f:v").second));
+    assert((mesh_bis.property_map<SMesh::Face_index, std::vector<double>>("f:uv").second));
+
+    f_uvmap = mesh_bis.property_map<SMesh::Face_index, std::vector<double>>("f:uv").first;
+    f_umap = mesh_bis.property_map<SMesh::Face_index, double>("f:u").first;
+    f_vmap = mesh_bis.property_map<SMesh::Face_index, double>("f:v").first;
+
+    dvalue=2001;
+    for (SMesh::Face_index f : faces(mesh_bis))
+    {
+      assert(f_uvmap[f].size()==2);
+      assert(f_uvmap[f][0]==dvalue);
+      assert(f_uvmap[f][1]==-dvalue);
+      assert(f_umap[f]==dvalue);
+      assert(f_vmap[f]==-dvalue);
+      ++dvalue;
+    }
+  }
+
   return 0;
 }


### PR DESCRIPTION
## Summary of Changes

Hi, I'd like to contribute the writing of PLY property lists.

This allows to directly write multi-texture PLY files with CGAL that can be opened directly in e.g. MeshLab, as well as other use cases that require `property list`.

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

