### PR TITLE
Various fixes for Hyperbolic_Delaunay_triangulation_2

### DIFF
--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/HDT2.cpp
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/HDT2.cpp
@@ -183,9 +183,11 @@ MainWindow::MainWindow()
   // We put mutually exclusive actions in an QActionGroup
   QActionGroup* ag = new QActionGroup(this);
   ag->addAction(this->actionInsertPoint);
-  //ag->addAction(this->actionMovingPoint);
+  ag->addAction(this->actionMovingPoint);
   ag->addAction(this->actionCircumcenter);
   ag->addAction(this->actionShowConflictZone);
+
+  this->actionMovingPoint->setDisabled(true);
 
   // Check two actions
   this->actionInsertPoint->setChecked(true);

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/HDT2.cpp
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/HDT2.cpp
@@ -199,20 +199,11 @@ MainWindow::MainWindow()
   this->actionInsertPoint->setChecked(true);
   this->actionShowDelaunay->setChecked(true);
 
-  //
   // Setup the scene and the view
-  //
   scene.setItemIndexMethod(QGraphicsScene::NoIndex);
   scene.setSceneRect(left_top_corner_x, left_top_corner_y, width, height);
   this->graphicsView->setScene(&scene);
   this->graphicsView->setMouseTracking(true);
-
-  // we want to adjust the coordinates of QGraphicsView to the coordinates of QGraphicsScene
-  // the following line must do this:
-  //   this->graphicsView->fitInView( scene.sceneRect(), Qt::KeepAspectRatio);
-  // It does not do this sufficiently well.
-  // Current solution:
-  this->graphicsView->shear(230, 230);
 
   // Turn the vertical axis upside down
   this->graphicsView->transform().scale(1, -1);
@@ -403,10 +394,17 @@ MainWindow::on_actionSavePoints_triggered()
 void
 MainWindow::on_actionRecenter_triggered()
 {
-  this->graphicsView->setSceneRect(dgi->boundingRect());
-  this->graphicsView->fitInView(dgi->boundingRect(), Qt::KeepAspectRatio);
-}
+  qreal origin_x = CGAL::to_double(p_disk.center().x());
+  qreal origin_y = CGAL::to_double(p_disk.center().y());
+  qreal radius = std::sqrt(CGAL::to_double(p_disk.squared_radius()));
+  qreal diameter = std::sqrt(CGAL::to_double(4 * p_disk.squared_radius()));
+  qreal scale = 1.1;
 
+  this->graphicsView->setSceneRect(origin_x - radius, origin_y - radius, diameter, diameter);
+  this->graphicsView->fitInView(origin_x - scale * radius, origin_y - scale * radius,
+                                scale * diameter, scale * diameter,
+                                Qt::KeepAspectRatio);
+}
 
 #include "HDT2.moc"
 
@@ -424,6 +422,7 @@ int main(int argc, char **argv)
 
   MainWindow mainWindow;
   mainWindow.show();
+  mainWindow.on_actionRecenter_triggered();
 
   QStringList args = app.arguments();
   args.removeAt(0);

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/HDT2.cpp
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/HDT2.cpp
@@ -206,7 +206,7 @@ MainWindow::MainWindow()
   this->graphicsView->setMouseTracking(true);
 
   // Turn the vertical axis upside down
-  this->graphicsView->transform().scale(1, -1);
+  this->graphicsView->scale(1, -1);
 
   // The navigation adds zooming and translation functionality to the
   // QGraphicsView

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/HyperbolicPainterOstream.h
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/HyperbolicPainterOstream.h
@@ -60,8 +60,8 @@ private:
 
   PainterOstream& operator<<(const Euclidean_segment_2& seg)
   {
-    const typename K::Point_2 & source = seg.source();
-    const typename K::Point_2 & target = seg.target();
+    const Point_2 & source = seg.source();
+    const Point_2 & target = seg.target();
 
     QPointF src(to_double(source.x()), to_double(source.y()));
     QPointF tgt(to_double(target.x()), to_double(target.y()));
@@ -78,22 +78,22 @@ public:
 
   using Base::operator <<;
 
-  PainterOstream& operator << (Hyperbolic_segment_2 s)
+  PainterOstream& operator<<(const Hyperbolic_segment_2& s)
   {
     if(const Euclidean_segment_2* seg = boost::get<Euclidean_segment_2>(&s)) {
-                CGAL::Qt::PainterOstream<K>::operator << (*seg);
+      CGAL::Qt::PainterOstream<K>::operator << (*seg);
       return *this;
     }
 
-    Circular_arc_2* arc = boost::get<Circular_arc_2>(&s);
+    const Circular_arc_2& arc = boost::get<const Circular_arc_2&>(s);
 
-    if(arc->squared_radius() > 100) {
-      Euclidean_segment_2 seg(arc->source(), arc->target());
-          CGAL::Qt::PainterOstream<K>::operator << (seg);
+    if(arc.squared_radius() > 100) {
+      Euclidean_segment_2 seg(arc.source(), arc.target());
+      CGAL::Qt::PainterOstream<K>::operator << (seg);
       return *this;
     }
 
-    operator << (*arc);
+    operator<<(arc);
     return *this;
   }
 

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/HyperbolicPainterOstreamCK.h
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/HyperbolicPainterOstreamCK.h
@@ -42,28 +42,25 @@ namespace Qt {
 
     using Base::operator <<;
 
-    PainterOstream& operator << (Hyperbolic_segment_2 s)
+    PainterOstream& operator <<(const Hyperbolic_segment_2& s)
       {
         if(const Line_arc* seg = boost::get<Line_arc>(&s)) {
           operator << (*seg);
           return *this;
         }
 
-        Circular_arc* arc = boost::get<Circular_arc>(&s);
+        const Circular_arc& arc = boost::get<const Circular_arc&>(s);
 
-        if(arc->squared_radius() > 10)
-          // due to rounding, the arc drawn does not look like it
-          // passes through the endpoints
+        if(arc.squared_radius() > 10)
+        {
+          // due to rounding, the arc drawn does not look like it passes through the endpoints
           // so we replace the arc by a line segment
-          {
-            Point_2 source(to_double(arc->source().x()),to_double(arc->source().y()));
-            Point_2 target(to_double(arc->target().x()),to_double(arc->target().y()));
-            const Line_arc seg(source,target);
-            operator << (seg);
-            return *this;
-          }
+          const Line_arc seg(arc.source(),arc.target());
+          operator << (seg);
+          return *this;
+        }
 
-        operator << (*arc);
+        operator<<(arc);
         return *this;
       }
 

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/HyperbolicVoronoiGraphicsItem.h
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/HyperbolicVoronoiGraphicsItem.h
@@ -97,9 +97,9 @@ VoronoiGraphicsItem<DT>::paint(QPainter *painter, const QStyleOptionGraphicsItem
   painter->setPen(temp);
   //
 
-  for(typename DT::All_edges_iterator eit = dt->all_edges_begin();
-      eit != dt->all_edges_end();
-      eit++)
+  for(typename DT::Hyperbolic_edges_iterator eit = dt->hyperbolic_edges_begin();
+      eit != dt->hyperbolic_edges_end();
+      ++eit)
     {
       typename DT::Hyperbolic_segment s = dt->dual(*eit);
       pos << s;

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationConflictZone.h
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationConflictZone.h
@@ -32,7 +32,7 @@ public:
   typedef typename DT::Face_handle Face_handle;
   typedef typename DT::Point Point;
 
-  TriangulationConflictZone(QGraphicsScene* s, DT  * dt_, QObject* parent);
+  TriangulationConflictZone(QGraphicsScene* s, DT* dt_, QObject* parent);
 
 protected:
   void localize_and_insert_point(QPointF qt_point);
@@ -44,7 +44,7 @@ protected:
 
   std::list<Face_handle> faces;
   std::list<QGraphicsPolygonItem*> qfaces;
-  DT * dt;
+  DT* dt;
   Converter<K> convert;
   QGraphicsScene *scene_;
   bool animate;
@@ -99,7 +99,6 @@ TriangulationConflictZone<T>::mousePressEvent(QGraphicsSceneMouseEvent *event)
   animate = true;
 }
 
-
 template <typename T>
 void
 TriangulationConflictZone<T>::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
@@ -108,7 +107,6 @@ TriangulationConflictZone<T>::mouseMoveEvent(QGraphicsSceneMouseEvent *event)
     localize_and_insert_point(event->scenePos());
   }
 }
-
 
 template <typename T>
 void
@@ -121,8 +119,6 @@ TriangulationConflictZone<T>::mouseReleaseEvent(QGraphicsSceneMouseEvent * /*eve
   qfaces.clear();
   animate = false;
 }
-
-
 
 template <typename T>
 bool
@@ -145,7 +141,6 @@ TriangulationConflictZone<T>::eventFilter(QObject *obj, QEvent *event)
     return QObject::eventFilter(obj, event);
   }
 }
-
 
 } // namespace Qt
 } // namespace CGAL

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationConflictZone.h
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationConflictZone.h
@@ -67,18 +67,18 @@ TriangulationConflictZone<T>::localize_and_insert_point(QPointF qt_point)
   faces.clear();
   for(QGraphicsPolygonItem* gpi : qfaces)
     delete gpi;
-
   qfaces.clear();
+
   hint = dt->locate(p, hint);
   dt->find_conflicts(p, std::back_inserter(faces), hint);
-  for(typename std::list<Face_handle>::iterator it = faces.begin();
-      it != faces.end();
-      ++it){
-    if(! dt->is_infinite(*it)){
-      QGraphicsPolygonItem *item = new QGraphicsPolygonItem(convert(dt->hyperbolic_triangle(*it)));
+
+  for(Face_handle fh : faces){
+    if(! dt->is_infinite(fh)){
+      QGraphicsPolygonItem *item = new QGraphicsPolygonItem(convert(dt->hyperbolic_triangle(fh)));
       QColor color(::Qt::blue);
       color.setAlpha(150);
       item->setBrush(color);
+      item->setPen(::Qt::NoPen);
       scene_->addItem(item);
       qfaces.push_back(item);
     }

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationConflictZone.h
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationConflictZone.h
@@ -15,11 +15,11 @@
 
 #include <CGAL/Qt/GraphicsViewInput.h>
 #include <CGAL/Qt/Converter.h>
+
 #include <QGraphicsSceneMouseEvent>
 #include <QEvent>
+
 #include <list>
-
-
 
 namespace CGAL {
 namespace Qt {
@@ -51,14 +51,12 @@ protected:
   Face_handle hint;
 };
 
-
 template <typename T>
 TriangulationConflictZone<T>::TriangulationConflictZone(QGraphicsScene* s,
-                                                        T * dt_,
+                                                        T* dt_,
                                                         QObject* parent)
   :  GraphicsViewInput(parent), dt(dt_), scene_(s), animate(false)
 {}
-
 
 template <typename T>
 void
@@ -67,11 +65,9 @@ TriangulationConflictZone<T>::localize_and_insert_point(QPointF qt_point)
   Point p(convert(qt_point));
 
   faces.clear();
-  for(std::list<QGraphicsPolygonItem*>::iterator it = qfaces.begin();
-      it != qfaces.end();
-      ++it){
-    delete *it;
-  }
+  for(QGraphicsPolygonItem* gpi : qfaces)
+    delete gpi;
+
   qfaces.clear();
   hint = dt->locate(p, hint);
   dt->find_conflicts(p, std::back_inserter(faces), hint);
@@ -88,8 +84,6 @@ TriangulationConflictZone<T>::localize_and_insert_point(QPointF qt_point)
     }
   }
 }
-
-
 
 template <typename T>
 void
@@ -121,11 +115,9 @@ void
 TriangulationConflictZone<T>::mouseReleaseEvent(QGraphicsSceneMouseEvent * /*event*/)
 {
   faces.clear();
-  for(std::list<QGraphicsPolygonItem*>::iterator it = qfaces.begin();
-      it != qfaces.end();
-      ++it){
-    delete *it;
-  }
+  for(QGraphicsPolygonItem* gpi : qfaces)
+    delete gpi;
+
   qfaces.clear();
   animate = false;
 }

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationGraphicsItem.h
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationGraphicsItem.h
@@ -22,6 +22,7 @@
 
 #include <QGraphicsScene>
 #include <QPainter>
+#include <QRectF>
 #include <QStyleOption>
 
 namespace CGAL {
@@ -101,7 +102,7 @@ protected:
 
 template <typename T>
 TriangulationGraphicsItem<T>::TriangulationGraphicsItem(T * t_)
-  :  t(t_), painterostream(0),
+  :  t(t_), painterostream(nullptr),
      bb(0,0,0,0), bb_initialized(false),
      visible_edges(true), visible_vertices(true)
 {
@@ -142,15 +143,13 @@ template <typename T>
 void
 TriangulationGraphicsItem<T>::drawAll(QPainter *painter)
 {
-  QPen pen;
-  pen.setWidthF(0.005);
-  pen.setBrush(::Qt::black);
+  QPen pen(::Qt::black, 0.005);
   painter->setPen(edges_pen);
   painterostream = PainterOstream<Geom_traits>(painter);
 
   if(visibleEdges()) {
-    for(typename T::All_edges_iterator eit = t->all_edges_begin();
-        eit != t->all_edges_end();
+    for(typename T::Hyperbolic_edges_iterator eit = t->hyperbolic_edges_begin();
+        eit != t->hyperbolic_edges_end();
         ++eit){
       painterostream << t->hyperbolic_segment(*eit);
     }

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationMovingPoint.h
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationMovingPoint.h
@@ -68,7 +68,7 @@ TriangulationMovingPoint<T>::localize_and_insert_point(QPointF qt_point)
   if(lt != T::VERTEX){
     vh = dt->insert(p, lt, fh, li);
     insertedPoint = true;
-    emit(modelChanged());
+    Q_EMIT(modelChanged());
   } else {
     vh = fh->vertex(0);
     insertedPoint = false;
@@ -123,7 +123,7 @@ TriangulationMovingPoint<T>::mouseReleaseEvent(QGraphicsSceneMouseEvent *event)
   }
   vh = Vertex_handle();
 
-  emit(modelChanged());
+  Q_EMIT(modelChanged());
 
   movePointToInsert = false;
 }

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationPointInputAndConflictZone.h
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationPointInputAndConflictZone.h
@@ -15,11 +15,11 @@
 
 #include <CGAL/Qt/GraphicsViewInput.h>
 #include <CGAL/Qt/Converter.h>
+
 #include <QGraphicsSceneMouseEvent>
 #include <QEvent>
+
 #include <list>
-
-
 
 namespace CGAL {
 namespace Qt {
@@ -32,7 +32,7 @@ public:
   typedef typename DT::Face_handle Face_handle;
   typedef typename DT::Point Point;
 
-  TriangulationPointInputAndConflictZone(QGraphicsScene* s, DT  * dt_, QObject* parent);
+  TriangulationPointInputAndConflictZone(QGraphicsScene* s, DT* dt_, QObject* parent);
 
 protected:
   void localize_and_insert_point(QPointF qt_point);
@@ -44,22 +44,18 @@ protected:
 
   std::list<Face_handle> faces;
   std::list<QGraphicsPolygonItem*> qfaces;
-  DT * dt;
+  DT* dt;
   Converter<K> convert;
   QGraphicsScene *scene_;
   Point p;
 };
 
-
 template <typename T>
 TriangulationPointInputAndConflictZone<T>::TriangulationPointInputAndConflictZone(QGraphicsScene* s,
-                                                        T * dt_,
+                                                        T* dt_,
                                                         QObject* parent)
   :  GraphicsViewInput(parent), dt(dt_), scene_(s)
 {}
-
-
-
 
 template <typename T>
 void
@@ -88,23 +84,18 @@ TriangulationPointInputAndConflictZone<T>::mousePressEvent(QGraphicsSceneMouseEv
   }
 }
 
-
 template <typename T>
 void
 TriangulationPointInputAndConflictZone<T>::mouseReleaseEvent(QGraphicsSceneMouseEvent * /*event*/)
 {
   faces.clear();
-  for(std::list<QGraphicsPolygonItem*>::iterator it = qfaces.begin();
-      it != qfaces.end();
-      ++it){
-    scene_->removeItem(*it);
-    delete *it;
+  for(QGraphicsPolygonItem* gpi : qfaces){
+    scene_->removeItem(gpi);
+    delete gpi;
   }
   qfaces.clear();
   emit (generate(CGAL::make_object(p)));
 }
-
-
 
 template <typename T>
 bool
@@ -123,7 +114,6 @@ TriangulationPointInputAndConflictZone<T>::eventFilter(QObject *obj, QEvent *eve
     return QObject::eventFilter(obj, event);
   }
 }
-
 
 } // namespace Qt
 } // namespace CGAL

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationPointInputAndConflictZone.h
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationPointInputAndConflictZone.h
@@ -70,14 +70,16 @@ TriangulationPointInputAndConflictZone<T>::mousePressEvent(QGraphicsSceneMouseEv
 
 
   dt->find_conflicts(p, std::back_inserter(faces));
-  for(typename std::list<Face_handle>::iterator it = faces.begin();
-      it != faces.end();
-      ++it){
-    if(dt->is_Delaunay_hyperbolic(*it)){
-      QGraphicsPolygonItem *item = new QGraphicsPolygonItem(convert(dt->hyperbolic_triangle(*it)));
+
+  QPen blackPen(::Qt::black, 0, ::Qt::SolidLine, ::Qt::RoundCap, ::Qt::RoundJoin);
+
+  for(Face_handle fh : faces){
+    if(! dt->is_infinite(fh)){
+      QGraphicsPolygonItem* item = new QGraphicsPolygonItem(convert(dt->hyperbolic_triangle(fh)));
       QColor color(::Qt::blue);
       color.setAlpha(150);
       item->setBrush(color);
+      item->setPen(::Qt::NoPen);
       scene_->addItem(item);
       qfaces.push_back(item);
     }

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationPointInputAndConflictZone.h
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationPointInputAndConflictZone.h
@@ -51,9 +51,10 @@ protected:
 };
 
 template <typename T>
-TriangulationPointInputAndConflictZone<T>::TriangulationPointInputAndConflictZone(QGraphicsScene* s,
-                                                        T* dt_,
-                                                        QObject* parent)
+TriangulationPointInputAndConflictZone<T>::
+TriangulationPointInputAndConflictZone(QGraphicsScene* s,
+                                       T* dt_,
+                                       QObject* parent)
   :  GraphicsViewInput(parent), dt(dt_), scene_(s)
 {}
 
@@ -68,10 +69,7 @@ TriangulationPointInputAndConflictZone<T>::mousePressEvent(QGraphicsSceneMouseEv
     return;
   }
 
-
   dt->find_conflicts(p, std::back_inserter(faces));
-
-  QPen blackPen(::Qt::black, 0, ::Qt::SolidLine, ::Qt::RoundCap, ::Qt::RoundJoin);
 
   for(Face_handle fh : faces){
     if(! dt->is_infinite(fh)){
@@ -96,7 +94,7 @@ TriangulationPointInputAndConflictZone<T>::mouseReleaseEvent(QGraphicsSceneMouse
     delete gpi;
   }
   qfaces.clear();
-  emit (generate(CGAL::make_object(p)));
+  Q_EMIT (generate(CGAL::make_object(p)));
 }
 
 template <typename T>

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationRemoveVertex.h
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/include/internal/Qt/TriangulationRemoveVertex.h
@@ -32,25 +32,20 @@ public:
   typedef typename DT::Vertex_handle Vertex_handle;
   typedef typename DT::Point Point;
 
-  TriangulationRemoveVertex(DT  * dt_, QObject* parent);
+  TriangulationRemoveVertex(DT* dt_, QObject* parent);
 
 protected:
-
   void mousePressEvent(QGraphicsSceneMouseEvent *event);
-
   bool eventFilter(QObject *obj, QEvent *event);
 
-  DT * dt;
+  DT* dt;
 };
-
 
 template <typename T>
 TriangulationRemoveVertex<T>::TriangulationRemoveVertex(T * dt_,
                                                           QObject* parent)
   :  GraphicsViewInput(parent), dt(dt_)
 {}
-
-
 
 template <typename T>
 void
@@ -65,11 +60,9 @@ TriangulationRemoveVertex<T>::mousePressEvent(QGraphicsSceneMouseEvent *event)
       typename T::Vertex_handle selected_vertex = dt->nearest_vertex(convert(event->scenePos()));
       dt->remove(selected_vertex);
     }
-    emit (modelChanged());
+    Q_EMIT (modelChanged());
   }
 }
-
-
 
 template <typename T>
 bool

--- a/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/CGAL/Hyperbolic_Delaunay_triangulation_2.h
+++ b/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/CGAL/Hyperbolic_Delaunay_triangulation_2.h
@@ -215,15 +215,6 @@ public:
     Vertex_handle insert(const Point  &p, Face_handle start = Face_handle());
 
     /*!
-      Inserts the point p at the location given by `(lt,loc,li)`.
-      The handle to the new vertex is returned.
-
-      \sa locate()
-    */
-    Vertex_handle insert(const Point& p, typename Locate_type lt, Face_handle loc, int li);
-
-
-    /*!
       Inserts the points in the range [first,last) into the triangulation.
       Returns the number of inserted points. Note that this function is not
       guaranteed to insert the points following the order of `InputIterator`,

--- a/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/Concepts/HyperbolicTriangulationFaceBase_2.h
+++ b/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/Concepts/HyperbolicTriangulationFaceBase_2.h
@@ -5,6 +5,33 @@
 \ingroup PkgHyperbolicTriangulation2Concepts
 \cgalConcept
 
+The concept `HyperbolicTriangulationFaceBase_2` describes the requirements for an internal
+data class that must be provided by the model of the `HyperbolicTriangulationFaceBase_2`.
+
+\sa `HyperbolicTriangulationFaceBase_2`
+*/
+class HyperbolicFaceData {
+public:
+  /// sets the face as infinite and non-Delaunay hyperbolic
+  void set_infinite();
+
+  /// sets the face as Delaunay hyperbolic
+  void set_Delaunay_hyperbolic();
+
+  /// returns whether the face is Delaunay hyperbolic, or not.
+  bool is_Delaunay_hyperbolic();
+
+  /// sets the `i`-th edge of the face as non-hyperbolic
+  void set_Delaunay_non_hyperbolic(int i);
+
+  /// returns whether the `i`-th edge of the face is non-hyperbolic
+  bool is_Delaunay_non_hyperbolic(int i);
+};
+
+/*!
+\ingroup PkgHyperbolicTriangulation2Concepts
+\cgalConcept
+
 \cgalRefines TriangulationFaceBase_2
 
 The concept `HyperbolicTriangulationFaceBase_2` describes the requirements for the base
@@ -17,12 +44,9 @@ internally by the triangulation class during the insertion of points in the tria
 \cgalHasModel `CGAL::Hyperbolic_triangulation_face_base_2`
 
 \sa `TriangulationDataStructure_2`
-
+\sa `HyperbolicFaceData`
 */
-
-
 class HyperbolicTriangulationFaceBase_2 {
-
 public:
 
   /// \name Internal Access Functions
@@ -33,16 +57,16 @@ public:
   /// @{
 
     /*!
-      This function gives non-`const` access to a variable of type `CGAL::Object`.
+      This function gives non-`const` access to a variable that is a model of `HyperbolicFaceData`.
       \cgalAdvancedFunction
     */
-    CGAL::Object& tds_data();
+    HyperbolicFaceData& hyperbolic_data();
 
     /*!
-      This function gives `const` access to a variable of type `CGAL::Object`.
+      This function gives `const` access to a variable of that is a model of `HyperbolicFaceData`.
       \cgalAdvancedFunction
     */
-    const CGAL::Object& tds_data() const;
+    const HyperbolicFaceData& hyperbolic_data() const;
   /// @}
 
 };

--- a/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/PackageDescription.txt
+++ b/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/PackageDescription.txt
@@ -46,8 +46,8 @@ The Delaunay triangulation of a set of points \f$P\f$ in the hyperbolic plane \f
 \cgalCRPSection{Concepts}
 
 - `HyperbolicDelaunayTriangulationTraits_2` describes the requirements for an interface for geometric objects, constructions, and predicates in the hyperbolic plane.
-- `HyperbolicTriangulationFaceBase_2` describes the requirements for faces of the hyperbolic Delaunay triangulation to be filtered from the faces of the Euclidean Delaunay triangulation.
-
+- `HyperbolicTriangulationFaceBase_2` describes the requirements for faces of the hyperbolic Delaunay triangulation.
+- `HyperbolicFaceData` describes the requirements for an hyperbolic marker of faces of the hyperbolic Delaunay triangulation, used to filter faces of the Euclidean Delaunay triangulation.
 
 \cgalCRPSection{Classes}
 

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_2.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_2.h
@@ -418,6 +418,10 @@ public:
     return v;
   }
 
+  // Note that this is _Base::Locate_type_ and not Locate_type.
+  // Do _not_ use this function with the result of a call to HDT2::locate(), which is a locate
+  // on the hyperbolic triangulation, and not the underlying Delaunay triangulation (in which
+  // new points are inserted, and thus it needs to be DT2::locate_type).
   Vertex_handle insert(const Point& p,
                        typename Base::Locate_type lt,
                        Face_handle loc, int li)

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_2.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_2.h
@@ -18,8 +18,10 @@
 #include <CGAL/Hyperbolic_triangulation_face_base_2.h>
 #include <CGAL/Delaunay_triangulation_2.h>
 
+#include <algorithm>
 #include <stack>
 #include <set>
+#include <vector>
 
 namespace CGAL {
 
@@ -77,7 +79,7 @@ public:
   Hyperbolic_Delaunay_triangulation_2(const Hyperbolic_Delaunay_triangulation_2<Gt,Tds> &tr)
     : Delaunay_triangulation_2<Gt,Tds>(tr), _gt()
   {
-    CGAL_triangulation_postcondition(this->is_valid());
+    CGAL_postcondition(this->is_valid());
   }
 
   template<class InputIterator>
@@ -289,13 +291,13 @@ public:
 
     Vertex& operator*() const
     {
-      CGAL_triangulation_precondition(pos != Face_handle() && _v != Vertex_handle());
+      CGAL_precondition(pos != Face_handle() && _v != Vertex_handle());
       return *(pos->vertex(_ri));
     }
 
     Vertex* operator->() const
     {
-      CGAL_triangulation_precondition(pos != Face_handle() && _v != Vertex_handle());
+      CGAL_precondition(pos != Face_handle() && _v != Vertex_handle());
       return &*(pos->vertex(_ri));
     }
 
@@ -307,10 +309,9 @@ public:
   };
 
 private:
-  Geom_traits   _gt;
+  Geom_traits _gt;
 
 public:
-
   Tds& tds()
   {
     return Base::tds();
@@ -343,16 +344,13 @@ public:
     tr.mark_finite_non_hyperbolic_faces();
   }
 
-
   Self& operator=(const Self &tr)
   {
-
     Self newone = Self(tr);
     this->swap(newone);
 
     return *this;
   }
-
 
   bool operator==(const Self& tr )
   {
@@ -452,11 +450,9 @@ public:
     return n;
   }
 
-
-
   void remove(Vertex_handle v)
   {
-    CGAL_triangulation_precondition(tds().is_vertex(v));
+    CGAL_precondition(tds().is_vertex(v));
     std::vector<Vertex_handle> nbr;
     bool dim_was_2 = false;
     if (this->dimension() == 2)
@@ -481,7 +477,6 @@ public:
     }
   }
 
-
   template <class VertexRemoveIterator>
   void remove(VertexRemoveIterator first, VertexRemoveIterator last)
   {
@@ -491,11 +486,6 @@ public:
     }
   }
 
-
-
-  /*
-    Needed by DT_2: do not document!
-  */
   template <typename T>
   bool is_infinite(T v) const { return Base::is_infinite(v); }
 
@@ -860,7 +850,7 @@ public:
 
   Hyperbolic_Voronoi_point dual(Face_handle f) const
   {
-    CGAL_triangulation_precondition(is_Delaunay_hyperbolic(f));
+    CGAL_precondition(is_Delaunay_hyperbolic(f));
     return geom_traits().construct_hyperbolic_circumcenter_2_object()(point(f,0),
                                                                       point(f,1),
                                                                       point(f,2));
@@ -870,7 +860,7 @@ public:
 
   Hyperbolic_segment dual(Face_handle f, int i) const
   {
-    CGAL_triangulation_precondition(is_Delaunay_hyperbolic(f, i));
+    CGAL_precondition(is_Delaunay_hyperbolic(f, i));
 
     if(dimension() == 1)
     {
@@ -888,7 +878,7 @@ public:
     bool fhyp = is_Delaunay_hyperbolic(f);
     bool nhyp = is_Delaunay_hyperbolic(n);
 
-    // both faces are non_hyperbolic, but the incident edge is hyperbolic
+    // both faces are non_hyperbolic, but the common edge is hyperbolic
     if(!fhyp && !nhyp)
     {
       const Point& p = point(f,ccw(i));
@@ -1060,7 +1050,7 @@ public:
       }
     }
 
-    // Here, the face has been located in the Euclidean face lh
+    // Here, the face has been located in the Euclidean face fh
     const Point& p = point(fh, 0);
     const Point& q = point(fh, 1);
     const Point& r = point(fh, 2);

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_2.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_2.h
@@ -552,22 +552,21 @@ private:
   */
   void ensure_hyperbolic_face_handle(Vertex_handle v)
   {
-    if(dimension() > 2)
+    if(dimension() <= 1)
+      return;
+
+    Face_circulator fc = this->incident_faces(v), done(fc);
+    if(fc != 0)
     {
-      Face_circulator fc = this->incident_faces(v), done(fc);
-      if(fc != 0)
+      do
       {
-        do
+        if(is_Delaunay_hyperbolic(fc))
         {
-          if(is_Delaunay_hyperbolic(fc))
-          {
-            v->set_face(fc);
-            break;
-          }
+          v->set_face(fc);
+          break;
         }
-        while(++fc != done);
       }
-      CGAL_triangulation_postcondition(is_Delaunay_hyperbolic(v->face()));
+      while(++fc != done);
     }
   }
 

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_2.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_2.h
@@ -928,33 +928,31 @@ public:
   }
 
 public:
-
-  const Point point(const Vertex_handle vh) const
+  const Point& point(const Vertex_handle vh) const
   {
+    CGAL_precondition(!is_infinite(vh));
     return vh->point();
   }
 
-  const Point point(const Face_handle fh, const int i) const
+  const Point& point(const Face_handle fh, const int i) const
   {
-    CGAL_triangulation_precondition(0 <= i);
-    CGAL_triangulation_precondition(i <= 2);
+    CGAL_precondition(!is_infinite(fh->vertex(i)));
+    CGAL_precondition(0 <= i && i <= 2);
     return fh->vertex(i)->point();
   }
 
-
-  Point point(const Vertex_handle vh)
+  Point& point(const Vertex_handle vh)
   {
+    CGAL_precondition(!is_infinite(vh));
     return vh->point();
   }
 
-  Point point(const Face_handle fh, const int i)
+  Point& point(const Face_handle fh, const int i)
   {
-    CGAL_triangulation_precondition(0 <= i);
-    CGAL_triangulation_precondition(i <= 2);
+    CGAL_precondition(!is_infinite(fh->vertex(i)));
+    CGAL_precondition(0 <= i && i <= 2);
     return fh->vertex(i)->point();
   }
-
-
 
   bool is_valid()
   {

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_2.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_2.h
@@ -86,8 +86,6 @@ public:
     : Delaunay_triangulation_2<Gt,Tds>(gt), _gt(gt)
   {
     insert(first, last);
-    for(All_vertices_iterator vit=all_vertices_begin(); vit!=all_vertices_end(); ++vit)
-      ensure_hyperbolic_face_handle(vit);
   }
 
   /*************************************

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_triangulation_2/internal/Hyperbolic_Delaunay_triangulation_traits_2_functions.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_triangulation_2/internal/Hyperbolic_Delaunay_triangulation_traits_2_functions.h
@@ -87,8 +87,6 @@ private:
   const Traits& _gt;
 }; // end Construct_supporting_circle_of_bisector
 
-
-
 template <typename Traits>
 class Construct_hyperbolic_segment_2
 {
@@ -136,8 +134,6 @@ private:
   const Traits& _gt;
 }; // end Construct_hyperbolic_segment_2
 
-
-
 // For details see the JoCG paper (5:56-85, 2014)
 template <typename Traits>
 class Is_Delaunay_hyperbolic
@@ -178,7 +174,7 @@ public:
                   const Hyperbolic_point_2& p2,
                   int& ind) const
   {
-    if(this->operator()(p0, p1, p2) == false)
+    if(!this->operator()(p0, p1, p2))
     {
       ind = find_non_hyperbolic_edge(p0, p1, p2);
       return false;
@@ -188,7 +184,7 @@ public:
   }
 
 private:
-  // assume the face (p0, p1, p2) is non-hyperbolic
+  // assumes that the face (p0, p1, p2) is non-hyperbolic
   int find_non_hyperbolic_edge(const Hyperbolic_point_2& p0,
                                const Hyperbolic_point_2& p1,
                                const Hyperbolic_point_2& p2) const

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_triangulation_2/internal/Hyperbolic_Delaunay_triangulation_traits_2_functions.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_triangulation_2/internal/Hyperbolic_Delaunay_triangulation_traits_2_functions.h
@@ -249,18 +249,7 @@ public:
     {
       Euclidean_line_2 seg(p, q);
       Orientation qori = _gt.orientation_2_object()(p, q, query);
-      if(qori == COLLINEAR)
-      {
-        return ON_ORIENTED_BOUNDARY;
-      }
-      else
-      {
-        // It is sufficient that these are consistent.
-        if(qori == LEFT_TURN)
-          return ON_POSITIVE_SIDE;
-        else
-          return ON_NEGATIVE_SIDE;
-      }
+      return qori;
     }
 
     Weighted_point_2 wp(p);
@@ -272,17 +261,7 @@ public:
 
     Circle_2 circle = _gt.construct_circle_2_object()(center, sq_radius);
     Bounded_side bs = _gt.bounded_side_2_object()(circle, query);
-    if(bs == ON_BOUNDARY)
-    {
-      return ON_ORIENTED_BOUNDARY;
-    }
-    else
-    {
-      if(bs == ON_BOUNDED_SIDE)
-        return ON_POSITIVE_SIDE;
-      else
-        return ON_NEGATIVE_SIDE;
-    }
+    return enum_cast<Oriented_side>(bs);
   }
 
 private:

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_triangulation_2/internal/Hyperbolic_Delaunay_triangulation_traits_2_functions.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_triangulation_2/internal/Hyperbolic_Delaunay_triangulation_traits_2_functions.h
@@ -33,7 +33,6 @@ class Construct_circle_or_line_supporting_bisector
   typedef typename Traits::Euclidean_line_2                   Euclidean_line_2;
   typedef typename Traits::Euclidean_circle_or_line_2         Euclidean_circle_or_line_2;
   typedef typename Traits::Circle_2                           Circle_2;
-  typedef typename Traits::Point_3                            Point_3;
 
 public:
   Construct_circle_or_line_supporting_bisector(const Traits& gt = Traits()) : _gt(gt) {}
@@ -41,15 +40,9 @@ public:
   Euclidean_circle_or_line_2 operator()(const Hyperbolic_point_2& p,
                                         const Hyperbolic_point_2& q) const
   {
-    Hyperbolic_point_2 po = CGAL::ORIGIN;
-
+    const Hyperbolic_point_2 po = CGAL::ORIGIN;
     if(_gt.compare_distance_2_object()(po, p, q) == EQUAL)
       return _gt.construct_bisector_2_object()(p, q);
-
-    FT dop2 = p.x()*p.x() + p.y()*p.y();
-    FT doq2 = q.x()*q.x() + q.y()*q.y();
-    Point_3 p3(p.x(), p.y(), dop2);
-    Point_3 q3(q.x(), q.y(), doq2);
 
     // TODO MT improve
 
@@ -142,7 +135,6 @@ public:
   typedef typename Traits::FT                                 FT;
   typedef typename Traits::Hyperbolic_point_2                 Hyperbolic_point_2;
   typedef typename Traits::Direction_2                        Direction_2;
-  typedef typename Traits::Point_3                            Point_3;
   typedef typename Traits::Vector_3                           Vector_3;
 
   Is_Delaunay_hyperbolic(const Traits& gt = Traits())

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_triangulation_face_base_2.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_triangulation_face_base_2.h
@@ -22,6 +22,40 @@
 
 namespace CGAL {
 
+class Hyperbolic_data
+{
+  typedef boost::int8_t Id;
+
+private:
+  // - 2 for infinite face
+  // - 1 for finite, hyperbolic face
+  //   0 for finite, non hyperbolic with non-hyperbolic edge at index 0
+  //   2 for finite, non hyperbolic with non-hyperbolic edge at index 1
+  //   1 for finite, non hyperbolic with non-hyperbolic edge at index 2
+  Id _hyperbolic_tag;
+
+public:
+  Hyperbolic_data(Id id = -2) : _hyperbolic_tag(id) { }
+
+  void set_infinite() { _hyperbolic_tag = -2; }
+
+  // a finite face is non_hyperbolic if its circumscribing circle intersects the circle at infinity
+  void set_Delaunay_hyperbolic() { _hyperbolic_tag = -1; }
+
+  bool is_Delaunay_hyperbolic() const
+  {
+    return (_hyperbolic_tag == -1);
+  }
+
+  // set and get the non-hyperbolic property of the edge #i
+  void set_Delaunay_non_hyperbolic(int i) { _hyperbolic_tag = i; }
+
+  bool is_Delaunay_non_hyperbolic(int i) const
+  {
+    return (_hyperbolic_tag == i);
+  }
+};
+
 template<typename Gt,
          typename Fb = Triangulation_ds_face_base_2<> >
 class Hyperbolic_triangulation_face_base_2
@@ -60,11 +94,11 @@ public:
   static int ccw(int i) {return Triangulation_cw_ccw_2::ccw(i);}
   static int  cw(int i) {return Triangulation_cw_ccw_2::cw(i);}
 
-  CGAL::Object& tds_data() { return this->_tds_data; }
-  const CGAL::Object& tds_data() const { return this->_tds_data; }
+  Hyperbolic_data& hyperbolic_data() { return this->_hyperbolic_data; }
+  const Hyperbolic_data& hyperbolic_data() const { return this->_hyperbolic_data; }
 
 private:
-  CGAL::Object         _tds_data;
+  Hyperbolic_data _hyperbolic_data;
 };
 
 } // namespace CGAL

--- a/Hyperbolic_triangulation_2/test/Hyperbolic_triangulation_2/ht2_test_locate.cpp
+++ b/Hyperbolic_triangulation_2/test/Hyperbolic_triangulation_2/ht2_test_locate.cpp
@@ -12,54 +12,83 @@ typedef HDTriangulation::Hyperbolic_segment                                 Hype
 
 int main()
 {
-        FT F100(100);
-        Point p1(-FT(81)/F100, -FT(35)/F100        );
-        Point p2(-FT(78)/F100,  FT(12)/F100        );
-        Point p3(-FT(64)/F100,  FT(59)/F100        );
-        Point p4(-FT(31)/F100, -FT(25)/F100        );
-        Point p5( FT(66)/F100,  FT(18)/F100 );
+  FT F100(100);
+  Point p1(-FT(81)/F100, -FT(35)/F100        );
+  Point p2(-FT(78)/F100,  FT(12)/F100        );
+  Point p3(-FT(64)/F100,  FT(59)/F100        );
+  Point p4(-FT(31)/F100, -FT(25)/F100        );
+  Point p5( FT(66)/F100,  FT(18)/F100 );
 
-        HDTriangulation tri;
-        tri.insert(p1);
-        tri.insert(p2);
-        tri.insert(p3);
-        tri.insert(p4);
-        tri.insert(p5);
+  HDTriangulation tri;
+  tri.insert(p1);
+  tri.insert(p2);
+  tri.insert(p3);
+  tri.insert(p4);
+  tri.insert(p5);
 
-        std::size_t nv = tri.number_of_vertices();
-        std::size_t nf = tri.number_of_hyperbolic_faces();
+  std::size_t nv = tri.number_of_vertices();
+  std::size_t nf = tri.number_of_hyperbolic_faces();
 
-        std::cout << " -------- inserting --------" << std::endl;
-        std::cout << "Vertices  in triangulation: " << nv << std::endl;
-        std::cout << "Faces     in triangulation: " << nf << std::endl;
-        std::cout << "Dimension of triangulation: " << tri.dimension() << std::endl;
-        assert(tri.dimension() == 2);
+  std::cout << " -------- inserting --------" << std::endl;
+  std::cout << "Vertices  in triangulation: " << nv << std::endl;
+  std::cout << "Faces     in triangulation: " << nf << std::endl;
+  std::cout << "Dimension of triangulation: " << tri.dimension() << std::endl;
+  assert(tri.dimension() == 2);
 
-    int idx;
-    Face_handle fh;
+  // Test a vertex location
+  int idx1 = -1;
+  Locate_type lt1;
+  Face_handle fh1 = tri.locate(p1, lt1, idx1);
+  assert(lt1 == HDTriangulation::VERTEX);
+  assert(fh1 != Face_handle());
+  assert(idx1 >= 0 && idx1 <= 2);
 
-        // Test a vertex location
-        Locate_type lt1;
-    fh = tri.locate(p1, lt1, idx);
-        assert(lt1 == HDTriangulation::VERTEX);
+  // Test an edge location
+  Hyperbolic_segment s1 = tri.geom_traits().construct_hyperbolic_segment_2_object()(p1, p2);
+  Hyperbolic_segment b1 = tri.geom_traits().construct_hyperbolic_bisector_2_object()(p1, p2);
+  Point i1 = tri.geom_traits().construct_intersection_2_object()(s1, b1);
+  int idx2 = -1;
+  Locate_type lt2;
+  Face_handle fh2 = tri.locate(i1, lt2, idx2);
+  assert(lt2 == HDTriangulation::EDGE);
+  assert(fh2 != Face_handle());
+  assert(idx2 >= 0 && idx2 <= 2);
 
-        // Test an edge location
-        Hyperbolic_segment s1 = tri.geom_traits().construct_hyperbolic_segment_2_object()(p1, p2);
-        Hyperbolic_segment b1 = tri.geom_traits().construct_hyperbolic_bisector_2_object()(p1, p2);
-        Point i1 = tri.geom_traits().construct_intersection_2_object()(s1, b1);
-        Locate_type lt2;
-        fh = tri.locate(i1, lt2, idx);
-        assert(lt2 == HDTriangulation::EDGE);
+  // Test a "dangling" edge location
+  Hyperbolic_segment s2 = tri.geom_traits().construct_hyperbolic_segment_2_object()(p4, p5);
+  Hyperbolic_segment b2 = tri.geom_traits().construct_hyperbolic_bisector_2_object()(p4, p5);
+  Point i2 = tri.geom_traits().construct_intersection_2_object()(s2, b2);
+  Locate_type lt3;
+  int idx3 = -1;
+  Face_handle fh3 = tri.locate(i2, lt3, idx3);
+  assert(lt3 == HDTriangulation::EDGE);
+  assert(fh3 != Face_handle());
+  assert(idx3 >= 0 && idx3 <= 2);
 
-        // Test a "dangling" edge location
-        Hyperbolic_segment s2 = tri.geom_traits().construct_hyperbolic_segment_2_object()(p4, p5);
-        Hyperbolic_segment b2 = tri.geom_traits().construct_hyperbolic_bisector_2_object()(p4, p5);
-        Point i2 = tri.geom_traits().construct_intersection_2_object()(s2, b2);
-        Locate_type lt3;
-        fh = tri.locate(i2, lt3, idx);
-        assert(lt3 == HDTriangulation::EDGE);
+  // Test a face location
+  Point c1 = CGAL::centroid(p1, p2, p4);
+  Locate_type lt4;
+  int idx4 = -1;
+  Face_handle fh4 = tri.locate(c1, lt4, idx4);
+  assert(lt4 == HDTriangulation::FACE);
+  assert(fh4 != Face_handle());
 
-        std::cout << " -------- SUCCESS --------" << std::endl;
+  // Test a non-hyperbolic face location
+  Point c2 = CGAL::centroid(p3, p4, p5);
+  Locate_type lt5;
+  int idx5 = -1;
+  Face_handle fh5 = tri.locate(c2, lt5, idx5);
+  assert(lt5 == HDTriangulation::OUTSIDE_CONVEX_HULL);
+  assert(fh5 == Face_handle());
 
-        return 0;
+  // Test a non-convex hull location
+  Locate_type lt6;
+  int idx6 = -1;
+  Face_handle fh6 = tri.locate(Point(0, -FT(80)/F100), lt6, idx6);
+  assert(lt6 == HDTriangulation::OUTSIDE_CONVEX_HULL);
+  assert(fh6 == Face_handle());
+
+  std::cout << " -------- SUCCESS --------" << std::endl;
+
+  return 0;
 }

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -41,6 +41,13 @@ CGAL tetrahedral Delaunay refinement algorithm.
 -   Deprecated two overloads of Function `refine_Delaunay_mesh()` and replaced them with versions using function named parameters.
 -   Add overloads of function `write_VTU()` with property maps for specifying the domain.    
 
+### [2D Hyperbolic Triangulations](https://doc.cgal.org/5.6/Manual/packages.html#PkgHyperbolicTriangulation2)
+
+-   **Breaking change**: the concept `HyperbolicTriangulationFaceBase_2` has been modified to
+    better reflect the triangulation's requirements and avoid a conflict with the requirements
+    described by the concept `TriangulationDataStructure_2::Face`. The model `CGAL::Hyperbolic_triangulation_face_base_2`
+    has been adapted correspondingly.
+
 [Release 5.5](https://github.com/CGAL/cgal/releases/tag/v5.5)
 -----------
 


### PR DESCRIPTION
## Summary of Changes

Various fixes for the `HT2` package and its demo; commits are atomic and self-explanatory.

There are some doc changes, but I would say these are fixes:
- The previous code tries to handle finite/infinite and hyperbolic/non-hyperbolic with a single flag, which caused errors to get stuff like finite but non-hyperbolic edges (see e.g. #6869). In addition, it used `tds_data()`, which is something that now also exists in `CGAL::triangulation_ds_face_base_2` and could create some conflicts. Hence, I completely re-implemented the way it was done, and added a new `tds_data`-like class in the face base called `Hyperbolic_face_data`, which adds new requirements in the face data class.
- I have removed `HDT2::insert(Point, Locate_type, int)`: The 'lt' is documented to be `HDT2::Locate_type`, which is wrong, the function's signature uses `HDT2::DT2::Locate_type`, and that's for a precise reason: `HDT2::locate()` returns location based on hyperbolic simplices, and not the underlying DT2 triangulation. So, one might retrieve `OUTSIDE_CONVEX_HULL` if a query is on a non-hyperbolic Delaunay face, but on a finite underlying DT2 face. In that configuration, it'd break the triangulation to do an insertion using `lt = OUTSIDE_CONVEX_HULL`. The documentation could be fixed, but it is too dangerous so it's best to just remove it. (Maybe it should also be simply removed from the triangulation class.)

TODO:
- [x] Announce breaking changes (doc)

## Release Management

* Affected package(s): `Hyperbolic_triangulation_2`
* Issue(s) solved (if any): fix #6869
* Feature/Small Feature (if any): N/A
* License and copyright ownership: no change

