### PR TITLE
CGAL kernel: Introduce CGAL_Kernel_pred_RT_or_FT

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -2506,7 +2506,7 @@ namespace CartesianKernelFunctors {
       FT rsy = psz*qsx-psx*qsz;
       FT rsz = psx*qsy-psy*qsx;
 
-      // The following determinants can be developped and simplified.
+      // The following determinants can be developed and simplified.
       //
       // FT num_x = determinant(psy,psz,ps2,
       //                              qsy,qsz,qs2,

--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -17,6 +17,7 @@
 #ifndef CGAL_CARTESIAN_FUNCTION_OBJECTS_H
 #define CGAL_CARTESIAN_FUNCTION_OBJECTS_H
 
+#include <CGAL/tags.h>
 #include <CGAL/Kernel/function_objects.h>
 #include <CGAL/predicates/kernel_ftC2.h>
 #include <CGAL/predicates/kernel_ftC3.h>
@@ -591,14 +592,14 @@ namespace CartesianKernelFunctors {
     }
 
     template <class T1, class T2, class T3>
-    result_type
+    Needs_FT<result_type>
     operator()(const T1& p, const T2& q, const T3& r) const
     {
       return CGAL::compare(squared_distance(p, q), squared_distance(p, r));
     }
 
     template <class T1, class T2, class T3, class T4>
-    result_type
+    Needs_FT<result_type>
     operator()(const T1& p, const T2& q, const T3& r, const T4& s) const
     {
       return CGAL::compare(squared_distance(p, q), squared_distance(r, s));

--- a/Cartesian_kernel/include/CGAL/predicates/kernel_ftC3.h
+++ b/Cartesian_kernel/include/CGAL/predicates/kernel_ftC3.h
@@ -754,7 +754,7 @@ power_side_of_bounded_power_sphereC3(
 }
 
 // return the sign of the power test of weighted point (rx,ry,rz,rw)
- // with respect to the smallest sphere orthogoanal to
+ // with respect to the smallest sphere orthogonal to
 // p,q
 template< class FT >
 typename Same_uncertainty_nt<Bounded_side, FT>::type

--- a/Filtered_kernel/include/CGAL/Filtered_kernel.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel.h
@@ -89,6 +89,15 @@ struct Filtered_kernel_base
     typedef Filtered_predicate<typename Exact_kernel_rt::P, typename Approximate_kernel::P, C2E_rt, C2F> P; \
     P Pf() const { return P(); }
 
+#define CGAL_Kernel_pred_RT_or_FT(P, Pf) \
+    typedef Filtered_predicate_RT_FT<typename Exact_kernel_rt::P, \
+                                     typename Exact_kernel::P, \
+                                     typename Approximate_kernel::P, \
+                                    C2E_rt, \
+                                    C2E, \
+                                    C2F> P; \
+    P Pf() const { return P(); }
+
     // We don't touch the constructions.
 #define CGAL_Kernel_cons(Y,Z)
 

--- a/Filtered_kernel/include/CGAL/Filtered_predicate.h
+++ b/Filtered_kernel/include/CGAL/Filtered_predicate.h
@@ -135,6 +135,13 @@ public:
     enum { value = std::is_same<Approx_res, Needs_FT<Ares>>::value };
   };
 
+  // ## Important note
+  //
+  // If you want to remove of rename that member function template `needs_ft`,
+  // please also change the lines with
+  // `CGAL_GENERATE_MEMBER_DETECTOR(needs_ft);`
+  // or `has_needs_ft<typename R::Compare_distance_3>` in
+  // the file `Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h`.
   template <typename... Args>
   bool needs_ft(const Args&...) const {
     return Call_operator_needs_FT<Args...>::value;

--- a/Filtered_kernel/include/CGAL/Lazy_kernel.h
+++ b/Filtered_kernel/include/CGAL/Lazy_kernel.h
@@ -89,7 +89,7 @@ protected:
 // Exact_kernel = exact kernel that will be made lazy
 // Kernel = lazy kernel
 
-// the Generic base simplies applies the generic magic functor stupidly.
+// the Generic base simply applies the generic magic functor stupidly.
 // then the real base fixes up a few special cases.
 template < typename EK_, typename AK_, typename E2A_, typename Kernel_ >
 class Lazy_kernel_generic_base : protected internal::Enum_holder

--- a/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
+++ b/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
@@ -99,7 +99,7 @@ function(CGAL_setup_CGAL_dependencies target)
 
   # CGAL now requires C++14. `decltype(auto)` is used as a marker of
   # C++14.
-  target_compile_features(${target} INTERFACE cxx_decltype_auto)
+  target_compile_features(${target} INTERFACE cxx_std_17)
 
   use_CGAL_Boost_support(${target} INTERFACE)
 

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -32,6 +32,13 @@
 #  define CGAL_Kernel_pred_RT(X, Y) CGAL_Kernel_pred(X, Y)
 #endif
 
+// Those predicates for which Simple_cartesian maybe use division of not.
+// Predicates using division must have Needs_FT<return_type> as actual return
+// type.
+#ifndef CGAL_Kernel_pred_RT_or_FT
+#  define CGAL_Kernel_pred_RT_or_FT(X, Y) CGAL_Kernel_pred(X, Y)
+#endif
+
 #ifndef CGAL_Kernel_cons
 #  define CGAL_Kernel_cons(X, Y)
 #endif
@@ -110,8 +117,8 @@ CGAL_Kernel_pred(Compare_dihedral_angle_3,
                  compare_dihedral_angle_3_object)
 CGAL_Kernel_pred(Compare_distance_2,
                  compare_distance_2_object)
-CGAL_Kernel_pred(Compare_distance_3,
-                 compare_distance_3_object)
+CGAL_Kernel_pred_RT_or_FT(Compare_distance_3,
+                          compare_distance_3_object)
 CGAL_Kernel_pred_RT(Compare_power_distance_2,
                     compare_power_distance_2_object)
 CGAL_Kernel_pred_RT(Compare_power_distance_3,
@@ -609,6 +616,7 @@ CGAL_Kernel_pred_RT(Side_of_oriented_circle_2,
 CGAL_Kernel_pred_RT(Side_of_oriented_sphere_3,
                     side_of_oriented_sphere_3_object)
 
+#undef CGAL_Kernel_pred_RT_or_FT
 #undef CGAL_Kernel_pred_RT
 #undef CGAL_Kernel_pred
 #undef CGAL_Kernel_cons

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -18,7 +18,7 @@
 // It's aimed at being included from within a kernel traits class, this
 // way we share more code.
 
-// It is the responsability of the including file to correctly set the 2
+// It is the responsibility of the including file to correctly set the 2
 // macros CGAL_Kernel_pred, CGAL_Kernel_cons and CGAL_Kernel_obj.
 // And they are #undefed at the end of this file.
 

--- a/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
+++ b/Kernel_23/test/Kernel_23/Filtered_cartesian.cpp
@@ -14,6 +14,10 @@
 //
 // Author(s)     : Sylvain Pion
 
+// This defines removes the operator/ from CGAL::Mpzf, to check that functors
+// declared with CGAL_Kernel_pred_RT in interface_macros.h really only need
+// a RT (ring type), without division.
+#define CGAL_NO_MPZF_DIVISION_OPERATOR 1
 
 #include <CGAL/Cartesian.h>
 #include <CGAL/Filtered_kernel.h>

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
@@ -22,8 +22,11 @@
 #include <CGAL/intersections.h>
 #include <CGAL/squared_distance_3.h>
 #include <CGAL/_test_compare_dihedral_angle_3.h>
+#include <CGAL/Has_member.h>
 
 #include <CGAL/use.h>
+
+CGAL_GENERATE_MEMBER_DETECTOR(needs_ft);
 
 using CGAL::internal::use;
 
@@ -605,6 +608,16 @@ test_new_3(const R& rep)
   Comparison_result tmp34ab = compare_dist(p2,p3,p4);
   tmp34ab = compare_dist(p2,p3,p2,p3);
   tmp34ab = compare_dist(p1, p2, p3, p4);
+  tmp34ab = compare_dist(l2, p1, p1);
+  tmp34ab = compare_dist(p1, p2, s2);
+  if constexpr (R::Has_filtered_predicates &&
+                has_needs_ft<typename R::Compare_distance_3>::value)
+{
+    assert(compare_dist.needs_ft(l1, p1, p1));
+    assert(compare_dist.needs_ft(p2, p3, p2, p3));
+    assert(!compare_dist.needs_ft(p1, p2, p3));
+    assert(!compare_dist.needs_ft(p2, p2, s2));
+  }
   (void) tmp34ab;
 
   typename R::Compare_squared_distance_3 compare_sq_dist

--- a/STL_Extension/doc/STL_Extension/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/Concurrent_compact_container.h
@@ -293,7 +293,7 @@ complexity. No exception is thrown.
 /// @{
   /// returns whether `pos` is in the range `[ccc.begin(),  ccc.end()]` (`ccc.end()` included).
   bool owns(const_iterator pos);
-  /// returns whether `pos` is in the range `[ccc.begin(), ccc`.end())` (`ccc.end()` excluded).
+  /// returns whether `pos` is in the range `[ccc.begin(), ccc.end())` (`ccc.end()` excluded).
   bool owns_dereferencable(const_iterator pos);
 
 /// @}

--- a/STL_Extension/include/CGAL/Handle.h
+++ b/STL_Extension/include/CGAL/Handle.h
@@ -122,7 +122,7 @@ class Handle
     int
     refs()  const noexcept { return PTR->count.load(std::memory_order_relaxed); }
 
-    Id_type id() const noexcept { return PTR - static_cast<Rep*>(0); }
+    Id_type id() const noexcept { return static_cast<Id_type>(reinterpret_cast<std::intptr_t>(static_cast<void*>(PTR)) / sizeof(Rep)); }
 
     bool identical(const Handle& h) const noexcept { return PTR == h.PTR; }
 

--- a/STL_Extension/include/CGAL/tags.h
+++ b/STL_Extension/include/CGAL/tags.h
@@ -81,6 +81,23 @@ Assert_compile_time_tag( const Tag&, const Derived& b)
   x.match_compile_time_tag(b);
 }
 
+template <typename T>
+struct Needs_FT {
+  T value;
+  Needs_FT(T v) : value(v) {}
+  operator T() const { return value; }
+};
+
+template <typename T>
+struct Remove_needs_FT {
+  using Type = T;
+};
+
+template <typename T>
+struct Remove_needs_FT<Needs_FT<T>> {
+  using Type = T;
+};
+
 } //namespace CGAL
 
 #endif // CGAL_TAGS_H


### PR DESCRIPTION
## Summary of Changes

This pull-request introduces a new kind of predicate in `<CGAL/Kernel/interface_macros.h>`. In addition to
  - `CGAL_kernel_pred` for predicates,
  - `CGAL_Kernel_pred_RT` for predicates that can be implemented using aring-type,

now there is also:
  - `CGAL_Kernel_pred_RT_or_FT` for predicates with multiple overloads of `operator()`, some needing a field type and other needing a ring type (without the division operator).

The C++ code can discriminate between the two cases with a special wrapper for the return type: `CGAL::Needs_FT<result_type` instead of `result_type` (defined in `<CGAL/tags.h>`.

In `<CGAL/Filtered_predicate.h>`, in addition to the usual class template `Filtered_predicate`, there is now also `Filtered_predicate_RT_FT` that takes three predicates as template parameters instead of two:
  - the exact predicate with an ring-type,
  - the exact predicate with a field-type,
  - the approximate predicate (with `Interval_nt` as number-type).

For the moment, only `Compare_distance_3` in `<CGAL/Cartesian/function_objects.h>` is using the new `Filtered_predicate_RT_FT`.

Before this commit, the file `Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h` was testing `Compare_distance_3` only with three points or for points. This commit adds:
  - a test with `Point_3, Point_3, Segment_3`, and
  - a test with `Line_3, Point_3, Point_3`, that actually needs a field type with its current implementation.

In the test `Kernel_23/test/Kernel_23/Filtered_cartesian.cpp`, the macro `CGAL_NO_MPZF_DIVISION_OPERATOR` is defined, to remove the division operator from `CGAL::Mpzf`. `CGAL::Mpzf` is a ring-type, even with its `operator/` (because that `operator/` can only compute exact divisions), but with `CGAL_NO_MPZF_DIVISION_OPERATOR` defined, that is now checked by the compiler.

## Release Management

**Please do not merge as it is: I have used C++17 `if constexpr` on purpose during my experimentation, and will revert to C++14 with tag dispatching before the pull-request can be merged.**

* Affected package(s): CGAL kernels
* Issue(s) solved (if any): fix #6792
* Feature/Small Feature (if any): no, because that is an undocumented implementation detail of CGAL kernels
* License and copyright ownership: maintenance by GeometryFactory
