### PR TITLE
Remove mention to boost::thread_specific_ptr

### DIFF
--- a/Documentation/doc/Documentation/Developer_manual/Chapter_multithreading.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_multithreading.txt
@@ -9,12 +9,12 @@
 
 The header file `<CGAL/tss.h>` provides a macro `CGAL_STATIC_THREAD_LOCAL_VARIABLE(TYPE,VAR,ARG1)`
 that creates a thread local variable `VAR` of type `TYPE`, and passes `ARG1` to the
-constructor.  The variable is either `threadlocal`, or a `boost::thread_specific_ptr`,
+constructor.  The variable is either `thread_local`,
 or just a local variable if `CGAL_HAS_THREADS` is not defined.
 
 
 \section Developer_manualMutex Mutex
 
-The header file `<CGAL/mutex.h>` provides a macro `CGAL_MUTEX` and a macro `CGAL_SCOPED_LOCK(M)` that is either a `std::unique_lock<std::mutex>` or a `boost::mutex::scoped_lock`.
+The header file `<CGAL/mutex.h>` provides a macro `CGAL_MUTEX` equivalent to `std::mutex` and a macro `CGAL_SCOPED_LOCK(M)` that is a `std::unique_lock<std::mutex>`.
 
 */

--- a/Installation/include/CGAL/atomic.h
+++ b/Installation/include/CGAL/atomic.h
@@ -33,7 +33,7 @@ using std::memory_order_seq_cst;
 using std::atomic_thread_fence;
 } }
 #else
-#  define CGAL_NO_ATOMIC "No atomic because CGAL_NO_THREADS is defined."
+#  define CGAL_NO_ATOMIC "No atomic because CGAL_HAS_NO_THREADS is defined."
 #endif // CGAL_HAS_THREADS
 
 #endif // CGAL_ATOMIC_H


### PR DESCRIPTION
## Summary of Changes

Fix #6680. Remove mention of Boost threading features.

## Release Management

* Affected package(s): Documentation
* Issue(s) solved (if any): fix #6680

