### PR TITLE
Add set_patch_id to split_long_edges 

### DIFF
--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
@@ -98,6 +98,7 @@ create_single_source_cgal_program("orientation_pipeline_example.cpp")
 #create_single_source_cgal_program( "snapping_example.cpp")
 create_single_source_cgal_program("match_faces.cpp")
 create_single_source_cgal_program("cc_compatible_orientations.cpp")
+create_single_source_cgal_program("split_long_edges.cpp")
 
 if(OpenMesh_FOUND)
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
@@ -98,7 +98,6 @@ create_single_source_cgal_program("orientation_pipeline_example.cpp")
 #create_single_source_cgal_program( "snapping_example.cpp")
 create_single_source_cgal_program("match_faces.cpp")
 create_single_source_cgal_program("cc_compatible_orientations.cpp")
-create_single_source_cgal_program("split_long_edges.cpp")
 
 if(OpenMesh_FOUND)
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -54,6 +54,7 @@
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
+#include <iostream>
 
 #ifdef CGAL_PMP_REMESHING_DEBUG
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
@@ -414,6 +415,10 @@ namespace internal {
         double sqlen = eit->first;
         long_edges.right.erase(eit);
 
+        //collect patch_ids
+        Patch_id patch_id = get_patch_id(face(he, mesh_));
+        Patch_id patch_id_opp = get_patch_id(face(opposite(he, mesh_), mesh_));
+
         //split edge
         Point refinement_point = this->midpoint(he);
         halfedge_descriptor hnew = CGAL::Euler::split_edge(he, mesh_);
@@ -444,6 +449,8 @@ namespace internal {
           halfedge_descriptor hnew2 =
             CGAL::Euler::split_face(hnew, next(next(hnew, mesh_), mesh_), mesh_);
           put(ecmap_, edge(hnew2, mesh_), false);
+          set_patch_id(face(hnew2, mesh_), patch_id);
+          set_patch_id(face(opposite(hnew2, mesh_), mesh_), patch_id);
         }
 
         //do it again on the other side if we're not on boundary
@@ -453,6 +460,8 @@ namespace internal {
           halfedge_descriptor hnew2 =
             CGAL::Euler::split_face(prev(hnew_opp, mesh_), next(hnew_opp, mesh_), mesh_);
           put(ecmap_, edge(hnew2, mesh_), false);
+          set_patch_id(face(hnew2, mesh_), patch_id_opp);
+          set_patch_id(face(opposite(hnew2, mesh_), mesh_), patch_id_opp);
         }
       }
 #ifdef CGAL_PMP_REMESHING_VERBOSE

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -54,7 +54,6 @@
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
-#include <iostream>
 
 #ifdef CGAL_PMP_REMESHING_DEBUG
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -377,6 +377,17 @@ void isotropic_remeshing(const FaceRange& faces
 *     \cgalParamDefault{an automatically indexed internal map}
 *   \cgalParamNEnd
 *
+*   \cgalParamNBegin{face_patch_map}
+*     \cgalParamDescription{a property map with the patch id's associated to the faces of `faces`}
+*     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<PolygonMesh>::%face_descriptor`
+*                    as key type and the desired property, model of `CopyConstructible` and `LessThanComparable` as value type.}
+*     \cgalParamDefault{a default property map where each face is associated with the ID of
+*                       the connected component it belongs to. Connected components are
+*                       computed with respect to the constrained edges listed in the property map
+*                       `edge_is_constrained_map`}
+*     \cgalParamExtra{The map is updated during the remeshing process while new faces are created.}
+*   \cgalParamNEnd
+*
 *   \cgalParamNBegin{edge_is_constrained_map}
 *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `pmesh`}
 *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<PolygonMesh>::%edge_descriptor`
@@ -421,14 +432,22 @@ void split_long_edges(const EdgeRange& edges
   ECMap ecmap = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
                                  Static_boolean_property_map<edge_descriptor, false>());
 
+  typedef typename internal_np::Lookup_named_param_def <
+      internal_np::face_patch_t,
+      NamedParameters,
+      internal::Connected_components_pmap<PM, FIMap>//default
+    > ::type FPMap;
+  FPMap fpmap = choose_parameter(
+    get_parameter(np, internal_np::face_patch),
+    internal::Connected_components_pmap<PM, FIMap>(faces(pmesh), pmesh, ecmap, fimap, false));
+
   typename internal::Incremental_remesher<PM, VPMap, GT, ECMap,
     Static_boolean_property_map<vertex_descriptor, false>, // no constraint pmap
-    internal::Connected_components_pmap<PM, FIMap>,
-    FIMap
+    FPMap,FIMap
   >
     remesher(pmesh, vpmap, gt, false/*protect constraints*/, ecmap,
              Static_boolean_property_map<vertex_descriptor, false>(),
-             internal::Connected_components_pmap<PM, FIMap>(faces(pmesh), pmesh, ecmap, fimap, false),
+             fpmap,
              fimap,
              false/*need aabb_tree*/);
 


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes

Fix the patch_id is inconsistent after split_long_edges();

## Release Management

* Issue(s) solved (if any): fix #6617 #6635


