### PR TITLE
Mesh 3 - fix construction of weights image for labeled image input

### DIFF
--- a/Mesh_3/examples/Mesh_3/mesh_3D_weighted_image.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_weighted_image.cpp
@@ -1,3 +1,5 @@
+#define CGAL_MESH_3_WEIGHTED_IMAGES_DEBUG
+
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Mesh_triangulation_3.h>
@@ -39,7 +41,7 @@ int main(int argc, char* argv[])
   /// [Loads image]
 
   /// [Domain creation]
-  const float sigma = 10.f;
+  const float sigma = (std::max)(image.vx(), (std::max)(image.vy(), image.vz()));
   CGAL::Image_3 img_weights =
     CGAL::Mesh_3::generate_label_weights(image, sigma);
 

--- a/Mesh_3/examples/Mesh_3/mesh_3D_weighted_image.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_weighted_image.cpp
@@ -1,5 +1,3 @@
-#define CGAL_MESH_3_WEIGHTED_IMAGES_DEBUG
-
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Mesh_triangulation_3.h>

--- a/Mesh_3/include/CGAL/Mesh_3/generate_label_weights.h
+++ b/Mesh_3/include/CGAL/Mesh_3/generate_label_weights.h
@@ -137,7 +137,7 @@ void convert_itk_to_image_3(itk::Image<Image_word_type, 3>* const itk_img,
             itk_img->GetBufferPointer() + size,
             img_ptr);
 
-  if(filename != "")
+  if(std::strlen(filename)!=0)
     _writeImage(img, filename);
 }
 

--- a/Mesh_3/include/CGAL/Mesh_3/generate_label_weights.h
+++ b/Mesh_3/include/CGAL/Mesh_3/generate_label_weights.h
@@ -108,9 +108,10 @@ SIGN get_sign()
 //    SGN_UNKNOWN
 }
 
+#ifdef CGAL_MESH_3_WEIGHTED_IMAGES_DEBUG
 template<typename Image_word_type>
 void convert_itk_to_image_3(itk::Image<Image_word_type, 3>* const itk_img,
-                            const char* filename = "")
+                            const char* filename)
 {
   auto t = itk_img->GetOrigin();
   auto v = itk_img->GetSpacing();
@@ -137,9 +138,9 @@ void convert_itk_to_image_3(itk::Image<Image_word_type, 3>* const itk_img,
             itk_img->GetBufferPointer() + size,
             img_ptr);
 
-  if(std::strlen(filename)!=0)
-    _writeImage(img, filename);
+  _writeImage(img, filename);
 }
+#endif
 
 }//namespace internal
 

--- a/Mesh_3/include/CGAL/Mesh_3/generate_label_weights.h
+++ b/Mesh_3/include/CGAL/Mesh_3/generate_label_weights.h
@@ -296,7 +296,13 @@ CGAL::Image_3 generate_label_weights_with_known_word_type(const CGAL::Image_3& i
 *
 * @param image the input labeled image from which the weights image is computed.
 *   Both will then be used to construct a `Labeled_mesh_domain_3`.
-* @param sigma the standard deviation parameter of the internal Gaussian filter
+* @param sigma the standard deviation parameter of the internal Gaussian filter,
+*   measured in real-world distances. The size of a voxel (e.g. shortest length
+*   or longest length) usually is a good value for this parameter.
+*   Note that if `sigma` is too small, the "stair-effect" of meshing from
+*   a voxel image can appear. On the other side, if `sigma` is too large,
+*   thin volumes (basically one voxel thick) may be lost in the meshing process
+*   because the computed weights are too blurry.
 *
 * @returns a `CGAL::Image_3` of weights used to build a quality `Labeled_mesh_domain_3`,
 * with the same dimensions as `image`


### PR DESCRIPTION
## Summary of Changes

Computation of weights for labeled image input was broken. Using `itkDiscreteGaussianImageFilter` with voxel-number standard deviation (instead of `itkRecursiveGaussianImageFilter` with absolute standard deviation) fixes it.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

Todo
- [ ] make screenshots before/after
- [x] check that user code has the same improvement
- [x] improve documentation about sigma 