### PR TITLE
fix typo and update documentation

### DIFF
--- a/Documentation/doc/Documentation/advanced/Configuration_variables.txt
+++ b/Documentation/doc/Documentation/advanced/Configuration_variables.txt
@@ -72,12 +72,12 @@ and will serverly limit performances.
 
 | Variable              | Description                                                           | Type        | %Default Value |
 | :-                    | :-                    | :-   |  :-            |
-| `CMAKE_BUILD_TYPE`    | Indicates type of build. Possible values are 'Debug' or 'Release'     | CMake       |  |
-| `CMAKE_INSTALL_PREFIX`| Installation directory path                                           | CMake       | Debug |
+| `CMAKE_BUILD_TYPE`    | Indicates type of build. Possible values are 'Debug' or 'Release'     | CMake       | none |
+| `CMAKE_INSTALL_PREFIX`| Installation directory path                                           | CMake       | platform-dependent |
 | `CMAKE_C_COMPILER`    | Full-path to the executable corresponding to the C compiler to use.   | CMake       | platform-dependent |
 | `CMAKE_CXX_COMPILER`  | Full-path to the executable corresponding to the C++ compiler to use. | CMake       | platform-dependent |
 | `CXX`                 | Idem                                                                  | Environment | Idem |
-| `BUILD_SHARED_LIBS`   | Whether to build shared or static libraries.                          | CMake       | TRUE |
+| `BUILD_SHARED_LIBS`   | Whether to build shared or static libraries.                          | CMake       | ON |
 
 \subsection installation_variables_building Variables Used Only When Building Programs (Such as Demos or Examples)
 

--- a/Documentation/doc/Documentation/advanced/Installation.txt
+++ b/Documentation/doc/Documentation/advanced/Installation.txt
@@ -138,8 +138,8 @@ all entries are grayed. You are now ready to press *Generate*. Once this is
 done, you can quit `cmake-gui`.
 
 Without an explicit `CMAKE_BUILD_TYPE`, `CMake` does not add any additional build flags.
-This will result in a default build without any optimizations and without any debug symbols.
-You should set the variable `CMAKE_BUILD_TYPE` to `Release` or `Debug` to enable optimizations or debug symbols.
+This will result in a default build without any debug symbols, and without any optimizations.
+You should set the variable `CMAKE_BUILD_TYPE` to `Debug` to compile with debug symbols, or `Release` to enable optimizations.
 
 \subsection installation_configuring_cmd Configuring CGAL with the cmake Command-Line Tool
 

--- a/Documentation/doc/Documentation/advanced/Installation.txt
+++ b/Documentation/doc/Documentation/advanced/Installation.txt
@@ -78,7 +78,7 @@ might need these \cgal-libraries and thus their dependencies. See the page
 \subsection installation_debugrelease Debug vs. Release
 
 The CMake variable `CMAKE_BUILD_TYPE` indicates how to build the executables.
-It accepts the values `Debug` or `Release`. Note that the default value is `Debug`, since it is
+It accepts the values `Debug` or `Release`. Note that the default value is an empty string, since it is
 default value in `CMake`. If you do not plan on debugging, it is important to set the variable
 to `Release` for performance reasons.
 
@@ -137,7 +137,9 @@ Providing information and pressing *Configure* goes on until
 all entries are grayed. You are now ready to press *Generate*. Once this is
 done, you can quit `cmake-gui`.
 
-If you do not need to debug, you should set the variable `CMAKE_BUILD_TYPE` to `Release`.
+Without an explicit `CMAKE_BUILD_TYPE`, `CMake` does not add any additional build flags.
+This will result in a default build without any optimizations and without any debug symbols.
+You should set the variable `CMAKE_BUILD_TYPE` to `Release` or `Debug` to enable optimizations or debug symbols.
 
 \subsection installation_configuring_cmd Configuring CGAL with the cmake Command-Line Tool
 


### PR DESCRIPTION
## Summary of Changes

Fix typo in `Documentation/doc/Documentation/advanced/Configuration_variables.txt`