### PR TITLE
Polyhedron demo - fix display of protecting balls

### DIFF
--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -1359,9 +1359,9 @@ QOpenGLShaderProgram* Viewer::getShaderProgram(int name) const
   case PROGRAM_CUTPLANE_SPHERES:
   {
     QOpenGLShaderProgram* program = isOpenGL_4_3()
-        ? declare_program(name, ":/cgal/Polyhedron_3/resources/shader_c3t3_spheres.vert" , ":/cgal/Polyhedron_3/resources/shader_c3t3.frag")
-        : declare_program(name, ":/cgal/Polyhedron_3/resources/compatibility_shaders/shader_c3t3_spheres.vert" ,
-                          ":/cgal/Polyhedron_3/resources/compatibility_shaders/shader_c3t3.frag");
+        ? declare_program(name, ":/cgal/Polyhedron_3/resources/shader_spheres.vert" , ":/cgal/Polyhedron_3/resources/shader_with_light.frag")
+        : declare_program(name, ":/cgal/Polyhedron_3/resources/compatibility_shaders/shader_spheres.vert" ,
+                          ":/cgal/Polyhedron_3/resources/compatibility_shaders/shader_with_light.frag");
     program->setProperty("hasLight", true);
     program->setProperty("hasNormals", true);
     program->setProperty("hasCenter", true);


### PR DESCRIPTION
## Summary of Changes

On some setups (including mine), the protecting balls for a C3t3 could not be displayed anymore in the demo.
This PR attempts to fix the display of protecting balls.

The regression was introduced by PR #5809 by the set of commits :
- e5914cf70fcd231cd0930f7ab1564b05e4013edc (the first **bad** wrt displaying protecting balls, that compiles and displays the C3t3 properly)
- 4f9fc89a10651c087083a66026a9c5f4c49c7c17
- 73eafddd39b595c1cb0cfcd862104551c748eb4f
- 2c36a1797cbec4dde5f0e08180d4c0e6a593e097
- last **good** was : ec41af7e33af779082dadd93bd3816a4c8e9ca52

My patch does not fix the code introduced by these commits, but disables the "c3t3 spheres" shader.

## Release Management

* Affected package(s): Polyhedron demo
* License and copyright ownership: unchanged

