### PR TITLE
Do not use `void` as default for the geometric traits if Eigen is not present

### DIFF
--- a/Optimal_bounding_box/include/CGAL/Optimal_bounding_box/oriented_bounding_box.h
+++ b/Optimal_bounding_box/include/CGAL/Optimal_bounding_box/oriented_bounding_box.h
@@ -26,6 +26,7 @@
 #include <CGAL/boost/graph/named_params_helper.h>
 #include <CGAL/convex_hull_3.h>
 #include <CGAL/Convex_hull_traits_3.h>
+#include <CGAL/Default.h>
 #include <CGAL/Iterator_range.h>
 #include <CGAL/Kernel_traits.h>
 #include <CGAL/Random.h>
@@ -338,14 +339,14 @@ void oriented_bounding_box(const PointRange& points,
   typedef typename CGAL::Kernel_traits<Point>::type                                     K;
   typedef Oriented_bounding_box_traits_3<K>                                             Default_traits;
 #else
-  typedef void                                                                          Default_traits;
+  typedef CGAL::Default                                                                 Default_traits;
 #endif
 
   typedef typename internal_np::Lookup_named_param_def<internal_np::geom_traits_t,
                                                        CGAL_BGL_NP_CLASS,
                                                        Default_traits>::type            Geom_traits;
 
-  CGAL_static_assertion_msg(!(std::is_same<Geom_traits, void>::value),
+  CGAL_static_assertion_msg(!(std::is_same<Geom_traits, CGAL::Default>::value),
                             "You must provide a traits class or have Eigen enabled!");
 
   Geom_traits traits = choose_parameter<Geom_traits>(get_parameter(np, internal_np::geom_traits));


### PR DESCRIPTION
## Summary of Changes

This change is caused by the improvements of named parameters which added support for reference named parameters: https://github.com/CGAL/cgal/commit/aaa3947e4001487e5b2c0c0a14e8459a9c20d7bb.
Despite not being used in OBB, compilers will try to compile the `::reference` type in `Lookup_named_param_def` if Eigen is not present, and then proceed to complain about the type being `Default& == void&`.

This PR changes the default to be `CGAL::Default`, which solves that, and also aligns with what is done in other packages such as `Surface_mesh_parameterization`.

Bug reported by @fdrmrc (thank you).

## Release Management

* Affected package(s): `Optimal_bounding_box`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): - 
* License and copyright ownership: no change

