### PR TITLE
Documentation error in Manual

### DIFF
--- a/Documentation/doc/Documentation/Tutorials/Tutorial_hello_world.txt
+++ b/Documentation/doc/Documentation/Tutorials/Tutorial_hello_world.txt
@@ -265,7 +265,7 @@ given by a direction, which is hardwired in the class
 
 \section intro_concept Concepts and Models
 
-In the previous section, we wrote that "Any model of the CGAL concept
+In the previous section, we wrote that: Any model of the CGAL concept
 Kernel provides what is required by the concept `ConvexHullTraits_2`.
 
 A \em concept is a set of requirements on a type, namely that it has

--- a/Documentation/doc/Documentation/Tutorials/Tutorial_hello_world.txt
+++ b/Documentation/doc/Documentation/Tutorials/Tutorial_hello_world.txt
@@ -241,8 +241,8 @@ ch_graham_andrew( InputIterator  first,
 There are two obvious questions: What can be used as argument for
 this template parameter? And why do we have template parameters at all?
 
-To answer the first question, any model of the \cgal concept `Kernel` provides
-what is required by the concept `ConvexHullTraits_2`.
+To answer the first question, any \em model of the \cgal \em concept `Kernel`
+provides what is required by the concept `ConvexHullTraits_2`.
 
 As for the second question, think about an application where we want to
 compute the convex hull of 3D points projected into the `yz` plane. Using
@@ -265,8 +265,8 @@ given by a direction, which is hardwired in the class
 
 \section intro_concept Concepts and Models
 
-In the previous section, we wrote that: Any model of the CGAL concept
-Kernel provides what is required by the concept `ConvexHullTraits_2`.
+In the previous section, we wrote that: any \em model of the \cgal \em concept
+`Kernel` provides what is required by the concept `ConvexHullTraits_2`.
 
 A \em concept is a set of requirements on a type, namely that it has
 certain nested types, certain member functions, or comes with certain


### PR DESCRIPTION
The construct:
```
In the previous section, we wrote that "Any model of the CGAL concept
Kernel provides what is required by the concept `ConvexHullTraits_2`.
```
leads to the fact that the entire paragraph is badly formatted as the double quote is not properly closed. Closing the double quote would lead to the fact that the `` `ConvexHullTraits_2` `` is not resolved properly

File:
- doc_output/Manual/tutorial_hello_world.html#intro_concept

**Old result**

![image](https://user-images.githubusercontent.com/5223533/192108031-add77308-73ec-4e6a-880c-c315251e980a.png)


**New result**

![image](https://user-images.githubusercontent.com/5223533/192108057-93204b27-657c-417b-a6e5-95e4faadc8e9.png)
