### PR TITLE
Using the tag `<details>` for cgalExamples

### DIFF
--- a/Documentation/doc/resources/1.9.3/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.9.3/BaseDoxyfile.in
@@ -304,7 +304,7 @@ ALIASES                = "cgal=%CGAL" \
                          "cpp=C++" \
                          "cpp11=C++11" \
                          "CC=C++" \
-                         "cgalExample{1}=<br><b>File</b> \ref \1 \include \1" \
+                         "cgalExample{1}=<br><details><summary><b>File</b> \ref \1</summary> \include \1 </details>" \
                          "cgalFigureAnchor{1}=\anchor fig__\1" \
                          "cgalFigureRef{1}=\ref fig__\1" \
                          "cgalFigureBegin{2}=\anchor fig__\1 ^^ \image html \2 ^^ \image latex \2 \"\" width=15cm ^^ \htmlonly[block] <div class=\"cgal_figure_caption\"> \endhtmlonly ^^ \ref fig__\1" \


### PR DESCRIPTION
Enhancement / suggestion

Since version `1.9.3 doxygen supports the HTML tag `<details>` so that parts of the documentation can be easily collapsed. This will make parts of the documentation  a bit clearer and cleaner.

The following will give a small overview of the old and the new situation for the Weights package, but it applies to all packages.

**old**

![image](https://user-images.githubusercontent.com/5223533/193024812-79c44bec-91fe-4eb3-8e91-6b9d96dff713.png)

**new**

![image](https://user-images.githubusercontent.com/5223533/193024934-3f4fba14-4b11-4b17-9ea0-4edf1ca99123.png)


**Note** 
In general a critical (re)view should be done regarding the white space above examples is (especially) now at some places a bit a bit large, but this would be a separate PR / task.