### PR TITLE
Fix warnings

### DIFF
--- a/Point_set_processing_3/include/CGAL/structure_point_set.h
+++ b/Point_set_processing_3/include/CGAL/structure_point_set.h
@@ -257,7 +257,7 @@ public:
     {
       m_points.push_back (get(point_map, *it));
       m_normals.push_back (get(normal_map, *it));
-      int plane_index = get (index_map, idx);
+      int plane_index = static_cast<int>(get (index_map, idx));
       if (plane_index != -1)
       {
         m_indices_of_assigned_points[std::size_t(plane_index)].push_back(idx);

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
@@ -941,6 +941,7 @@ void Scene_edit_box_item_priv::remodel_box(const QVector3D &dir)
   Q_FOREACH(Scene_edit_box_item::vertex*  selected_vertex, selected_vertices )
   {
     int id = selected_vertex->id;
+    CGAL_assume(id<8);
     *selected_vertex->x = applyX(id, last_pool[id][0], dir.x());
     *selected_vertex->y = applyY(id, last_pool[id][1], dir.y());
     *selected_vertex->z = applyZ(id, last_pool[id][2], dir.z());

--- a/Shape_regularization/include/CGAL/Shape_regularization/internal/utils.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/internal/utils.h
@@ -508,7 +508,7 @@ namespace internal {
 
     std::vector< std::vector<Point> > listp(nb_planes);
     for (std::size_t i = 0; i < points.size(); ++i) {
-      const int idx = get(index_map, i);
+      const int idx = static_cast<int>(get(index_map, i));
       if (idx != -1) {
         listp[std::size_t(idx)].push_back(
           get(point_map, *(points.begin() + i)));


### PR DESCRIPTION
Fixes:

- [[w]](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.6-Ic-40/Polyhedron_Demo/TestReport_Christo_MSVC2017-Debug-64bits.gz) Polyhedron_Demo/TestReport_Christo_MSVC2017-Release-64bits.gz:   202>C:\CGAL_ROOT\CGAL-5.6-Ic-40\include\CGAL/Shape_regularization/internal/utils.h(511): warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data [C:\CGAL_ROOT\CGAL-5.6-Ic-40\cmake\platforms\MSVC2017-Release-64bits\test\Polyhedron_Demo\Plugins\Point_set\point_set_shape_detection_plugin.vcxproj]
- [[w]](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.6-Ic-40/Polyhedron_Demo/TestReport_Christo_MSVC2017-Debug-64bits.gz) Polyhedron_Demo/TestReport_Christo_MSVC2017-Release-64bits.gz:   202>C:\CGAL_ROOT\CGAL-5.6-Ic-40\include\CGAL/structure_point_set.h(260): warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data [C:\CGAL_ROOT\CGAL-5.6-Ic-40\cmake\platforms\MSVC2017-Release-64bits\test\Polyhedron_Demo\Plugins\Point_set\point_set_shape_detection_plugin.vcxproj]
Polyhedron_Demo/TestReport_Christo_MSVC2017-Release-64bits.gz:         C:\CGAL_ROOT\CGAL-5.6-Ic-40\include\CGAL/structure_point_set.h(260): warning C4267: 'initializing': conversion from 'size_t' to 'int', possible loss of data [C:\CGAL_ROOT\CGAL-5.6-Ic-40\cmake\platforms\MSVC2017-Release-64bits\test\Polyhedron_Demo\Plugins\Point_set\point_set_shape_detection_plugin.vcxproj]
- [[w]](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.6-Ic-40/Polyhedron_Demo/TestReport_lrineau_Fedora-with-LEDA.gz) Polyhedron_Demo/TestReport_lrineau_Fedora-with-LEDA.gz:/home/cgal_tester/build/src/cmake/platforms/Fedora-with-LEDA/test/Polyhedron_Demo/Plugins/PCA/Scene_edit_box_item.cpp:945:50: warning: array subscript [0, 7] is outside array bounds of ‘double [8][3]’ [-Warray-bounds]

