### PR TITLE
Mesh_3 - weighted images oracle improvements

### DIFF
--- a/Mesh_3/examples/Mesh_3/mesh_3D_weighted_image.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_weighted_image.cpp
@@ -1,3 +1,5 @@
+#define CGAL_MESH_3_WEIGHTED_IMAGES_DEBUG
+
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Mesh_triangulation_3.h>
@@ -39,9 +41,7 @@ int main(int argc, char* argv[])
   /// [Loads image]
 
   /// [Domain creation]
-  const float sigma = 10.f;
-  CGAL::Image_3 img_weights =
-    CGAL::Mesh_3::generate_label_weights(image, sigma);
+  CGAL::Image_3 img_weights = CGAL::Mesh_3::generate_label_weights(image);
 
   Mesh_domain domain
     = Mesh_domain::create_labeled_image_mesh_domain(image,

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -778,7 +778,7 @@ void Mesh_3_plugin::mesh_3(const Mesh_type mesh_type,
       && sigma_weights != image_item->sigma_weights())
     {
       image_item->set_image_weights(
-        CGAL::Mesh_3::generate_label_weights(*pImage, sigma_weights),
+        CGAL::Mesh_3::generate_label_weights(*pImage),
         sigma_weights);
     }
 #endif


### PR DESCRIPTION
## Summary of Changes

The weighted images oracle does not generate as smooth meshes as we expected. This PR introduces some hints to improve it.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

