### PR TITLE
Polyline simplification: Use const&  in demo instead of copying a polygon

### DIFF
--- a/Polyline_simplification_2/demo/Polyline_simplification_2/Polyline_simplification_2.cpp
+++ b/Polyline_simplification_2/demo/Polyline_simplification_2/Polyline_simplification_2.cpp
@@ -397,7 +397,7 @@ void MainWindow::loadWKT(QString fileName)
       m_pct.insert_constraint(poly.begin(), poly.end());
     }
   }
- for(Polygon_with_holes_2 poly : polygons){
+ for(const Polygon_with_holes_2& poly : polygons){
    m_pct.insert_constraint(poly.outer_boundary().vertices_begin(), poly.outer_boundary().vertices_end());
    for(Polygon_with_holes_2::Hole_const_iterator it = poly.holes_begin(); it != poly.holes_end(); ++it){
      const Polygon_2& hole = *it;


### PR DESCRIPTION
## Summary of Changes

cleaning code

## Release Management

* Affected package(s): Polyline_simplification
