### PR TITLE
STL_extension: Fix memory leak in Skiplist

### DIFF
--- a/STL_Extension/include/CGAL/Skiplist.h
+++ b/STL_Extension/include/CGAL/Skiplist.h
@@ -234,11 +234,8 @@ public:
 
   void pop_back()
   {
-    Node& a = all_.back();
-    all_.pop_back();
     skip_.pop_back();
-    Node* ap = &a;
-    delete ap;
+    all_.pop_back_and_dispose(Node_disposer());
   }
 
   /// Insert \c t before \c pos in the all_view. \t will not be inserted into the skip view.

--- a/STL_Extension/include/CGAL/Skiplist.h
+++ b/STL_Extension/include/CGAL/Skiplist.h
@@ -234,8 +234,11 @@ public:
 
   void pop_back()
   {
+    Node& a = all_.back();
     all_.pop_back();
     skip_.pop_back();
+    Node* ap = &a;
+    delete ap;
   }
 
   /// Insert \c t before \c pos in the all_view. \t will not be inserted into the skip view.


### PR DESCRIPTION
## Summary of Changes

While `push_back()` creates elements on the heap and `clear()` deletes them, `pop_back()` does not, which led to a memory leak.
The class `Skiplist` is used by packages such as 2D Triangulations.

## Release Management

* Affected package(s): STL_Extension

