### PR TITLE
STL_extension: Fix URL to boost libs

### DIFF
--- a/Documentation/doc/Documentation/Developer_manual/Chapter_code_format.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_code_format.txt
@@ -257,29 +257,6 @@ The first list of items are meant as rules, <I>i.e.</I>, you should follow them.
   ...
   #endif // CGAL_THIS_IS_AN_EXAMPLE_H
   \endcode
-- Support the
-  <A HREF="https://en.cppreference.com/w/cpp/types/result_of">result_of</A>
-  protocol whenever your functors have more than one return type
-  otherwise provide a `result_type` member typedef.
-  An example for this is a C++03 style `identity` functor:
-  \code{.cpp}
-        struct Identity {
-          template<typename T>
-          T& operator()(T& t) { return t; }
-          template<typename T>
-          const T& operator()(const T& t) { return t; }
-          template<typename>
-          struct result;
-          template<typename F, typename T>
-          struct result<F(T&)> {
-            typedef T& type;
-          };
-          template<typename F, typename T>
-          struct result<F(const T&)> {
-            typedef const T& type;
-          };
-        };
-  \endcode
 
 The following items can be seen as recommendations
 in contrast to the rules of previous paragraph.

--- a/Documentation/doc/Documentation/Developer_manual/Chapter_code_format.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_code_format.txt
@@ -258,7 +258,7 @@ The first list of items are meant as rules, <I>i.e.</I>, you should follow them.
   #endif // CGAL_THIS_IS_AN_EXAMPLE_H
   \endcode
 - Support the
-  <A HREF="https://www.boost.org/doc/libs/release/libs/utility/utility.htm#result_of">result_of</A>
+  <A HREF="https://en.cppreference.com/w/cpp/types/result_of">result_of</A>
   protocol whenever your functors have more than one return type
   otherwise provide a `result_type` member typedef.
   An example for this is a C++03 style `identity` functor:

--- a/Documentation/doc/Documentation/Preliminaries.txt
+++ b/Documentation/doc/Documentation/Preliminaries.txt
@@ -47,7 +47,7 @@ After being based on the \CC standard released in 1998 (and later refined in 200
 \section Preliminaries_functor Functor Return Types
 
 \cgal functors support the
-<a href="https://www.boost.org/doc/libs/release/libs/utility/utility.htm#result_of">result_of</a>
+<a href="https://en.cppreference.com/w/cpp/types/result_of">result_of</a>
 protocol. If a functor `F` has the same return type across all
 overloads of `operator()`, the nested type
 `F::result_type` is defined to be that type. Otherwise the

--- a/Documentation/doc/Documentation/Preliminaries.txt
+++ b/Documentation/doc/Documentation/Preliminaries.txt
@@ -44,16 +44,6 @@ also avoid CMake to link with the native threads support library on your system.
 After being based on the \CC standard released in 1998 (and later refined in 2003) for a long time,
 \cgal is now based on a newer major version of the standard, <a href="https://isocpp.org/wiki/faq/cpp14">C++14</a>.
 
-\section Preliminaries_functor Functor Return Types
-
-\cgal functors support the
-<a href="https://en.cppreference.com/w/cpp/types/result_of">result_of</a>
-protocol. If a functor `F` has the same return type across all
-overloads of `operator()`, the nested type
-`F::result_type` is defined to be that type. Otherwise the
-return type of calling the functor with an argument of type
-`Arg` can be accessed through \link CGAL::cpp11::result_of::type `CGAL::cpp11::result_of<F(Arg)>::type` \endlink.
-
 \section preliminaries_secchecks Checks
 
 Much of the \cgal code contains assert statements for preconditions, and postconditions of functions

--- a/STL_Extension/doc/STL_Extension/Concepts/Hashable.h
+++ b/STL_Extension/doc/STL_Extension/Concepts/Hashable.h
@@ -14,12 +14,11 @@ They can be disables by defining the macro `CGAL_DISABLE_HASH_OPENMESH`.
 \sa `CGAL::Unique_hash_map<Key,Mapped,Hash>`
 \sa <A HREF="http://www.cplusplus.com/reference/unordered_set/unordered_set/">`std::unordered_set`</a>
 \sa <A HREF="http://www.cplusplus.com/reference/unordered_set/unordered_map/">`std::unordered_map`</a>
-\sa <A HREF="https://www.boost.org/doc/libs/release/doc/html/boost/unordered_set.html">`boost::unordered_set`</a>
-\sa <A HREF="https://www.boost.org/doc/libs/release/doc/html/boost/unordered_map.html">`boost::unordered_map`</a>
+\sa <A HREF="https://www.boost.org/libs/unordered/doc/html/unordered.html#unordered_set">`boost::unordered_set`</a>
+\sa <A HREF="https://www.boost.org/libs/unordered/doc/html/unordered.html#unordered_map">`boost::unordered_map`</a>
 
 */
 
 class Hashable {
 
 };
-


### PR DESCRIPTION
## Summary of Changes

Change links to some boost ref manual pages as boost.org is not willing to add redirects.

TODO:
- [x] result_of links

## Release Management

* Affected package(s): STL_Extension
* Issue(s) solved (if any): fix #6511


