### PR TITLE
PMP: Fast clipping with a plane

### DIFF
--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
@@ -54,6 +54,7 @@ if(TARGET CGAL::Eigen3_support)
   target_link_libraries(mesh_smoothing_example PUBLIC CGAL::Eigen3_support)
 endif()
 
+create_single_source_cgal_program( "clip_example.cpp" )
 create_single_source_cgal_program( "extrude.cpp" )
 create_single_source_cgal_program( "polyhedral_envelope.cpp" )
 create_single_source_cgal_program( "polyhedral_envelope_of_triangle_soup.cpp" )

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/clip_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/clip_example.cpp
@@ -1,8 +1,9 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polygon_mesh_processing/clip.h>
 #include <CGAL/Surface_mesh.h>
+#include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
 #include <CGAL/boost/graph/generators.h>
-
+#include <CGAL/Timer.h>
 #include <boost/property_map/property_map.hpp>
 
 #include <iostream>
@@ -16,16 +17,32 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Surface_mesh<K::Point_3> Surface_mesh;
 typedef K::Point_3 Point_3;
 
-int main()
+int main(int argc, char* argv[])
 {
-  Surface_mesh tet, tri;
 
-  CGAL::make_tetrahedron(Point_3(0,0,0), Point_3(10,0,0), Point_3(0, 10,0), Point_3(0,0,10), tet);
+    const std::string filename1 = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/blobby.off");
+    const std::string filename2 = (argc > 2) ? argv[2] : CGAL::data_file_path("meshes/eight.off");
+    Surface_mesh tet, tri;
+    
+    if (!PMP::IO::read_polygon_mesh(filename1, tet) || !PMP::IO::read_polygon_mesh(filename2, tri))
+    {
+        std::cerr << "Invalid input." << std::endl;
+        return 1;
+    }
 
-  CGAL::make_triangle(Point_3(-1, -1, 1), Point_3(11, -1, 1), Point_3(-1, 11,1), tri);
+  
 
+ // CGAL::make_tetrahedron(Point_3(0,0,0), Point_3(10,0,0), Point_3(0, 10,0), Point_3(0,0,10), tet);
+
+  //CGAL::make_triangle(Point_3(-1, -1, 1), Point_3(11, -1, 1), Point_3(-1, 11,1), tri);
+
+    CGAL::Timer t;
+    t.start();
   PMP::clip(tet, tri);
-  std::cout << tet << std::endl;
+  std::cout << t.time() << " sec." << std::endl;
+  std::ofstream out("out.off");
+  out.precision(17);
+  out << tet << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/clip_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/clip_example.cpp
@@ -1,0 +1,31 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/clip.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/boost/graph/generators.h>
+
+#include <boost/property_map/property_map.hpp>
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+
+namespace PMP = CGAL::Polygon_mesh_processing;
+namespace params = CGAL::parameters;
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef CGAL::Surface_mesh<K::Point_3> Surface_mesh;
+typedef K::Point_3 Point_3;
+
+int main()
+{
+  Surface_mesh tet, tri;
+
+  CGAL::make_tetrahedron(Point_3(0,0,0), Point_3(10,0,0), Point_3(0, 10,0), Point_3(0,0,10), tet);
+
+  CGAL::make_triangle(Point_3(-1, -1, 1), Point_3(11, -1, 1), Point_3(-1, 11,1), tri);
+
+  PMP::clip(tet, tri);
+  std::cout << tet << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/clip_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/clip_example.cpp
@@ -23,14 +23,14 @@ int main(int argc, char* argv[])
     const std::string filename1 = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/blobby.off");
     const std::string filename2 = (argc > 2) ? argv[2] : CGAL::data_file_path("meshes/eight.off");
     Surface_mesh tet, tri;
-    
+
     if (!PMP::IO::read_polygon_mesh(filename1, tet) || !PMP::IO::read_polygon_mesh(filename2, tri))
     {
         std::cerr << "Invalid input." << std::endl;
         return 1;
     }
 
-  
+
 
  // CGAL::make_tetrahedron(Point_3(0,0,0), Point_3(10,0,0), Point_3(0, 10,0), Point_3(0,0,10), tet);
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_callbacks.h
@@ -104,9 +104,8 @@ public:
   , coplanar_faces(coplanar_faces)
   {}
 
-  void operator()( const Box& face_box, const Box& edge_box) const {
-    halfedge_descriptor fh = face_box.info();
-    halfedge_descriptor eh = edge_box.info();
+  void operator()( halfedge_descriptor fh, halfedge_descriptor eh) const
+  {
     if(is_border(eh,tm_edges)) eh = opposite(eh, tm_edges);
 
     //check if the segment intersects the plane of the facet or if it is included in the plane
@@ -144,6 +143,10 @@ public:
     }
     // non-coplanar case
     edge_to_faces[edge(eh,tm_edges)].insert(face(fh, tm_faces));
+  }
+
+  void operator()(const Box& face_box, const Box& edge_box) const {
+      operator()(face_box.info(), edge_box.info());
   }
 
   void operator()(const Box* face_box_ptr, const Box* edge_box_ptr) const

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -263,11 +263,16 @@ class Intersection_of_triangle_meshes
           Edge_to_faces& edge_to_faces = &tm_e < &tm_f
               ? stm_edge_to_ltm_faces
               : ltm_edge_to_stm_faces;
+#ifdef DO_NOT_HANDLE_COPLANAR_FACES
+           typedef Collect_face_bbox_per_edge_bbox<TriangleMesh, Edge_to_faces> Callback;
+           Callback callback(tm_f, tm_e, edge_to_faces);
+#else
+
           typedef Collect_face_bbox_per_edge_bbox_with_coplanar_handling<
               TriangleMesh, VPMF, VPME, Edge_to_faces, Coplanar_face_set>
               Callback;
           Callback  callback(tm_f, tm_e, vpm_f, vpm_e, edge_to_faces, coplanar_faces);
-
+#endif
           for (edge_descriptor e : edges(tm_e))
           {
               vertex_descriptor src = source(e, tm_e), tgt = target(e, tm_e);


### PR DESCRIPTION
## Summary of Changes

When we clip with a plane no need for fast box intersection.

This is work in progress as there is no clean API.   I even break the code, as we encode the plane as a mesh with just one triangle. 

## Release Management

* Affected package(s): PMP
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: unchanged

