### PR TITLE
STL_Extension: wrong formulation of precondition

### DIFF
--- a/STL_Extension/doc/STL_Extension/CGAL/In_place_list.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/In_place_list.h
@@ -723,7 +723,7 @@ void unique();
 /*!
 merges the list `ipl2`
 into the list `ipl` and `ipl2` becomes empty. It is stable.
-\pre Both lists are increasingly sorted. A suitable `operator<` for the type `T`.
+\pre Both lists are sorted in increasing order by means of a suitable `operator<` for the type `T`.
 */
 void merge(In_place_list<T,bool>& ipl2);
 

--- a/STL_Extension/include/CGAL/In_place_list.h
+++ b/STL_Extension/include/CGAL/In_place_list.h
@@ -575,14 +575,15 @@ public:
 
   void merge(Self& x);
   // merges the list x into the list `l' and x becomes empty. It is
-  // stable. Precondition: Both lists are increasingly sorted. A
-  // suitable `operator<' for the type T.
+  // stable. Precondition: Both lists are sorted in increasing order
+  // by means of a suitable `operator<` for the type `T`.
 
   template < class StrictWeakOrdering >
   void merge(Self& x, StrictWeakOrdering ord)
   // merges the list x into the list `l' and x becomes empty.
   // It is stable.
-  // Precondition: Both lists are increasingly sorted wrt. ord.
+  // stable. Precondition: Both lists are sorted in increasing order
+  // wrt. ord.
   {
     iterator first1 = begin();
     iterator last1 = end();

--- a/STL_Extension/include/CGAL/In_place_list.h
+++ b/STL_Extension/include/CGAL/In_place_list.h
@@ -582,8 +582,7 @@ public:
   void merge(Self& x, StrictWeakOrdering ord)
   // merges the list x into the list `l' and x becomes empty.
   // It is stable.
-  // stable. Precondition: Both lists are sorted in increasing order
-  // wrt. ord.
+  // Precondition: Both lists are sorted in increasing order wrt. `ord`.
   {
     iterator first1 = begin();
     iterator last1 = end();


### PR DESCRIPTION
In  STL_Extension/classCGAL_1_1In__place__list.html we see the line:
```
Both lists are increasingly sorted. A suitable operator< for the type T
```
the word `increasingly` means `more and more`, though most likely `in increasing order` is meant here



