### PR TITLE
Polyline_simplification: Clean up examples

### DIFF
--- a/Polyline_simplification_2/examples/Polyline_simplification_2/points_and_vertices.cpp
+++ b/Polyline_simplification_2/examples/Polyline_simplification_2/points_and_vertices.cpp
@@ -1,7 +1,5 @@
 #include <iostream>
 #include <fstream>
-#include <boost/config.hpp>
-#include <boost/version.hpp>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polygon_2.h>
@@ -74,5 +72,3 @@ int main(int argc, char* argv[])
   print(ct, cid);
   return 0;
 }
-
-

--- a/Polyline_simplification_2/examples/Polyline_simplification_2/simplify.cpp
+++ b/Polyline_simplification_2/examples/Polyline_simplification_2/simplify.cpp
@@ -1,6 +1,3 @@
-#include <boost/config.hpp>
-#include <boost/version.hpp>
-
 #include <iostream>
 #include <fstream>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
@@ -56,4 +53,3 @@ int main(int argc, char* argv[])
   }
   return 0;
 }
-

--- a/Polyline_simplification_2/examples/Polyline_simplification_2/simplify_polygon.cpp
+++ b/Polyline_simplification_2/examples/Polyline_simplification_2/simplify_polygon.cpp
@@ -1,5 +1,3 @@
-#include <boost/config.hpp>
-#include <boost/version.hpp>
 #include <iostream>
 #include <fstream>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>

--- a/Polyline_simplification_2/examples/Polyline_simplification_2/simplify_polyline.cpp
+++ b/Polyline_simplification_2/examples/Polyline_simplification_2/simplify_polyline.cpp
@@ -1,11 +1,8 @@
-#include <boost/config.hpp>
-#include <boost/version.hpp>
 #include <iostream>
 #include <fstream>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polyline_simplification_2/simplify.h>
 #include <CGAL/IO/WKT.h>
-#include <list>
 #include <deque>
 
 namespace PS = CGAL::Polyline_simplification_2;


### PR DESCRIPTION
## Summary of Changes

Remove  `#include`s that are not needed.

## Release Management

* Affected package(s):  Polyline_simplification

