### PR TITLE
QP_solver: Missing links to include file

### DIFF
--- a/QP_solver/doc/QP_solver/CGAL/QP_models.h
+++ b/QP_solver/doc/QP_solver/CGAL/QP_models.h
@@ -54,7 +54,7 @@ namespace CGAL {
   should give you a flavor of the use of this
   model in practice.
 
-  `QP_solver/solve_convex_hull_containment_lp.h`
+  \ref QP_solver/solve_convex_hull_containment_lp.h
 
   \ref QP_solver/convex_hull_containment.cpp
 
@@ -305,7 +305,7 @@ make_quadratic_program_from_iterators (
 
   \ref QP_solver/first_nonnegative_lp_from_iterators.cpp
 
-  `QP_solver/solve_convex_hull_containment_lp.h`
+  \ref QP_solver/solve_convex_hull_containment_lp.h
 
   \ref QP_solver/convex_hull_containment.cpp
 
@@ -390,7 +390,7 @@ public:
   should give you a flavor of the use of this
   model in practice.
 
-  `QP_solver/solve_convex_hull_containment_lp.h`
+  \ref QP_solver/solve_convex_hull_containment_lp.h
 
   \ref QP_solver/convex_hull_containment.cpp
 
@@ -478,7 +478,7 @@ public:
   should give you a flavor of the use of this
   model in practice.
 
-  `QP_solver/solve_convex_hull_containment_lp.h`
+  \ref QP_solver/solve_convex_hull_containment_lp.h
 
   \ref QP_solver/convex_hull_containment.cpp
 

--- a/QP_solver/doc/QP_solver/QP_solver.txt
+++ b/QP_solver/doc/QP_solver/QP_solver.txt
@@ -559,7 +559,7 @@ You can avoid the explicit construction of the type
 `Nonnegative_linear_program_from_iterators<A_it, B_it, R_it, C_it>`
 if you only need an expression of it, e.g. to pass it directly
 as an argument to the solving function. Here is an alternative
-version of `QP_solver/solve_convex_hull_containment_lp.h`
+version of \ref QP_solver/solve_convex_hull_containment_lp.h
 that shows how this works. In effect, you get shorter and more
 readable code.
 


### PR DESCRIPTION
In the documentation of QP_solver there are no links to the example file  `QP_solver/solve_convex_hull_containment_lp.h` whilst this would be  beneficial (in my opinion).

See:
- QP_solver/classCGAL_1_1Nonnegative__linear__program__from__iterators.html
- QP_solver/classCGAL_1_1Nonnegative__quadratic__program__from__iterators.html
- QP_solver/index.html#title13