### PR TITLE
Regularized Boolean Set Operations:  Help compiler to disambiguate

### DIFF
--- a/Boolean_set_operations_2/include/CGAL/Boolean_set_operations_2/do_intersect.h
+++ b/Boolean_set_operations_2/include/CGAL/Boolean_set_operations_2/do_intersect.h
@@ -237,7 +237,9 @@ inline bool do_intersect(const General_polygon_with_holes_2<Polygon_>& pgn1,
 // With Traits
 template <typename InputIterator, typename Traits>
 inline bool do_intersect(InputIterator begin, InputIterator end, Traits& traits,
-                         unsigned int k=5)
+                         unsigned int k=5,
+                         typename boost::enable_if
+               <typename CGAL::is_iterator<InputIterator>>::type* = 0)
 { return r_do_intersect(begin, end, traits, k); }
 
 // Without Traits
@@ -245,6 +247,8 @@ inline bool do_intersect(InputIterator begin, InputIterator end, Traits& traits,
 template <typename InputIterator>
 inline bool do_intersect(InputIterator begin, InputIterator end,
                          Tag_true = Tag_true(), unsigned int k=5,
+                         typename boost::enable_if
+                         <typename CGAL::is_iterator<InputIterator>>::type* = 0,
                          Enable_if_Polygon_2_iterator<InputIterator>* = 0)
 { return r_do_intersect(begin, end, k); }
 
@@ -252,6 +256,8 @@ inline bool do_intersect(InputIterator begin, InputIterator end,
 template <typename InputIterator>
 inline bool do_intersect(InputIterator begin, InputIterator end,
                          Tag_false, unsigned int k=5,
+                         typename boost::enable_if
+                         <typename CGAL::is_iterator<InputIterator>>::type* = 0,
                          Enable_if_Polygon_2_iterator<InputIterator>* = 0)
 {
   typename Iterator_to_gps_traits<InputIterator>::Traits traits;
@@ -262,6 +268,8 @@ inline bool do_intersect(InputIterator begin, InputIterator end,
 template <typename InputIterator>
 inline bool do_intersect(InputIterator begin, InputIterator end,
                          unsigned int k=5,
+                         typename boost::enable_if
+                         <typename CGAL::is_iterator<InputIterator>>::type* = 0,
                          Disable_if_Polygon_2_iterator<InputIterator>* = 0)
 {
   typename Iterator_to_gps_traits<InputIterator>::Traits traits;


### PR DESCRIPTION
## Summary of Changes

Address Issue #6600   with an `enable_if`  for being an iterator just as it is done for the function `intersection()`.

## Release Management

* Affected package(s): Boolean set operations
* Issue(s) solved (if any): fix #6600 

