### PR TITLE
Mesh_3 speedup (filter failures in `Compare_distance_3(Point_3, Segment_3, Point_3)` )

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -443,8 +443,9 @@ private:
                               const T1& obj1,
                               const T2& obj2) const
   {
-    return CGAL::compare(CGAL::squared_distance(p, obj1),
-                         CGAL::squared_distance(p, obj2));
+    typename Kernel::Compare_distance_3 compare_distance =
+      Kernel().compare_distance_3_object();
+    return compare_distance(p,obj1,obj2);
   }
 
 public:


### PR DESCRIPTION
There are more than 90% filter failures in calls to
`Compare_distance_3()(Point_3, Segment_3, Point_3)`, while called by the protecting balls placement algorithm.

This commit divides by 10 the initialization (protecting ball placement) time, at least on polyhedral surfaces input.

## Summary of Changes

I temporarily replaced the explicit kernel-calling code by a simple call to global functions, before we have a proper fix.

## Release Management

The full Mesh_3 `ctest` testsuite (examples and tests) passes, in Release and Debug mode, on my machine

* Affected package(s): Mesh_3 (and Kernel)
* Issue(s) solved (if any): fix #6792
* License and copyright ownership: unchanged

