### PR TITLE
Triangulation_d: fix invalid triangulation after I/O 

### DIFF
--- a/Triangulation/include/CGAL/Triangulation_data_structure.h
+++ b/Triangulation/include/CGAL/Triangulation_data_structure.h
@@ -1364,7 +1364,7 @@ Triangulation_data_structure<Dimen, Vb, Fcb>
             else
                 read(is, index);
             s->set_vertex(j, vertices[index]);
-	    s->vertex(j)->set_full_cell(s);
+            s->vertex(j)->set_full_cell(s);
         }
         // read other non-combinatorial information for the full_cells
         is >> (*s);

--- a/Triangulation/include/CGAL/Triangulation_data_structure.h
+++ b/Triangulation/include/CGAL/Triangulation_data_structure.h
@@ -1364,6 +1364,7 @@ Triangulation_data_structure<Dimen, Vb, Fcb>
             else
                 read(is, index);
             s->set_vertex(j, vertices[index]);
+	    s->vertex(j)->set_full_cell(s);
         }
         // read other non-combinatorial information for the full_cells
         is >> (*s);

--- a/Triangulation/test/Triangulation/CMakeLists.txt
+++ b/Triangulation/test/Triangulation/CMakeLists.txt
@@ -25,8 +25,9 @@ if(TARGET CGAL::Eigen3_support)
   create_single_source_cgal_program("test_tds.cpp")
   create_single_source_cgal_program("test_torture.cpp")
   create_single_source_cgal_program("test_insert_if_in_star.cpp")
+  create_single_source_cgal_program("simple_io_test.cpp")
   foreach(target test_triangulation test_delaunay test_regular test_tds
-                 test_torture test_insert_if_in_star)
+                 test_torture test_insert_if_in_star simple_io_test)
     target_link_libraries(${target} PUBLIC CGAL::Eigen3_support)
   endforeach()
 

--- a/Triangulation/test/Triangulation/simple_io_test.cpp
+++ b/Triangulation/test/Triangulation/simple_io_test.cpp
@@ -1,0 +1,21 @@
+#include <CGAL/Epick_d.h>
+#include <CGAL/Delaunay_triangulation.h>
+#include <sstream>
+
+int main()
+{
+  typedef CGAL::Delaunay_triangulation<CGAL::Epick_d<CGAL::Dimension_tag<2>>> T;
+  T dt1(2), dt2(2);
+
+  std::vector<T::Point> points;
+  points.emplace_back(1,0);
+  points.emplace_back(0,1);
+  points.emplace_back(2,2);
+  dt1.insert(points.begin(), points.end());
+
+  std::stringstream f;
+  f << dt1 << std::endl;
+  std::cout << f.str();
+  f >> dt2;
+  assert(dt2.is_valid(true));
+}

--- a/Triangulation/test/Triangulation/test_tds.cpp
+++ b/Triangulation/test/Triangulation/test_tds.cpp
@@ -104,6 +104,7 @@ void test(const int d, const string & type)
         CGAL::IO::set_binary_mode(fi);
     TDS input_tds(d);
     fi >> input_tds;
+    assert( input_tds.is_valid(true) );
     fi.close();
 
     // TEST Copy Constructor


### PR DESCRIPTION
## Summary of Changes
Fixing the triangulation_data_structure.h I/O to make the loaded triangulation valid.
- Issue :  Giving  "vertex's adjacent full cell does not contain that vertex"  error when calling is_valid()  after dumping and reading the triangulation with the stream operator on the loaded triangulation.  (fail at Triangulation_ds_vertex.h:96)    
- Fix :
  - Testing validity of the loaded triangulation
  -  linking back the full cell of a vertex each time a vertex is linked to a cell.

TODO:
- [x] Check that it fixes #5275
- [x] Rebase to 5.4.x

## Release Management

* Affected package(s): `Triangulation`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: 