### PR TITLE
Polyhedron demo: Fix segfaults at exit

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Engrave_text_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Engrave_text_plugin.cpp
@@ -961,8 +961,8 @@ private:
   int pointsize;
   bool locked;
   EPICK::Line_2 bf_line;
-  QGraphicsScene *graphics_scene;
-  Navigation* navigation;
+  QGraphicsScene *graphics_scene = nullptr;
+  Navigation* navigation = nullptr;
 };
 #include "Engrave_text_plugin.moc"
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Mean_curvature_flow_skeleton_plugin.cpp
@@ -321,8 +321,8 @@ public Q_SLOTS:
 private:
   Scene_mcf_item *getMCFItem();
   void createContractedItem(Scene_mcf_item* item);
-  QDockWidget* dockWidget;
-  Ui::Mean_curvature_flow_skeleton_plugin* ui;
+  QDockWidget* dockWidget = nullptr;
+  Ui::Mean_curvature_flow_skeleton_plugin* ui = nullptr;
 
 }; // end Polyhedron_demo_mean_curvature_flow_skeleton_plugin
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh/Parameterization_plugin.cpp
@@ -495,14 +495,14 @@ protected:
   void parameterize(Parameterization_method method);
 
 private:
-  Messages_interface *messages;
+  Messages_interface *messages = nullptr;
   QList<QAction*> _actions;
-  QDockWidget* dock_widget;
+  QDockWidget* dock_widget = nullptr;
   Ui::Parameterization ui_widget;
   QGraphicsScene *graphics_scene;
-  Navigation* navigation;
+  Navigation* navigation = nullptr;
   QMap<Scene_item*, UVItem*> projections;
-  UVItem* current_uv_item;
+  UVItem* current_uv_item = nullptr;
 }; // end Polyhedron_demo_parameterization_plugin
 
 void Polyhedron_demo_parameterization_plugin::on_prevButton_pressed()

--- a/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Surface_mesh_deformation/Edit_polyhedron_plugin.cpp
@@ -79,11 +79,11 @@ private:
   void updateSelectionItems(Scene_facegraph_item* target);
 
   Ui::DeformMesh ui_widget;
-  QDockWidget* dock_widget;
+  QDockWidget* dock_widget = nullptr;
 
-  QAction* actionDeformation;
+  QAction* actionDeformation = nullptr;
   RenderingMode last_RM;
-  QShortcut* e_shortcut;
+  QShortcut* e_shortcut = nullptr;
 }; // end Polyhedron_demo_edit_polyhedron_plugin
 
 QList<QAction*> Polyhedron_demo_edit_polyhedron_plugin::actions() const {


### PR DESCRIPTION
## Summary of Changes

Fix segfaults at exit. The segfaults at the destruction of plugins were because of uninitialized pointers.

## Release Management

* Affected package(s): Polyhedron

