### PR TITLE
Segment_Delaunay_graph_2: Incorrect backticks

### DIFF
--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_2.h
@@ -17,9 +17,9 @@ Currently it only supports the insertions of sites.
         models of the concepts `SegmentDelaunayGraphVertexBase_2` and `TriangulationFaceBase_2`, respectively.
         It defaults to:
         \code
-        `CGAL::Triangulation_data_structure_2<
+        CGAL::Triangulation_data_structure_2<
                   CGAL::Segment_Delaunay_graph_vertex_base_2<St>,
-                  CGAL::Segment_Delaunay_graph_face_base_2<Gt> >`
+                  CGAL::Segment_Delaunay_graph_face_base_2<Gt> >
         \endcode
 
 \cgalHeading{Storage}

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_hierarchy_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_hierarchy_2.h
@@ -57,10 +57,10 @@ data structure must be a model of the
 `SegmentDelaunayGraphHierarchyVertexBase_2`
 concept. The fourth template parameter defaults to:
 \code
-`CGAL::Triangulation_data_structure_2<
+CGAL::Triangulation_data_structure_2<
           CGAL::Segment_Delaunay_graph_hierarchy_vertex_base_2<
             CGAL::Segment_Delaunay_graph_vertex_base_2<St>,
-          CGAL::Segment_Delaunay_graph_face_base_2<Gt> >`
+          CGAL::Segment_Delaunay_graph_face_base_2<Gt> >
 \endcode
 
 The `Segment_Delaunay_graph_hierarchy_2` class derives publicly from the

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_storage_traits_with_info_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/CGAL/Segment_Delaunay_graph_storage_traits_with_info_2.h
@@ -11,7 +11,7 @@ The class `Segment_Delaunay_graph_storage_traits_with_info_2` provides a model f
 
 \cgalModels `SegmentDelaunayGraphStorageTraits_2`
 
-\sa `CGAL::`Segment_Delaunay_graph_storage_site_with_info_2`
+\sa `CGAL::Segment_Delaunay_graph_storage_site_with_info_2`
 */
   template<class Gt, class Info, class Converter, class Merger>
 class Segment_Delaunay_graph_storage_traits_with_info_2


### PR DESCRIPTION
Correcting some incorrect backticks:
Inside code part there should not be extra backticks
- Segment_Delaunay_graph_2/classCGAL_1_1Segment__Delaunay__graph__2.html
- Segment_Delaunay_graph_2/classCGAL_1_1Segment__Delaunay__graph__hierarchy__2.html

In the see also section there was an incorrect backtick inside the
- Segment_Delaunay_graph_2/classCGAL_1_1Segment__Delaunay__graph__storage__traits__with__info__2.html


