### PR TITLE
Fix exterior offset creation for a polygon with holes

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -21,6 +21,11 @@ Release date: June 2022
 
     See also the [announcement page](https://www.cgal.org/2022/05/18/alpha_wrap/).
 
+### [2D Straight Skeleton and Polygon Offsetting (breaking change)](https://doc.cgal.org/5.5/Manual/packages.html#PkgStraightSkeleton2)
+-   Fix the output of the function [CGAL::create_exterior_skeleton_and_offset_polygons_with_holes_2()](https://doc.cgal.org/5.5/Straight_skeleton_2/group__PkgStraightSkeleton2OffsetFunctions.html#gaa159f093e5d6d7fdb62c1660a44f95fe)
+    to not take into account the offset of the outer frame.
+-   Fix the computation of the exterior offset of a polygon with holes that was not computing the offset of the holes
+
 ### [3D Convex Hulls](https://doc.cgal.org/5.5/Manual/packages.html#PkgConvexHull3)
 
 -   Added an [overload of the function `CGAL::convex_hull_3()`](https://doc.cgal.org/5.5/Convex_hull_3/group__PkgConvexHull3Functions.html#ga52fca4745c2ef0351063fbe66b035fd1), which writes the result in an indexed triangle set.

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/create_offset_polygons_from_polygon_with_holes_2.h
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/CGAL/create_offset_polygons_from_polygon_with_holes_2.h
@@ -38,9 +38,13 @@ create_interior_skeleton_and_offset_polygons_with_holes_2(FT offset,
 \ingroup PkgStraightSkeleton2OffsetFunctions
 
 returns a container with all the outer offset polygons <I>with holes</I>
-at distance `offset` of the 2D polygon `poly_with_holes`.
+at distance `offset` of the 2D polygon `poly_with_holes`. Note that the
+offset of the outer frame is ignored.
 
-This is equivalent to `arrange_offset_polygons_2(create_exterior_skeleton_and_offset_polygons_2(offset, poly_with_holes, ofk, ssk))`.
+This is equivalent to a call to `CGAL::arrange_offset_polygons_2()` on the
+output of \link CGAL::create_exterior_skeleton_and_offset_polygons_2() `create_exterior_skeleton_and_offset_polygons_2(offset, poly_with_holes, ofk, ssk))` \endlink
+after having filtered out the polygon corresponding to the offset of the outer frame and
+having reversed the orientation of all other polygons.
 
 \tparam OfK must be a model of `Kernel`. It is used to instantiate
             `Polygon_offset_builder_traits_2<OfK>` for constructing the offset polygons.

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/Straight_skeleton_2.txt
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/Straight_skeleton_2.txt
@@ -422,10 +422,14 @@ This \cgal packages provides a helper function to compute the required separatio
 
 If you use this function to place the outer frame you are guaranteed to obtain an offset contour corresponding exclusively to the frame, which you can always identify as the one with the largest area and which you can simple remove from the result (to keep just the relevant outer contours).
 
-
 \cgalFigureBegin{Exterior,exterior_skeleton.png,exterior_offset.png}
 Exterior skeleton obtained using a frame (left) and 2 sample exterior offset contours (right)
 \cgalFigureEnd
+
+For convenience, the following functions are provided:
+
+- `CGAL::create_exterior_skeleton_and_offset_polygons_2()` adds the outer frame to the input polygon (with or without holes) and provides output offset polygons (`CGAL::Polygon_2<K>`), including the offset of the outer frame.
+- `CGAL::create_exterior_skeleton_and_offset_polygons_with_holes_2()` adds the outer frame to the input polygon (with or without holes) and provides as output offset polygons with holes (`CGAL::Polygon_with_holes_2`), exclusing the offset of the outer frame.
 
 \section Straight_skeleton_2Straight Straight Skeletons, Medial Axis and Voronoi Diagrams
 

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/Straight_skeleton_2.txt
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/Straight_skeleton_2.txt
@@ -441,7 +441,7 @@ On the other hand, only reflex vertices (whose internal angle \f$ > \pi\f$)
 are the source of deviations of the bisectors from its center
 location. Therefore, for convex polygons, the straight skeleton, the
 medial axis and the Voronoi diagram are exactly equivalent,
-and, if a non-convex polygon contains only vertices of lowfor f in *.txt ; do echo $f ; aspell list < $f | sort | uniq -c ; done
+and, if a non-convex polygon contains only vertices of low
 reflexivity, the straight skeleton bisectors will be placed nearly
 equidistant to their defining edges, producing a straight skeleton
 pretty much alike a proper medial axis.

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/CMakeLists.txt
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/CMakeLists.txt
@@ -15,6 +15,7 @@ endforeach()
 
 if(CGAL_Qt5_FOUND)
   target_link_libraries(draw_straight_skeleton_2 PUBLIC CGAL::CGAL_Basic_viewer)
+  target_link_libraries(exterior_offset_of_multiple_polygons_with_holes PUBLIC CGAL::CGAL_Basic_viewer)
 else()
   message(STATUS "NOTICE: The example draw_straight_skeleton_2 requires Qt and will not be compiled.")
 endif()

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/exterior_offset_of_multiple_polygons_with_holes.cpp
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/exterior_offset_of_multiple_polygons_with_holes.cpp
@@ -14,11 +14,11 @@
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K ;
 
 typedef K::Point_2                    Point ;
-typedef CGAL::Polygon_2<K>            Polygon ;
+typedef CGAL::Polygon_2<K>            Polygon_2 ;
 typedef CGAL::Polygon_with_holes_2<K> PolygonWithHoles ;
 
 typedef boost::shared_ptr<PolygonWithHoles> PolygonWithHolesPtr ;
-typedef boost::shared_ptr<Polygon> PolygonPtr ;
+typedef boost::shared_ptr<Polygon_2> PolygonPtr ;
 
 typedef std::vector<PolygonWithHolesPtr> PolygonWithHolesPtrVector;
 typedef std::vector<PolygonPtr> PolygonPtrVector;
@@ -45,13 +45,13 @@ exterior_offset_of_disjoint_polygons_with_holes(double lOffset, const std::vecto
     double fymin = bbox.ymin() - lm ;
     double fymax = bbox.ymax() + lm ;
 
-    Polygon frame ;
+    Polygon_2 frame ;
     frame.push_back( Point(fxmin,fymin) );
     frame.push_back( Point(fxmax,fymin) );
     frame.push_back( Point(fxmax,fymax) );
     frame.push_back( Point(fxmin,fymax) );
 
-    std::vector<Polygon> outer_as_holes;
+    std::vector<Polygon_2> outer_as_holes;
     outer_as_holes.reserve(pwhs.size());
     for (const PolygonWithHoles& pwh : pwhs)
       outer_as_holes.emplace_back(pwh.outer_boundary().container().rbegin(),
@@ -86,7 +86,7 @@ exterior_offset_of_disjoint_polygons_with_holes(double lOffset, const std::vecto
                                                  hit!=pwh.holes_end();
                                                  ++hit)
       {
-        Polygon h = *hit;
+        Polygon_2 h = *hit;
         h.reverse_orientation();
         PolygonPtrVector off_hole = CGAL::create_interior_skeleton_and_offset_polygons_2(lOffset,h);
         off_polys.insert(off_polys.end(), off_hole.begin(), off_hole.end());
@@ -105,14 +105,14 @@ int main()
 
   for (int i=0; i<4; ++i)
   {
-    Polygon outer;
+    Polygon_2 outer;
     outer.push_back( Point(i+0+i*10, 0) );
     outer.push_back( Point(i+0+(i+1)*10, 0) );
     outer.push_back( Point(i+0+(i+1)*10, 10) );
     outer.push_back( Point(i+0+i*10, 10) );
     pwhs.emplace_back(outer);
 
-    Polygon hole;
+    Polygon_2 hole;
     hole.push_back( Point(i+3+i*10,3) ) ;
     hole.push_back( Point(i+6+i*10,3) ) ;
     hole.push_back( Point(i+6+i*10,6) ) ;

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/exterior_offset_of_multiple_polygons_with_holes.cpp
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/exterior_offset_of_multiple_polygons_with_holes.cpp
@@ -1,0 +1,131 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/Polygon_with_holes_2.h>
+#include <CGAL/create_offset_polygons_from_polygon_with_holes_2.h>
+
+#include <boost/shared_ptr.hpp>
+
+#include <CGAL/draw_polygon_with_holes_2.h>
+
+
+#include <vector>
+#include <cassert>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K ;
+
+typedef K::Point_2                    Point ;
+typedef CGAL::Polygon_2<K>            Polygon ;
+typedef CGAL::Polygon_with_holes_2<K> PolygonWithHoles ;
+
+typedef boost::shared_ptr<PolygonWithHoles> PolygonWithHolesPtr ;
+typedef boost::shared_ptr<Polygon> PolygonPtr ;
+
+typedef std::vector<PolygonWithHolesPtr> PolygonWithHolesPtrVector;
+typedef std::vector<PolygonPtr> PolygonPtrVector;
+
+PolygonWithHolesPtrVector
+exterior_offset_of_disjoint_polygons_with_holes(double lOffset, const std::vector<PolygonWithHoles>& pwhs)
+{
+  std::vector<Point> outer_vertices;
+  for (const PolygonWithHoles& pwh : pwhs)
+    outer_vertices.insert(outer_vertices.end(),
+                          pwh.outer_boundary().container().begin(),
+                          pwh.outer_boundary().container().end());
+  boost::optional<double> margin = compute_outer_frame_margin(outer_vertices.begin(),
+                                                              outer_vertices.end(),
+                                                              lOffset);
+
+  if ( margin )
+  {
+    double lm = CGAL::to_double(*margin);
+    CGAL::Bbox_2 bbox = bbox_2(outer_vertices.begin(), outer_vertices.end());
+
+    double fxmin = bbox.xmin() - lm ;
+    double fxmax = bbox.xmax() + lm ;
+    double fymin = bbox.ymin() - lm ;
+    double fymax = bbox.ymax() + lm ;
+
+    Polygon frame ;
+    frame.push_back( Point(fxmin,fymin) );
+    frame.push_back( Point(fxmax,fymin) );
+    frame.push_back( Point(fxmax,fymax) );
+    frame.push_back( Point(fxmin,fymax) );
+
+    std::vector<Polygon> outer_as_holes;
+    outer_as_holes.reserve(pwhs.size());
+    for (const PolygonWithHoles& pwh : pwhs)
+      outer_as_holes.emplace_back(pwh.outer_boundary().container().rbegin(),
+                                  pwh.outer_boundary().container().rend());
+
+    PolygonWithHoles pwh(frame, outer_as_holes.begin(), outer_as_holes.end());
+    PolygonPtrVector off_polys = CGAL::create_interior_skeleton_and_offset_polygons_2(lOffset,pwh);
+
+    // filter outer frame
+    Point xtrm_pt = *(off_polys[0]->begin());
+    std::size_t outer_id=0;
+    for(std::size_t i=0; i<off_polys.size(); ++i)
+      if (off_polys[i]->orientation() == CGAL::COUNTERCLOCKWISE)
+      {
+        for (const Point& p : off_polys[i]->container())
+          if (p < xtrm_pt)
+          {
+            xtrm_pt=p;
+            outer_id=i;
+          }
+      }
+    if (outer_id != (off_polys.size()-1))
+      std::swap(off_polys[outer_id], off_polys.back());
+    off_polys.pop_back();
+    for (PolygonPtr ptr : off_polys)
+      ptr->reverse_orientation();
+
+    // offset of holes
+    for (const PolygonWithHoles& pwh : pwhs)
+    {
+      for (PolygonWithHoles::Hole_const_iterator hit=pwh.holes_begin();
+                                                 hit!=pwh.holes_end();
+                                                 ++hit)
+      {
+        Polygon h = *hit;
+        h.reverse_orientation();
+        PolygonPtrVector off_hole = CGAL::create_interior_skeleton_and_offset_polygons_2(lOffset,h);
+        off_polys.insert(off_polys.end(), off_hole.begin(), off_hole.end());
+      }
+    }
+
+    return CGAL::arrange_offset_polygons_2<PolygonWithHoles>(off_polys);
+  }
+
+  return PolygonWithHolesPtrVector();
+}
+
+int main()
+{
+  std::vector<PolygonWithHoles> pwhs;
+
+  for (int i=0; i<4; ++i)
+  {
+    Polygon outer;
+    outer.push_back( Point(i+0+i*10, 0) );
+    outer.push_back( Point(i+0+(i+1)*10, 0) );
+    outer.push_back( Point(i+0+(i+1)*10, 10) );
+    outer.push_back( Point(i+0+i*10, 10) );
+    pwhs.emplace_back(outer);
+
+    Polygon hole;
+    hole.push_back( Point(i+3+i*10,3) ) ;
+    hole.push_back( Point(i+6+i*10,3) ) ;
+    hole.push_back( Point(i+6+i*10,6) ) ;
+    hole.push_back( Point(i+3+i*10,6) ) ;
+    pwhs[i].add_hole( hole ) ;
+  }
+
+  double lOffset = 1.1 ;
+
+  PolygonWithHolesPtrVector offset_poly_with_holes = exterior_offset_of_disjoint_polygons_with_holes(lOffset,pwhs);
+
+  for (PolygonWithHolesPtr ptr : offset_poly_with_holes)
+    CGAL::draw(*ptr);
+
+  return 0;
+}

--- a/Straight_skeleton_2/include/CGAL/create_offset_polygons_2.h
+++ b/Straight_skeleton_2/include/CGAL/create_offset_polygons_2.h
@@ -389,7 +389,25 @@ create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
            ofk);
 }
 
-// Overloads common to both polygons with and without holes, a simple polygon is returned in any case
+/*! create_interior_skeleton_and_offset_polygons_2 with a polygon with holes */
+
+// overload where PolygonWithHoles actually is a type of Polygon that supports holes
+template<class FT, class PolygonWithHoles, class OfK, class SsK,
+         class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<PolygonWithHoles, OfK>::type>
+std::vector<boost::shared_ptr<OutPolygon> >
+inline
+create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
+                                               const PolygonWithHoles& aPoly,
+                                               const OfK& ofk,
+                                               const SsK& ssk,
+                                               typename std::enable_if<
+                                                 CGAL_SS_i::has_Hole_const_iterator<PolygonWithHoles>::value>::type* = nullptr)
+{
+  return create_exterior_skeleton_and_offset_polygons_2(aOffset, aPoly.outer_boundary(), ofk, ssk);
+}
+
+
+// Overloads common to both polygons with and without holes, a simple polygons are returned in any case
 template<class FT, class APolygon, class OfK,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<APolygon, OfK>::type>
 std::vector< boost::shared_ptr<OutPolygon> >

--- a/Straight_skeleton_2/include/CGAL/create_offset_polygons_2.h
+++ b/Straight_skeleton_2/include/CGAL/create_offset_polygons_2.h
@@ -403,7 +403,21 @@ create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                typename std::enable_if<
                                                  CGAL_SS_i::has_Hole_const_iterator<PolygonWithHoles>::value>::type* = nullptr)
 {
-  return create_exterior_skeleton_and_offset_polygons_2(aOffset, aPoly.outer_boundary(), ofk, ssk);
+  std::vector<boost::shared_ptr<OutPolygon> > polygons =
+    create_exterior_skeleton_and_offset_polygons_2(aOffset, aPoly.outer_boundary(), ofk, ssk);
+
+  for (typename PolygonWithHoles::Hole_const_iterator hit=aPoly.holes_begin(); hit!=aPoly.holes_end(); ++hit)
+  {
+    typename PolygonWithHoles::Polygon_2 hole = *hit;
+    hole.reverse_orientation();
+    std::vector<boost::shared_ptr<OutPolygon> > hole_polygons =
+        create_interior_skeleton_and_offset_polygons_2(aOffset,
+                                                       hole,
+                                                       ofk,ssk);
+    polygons.insert(polygons.end(), hole_polygons.begin(), hole_polygons.end());
+  }
+
+  return polygons;
 }
 
 

--- a/Straight_skeleton_2/include/CGAL/create_offset_polygons_2.h
+++ b/Straight_skeleton_2/include/CGAL/create_offset_polygons_2.h
@@ -334,6 +334,25 @@ create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                         ofk, ssk);
 }
 
+/*! create_interior_skeleton_and_offset_polygons_2 (no sorting of the result) */
+
+// overload where PolygonWithHoles actually is a type of Polygon that supports holes
+template<class FT, class PolygonWithHoles, class OfK, class SsK,
+         class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<PolygonWithHoles, OfK>::type> // Hole-less polygon type
+std::vector<boost::shared_ptr<OutPolygon> >
+inline
+create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
+                                               const PolygonWithHoles& aPoly,
+                                               const OfK& ofk,
+                                               const SsK& ssk,
+                                               typename std::enable_if<
+                                                 CGAL_SS_i::has_Hole_const_iterator<PolygonWithHoles>::value>::type* = nullptr)
+{
+  return create_interior_skeleton_and_offset_polygons_2(aOffset, aPoly.outer_boundary(),
+                                                        aPoly.holes_begin(), aPoly.holes_end(),
+                                                        ofk, ssk);
+}
+
 // Overloads common to both polygons with and without holes, a simple polygon is returned in any case
 template<class FT, class APolygon, class OfK,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<APolygon, OfK>::type>

--- a/Straight_skeleton_2/include/CGAL/create_offset_polygons_2.h
+++ b/Straight_skeleton_2/include/CGAL/create_offset_polygons_2.h
@@ -334,25 +334,6 @@ create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
                                                         ofk, ssk);
 }
 
-/*! create_interior_skeleton_and_offset_polygons_2 (no sorting of the result) */
-
-// overload where PolygonWithHoles actually is a type of Polygon that supports holes
-template<class FT, class PolygonWithHoles, class OfK, class SsK,
-         class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<PolygonWithHoles, OfK>::type> // Hole-less polygon type
-std::vector<boost::shared_ptr<OutPolygon> >
-inline
-create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
-                                               const PolygonWithHoles& aPoly,
-                                               const OfK& ofk,
-                                               const SsK& ssk,
-                                               typename std::enable_if<
-                                                 CGAL_SS_i::has_Hole_const_iterator<PolygonWithHoles>::value>::type* = nullptr)
-{
-  return create_interior_skeleton_and_offset_polygons_2(aOffset, aPoly.outer_boundary(),
-                                                        aPoly.holes_begin(), aPoly.holes_end(),
-                                                        ofk, ssk);
-}
-
 // Overloads common to both polygons with and without holes, a simple polygon is returned in any case
 template<class FT, class APolygon, class OfK,
          class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<APolygon, OfK>::type>
@@ -407,38 +388,6 @@ create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
                ssk)),
            ofk);
 }
-
-/*! create_interior_skeleton_and_offset_polygons_2 with a polygon with holes */
-
-// overload where PolygonWithHoles actually is a type of Polygon that supports holes
-template<class FT, class PolygonWithHoles, class OfK, class SsK,
-         class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<PolygonWithHoles, OfK>::type>
-std::vector<boost::shared_ptr<OutPolygon> >
-inline
-create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
-                                               const PolygonWithHoles& aPoly,
-                                               const OfK& ofk,
-                                               const SsK& ssk,
-                                               typename std::enable_if<
-                                                 CGAL_SS_i::has_Hole_const_iterator<PolygonWithHoles>::value>::type* = nullptr)
-{
-  std::vector<boost::shared_ptr<OutPolygon> > polygons =
-    create_exterior_skeleton_and_offset_polygons_2(aOffset, aPoly.outer_boundary(), ofk, ssk);
-
-  for (typename PolygonWithHoles::Hole_const_iterator hit=aPoly.holes_begin(); hit!=aPoly.holes_end(); ++hit)
-  {
-    typename PolygonWithHoles::Polygon_2 hole = *hit;
-    hole.reverse_orientation();
-    std::vector<boost::shared_ptr<OutPolygon> > hole_polygons =
-        create_interior_skeleton_and_offset_polygons_2(aOffset,
-                                                       hole,
-                                                       ofk,ssk);
-    polygons.insert(polygons.end(), hole_polygons.begin(), hole_polygons.end());
-  }
-
-  return polygons;
-}
-
 
 // Overloads common to both polygons with and without holes, a simple polygons are returned in any case
 template<class FT, class APolygon, class OfK,

--- a/Straight_skeleton_2/include/CGAL/create_offset_polygons_from_polygon_with_holes_2.h
+++ b/Straight_skeleton_2/include/CGAL/create_offset_polygons_from_polygon_with_holes_2.h
@@ -97,23 +97,6 @@ create_interior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /// EXTERIOR
 
-/*! create_interior_skeleton_and_offset_polygons_2 with a polygon with holes */
-
-// overload where PolygonWithHoles actually is a type of Polygon that supports holes
-template<class FT, class PolygonWithHoles, class OfK, class SsK,
-         class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<PolygonWithHoles, OfK>::type>
-std::vector<boost::shared_ptr<OutPolygon> >
-inline
-create_exterior_skeleton_and_offset_polygons_2(const FT& aOffset,
-                                               const PolygonWithHoles& aPoly,
-                                               const OfK& ofk,
-                                               const SsK& ssk,
-                                               typename std::enable_if<
-                                                 CGAL_SS_i::has_Hole_const_iterator<PolygonWithHoles>::value>::type* = nullptr)
-{
-  return create_exterior_skeleton_and_offset_polygons_2(aOffset, aPoly.outer_boundary(), ofk, ssk);
-}
-
 /*! create_exterior_skeleton_and_offset_polygons_with_holes_2 (orders the resulting polygons) */
 
 // Polygon might be a Polygon with holes or not, but it returns a Polygon with holes

--- a/Straight_skeleton_2/include/CGAL/create_offset_polygons_from_polygon_with_holes_2.h
+++ b/Straight_skeleton_2/include/CGAL/create_offset_polygons_from_polygon_with_holes_2.h
@@ -33,25 +33,6 @@ namespace CGAL {
 ////////////////////////////////////////////////////////////////////////////////////////////////////
 /// INTERIOR
 
-/*! create_interior_skeleton_and_offset_polygons_2 (no sorting of the result) */
-
-// overload where PolygonWithHoles actually is a type of Polygon that supports holes
-template<class FT, class PolygonWithHoles, class OfK, class SsK,
-         class OutPolygon = typename CGAL_SS_i::Default_return_polygon_type<PolygonWithHoles, OfK>::type> // Hole-less polygon type
-std::vector<boost::shared_ptr<OutPolygon> >
-inline
-create_interior_skeleton_and_offset_polygons_2(const FT& aOffset,
-                                               const PolygonWithHoles& aPoly,
-                                               const OfK& ofk,
-                                               const SsK& ssk,
-                                               typename std::enable_if<
-                                                 CGAL_SS_i::has_Hole_const_iterator<PolygonWithHoles>::value>::type* = nullptr)
-{
-  return create_interior_skeleton_and_offset_polygons_2(aOffset, aPoly.outer_boundary(),
-                                                        aPoly.holes_begin(), aPoly.holes_end(),
-                                                        ofk, ssk);
-}
-
 /*! create_interior_skeleton_and_offset_polygons_with_holes_2 (orders the resulting polygons) */
 
 // Polygon might be a Polygon with holes or not, but it returns a Polygon with holes

--- a/Straight_skeleton_2/include/CGAL/create_offset_polygons_from_polygon_with_holes_2.h
+++ b/Straight_skeleton_2/include/CGAL/create_offset_polygons_from_polygon_with_holes_2.h
@@ -90,8 +90,30 @@ create_exterior_skeleton_and_offset_polygons_with_holes_2(const FT& aOffset,
                                                           const OfK& ofk,
                                                           const SsK& ssk)
 {
-  return arrange_offset_polygons_2<OutPolygonWithHoles>(
-           create_exterior_skeleton_and_offset_polygons_2(aOffset, aPoly, ofk, ssk));
+  typedef typename CGAL_SS_i::Default_return_polygon_type<Polygon, OfK>::type Polygon_;
+  std::vector<boost::shared_ptr<Polygon_> > raw_output =
+    create_exterior_skeleton_and_offset_polygons_2(aOffset, aPoly, ofk, ssk);
+
+  // filter offset of the outer frame
+  typename OfK::Point_2 xtrm_pt = *(raw_output[0]->begin());
+  std::size_t outer_id=0;
+  for(std::size_t i=0; i<raw_output.size(); ++i)
+    if (raw_output[i]->orientation() == COUNTERCLOCKWISE)
+    {
+      for (const typename OfK::Point_2& p : raw_output[i]->container())
+        if (p < xtrm_pt)
+        {
+          xtrm_pt=p;
+          outer_id=i;
+        }
+    }
+  if (outer_id != (raw_output.size()-1))
+    std::swap(raw_output[outer_id], raw_output.back());
+  raw_output.pop_back();
+  for (boost::shared_ptr<Polygon_> ptr : raw_output)
+    ptr->reverse_orientation();
+
+  return arrange_offset_polygons_2<OutPolygonWithHoles>(raw_output);
 }
 
 template<class FT, class Polygon, class OfK,

--- a/Straight_skeleton_2/test/Straight_skeleton_2/test_sls_offset.cpp
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/test_sls_offset.cpp
@@ -806,6 +806,44 @@ void test_offset_polygon_exterior()
 }
 
 template <typename K>
+void test_offset_polygon_with_holes_exterior()
+{
+  std::cout << " --- Test Polygon exterior, kernel: " << typeid(K).name() << std::endl;
+
+  typedef typename K::Point_2                                        Point;
+
+  typedef CGAL::Polygon_2<K>                                         Polygon_2;
+  typedef CGAL::Polygon_with_holes_2<K>                              Polygon_with_holes_2;
+  typedef boost::shared_ptr<Polygon_with_holes_2>                    Polygon_with_holes_2_ptr;
+  typedef std::vector<Polygon_with_holes_2_ptr>                      Polygon_with_holes_2_ptr_container;
+
+  Polygon_2 outer ;
+    outer.push_back( Point( 10.0, 10.0) ) ;
+    outer.push_back( Point(-10.0, 10.0) ) ;
+    outer.push_back( Point(-10.0, -10.0) ) ;
+    outer.push_back( Point(10.0, -10.0) ) ;
+
+  Polygon_2 hole ;
+    hole.push_back( Point(5.0,5.0) ) ;
+    hole.push_back( Point(5.0,-5.0) ) ;
+    hole.push_back( Point(-5.0,-5.0) ) ;
+    hole.push_back( Point(-5.0,5.0) ) ;
+
+  Polygon_with_holes_2 pwh(outer) ;
+  pwh.add_hole( hole ) ;
+
+  Polygon_with_holes_2_ptr_container offset_poly_with_holes_1 =
+    CGAL::create_exterior_skeleton_and_offset_polygons_with_holes_2(1., pwh, K(), EPICK());
+  assert(offset_poly_with_holes_1.size()==1);
+  assert(offset_poly_with_holes_1[0]->number_of_holes()==1);
+
+  Polygon_with_holes_2_ptr_container offset_poly_with_holes_2 =
+    CGAL::create_exterior_skeleton_and_offset_polygons_with_holes_2(5., pwh, K(), EPICK());
+  assert(offset_poly_with_holes_2.size()==1);
+  assert(offset_poly_with_holes_2[0]->number_of_holes()==0);
+}
+
+template <typename K>
 void test_offset(const char* filename)
 {
   std::cout << "Construct inner offset of input: " << filename
@@ -937,6 +975,7 @@ void test_kernel()
   test_offset_non_manifold<K>();
   test_offset_non_manifold_2<K>();
   test_offset_polygon_exterior<K>();
+  test_offset_polygon_with_holes_exterior<K>();
   test_offset_multiple_CCs<K>();
 
   // Real data

--- a/Straight_skeleton_2/test/Straight_skeleton_2/test_sls_offset.cpp
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/test_sls_offset.cpp
@@ -760,9 +760,8 @@ void test_offset_polygon_exterior()
 //    print_polygon_with_holes(*offp);
 
   assert(offset_poly_with_holes.size() == 1);
-  assert(offset_poly_with_holes[0]->outer_boundary().size() == 4);
-  assert(offset_poly_with_holes[0]->number_of_holes() == 1);
-  assert(offset_poly_with_holes[0]->holes_begin()->size() == 12);
+  assert(offset_poly_with_holes[0]->outer_boundary().size() == 12);
+  assert(offset_poly_with_holes[0]->number_of_holes() == 0);
 
   // -----------------------------------------------------------------------------------------------
   // Value such that it is clearly separated into two contours
@@ -770,20 +769,19 @@ void test_offset_polygon_exterior()
   offset_poly_with_holes =
     create_exterior_skeleton_and_offset_polygons_with_holes_2(FT(7), poly, K(), EPICK());
 
-//  for(const auto& offp : offset_poly_with_holes)
-//    print_polygon_with_holes(*offp);
+  // for(const auto& offp : offset_poly_with_holes)
+  //  print_polygon_with_holes(*offp);
 
-  assert(offset_poly_with_holes.size() == 2);
-  assert(offset_poly_with_holes[0]->outer_boundary().size() == 4);
+  assert(offset_poly_with_holes.size() == 1);
   assert(offset_poly_with_holes[0]->number_of_holes() == 1);
 
   // Technically both polygons below should be rectangles, but the algorithm puts a 5th vertex collinear.
   // Tolerating it for now...
 
-  // assert(offset_poly_with_holes[0]->holes_begin()->size() == 4);
-  // assert(offset_poly_with_holes[1]->outer_boundary().size() == 4);
+  assert(offset_poly_with_holes[0]->holes_begin()->size() >= 4);
+  assert(offset_poly_with_holes[0]->outer_boundary().size() >= 4);
   assert(offset_poly_with_holes[0]->holes_begin()->is_simple());
-  assert(offset_poly_with_holes[1]->outer_boundary().is_simple());
+  assert(offset_poly_with_holes[0]->outer_boundary().is_simple());
 
   // -----------------------------------------------------------------------------------------------
   // Border value between a single contour and two contours
@@ -795,17 +793,16 @@ void test_offset_polygon_exterior()
 //  for(const auto& offp : offset_poly_with_holes)
 //    print_polygon_with_holes(*offp);
 
-  assert(offset_poly_with_holes.size() == 2);
-  assert(offset_poly_with_holes[0]->outer_boundary().size() == 4);
+  assert(offset_poly_with_holes.size() >= 1);
   assert(offset_poly_with_holes[0]->number_of_holes() == 1);
 
   // Technically both polygons below should be rectangles, but the algorithm puts a 5th vertex collinear.
   // Tolerating it for now...
 
-  // assert(offset_poly_with_holes[0]->holes_begin()->size() == 4);
-  // assert(offset_poly_with_holes[1]->outer_boundary().size() == 4);
+  assert(offset_poly_with_holes[0]->holes_begin()->size() >= 4);
+  assert(offset_poly_with_holes[0]->outer_boundary().size() >= 4);
   assert(offset_poly_with_holes[0]->holes_begin()->is_simple());
-  assert(offset_poly_with_holes[1]->outer_boundary().is_simple());
+  assert(offset_poly_with_holes[0]->outer_boundary().is_simple());
 }
 
 template <typename K>


### PR DESCRIPTION
This PR is both a fix and a breaking change of a behavior that was IMO buggy in the first place (thus not backported to 5.4).

Fix the function creating exterior offsets to also consider holes + update functions dumping exterior offsets as polygons with holes to ignore the offset of the outer frame.