### PR TITLE
Corrections for more strict doxygen symbol resolver

### DIFF
--- a/Algebraic_foundations/doc/Algebraic_foundations/Concepts/RealEmbeddableTraits.h
+++ b/Algebraic_foundations/doc/Algebraic_foundations/Concepts/RealEmbeddableTraits.h
@@ -25,7 +25,7 @@ typedef unspecified_type Type;
 /*!
 Tag indicating whether the associated type is real embeddable.
 
-This is either \link Tag_true `Tag_true`\endlink or \link Tag_false `Tag_false`\endlink.
+This is either \link CGAL::Tag_true `Tag_true`\endlink or \link CGAL::Tag_false `Tag_false`\endlink.
 */
 typedef unspecified_type Is_real_embeddable;
 

--- a/Linear_cell_complex/doc/Linear_cell_complex/Concepts/LinearCellComplexTraits.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/Concepts/LinearCellComplexTraits.h
@@ -52,7 +52,7 @@ Functor that provides
 \link LinearCellComplexTraits::Point `Point`\endlink `operator() (const` \link Point `Point`\endlink`& p, const` \link LinearCellComplexTraits::Vector `Vector`\endlink`& v)`,
 which constructs the translation of point `p` by vector `v`, and
 \link LinearCellComplexTraits::Point `Point`\endlink `operator() (const CGAL::Origin&, const` \link LinearCellComplexTraits::Vector `Vector`\endlink`& v)`,
-which constructs the translation of a point at the origin by vector `v` (used in \link CGAL::LinearCellComplex::barycenter `LinearCellComplex::barycenter`\endlink).
+which constructs the translation of a point at the origin by vector `v` (used in \link CGAL::barycenter `barycenter`\endlink).
 */
 typedef unspecified_type Construct_translated_point;
 
@@ -61,7 +61,7 @@ Functor that provides \link LinearCellComplexTraits::Vector ` Vector `\endlink `
 which constructs a vector as the difference of points `p2-p1`, and
 \link LinearCellComplexTraits::Vector ` Vector `\endlink `operator() (const CGAL::Origin&, const ` \link Point ` Point`\endlink`& p)`
 which constructs a vector as the difference of point `p` and a point at the origin
-(used in \link CGAL::LinearCellComplex::barycenter `LinearCellComplex::barycenter`\endlink
+(used in \link CGAL::barycenter `barycenter`\endlink
 and `CGAL::import_from_plane_graph`).
 */
 typedef unspecified_type Construct_vector;
@@ -69,7 +69,7 @@ typedef unspecified_type Construct_vector;
 /*!
 Functor that provides \link LinearCellComplexTraits::Vector ` Vector `\endlink `operator() (const` \link LinearCellComplexTraits::Vector ` Vector`\endlink`& v1, const` \link LinearCellComplexTraits::Vector ` Vector`\endlink`& v2)`
 which constructs a vector as the sum of vectors `v1+v2`
-(used in \link CGAL::LinearCellComplex::barycenter `LinearCellComplex::barycenter`\endlink,
+(used in \link CGAL::barycenter `barycenter`\endlink,
 `CGAL::compute_normal_of_cell_0`
 and `CGAL::compute_normal_of_cell_2`).
 */
@@ -78,7 +78,7 @@ typedef unspecified_type Construct_sum_of_vectors;
 /*!
 Functor that provides \link LinearCellComplexTraits::Vector ` Vector `\endlink `operator() (const` \link LinearCellComplexTraits::Vector ` Vector`\endlink`& v, ` \link LinearCellComplexTraits::FT `FT`\endlink `scale)`
 which constructs a vector equal to vector `v` scaled by `scale` factor
-(used in \link CGAL::LinearCellComplex::barycenter `LinearCellComplex::barycenter`\endlink,
+(used in \link CGAL::barycenter `barycenter`\endlink,
 `CGAL::compute_normal_of_cell_0` and `CGAL::compute_normal_of_cell_2`).
 */
 typedef unspecified_type Construct_scaled_vector;
@@ -86,7 +86,7 @@ typedef unspecified_type Construct_scaled_vector;
 /*!
 Functor that provides \link LinearCellComplexTraits::Point `Point `\endlink `operator() (const ` \link Point `Point`\endlink`& p1, const ` \link Point `Point`\endlink`& p2)`
 which constructs the midpoint of points `p1` and `p2`
-(used in \link CGAL::LinearCellComplex::barycenter `LinearCellComplex::barycenter`\endlink).
+(used in \link CGAL::barycenter `barycenter`\endlink).
 */
 typedef unspecified_type Construct_midpoint;
 

--- a/Linear_cell_complex/doc/Linear_cell_complex/Concepts/LinearCellComplexTraits.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/Concepts/LinearCellComplexTraits.h
@@ -52,7 +52,7 @@ Functor that provides
 \link LinearCellComplexTraits::Point `Point`\endlink `operator() (const` \link Point `Point`\endlink`& p, const` \link LinearCellComplexTraits::Vector `Vector`\endlink`& v)`,
 which constructs the translation of point `p` by vector `v`, and
 \link LinearCellComplexTraits::Point `Point`\endlink `operator() (const CGAL::Origin&, const` \link LinearCellComplexTraits::Vector `Vector`\endlink`& v)`,
-which constructs the translation of a point at the origin by vector `v` (used in \link CGAL::barycenter `barycenter`\endlink).
+which constructs the translation of a point at the origin by vector `v` (used in \link LinearCellComplex::barycenter `barycenter()`\endlink).
 */
 typedef unspecified_type Construct_translated_point;
 

--- a/Mesh_2/doc/Mesh_2/Concepts/ConformingDelaunayTriangulationTraits_2.h
+++ b/Mesh_2/doc/Mesh_2/Concepts/ConformingDelaunayTriangulationTraits_2.h
@@ -95,8 +95,8 @@ typedef unspecified_type Angle_2;
 /*!
 Predicate object. Must provide the operator
 `CGAL::Oriented_side operator()(Segment_2 s, Triangle_2 t)` that
-returns \ref ON_ORIENTED_BOUNDARY, \ref ON_NEGATIVE_SIDE,
-or \ref ON_POSITIVE_SIDE,
+returns \ref CGAL::ON_ORIENTED_BOUNDARY, \ref CGAL::ON_NEGATIVE_SIDE,
+or \ref CGAL::ON_POSITIVE_SIDE,
 depending on the position of the circumcenter of `t` relative
 to the oriented supporting line of `s`. The orientation of the
 supporting line is the same as the orientation of `s`.

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -947,7 +947,7 @@ This package provides methods to compute (approximate) distances between meshes 
 
 \subsection ApproxHD Approximate Hausdorff Distance
 
-The function \link approximate_Hausdorff_distance() `approximate_Hausdorff_distance()`\endlink
+The function \link Polygon_mesh_processing::approximate_Hausdorff_distance() `approximate_Hausdorff_distance()`\endlink
 computes an approximation of the Hausdorff distance from a mesh `tm1` to a mesh `tm2`. Given a
 a sampling of `tm1`, it computes the distance to `tm2` of the farthest sample point to `tm2` \cgalCite{cignoni1998metro}.
 The symmetric version (\link CGAL::Polygon_mesh_processing::approximate_symmetric_Hausdorff_distance() `approximate_symmetric_Hausdorff_distance()`\endlink)

--- a/Three/doc/Three/Three.txt
+++ b/Three/doc/Three/Three.txt
@@ -28,7 +28,7 @@ A basic plugin will inherit from `CGAL::Three::Polyhedron_demo_plugin_interface`
 It must be created in the corresponding folder named after its package, and containing all the files created for the plugin, and a CMakeLists.txt file.
 Its name must be of the form Xxxx_yyyy_plugin. \n
 
-  [init()]: @ref CGAL::Three::Polyhedron_demo_plugin_interface#init(QMainWindow *, Scene_interface *, Messages_interface*)
+  [init()]: @ref CGAL::Three::Polyhedron_demo_plugin_interface#init(QMainWindow*,CGAL::Three::Scene_interface*,Messages_interface*)
   [applicable()]: @ref CGAL::Three::Polyhedron_demo_plugin_interface#applicable()
   [actions()]: @ref CGAL::Three::Polyhedron_demo_plugin_interface#actions()
   The class must contain the following lines :\n


### PR DESCRIPTION
The doxygen  symbol resolver for the doxygen master version (1.9.5 (https://github.com/doxygen/doxygen/commit/35711f2d14acc81cff83f81f04c566ad8c8c6fe8)) has been improved (made stricter) but this means also means that some links have to be corrected.
The patch has been tested against the mentioned doxygen master and against doxygen 1.8.13 and the results look in both cases correct (without the patch the master version has some warnings and some incorrect links)..

The patch has been created by @doxygen and upon request created into a pull request by me.

