### PR TITLE
Documentation error in Three

### DIFF
--- a/Three/include/CGAL/Three/Edge_container.h
+++ b/Three/include/CGAL/Three/Edge_container.h
@@ -63,8 +63,8 @@ struct DEMO_FRAMEWORK_EXPORT Edge_container :public Primitive_container
   //! \brief initGL creates the `Vbo`s and `Vao`s of this `Edge_container`.
   //! \attention It must be called within a valid OpenGL context. The `draw()` function of an item is always a safe place to call this.
   //!
-  //! \todo Is it a good idea to call InitGL of each item in the scene so the developper doesn't have to worry about this in each draw() of each item ?
-  //!`.
+  //! \todo Is it a good idea to call InitGL of each item in the scene so the developer doesn't have to worry about this in each draw() of each item ?
+  //!
   //! \param viewer the active `Viewer_interface`.
   //!
   void initGL(Viewer_interface *viewer)  Q_DECL_OVERRIDE;

--- a/Three/include/CGAL/Three/Point_container.h
+++ b/Three/include/CGAL/Three/Point_container.h
@@ -59,8 +59,8 @@ struct DEMO_FRAMEWORK_EXPORT Point_container :public Primitive_container
   //! \brief initGL creates the `Vbo`s and `Vao`s of this `Point_container`.
   //! \attention It must be called within a valid OpenGL context. The `draw()` function of an item is always a safe place to call this.
   //!
-  //! \todo Is it a good idea to call InitGL of each item in the scene so the developper doesn't have to worry about this in each draw() of each item ?
-  //!`.
+  //! \todo Is it a good idea to call InitGL of each item in the scene so the developer doesn't have to worry about this in each draw() of each item ?
+  //!
   //! \param viewer the active `Viewer_interface`.
   //!
   void initGL(Viewer_interface *viewer)  Q_DECL_OVERRIDE;


### PR DESCRIPTION
The construct:
```
...of each item ?
  //!`.
  //! \param viewer the active `Viewer_interface`.
```
leads to the fact that the `todo` and the `param` are joined and shown as:
```
... of each item ? . \param viewer the activeViewer_interface`.
```

Files:
- doc_output/Three/structCGAL_1_1Three_1_1Edge__container.html
- doc_output/Three/structCGAL_1_1Three_1_1Point__container.html

(also corrected a typo)

**Old result**

![image](https://user-images.githubusercontent.com/5223533/192098968-dd3aa257-4690-4609-90c0-fa61abaeab79.png)


**New Result**

![image](https://user-images.githubusercontent.com/5223533/192098991-7818d0d8-a7e4-45a4-9f84-6fdaa65813bb.png)
