### PR TITLE
Parameterization: Make Iterative_authalic_parameterization faster (WIP)

### DIFF
--- a/Solver_interface/doc/Solver_interface/Concepts/SparseLinearAlgebraTraits_d.h
+++ b/Solver_interface/doc/Solver_interface/Concepts/SparseLinearAlgebraTraits_d.h
@@ -127,6 +127,7 @@ NT& operator[](Index row);
 
 `SparseLinearAlgebraTraits_d::Matrix` is a concept of a sparse matrix class.
 
+\cgalRefines Assignable
 \cgalRefines DefaultConstructible
 
 \cgalHasModel `CGAL::Eigen_sparse_matrix<T>`
@@ -220,10 +221,6 @@ operator*(const NT& c, const Matrix& M);
 /// Sum of two matrices.
 friend Matrix
 operator+(const Matrix& M0, const Matrix& M1);
-
-/// Assignment operator
-friend Matrix
-operator=(const Matrix& M);
 
 /// @}
 

--- a/Solver_interface/doc/Solver_interface/Concepts/SparseLinearAlgebraTraits_d.h
+++ b/Solver_interface/doc/Solver_interface/Concepts/SparseLinearAlgebraTraits_d.h
@@ -221,6 +221,10 @@ operator*(const NT& c, const Matrix& M);
 friend Matrix
 operator+(const Matrix& M0, const Matrix& M1);
 
+/// Assignment operator
+friend Matrix
+operator=(const Matrix& M);
+
 /// @}
 
 }; /* end Matrix */

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Iterative_authalic_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Iterative_authalic_parameterizer_3.h
@@ -50,7 +50,7 @@
 #include <iomanip>
 #include <unordered_set>
 
-// #define DEBUG_L0 1 // @fixme
+#define DEBUG_L0 0 // @fixme
 
 /// \file Iterative_authalic_parameterizer_3.h
 

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Iterative_authalic_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Iterative_authalic_parameterizer_3.h
@@ -304,32 +304,6 @@ public:
   }
 
   // Computation helpers
-protected:
-  // `operator=(onst Matrix& other)` isn't part of the concept...
-  template <typename VertexIndexMap>
-  void copy_sparse_matrix(const Matrix& src,
-                          Matrix& dest,
-                          const Triangle_mesh& tmesh,
-                          const Vertex_set& vertices,
-                          const VertexIndexMap vimap)
-  {
-    dest = src;
-    return;
-    CGAL_precondition(src.row_dimension() == dest.row_dimension());
-    CGAL_precondition(src.column_dimension() == dest.column_dimension());
-
-    for(vertex_descriptor vertex : vertices)
-    {
-      const int i = get(vimap, vertex);
-      vertex_around_target_circulator v_j(halfedge(vertex, tmesh), tmesh), end = v_j;
-      CGAL_For_all(v_j, end)
-      {
-        const int j = get(vimap, *v_j);
-        dest.set_coef(i, j, src.get_coef(i, j), false);
-      }
-    }
-  }
-
 private:
   double compute_vertex_L2(const Triangle_mesh& tmesh,
                            const vertex_descriptor v) const
@@ -999,8 +973,8 @@ public:
 //      for(std::size_t i=0; i<nv; ++i)
 //        std::cout << "Sol[" << i << "] = " << Xu[i] << " " << Xv[i] << std::endl;
 
-      // Copy A to A_prev, it is a computationally inefficient task but neccesary
-      copy_sparse_matrix(A, A_prev, tmesh, cc_vertices, vimap);
+      // Copy A to A_prev
+      A_prev = A;
 
       // Copy Xu and Xv coordinates into the (u,v) pair of each vertex
       for(vertex_descriptor v : cc_vertices)

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Iterative_authalic_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Iterative_authalic_parameterizer_3.h
@@ -50,7 +50,7 @@
 #include <iomanip>
 #include <unordered_set>
 
-#define DEBUG_L0 1 // @fixme
+// #define DEBUG_L0 1 // @fixme
 
 /// \file Iterative_authalic_parameterizer_3.h
 
@@ -313,6 +313,8 @@ protected:
                           const Vertex_set& vertices,
                           const VertexIndexMap vimap)
   {
+    dest = src;
+    return;
     CGAL_precondition(src.row_dimension() == dest.row_dimension());
     CGAL_precondition(src.column_dimension() == dest.column_dimension());
 


### PR DESCRIPTION
## Summary of Changes

I hard coded the copy of a sparse matrix.   We have to add this properly to a Solver API.
I removed debug output that writes the mesh after each iteration.

## Release Management

* Affected package(s): Surface_mesh_parameterization
* Issue(s) solved (if any): fix #6694

