### PR TITLE
Complete array-based polygon soup repair

### DIFF
--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/repair_polygon_soup_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/repair_polygon_soup_example.cpp
@@ -17,7 +17,12 @@ typedef K::Point_3                                              Point_3;
 typedef CGAL::Surface_mesh<Point_3>                             Mesh;
 
 typedef std::array<FT, 3>                                       Custom_point;
+//#define CGAL_USE_ARRAY_POLYGONS_IN_EXAMPLE
+#ifdef CGAL_USE_ARRAY_POLYGONS_IN_EXAMPLE
+typedef std::array<std::size_t, 3>                              CGAL_Polygon;
+#else
 typedef std::vector<std::size_t>                                CGAL_Polygon;
+#endif
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -47,50 +52,37 @@ int main(int, char**)
   std::vector<std::array<FT, 3> > points;
   std::vector<CGAL_Polygon> polygons;
 
-  points.push_back(CGAL::make_array<FT>(0,0,0));
-  points.push_back(CGAL::make_array<FT>(1,0,0));
-  points.push_back(CGAL::make_array<FT>(0,1,0));
-  points.push_back(CGAL::make_array<FT>(-1,0,0));
-  points.push_back(CGAL::make_array<FT>(0,-1,0));
-  points.push_back(CGAL::make_array<FT>(0,1,0)); // duplicate point
-  points.push_back(CGAL::make_array<FT>(0,-2,0)); // unused point
+  points.push_back(CGAL::make_array<FT>( 0,  0, 0)); // 0
+  points.push_back(CGAL::make_array<FT>( 1,  0, 0)); // 1
+  points.push_back(CGAL::make_array<FT>( 0,  1, 0)); // 2
+  points.push_back(CGAL::make_array<FT>(-1,  0, 0)); // 3
+  points.push_back(CGAL::make_array<FT>( 0, -1, 0)); // 4
+  points.push_back(CGAL::make_array<FT>( 0,  1, 0)); // 5 -- duplicate point with 2
+  points.push_back(CGAL::make_array<FT>( 0, -2, 0)); // 6 -- unused point
 
-  CGAL_Polygon p;
-  p.push_back(0); p.push_back(1); p.push_back(2);
-  polygons.push_back(p);
-
-  // degenerate face
-  p.clear();
-  p.push_back(0); p.push_back(0); p.push_back(0);
-  polygons.push_back(p);
-
-  p.clear();
-  p.push_back(0); p.push_back(1); p.push_back(4);
-  polygons.push_back(p);
-
-  // duplicate face with different orientation
-  p.clear();
-  p.push_back(0); p.push_back(4); p.push_back(1);
-  polygons.push_back(p);
-
-  p.clear();
-  p.push_back(0); p.push_back(3); p.push_back(5);
-  polygons.push_back(p);
+  // normal face
+  polygons.push_back({0,1,2});
 
   // degenerate face
-  p.clear();
-  p.push_back(0); p.push_back(3); p.push_back(0);
-  polygons.push_back(p);
+  polygons.push_back({0,0,0});
 
-  p.clear();
-  p.push_back(0); p.push_back(3); p.push_back(4);
-  polygons.push_back(p);
+  // duplicate faces with different orientations
+  polygons.push_back({0,1,4});
+  polygons.push_back({0,4,1});
 
+  // normal face
+  polygons.push_back({0,3,5});
+
+  // degenerate face
+  polygons.push_back({0,3,0});
+
+  // normal face
+  polygons.push_back({0,3,4});
+
+#ifndef CGAL_USE_ARRAY_POLYGONS_IN_EXAMPLE
   // pinched and degenerate face
-  p.clear();
-  p.push_back(0); p.push_back(1); p.push_back(2); p.push_back(3);
-  p.push_back(4); p.push_back(3); p.push_back(2); p.push_back(1);
-  polygons.push_back(p);
+  polygons.push_back({0,1,2,3,4,3,2,1});
+#endif
 
   std::cout << "Before reparation, the soup has " << points.size() << " vertices and " << polygons.size() << " faces" << std::endl;
   PMP::repair_polygon_soup(points, polygons, CGAL::parameters::geom_traits(Array_traits()));

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
@@ -723,14 +723,14 @@ Polygon construct_canonical_polygon(const PointRange& points,
   return construct_canonical_polygon(points, polygon, useless, traits);
 }
 
-template <typename PointRange, typename PolygonRange, typename Traits>
+template <typename PointRange, typename PolygonRange>
 struct Polygon_hash
 {
   typedef std::size_t                                                             result_type;
   typedef typename internal::Polygon_types<PointRange, PolygonRange>::Polygon_3   Polygon_3;
 
-  Polygon_hash(const PointRange& points, const PolygonRange& canonical_polygons, const Traits& traits)
-    : points(points), canonical_polygons(canonical_polygons), traits(traits)
+  Polygon_hash(const PointRange& points, const PolygonRange& canonical_polygons)
+    : points(points), canonical_polygons(canonical_polygons)
   { }
 
   template <typename Polygon_ID>
@@ -748,7 +748,6 @@ struct Polygon_hash
 private:
   const PointRange& points;
   const PolygonRange& canonical_polygons;
-  const Traits& traits;
 };
 
 template <typename PointRange, typename PolygonRange, typename Reversed_markers, typename Traits>
@@ -849,11 +848,11 @@ DuplicateOutputIterator collect_duplicate_polygons(const PointRange& points,
 {
   typedef typename internal::Polygon_types<PointRange, PolygonRange>::P_ID        P_ID;
 
-  typedef internal::Polygon_hash<PointRange, PolygonRange, Traits>                Hasher;
+  typedef internal::Polygon_hash<PointRange, PolygonRange>                        Hasher;
   typedef boost::dynamic_bitset<>                                                 Reversed_markers;
   typedef internal::Polygon_equality_tester<PointRange, PolygonRange,
                                             Reversed_markers, Traits>             Equality;
-  typedef std::unordered_set<P_ID, Hasher, Equality>                      Unique_polygons;
+  typedef std::unordered_set<P_ID, Hasher, Equality>                              Unique_polygons;
 
   const std::size_t polygons_n = polygons.size();
 
@@ -871,7 +870,7 @@ DuplicateOutputIterator collect_duplicate_polygons(const PointRange& points,
       is_reversed.set(polygon_index);
   }
 
-  Hasher hash(points, canonical_polygons, traits);
+  Hasher hash(points, canonical_polygons);
   Equality equal(points, canonical_polygons, is_reversed, traits, same_orientation);
 
   Unique_polygons unique_polygons(polygons_n /*bucket size*/, hash, equal);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_polygon_soup.h
@@ -203,22 +203,12 @@ std::size_t simplify_polygons_in_polygon_soup(PointRange& points,
 // \tparam PolygonRange a model of the concept `SequenceContainer`
 //                      whose `value_type` is itself a model of the concepts `SequenceContainer`
 //                      and `Swappable` whose `value_type` is `std::size_t`.
-// \tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
+// \tparam Traits a traits class providing `Equal_3` and `Less_xyz_3` for two 3D points
 //
 // \param points points of the soup of polygons
 // \param polygons a vector of polygons. Each element in the vector describes a polygon
-//        using the indices of the points in `points`.
-// \param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
-//
-// \cgalNamedParamsBegin
-//   \cgalParamNBegin{geom_traits}
-//     \cgalParamDescription{an instance of a geometric traits class}
-//     \cgalParamType{The traits class must provide the nested functor `Less_xyz_3`
-//                    to compare lexicographically two points a function `Less_xyz_3 less_xyz_3_object()`.}
-//     \cgalParamDefault{a \cgal Kernel deduced from the point type, using `CGAL::Kernel_traits`}
-//     \cgalParamExtra{The geometric traits class must be compatible with the vertex point type.}
-//   \cgalParamNEnd
-// \cgalNamedParamsEnd
+//                 using the indices of the points in `points`.
+// \param traits an instance of traits
 //
 // \sa `repair_polygon_soup()`
 template <typename Traits, typename PointRange, typename PolygonRange>
@@ -309,11 +299,10 @@ std::size_t split_pinched_polygons_in_polygon_soup(PointRange& points,
 // \tparam PolygonRange a model of the concept `SequenceContainer`
 //                      whose `value_type` is itself a model of the concept `Container`
 //                      whose `value_type` is `std::size_t`.
-// \tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
 //
 // \param points points of the soup of polygons
 // \param polygons a vector of polygons. Each element in the vector describes a polygon
-//        using the indices of the points in `points`.
+//                 using the indices of the points in `points`.
 //
 // \sa `repair_polygon_soup()`
 template <typename PointRange, typename PolygonRange>
@@ -352,11 +341,12 @@ std::size_t remove_invalid_polygons_in_polygon_soup(PointRange& /*points*/,
 // \tparam PointRange a model of the concept `Container` whose value type is the point type.
 // \tparam PolygonRange a model of the concept `SequenceContainer`
 //                      whose value_type is `std::array<std::size_t, N>` with `N`.
-// \tparam NamedParameters a sequence of \ref pmp_namedparameters "Named Parameters"
+// \tparam Traits Traits class providing `Equal_3` for two points.
 //
 // \param points points of the soup of polygons.
 // \param polygons a vector of polygons. Each element in the vector describes a polygon
-//        using the indices of the points in `points`.
+//                 using the indices of the points in `points`.
+// \param traits an instance of the traits clas
 //
 template <typename Traits, typename PointRange, typename PolygonRange>
 std::size_t remove_invalid_polygons_in_array_polygon_soup(PointRange& points,
@@ -839,12 +829,14 @@ struct Duplicate_collector<ValueType, CGAL::Emptyset_iterator>
 //                      and `ReversibleContainer` whose `value_type` is `std::size_t`.
 // \tparam DuplicateOutputIterator a model of `OutputIterator` with value type
 //                                 `std::vector<std::vector<std::size_t> >`.
+// \tparam Traits a traits class providing `Less_xyz_3` for two 3D points
 //
 // \param points points of the soup of polygons
 // \param polygons a vector of polygons. Each element in the vector describes a polygon
 //        using the indices of the points in `points`.
 // \param out the output iterator in which duplicate polygons are put. Each entry is a vector of
 //            polygon ids `i0`, `i1`, etc. such that `polygons[i0] = polygons[i1] = ...`
+// \param traits an instance of traits
 // \param same_orientation whether two polygons should have the same orientation to be duplicates.
 //
 // \sa `repair_polygon_soup()`


### PR DESCRIPTION
## Summary of Changes

Follow-up of #6704: in the original pipeline, the "split pinched" + "remove consecutive" will make it so invalid faces have size `< 3`. For array-based soups, we cannot apply these functions since they modify the size, but we still need to remove those invalid faces.

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

