### PR TITLE
initialize some stack variables

### DIFF
--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -1076,7 +1076,7 @@ Delaunay_triangulation_3<Gt,Tds,Default,Lds>::
 insert(const Point& p, Cell_handle start, bool *could_lock_zone)
 {
   Locate_type lt;
-  int li, lj;
+  int li = 0, lj = 0;
 
   // Parallel
   if(could_lock_zone)

--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -1076,7 +1076,7 @@ Delaunay_triangulation_3<Gt,Tds,Default,Lds>::
 insert(const Point& p, Cell_handle start, bool *could_lock_zone)
 {
   Locate_type lt;
-  int li = 0, lj = 0;
+  int li = -1, lj = -1;
 
   // Parallel
   if(could_lock_zone)

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -3862,7 +3862,7 @@ Triangulation_3<GT,Tds,Lds>::
 insert(const Point& p, Cell_handle start)
 {
   Locate_type lt;
-  int li, lj;
+  int li = 0, lj = 0;
   Cell_handle c = locate(p, lt, li, lj, start);
   return insert(p, lt, c, li, lj);
 }

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -3862,7 +3862,7 @@ Triangulation_3<GT,Tds,Lds>::
 insert(const Point& p, Cell_handle start)
 {
   Locate_type lt;
-  int li = 0, lj = 0;
+  int li = -1, lj = -1;
   Cell_handle c = locate(p, lt, li, lj, start);
   return insert(p, lt, c, li, lj);
 }

--- a/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
@@ -538,7 +538,7 @@ insert(const Point &p, Cell_handle start)
 {
   int vertex_level = random_level();
   Locate_type lt;
-  int i, j;
+  int i = 0, j = 0;
   // locate using hierarchy
   locs positions[maxlevel];
   locate(p, lt, i, j, positions, start);
@@ -578,7 +578,7 @@ insert_and_give_new_cells(const Point &p, OutputItCells fit, Cell_handle start)
   Locate_type lt;
   int i, j;
   // locate using hierarchy
-  locs positions[maxlevel];
+  locs positions[maxlevel] = {0};
   locate(p, lt, i, j, positions, start);
   // insert at level 0
   Vertex_handle vertex = hierarchy[0]->insert_and_give_new_cells(p,

--- a/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
@@ -538,7 +538,7 @@ insert(const Point &p, Cell_handle start)
 {
   int vertex_level = random_level();
   Locate_type lt;
-  int i = 0, j = 0;
+  int i = -1, j = -1;
   // locate using hierarchy
   locs positions[maxlevel];
   locate(p, lt, i, j, positions, start);
@@ -578,7 +578,7 @@ insert_and_give_new_cells(const Point &p, OutputItCells fit, Cell_handle start)
   Locate_type lt;
   int i, j;
   // locate using hierarchy
-  locs positions[maxlevel] = {0};
+  locs positions[maxlevel] = {-1};
   locate(p, lt, i, j, positions, start);
   // insert at level 0
   Vertex_handle vertex = hierarchy[0]->insert_and_give_new_cells(p,

--- a/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_hierarchy_3.h
@@ -439,7 +439,7 @@ protected:
 
   struct locs {
       Cell_handle pos;
-      int li, lj;
+      int li = -1, lj = -1;
       Locate_type lt;
   };
 
@@ -578,7 +578,7 @@ insert_and_give_new_cells(const Point &p, OutputItCells fit, Cell_handle start)
   Locate_type lt;
   int i, j;
   // locate using hierarchy
-  locs positions[maxlevel] = {-1};
+  locs positions[maxlevel];
   locate(p, lt, i, j, positions, start);
   // insert at level 0
   Vertex_handle vertex = hierarchy[0]->insert_and_give_new_cells(p,


### PR DESCRIPTION
## Summary of Changes

Initialize a few stack variables.  Using clang memory sanitizer, they were detected as uninitialized in some cases.

These changes should result in no functional change (NFC).

