### PR TITLE
Orthtree: Fix memory leak in test code

### DIFF
--- a/Orthtree/include/CGAL/Orthtree/Node.h
+++ b/Orthtree/include/CGAL/Orthtree/Node.h
@@ -45,7 +45,7 @@ struct Node_access
   template <typename Node>
   static void split(Node node) { return node.split(); }
 
-  template <int D, typename Node>
+  template <typename Node>
   static void free(Node node)
   {
     std::queue<Node> nodes;
@@ -55,7 +55,7 @@ struct Node_access
       Node node = nodes.front();
       nodes.pop();
       if (!node.is_leaf())
-        for (std::size_t i = 0; i < D; ++ i)
+        for (std::size_t i = 0; i < Node::Dimension::value; ++ i)
           nodes.push (node[i]);
       node.free();
     }

--- a/Orthtree/include/CGAL/Orthtree/Node.h
+++ b/Orthtree/include/CGAL/Orthtree/Node.h
@@ -44,6 +44,22 @@ struct Node_access
 
   template <typename Node>
   static void split(Node node) { return node.split(); }
+
+  template <typename Node, int D>
+  static void free(Node node)
+  {
+    std::queue<Node> nodes;
+    nodes.push(node);
+    while (!nodes.empty())
+    {
+      Node node = nodes.front();
+      nodes.pop();
+      if (!node.is_leaf())
+        for (std::size_t i = 0; i < D; ++ i)
+          nodes.push (node[i]);
+      node.free();
+    }
+  }
 };
 
 } // namespace Orthtrees

--- a/Orthtree/include/CGAL/Orthtree/Node.h
+++ b/Orthtree/include/CGAL/Orthtree/Node.h
@@ -45,7 +45,7 @@ struct Node_access
   template <typename Node>
   static void split(Node node) { return node.split(); }
 
-  template <typename Node, int D>
+  template <int D, typename Node>
   static void free(Node node)
   {
     std::queue<Node> nodes;

--- a/Orthtree/test/Orthtree/test_octree_refine.cpp
+++ b/Orthtree/test/Orthtree/test_octree_refine.cpp
@@ -30,7 +30,7 @@ void test_1_point() {
     = CGAL::Orthtrees::Node_access::points(octree.root());
   assert(Node::is_topology_equal(single_node, octree.root()));
   assert(0 == octree.depth());
-  CGAL::Orthtrees::Node_access::free<Node,3>(single_node);
+  CGAL::Orthtrees::Node_access::free<3>(single_node);
 }
 
 void test_2_points() {
@@ -49,7 +49,7 @@ void test_2_points() {
   CGAL::Orthtrees::Node_access::split(other);
   assert(Node::is_topology_equal(other, octree.root()));
   assert(1 == octree.depth());
-  CGAL::Orthtrees::Node_access::free<Node,3>(other);
+  CGAL::Orthtrees::Node_access::free<3>(other);
 
 }
 
@@ -72,7 +72,7 @@ void test_4_points() {
   CGAL::Orthtrees::Node_access::split(other[7]);
   assert(Node::is_topology_equal(other, octree.root()));
   assert(2 == octree.depth());
-  CGAL::Orthtrees::Node_access::free<Node,3>(other);
+  CGAL::Orthtrees::Node_access::free<3>(other);
 }
 
 int main(void) {

--- a/Orthtree/test/Orthtree/test_octree_refine.cpp
+++ b/Orthtree/test/Orthtree/test_octree_refine.cpp
@@ -30,7 +30,7 @@ void test_1_point() {
     = CGAL::Orthtrees::Node_access::points(octree.root());
   assert(Node::is_topology_equal(single_node, octree.root()));
   assert(0 == octree.depth());
-
+  CGAL::Orthtrees::Node_access::free<Node,3>(single_node);
 }
 
 void test_2_points() {
@@ -49,6 +49,7 @@ void test_2_points() {
   CGAL::Orthtrees::Node_access::split(other);
   assert(Node::is_topology_equal(other, octree.root()));
   assert(1 == octree.depth());
+  CGAL::Orthtrees::Node_access::free<Node,3>(other);
 
 }
 
@@ -71,6 +72,7 @@ void test_4_points() {
   CGAL::Orthtrees::Node_access::split(other[7]);
   assert(Node::is_topology_equal(other, octree.root()));
   assert(2 == octree.depth());
+  CGAL::Orthtrees::Node_access::free<Node,3>(other);
 }
 
 int main(void) {

--- a/Orthtree/test/Orthtree/test_octree_refine.cpp
+++ b/Orthtree/test/Orthtree/test_octree_refine.cpp
@@ -30,7 +30,7 @@ void test_1_point() {
     = CGAL::Orthtrees::Node_access::points(octree.root());
   assert(Node::is_topology_equal(single_node, octree.root()));
   assert(0 == octree.depth());
-  CGAL::Orthtrees::Node_access::free<3>(single_node);
+  CGAL::Orthtrees::Node_access::free(single_node);
 }
 
 void test_2_points() {
@@ -49,7 +49,7 @@ void test_2_points() {
   CGAL::Orthtrees::Node_access::split(other);
   assert(Node::is_topology_equal(other, octree.root()));
   assert(1 == octree.depth());
-  CGAL::Orthtrees::Node_access::free<3>(other);
+  CGAL::Orthtrees::Node_access::free(other);
 
 }
 
@@ -72,7 +72,7 @@ void test_4_points() {
   CGAL::Orthtrees::Node_access::split(other[7]);
   assert(Node::is_topology_equal(other, octree.root()));
   assert(2 == octree.depth());
-  CGAL::Orthtrees::Node_access::free<3>(other);
+  CGAL::Orthtrees::Node_access::free(other);
 }
 
 int main(void) {


### PR DESCRIPTION
## Summary of Changes

The helper class generates nodes that allocate memory without freeing it. 

## Release Management

* Affected package(s):  Orthtree

