### PR TITLE
Parameterization: instanciation ->  instantiation

### DIFF
--- a/Alpha_shapes_3/include/CGAL/Alpha_shape_3.h
+++ b/Alpha_shapes_3/include/CGAL/Alpha_shape_3.h
@@ -319,7 +319,7 @@ private :
   }
 
  // the version to be used with Tag_true is templated to avoid
- // instanciation through explicit instantiation of the whole class
+ // instantiation through explicit instantiation of the whole class
   void set_alpha_min_of_vertices(Tag_false)
   {
     for( Finite_vertices_iterator vit = finite_vertices_begin();

--- a/NewKernel_d/include/CGAL/NewKernel_d/utils.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/utils.h
@@ -138,7 +138,7 @@ struct Has_type_different_from <T, No, true>
 }
 
 // TODO: make a Cartesian-only variant
-// WARNING: do not use the Req* parameters too much, they can cause circular instanciations and are only useful for dispatching.
+// WARNING: do not use the Req* parameters too much, they can cause circular instantiations and are only useful for dispatching.
 #define CGAL_STRIP_PAREN_(...) __VA_ARGS__
 #define CGAL_STRIP_PAREN(...) CGAL_STRIP_PAREN_ __VA_ARGS__
 // What to do with O? pass it down to other functors or drop it?

--- a/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/Concepts/Parameterizer_3.h
+++ b/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/Concepts/Parameterizer_3.h
@@ -58,9 +58,9 @@ public:
   ///
   /// \param mesh a triangulated surface.
   /// \param bhd a halfedge descriptor on the boundary of `mesh`.
-  /// \param uvmap an instanciation of the class `VertexUVmap`.
-  /// \param vimap an instanciation of the class `VertexIndexMap`.
-  /// \param vpmap an instanciation of the class `VertexParameterizedMap`.
+  /// \param uvmap an instantiation of the class `VertexUVmap`.
+  /// \param vimap an instantiation of the class `VertexIndexMap`.
+  /// \param vpmap an instantiation of the class `VertexParameterizedMap`.
   ///
   /// \pre `mesh` must be a triangular mesh.
   /// \pre The vertices must be indexed (`vimap` must be initialized)
@@ -75,4 +75,3 @@ public:
   /// @}
 
 }; /* end Parameterizer_3 */
-

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -138,7 +138,7 @@ namespace Surface_mesh_parameterization {
 ///
 /// \tparam TriangleMesh_ must be a model of `FaceGraph`.
 ///
-/// \tparam BorderParameterizer_ is a Strategy to parameterize the surface border
+/// \tparam BorderParameterizer_ is a strategy to parameterize the surface border
 ///         and must be a model of `Parameterizer_3`.<br>
 ///         <b>%Default:</b>
 /// \code

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -1293,9 +1293,9 @@ public:
   ///
   /// \param mesh a triangulated surface.
   /// \param bhd a halfedge descriptor on the boundary of `mesh`.
-  /// \param uvmap an instanciation of the class `VertexUVmap`.
-  /// \param vimap an instanciation of the class `VertexIndexMap`.
-  /// \param vpmap an instanciation of the class `VertexParameterizedMap`.
+  /// \param uvmap an instantiation of the class `VertexUVmap`.
+  /// \param vimap an instantiation of the class `VertexIndexMap`.
+  /// \param vpmap an instantiation of the class `VertexParameterizedMap`.
   ///
   /// \pre `mesh` must be a triangular mesh.
   /// \pre The vertices must be indexed (vimap must be initialized).

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Barycentric_mapping_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Barycentric_mapping_parameterizer_3.h
@@ -53,7 +53,7 @@ namespace Surface_mesh_parameterization {
 ///
 /// \tparam TriangleMesh_ must be a model of `FaceGraph`.
 ///
-/// \tparam BorderParameterizer_ is a Strategy to parameterize the surface border
+/// \tparam BorderParameterizer_ is a strategy to parameterize the surface border
 ///         and must be a model of `Parameterizer_3`.<br>
 ///         <b>%Default:</b>
 /// \code

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Barycentric_mapping_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Barycentric_mapping_parameterizer_3.h
@@ -157,8 +157,7 @@ public:
   // Default copy constructor and operator =() are fine
 
   /// returns whether the 3D -> 2D mapping is one-to-one.
-  template <typename VertexUVMap,
-            typename Faces_Container>
+  template <typename VertexUVMap>
   bool is_one_to_one_mapping(const Triangle_mesh& mesh,
                              halfedge_descriptor bhd,
                              const VertexUVMap uvmap) const

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Circular_border_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Circular_border_parameterizer_3.h
@@ -119,8 +119,8 @@ public:
   ///
   /// \param mesh a triangulated surface.
   /// \param bhd a halfedge descriptor on the boundary of `mesh`.
-  /// \param uvmap an instanciation of the class `VertexUVmap`.
-  /// \param vpmap an instanciation of the class `VertexParameterizedMap`.
+  /// \param uvmap an instantiation of the class `VertexUVmap`.
+  /// \param vpmap an instantiation of the class `VertexParameterizedMap`.
   ///
   /// \pre `mesh` must be a triangular mesh.
   /// \pre The vertices must be indexed (vimap must be initialized).

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Discrete_authalic_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Discrete_authalic_parameterizer_3.h
@@ -54,7 +54,7 @@ namespace Surface_mesh_parameterization {
 ///
 /// \tparam TriangleMesh_ must be a model of `FaceGraph`.
 ///
-/// \tparam BorderParameterizer_ is a Strategy to parameterize the surface border
+/// \tparam BorderParameterizer_ is a strategy to parameterize the surface border
 ///         and must be a model of `Parameterizer_3`.<br>
 ///         <b>%Default:</b>
 /// \code

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Discrete_conformal_map_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Discrete_conformal_map_parameterizer_3.h
@@ -54,7 +54,7 @@ namespace Surface_mesh_parameterization {
 ///
 /// \tparam TriangleMesh_ must be a model of `FaceGraph`
 ///
-/// \tparam BorderParameterizer_ is a Strategy to parameterize the surface border
+/// \tparam BorderParameterizer_ is a strategy to parameterize the surface border
 ///         and must be a model of `Parameterizer_3`.<br>
 ///         <b>%Default:</b>
 /// \code

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Fixed_border_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Fixed_border_parameterizer_3.h
@@ -68,7 +68,7 @@ namespace Surface_mesh_parameterization {
 ///
 /// \tparam TriangleMesh_ must be a model of `FaceGraph`.
 ///
-/// \tparam BorderParameterizer_ is a Strategy to parameterize the surface border
+/// \tparam BorderParameterizer_ is a strategy to parameterize the surface border
 ///         and must be a model of `Parameterizer_3`.<br>
 ///         <b>%Default:</b>
 /// \code

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Fixed_border_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Fixed_border_parameterizer_3.h
@@ -190,9 +190,9 @@ public:
   ///
   /// \param mesh a triangulated surface.
   /// \param bhd a halfedge descriptor on the boundary of `mesh`.
-  /// \param uvmap an instanciation of the class `VertexUVmap`.
-  /// \param vimap an instanciation of the class `VertexIndexMap`.
-  /// \param vpmap an instanciation of the class `VertexParameterizedMap`.
+  /// \param uvmap an instantiation of the class `VertexUVmap`.
+  /// \param vimap an instantiation of the class `VertexIndexMap`.
+  /// \param vpmap an instantiation of the class `VertexParameterizedMap`.
   ///
   /// \pre `mesh` must be a triangular mesh.
   /// \pre The mesh border must be mapped onto a convex polygon.
@@ -323,8 +323,8 @@ protected:
   /// \param Bv the right hand side vector in the linear system of y coordinates
   /// \param mesh a triangulated surface.
   /// \param bhd a halfedge descriptor on the boundary of `mesh`.
-  /// \param uvmap an instanciation of the class `VertexUVmap`.
-  /// \param vimap an instanciation of the class `VertexIndexMap`.
+  /// \param uvmap an instantiation of the class `VertexUVmap`.
+  /// \param vimap an instantiation of the class `VertexIndexMap`.
   ///
   /// \pre Vertices must be indexed (`vimap` must be initialized).
   /// \pre `A`, `Bu`, and `Bv` must be allocated.

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Iterative_authalic_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Iterative_authalic_parameterizer_3.h
@@ -806,8 +806,8 @@ public:
   /// \param Bv the right hand side vector in the linear system of y coordinates
   /// \param tmesh a triangulated surface
   /// \param bhd a halfedge descriptor on the boundary of `mesh`
-  /// \param uvmap an instanciation of the class `VertexUVmap`
-  /// \param vimap an instanciation of the class `VertexIndexMap`
+  /// \param uvmap an instantiation of the class `VertexUVmap`
+  /// \param vimap an instantiation of the class `VertexIndexMap`
   ///
   /// \pre Vertices must be indexed (`vimap` must be initialized).
   /// \pre `A`, `Bu`, and `Bv` must be allocated.
@@ -1082,9 +1082,9 @@ public:
   ///
   /// \param tmesh a triangulated surface
   /// \param bhd a halfedge descriptor on the boundary of `mesh`
-  /// \param uvmap an instanciation of the class `VertexUVmap`
-  /// \param vimap an instanciation of the class `VertexIndexMap`
-  /// \param vpmap an instanciation of the class `VertexParameterizedMap`
+  /// \param uvmap an instantiation of the class `VertexUVmap`
+  /// \param vimap an instantiation of the class `VertexIndexMap`
+  /// \param vpmap an instantiation of the class `VertexParameterizedMap`
   /// \param iterations an integer number of iterations to run the parameterization
   ///
   /// \pre `tmesh` must be a triangular mesh.

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Iterative_authalic_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Iterative_authalic_parameterizer_3.h
@@ -69,7 +69,7 @@ namespace Surface_mesh_parameterization {
 /// the \f$ L_2\f$ stretch - as defined by Sander et al. \cgalCite{cgal:ssgh-tmpm-01} - over the mesh.
 ///
 /// \tparam TriangleMesh_ must be a model of `FaceGraph`.
-/// \tparam BorderParameterizer_ is a Strategy to parameterize the surface border
+/// \tparam BorderParameterizer_ is a strategy to parameterize the surface border
 ///         and must be a model of `Parameterizer_3`.<br>
 ///         <b>%Default:</b>
 /// \code

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/LSCM_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/LSCM_parameterizer_3.h
@@ -182,9 +182,9 @@ public:
   ///
   /// \param mesh a triangulated surface.
   /// \param bhd a halfedge descriptor on the boundary of `mesh`.
-  /// \param uvmap an instanciation of the class `VertexUVmap`.
-  /// \param vimap an instanciation of the class `VertexIndexMap`.
-  /// \param vpmap an instanciation of the class `VertexParameterizedMap`.
+  /// \param uvmap an instantiation of the class `VertexUVmap`.
+  /// \param vimap an instantiation of the class `VertexIndexMap`.
+  /// \param vpmap an instantiation of the class `VertexParameterizedMap`.
   ///
   /// \pre `mesh` must be a triangular mesh.
   /// \pre The vertices must be indexed (`vimap` must be initialized).

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/LSCM_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/LSCM_parameterizer_3.h
@@ -61,7 +61,7 @@ namespace Surface_mesh_parameterization {
 ///
 /// \tparam TriangleMesh_ must be a model of `FaceGraph`.
 ///
-/// \tparam BorderParameterizer_ is a Strategy to parameterize the surface border
+/// \tparam BorderParameterizer_ is a strategy to parameterize the surface border
 ///         and must be a model of `Parameterizer_3`.<br>
 ///         <b>%Default:</b>
 /// \code

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/MVC_post_processor_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/MVC_post_processor_3.h
@@ -726,8 +726,8 @@ public:
   ///
   /// \param mesh a triangulated surface.
   /// \param bhd a halfedge descriptor on the boundary of `mesh`.
-  /// \param uvmap an instanciation of the class `VertexUVmap`.
-  /// \param vimap an instanciation of the class `VertexIndexMap`.
+  /// \param uvmap an instantiation of the class `VertexUVmap`.
+  /// \param vimap an instantiation of the class `VertexIndexMap`.
   ///
   template <typename VertexUVMap,
             typename VertexIndexMap>

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Mean_value_coordinates_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Mean_value_coordinates_parameterizer_3.h
@@ -53,7 +53,7 @@ namespace Surface_mesh_parameterization {
 ///
 /// \tparam TriangleMesh_ must be a model of `FaceGraph`.
 ///
-/// \tparam BorderParameterizer_ is a Strategy to parameterize the surface border
+/// \tparam BorderParameterizer_ is a strategy to parameterize the surface border
 ///         and must be a model of `Parameterizer_3`.<br>
 ///         <b>%Default:</b>
 /// \code

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Orbifold_Tutte_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Orbifold_Tutte_parameterizer_3.h
@@ -888,8 +888,8 @@ public:
   /// \param cmap a mapping of the `vertex_descriptor`s of `mesh` that are cones
   ///             to their respective \link PkgSurfaceMeshParameterizationEnums Cone_type \endlink
   ///             classification.
-  /// \param uvmap an instanciation of the class `VertexUVmap`.
-  /// \param vimap an instanciation of the class `VertexIndexMap`.
+  /// \param uvmap an instantiation of the class `VertexUVmap`.
+  /// \param vimap an instantiation of the class `VertexIndexMap`.
   ///
   /// \pre `mesh` must be a triangular mesh.
   /// \pre The underlying mesh of `mesh` is a topological ball.

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Square_border_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Square_border_parameterizer_3.h
@@ -273,8 +273,8 @@ public:
   ///
   /// \param mesh a triangulated surface.
   /// \param bhd a halfedge descriptor on the boundary of `mesh`.
-  /// \param uvmap an instanciation of the class `VertexUVmap`.
-  /// \param vpmap an instanciation of the class `VertexParameterizedMap`.
+  /// \param uvmap an instantiation of the class `VertexUVmap`.
+  /// \param vpmap an instantiation of the class `VertexParameterizedMap`.
   ///
   /// \pre `mesh` must be a triangular mesh.
   /// \pre The vertices must be indexed (vimap must be initialized).

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Two_vertices_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Two_vertices_parameterizer_3.h
@@ -288,9 +288,9 @@ public:
   ///
   /// \param mesh a triangulated surface.
   /// \param bhd a halfedge descriptor on the boundary of `mesh`.
-  /// \param uvmap an instanciation of the class `VertexUVmap`.
-  /// \param vimap an instanciation of the class `VertexIndexMap`.
-  /// \param vpmap an instanciation of the class `VertexParameterizedMap`.
+  /// \param uvmap an instantiation of the class `VertexUVmap`.
+  /// \param vimap an instantiation of the class `VertexIndexMap`.
+  /// \param vpmap an instantiation of the class `VertexParameterizedMap`.
   ///
   /// \pre `mesh` must be a triangular mesh.
   /// \pre The vertices must be indexed (vimap must be initialized).

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/orbifold_enums.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/orbifold_enums.h
@@ -45,7 +45,7 @@ enum Cone_type
 
 /// \ingroup PkgSurfaceMeshParameterizationEnums
 ///
-/// The four Orbifold types available in the Orbifold Tutte parameterization.
+/// The four orbifold types available in the Orbifold Tutte parameterization.
 /// The different shapes result from the number of cones and the angle constraints
 /// at the cones.
 enum Orbifold_type
@@ -59,7 +59,7 @@ enum Orbifold_type
 /// \ingroup PkgSurfaceMeshParameterizationEnums
 /// \brief Convert the orbifold type to a literal message.
 /// \param orb_type the integer value in the enum
-/// \return the string describing the Orbifold type.
+/// \return the string describing the orbifold type.
 const char* get_orbifold_type(int orb_type)
 {
   // Messages corresponding to the different orbifold types.

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/parameterize.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/parameterize.h
@@ -48,7 +48,7 @@ namespace Surface_mesh_parameterization {
 /// \param mesh a triangulated surface.
 /// \param parameterizer a parameterizer.
 /// \param bhd a halfedge descriptor on the boundary of `mesh`.
-/// \param uvmap an instanciation of the class `VertexUVmap`.
+/// \param uvmap an instantiation of the class `VertexUVmap`.
 ///
 /// \pre `mesh` must be a triangular mesh.
 /// \pre The mesh border must be mapped onto a convex polygon
@@ -95,7 +95,7 @@ Error_code parameterize(TriangleMesh& mesh,
 ///
 /// \param mesh a triangulated surface.
 /// \param bhd a halfedge descriptor on the boundary of `mesh`.
-/// \param uvmap an instanciation of the class `VertexUVmap`.
+/// \param uvmap an instantiation of the class `VertexUVmap`.
 ///
 /// \pre `mesh` must be a triangular mesh.
 /// \pre The vertices must be indexed (vimap must be initialized).

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/parameterize.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/parameterize.h
@@ -39,7 +39,7 @@ namespace Surface_mesh_parameterization {
 /// \tparam TriangleMesh must be a model of `FaceGraph`.
 /// \tparam Parameterizer must be a model of `Parameterizer_3`.
 /// \tparam HD must be the halfedge_descriptor type corresponding to the graph
-///         traits of TriangleMesh.
+///         traits of `TriangleMesh`.
 /// \tparam VertexUVmap must be a model of `ReadWritePropertyMap` with
 ///         `boost::graph_traits<TriangleMesh>::%vertex_descriptor` as key type and
 ///         %Point_2 (type deduced from `TriangleMesh` using `Kernel_traits`)
@@ -87,7 +87,7 @@ Error_code parameterize(TriangleMesh& mesh,
 ///
 /// \tparam TriangleMesh must be a model of `FaceGraph`.
 /// \tparam HD must be the halfedge_descriptor type corresponding to the graph
-///         traits of TriangleMesh.
+///         traits of `TriangleMesh`.
 /// \tparam VertexUVmap must be a model of `ReadWritePropertyMap` with
 ///         `boost::graph_traits<TriangleMesh>::%vertex_descriptor` as key type and
 ///         %Point_2 (type deduced from `TriangleMesh` using `Kernel_traits`)

--- a/Triangulation_2/include/CGAL/Triangulation_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_hierarchy_2.h
@@ -267,7 +267,7 @@ private:
 
   // helping function to copy_triangulation
   // the version to be used with Tag_true is templated to avoid
-  // systematique instanciation
+  // systematic instantiation
   template <class Tag>
   void add_hidden_vertices_into_map(Tag,
                                     std::map<Vertex_handle,Vertex_handle >& V)


### PR DESCRIPTION
## Summary of Changes

Fix typo  in several packages but mainly _Surface Mesh Parameterization_, for example [here](https://doc.cgal.org/latest/Surface_mesh_parameterization/group__PkgSurfaceMeshParameterizationMainFunction.html).



