### PR TITLE
Polyhedron_3: Fix saving a polyline as part of a scene

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/Polylines_io_plugin.cpp
@@ -62,7 +62,7 @@ public:
 
     }
   QString name() const override{ return "polylines_io_plugin"; }
-  QString nameFilters() const override{ return "Polylines files (*.polylines.txt *.cgal)"; }
+  QString nameFilters() const override{ return "Polylines files (*.polylines.txt);; CGAL Polylines files (*.cgal)"; }
   bool canLoad(QFileInfo fileinfo) const override;
   QList<Scene_item*> load(QFileInfo fileinfo, bool& ok, bool add_to_scene=true) override;
 


### PR DESCRIPTION
## Summary of Changes

A scene cannot be saved as `.js` file when it contains a polyline item.

## Release Management

* Affected package(s):  Polyhedron demo

