### PR TITLE
PMP.repair_polygon_soup.h Add #include <deque>

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
@@ -31,6 +31,7 @@
 #include <map>
 #include <set>
 #include <vector>
+#include <deque>
 #include <utility>
 #include <unordered_map>
 #include <unordered_set>


### PR DESCRIPTION
## Summary of Changes

https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.6-Ic-1/Polygon_mesh_processing/TestReport_lrineau_ArchLinux-clang-CXX20-Release.gz
```
[ 50%] Building CXX object CMakeFiles/test_repair_polygon_soup.dir/test_repair_polygon_soup.cpp.o
/bin/clang++ -DCGAL_DATA_DIR=\"/mnt/testsuite/data/\" -DCGAL_TEST_SUITE=1 -DCGAL_USE_CORE=1 -DCGAL_USE_GMPXX=1 -I/mnt/testsuite/include -I/usr/local/boost/include -Wall -O3 -std=c++20 -DCGAL_NDEBUG -MD -MT CMakeFiles/test_repair_polygon_soup.dir/test_repair_polygon_soup.cpp.o -MF CMakeFiles/test_repair_polygon_soup.dir/test_repair_polygon_soup.cpp.o.d -o CMakeFiles/test_repair_polygon_soup.dir/test_repair_polygon_soup.cpp.o -c /home/cgal_tester/build/src/cmake/platforms/ArchLinux-clang-CXX20-Release/test/Polygon_mesh_processing/test_repair_polygon_soup.cpp
In file included from /home/cgal_tester/build/src/cmake/platforms/ArchLinux-clang-CXX20-Release/test/Polygon_mesh_processing/test_repair_polygon_soup.cpp:5:
/mnt/testsuite/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h:905:8: error: no member named 'deque' in namespace 'std'
  std::deque<std::vector<P_ID> > all_duplicate_polygons;
  ~~~~~^
```

## Release Management

* Affected package(s): PMP
* License and copyright ownership: maintenance by GeometryFactory
