### PR TITLE
Surface_mesh: fixed saving of face colors using property maps from named parameters

### DIFF
--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -578,8 +578,8 @@ std::string get_property_raw_name(const std::string& prop, typename Surface_mesh
 template <typename Point, typename Simplex, typename Simplex2, bool = std::is_same<Simplex, Simplex2>::value >
 struct add_color_map {
   add_color_map() {}
-  void operator()(std::vector<Abstract_property_printer<Simplex>*>& printers,
-    typename Surface_mesh<Point>::template Property_map<Simplex2, CGAL::IO::Color>& pmap) {
+  void operator()(std::vector<Abstract_property_printer<Simplex>*>&,
+    typename Surface_mesh<Point>::template Property_map<Simplex2, CGAL::IO::Color>&) {
   }
 };
 
@@ -593,7 +593,6 @@ struct add_color_map<Point, Simplex, Simplex2, true> {
   }
 
   void operator()(std::vector<Abstract_property_printer<Simplex>*>& printers,
-    //CGAL::internal::Dynamic<CGAL::Surface_mesh<Point_3>,CGAL::Surface_mesh<Point_3>::Property_map<CGAL::Surface_mesh<Point_3>::Face_index,T>>
     CGAL::internal::Dynamic<Surface_mesh<Point>, typename Surface_mesh<Point>::template Property_map<Simplex2, CGAL::IO::Color> >& pmap) {
     printers.push_back(new Property_printer<Simplex, typename Surface_mesh<Point>::template Property_map<Simplex, CGAL::IO::Color>>(*pmap.map_));
   }
@@ -602,11 +601,11 @@ struct add_color_map<Point, Simplex, Simplex2, true> {
 template <typename Point, typename Simplex, typename Simplex2>
 struct add_color_map<Point, Simplex, Simplex2, false> {
   add_color_map() {}
-  void operator()(std::vector<Abstract_property_printer<Simplex>*>& printers,
-    typename Surface_mesh<Point>::template Property_map<Simplex2, CGAL::IO::Color>& pmap) {
+  void operator()(std::vector<Abstract_property_printer<Simplex>*>&,
+    typename Surface_mesh<Point>::template Property_map<Simplex2, CGAL::IO::Color>&) {
   }
-  void operator()(std::vector<Abstract_property_printer<Simplex>*>& printers,
-    CGAL::internal::Dynamic<Surface_mesh<Point>, typename Surface_mesh<Point>::template Property_map<Simplex2, CGAL::IO::Color> >& pmap) {
+  void operator()(std::vector<Abstract_property_printer<Simplex>*>&,
+    CGAL::internal::Dynamic<Surface_mesh<Point>, typename Surface_mesh<Point>::template Property_map<Simplex2, CGAL::IO::Color> >&) {
   }
 };
 

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -487,9 +487,9 @@ bool fill_simplex_specific_header(std::ostream& os,
                                   typename Surface_mesh<Point>::Face_index>*>& printers,
                                   const std::string& prop)
 {
-  typedef Surface_mesh<Point>                                   SMesh;
-  typedef typename SMesh::Face_index                            FIndex;
-  typedef typename SMesh::template Property_map<FIndex, Color>  Fcolor_map;
+  typedef typename Surface_mesh<Point>::Face_index                            FIndex;
+  typedef CGAL::IO::Color Color;
+  typedef typename Surface_mesh<Point>::template Property_map<FIndex, Color>  Fcolor_map;
 
   if(prop == "f:connectivity" || prop == "f:removed")
     return true;
@@ -575,9 +575,46 @@ std::string get_property_raw_name(const std::string& prop, typename Surface_mesh
   return name;
 }
 
-template <typename Point, typename Simplex>
+template <typename Point, typename Simplex, typename Simplex2, bool = std::is_same<Simplex, Simplex2>::value >
+struct add_color_map {
+  add_color_map() {}
+  void operator()(std::vector<Abstract_property_printer<Simplex>*>& printers,
+    typename Surface_mesh<Point>::template Property_map<Simplex2, CGAL::IO::Color>& pmap) {
+  }
+};
+
+template <typename Point, typename Simplex, typename Simplex2>
+struct add_color_map<Point, Simplex, Simplex2, true> {
+  add_color_map() {}
+
+  void operator()(std::vector<Abstract_property_printer<Simplex>*>& printers,
+    typename Surface_mesh<Point>::template Property_map<Simplex2, CGAL::IO::Color>& pmap) {
+    printers.push_back(new Property_printer<Simplex, typename Surface_mesh<Point>::template Property_map<Simplex, CGAL::IO::Color>>(pmap));
+  }
+
+  void operator()(std::vector<Abstract_property_printer<Simplex>*>& printers,
+    //CGAL::internal::Dynamic<CGAL::Surface_mesh<Point_3>,CGAL::Surface_mesh<Point_3>::Property_map<CGAL::Surface_mesh<Point_3>::Face_index,T>>
+    CGAL::internal::Dynamic<Surface_mesh<Point>, typename Surface_mesh<Point>::template Property_map<Simplex2, CGAL::IO::Color> >& pmap) {
+    printers.push_back(new Property_printer<Simplex, typename Surface_mesh<Point>::template Property_map<Simplex, CGAL::IO::Color>>(*pmap.map_));
+  }
+};
+
+template <typename Point, typename Simplex, typename Simplex2>
+struct add_color_map<Point, Simplex, Simplex2, false> {
+  add_color_map() {}
+  void operator()(std::vector<Abstract_property_printer<Simplex>*>& printers,
+    typename Surface_mesh<Point>::template Property_map<Simplex2, CGAL::IO::Color>& pmap) {
+  }
+  void operator()(std::vector<Abstract_property_printer<Simplex>*>& printers,
+    CGAL::internal::Dynamic<Surface_mesh<Point>, typename Surface_mesh<Point>::template Property_map<Simplex2, CGAL::IO::Color> >& pmap) {
+  }
+};
+
+template <typename Point, typename Simplex,
+          typename CGAL_NP_TEMPLATE_PARAMETERS>
 void fill_header(std::ostream& os, const Surface_mesh<Point>& sm,
-                 std::vector<Abstract_property_printer<Simplex>*>& printers)
+                 std::vector<Abstract_property_printer<Simplex>*>& printers,
+                 const CGAL_NP_CLASS& np = parameters::default_values())
 {
   typedef Surface_mesh<Point>                                             SMesh;
   typedef typename SMesh::template Property_map<Simplex, boost::int8_t>   Int8_map;
@@ -591,10 +628,60 @@ void fill_header(std::ostream& os, const Surface_mesh<Point>& sm,
   typedef typename SMesh::template Property_map<Simplex, float>           Float_map;
   typedef typename SMesh::template Property_map<Simplex, double>          Double_map;
 
+  typedef typename SMesh::Face_index                            FIndex;
+  typedef typename SMesh::Vertex_index                          VIndex;
+
+  typedef CGAL::IO::Color Color;
+  using VCM = typename internal_np::Lookup_named_param_def<
+    internal_np::vertex_color_map_t,
+    CGAL_NP_CLASS,
+    Surface_mesh<Point>::template Property_map<VIndex, CGAL::IO::Color> >::type;
+
+  using parameters::choose_parameter;
+  using parameters::is_default_parameter;
+  using parameters::get_parameter;
+
+  VCM vcm = choose_parameter(get_parameter(np, internal_np::vertex_color_map), VCM());
+  bool has_vcolor = !is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>::value;
+
+  typedef typename SMesh::template Property_map<FIndex, Color>  Fcolor_map;
+
+  using FCM = typename internal_np::Lookup_named_param_def<
+    internal_np::face_color_map_t,
+    CGAL_NP_CLASS,
+    Surface_mesh<Point>::template Property_map<FIndex, CGAL::IO::Color> >::type;
+  FCM fcm = choose_parameter(get_parameter(np, internal_np::face_color_map), FCM());
+  bool has_fcolor = !is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>::value;
+
   std::vector<std::string> prop = sm.template properties<Simplex>();
+
+  if (std::is_same<Simplex, FIndex>::value && has_fcolor) {
+    os << "property uchar red" << std::endl
+      << "property uchar green" << std::endl
+      << "property uchar blue" << std::endl
+      << "property uchar alpha" << std::endl;
+    add_color_map<Point, Simplex, FIndex>()(printers, fcm);
+  }
+
+  if (std::is_same<Simplex, VIndex>::value && has_vcolor)
+  {
+    os << "property uchar red" << std::endl
+      << "property uchar green" << std::endl
+      << "property uchar blue" << std::endl
+      << "property uchar alpha" << std::endl;
+
+    add_color_map<Point, Simplex, VIndex>()(printers, vcm);
+  }
 
   for(std::size_t i = 0; i < prop.size(); ++i)
   {
+    // Override internal color maps if additional ones are provided via named parameters.
+    if (has_vcolor && prop[i] == "v:color")
+      continue;
+
+    if (has_fcolor && prop[i] == "f:color")
+      continue;
+
     if(fill_simplex_specific_header(os, sm, printers, prop[i]))
       continue;
 
@@ -942,19 +1029,19 @@ bool write_PLY(std::ostream& os,
   os << "element vertex " << sm.number_of_vertices() << std::endl;
 
   std::vector<internal::Abstract_property_printer<VIndex>*> vprinters;
-  internal::fill_header(os, sm, vprinters);
+  internal::fill_header(os, sm, vprinters, np);
 
   os << "element face " << sm.number_of_faces() << std::endl;
   os << "property list uchar int vertex_indices" << std::endl;
   std::vector<internal::Abstract_property_printer<FIndex>*> fprinters;
-  internal::fill_header(os, sm, fprinters);
+  internal::fill_header(os, sm, fprinters, np);
 
 
   std::vector<internal::Abstract_property_printer<EIndex>*> eprinters;
   if(sm.template properties<EIndex>().size() > 1)
   {
     std::ostringstream oss;
-    internal::fill_header(oss, sm, eprinters);
+    internal::fill_header(oss, sm, eprinters, np);
 
     if(!eprinters.empty())
     {
@@ -969,7 +1056,7 @@ bool write_PLY(std::ostream& os,
   if(sm.template properties<HIndex>().size() > 1)
   {
     std::ostringstream oss;
-    internal::fill_header(oss, sm, hprinters);
+    internal::fill_header(oss, sm, hprinters, np);
 
     if(!hprinters.empty())
     {

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -631,11 +631,10 @@ void fill_header(std::ostream& os, const Surface_mesh<Point>& sm,
   typedef typename SMesh::Face_index                            FIndex;
   typedef typename SMesh::Vertex_index                          VIndex;
 
-  typedef CGAL::IO::Color Color;
   using VCM = typename internal_np::Lookup_named_param_def<
     internal_np::vertex_color_map_t,
     CGAL_NP_CLASS,
-    Surface_mesh<Point>::template Property_map<VIndex, CGAL::IO::Color> >::type;
+    typename Surface_mesh<Point>::template Property_map<VIndex, CGAL::IO::Color> >::type;
 
   using parameters::choose_parameter;
   using parameters::is_default_parameter;
@@ -644,12 +643,10 @@ void fill_header(std::ostream& os, const Surface_mesh<Point>& sm,
   VCM vcm = choose_parameter(get_parameter(np, internal_np::vertex_color_map), VCM());
   bool has_vcolor = !is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>::value;
 
-  typedef typename SMesh::template Property_map<FIndex, Color>  Fcolor_map;
-
   using FCM = typename internal_np::Lookup_named_param_def<
     internal_np::face_color_map_t,
     CGAL_NP_CLASS,
-    Surface_mesh<Point>::template Property_map<FIndex, CGAL::IO::Color> >::type;
+    typename Surface_mesh<Point>::template Property_map<FIndex, CGAL::IO::Color> >::type;
   FCM fcm = choose_parameter(get_parameter(np, internal_np::face_color_map), FCM());
   bool has_fcolor = !is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>::value;
 


### PR DESCRIPTION
## Summary of Changes

Changed ply.h to consider a color property map from named parameters before searching for internal property map.
Tested by using CGAL::IO::write_PLY

## Release Management

* Affected package(s): Surface_mesh
