### PR TITLE
Cleanup CMake scripts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CGAL_BRANCH_BUILD
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/CGALConfigVersion.cmake)
 include(${CMAKE_CURRENT_SOURCE_DIR}/Installation/cmake/modules/CGAL_SCM.cmake)
+include(${CMAKE_CURRENT_SOURCE_DIR}/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake)
 cgal_detect_git(${CMAKE_CURRENT_SOURCE_DIR})
 
 function(CGAL_error_if_detect_in_source_build)

--- a/Installation/cmake/modules/CGAL_add_test.cmake
+++ b/Installation/cmake/modules/CGAL_add_test.cmake
@@ -132,7 +132,7 @@ function(cgal_add_compilation_test exe_name)
       set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
         APPEND PROPERTY LABELS "CGAL_build_system")
       set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
-        PROPERTY FIXTURES_SETUP "check_build_system_SetupFixture")
+        PROPERTY FIXTURES_SETUP "CGAL_Qt5_moc_and_resources_Fixture")
       set_property(TEST "compilation_of__CGAL_Qt5_moc_and_resources"
         APPEND PROPERTY DEPENDS "check_build_system")
     endif()

--- a/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
+++ b/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
@@ -155,7 +155,7 @@ function(CGAL_run_at_the_end_of_configuration variable access value current_list
 endfunction()
 
 function(CGAL_install_hooks)
-  if(CMAKE_VERSION VERSION_LESS 3.18)
+  if(CMAKE_VERSION VERSION_LESS 3.19)
     variable_watch("CMAKE_CURRENT_LIST_DIR" CGAL_run_at_the_end_of_configuration)
   else()
     cmake_language(DEFER CALL CGAL_hooks_at_end_of_all_directories)

--- a/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
+++ b/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
@@ -6,6 +6,7 @@
 # the configuration.
 #
 # See https://stackoverflow.com/a/43300621/1728537 for the starting point.
+cmake_minimum_required(VERSION 3.3...3.24)
 
 if(CGAL_SKIP_CMAKE_HOOKS)
   return()
@@ -102,9 +103,25 @@ disable this ${type}.\n\
   endif()
 endfunction()
 
+function(CGAL_hook_fix_ctest_depending_on_Qt5)
+  get_property(_targets DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY BUILDSYSTEM_TARGETS)
+  foreach(_target ${_targets})
+    if(NOT TEST compilation_of__${_target})
+      continue()
+    endif()
+    get_property(_target_links TARGET ${_target} PROPERTY LINK_LIBRARIES)
+    if("CGAL_Qt5" IN_LIST _target_links OR "CGAL::CGAL_Qt5" IN_LIST _target_links)
+      set_property(TEST compilation_of__${_target} APPEND PROPERTY FIXTURES_REQUIRED CGAL_Qt5_moc_and_resources_Fixture)
+    endif()
+    endforeach()
+endfunction()
+
 function(CGAL_hooks_at_end_of_all_directories)
   CGAL_hook_check_targets()
   CGAL_hook_check_unused_cpp_files()
+  if(BUILD_TESTING)
+    CGAL_hook_fix_ctest_depending_on_Qt5()
+  endif()
 endfunction()
 
 function(CGAL_run_at_the_end_of_configuration variable access value current_list_file stack)

--- a/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
+++ b/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
@@ -7,85 +7,78 @@
 #
 # See https://stackoverflow.com/a/43300621/1728537 for the starting point.
 
+if(CGAL_SKIP_CMAKE_HOOKS)
+  return()
+endif()
 get_property(PROPERTY_CGAL_run_at_the_end_of_configuration_INCLUDED
   GLOBAL PROPERTY CGAL_run_at_the_end_of_configuration_INCLUDED)
-if(CGAL_SKIP_CMAKE_HOOKS OR PROPERTY_CGAL_run_at_the_end_of_configuration_INCLUDED)
+if(PROPERTY_CGAL_run_at_the_end_of_configuration_INCLUDED)
+  CGAL_install_hooks()
   return()
 endif()
 
-function(CGAL_run_at_the_end_of_configuration variable access value current_list_file stack)
-  if(NOT access STREQUAL "MODIFIED_ACCESS")
+function(CGAL_hook_check_targets)
+  if(NOT CGAL_CHECK_UNREFERENCES_TARGETS)
     return()
-  endif()
-  if(current_list_file STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
-        AND NOT current_list_file STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
-        OR NOT stack STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
-        AND stack STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
-        OR stack MATCHES doc/CMakeLists.txt
-        OR stack MATCHES demo/Polyhedron/)
-      return()
   endif()
   get_property(_targets DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY BUILDSYSTEM_TARGETS)
-  if(CGAL_CHECK_UNREFERENCES_TARGETS)
-    set(_list_of_deps)
-    set(_special_targets  demos examples tests ALL_CGAL_TARGETS CGAL_Qt5_moc_and_resources uninstall install_FindCGAL)
-    foreach(t ${_special_targets})
-      if(NOT TARGET ${t})
-        continue()
-      endif()
-      get_property(_deps TARGET ${t} PROPERTY MANUALLY_ADDED_DEPENDENCIES)
-#      message("  deps of ${t}: ${_deps}")
-      list(APPEND _list_of_deps ${_deps})
-    endforeach()
-    list(APPEND _list_of_deps ${CGAL_EXECUTABLE_TARGETS})
-#    message(STATUS "  all deps: ${_list_of_deps}")
-    foreach(target ${_targets})
-#      message(STATUS "  new target: ${target}")
-      if(${target} IN_LIST _special_targets)
-        continue()
-      endif()
-      if(NOT ${target} IN_LIST _list_of_deps)
-        message(AUTHOR_WARNING "  orphan target: ${target}")
-      endif()
-    endforeach()
-  endif()
-  if(CGAL_CHECK_UNUSED_CPP_FILES
-      AND NOT current_list_file STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
-      AND stack STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt")
-    file(GLOB _cppfiles ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
-    if(_targets AND _cppfiles)
-      set(_sources)
-      foreach(_target ${_targets})
-        get_property(_target_type TARGET ${_target} PROPERTY TYPE)
-        if(_target_type STREQUAL INTERFACE_LIBRARY)
-          continue()
-        endif()
-        get_property(_target_sources TARGET ${_target} PROPERTY SOURCES)
-        list(APPEND _sources ${_target_sources})
-      endforeach()
-      if(_sources)
-        list(REMOVE_ITEM _cppfiles ${_sources})
-      endif()
-      if(_cppfiles)
-        set(_warning "In ${CMAKE_CURRENT_SOURCE_DIR}, the following files are unused:")
-        foreach(_cppfile ${_cppfiles})
-          set(_warning "${_warning}
-  ${_cppfile}")
-        endforeach()
-        set(_warning  "${_warning}
-")
-        message(AUTHOR_WARNING "${_warning}")
-      endif()
+  set(_list_of_deps)
+  set(_special_targets  demos examples tests ALL_CGAL_TARGETS CGAL_Qt5_moc_and_resources uninstall install_FindCGAL)
+  foreach(t ${_special_targets})
+    if(NOT TARGET ${t})
+      continue()
     endif()
-  endif()
+    get_property(_deps TARGET ${t} PROPERTY MANUALLY_ADDED_DEPENDENCIES)
+    # message("  deps of ${t}: ${_deps}")
+    list(APPEND _list_of_deps ${_deps})
+  endforeach()
+  list(APPEND _list_of_deps ${CGAL_EXECUTABLE_TARGETS})
+  # message(STATUS "  all deps: ${_list_of_deps}")
+  foreach(target ${_targets})
+    # message(STATUS "  new target: ${target}")
+    if(${target} IN_LIST _special_targets)
+      continue()
+    endif()
+    if(NOT ${target} IN_LIST _list_of_deps)
+      message(AUTHOR_WARNING "  orphan target: ${target}")
+    endif()
+  endforeach()
+endfunction()
 
-  if(value)
-    # Only do the following at the end of the CMake process, when the
-    # value of variable CMAKE_CURRENT_LIST_DIR is changed to the empty
-    # string.
+function(CGAL_hook_check_unused_cpp_files)
+  if(NOT CGAL_CHECK_UNUSED_CPP_FILES)
     return()
   endif()
+  get_property(_targets DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY BUILDSYSTEM_TARGETS)
+  file(GLOB _cppfiles ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+  if(NOT _targets OR NOT _cppfiles)
+    return()
+  endif()
+  set(_sources)
+  foreach(_target ${_targets})
+    get_property(_target_type TARGET ${_target} PROPERTY TYPE)
+    if(_target_type STREQUAL INTERFACE_LIBRARY)
+      continue()
+    endif()
+    get_property(_target_sources TARGET ${_target} PROPERTY SOURCES)
+    list(APPEND _sources ${_target_sources})
+  endforeach()
+  if(_sources)
+    list(REMOVE_ITEM _cppfiles ${_sources})
+  endif()
+  if(_cppfiles)
+    set(_warning "In ${CMAKE_CURRENT_SOURCE_DIR}, the following files are unused:")
+    foreach(_cppfile ${_cppfiles})
+      set(_warning "${_warning}
+  ${_cppfile}")
+    endforeach()
+    set(_warning  "${_warning}
+  ")
+    message(AUTHOR_WARNING "${_warning}")
+  endif()
+endfunction()
 
+function(CGAL_hook_check_CMAKE_BUILD_TYPE)
   # Warn when CMAKE_BUILD_TYPE is empty or Debug
   if(DEFINED CMAKE_BUILD_TYPE AND ( NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "Debug") )
     set(keyword WARNING)
@@ -109,6 +102,52 @@ disable this ${type}.\n\
   endif()
 endfunction()
 
-variable_watch("CMAKE_CURRENT_LIST_DIR" CGAL_run_at_the_end_of_configuration)
+function(CGAL_hooks_at_end_of_all_directories)
+  CGAL_hook_check_targets()
+  CGAL_hook_check_unused_cpp_files()
+endfunction()
+
+function(CGAL_run_at_the_end_of_configuration variable access value current_list_file stack)
+  if(NOT access STREQUAL "MODIFIED_ACCESS")
+    return()
+  endif()
+  if(current_list_file STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
+        AND NOT current_list_file STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
+        OR NOT stack STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
+        AND stack STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
+        OR stack MATCHES doc/CMakeLists.txt
+        OR stack MATCHES demo/Polyhedron/)
+      return()
+  endif()
+
+
+  if(NOT current_list_file STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt"
+     AND stack STREQUAL "${CMAKE_CURRENT_SOURCE_DIR}/CMakeLists.txt")
+    CGAL_hooks_at_end_of_all_directories()
+  endif()
+
+  if(value)
+    # Only do the following at the end of the CMake process, when the
+    # value of variable CMAKE_CURRENT_LIST_DIR is changed to the empty
+    # string.
+    return()
+  endif()
+
+  CGAL_hook_check_CMAKE_BUILD_TYPE()
+
+endfunction()
+
+function(CGAL_install_hooks)
+  if(CMAKE_VERSION VERSION_LESS 3.18)
+    variable_watch("CMAKE_CURRENT_LIST_DIR" CGAL_run_at_the_end_of_configuration)
+  else()
+    cmake_language(DEFER CALL CGAL_hooks_at_end_of_all_directories)
+    if("${CMAKE_CURRENT_SOURCE_DIR}" STREQUAL "${CMAKE_SOURCE_DIR}")
+      cmake_language(DEFER CALL CGAL_hook_check_CMAKE_BUILD_TYPE)
+    endif()
+  endif()
+endfunction()
+
+CGAL_install_hooks()
 
 set_property(GLOBAL PROPERTY CGAL_run_at_the_end_of_configuration_INCLUDED TRUE)

--- a/Installation/lib/cmake/CGAL/CGALConfig.cmake
+++ b/Installation/lib/cmake/CGAL/CGALConfig.cmake
@@ -111,6 +111,7 @@ include(${CGAL_MODULES_DIR}/CGAL_CreateSingleSourceCGALProgram.cmake)
 include(${CGAL_MODULES_DIR}/CGAL_Macros.cmake)
 include(${CGAL_MODULES_DIR}/CGAL_Common.cmake)
 include(${CGAL_MODULES_DIR}/CGAL_TweakFindBoost.cmake)
+include(${CGAL_MODULES_DIR}/CGAL_enable_end_of_configuration_hook.cmake)
 
 set(CGAL_USE_FILE ${CGAL_MODULES_DIR}/UseCGAL.cmake)
 
@@ -199,5 +200,3 @@ if( CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST )
   # Do not use -isystem for CGAL include paths
   set(CMAKE_NO_SYSTEM_FROM_IMPORTED TRUE)
 endif()
-
-include("${CGAL_MODULES_DIR}/CGAL_enable_end_of_configuration_hook.cmake")

--- a/Polyhedron/demo/Polyhedron/polyhedron_demo_macros.cmake
+++ b/Polyhedron/demo/Polyhedron/polyhedron_demo_macros.cmake
@@ -47,7 +47,7 @@ include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
               set_property(TEST "compilation_of__demo_framework"
                 APPEND PROPERTY LABELS "CGAL_build_system")
               set_property(TEST "compilation_of__demo_framework"
-                PROPERTY FIXTURES_SETUP "check_build_system_SetupFixture")
+                APPEND PROPERTY FIXTURES_SETUP "demo_framework_SetupFixture")
               set_property(TEST "compilation_of__demo_framework"
                 APPEND PROPERTY DEPENDS "compilation_of__CGAL_Qt5_moc_and_resources")
         endif()
@@ -55,6 +55,9 @@ include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
     else()
       target_link_libraries( ${plugin_name} PUBLIC Polyhedron_demo_framework)
       add_dependencies(${plugin_name} Polyhedron_demo_framework)
+    endif()
+    if(TARGET compilation_of__demo_framework)
+      set_property(TEST compilation_of__${plugin_name} APPEND PROPERTY FIXTURES_REQUIRED demo_framework_SetupFixture)
     endif()
     # Link with CGAL
     target_link_libraries( ${plugin_name} PUBLIC ${CGAL_LIBRARIES} ${CGAL_3RD_PARTY_LIBRARIES} )


### PR DESCRIPTION
## Summary of Changes

1. Starting with CMake 3.18, use `cmake_language(DEFER CALL..)` instead of `variable_watch`. That was a really bad hack!
2. Create fixture `demo_framework_SetupFixture`.
   That avoids that all targets of CGAL depend on `demo_framework`. Now only the plugins depend on it.
3.  Fix the dependencies of CTest tests on `compilation_of__CGAL_Qt5_moc_and_resources`.

## Release Management

* Affected package(s): Installation, Polyhedron demo
* License and copyright ownership: maintenance by GeometryFactory

