### PR TITLE
Polygon: Add move semantics

### DIFF
--- a/Polygon/include/CGAL/General_polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/General_polygon_with_holes_2.h
@@ -127,10 +127,10 @@ protected:
 //                          operator<<
 //-----------------------------------------------------------------------//
 /*!
-This operator exports a General_polygon_with_holes_2 to the output stream `out`.
+This operator exports a `General_polygon_with_holes_2` to the output stream `os`.
 
 An \ascii and a binary format exist. The format can be selected with
-the \cgal modifiers for streams, `set_ascii_mode(0` and `set_binary_mode()`
+the \cgal modifiers for streams, `set_ascii_mode()` and `set_binary_mode()`,
 respectively. The modifier `set_pretty_mode()` can be used to allow for (a
 few) structuring comments in the output. Otherwise, the output would
 be free of comments. The default for writing is \ascii without comments.
@@ -178,9 +178,9 @@ operator<<(std::ostream& os, const General_polygon_with_holes_2<Polygon_>& p) {
 //-----------------------------------------------------------------------//
 
 /*!
-This operator imports a General_polygon_with_holes_2 from the input stream `in`.
+This operator imports a `General_polygon_with_holes_2` from the input stream `is`.
 
-Both ASCII and binary formats are supported, and the format is automatically detected.
+Both \ascii and binary formats are supported, and the format is automatically detected.
 
 The format consists of the number of curves of the outer boundary
 followed by the curves themselves, followed

--- a/Polygon/include/CGAL/General_polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/General_polygon_with_holes_2.h
@@ -63,11 +63,23 @@ public:
     m_pgn(pgn_boundary)
   {}
 
+  explicit General_polygon_with_holes_2(Polygon_2&& pgn_boundary) :
+    m_pgn(std::move(pgn_boundary))
+  {}
+
   template <typename HolesInputIterator>
   General_polygon_with_holes_2(const Polygon_2& pgn_boundary,
                                HolesInputIterator h_begin,
                                HolesInputIterator h_end) :
     m_pgn(pgn_boundary),
+    m_holes(h_begin, h_end)
+  {}
+
+  template <typename HolesInputIterator>
+  General_polygon_with_holes_2(Polygon_2&& pgn_boundary,
+                               HolesInputIterator h_begin,
+                               HolesInputIterator h_end) :
+    m_pgn(std::move(pgn_boundary)),
     m_holes(h_begin, h_end)
   {}
 
@@ -90,6 +102,8 @@ public:
   const Polygon_2& outer_boundary() const { return m_pgn; }
 
   void add_hole(const Polygon_2& pgn_hole) { m_holes.push_back(pgn_hole); }
+
+  void add_hole(Polygon_2&& pgn_hole) { m_holes.emplace_back(std::move(pgn_hole)); }
 
   void erase_hole(Hole_iterator hit) { m_holes.erase(hit); }
 
@@ -187,7 +201,7 @@ operator>>(std::istream& is, General_polygon_with_holes_2<Polygon_>& p) {
     Polygon_ pgn_hole;
     for (unsigned int i=0; i<n_holes; ++i) {
       is >> pgn_hole;
-      p.add_hole(pgn_hole);
+      p.add_hole(std::move(pgn_hole));
     }
   }
 

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -163,6 +163,9 @@ class Polygon_2 {
     Polygon_2(const Polygon_2<Traits_P,Container_P>& polygon)
       : d_container(polygon.d_container), traits(polygon.traits) {}
 
+    Polygon_2(Polygon_2<Traits_P,Container_P>&& polygon)
+      : d_container(std::move(polygon.d_container)), traits(polygon.traits) {}
+
     /// Creates a polygon with vertices from the sequence
     /// defined by the range \c [first,last).
     /// The value type of \c InputIterator must be \c Point_2.
@@ -174,6 +177,10 @@ class Polygon_2 {
 
 #ifndef DOXYGEN_RUNNING
   Polygon_2& operator=(const Polygon_2&)=default;
+  Polygon_2& operator=(Polygon_2&& p)
+  {
+    d_container = std::move(p.d_container);
+  }
 #endif
 
     /// @}

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -577,7 +577,7 @@ operator!=(const Polygon_2<Traits_P,Container1_P> &p1,
            const Polygon_2<Traits_P,Container2_P> &p2);
 
 /// Returns the image of the polygon \c p under the transformation \c t.
-/// \memberof Polygon_2
+/// \relates Polygon_2
 template <class Transformation, class Traits_P, class Container_P>
 Polygon_2<Traits_P,Container_P>
 transform(const Transformation& t, const Polygon_2<Traits_P,Container_P>& p);
@@ -591,13 +591,13 @@ transform(const Transformation& t, const Polygon_2<Traits_P,Container_P>& p);
 
 /// Reads a polygon from stream `is` and assigns it to `p`.
 /// \pre The extract operator must be defined for `Point_2`.
-/// \memberof Polygon_2
+/// \relates Polygon_2
 template <class Traits_P, class Container_P>
 std::istream &operator>>(std::istream &is, Polygon_2<Traits_P,Container_P>& p);
 
 /// Inserts the polygon `p` into the stream `os`.
 /// \pre The insert operator must be defined for `Point_2`.
-/// \memberof Polygon_2
+/// \relates Polygon_2
 template <class Traits_P, class Container_P>
 std::ostream &operator<<(std::ostream &os, const Polygon_2<Traits_P,Container_P>& p);
 

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -163,6 +163,7 @@ class Polygon_2 {
     Polygon_2(const Polygon_2<Traits_P,Container_P>& polygon)
       : d_container(polygon.d_container), traits(polygon.traits) {}
 
+    /// Move constructor
     Polygon_2(Polygon_2<Traits_P,Container_P>&& polygon)
       : d_container(std::move(polygon.d_container)), traits(polygon.traits) {}
 

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -181,6 +181,7 @@ class Polygon_2 {
   Polygon_2& operator=(Polygon_2&& p)
   {
     d_container = std::move(p.d_container);
+    return *this;
   }
 #endif
 

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -42,11 +42,11 @@
 namespace CGAL {
 
 /// \ingroup PkgPolygon2Ref
-/// The class Polygon_2 implements polygons. The Polygon_2 is
+/// The class `Polygon_2` implements polygons. The `Polygon_2` is
 /// parameterized by a traits class and a container class.  The latter
 /// can be any class that fulfills the requirements for an STL
-/// container, and has a function `resize()` that takes an std::size_t as argument
-///  . It defaults to the std::vector class.
+/// container, and has a function `resize()` that takes an `std::size_t` as argument.
+/// It defaults to the `std::vector` class.
 ///
 /// \cgalHeading{Implementation}
 ///
@@ -165,7 +165,10 @@ class Polygon_2 {
 
     /// Move constructor
     Polygon_2(Polygon_2<Traits_P,Container_P>&& polygon)
-      : d_container(std::move(polygon.d_container)), traits(polygon.traits) {}
+      : d_container(std::move(polygon.d_container)), traits(polygon.traits)
+    {
+        CGAL_assertion(polygon.is_empty());
+    }
 
     /// Creates a polygon with vertices from the sequence
     /// defined by the range \c [first,last).

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -154,21 +154,16 @@ class Polygon_2 {
     /// @{
 
     /// Creates an empty polygon.
-    Polygon_2() : traits() {}
+    Polygon_2() = default;
 
     /// Creates an empty polygon.
     Polygon_2(const Traits & p_traits) : traits(p_traits) {}
 
     /// Copy constructor.
-    Polygon_2(const Polygon_2<Traits_P,Container_P>& polygon)
-      : d_container(polygon.d_container), traits(polygon.traits) {}
+    Polygon_2(const Polygon_2<Traits_P,Container_P>& polygon) = default;
 
     /// Move constructor
-    Polygon_2(Polygon_2<Traits_P,Container_P>&& polygon)
-      : d_container(std::move(polygon.d_container)), traits(polygon.traits)
-    {
-        CGAL_assertion(polygon.is_empty());
-    }
+    Polygon_2(Polygon_2<Traits_P,Container_P>&& polygon) = default;
 
     /// Creates a polygon with vertices from the sequence
     /// defined by the range \c [first,last).
@@ -180,12 +175,8 @@ class Polygon_2 {
     {}
 
 #ifndef DOXYGEN_RUNNING
-  Polygon_2& operator=(const Polygon_2&)=default;
-  Polygon_2& operator=(Polygon_2&& p)
-  {
-    d_container = std::move(p.d_container);
-    return *this;
-  }
+  Polygon_2& operator=(const Polygon_2&) = default;
+  Polygon_2& operator=(Polygon_2&& p) = default;
 #endif
 
     /// @}

--- a/Polygon/include/CGAL/Polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/Polygon_with_holes_2.h
@@ -63,6 +63,7 @@ public:
     Base (pgn_boundary)
   {}
 
+  /*! Move constructor */
   explicit Polygon_with_holes_2 (Polygon_2&& pgn_boundary) :
     Base (std::move(pgn_boundary))
   {}
@@ -75,6 +76,10 @@ public:
     Base (pgn_boundary, h_begin, h_end)
   {}
 
+  /*! Move constructor.
+   * \note In order to move the hole polygons a
+   * `std::move_iterator` can be used.
+   */
   template <class HolesInputIterator>
   Polygon_with_holes_2 (Polygon_2&& pgn_boundary,
                         HolesInputIterator h_begin,

--- a/Polygon/include/CGAL/Polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/Polygon_with_holes_2.h
@@ -91,10 +91,10 @@ public:
 //-----------------------------------------------------------------------//
 
 /*!
-This operator exports a polygon with holes to the output stream `out`.
+This operator exports a polygon with holes to the output stream `os`.
 
 An \ascii and a binary format exist. The format can be selected with
-the \cgal modifiers for streams, `set_ascii_mode()` and `set_binary_mode()`
+the \cgal modifiers for streams, `set_ascii_mode()` and `set_binary_mode()`,
 respectively. The modifier `set_pretty_mode()` can be used to allow for (a
 few) structuring comments in the output. Otherwise, the output would
 be free of comments. The default for writing is \ascii without comments.
@@ -154,9 +154,9 @@ std::ostream& operator<<(std::ostream &os,
 //-----------------------------------------------------------------------//
 
 /*!
-This operator imports a polygon with holes from the input stream `in`.
+This operator imports a polygon with holes from the input stream `is`.
 
-Both ASCII and binary formats are supported, and the format is automatically detected.
+Both \ascii and binary formats are supported, and the format is automatically detected.
 
 The format consists of the number of points of the outer boundary followed
 by the points themselves in counterclockwise order, followed by the number of holes,

--- a/Polygon/include/CGAL/Polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/Polygon_with_holes_2.h
@@ -63,12 +63,23 @@ public:
     Base (pgn_boundary)
   {}
 
+  explicit Polygon_with_holes_2 (Polygon_2&& pgn_boundary) :
+    Base (std::move(pgn_boundary))
+  {}
+
   /*! Constructor from a polygon (outer boundary) and hole polygons. */
   template <class HolesInputIterator>
   Polygon_with_holes_2 (const Polygon_2& pgn_boundary,
                         HolesInputIterator h_begin,
                         HolesInputIterator h_end) :
     Base (pgn_boundary, h_begin, h_end)
+  {}
+
+  template <class HolesInputIterator>
+  Polygon_with_holes_2 (Polygon_2&& pgn_boundary,
+                        HolesInputIterator h_begin,
+                        HolesInputIterator h_end) :
+    Base (std::move(pgn_boundary), h_begin, h_end)
   {}
 
   /*! Obtain the bounding box of the polygon with holes */
@@ -170,7 +181,7 @@ std::istream &operator>>(std::istream &is,
      {
        Polygon_2 hole;
        is >> hole;
-       p.add_hole(hole);
+       p.add_hole(std::move(hole));
      }
   }
 

--- a/Polygon/include/CGAL/Polygon_with_holes_2.h
+++ b/Polygon/include/CGAL/Polygon_with_holes_2.h
@@ -78,7 +78,7 @@ public:
 
   /*! Move constructor.
    * \note In order to move the hole polygons a
-   * `std::move_iterator` can be used.
+   * `std::move_iterator` may be used.
    */
   template <class HolesInputIterator>
   Polygon_with_holes_2 (Polygon_2&& pgn_boundary,

--- a/Polygon/test/Polygon/PolygonTest.cpp
+++ b/Polygon/test/Polygon/PolygonTest.cpp
@@ -51,6 +51,18 @@ void test_default_methods(      vector<Point>& pvec0,
 
     x=p0;
     assert(x == p0);
+
+    // move assignement and constructor
+    x.clear();
+    assert(x.is_empty());
+    x = std::move(p0);
+    assert(p0.is_empty());
+    assert(x == p0_copy);
+
+    CGAL::Polygon_2<K, list<Point> > xm(std::move(x));
+     assert(x.is_empty());
+    assert(xm == p0_copy);
+
   }
 
   {
@@ -336,4 +348,3 @@ int main()
 
   return 0;
 }
-

--- a/Polygon/test/Polygon/Polygon_with_holes_test.cpp
+++ b/Polygon/test/Polygon/Polygon_with_holes_test.cpp
@@ -1,0 +1,38 @@
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Polygon_2.h>
+#include <CGAL/Polygon_with_holes_2.h>
+
+#include <vector>
+#include <iostream>
+#include <cassert>
+#include <iterator>
+
+
+typedef CGAL::Simple_cartesian<double> K;
+typedef K::Point_2 Point;
+
+
+typedef CGAL::Polygon_2<K> Polygon_2;
+typedef CGAL::General_polygon_with_holes_2<Polygon_2> Polygon_with_holes_2;
+
+int main()
+{
+  std::array<Point,4> outer = { Point(0, 0), Point(10, 0), Point(10, 10), Point(0, 10) };
+  std::array<Point, 4> hole1 = { Point(1, 1), Point(1, 2), Point(2, 2), Point(2, 1) };
+  std::array<Point, 4> hole2 = { Point(3, 3), Point(3, 4), Point(4, 4), Point(4, 3) };
+
+  std::vector<Polygon_2> holes;
+  holes.reserve(2);
+  holes.emplace_back(hole1.begin(), hole1.end());
+  holes.emplace_back(hole2.begin(), hole2.end());
+
+  Polygon_2 pouter(outer.begin(), outer.end());
+
+  Polygon_with_holes_2 pwh(std::move(pouter), std::move_iterator<std::vector<Polygon_2>::iterator>(holes.begin()), std::move_iterator<std::vector<Polygon_2>::iterator>(holes.end()));
+
+  std::cout << pwh << std::endl;
+  assert(pouter.is_empty());
+  assert(holes[0].is_empty());
+  assert(holes[1].is_empty());
+  return 0;
+}

--- a/Polygon/test/Polygon/Polygon_with_holes_test.cpp
+++ b/Polygon/test/Polygon/Polygon_with_holes_test.cpp
@@ -13,7 +13,7 @@ typedef K::Point_2 Point;
 
 
 typedef CGAL::Polygon_2<K> Polygon_2;
-typedef CGAL::General_polygon_with_holes_2<Polygon_2> Polygon_with_holes_2;
+typedef CGAL::Polygon_with_holes_2<K> Polygon_with_holes_2;
 
 int main()
 {
@@ -30,7 +30,6 @@ int main()
 
   Polygon_with_holes_2 pwh(std::move(pouter), std::move_iterator<std::vector<Polygon_2>::iterator>(holes.begin()), std::move_iterator<std::vector<Polygon_2>::iterator>(holes.end()));
 
-  std::cout << pwh << std::endl;
   assert(pouter.is_empty());
   assert(holes[0].is_empty());
   assert(holes[1].is_empty());

--- a/Polygon/test/Polygon/Polygon_with_holes_test.cpp
+++ b/Polygon/test/Polygon/Polygon_with_holes_test.cpp
@@ -33,5 +33,13 @@ int main()
   assert(pouter.is_empty());
   assert(holes[0].is_empty());
   assert(holes[1].is_empty());
+
+  Polygon_with_holes_2 pwh_copy(pwh);
+  assert(pwh_copy == pwh);
+  Polygon_with_holes_2 pwh_move_cstructed(std::move(pwh));
+  assert(pwh.holes().empty());
+  assert(pwh.outer_boundary().is_empty());
+  Polygon_with_holes_2 pwh_move_assigned;
+  pwh_move_assigned = std::move(pwh_copy);
   return 0;
 }

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -914,6 +914,7 @@ public:
     /// Copy constructor: copies `rhs` to `*this`. Performs a deep copy of all properties.
     Surface_mesh(const Surface_mesh& rhs) { *this = rhs; }
 
+    /// Move constructor.
     Surface_mesh(Surface_mesh&& sm)
       : vprops_(std::move(sm.vprops_))
       , hprops_(std::move(sm.hprops_))
@@ -940,7 +941,7 @@ public:
     /// assigns `rhs` to `*this`. Performs a deep copy of all properties.
     Surface_mesh& operator=(const Surface_mesh& rhs);
 
-
+    /// move assignment
     Surface_mesh& operator=(Surface_mesh&& sm)
     {
       vprops_ = std::move(sm.vprops_);


### PR DESCRIPTION
## Summary of Changes

Use move semantics for `Polygon_2`  and `Polygon_with_holes_2`.   
The latter gets passed a polygon as outer boundary and an iterator range of polygons for the holes.  


## Release Management

* Affected package(s):  Polygon_2


