### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -2,6 +2,9 @@ name: CMake Test Merge Branch
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 

--- a/.github/workflows/cmake-all.yml
+++ b/.github/workflows/cmake-all.yml
@@ -2,6 +2,9 @@ name: CMake Testsuite
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   cmake-testsuite:
 

--- a/.github/workflows/delete_doc.yml
+++ b/.github/workflows/delete_doc.yml
@@ -3,9 +3,14 @@ name: Documentation Removal
 on:
   pull_request_target:
     types: [closed, removed]
+permissions:
+  contents: read
+
 jobs:
   build:
 
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -2,6 +2,9 @@ name: Test Polyhedron Demo
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   batch_1:
     runs-on: ubuntu-latest


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
