### PR TITLE
Polynomial: Spurious backslashes

### DIFF
--- a/Polynomial/doc/Polynomial/CGAL/Polynomial.h
+++ b/Polynomial/doc/Polynomial/CGAL/Polynomial.h
@@ -12,11 +12,11 @@ The template argument `Coeff` must be at
 least a model of `IntegralDomainWithoutDivision`.
 For all operations naturally involving division, an `IntegralDomain`
 is required.
-`Polynomial` offers a full set of algebraic operators, i.e.\
+`Polynomial` offers a full set of algebraic operators, i.e.
 binary <TT>+</TT>, <TT>-</TT>, <TT>*</TT>, <TT>/</TT> as well as
 <TT>+=</TT>, <TT>-=</TT>, <TT>*=</TT>, <TT>/=</TT>; not only for polynomials
 but also for a polynomial and a number of the coefficient type.
-(The <TT>/</TT> operator must only be used for integral divisions, i.e.\
+(The <TT>/</TT> operator must only be used for integral divisions, i.e.
 those with remainder zero.)
 The operations are implemented naively: <TT>+</TT> and <TT>-</TT> need a number of `Coeff`
 operations which is linear in the degree while * is quadratic.


### PR DESCRIPTION
In the file Polynomial/doc/Polynomial/CGAL/Polynomial.h we see some spurious backslashes resulting in the file Polynomial/classCGAL_1_1Polynomial.html in:

```
The template argument Coeff must be at least a model of IntegralDomainWithoutDivision. For all operations naturally involving division, an IntegralDomain is required. Polynomial offers a full set of algebraic operators, i.e.\ binary +, -, *, / as well as +=, -=, *=, /=; not only for polynomials but also for a polynomial and a number of the coefficient type. (The / operator must only be used for integral divisions, i.e.\ those with remainder zero.) The operations are implemented naively: + and - need a number of Coeff operations which is linear in the degree while * is quadratic. Unary + and - and (in)equality ==, != are provided as well.
```
