### PR TITLE
STL_Extension Documentation permanent redirects

### DIFF
--- a/STL_Extension/doc/STL_Extension/Concepts/Hashable.h
+++ b/STL_Extension/doc/STL_Extension/Concepts/Hashable.h
@@ -12,8 +12,8 @@ of the `graph_traits` header files provided by \cgal.
 They can be disables by defining the macro `CGAL_DISABLE_HASH_OPENMESH`.
 
 \sa `CGAL::Unique_hash_map<Key,Mapped,Hash>`
-\sa <A HREF="http://www.cplusplus.com/reference/unordered_set/unordered_set/">`std::unordered_set`</a>
-\sa <A HREF="http://www.cplusplus.com/reference/unordered_set/unordered_map/">`std::unordered_map`</a>
+\sa <A HREF="https://en.cppreference.com/w/cpp/container/unordered_set">`std::unordered_set`</a>
+\sa <A HREF="https://en.cppreference.com/w/cpp/container/unordered_map">`std::unordered_map`</a>
 \sa <A HREF="https://www.boost.org/doc/libs/release/doc/html/boost/unordered_set.html">`boost::unordered_set`</a>
 \sa <A HREF="https://www.boost.org/doc/libs/release/doc/html/boost/unordered_map.html">`boost::unordered_map`</a>
 


### PR DESCRIPTION
For the file STL_Extension/classHashable.html we got some permanent redirects:
```
List of redirects
http://www.cplusplus.com/reference/unordered_set/unordered_set/
-> https://cplusplus.com/reference/unordered_set/unordered_set/
  Line: 177
  Code: 301 -> 200 OK
 To do: This is a permanent redirect. The link should be updated.

http://www.cplusplus.com/reference/unordered_set/unordered_map/
-> https://cplusplus.com/reference/unordered_set/unordered_map/
  Line: 179
  Code: 301 -> 200 OK
 To do: This is a permanent redirect. The link should be updated.

```
