### PR TITLE
Number types:   Use mathbb for mathematical Z, Q, and R

### DIFF
--- a/Number_types/doc/Number_types/CGAL/CORE_BigInt.h
+++ b/Number_types/doc/Number_types/CGAL/CORE_BigInt.h
@@ -4,7 +4,7 @@ namespace CORE {
 /*!
 \ingroup nt_core
 
-The class `CORE::BigInt` provides exact computation in \f$ \Z\f$.
+The class `CORE::BigInt` provides exact computation in \f$ \mathbb{Z}\f$.
 Operations and comparisons between objects of this type are guaranteed
 to be exact.
 This number type is provided by the \core library \cgalCite{klpy-clp-99}.

--- a/Number_types/doc/Number_types/CGAL/CORE_BigRat.h
+++ b/Number_types/doc/Number_types/CGAL/CORE_BigRat.h
@@ -3,7 +3,7 @@ namespace CORE {
 /*!
 \ingroup nt_core
 
-The class `CORE::BigRat` provides exact computation in \f$ \Q\f$.
+The class `CORE::BigRat` provides exact computation in \f$ \mathbb{Q}\f$.
 Operations and comparisons between objects of this type are guaranteed to be exact.
 This number type is provided by the \core library \cgalCite{klpy-clp-99}.
 

--- a/Number_types/doc/Number_types/CGAL/Root_of_traits.h
+++ b/Number_types/doc/Number_types/CGAL/Root_of_traits.h
@@ -6,7 +6,7 @@ namespace CGAL {
 The function `compute_roots_of_2()` solves a univariate polynomial as it is defined by the
 coefficients given to the function. The solutions are written into the given
 `OutputIterator`.
-Writes the real roots of the polynomial \f$ aX^2+bX+c\f$ into \f$ oit\f$ in ascending order.
+Writes the real roots of the polynomial \f$ aX^2+bX+c\f$ into `oit` in ascending order.
 
 `OutputIterator` is required to accept \link Root_of_traits::Root_of_2 `Root_of_traits<RT>::Root_of_2`\endlink.
 
@@ -81,8 +81,8 @@ namespace CGAL {
 /*!
 \ingroup nt_ralgebraic
 
-The function `make_sqrt()` constructs a square root of a given value of type \f$ RT\f$.
-Depending on the type \f$ RT\f$ the square root may be returned in a new type that
+The function `make_sqrt()` constructs a square root of a given value of type `RT`.
+Depending on the type `RT` the square root may be returned in a new type that
 can represent algebraic extensions of degree \f$ 2\f$.
 
 \returns \f$ \sqrt{x}.\f$

--- a/Number_types/doc/Number_types/CGAL/Root_of_traits.h
+++ b/Number_types/doc/Number_types/CGAL/Root_of_traits.h
@@ -37,7 +37,7 @@ The function `make_root_of_2()` constructs an algebraic number of degree 2 over 
 ring number type.
 
 Returns the smallest real root of the polynomial \f$ aX^2+bX+c\f$ if
-\f$ s\f$ is true, and the largest root is \f$ s\f$ is false.
+\f$ s\f$ is `true`, and the largest root is \f$ s\f$ is `false`.
 
 \pre `RT` is an `IntegralDomainWithoutDivision`.
 \pre The polynomial has at least one real root.

--- a/Number_types/doc/Number_types/CGAL/Sqrt_extension.h
+++ b/Number_types/doc/Number_types/CGAL/Sqrt_extension.h
@@ -3,9 +3,9 @@ namespace CGAL {
 /*!
 \ingroup nt_ralgebraic
 
-An instance of this class represents an extension of the type `NT` by *one* square root of the type `ROOT`.
+An instance of this class represents an extension of the type `NT` by *one* square root of the type `Root`.
 
-`NT` is required to be constructible from `ROOT`.
+`NT` is required to be constructible from `Root`.
 
 `NT` is required to be an `IntegralDomainWithoutDivision`.
 
@@ -23,9 +23,9 @@ The result would be in \f$ \mathbb{Z}[\sqrt{a},\sqrt{b}]\f$, which is not
 representable by `Sqrt_extension<Integer,Integer>`.
 
 \attention The user is responsible to check that arithmetic operations are carried out for elements from the same extensions only.
-
 This is not tested by `Sqrt_extension` for efficiency reasons.
 A violation of the precondition leads to undefined behavior.
+
 Be aware that for efficiency reasons the given \f$\mathrm{root}\f$ is stored as it is given to
 the constructor. In particular, an extension by a square root of a square is
 considered as an extension.
@@ -104,7 +104,7 @@ In case `NT` is not `RealEmbeddable`, `DifferentExtensionComparable` as well as 
 \sa \cgalTagFalse
 
 */
-template< typename NT, typename ROOT,
+template< typename NT, typename Root,
           typename DifferentExtensionComparable = Tag_false,
           typename FilterPredicates = Tag_false>
 class Sqrt_extension {
@@ -148,7 +148,7 @@ Sqrt_extension (int a0, int a1, int r);
 /*!
 General constructor: `ext`\f$ = a0 + a1 \cdot sqrt(r)\f$. \pre \f$ r \neq0\f$
 */
-Sqrt_extension (NT a0, NT a1, ROOT r);
+Sqrt_extension (NT a0, NT a1, Root r);
 
 /// @}
 
@@ -172,10 +172,10 @@ const NT & a1 () const ;
 /*!
 Const access operator for root
 */
-const ROOT &         root () const;
+const Root &         root () const;
 
 /*!
-Returns true in case root of `ext` is not zero.
+Returns `true` in case root of `ext` is not zero.
 
 Note that \f$ a1 == 0 \f$ does not imply \f$ \mathrm{root} == 0\f$.
 */
@@ -192,7 +192,7 @@ of `ext`. see also: `AlgebraicStructureTraits::Simplify`.
 void         simplify ();
 
 /*!
-returns true if `ext` represents the value zero.
+returns `true` if `ext` represents the value zero.
 */
 bool         is_zero () const;
 
@@ -326,19 +326,19 @@ In case the mode is `CGAL::IO::ASCII` the format is `EXT[a0,a1,root]`.
 
 In case the mode is `CGAL::IO::PRETTY` the format is human readable.
 
-\attention `operator>>` must be defined for `ROOT` and `NT`.
+\attention `operator>>` must be defined for `Root` and `NT`.
 
 \relates Sqrt_extension
 */
-std::ostream& operator<<(std::ostream& os, const Sqrt_extension<NT,ROOT> &ext);
+std::ostream& operator<<(std::ostream& os, const Sqrt_extension<NT,Root> &ext);
 
 /*!
 reads `ext` from istream `is` in format `EXT[a0,a1,root]`, the output format in mode `CGAL::IO::ASCII`
 
-\attention `operator<<` must be defined exist for `ROOT` and `NT`.
+\attention `operator<<` must be defined exist for `Root` and `NT`.
 
 \relates Sqrt_extension
 */
-std::istream& operator>>(std::istream& is, const Sqrt_extension<NT,ROOT> &ext);
+std::istream& operator>>(std::istream& is, const Sqrt_extension<NT,Root> &ext);
 
 } /* end namespace CGAL */

--- a/Number_types/doc/Number_types/CGAL/Sqrt_extension.h
+++ b/Number_types/doc/Number_types/CGAL/Sqrt_extension.h
@@ -19,7 +19,7 @@ construction time, or set to zero if it is not specified.
 
 Arithmetic operations among different extensions, say \f$ \mathbb{Z}[\sqrt{a}]\f$
 and \f$ \mathbb{Z}[\sqrt{b}]\f$, are not supported.
-The result would be in \f$ \mathb{Z}Z[\sqrt{a},\sqrt{b}]\f$, which is not
+The result would be in \f$ \mathbb{Z}[\sqrt{a},\sqrt{b}]\f$, which is not
 representable by `Sqrt_extension<Integer,Integer>`.
 
 \attention The user is responsible to check that arithmetic operations are carried out for elements from the same extensions only.
@@ -91,8 +91,8 @@ In case `NT` is not `RealEmbeddable`, `DifferentExtensionComparable` as well as 
 \cgalModels `CopyConstructible`
 \cgalModels `DefaultConstructible`
 \cgalModels `EqualityComparable`
-\cgalModels `ImplicitInteroperable` with int
-\cgalModels `ImplicitInteroperable` with NT
+\cgalModels `ImplicitInteroperable` with `int`
+\cgalModels `ImplicitInteroperable` with `NT`
 \cgalModels `Fraction` if NT is a `Fraction`
 \cgalModels `RootOf_2`
 

--- a/Number_types/doc/Number_types/CGAL/Sqrt_extension.h
+++ b/Number_types/doc/Number_types/CGAL/Sqrt_extension.h
@@ -11,15 +11,15 @@ An instance of this class represents an extension of the type `NT` by *one* squa
 
 `Sqrt_extension` is `RealEmbeddable` if NT is `RealEmbeddable`.
 
-For example, let `Integer` be some type representing \f$ \Z\f$, then
-`Sqrt_extension<Integer,Integer>` is able to represent \f$ \Z[\sqrt{\mathrm{root}}]\f$
+For example, let `Integer` be some type representing \f$ \mathbb{Z}\f$, then
+`Sqrt_extension<Integer,Integer>` is able to represent \f$ \mathbb{Z}[\sqrt{\mathrm{root}}]\f$
 for some arbitrary Integer \f$\mathrm{root}\f$. \cgalFootnote{\f$ R[a]\f$ denotes the extension of a ring \f$ R\f$ by an element \f$ a\f$. See also: <A HREF="http://mathworld.wolfram.com/ExtensionRing.html">\cgalFootnoteCode{http://mathworld.wolfram.com/ExtensionRing.html}</A>}
 The value of \f$\mathrm{root}\f$ is set at
 construction time, or set to zero if it is not specified.
 
-Arithmetic operations among different extensions, say \f$ \Z[\sqrt{a}]\f$
-and \f$ \Z[\sqrt{b}]\f$, are not supported.
-The result would be in \f$ \Z[\sqrt{a},\sqrt{b}]\f$, which is not
+Arithmetic operations among different extensions, say \f$ \mathbb{Z}[\sqrt{a}]\f$
+and \f$ \mathbb{Z}[\sqrt{b}]\f$, are not supported.
+The result would be in \f$ \mathb{Z}Z[\sqrt{a},\sqrt{b}]\f$, which is not
 representable by `Sqrt_extension<Integer,Integer>`.
 
 \attention The user is responsible to check that arithmetic operations are carried out for elements from the same extensions only.
@@ -78,7 +78,7 @@ NT
 </TABLE>
 
 The extension of a `UniqueFactorizationDomain` or
-`EuclideanRing` is just an `IntegralDomain`, since the extension in general destroys the unique factorization property. For instance consider \f$ \Z[\sqrt{10}]\f$, the extension of \f$ \Z\f$ by \f$ \sqrt{10}\f$: in \f$ \Z[\sqrt{10}]\f$ the element 10 has two different factorizations \f$ \sqrt{10} \cdot \sqrt{10}\f$ and \f$ 2 \cdot 5\f$. In particular, the factorization is not unique.
+`EuclideanRing` is just an `IntegralDomain`, since the extension in general destroys the unique factorization property. For instance consider \f$ \mathbb{Z}[\sqrt{10}]\f$, the extension of \f$ \mathbb{Z}\f$ by \f$ \sqrt{10}\f$: in \f$ \mathbb{Z}[\sqrt{10}]\f$ the element 10 has two different factorizations \f$ \sqrt{10} \cdot \sqrt{10}\f$ and \f$ 2 \cdot 5\f$. In particular, the factorization is not unique.
 
 If `NT` is a model of `RealEmbeddable` the type `Sqrt_extension` is also considered as `RealEmbeddable`. However, by default it is not allowed to compare values from different extensions for efficiency reasons. In case such a comparison becomes necessary, use the member function compare with the according Boolean flag.
 If such a comparison is a very frequent case, override the default of `DifferentExtensionComparable` by giving \cgalTagTrue as third template parameter. This effects the behavior of compare functions as well as the compare operators.

--- a/Number_types/doc/Number_types/CGAL/leda_integer.h
+++ b/Number_types/doc/Number_types/CGAL/leda_integer.h
@@ -3,7 +3,7 @@
 /*!
 \ingroup nt_leda
 
-The class `leda_integer` provides exact computation in \f$ \Z\f$.
+The class `leda_integer` provides exact computation in \f$  \mathbb{Z}\f$.
 The class `leda_integer` is a wrapper class that provides the functions
 needed to use the number type `leda::integer`, representing exact
 multiprecision integers provided by \leda.

--- a/Number_types/doc/Number_types/Concepts/RootOf_2.h
+++ b/Number_types/doc/Number_types/Concepts/RootOf_2.h
@@ -30,8 +30,8 @@ special construction for extensions of degree 2:
 \cgalRefines `DefaultConstructible`
 \cgalRefines `CopyConstructible`
 \cgalRefines `FromIntConstructible`
-\cgalRefines `ImplicitInteroperable` with RT
-\cgalRefines `ImplicitInteroperable` with FT
+\cgalRefines `ImplicitInteroperable` with `RT`
+\cgalRefines `ImplicitInteroperable` with `FT`
 
 \cgalHasModel `double` (not exact)
 \cgalHasModel `CGAL::Sqrt_extension`
@@ -76,4 +76,3 @@ bool operator< (const RootOf_2&a,const RootOf_2& b);
 /// @}
 
 }; /* end RootOf_2 */
-


### PR DESCRIPTION
## Summary of Changes

Use `\mathbb`

## Release Management

* Affected package(s):  Number_types
