### PR TITLE
Number_types: Fix in testsuite code concerning min() and VC++

### DIFF
--- a/Number_types/test/Number_types/to_interval_test_boost.cpp
+++ b/Number_types/test/Number_types/to_interval_test_boost.cpp
@@ -213,7 +213,7 @@ void test_to_interval_tight_rational_1() {
   std::cout << "ref: inf" << std::endl;
   std::cout << std::endl;
 
-  assert(i == std::numeric_limits<double>::max());
+  assert(i == (std::numeric_limits<double>::max)());
   assert(s == std::numeric_limits<double>::infinity());
 
   #endif
@@ -236,8 +236,8 @@ void test_to_interval_tight_rational_1() {
   std::cout << "ref: 0.0 or higher" << std::endl;
   std::cout << std::endl;
 
-  assert(i >= 0.0 && i <= std::numeric_limits<double>::min() * 2.0);
-  assert(s >= 0.0 && s <= std::numeric_limits<double>::min() * 2.0);
+  assert(i >= 0.0 && i <= (std::numeric_limits<double>::min)() * 2.0);
+  assert(s >= 0.0 && s <= (std::numeric_limits<double>::min)() * 2.0);
   assert(i <= s);
 
   #endif
@@ -518,7 +518,7 @@ void test_to_interval_tight_rational_2() {
   std::cout << "ref: inf" << std::endl;
   std::cout << std::endl;
 
-  assert(i == std::numeric_limits<double>::max());
+  assert(i == (std::numeric_limits<double>::max)());
   assert(s == std::numeric_limits<double>::infinity());
 
   #endif
@@ -540,8 +540,8 @@ void test_to_interval_tight_rational_2() {
   std::cout << "ref: 0.0 or higher" << std::endl;
   std::cout << std::endl;
 
-  assert(i >= 0.0 && i <= std::numeric_limits<double>::min() * 2.0);
-  assert(s >= 0.0 && s <= std::numeric_limits<double>::min() * 2.0);
+  assert(i >= 0.0 && i <= (std::numeric_limits<double>::min)() * 2.0);
+  assert(s >= 0.0 && s <= (std::numeric_limits<double>::min)() * 2.0);
   assert(i <= s);
 
   #endif
@@ -785,7 +785,7 @@ void test_to_interval_tight_integer() {
   std::cout << "ref: inf" << std::endl;
   std::cout << std::endl;
 
-  assert(i == std::numeric_limits<double>::max());
+  assert(i == (std::numeric_limits<double>::max)());
   assert(s == std::numeric_limits<double>::infinity());
 
   #endif


### PR DESCRIPTION
## Summary of Changes

Fix 'N' in this [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.6-Ic-74/Number_types/TestReport_Christo_MSVC-2019-Community-Release.gz)

Note that the bug is in the testsuite code, and not in CGAL itself.
## Release Management

* Affected package(s): Number_types


