### PR TITLE
Qualify do_intersect to avoid ambiguous dispatch

### DIFF
--- a/Intersections_3/include/CGAL/Intersections_3/internal/Segment_3_Segment_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Segment_3_Segment_3_do_intersect.h
@@ -30,7 +30,7 @@ do_intersect(const typename K::Segment_3& s1,
 {
   CGAL_precondition(!s1.is_degenerate() && !s2.is_degenerate());
 
-  bool b = do_intersect(s1.supporting_line(), s2.supporting_line(), k);
+  bool b = internal::do_intersect(s1.supporting_line(), s2.supporting_line(), k);
   if(b)
   {
     // supporting_line intersects: points are coplanar


### PR DESCRIPTION
## Summary of Changes

Add qualifying namespace to resolve ambiguity in do_intersect dispatch.

## Release Management

* Issue(s) solved (if any): fix #6600 