### PR TITLE
Use `<details>` in the `cgalNParam`

### DIFF
--- a/Documentation/doc/resources/1.9.3/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.9.3/BaseDoxyfile.in
@@ -367,12 +367,12 @@ ALIASES                = "cgal=%CGAL" \
                          "cgalNamedParamsBegin=<dl class=\"params\"><dt>Optional Named Parameters</dt><dd> <table class=\"params\">" \
                          "cgalNamedParamsBegin{1}=<dl class=\"params\"><dt>\1</dt><dd> <table class=\"params\">" \
                          "cgalNamedParamsEnd=</table> </dd> </dl>" \
-                         "cgalParamNBegin{1}=<tr><td class> \htmlonly[block] <button class=\"collapsible\">\endhtmlonly <b>\1</b> \htmlonly[block]</button> <div class=\"content\">\endhtmlonly<ul>" \
+                         "cgalParamNBegin{1}=<tr><td class> <details><summary><b>\1</b></summary><ul>" \
                          "cgalParamDescription{1}=<li>\1</li>" \
                          "cgalParamType{1}=<li><b>Type: </b>\1</li>" \
                          "cgalParamDefault{1}=<li><b>%Default: </b>\1</li>" \
                          "cgalParamExtra{1}=<li><b>Extra: </b>\1</li>" \
-                         "cgalParamNEnd=</ul> \htmlonly[block] </div> \endhtmlonly </td><td></td></tr>"
+                         "cgalParamNEnd=</ul> </details></td><td></td></tr>"
 
 # Set the OPTIMIZE_OUTPUT_FOR_C tag to YES if your project consists of C sources
 # only. Doxygen will then generate output that is more tailored for C. For


### PR DESCRIPTION
Since doxygen 1.9.3 doxygen supports the HTML `<details>` tag, so no difficult constructs necessary with `\htmlonly`.

`cgalNParam` is used in 122 files.
Example `etrahedral_remeshing/group__PkgTetrahedralRemeshingRef.html#gadeec4a90f1b4f8c9bca76eaee9181235`

**Old**

![image](https://user-images.githubusercontent.com/5223533/193326082-f42c9d9f-9711-4634-96f7-d7dfe95c5f20.png)

**New**

![image](https://user-images.githubusercontent.com/5223533/193326148-1998d2b4-e955-44a2-8f0a-887fc3323369.png)
