### PR TITLE
Installation - update minimal valid Boost version

### DIFF
--- a/Installation/cmake/modules/CGAL_SetupBoost.cmake
+++ b/Installation/cmake/modules/CGAL_SetupBoost.cmake
@@ -17,7 +17,7 @@ set ( CGAL_Boost_Setup TRUE )
 
 include(${CMAKE_CURRENT_LIST_DIR}/CGAL_TweakFindBoost.cmake)
 
-find_package( Boost 1.48 REQUIRED )
+find_package( Boost 1.66 REQUIRED )
 
 if(Boost_FOUND AND Boost_VERSION VERSION_LESS 1.70)
   if(DEFINED Boost_DIR AND NOT Boost_DIR)


### PR DESCRIPTION
## Summary of Changes

The [documentation of Boost as third party](https://doc.cgal.org/latest/Manual/thirdparty.html#thirdpartyBoost) mentions that Boost 1.66 or more recent should be used, and `CGAL_SetupBoost.cmake` has Boost >=1.48 as requirement, and all the CMake calls then say
```
-- Found Boost: C:/dev/boost/boost_1_68_0 (found suitable version "1.68.0", minimum required is "1.48")
```
This PR fixes this number to 1.66

## Release Management

* Affected package(s): Installation
* License and copyright ownership: unchanged

