### PR TITLE
Arrangement_on_surface_2 missing link

### DIFF
--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrTraits--CompareYOnBoundary_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrTraits--CompareYOnBoundary_2.h
@@ -8,7 +8,6 @@ namespace ArrTraits {
  * \cgalHasModel ArrangementClosedLeftTraits_2::Compare_y_on_boundary_2
  * \cgalHasModel ArrangementClosedRightTraits_2::Compare_y_on_boundary_2
  * \cgalHasModel ArrangementIdentifiedVerticalTraits_2::Compare_y_on_boundary_2
- * \cgalHasModel ArrangementOpenBoundaryTraits_2::Compare_y_on_boundary_2
  * \cgalHasModel ArrangementSphericalBoundaryTraits_2::Compare_y_on_boundary_2
  */
 class CompareYOnBoundary_2 {


### PR DESCRIPTION
Fix as indicated by @efifogel:
> ArrangementOpenBoundaryTraits_2::Compare_y_on_boundary is not a model of CompareYOnBoundary_2, so this line should be removed.
