### PR TITLE
Fix static filter of Do_intersect_3(Bbox_3,Triangle_3)

### DIFF
--- a/Filtered_kernel/include/CGAL/Filtered_kernel/internal/Static_filters/Do_intersect_3.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/internal/Static_filters/Do_intersect_3.h
@@ -509,6 +509,8 @@ public:
             (pts[i][1] >= b.ymin() && pts[i][1] <= b.ymax()) &&
             (pts[i][2] >= b.zmin() && pts[i][2] <= b.zmax()) )
         {
+          // If any of the three points of the triangle is inside the bbox,
+          // then the box and triangle intersect.
           return true;
         }
 
@@ -518,6 +520,21 @@ public:
       {
         return Base::operator()(t,b);
       }
+    }
+
+    // If the bbox of the triangle does not intersect `b`, then the bbox and
+    // the triangle do not intersect.
+    for(int i=0; i< 3; ++i) {
+      double triangle_bbox_min = pts[0][i];
+      double triangle_bbox_max = triangle_bbox_min;
+      for(int j=1; j<3; ++j) {
+        if(pts[j][i] < triangle_bbox_min)
+          triangle_bbox_min = pts[j][i];
+        if(pts[j][i] > triangle_bbox_max)
+          triangle_bbox_max = pts[j][i];
+      }
+      if(triangle_bbox_min > b.max_coord(i) || triangle_bbox_max < b.min_coord(i))
+        return false;
     }
 
     // copy of the regular code with do_axis_intersect_aux_impl statically filtered

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Bbox_3_Triangle_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Bbox_3_Triangle_3_do_intersect.h
@@ -273,13 +273,13 @@ do_intersect_bbox_or_iso_cuboid_impl(const std::array< std::array<FT, 3>, 3>& tr
   }};
 
   int forbidden_axis = -1;
-  int forbidden_size = -1;
+  int forbidden_side = -1;
   //determine whether one vector is collinear with an axis
   int tmp = collinear_axis<FT>(sides[0]);
   if(tmp != -1)
   {
     forbidden_axis = tmp;
-    forbidden_size = 0;
+    forbidden_side = 0;
   }
   else
   {
@@ -287,7 +287,7 @@ do_intersect_bbox_or_iso_cuboid_impl(const std::array< std::array<FT, 3>, 3>& tr
     if(tmp != -1)
     {
       forbidden_axis = tmp;
-      forbidden_size = 1;
+      forbidden_side = 1;
     }
     else
     {
@@ -295,7 +295,7 @@ do_intersect_bbox_or_iso_cuboid_impl(const std::array< std::array<FT, 3>, 3>& tr
       if(tmp != -1)
       {
         forbidden_axis = tmp;
-        forbidden_size = 2;
+        forbidden_side = 2;
       }
     }
   }
@@ -305,7 +305,7 @@ do_intersect_bbox_or_iso_cuboid_impl(const std::array< std::array<FT, 3>, 3>& tr
 
   if(forbidden_axis != 0)
   {
-    if(forbidden_size != 0)
+    if(forbidden_side != 0)
     {
       Uncertain<bool> b = do_axis_intersect<FT,Box3,0,0>(triangle, sides, bbox, do_axis_intersect_aux_impl);
       if(is_indeterminate(b))
@@ -314,7 +314,7 @@ do_intersect_bbox_or_iso_cuboid_impl(const std::array< std::array<FT, 3>, 3>& tr
         return false;
     }
 
-    if(forbidden_size != 1)
+    if(forbidden_side != 1)
     {
       Uncertain<bool> b = do_axis_intersect<FT,Box3,0,1>(triangle, sides, bbox, do_axis_intersect_aux_impl);
       if(is_indeterminate(b))
@@ -323,7 +323,7 @@ do_intersect_bbox_or_iso_cuboid_impl(const std::array< std::array<FT, 3>, 3>& tr
         return false;
     }
 
-    if(forbidden_size != 2)
+    if(forbidden_side != 2)
     {
       Uncertain<bool> b = do_axis_intersect<FT,Box3,0,2>(triangle, sides, bbox, do_axis_intersect_aux_impl);
       if(is_indeterminate(b))
@@ -335,7 +335,7 @@ do_intersect_bbox_or_iso_cuboid_impl(const std::array< std::array<FT, 3>, 3>& tr
 
   if(forbidden_axis != 1)
   {
-    if(forbidden_size != 0)
+    if(forbidden_side != 0)
     {
       Uncertain<bool> b = do_axis_intersect<FT,Box3,1,0>(triangle, sides, bbox, do_axis_intersect_aux_impl);
       if(is_indeterminate(b))
@@ -344,7 +344,7 @@ do_intersect_bbox_or_iso_cuboid_impl(const std::array< std::array<FT, 3>, 3>& tr
         return false;
     }
 
-    if(forbidden_size != 1)
+    if(forbidden_side != 1)
     {
       Uncertain<bool> b = do_axis_intersect<FT,Box3,1,1>(triangle, sides, bbox, do_axis_intersect_aux_impl);
       if(is_indeterminate(b))
@@ -353,7 +353,7 @@ do_intersect_bbox_or_iso_cuboid_impl(const std::array< std::array<FT, 3>, 3>& tr
         return false;
     }
 
-    if(forbidden_size != 2)
+    if(forbidden_side != 2)
     {
       Uncertain<bool> b = do_axis_intersect<FT,Box3,1,2>(triangle, sides, bbox, do_axis_intersect_aux_impl);
       if(is_indeterminate(b))
@@ -365,7 +365,7 @@ do_intersect_bbox_or_iso_cuboid_impl(const std::array< std::array<FT, 3>, 3>& tr
 
   if(forbidden_axis != 2)
   {
-    if(forbidden_size != 0)
+    if(forbidden_side != 0)
     {
       Uncertain<bool> b = do_axis_intersect<FT,Box3,2,0>(triangle, sides, bbox, do_axis_intersect_aux_impl);
       if(is_indeterminate(b))
@@ -374,7 +374,7 @@ do_intersect_bbox_or_iso_cuboid_impl(const std::array< std::array<FT, 3>, 3>& tr
         return false;
     }
 
-    if(forbidden_size != 1)
+    if(forbidden_side != 1)
     {
       Uncertain<bool> b = do_axis_intersect<FT,Box3,2,1>(triangle, sides, bbox, do_axis_intersect_aux_impl);
       if(is_indeterminate(b))
@@ -383,7 +383,7 @@ do_intersect_bbox_or_iso_cuboid_impl(const std::array< std::array<FT, 3>, 3>& tr
         return false;
     }
 
-    if(forbidden_size != 2)
+    if(forbidden_side != 2)
     {
       Uncertain<bool> b = do_axis_intersect<FT,Box3,2,2>(triangle, sides, bbox, do_axis_intersect_aux_impl);
       if(is_indeterminate(b))

--- a/Intersections_3/test/Intersections_3/bbox_other_do_intersect_test.cpp
+++ b/Intersections_3/test/Intersections_3/bbox_other_do_intersect_test.cpp
@@ -563,7 +563,7 @@ bool test(bool exact_kernel = false)
   Triangle t3(Point(0, 1, 1), Point(0, 0, 0), Point(0, 0, 1));   // parallel to the left side
   Triangle t4(Point(-1, 3, 2), Point(0, 2, 2), Point(0, 3, 2));  // projection inside the left side
   Triangle t5(Point(-1, 3, 2), Point(0, 1, 2), Point(0, 3, -1)); // projection with one point outside of the left side
- 
+
   b &= test_aux(t123,"t123",bbox,true);
   b &= test_aux(t124,"t124",bbox,true);
   b &= test_aux(t126,"t126",bbox,true);

--- a/Intersections_3/test/Intersections_3/bbox_other_do_intersect_test.cpp
+++ b/Intersections_3/test/Intersections_3/bbox_other_do_intersect_test.cpp
@@ -378,7 +378,7 @@ bool test(bool exact_kernel = false)
   typedef typename K::Triangle_3 Triangle;
   typedef typename K::Iso_cuboid_3 Iso_cuboid_3;
 
-  CGAL::Bbox_3 bbox(1.0,1.0,1.0,10.0,50.0,100.0);
+  CGAL::Bbox_3 bbox(1.0,1.0,1.0, 10.0,50.0,100.0);
 
   Point p1(FT(0.), FT(0.), FT(0.));
   Point p2(FT(0.), FT(100.), FT(100.));
@@ -559,8 +559,11 @@ bool test(bool exact_kernel = false)
   Triangle tABC(pA,pB,pC);
   Triangle t1(Point(1,1,1),Point(0,0,0),Point(0,0,1));
   Triangle t2(Point(4,1,7),Point(8,1,99),Point(7,1,11));
-  Triangle t3(Point(0,1,1),Point(0,0,0),Point(0,0,1));
-
+  // triangles completely to the left side of the cube
+  Triangle t3(Point(0, 1, 1), Point(0, 0, 0), Point(0, 0, 1));   // parallel to the left side
+  Triangle t4(Point(-1, 3, 2), Point(0, 2, 2), Point(0, 3, 2));  // projection inside the left side
+  Triangle t5(Point(-1, 3, 2), Point(0, 1, 2), Point(0, 3, -1)); // projection with one point outside of the left side
+ 
   b &= test_aux(t123,"t123",bbox,true);
   b &= test_aux(t124,"t124",bbox,true);
   b &= test_aux(t126,"t126",bbox,true);
@@ -569,6 +572,9 @@ bool test(bool exact_kernel = false)
   b &= test_aux(t1,"t1",bbox,true);
   b &= test_aux(t2,"t2",bbox,true);
   b &= test_aux(t3,"t3",bbox,false);
+  b &= test_aux(t4,"t4",bbox,false);
+  b &= test_aux(t5,"t5",bbox, false);
+
 
   b &= test_aux(t123,"t123",Iso_cuboid_3(bbox),true);
   b &= test_aux(t124,"t124",Iso_cuboid_3(bbox),true);


### PR DESCRIPTION
## Summary of Changes

Fix static filter of `Do_intersect_3(Bbox_3,Triangle_3)`.

See the publication at https://www.semanticscholar.org/paper/High-performance-triangle-versus-box-intersection-Christensen-Karlsson/bad661b58359ec01be2deb2f47ec8fd8eb293747.

The test of intersection of `bbox` and `triangle.bbox` was missing. It implements 3 of the test out of the 13 that are needed.

## Release Management

* Affected package(s): Filtered_kernel
* Issue(s) solved (if any): fix #6808
* License and copyright ownership: maintenance by GeometryFactory

