### PR TITLE
Documentation error in Arrangement_on_surface_2

### DIFF
--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
@@ -1937,8 +1937,8 @@ perform a point-location query on the resulting arrangement. The query
 point \f$q\f$ is drawn as a plus sign. The face that contains it is
 drawn with a shaded texture. The program calls an instance of the
 function template `print_arrangement_size()`, which prints
-quantitative measures of the arrangement; see \ref lst_paz "code
-example" for its listing in Section \ref aos_ssec-basic-arr_class.
+quantitative measures of the arrangement; see \ref lst_paz
+"code example" for its listing in Section \ref aos_ssec-basic-arr_class.
 
 \cgalExample{Arrangement_on_surface_2/incremental_insertion.cpp}
 


### PR DESCRIPTION
The construct:
```
...\ref lst_paz "code
example" ...
```
leads to the fact that the link is shown as:
```
 codeexample"
```
Note the joined words and the `"` as doxygen doesn't like the return in the string here.

File: doc_output/Arrangement_on_surface_2/index.html

**Old result**

![image](https://user-images.githubusercontent.com/5223533/192097758-2e89c937-c8d6-4fb8-a3d4-645e85679ead.png)


**New result**

![image](https://user-images.githubusercontent.com/5223533/192097786-a69b03a1-b97d-4828-8d4c-9e5c82967e5b.png)
