### PR TITLE
Workaround warning with gcc master

### DIFF
--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementPainterOstream.cpp
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementPainterOstream.cpp
@@ -289,7 +289,7 @@ ArrangementPainterOstream<CGAL::Arr_linear_traits_2<Kernel_>>::operator<<(
     QRectF seg_bb = this->convert(seg.bbox());
     if (
       this->clippingRect.isValid() &&
-      !this->clippingRect.intersects(seg_bb) &
+      !this->clippingRect.intersects(seg_bb) &&
         (!seg.is_horizontal() && !seg.is_vertical()))
     { return *this; }
 

--- a/Kernel_23/include/CGAL/Kernel_23/internal/Projection_traits_3.h
+++ b/Kernel_23/include/CGAL/Kernel_23/internal/Projection_traits_3.h
@@ -960,7 +960,7 @@ public:
 
       Equal_x_2 eqx;
       Equal_y_2 eqy;
-      return eqx(p,q) & eqy(p,q);
+      return eqx(p,q) && eqy(p,q);
     }
   };
 

--- a/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
@@ -73,11 +73,18 @@ search_for_connected_components_in_labeled_image(const CGAL::Image_3& image,
       for(uint i=0; i<nx; i++)
       {
         using CGAL::IMAGEIO::static_evaluate;
-
+#ifdef __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#  pragma GCC diagnostic ignored "-Wbitwise-instead-of-logical"
+#endif
         if(visited[voxel_index] | second_pass[voxel_index]) {
           ++voxel_index;
           continue;
         }
+#ifdef __GNUC__
+#  pragma GCC diagnostic pop
+#endif
         const Label current_label =
           transform(static_evaluate<Image_word_type>(image.image(),
                                                      voxel_index));

--- a/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
@@ -73,22 +73,10 @@ search_for_connected_components_in_labeled_image(const CGAL::Image_3& image,
       for(uint i=0; i<nx; i++)
       {
         using CGAL::IMAGEIO::static_evaluate;
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
-#ifdef __clang__
-#  pragma GCC diagnostic ignored "-Wunknown-warning-option"
-#else
-#  pragma GCC diagnostic ignored "-Wpragmas"
-#endif
-#  pragma GCC diagnostic ignored "-Wbitwise-instead-of-logical"
-#endif
-        if(visited[voxel_index] | second_pass[voxel_index]) {
+        if(visited[voxel_index] || second_pass[voxel_index]) {
           ++voxel_index;
           continue;
         }
-#ifdef __GNUC__
-#  pragma GCC diagnostic pop
-#endif
         const Label current_label =
           transform(static_evaluate<Image_word_type>(image.image(),
                                                      voxel_index));

--- a/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
@@ -73,16 +73,20 @@ search_for_connected_components_in_labeled_image(const CGAL::Image_3& image,
       for(uint i=0; i<nx; i++)
       {
         using CGAL::IMAGEIO::static_evaluate;
-#if defined(__GNUC__) && !defined(__clang__)
+#ifdef __GNUC__
 #  pragma GCC diagnostic push
+#ifdef __clang__
+#  pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#else
 #  pragma GCC diagnostic ignored "-Wpragmas"
+#endif
 #  pragma GCC diagnostic ignored "-Wbitwise-instead-of-logical"
 #endif
         if(visited[voxel_index] | second_pass[voxel_index]) {
           ++voxel_index;
           continue;
         }
-#if defined(__GNUC__) && !defined(__clang__)
+#ifdef __GNUC__
 #  pragma GCC diagnostic pop
 #endif
         const Label current_label =

--- a/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
@@ -73,16 +73,16 @@ search_for_connected_components_in_labeled_image(const CGAL::Image_3& image,
       for(uint i=0; i<nx; i++)
       {
         using CGAL::IMAGEIO::static_evaluate;
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#  pragma GCC diagnostic ignored "-Wpragmas"
 #  pragma GCC diagnostic ignored "-Wbitwise-instead-of-logical"
 #endif
         if(visited[voxel_index] | second_pass[voxel_index]) {
           ++voxel_index;
           continue;
         }
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #  pragma GCC diagnostic pop
 #endif
         const Label current_label =

--- a/Number_types/include/CGAL/GMP/Gmpzf_type.h
+++ b/Number_types/include/CGAL/GMP/Gmpzf_type.h
@@ -157,7 +157,7 @@ public:
       return;
     }
     const int p = std::numeric_limits<double>::digits;
-    CGAL_assertion(CGAL_NTS is_finite(d) & is_valid(d));
+    CGAL_assertion(CGAL_NTS is_finite(d) && is_valid(d));
     int exp;
     double x = std::frexp(d, &exp); // x in [1/2, 1], x*2^exp = d
     mpz_init_set_d (man(), // to the following integer:

--- a/Number_types/include/CGAL/MP_Float.h
+++ b/Number_types/include/CGAL/MP_Float.h
@@ -762,7 +762,7 @@ namespace INTERN_MP_FLOAT {
     while (true) {
       x = x % y;
       if (x == 0) {
-        CGAL_postcondition(internal::divides(y, a) & internal::divides(y, b));
+        CGAL_postcondition(internal::divides(y, a) && internal::divides(y, b));
         y.gcd_normalize();
         return y;
       }

--- a/STL_Extension/include/CGAL/Uncertain.h
+++ b/STL_Extension/include/CGAL/Uncertain.h
@@ -291,6 +291,7 @@ Uncertain<bool> operator!(Uncertain<bool> a)
 
 #ifdef __GNUC__
 #  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wunknown-warning-option"
 #  pragma GCC diagnostic ignored "-Wbitwise-instead-of-logical"
 #endif
 inline

--- a/STL_Extension/include/CGAL/Uncertain.h
+++ b/STL_Extension/include/CGAL/Uncertain.h
@@ -289,6 +289,10 @@ Uncertain<bool> operator!(Uncertain<bool> a)
   return Uncertain<bool>(!a.sup(), !a.inf());
 }
 
+#ifdef __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#endif
 inline
 Uncertain<bool> operator|(Uncertain<bool> a, Uncertain<bool> b)
 {
@@ -324,7 +328,9 @@ Uncertain<bool> operator&(Uncertain<bool> a, bool b)
 {
   return Uncertain<bool>(a.inf() & b, a.sup() & b);
 }
-
+#ifdef __GNUC__
+#  pragma GCC diagnostic pop
+#endif
 
 // Equality operators
 

--- a/STL_Extension/include/CGAL/Uncertain.h
+++ b/STL_Extension/include/CGAL/Uncertain.h
@@ -291,7 +291,7 @@ Uncertain<bool> operator!(Uncertain<bool> a)
 
 #ifdef __GNUC__
 #  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wstrict-aliasing"
+#  pragma GCC diagnostic ignored "-Wbitwise-instead-of-logical"
 #endif
 inline
 Uncertain<bool> operator|(Uncertain<bool> a, Uncertain<bool> b)

--- a/STL_Extension/include/CGAL/Uncertain.h
+++ b/STL_Extension/include/CGAL/Uncertain.h
@@ -289,9 +289,9 @@ Uncertain<bool> operator!(Uncertain<bool> a)
   return Uncertain<bool>(!a.sup(), !a.inf());
 }
 
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#  pragma GCC diagnostic ignored "-Wpragmas"
 #  pragma GCC diagnostic ignored "-Wbitwise-instead-of-logical"
 #endif
 inline
@@ -329,7 +329,7 @@ Uncertain<bool> operator&(Uncertain<bool> a, bool b)
 {
   return Uncertain<bool>(a.inf() & b, a.sup() & b);
 }
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)
 #  pragma GCC diagnostic pop
 #endif
 

--- a/STL_Extension/include/CGAL/Uncertain.h
+++ b/STL_Extension/include/CGAL/Uncertain.h
@@ -289,9 +289,13 @@ Uncertain<bool> operator!(Uncertain<bool> a)
   return Uncertain<bool>(!a.sup(), !a.inf());
 }
 
-#if defined(__GNUC__) && !defined(__clang__)
+#ifdef __GNUC__
 #  pragma GCC diagnostic push
+#ifdef __clang__
+#  pragma GCC diagnostic ignored "-Wunknown-warning-option"
+#else
 #  pragma GCC diagnostic ignored "-Wpragmas"
+#endif
 #  pragma GCC diagnostic ignored "-Wbitwise-instead-of-logical"
 #endif
 inline
@@ -329,7 +333,7 @@ Uncertain<bool> operator&(Uncertain<bool> a, bool b)
 {
   return Uncertain<bool>(a.inf() & b, a.sup() & b);
 }
-#if defined(__GNUC__) && !defined(__clang__)
+#ifdef __GNUC__
 #  pragma GCC diagnostic pop
 #endif
 

--- a/STL_Extension/include/CGAL/Uncertain.h
+++ b/STL_Extension/include/CGAL/Uncertain.h
@@ -289,13 +289,9 @@ Uncertain<bool> operator!(Uncertain<bool> a)
   return Uncertain<bool>(!a.sup(), !a.inf());
 }
 
-#ifdef __GNUC__
-#  pragma GCC diagnostic push
 #ifdef __clang__
+#  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wunknown-warning-option"
-#else
-#  pragma GCC diagnostic ignored "-Wpragmas"
-#endif
 #  pragma GCC diagnostic ignored "-Wbitwise-instead-of-logical"
 #endif
 inline
@@ -333,7 +329,7 @@ Uncertain<bool> operator&(Uncertain<bool> a, bool b)
 {
   return Uncertain<bool>(a.inf() & b, a.sup() & b);
 }
-#ifdef __GNUC__
+#ifdef __clang__
 #  pragma GCC diagnostic pop
 #endif
 

--- a/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
@@ -45,7 +45,7 @@ bool are_parallel_edges_equally_oriented( Segment_2_with_ID<K> const& e0, Segmen
 template<class K>
 bool are_edges_orderly_collinear( Segment_2_with_ID<K> const& e0, Segment_2_with_ID<K> const& e1 )
 {
-  return are_edges_collinear(e0,e1) & are_parallel_edges_equally_oriented(e0,e1);
+  return are_edges_collinear(e0,e1) && are_parallel_edges_equally_oriented(e0,e1);
 }
 
 


### PR DESCRIPTION
Should remove [those warnings](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.6-I-19/AABB_tree/TestReport_lrineau_ArchLinux-clang-CXX20-Release.gz)