### PR TITLE
STL_Extension: example not shown properly

### DIFF
--- a/STL_Extension/doc/STL_Extension/CGAL/iterator.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/iterator.h
@@ -120,7 +120,7 @@ must be a subset of the parameters of `V`. Should the
 
 \cgalModels `OutputIterator`
 
-cgalExample{STL_Extension/Dispatch_output_iterator.cpp}
+\cgalExample{STL_Extension/Dispatch_output_iterator.cpp}
 
 \sa `CGAL::Dispatch_output_iterator<V,O>`
 */

--- a/STL_Extension/doc/STL_Extension/examples.txt
+++ b/STL_Extension/doc/STL_Extension/examples.txt
@@ -1,5 +1,6 @@
 /*!
 \example STL_Extension/Default.cpp
+\example STL_Extension/Dispatch_output_iterator.cpp
 \example STL_Extension/in_place_list_prog.cpp
 \example STL_Extension/min_element_if_example.cpp
 \example STL_Extension/min_max_element_example.cpp


### PR DESCRIPTION
On the page `STL_Extension/classCGAL_1_1Dispatch__or__drop__output__iterator.html` it is obvious that the `\` is missing. To get the reference right (due to the `\ref` in the `cgalExample`) the file must also be added to the list of examples
