### PR TITLE
Pmp tests only for epeck

### DIFF
--- a/Intersections_3/test/Intersections_3/intersection_test_helper.h
+++ b/Intersections_3/test/Intersections_3/intersection_test_helper.h
@@ -237,8 +237,8 @@ public:
 
     const auto ires12 = CGAL::intersection(o1, o2);
 
-     Res tmp;
-    if(has_exact_p)
+    Res tmp;
+    if(has_exact_c)
     {
       assert(CGAL::assign(tmp, ires12));
       assert(approx_equal(tmp, result));
@@ -246,7 +246,7 @@ public:
     else
     {
       if(CGAL::assign(tmp, ires12))
-        assert(approx_equal(tmp, result));
+        CGAL_warning(approx_equal(tmp, result));
       else
         CGAL_warning_msg(false, "Expected an intersection, but it was not found!");
     }

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_2.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_aff_transformation_2.h
@@ -268,7 +268,7 @@ _test_cls_aff_transformation_2(const R& )
  assert( pnt.transform(gat3).transform(gat2) == pnt.transform(co1) );
  assert( dir.transform(gat3).transform(gat2) == dir.transform(co1) );
  assert( vec.transform(gat3).transform(gat2) == vec.transform(co1) );
- assert( lin.transform(gat3).transform(gat2) == lin.transform(co1) );
+ assert( lin.transform(gat3).transform(gat2) == lin.transform(co1) || nonexact);
  co1 = ident * gat1;
  assert( vec.transform(gat1) == vec.transform(co1) );
  assert( dir.transform(gat1) == dir.transform(co1) );
@@ -281,7 +281,7 @@ _test_cls_aff_transformation_2(const R& )
  assert( lin.transform(gat1) == lin.transform(co1) );
  co1 = gat1 * gat1.inverse() ;
  assert( vec == vec.transform(co1) );
- assert( pnt == pnt.transform(co1) );
+ assert( pnt == pnt.transform(co1) || nonexact);
  assert( dir == dir.transform(co1) );
  assert( lin == lin.transform(co1) );
 
@@ -619,7 +619,7 @@ _test_cls_aff_transformation_2(const R& )
                                       CGAL::Point_2<R>(1,3),
                                       CGAL::Point_2<R>(2,1)));
  CGAL::Point_2<R> p(4,2);
- assert(p.transform(refl) == CGAL::Point_2<R>(0,0));
+ assert(p.transform(refl) == CGAL::Point_2<R>(0,0) || nonexact);
 
 
  //with translation
@@ -642,7 +642,7 @@ _test_cls_aff_transformation_2(const R& )
  assert(p1 == p.transform(comp1));
  p1 = p.transform(refl);
  p1 = p1.transform(scal);
- assert(p1 == p.transform(comp2));
+ assert(p1 == p.transform(comp2) || nonexact);
  //with rotation
  CGAL::Aff_transformation_2<R> rot(CGAL::ROTATION, 1, 0);
  comp1 = refl*rot;
@@ -652,7 +652,7 @@ _test_cls_aff_transformation_2(const R& )
  assert(p1 == p.transform(comp1));
  p1 = p.transform(refl);
  p1 = p1.transform(rot);
- assert(p1 == p.transform(comp2));
+ assert(p1 == p.transform(comp2) || nonexact);
  //with reflection
  CGAL::Aff_transformation_2<R> refl2(CGAL::REFLECTION, CGAL::Line_2<R>(
                                       CGAL::Point_2<R>(0,0),
@@ -664,7 +664,7 @@ _test_cls_aff_transformation_2(const R& )
  assert(p1 == p.transform(comp1));
  p1 = p.transform(refl);
  p1 = p1.transform(refl2);
- assert(p1 == p.transform(comp2));
+ assert(p1 == p.transform(comp2) || nonexact);
  //with transformation
  CGAL::Aff_transformation_2<R> afft(1,2,3,4,5,6);
  comp1 = refl*afft;
@@ -674,7 +674,7 @@ _test_cls_aff_transformation_2(const R& )
  assert(p1 == p.transform(comp1));
  p1 = p.transform(refl);
  p1 = p1.transform(afft);
- assert(p1 == p.transform(comp2));
+ assert(p1 == p.transform(comp2) || nonexact);
 
  //equality
  CGAL::Aff_transformation_2<R> a2(0,1,0,1),

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_sphere_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_cls_sphere_3.h
@@ -88,11 +88,11 @@ _test_cls_sphere_3(const R& )
  assert( cc != c8 );
  assert( cc == c7 );
 
- assert( c5.center() == p3 );
+ assert( c5.center() == p3 || nonexact);
  assert( cc.center() == p3 );
  assert( c5.squared_radius() == FT( n9 ) );
  assert( c4.squared_radius() == cc.squared_radius() );
- assert( c4 == c5 );
+ assert( c4 == c5 || nonexact);
  assert( c4 == c7 );
  assert( c4 != c8 );
  assert( cn == cp.opposite() );
@@ -114,7 +114,7 @@ _test_cls_sphere_3(const R& )
  std::cout << '.';
 
  assert( c4.center() == p3 );
- assert( c5.center() == p3 );
+ assert( c5.center() == p3 || nonexact);
  assert( c4.squared_radius() == FT( n9 ) );
  assert( c5.squared_radius() == FT( n9 ) );
  assert( c8.squared_radius() == FT( n9 ) );

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_points_implicit_sphere.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_points_implicit_sphere.h
@@ -92,7 +92,7 @@ _test_fct_points_implicit_sphere(const R&)
 
   assert( CGAL::squared_distance(   r, org ) == FT1 );
   tpt = r.transform(rot_z);
-  assert( CGAL::squared_distance( tpt, org ) == FT1 );
+  assert( CGAL::squared_distance( tpt, org ) == FT1 || nonexact);
   r = tpt.transform(rot_y);
   assert( CGAL::squared_distance(   r, org ) == FT1 || nonexact );
 

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_mf_plane_3_to_2d.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_mf_plane_3_to_2d.h
@@ -68,11 +68,11 @@ _test_mf_plane_3_to_2d(const R& )
  Point_3 p6( n4, n5, n0, n8);
  Plane_3 pl3( p4, p5, p6);
  assert( p4 == pl3.to_3d( pl3.to_2d( p4)) || nonexact );
- assert( p5 == pl3.to_3d( pl3.to_2d( p5)) );
+ assert( p5 == pl3.to_3d( pl3.to_2d( p5)) || nonexact);
  assert( p6 == pl3.to_3d( pl3.to_2d( p6)) || nonexact );
  Plane_3 pl4( p4, p6, p5);
  assert( p4 == pl4.to_3d( pl4.to_2d( p4)) || nonexact );
- assert( p5 == pl4.to_3d( pl4.to_2d( p5)) );
+ assert( p5 == pl4.to_3d( pl4.to_2d( p5)) || nonexact);
  assert( p6 == pl4.to_3d( pl4.to_2d( p6)) || nonexact );
 
  Point_3 p7 = CGAL::midpoint( p1, p2);

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/pmp_compute_normals_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/pmp_compute_normals_test.cpp
@@ -98,8 +98,11 @@ void test(const Mesh& mesh,
     // tests on non triangular meshes are @todo
     if(CGAL::is_triangle(halfedge(f, mesh), mesh))
     {
-      if(PMP::is_degenerate_triangle_face(f, mesh))
-        assert(get(fnormals, f) == CGAL::NULL_VECTOR);
+      if (PMP::is_degenerate_triangle_face(f, mesh))
+      {
+        if (std::is_same<K, EPECK>())
+          assert(get(fnormals, f) == CGAL::NULL_VECTOR);
+      }
       else
         assert(get(fnormals, f) != CGAL::NULL_VECTOR);
     }

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_locate.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_locate.cpp
@@ -514,8 +514,10 @@ void test_locate_in_face(const G& g,
     PMP::locate_in_adjacent_face(loc, neigh_f, g);
     assert(PMP::locate_in_common_face<FT>(loc, neigh_loc, g));
 
-    assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K())));
-    assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K()), 1e-7));
+    if (std::is_same<K, EPECK>()) {
+      assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K())));
+      assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K()), 1e-7));
+    }
   }
 }
 
@@ -588,13 +590,19 @@ struct Locate_with_AABB_tree_Tester // 2D case
     assert(is_equal(CGAL::squared_distance(to_p3(
       PMP::construct_point(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
 
-    assert(PMP::is_in_face(loc, g));
+    if (std::is_same<K, EPECK>()) {
+      assert(PMP::is_in_face(loc, g));
+    }
 
     loc = PMP::locate_with_AABB_tree(CGAL::ORIGIN, tree_b, g, CGAL::parameters::vertex_point_map(vpm_b));
-    assert(PMP::is_in_face(loc, g));
+    if (std::is_same<K, EPECK>()) {
+      assert(PMP::is_in_face(loc, g));
+    }
 
     loc = PMP::locate(CGAL::ORIGIN, g, CGAL::parameters::vertex_point_map(vpm_b));
-    assert(PMP::is_in_face(loc, g));
+    if (std::is_same<K, EPECK>()) {
+      assert(PMP::is_in_face(loc, g));
+    }
 
     // ---------------------------------------------------------------------------
     Ray_2 r2 = random_2D_ray<CGAL::AABB_tree<AABB_face_graph_traits> >(tree_a, rnd);
@@ -894,7 +902,7 @@ void test(CGAL::Random& rnd)
 {
   test_2D_triangulation<K>("data/stair.xy", rnd);
 //  test_2D_surface_mesh<K>("data/blobby_2D.off", rnd); // temporarily disabled, until Surface_mesh's IO is "fixed"
-  test_surface_mesh_3D<K>(CGAL::data_file_path("meshes/mech-holes-shark.off"), rnd);
+  test_surface_mesh_3D<K>("meshes/mech-holes-shark.off", rnd);
   test_surface_mesh_projection<K>("data/unit-grid.off", rnd);
   test_polyhedron<K>("data-coref/elephant_split_2.off", rnd);
 }

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_locate.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_locate.cpp
@@ -172,15 +172,25 @@ void test_constructions(const G& g,
 
   // ---------------------------------------------------------------------------
   bar = PMP::barycentric_coordinates(p, q, r, p, K());
-  assert(is_equal(bar[0], FT(1)) && is_equal(bar[1], FT(0)) && is_equal(bar[2], FT(0)));
+  if (std::is_same<K, EPECK>()) {
+    assert(is_equal(bar[0], FT(1)) && is_equal(bar[1], FT(0)) && is_equal(bar[2], FT(0)));
+  }
+
   bar = PMP::barycentric_coordinates(p, q, r, q, K());
-  assert(is_equal(bar[0], FT(0)) && is_equal(bar[1], FT(1)) && is_equal(bar[2], FT(0)));
+  if (std::is_same<K, EPECK>()) {
+    assert(is_equal(bar[0], FT(0)) && is_equal(bar[1], FT(1)) && is_equal(bar[2], FT(0)));
+  }
+
   bar = PMP::barycentric_coordinates(p, q, r, r, K());
-  assert(is_equal(bar[0], FT(0)) && is_equal(bar[1], FT(0)) && is_equal(bar[2], FT(1)));
+  if (std::is_same<K, EPECK>()) {
+    assert(is_equal(bar[0], FT(0)) && is_equal(bar[1], FT(0)) && is_equal(bar[2], FT(1)));
+  }
 
   Point mp = Point(CGAL::midpoint(bp, bq));
   bar = PMP::barycentric_coordinates(p, q, r, mp);
-  assert(is_equal(bar[0], FT(0.5)) && is_equal(bar[1], FT(0.5)) && is_equal(bar[2], FT(0)));
+  if (std::is_same<K, EPECK>()) {
+    assert(is_equal(bar[0], FT(0.5)) && is_equal(bar[1], FT(0.5)) && is_equal(bar[2], FT(0)));
+  }
 
   int n = 100;
   while(n --> 0) // :)
@@ -192,7 +202,9 @@ void test_constructions(const G& g,
     // Point to location and inversely
     Bare_point barycentric_pt = CGAL::barycenter(bp, a, bq, b, br, c);
     bar = PMP::barycentric_coordinates(p, q, r, Point(barycentric_pt));
-    assert(is_equal(bar[0], a) && is_equal(bar[1], b) && is_equal(bar[2], c));
+    if (std::is_same<K, EPECK>()) {
+      assert(is_equal(bar[0], a) && is_equal(bar[1], b) && is_equal(bar[2], c));
+    }
 
     loc.second = bar;
     const Bare_point barycentric_pt_2 =
@@ -201,22 +213,31 @@ void test_constructions(const G& g,
                                                        .geom_traits(K())));
 
     const FT sq_dist = CGAL::squared_distance(barycentric_pt, barycentric_pt_2);
-    assert(is_equal(sq_dist, FT(0)));
+    if (std::is_same<K, EPECK>()) {
+      assert(is_equal(sq_dist, FT(0)));
+    }
   }
 
   // ---------------------------------------------------------------------------
   loc = std::make_pair(f, CGAL::make_array(FT(0.3), FT(0.4), FT(0.3)));
   descriptor_variant dv = PMP::get_descriptor_from_location(loc, g);
   const face_descriptor* fd = boost::get<face_descriptor>(&dv);
-  assert(fd);
+  if (std::is_same<K, EPECK>()) {
+    assert(fd);
+  }
 
   loc = std::make_pair(f, CGAL::make_array(FT(0.5), FT(0.5), FT(0)));
   dv = PMP::get_descriptor_from_location(loc, g);
   const halfedge_descriptor* hd = boost::get<halfedge_descriptor>(&dv);
-  assert(hd);
+  if (std::is_same<K, EPECK>()) {
+    assert(hd);
+  }
 
   loc = std::make_pair(f, CGAL::make_array(FT(1), FT(0), FT(0)));
-  assert(PMP::is_on_vertex(loc, source(halfedge(f, g), g), g));
+  if (std::is_same<K, EPECK>()) {
+    assert(PMP::is_on_vertex(loc, source(halfedge(f, g), g), g));
+  }
+
   dv = PMP::get_descriptor_from_location(loc, g);
   if(const vertex_descriptor* v = boost::get<vertex_descriptor>(&dv)) { } else { assert(false); }
 
@@ -249,24 +270,33 @@ void test_random_entities(const G& g, CGAL::Random& rnd)
   while(nn --> 0) // the infamous 'go to zero' operator
   {
     loc = PMP::random_location_on_mesh<FT>(g, rnd);
-    assert(loc.first != boost::graph_traits<G>::null_face());
-    assert(loc.second[0] >= FT(0) && loc.second[0] <= FT(1) &&
-           loc.second[1] >= FT(0) && loc.second[1] <= FT(1) &&
-           loc.second[2] >= FT(0) && loc.second[2] <= FT(1));
+    if (std::is_same<K, EPECK>()) {
+      assert(loc.first != boost::graph_traits<G>::null_face());
+      assert(loc.second[0] >= FT(0) && loc.second[0] <= FT(1) &&
+        loc.second[1] >= FT(0) && loc.second[1] <= FT(1) &&
+        loc.second[2] >= FT(0) && loc.second[2] <= FT(1));
+    }
 
     loc = PMP::random_location_on_face<FT>(f, g, rnd);
-    assert(loc.first == f);
-    assert(loc.second[0] >= FT(0) && loc.second[0] <= FT(1) &&
-           loc.second[1] >= FT(0) && loc.second[1] <= FT(1) &&
-           loc.second[2] >= FT(0) && loc.second[2] <= FT(1));
+    if (std::is_same<K, EPECK>()) {
+      assert(loc.first == f);
+      assert(loc.second[0] >= FT(0) && loc.second[0] <= FT(1) &&
+        loc.second[1] >= FT(0) && loc.second[1] <= FT(1) &&
+        loc.second[2] >= FT(0) && loc.second[2] <= FT(1));
+    }
 
     loc = PMP::random_location_on_halfedge<FT>(h, g, rnd);
-    assert(loc.first == face(h, g));
-    assert(loc.second[0] >= FT(0) && loc.second[0] <= FT(1) &&
-           loc.second[1] >= FT(0) && loc.second[1] <= FT(1) &&
-           loc.second[2] >= FT(0) && loc.second[2] <= FT(1));
+    if (std::is_same<K, EPECK>()) {
+      assert(loc.first == face(h, g));
+      assert(loc.second[0] >= FT(0) && loc.second[0] <= FT(1) &&
+        loc.second[1] >= FT(0) && loc.second[1] <= FT(1) &&
+        loc.second[2] >= FT(0) && loc.second[2] <= FT(1));
+    }
     int h_id = CGAL::halfedge_index_in_face(h, g);
-    assert(loc.second[(h_id+2)%3] == FT(0));
+
+    if (std::is_same<K, EPECK>()) {
+      assert(loc.second[(h_id + 2) % 3] == FT(0));
+    }
   }
 }
 
@@ -307,14 +337,18 @@ void test_helpers(const G& g, CGAL::Random& rnd)
   Face_location loc = PMP::random_location_on_face<FT>(f, g, rnd);
   std::set<face_descriptor> s;
   PMP::internal::incident_faces(loc, g, std::inserter(s, s.begin()));
-  assert(PMP::is_on_face_border(loc, g) || s.size() == 1);
+  if (std::is_same<K, EPECK>()) {
+    assert(PMP::is_on_face_border(loc, g) || s.size() == 1);
+  }
 
   loc = PMP::random_location_on_halfedge<FT>(h, g, rnd);
   std::vector<face_descriptor> vec;
   PMP::internal::incident_faces(loc, g, std::back_inserter(vec));
-  assert(PMP::is_on_vertex(loc, source(h, g), g) ||
-         PMP::is_on_vertex(loc, target(h, g), g) ||
-         vec.size() == 2);
+  if (std::is_same<K, EPECK>()) {
+    assert(PMP::is_on_vertex(loc, source(h, g), g) ||
+      PMP::is_on_vertex(loc, target(h, g), g) ||
+      vec.size() == 2);
+  }
 }
 
 template<typename K, typename G>
@@ -432,28 +466,39 @@ void test_locate_in_face(const G& g,
   Point_reference p = get(vpm, v);
 
   loc = PMP::locate_vertex<FT>(v, g);
-  assert(is_equal(loc.second[CGAL::vertex_index_in_face(v, loc.first, g)], FT(1)));
-  assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g)+1)%3], FT(0)));
-  assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g)+2)%3], FT(0)));
+
+  if (std::is_same<K, EPECK>()) {
+    assert(is_equal(loc.second[CGAL::vertex_index_in_face(v, loc.first, g)], FT(1)));
+    assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 1) % 3], FT(0)));
+    assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 2) % 3], FT(0)));
+  }
 
   loc = PMP::locate_vertex<FT>(v, f, g);
-  assert(loc.first == f);
-  assert(is_equal(loc.second[0], FT(0)) && is_equal(loc.second[1], FT(1)) && is_equal(loc.second[2], FT(0)));
+  if (std::is_same<K, EPECK>()) {
+    assert(loc.first == f);
+    assert(is_equal(loc.second[0], FT(0)) && is_equal(loc.second[1], FT(1)) && is_equal(loc.second[2], FT(0)));
+  }
 
   loc = PMP::locate_on_halfedge<FT>(h, a, g);
   const int h_id = CGAL::halfedge_index_in_face(h, g);
-  assert(loc.first == f && is_equal(loc.second[(h_id+2)%3], FT(0)));
+  if (std::is_same<K, EPECK>()) {
+    assert(loc.first == f && is_equal(loc.second[(h_id + 2) % 3], FT(0)));
+  }
 
   loc = PMP::locate_in_face(p, f, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K()));
   int v_id = CGAL::vertex_index_in_face(v, f, g);
-  assert(loc.first == f && is_equal(loc.second[v_id], FT(1)));
+  if (std::is_same<K, EPECK>()) {
+    assert(loc.first == f && is_equal(loc.second[v_id], FT(1)));
+  }
 
   // Internal vertex point pmap
   typedef typename boost::property_map_value<G, CGAL::vertex_point_t>::type     Point;
 
   Point p2 = get(CGAL::vertex_point, g, v);
   PMP::locate_in_face(p2, f, g);
-  assert(loc.first == f && is_equal(loc.second[v_id], FT(1)));
+  if (std::is_same<K, EPECK>()) {
+    assert(loc.first == f && is_equal(loc.second[v_id], FT(1)));
+  }
 
   // ---------------------------------------------------------------------------
   loc.second[0] = FT(0.2);
@@ -475,11 +520,12 @@ void test_locate_in_face(const G& g,
     neigh_loc.second[(neigh_hd_id+2)%3] = FT(0);
 
     PMP::locate_in_adjacent_face(loc, neigh_f, g);
+    if (std::is_same<K, EPECK>()) {
+      assert(PMP::locate_in_common_face<FT>(loc, neigh_loc, g));
 
-    assert(PMP::locate_in_common_face<FT>(loc, neigh_loc, g));
-
-    assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K())));
-    assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K()), 1e-7));
+      assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K())));
+      assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K()), 1e-7));
+    }
   }
 }
 
@@ -537,33 +583,44 @@ struct Locate_with_AABB_tree_Tester // 2D case
     // sanitize otherwise some test platforms fail
     PMP::internal::snap_location_to_border(loc, g, FT(1e-7));
 
-    assert(PMP::is_on_vertex(loc, v, g)); // might fail du to precision issues...
-    assert(is_equal(loc.second[CGAL::vertex_index_in_face(v, loc.first, g)], FT(1)));
-    assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g)+1)%3], FT(0)));
-    assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g)+2)%3], FT(0)));
-    assert(is_equal(CGAL::squared_distance(to_p3(
-      PMP::construct_point<FT>(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
+    if (std::is_same<K, EPECK>()) {
+      assert(PMP::is_on_vertex(loc, v, g)); // might fail due to precision issues...
+      assert(is_equal(loc.second[CGAL::vertex_index_in_face(v, loc.first, g)], FT(1)));
+      assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 1) % 3], FT(0)));
+      assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 2) % 3], FT(0)));
+      assert(is_equal(CGAL::squared_distance(to_p3(
+        PMP::construct_point<FT>(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
+    }
 
     loc = PMP::locate_with_AABB_tree(p_a, tree_a, g, CGAL::parameters::vertex_point_map(vpm));
-    assert(is_equal(CGAL::squared_distance(to_p3(
-      PMP::construct_point<FT>(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
+    if (std::is_same<K, EPECK>()) {
+      assert(is_equal(CGAL::squared_distance(to_p3(
+        PMP::construct_point<FT>(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
+    }
 
     // ---------------------------------------------------------------------------
     loc = PMP::locate(p_a, g, CGAL::parameters::vertex_point_map(vpm));
-    assert(is_equal(CGAL::squared_distance(to_p3(
-      PMP::construct_point(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
-    assert(PMP::is_in_face(loc, g));
+    if (std::is_same<K, EPECK>()) {
+      assert(is_equal(CGAL::squared_distance(to_p3(
+        PMP::construct_point(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
+
+      assert(PMP::is_in_face(loc, g));
+    }
 
     loc = PMP::locate_with_AABB_tree(CGAL::ORIGIN, tree_b, g, CGAL::parameters::vertex_point_map(vpm_b));
-    assert(PMP::is_in_face(loc, g));
+    if (std::is_same<K, EPECK>()) {
+      assert(PMP::is_in_face(loc, g));
+    }
 
     loc = PMP::locate(CGAL::ORIGIN, g, CGAL::parameters::vertex_point_map(vpm_b));
-    assert(PMP::is_in_face(loc, g));
+    if (std::is_same<K, EPECK>()) {
+      assert(PMP::is_in_face(loc, g));
+    }
 
     // ---------------------------------------------------------------------------
     Ray_2 r2 = random_2D_ray<CGAL::AABB_tree<AABB_face_graph_traits> >(tree_a, rnd);
     loc = PMP::locate_with_AABB_tree(r2, tree_a, g, CGAL::parameters::vertex_point_map(vpm));
-    if(loc.first != boost::graph_traits<G>::null_face())
+    if(loc.first != boost::graph_traits<G>::null_face() && std::is_same<K, EPECK>())
       assert(PMP::is_in_face(loc, g));
 
     Ray_3 r3 = random_3D_ray<CGAL::AABB_tree<AABB_face_graph_traits> >(tree_b, rnd);
@@ -654,25 +711,35 @@ struct Locate_with_AABB_tree_Tester<K, VPM, 3> // 3D
     assert(tree_b.size() == num_faces(g));
 
     Face_location loc = PMP::locate_with_AABB_tree(p3_a, tree_a, g, CGAL::parameters::vertex_point_map(vpm));
-    assert(is_equal(loc.second[CGAL::vertex_index_in_face(v, loc.first, g)], FT(1)));
-    assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g)+1)%3], FT(0)));
-    assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g)+2)%3], FT(0)));
-    assert(is_equal(CGAL::squared_distance(PMP::construct_point(loc, g), p3_a), FT(0)));
+    if (std::is_same<K, EPECK>()) {
+      assert(is_equal(loc.second[CGAL::vertex_index_in_face(v, loc.first, g)], FT(1)));
+      assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 1) % 3], FT(0)));
+      assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 2) % 3], FT(0)));
+      assert(is_equal(CGAL::squared_distance(PMP::construct_point(loc, g), p3_a), FT(0)));
+    }
 
     loc = PMP::locate_with_AABB_tree(p3_a, tree_a, g, CGAL::parameters::vertex_point_map(vpm));
-    assert(is_equal(CGAL::squared_distance(PMP::construct_point(loc, g), p3_a), FT(0)));
+    if (std::is_same<K, EPECK>()) {
+      assert(is_equal(CGAL::squared_distance(PMP::construct_point(loc, g), p3_a), FT(0)));
+    }
 
     // ---------------------------------------------------------------------------
     loc = PMP::locate(p3_a, g, CGAL::parameters::snapping_tolerance(1e-7));
-    assert(is_equal(CGAL::squared_distance(PMP::construct_point(loc, g), p3_a), FT(0)));
-    assert(PMP::is_in_face(loc, g));
+    if (std::is_same<K, EPECK>()) {
+      assert(is_equal(CGAL::squared_distance(PMP::construct_point(loc, g), p3_a), FT(0)));
+      assert(PMP::is_in_face(loc, g));
+    }
 
     loc = PMP::locate_with_AABB_tree(CGAL::ORIGIN, tree_b, g, CGAL::parameters::vertex_point_map(custom_vpm_3D));
-    assert(PMP::is_in_face(loc, g));
+    if (std::is_same<K, EPECK>()) {
+      assert(PMP::is_in_face(loc, g));
+    }
 
     // Doesn't necessarily have to wrap with a P_to_P3: it can be done automatically internally
     loc = PMP::locate(CGAL::ORIGIN, g, CGAL::parameters::vertex_point_map(custom_vpm));
-    assert(PMP::is_in_face(loc, g));
+    if (std::is_same<K, EPECK>()) {
+      assert(PMP::is_in_face(loc, g));
+    }
 
     // ---------------------------------------------------------------------------
     Ray_3 r3 = random_3D_ray<CGAL::AABB_tree<AABB_face_graph_traits_with_WVPM> >(tree_b, rnd);

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_locate.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_locate.cpp
@@ -172,25 +172,17 @@ void test_constructions(const G& g,
 
   // ---------------------------------------------------------------------------
   bar = PMP::barycentric_coordinates(p, q, r, p, K());
-  if (std::is_same<K, EPECK>()) {
-    assert(is_equal(bar[0], FT(1)) && is_equal(bar[1], FT(0)) && is_equal(bar[2], FT(0)));
-  }
+  assert(is_equal(bar[0], FT(1)) && is_equal(bar[1], FT(0)) && is_equal(bar[2], FT(0)));
 
   bar = PMP::barycentric_coordinates(p, q, r, q, K());
-  if (std::is_same<K, EPECK>()) {
-    assert(is_equal(bar[0], FT(0)) && is_equal(bar[1], FT(1)) && is_equal(bar[2], FT(0)));
-  }
+  assert(is_equal(bar[0], FT(0)) && is_equal(bar[1], FT(1)) && is_equal(bar[2], FT(0)));
 
   bar = PMP::barycentric_coordinates(p, q, r, r, K());
-  if (std::is_same<K, EPECK>()) {
-    assert(is_equal(bar[0], FT(0)) && is_equal(bar[1], FT(0)) && is_equal(bar[2], FT(1)));
-  }
+  assert(is_equal(bar[0], FT(0)) && is_equal(bar[1], FT(0)) && is_equal(bar[2], FT(1)));
 
   Point mp = Point(CGAL::midpoint(bp, bq));
   bar = PMP::barycentric_coordinates(p, q, r, mp);
-  if (std::is_same<K, EPECK>()) {
-    assert(is_equal(bar[0], FT(0.5)) && is_equal(bar[1], FT(0.5)) && is_equal(bar[2], FT(0)));
-  }
+  assert(is_equal(bar[0], FT(0.5)) && is_equal(bar[1], FT(0.5)) && is_equal(bar[2], FT(0)));
 
   int n = 100;
   while(n --> 0) // :)
@@ -202,9 +194,7 @@ void test_constructions(const G& g,
     // Point to location and inversely
     Bare_point barycentric_pt = CGAL::barycenter(bp, a, bq, b, br, c);
     bar = PMP::barycentric_coordinates(p, q, r, Point(barycentric_pt));
-    if (std::is_same<K, EPECK>()) {
-      assert(is_equal(bar[0], a) && is_equal(bar[1], b) && is_equal(bar[2], c));
-    }
+    assert(is_equal(bar[0], a) && is_equal(bar[1], b) && is_equal(bar[2], c));
 
     loc.second = bar;
     const Bare_point barycentric_pt_2 =
@@ -213,30 +203,22 @@ void test_constructions(const G& g,
                                                        .geom_traits(K())));
 
     const FT sq_dist = CGAL::squared_distance(barycentric_pt, barycentric_pt_2);
-    if (std::is_same<K, EPECK>()) {
-      assert(is_equal(sq_dist, FT(0)));
-    }
+    assert(is_equal(sq_dist, FT(0)));
   }
 
   // ---------------------------------------------------------------------------
   loc = std::make_pair(f, CGAL::make_array(FT(0.3), FT(0.4), FT(0.3)));
   descriptor_variant dv = PMP::get_descriptor_from_location(loc, g);
   const face_descriptor* fd = boost::get<face_descriptor>(&dv);
-  if (std::is_same<K, EPECK>()) {
-    assert(fd);
-  }
+  assert(fd);
 
   loc = std::make_pair(f, CGAL::make_array(FT(0.5), FT(0.5), FT(0)));
   dv = PMP::get_descriptor_from_location(loc, g);
   const halfedge_descriptor* hd = boost::get<halfedge_descriptor>(&dv);
-  if (std::is_same<K, EPECK>()) {
-    assert(hd);
-  }
+  assert(hd);
 
   loc = std::make_pair(f, CGAL::make_array(FT(1), FT(0), FT(0)));
-  if (std::is_same<K, EPECK>()) {
-    assert(PMP::is_on_vertex(loc, source(halfedge(f, g), g), g));
-  }
+  assert(PMP::is_on_vertex(loc, source(halfedge(f, g), g), g));
 
   dv = PMP::get_descriptor_from_location(loc, g);
   if(const vertex_descriptor* v = boost::get<vertex_descriptor>(&dv)) { } else { assert(false); }
@@ -270,20 +252,16 @@ void test_random_entities(const G& g, CGAL::Random& rnd)
   while(nn --> 0) // the infamous 'go to zero' operator
   {
     loc = PMP::random_location_on_mesh<FT>(g, rnd);
-    if (std::is_same<K, EPECK>()) {
-      assert(loc.first != boost::graph_traits<G>::null_face());
-      assert(loc.second[0] >= FT(0) && loc.second[0] <= FT(1) &&
-        loc.second[1] >= FT(0) && loc.second[1] <= FT(1) &&
-        loc.second[2] >= FT(0) && loc.second[2] <= FT(1));
-    }
+    assert(loc.first != boost::graph_traits<G>::null_face());
+    assert(loc.second[0] >= FT(0) && loc.second[0] <= FT(1) &&
+      loc.second[1] >= FT(0) && loc.second[1] <= FT(1) &&
+      loc.second[2] >= FT(0) && loc.second[2] <= FT(1));
 
     loc = PMP::random_location_on_face<FT>(f, g, rnd);
-    if (std::is_same<K, EPECK>()) {
-      assert(loc.first == f);
-      assert(loc.second[0] >= FT(0) && loc.second[0] <= FT(1) &&
-        loc.second[1] >= FT(0) && loc.second[1] <= FT(1) &&
-        loc.second[2] >= FT(0) && loc.second[2] <= FT(1));
-    }
+    assert(loc.first == f);
+    assert(loc.second[0] >= FT(0) && loc.second[0] <= FT(1) &&
+      loc.second[1] >= FT(0) && loc.second[1] <= FT(1) &&
+      loc.second[2] >= FT(0) && loc.second[2] <= FT(1));
 
     loc = PMP::random_location_on_halfedge<FT>(h, g, rnd);
     assert(loc.first == face(h, g));
@@ -459,38 +437,28 @@ void test_locate_in_face(const G& g,
 
   loc = PMP::locate_vertex<FT>(v, g);
 
-  if (std::is_same<K, EPECK>()) {
-    assert(is_equal(loc.second[CGAL::vertex_index_in_face(v, loc.first, g)], FT(1)));
-    assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 1) % 3], FT(0)));
-    assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 2) % 3], FT(0)));
-  }
+  assert(is_equal(loc.second[CGAL::vertex_index_in_face(v, loc.first, g)], FT(1)));
+  assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 1) % 3], FT(0)));
+  assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 2) % 3], FT(0)));
 
   loc = PMP::locate_vertex<FT>(v, f, g);
-  if (std::is_same<K, EPECK>()) {
-    assert(loc.first == f);
-    assert(is_equal(loc.second[0], FT(0)) && is_equal(loc.second[1], FT(1)) && is_equal(loc.second[2], FT(0)));
-  }
+  assert(loc.first == f);
+  assert(is_equal(loc.second[0], FT(0)) && is_equal(loc.second[1], FT(1)) && is_equal(loc.second[2], FT(0)));
 
   loc = PMP::locate_on_halfedge<FT>(h, a, g);
   const int h_id = CGAL::halfedge_index_in_face(h, g);
-  if (std::is_same<K, EPECK>()) {
-    assert(loc.first == f && is_equal(loc.second[(h_id + 2) % 3], FT(0)));
-  }
+  assert(loc.first == f && is_equal(loc.second[(h_id + 2) % 3], FT(0)));
 
   loc = PMP::locate_in_face(p, f, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K()));
   int v_id = CGAL::vertex_index_in_face(v, f, g);
-  if (std::is_same<K, EPECK>()) {
-    assert(loc.first == f && is_equal(loc.second[v_id], FT(1)));
-  }
+  assert(loc.first == f && is_equal(loc.second[v_id], FT(1)));
 
   // Internal vertex point pmap
   typedef typename boost::property_map_value<G, CGAL::vertex_point_t>::type     Point;
 
   Point p2 = get(CGAL::vertex_point, g, v);
   PMP::locate_in_face(p2, f, g);
-  if (std::is_same<K, EPECK>()) {
-    assert(loc.first == f && is_equal(loc.second[v_id], FT(1)));
-  }
+  assert(loc.first == f && is_equal(loc.second[v_id], FT(1)));
 
   // ---------------------------------------------------------------------------
   loc.second[0] = FT(0.2);
@@ -516,8 +484,8 @@ void test_locate_in_face(const G& g,
 
     if (std::is_same<K, EPECK>()) {
       assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K())));
-      assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K()), 1e-7));
     }
+    assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K()), 1e-7));
   }
 }
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_locate.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_locate.cpp
@@ -286,17 +286,13 @@ void test_random_entities(const G& g, CGAL::Random& rnd)
     }
 
     loc = PMP::random_location_on_halfedge<FT>(h, g, rnd);
-    if (std::is_same<K, EPECK>()) {
-      assert(loc.first == face(h, g));
-      assert(loc.second[0] >= FT(0) && loc.second[0] <= FT(1) &&
-        loc.second[1] >= FT(0) && loc.second[1] <= FT(1) &&
-        loc.second[2] >= FT(0) && loc.second[2] <= FT(1));
-    }
+    assert(loc.first == face(h, g));
+    assert(loc.second[0] >= FT(0) && loc.second[0] <= FT(1) &&
+      loc.second[1] >= FT(0) && loc.second[1] <= FT(1) &&
+      loc.second[2] >= FT(0) && loc.second[2] <= FT(1));
     int h_id = CGAL::halfedge_index_in_face(h, g);
 
-    if (std::is_same<K, EPECK>()) {
-      assert(loc.second[(h_id + 2) % 3] == FT(0));
-    }
+    assert(loc.second[(h_id + 2) % 3] == FT(0));
   }
 }
 
@@ -337,18 +333,14 @@ void test_helpers(const G& g, CGAL::Random& rnd)
   Face_location loc = PMP::random_location_on_face<FT>(f, g, rnd);
   std::set<face_descriptor> s;
   PMP::internal::incident_faces(loc, g, std::inserter(s, s.begin()));
-  if (std::is_same<K, EPECK>()) {
-    assert(PMP::is_on_face_border(loc, g) || s.size() == 1);
-  }
+  assert(PMP::is_on_face_border(loc, g) || s.size() == 1);
 
   loc = PMP::random_location_on_halfedge<FT>(h, g, rnd);
   std::vector<face_descriptor> vec;
   PMP::internal::incident_faces(loc, g, std::back_inserter(vec));
-  if (std::is_same<K, EPECK>()) {
-    assert(PMP::is_on_vertex(loc, source(h, g), g) ||
-      PMP::is_on_vertex(loc, target(h, g), g) ||
-      vec.size() == 2);
-  }
+  assert(PMP::is_on_vertex(loc, source(h, g), g) ||
+    PMP::is_on_vertex(loc, target(h, g), g) ||
+    vec.size() == 2);
 }
 
 template<typename K, typename G>
@@ -520,12 +512,10 @@ void test_locate_in_face(const G& g,
     neigh_loc.second[(neigh_hd_id+2)%3] = FT(0);
 
     PMP::locate_in_adjacent_face(loc, neigh_f, g);
-    if (std::is_same<K, EPECK>()) {
-      assert(PMP::locate_in_common_face<FT>(loc, neigh_loc, g));
+    assert(PMP::locate_in_common_face<FT>(loc, neigh_loc, g));
 
-      assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K())));
-      assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K()), 1e-7));
-    }
+    assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K())));
+    assert(PMP::locate_in_common_face<FT>(loc, p, neigh_loc, g, CGAL::parameters::vertex_point_map(vpm).geom_traits(K()), 1e-7));
   }
 }
 
@@ -582,40 +572,29 @@ struct Locate_with_AABB_tree_Tester // 2D case
 
     // sanitize otherwise some test platforms fail
     PMP::internal::snap_location_to_border(loc, g, FT(1e-7));
-
-    if (std::is_same<K, EPECK>()) {
-      assert(PMP::is_on_vertex(loc, v, g)); // might fail due to precision issues...
-      assert(is_equal(loc.second[CGAL::vertex_index_in_face(v, loc.first, g)], FT(1)));
-      assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 1) % 3], FT(0)));
-      assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 2) % 3], FT(0)));
-      assert(is_equal(CGAL::squared_distance(to_p3(
-        PMP::construct_point<FT>(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
-    }
+    assert(PMP::is_on_vertex(loc, v, g)); // might fail due to precision issues...
+    assert(is_equal(loc.second[CGAL::vertex_index_in_face(v, loc.first, g)], FT(1)));
+    assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 1) % 3], FT(0)));
+    assert(is_equal(loc.second[(CGAL::vertex_index_in_face(v, loc.first, g) + 2) % 3], FT(0)));
+    assert(is_equal(CGAL::squared_distance(to_p3(
+      PMP::construct_point<FT>(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
 
     loc = PMP::locate_with_AABB_tree(p_a, tree_a, g, CGAL::parameters::vertex_point_map(vpm));
-    if (std::is_same<K, EPECK>()) {
-      assert(is_equal(CGAL::squared_distance(to_p3(
-        PMP::construct_point<FT>(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
-    }
+    assert(is_equal(CGAL::squared_distance(to_p3(
+      PMP::construct_point<FT>(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
 
     // ---------------------------------------------------------------------------
     loc = PMP::locate(p_a, g, CGAL::parameters::vertex_point_map(vpm));
-    if (std::is_same<K, EPECK>()) {
-      assert(is_equal(CGAL::squared_distance(to_p3(
-        PMP::construct_point(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
+    assert(is_equal(CGAL::squared_distance(to_p3(
+      PMP::construct_point(loc, g, CGAL::parameters::vertex_point_map(vpm))), p3_a), FT(0)));
 
-      assert(PMP::is_in_face(loc, g));
-    }
+    assert(PMP::is_in_face(loc, g));
 
     loc = PMP::locate_with_AABB_tree(CGAL::ORIGIN, tree_b, g, CGAL::parameters::vertex_point_map(vpm_b));
-    if (std::is_same<K, EPECK>()) {
-      assert(PMP::is_in_face(loc, g));
-    }
+    assert(PMP::is_in_face(loc, g));
 
     loc = PMP::locate(CGAL::ORIGIN, g, CGAL::parameters::vertex_point_map(vpm_b));
-    if (std::is_same<K, EPECK>()) {
-      assert(PMP::is_in_face(loc, g));
-    }
+    assert(PMP::is_in_face(loc, g));
 
     // ---------------------------------------------------------------------------
     Ray_2 r2 = random_2D_ray<CGAL::AABB_tree<AABB_face_graph_traits> >(tree_a, rnd);

--- a/Spatial_searching/test/Spatial_searching/Orthogonal_incremental_neighbor_search.cpp
+++ b/Spatial_searching/test/Spatial_searching/Orthogonal_incremental_neighbor_search.cpp
@@ -71,21 +71,21 @@ void run()
   typename K_search::iterator it = oins.begin();
   typename K_search::Point_with_transformed_distance pd = *it;
   points2.push_back(get_point(pd.first));
-  if(CGAL::squared_distance(query,get_point(pd.first)) != pd.second){
+  if(abs(CGAL::squared_distance(query, get_point(pd.first)) - pd.second) >= 0.000000001){
     std::cout << "different distances: " << CGAL::squared_distance(query,get_point(pd.first)) << " != " << pd.second << std::endl;
   }
 
-  assert(CGAL_IA_FORCE_TO_DOUBLE(CGAL::squared_distance(query,get_point(pd.first))) == pd.second);
+  assert(abs(CGAL::squared_distance(query, get_point(pd.first)) - pd.second) < 0.000000001);
   it++;
   for(; it != oins.end();it++){
     typename K_search::Point_with_transformed_distance qd = *it;
     assert(pd.second <= qd.second);
     pd = qd;
     points2.push_back(get_point(pd.first));
-    if(CGAL_IA_FORCE_TO_DOUBLE(CGAL::squared_distance(query,get_point(pd.first))) != pd.second){
+    if(abs(CGAL::squared_distance(query, get_point(pd.first)) - pd.second) >= 0.000000001){
       std::cout  << "different distances: " << CGAL::squared_distance(query,get_point(pd.first)) << " != " << pd.second << std::endl;
     }
-    assert(CGAL_IA_FORCE_TO_DOUBLE(CGAL::squared_distance(query,get_point(pd.first))) == pd.second);
+    assert(abs(CGAL::squared_distance(query, get_point(pd.first)) - pd.second) < 0.000000001);
   }
 
 
@@ -176,6 +176,7 @@ bool search(bool nearest)
 
 int
 main() {
+  std::cout << std::setprecision(17);
   bool OK=true;
   std::cout << "Testing Incremental_neighbor_search\n";
   run<Incremental_neighbor_search>();

--- a/Spatial_searching/test/Spatial_searching/Splitters.cpp
+++ b/Spatial_searching/test/Spatial_searching/Splitters.cpp
@@ -60,20 +60,23 @@ struct Splitter_test {
     typename Orthogonal_incremental_neighbor_search::iterator it = oins.begin();
     Point_with_transformed_distance pd = *it;
     points2.push_back(get_point(pd.first));
-    if(CGAL::squared_distance(query,get_point(pd.first)) != pd.second){
+
+    std::cout << std::setprecision(17);
+
+    if(abs(CGAL::squared_distance(query, get_point(pd.first)) - pd.second) >= 0.000000001){
       std::cout << CGAL::squared_distance(query,get_point(pd.first)) << " != " << pd.second << std::endl;
     }
-    assert(CGAL_IA_FORCE_TO_DOUBLE(CGAL::squared_distance(query,get_point(pd.first))) == pd.second);
+    assert(abs(CGAL::squared_distance(query,get_point(pd.first)) - pd.second) < 0.000000001);
     it++;
     for(; it != oins.end();it++){
       Point_with_transformed_distance qd = *it;
       assert(pd.second <= qd.second);
       pd = qd;
       points2.push_back(get_point(pd.first));
-      if(CGAL_IA_FORCE_TO_DOUBLE(CGAL::squared_distance(query,get_point(pd.first))) != pd.second){
+      if(abs(CGAL::squared_distance(query, get_point(pd.first)) - pd.second) >= 0.000000001){
         std::cout << CGAL::squared_distance(query,get_point(pd.first)) << " != " << pd.second << std::endl;
       }
-      assert(CGAL_IA_FORCE_TO_DOUBLE(CGAL::squared_distance(query,get_point(pd.first))) == pd.second);
+      assert(abs(CGAL::squared_distance(query, get_point(pd.first)) - pd.second) < 0.000000001);
     }
     std::sort(points.begin(),points.end());
     std::sort(points2.begin(),points2.end());


### PR DESCRIPTION
## Summary of Changes

pmp_compute_normals_test: Computation of null vector as normal for degenerate faces is only verified for epeck
test_pmp_locate: Several predicates are only verified for epeck as they can fail with non-exact kernels

Should fix test on [this plateform](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.6-I-76/Polygon_mesh_processing/TestReport_gimeno_ArchLinux-clang-Release.gz).

## Release Management

* Affected package(s): PMP
* Issue(s) solved (if any): fix #6783

