### PR TITLE
SMDS_3 Incorrect link

### DIFF
--- a/SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h
+++ b/SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h
@@ -165,7 +165,7 @@ namespace CGAL {
   * @post the output triangulation must be a triangulation of the convex hull of `points`
   * @post `is_valid()` returns `true` for the returned triangulation
   *
-  * @sa \link polygon_soup_to_polygon_mesh() `CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh()` \endlink
+  * @sa \link Polygon_mesh_processing::polygon_soup_to_polygon_mesh() `CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh()` \endlink
   * @sa @ref SMDS_3/tetrahedron_soup_to_c3t3_example.cpp
   *
   */


### PR DESCRIPTION
We get the warning:
```
SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h:210: warning: unable to resolve link to 'polygon_soup_to_polygon_mesh()' for \link command
```

see also:
- https://cgal.geometryfactory.com/CGAL/Manual_doxygen_test/CGAL-5.6-Ic-16/logs_master/SMDS_3.log
- https://github.com/CGAL/cgal/pull/6645


