### PR TITLE
Fix a potential uninitialized memory error

### DIFF
--- a/Alpha_wrap_3/include/CGAL/Alpha_wrap_3/internal/Alpha_wrap_3.h
+++ b/Alpha_wrap_3/include/CGAL/Alpha_wrap_3/internal/Alpha_wrap_3.h
@@ -1050,7 +1050,7 @@ private:
         CGAL_assertion(CGAL::abs(CGAL::approximate_sqrt(m_oracle.squared_distance(steiner_point)) - m_offset) <= 1e-2 * m_offset);
 
         // locate cells that are going to be destroyed and remove their facet from the queue
-        int li, lj = 0;
+        int li = 0, lj = 0;
         Locate_type lt;
         const Cell_handle conflict_cell = m_dt.locate(steiner_point, lt, li, lj, neighbor);
         CGAL_assertion(lt != Dt::VERTEX);


### PR DESCRIPTION
## Summary of Changes

Fixes an msan error

==1142==WARNING: MemorySanitizer: use-of-uninitialized-value
    #0 0x7f378950d748 in CGAL::Alpha_wraps_3::internal::Alpha_wrap_3<CGAL::Alpha_wraps_3::internal::Triangle_mesh_oracle<CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick> >, CGAL::Named_function_parameters<bool, CGAL::internal_np::all_default_t, CGAL::internal_np::No_property>, true, int>, CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick> >, CGAL::Surface_mesh<CGAL::Point_3<CGAL::Epick> >::Property_map<CGAL::SM_Vertex_index, CGAL::Point_3<CGAL::Epick> >, CGAL::Epick>::alpha_flood_fill()

## Release Management

* Affected package(s): Alpha_wrap_3
