### PR TITLE
Arrangement_on_surface_2: unknown attribute compact specified

### DIFF
--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
@@ -6241,7 +6241,7 @@ face, respectively, \f$v_b\f$, \f$e_b\f$, and \f$f_b\f$ denote input
 <span style="color:blue;">blue</span> features, and \f$v\f$, \f$e\f$,
 and \f$f\f$ denote output features.
 
-<OL compact>
+<OL>
 
 <LI> A new vertex \f$v\f$ is induced by coinciding vertices
 \f$v_r\f$ and \f$v_b\f$.</LI>


### PR DESCRIPTION
The `<OL>` tag has no attribute `compact`.
- only the HTML tag `<menu>` has the `compact` attribute according to https://www.w3schools.com/tags/att_menu_compact.asp but it is not supported in any major browser.
- according to https://www.geeksforgeeks.org/html-ol-compact-attribute/ the `<OL>` tag can have a `compact` attribute but it is not supported by any any major browser.



