### PR TITLE
Surface_mesh_segmentation: fix the memory leak

### DIFF
--- a/Surface_mesh_segmentation/include/CGAL/Surface_mesh_segmentation/internal/auxiliary/graph.h
+++ b/Surface_mesh_segmentation/include/CGAL/Surface_mesh_segmentation/internal/auxiliary/graph.h
@@ -520,6 +520,8 @@ public:
   /* Destructor */
   ~Graph();
 
+  void clear();
+
   /* Adds a node to the graph */
   node_id add_node();
 
@@ -701,7 +703,7 @@ inline Graph::Graph(void (*err_function)(const char *))
   flow = 0;
 }
 
-inline Graph::~Graph()
+inline void Graph::clear()
 {
   while (node_block_first) {
     node_block *next = node_block_first -> next;
@@ -720,6 +722,11 @@ inline Graph::~Graph()
     delete[] arc_rev_block_first -> start;
     arc_rev_block_first = next;
   }
+}
+
+inline Graph::~Graph()
+{
+  clear();
 }
 
 inline Graph::node_id Graph::add_node()

--- a/Surface_mesh_segmentation/include/CGAL/boost/graph/Alpha_expansion_MaxFlow_tag.h
+++ b/Surface_mesh_segmentation/include/CGAL/boost/graph/Alpha_expansion_MaxFlow_tag.h
@@ -47,7 +47,7 @@ public:
 
   void clear_graph()
   {
-    graph = MaxFlow::Graph();
+    graph.clear();
   }
 
   Vertex_descriptor add_vertex()


### PR DESCRIPTION
## Summary of Changes

As pointed out by @lrineau the assignment of an empty graph, does not clear le lhs of the assignment.   Instead of writing an assignment operator for `graph` this PR adds a method    `graph::clear()".   
## Release Management

* Affected package(s): Surface_mesh_segmentation


