### PR TITLE
Allow manually fixing a range of vertices, when using  `Mean_curvature_flow_skeletonization`

### DIFF
--- a/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
+++ b/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
@@ -392,7 +392,7 @@ public:
                                       const Traits& traits = Traits())
     : m_traits(traits), m_weight_calculator(true /* use_clamped_version */)
   {
-    init(tmesh);
+    init(tmesh, get(vertex_point, tmesh));
   }
   #endif
   /// @} Constructor
@@ -843,12 +843,13 @@ private:
   }
 
   /// Initialize some global data structures such as vertex id.
-  void init(const TriangleMesh& tmesh)
+  void init(const TriangleMesh& tmesh, VertexPointMap vpm)
   {
     typedef std::pair<Input_vertex_descriptor, vertex_descriptor> Vertex_pair;
     std::vector<Vertex_pair> v2v;
     copy_face_graph(tmesh, m_tmesh,
-                    CGAL::parameters::vertex_to_vertex_output_iterator(std::back_inserter(v2v)));
+                    CGAL::parameters::vertex_to_vertex_output_iterator(
+                      std::back_inserter(v2v)).vertex_point_map(vpm));
 
     // copy input vertices to keep correspondence
     for(const Vertex_pair& vp : v2v)

--- a/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
+++ b/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
@@ -515,12 +515,13 @@ public:
 
   /// \cgalAdvancedFunction
   /// \cgalAdvancedBegin
-  /// Fixes a range of vertices.  Fixed vertices will not be moved
+  /// sets the vertices in the range `[begin, end)` as fixed.  Fixed vertices will not be moved
   /// during contraction and this will therefore prevent convergence
   /// towards the skeleton if `contract_until_convergence()` is used.
-  /// It is only useful if the object is to retrieve the meso-skeleton
+  /// It is useful only if the end goal is to retrieve the meso-skeleton
   /// after a number of `contract_geometry()`, keeping the specified
   /// vertices fixed in place.
+  /// \tparam InputIterator a model of `InputIterator` with `boost::graph_traits<TriangleMesh>::%vertex_descriptor` as value type.
   /// \cgalAdvancedEnd
   template<class InputIterator>
   void set_fixed_vertices(InputIterator begin, InputIterator end)

--- a/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
+++ b/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
@@ -513,6 +513,28 @@ public:
     m_omega_P = value;
   }
 
+  /// \cgalAdvancedFunction
+  /// \cgalAdvancedBegin
+  /// Fixes a range of vertices.  Fixed vertices will not be moved
+  /// during contraction and this will therefore prevent convergence
+  /// towards the skeleton if `contract_until_convergence()` is used.
+  /// It is only useful if the object is to retrieve the meso-skeleton
+  /// after a number of `contract_geometry()`, keeping the specified
+  /// vertices fixed in place.
+  /// \cgalAdvancedEnd
+  template<class InputIterator>
+  void set_fixed_vertices(InputIterator begin, InputIterator end)
+  {
+    std::unordered_set<Input_vertex_descriptor> set(begin, end);
+
+    for(vertex_descriptor vd : vertices(m_tmesh))
+    {
+      if (set.find(vd->vertices[0]) != set.end()) {
+        vd->is_fixed = true;
+      }
+    }
+  }
+
   /// \cond SKIP_FROM_MANUAL
   void set_zero_TH(double value)
   {


### PR DESCRIPTION
This patch allows manually fixing a range of vertices, preventing them from moving during contraction when using `Mean_curvature_flow_skeletonization`.  Naturally, this will prevent convergence towards the skeleton, but its intended use is in cases where one is interested in the meso-skeleton and needs to keep part of it fixed, similar to the `vertex_is_constrained_map` named parameter of many functions.  (My current use for it, is in combination with `smooth_shape`, which is essentially complementary to it and already has the aforementioned `vertex_is_constrained_map` feature, to achieve relatively uniform contraction of a mesh, keeping a part of it fixed.) 

The implementation is trivial, since it uses an existing part of the algorithm and it seems to work as expected in the cases I've tried.  The only issue is the interface.  I've mimicked the interface of the surface deformation package (as in `insert_roi_vertices` for instance), but perhaps you'll have a better suggestion.  The current implementation has the minor drawback of requiring the creation of a set with the given descriptors, plus a pass through the mesh vertices, which could probably be avoided if the fixed vertices were available during initialization (when copying the input mesh in `init()`).  Other than that the implementation should be ok in terms of operation, as far as I can see.

Let me know if you'd like me to make additional changes; this is only meant as a proof of concept implementation.
