### PR TITLE
Spatial_searching: unsigned int -> size_t for vector copy

### DIFF
--- a/Spatial_searching/include/CGAL/Kd_tree.h
+++ b/Spatial_searching/include/CGAL/Kd_tree.h
@@ -330,7 +330,7 @@ public:
     dim_ = static_cast<int>(std::distance(ccci(p), ccci(p,0)));
 
     data.reserve(pts.size());
-    for(unsigned int i = 0; i < pts.size(); i++){
+    for(std::size_t i = 0; i < pts.size(); i++){
       data.push_back(&pts[i]);
     }
 


### PR DESCRIPTION
## Summary of Changes

Quick web-based driveby contribution (not tested) to fix what looks like a likely integer overflow for large point clouds.

## Release Management

* Affected package(s): `Spatial_searching`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

