### PR TITLE
Arrangement_on_surface_2: strange documentation

### DIFF
--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_segment_traits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_segment_traits_2.h
@@ -112,7 +112,7 @@ public:
   typedef X_monotone_curve_2                    Curve_2;
 
   //! A functor that trims curves.
-  Class Trim_2 {
+  class Trim_2 {
   public:
     //! \name Creation
     //! @{


### PR DESCRIPTION
Replacing the word `Class` by `class`

See issue #6882

