### PR TITLE
Nef_3: Fix in nary functions

### DIFF
--- a/Nef_3/doc/Nef_3/CGAL/Nef_nary_union_3.h
+++ b/Nef_3/doc/Nef_3/CGAL/Nef_nary_union_3.h
@@ -38,7 +38,9 @@ Nef_nary_union_3<NefPolyhedron_3>();
 /// @{
 
 /*!
-returns the union of the polyhedra previously added to the class.
+returns the union of the polyhedra previously added to the class. The
+union does not get removed so that further Nef polyhedra can be added
+later.
 */
 NefPolyhedron_3 get_union() const;
 

--- a/Nef_3/include/CGAL/Nef_nary_intersection_3.h
+++ b/Nef_3/include/CGAL/Nef_nary_intersection_3.h
@@ -56,7 +56,7 @@ class Nef_nary_intersection_3 {
       return empty;
     while(queue.size() > 1)
       intersect();
-    inserted = 0;
+    inserted = 1;
     return queue.front();
   }
 };

--- a/Nef_3/include/CGAL/Nef_nary_union_3.h
+++ b/Nef_3/include/CGAL/Nef_nary_union_3.h
@@ -56,7 +56,7 @@ class Nef_nary_union_3 {
       return empty;
     while(queue.size() > 1)
       unite();
-    inserted = 0;
+    inserted = 1;
     return queue.front();
   }
 };


### PR DESCRIPTION
## Summary of Changes

As the result of the nary operations stays in the  `Nef_nary_union` object the queue size must be set to 1 and not to 0. 

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): fix #6771 

