### PR TITLE
Add an option to a remove_almost_degenerate_faces

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -853,11 +853,12 @@ namespace internal {
             mesh_, vpmap_, vcmap_, ecmap_, gt_,
             cap_threshold, // bound on the angle: above 160 deg => cap
             4, // bound on shortest/longest edge above 4 => needle
-            0);// collapse length threshold : not needed here
+            0,// collapse length threshold : not needed here
+            0); // flip triangle height threshold
 
         std::array<halfedge_descriptor, 2> r2 = internal::is_badly_shaped(
             face(opposite(he, mesh_), mesh_),
-            mesh_, vpmap_, vcmap_, ecmap_, gt_, cap_threshold, 4, 0);
+            mesh_, vpmap_, vcmap_, ecmap_, gt_, cap_threshold, 4, 0, 0);
 
         const bool badly_shaped = (r1[0] != boost::graph_traits<PolygonMesh>::null_halfedge()//needle
                                 || r1[1] != boost::graph_traits<PolygonMesh>::null_halfedge()//cap

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/shape_predicates.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/shape_predicates.h
@@ -503,7 +503,7 @@ struct Is_cap_angle_over_threshold<K, true>
 /// \ingroup PMP_predicates_grp
 ///
 /// checks whether a triangle face is a cap.
-/// A triangle is said to be a <i>cap</i> if one of the its angles is close to `180` degrees.
+/// A triangle is said to be a <i>cap</i> if one of its angles is close to `180` degrees.
 ///
 /// @tparam TriangleMesh a model of `FaceGraph`
 /// @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"

--- a/STL_Extension/include/CGAL/STL_Extension/internal/parameters_interface.h
+++ b/STL_Extension/include/CGAL/STL_Extension/internal/parameters_interface.h
@@ -130,6 +130,7 @@ CGAL_add_named_parameter(match_faces_t, match_faces, match_faces)
 CGAL_add_named_parameter(face_epsilon_map_t, face_epsilon_map, face_epsilon_map)
 CGAL_add_named_parameter(maximum_number_t, maximum_number, maximum_number)
 CGAL_add_named_parameter(use_one_sided_hausdorff_t, use_one_sided_hausdorff, use_one_sided_hausdorff)
+CGAL_add_named_parameter(flip_triangle_height_threshold_t, flip_triangle_height_threshold, flip_triangle_height_threshold)
 
 // List of named parameters that we use in the package 'Surface Mesh Simplification'
 CGAL_add_named_parameter(get_cost_policy_t, get_cost_policy, get_cost)


### PR DESCRIPTION
Add an option to a non-documented function prevent flipping triangles with a height larger than a given input threshold.