### PR TITLE
Linear_cell_complex: Replace call to rand() in one testcase

### DIFF
--- a/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_copy_test.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_copy_test.cpp
@@ -93,7 +93,7 @@ public:
 
 struct MonInfo
 {
-  MonInfo(long long int i=0) : mnb(i==0?rand():i),
+  MonInfo(long long int i=0) : mnb(i==0?CGAL::get_default_random().get_int(0,RAND_MAX):i),
                                ptr(reinterpret_cast<char*>(this))
   {}
   long long int mnb;


### PR DESCRIPTION
## Summary of Changes

Make the testsuite reproducible by replacing the call to `rand()`.

## Release Management

* Affected package(s): Linear_cell_complex
* Issue(s) solved (if any): related to #6579
