### PR TITLE
Poisson_surface_reconstruction_3: unknown command `@commentheading`

### DIFF
--- a/Poisson_surface_reconstruction_3/include/CGAL/IO/output_surface_facets_to_triangle_soup.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/IO/output_surface_facets_to_triangle_soup.h
@@ -26,7 +26,6 @@ namespace CGAL {
 ///
 /// This variant exports the surface as a triangle soup.
 ///
-/// @commentheading Template Parameters:
 /// @tparam OutputIteratorValueType value_type of OutputIterator.
 ///        It is default to value_type_traits<OutputIterator>::type, and can be omitted when the default is fine.
 /// @tparam SurfaceMeshComplex_2InTriangulation_3 model of the SurfaceMeshComplex_2InTriangulation_3 concept.


### PR DESCRIPTION
Found the warning:
```
output_surface_facets_to_triangle_soup.h:29: warning: Found unknown command '@commentheading'
```

Command is superfluous as the `tparam` command will provide the relevant header.

(Tested CGAL documentation with `GENERATE_XML = YES`)



