### PR TITLE
BGL graph validity improvements

### DIFF
--- a/BGL/include/CGAL/boost/graph/Euler_operations.h
+++ b/BGL/include/CGAL/boost/graph/Euler_operations.h
@@ -1171,7 +1171,7 @@ void fill_hole(typename boost::graph_traits<Graph>::halfedge_descriptor h,
   typedef typename Traits::halfedge_descriptor halfedge_descriptor;
 
   CGAL_precondition(is_valid_halfedge_descriptor(h, g));
-  CGAL_precondition(!is_border(h, g));
+  CGAL_precondition(is_border(h, g));
 
   face_descriptor f = add_face(g);
   for(halfedge_descriptor hd : halfedges_around_face(h,g)){

--- a/BGL/include/CGAL/boost/graph/Euler_operations.h
+++ b/BGL/include/CGAL/boost/graph/Euler_operations.h
@@ -43,6 +43,7 @@ join_face(typename boost::graph_traits<Graph>::halfedge_descriptor h,
 
   typedef typename Traits::face_descriptor               face_descriptor;
 
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
 
   halfedge_descriptor hop = opposite(h,g);
   halfedge_descriptor hprev = prev(h, g), gprev = prev(hop, g);
@@ -116,6 +117,8 @@ join_vertex(typename boost::graph_traits<Graph>::halfedge_descriptor h,
   typedef typename Traits::halfedge_descriptor             halfedge_descriptor;
   typedef typename Traits::vertex_descriptor               vertex_descriptor;
   typedef Halfedge_around_target_iterator<Graph>           halfedge_around_vertex_iterator;
+
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
 
   halfedge_descriptor hop = opposite(h, g)
     , hprev = prev(hop, g)
@@ -191,8 +194,9 @@ split_vertex(typename boost::graph_traits<Graph>::halfedge_descriptor h1,
              typename boost::graph_traits<Graph>::halfedge_descriptor h2,
              Graph& g)
 {
-  CGAL_assertion(h1 != h2);
-  CGAL_assertion(target(h1, g) == target(h2, g));
+  CGAL_precondition(is_valid_halfedge_descriptor(h1, g) && is_valid_halfedge_descriptor(h2, g));
+  CGAL_precondition(h1 != h2);
+  CGAL_precondition(target(h1, g) == target(h2, g));
 
   typename boost::graph_traits<Graph>::halfedge_descriptor
     hnew = halfedge(add_edge(g), g),
@@ -226,8 +230,11 @@ split_vertex(typename boost::graph_traits<Graph>::halfedge_descriptor h1,
 template<typename Graph>
 typename boost::graph_traits<Graph>::halfedge_descriptor
 split_edge(typename boost::graph_traits<Graph>::halfedge_descriptor h, Graph& g)
-{ return opposite(split_vertex(prev(h,g), opposite(h,g),g), g); }
+{
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
 
+  return opposite(split_vertex(prev(h,g), opposite(h,g),g), g);
+}
 
 /**
  * joins the two faces incident to `h` and `opposite(h,g)`.
@@ -288,6 +295,12 @@ split_face(typename boost::graph_traits<Graph>::halfedge_descriptor h1,
   typedef typename boost::graph_traits<Graph> Traits;
   typedef typename Traits::halfedge_descriptor halfedge_descriptor;
   typedef typename Traits::face_descriptor face_descriptor;
+
+  CGAL_precondition(is_valid_halfedge_descriptor(h1, g) && is_valid_halfedge_descriptor(h2, g));
+  CGAL_precondition(h1 != h2);
+  CGAL_precondition(face(h1, g) == face(h2, g));
+  CGAL_precondition(next(h1, g) != h2 && next(h2, g) != h1);
+
   halfedge_descriptor hnew = halfedge(add_edge(g), g);
   face_descriptor fnew = add_face(g);
   internal::insert_tip( hnew, h2, g);
@@ -326,7 +339,9 @@ join_loop(typename boost::graph_traits<Graph>::halfedge_descriptor h1,
   typedef typename boost::graph_traits<Graph>              Traits;
   typedef typename Traits::halfedge_descriptor             halfedge_descriptor;
 
+  CGAL_precondition(is_valid_halfedge_descriptor(h1, g) && is_valid_halfedge_descriptor(h2, g));
   CGAL_precondition( is_border(h1,g) || face(h1, g) != face(h2, g));
+
   if (! is_border(h1,g))
     remove_face(face(h1, g), g);
   if (! is_border(h2,g))
@@ -400,13 +415,18 @@ split_loop(typename boost::graph_traits<Graph>::halfedge_descriptor h1,
   typedef typename Traits::halfedge_descriptor             halfedge_descriptor;
   typedef typename Traits::face_descriptor                 face_descriptor;
 
+  CGAL_precondition(is_valid_halfedge_descriptor(h1, g) &&
+                    is_valid_halfedge_descriptor(h2, g) &&
+                    is_valid_halfedge_descriptor(h3, g));
+
   halfedge_descriptor h = h1, i = h2, j = h3;
-   CGAL_precondition( h != i);
-        CGAL_precondition( h != j);
-        CGAL_precondition( i != j);
-        CGAL_precondition( target(h,g) == target(opposite(i,g),g));
-        CGAL_precondition( target(i,g) == target(opposite(j,g),g));
-        CGAL_precondition( target(j,g) == target(opposite(h,g),g));
+  CGAL_precondition(h != i);
+  CGAL_precondition(h != j);
+  CGAL_precondition(i != j);
+  CGAL_precondition(target(h,g) == target(opposite(i,g),g));
+  CGAL_precondition(target(i,g) == target(opposite(j,g),g));
+  CGAL_precondition(target(j,g) == target(opposite(h,g),g));
+
         // Create a copy of the triangle.
         halfedge_descriptor hnew = internal::copy(h,g);
         halfedge_descriptor inew = internal::copy(i,g);
@@ -504,6 +524,7 @@ void remove_face(typename boost::graph_traits<Graph>::halfedge_descriptor h,
   typedef typename Traits::halfedge_descriptor           halfedge_descriptor;
   typedef typename Traits::face_descriptor               face_descriptor;
 
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   CGAL_precondition(! is_border(h,g));
 
   face_descriptor f = face(h, g);
@@ -551,6 +572,8 @@ add_edge(typename boost::graph_traits<Graph>::vertex_descriptor s,
          typename boost::graph_traits<Graph>::vertex_descriptor t,
          Graph& g)
 {
+  CGAL_precondition(is_valid_vertex_descriptor(s, g) && is_valid_vertex_descriptor(t, g));
+
   typename boost::graph_traits<Graph>::edge_descriptor e = add_edge(g);
   set_target(halfedge(e, g), t, g);
   set_target(opposite(halfedge(e, g), g), s, g);
@@ -567,6 +590,9 @@ bool can_add_face(const VertexRange& vrange, const PMesh& sm)
 {
   typedef typename boost::graph_traits<PMesh>::vertex_descriptor vertex_descriptor;
   typedef typename boost::graph_traits<PMesh>::halfedge_descriptor halfedge_descriptor;
+
+  CGAL_precondition_code(for(vertex_descriptor v : vrange))
+  CGAL_precondition(is_valid_vertex_descriptor(v, sm));
 
   std::vector<typename boost::graph_traits<PMesh>::vertex_descriptor> face(vrange.begin(), vrange.end());
 
@@ -696,6 +722,9 @@ add_face(const VertexRange& vr, Graph& g)
   typedef typename boost::graph_traits<Graph>::halfedge_descriptor halfedge_descriptor;
   typedef typename boost::graph_traits<Graph>::face_descriptor     face_descriptor;
   typedef typename boost::graph_traits<Graph>::edge_descriptor     edge_descriptor;
+
+  CGAL_precondition_code(for(vertex_descriptor v : vr))
+  CGAL_precondition(is_valid_vertex_descriptor(v, g));
 
   std::vector<vertex_descriptor> vertices(vr.begin(), vr.end()); // quick and dirty copy
   unsigned int n = (unsigned int)vertices.size();
@@ -1115,7 +1144,9 @@ void make_hole(typename boost::graph_traits<Graph>::halfedge_descriptor h,
   typedef typename Traits::face_descriptor               face_descriptor;
   typedef Halfedge_around_face_iterator<Graph>           halfedge_around_face_iterator;
 
-  CGAL_precondition(! is_border(h,g));
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
+  CGAL_precondition(!is_border(h, g));
+
   face_descriptor fd = face(h, g);
   halfedge_around_face_iterator hafib, hafie;
   for(boost::tie(hafib, hafie) = halfedges_around_face(h, g);
@@ -1138,6 +1169,9 @@ void fill_hole(typename boost::graph_traits<Graph>::halfedge_descriptor h,
   typedef typename boost::graph_traits<Graph>  Traits;
   typedef typename Traits::face_descriptor     face_descriptor;
   typedef typename Traits::halfedge_descriptor halfedge_descriptor;
+
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
+  CGAL_precondition(!is_border(h, g));
 
   face_descriptor f = add_face(g);
   for(halfedge_descriptor hd : halfedges_around_face(h,g)){
@@ -1178,6 +1212,9 @@ add_center_vertex(typename boost::graph_traits<Graph>::halfedge_descriptor h,
   typedef typename Traits::vertex_descriptor               vertex_descriptor;
   typedef typename Traits::halfedge_descriptor             halfedge_descriptor;
   typedef typename Traits::face_descriptor                 face_descriptor;
+
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
+  CGAL_precondition(!is_border(h, g));
 
   halfedge_descriptor hnew = halfedge(add_edge(g),g);
   vertex_descriptor vnew = add_vertex(g);
@@ -1236,6 +1273,8 @@ remove_center_vertex(typename boost::graph_traits<Graph>::halfedge_descriptor h,
   typedef typename boost::graph_traits<Graph>              Traits;
   typedef typename Traits::halfedge_descriptor             halfedge_descriptor;
 
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
+
   // h points to the vertex that gets removed
   halfedge_descriptor h2    = opposite(next(h, g), g);
   halfedge_descriptor hret = prev(h, g);
@@ -1283,14 +1322,28 @@ add_vertex_and_face_to_border(typename boost::graph_traits<Graph>::halfedge_desc
                               typename boost::graph_traits<Graph>::halfedge_descriptor h2,
                               Graph& g)
 {
-  typename boost::graph_traits<Graph>::vertex_descriptor v = add_vertex(g);
-  typename boost::graph_traits<Graph>::face_descriptor f = add_face(g);
-  typename boost::graph_traits<Graph>::edge_descriptor e1 = add_edge(g);
-  typename boost::graph_traits<Graph>::edge_descriptor e2 = add_edge(g);
-  typename boost::graph_traits<Graph>::halfedge_descriptor he1= halfedge(e1, g);
-  typename boost::graph_traits<Graph>::halfedge_descriptor he2= halfedge(e2, g);
-  typename boost::graph_traits<Graph>::halfedge_descriptor ohe1= opposite(he1, g);
-  typename boost::graph_traits<Graph>::halfedge_descriptor ohe2= opposite(he2, g);
+  typedef typename boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor;
+  typedef typename boost::graph_traits<Graph>::halfedge_descriptor halfedge_descriptor;
+  typedef typename boost::graph_traits<Graph>::edge_descriptor edge_descriptor;
+  typedef typename boost::graph_traits<Graph>::face_descriptor face_descriptor;
+
+  CGAL_precondition(is_valid_halfedge_descriptor(h1, g) && is_valid_halfedge_descriptor(h2, g));
+  CGAL_precondition(is_border(h1, g) && is_border(h2, g));
+  CGAL_precondition(h1 != h2);
+
+  CGAL_precondition_code(halfedge_descriptor h = h1;)
+  CGAL_precondition_code(const halfedge_descriptor done = h1;)
+  CGAL_precondition_code(do { if(h == h2) break; h = next(h, g); } while(h != done);)
+  CGAL_precondition(h != done);
+
+  vertex_descriptor v = add_vertex(g);
+  face_descriptor f = add_face(g);
+  edge_descriptor e1 = add_edge(g);
+  edge_descriptor e2 = add_edge(g);
+  halfedge_descriptor he1 = halfedge(e1, g);
+  halfedge_descriptor he2 = halfedge(e2, g);
+  halfedge_descriptor ohe1= opposite(he1, g);
+  halfedge_descriptor ohe2= opposite(he2, g);
 
   set_next(ohe1, next(h1,g),g);
   set_next(h1,he1,g);
@@ -1340,6 +1393,7 @@ add_face_to_border(typename boost::graph_traits<Graph>::halfedge_descriptor h1,
                    typename boost::graph_traits<Graph>::halfedge_descriptor h2,
                    Graph& g)
 {
+  CGAL_precondition(is_valid_halfedge_descriptor(h1, g) && is_valid_halfedge_descriptor(h2, g));
   CGAL_precondition(is_border(h1,g) == true);
   CGAL_precondition(is_border(h2,g) == true);
   CGAL_precondition(h1 != h2);
@@ -1408,6 +1462,8 @@ collapse_edge(typename boost::graph_traits<Graph>::edge_descriptor e,
   typedef boost::graph_traits< Graph > Traits;
   typedef typename Traits::vertex_descriptor          vertex_descriptor;
   typedef typename Traits::halfedge_descriptor            halfedge_descriptor;
+
+  CGAL_precondition(is_valid_edge_descriptor(e, g));
 
   halfedge_descriptor pq = halfedge(e,g);
   halfedge_descriptor qp = opposite(pq, g);
@@ -1527,8 +1583,10 @@ collapse_edge(typename boost::graph_traits<Graph>::edge_descriptor v0v1,
   typedef typename Traits::vertex_descriptor          vertex_descriptor;
   typedef typename Traits::halfedge_descriptor            halfedge_descriptor;
 
+  CGAL_precondition(is_valid_edge_descriptor(v0v1, g));
+  CGAL_precondition(!get(Edge_is_constrained_map, v0v1));
+
   halfedge_descriptor pq = halfedge(v0v1,g);
-  CGAL_assertion( !get(Edge_is_constrained_map,v0v1) );
 
   halfedge_descriptor qp = opposite(pq,g);
   halfedge_descriptor pt = opposite(prev(pq,g),g);
@@ -1666,6 +1724,8 @@ flip_edge(typename boost::graph_traits<Graph>::halfedge_descriptor h,
   typedef typename Traits::halfedge_descriptor halfedge_descriptor;
   typedef typename Traits::face_descriptor     face_descriptor;
 
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
+
   vertex_descriptor s = source(h,g);
   vertex_descriptor t = target(h,g);
   halfedge_descriptor nh = next(h,g), nnh = next(nh,g), oh = opposite(h,g), noh = next(oh,g), nnoh = next(noh,g);
@@ -1705,6 +1765,8 @@ does_satisfy_link_condition(typename boost::graph_traits<Graph>::edge_descriptor
   typedef typename boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor;
   typedef typename boost::graph_traits<Graph>::halfedge_descriptor halfedge_descriptor;
   typedef CGAL::Halfedge_around_source_iterator<Graph> out_edge_iterator;
+
+  CGAL_precondition(is_valid_edge_descriptor(e, g));
 
   halfedge_descriptor v0_v1 = halfedge(e,g);
   halfedge_descriptor v1_v0 = opposite(v0_v1,g);

--- a/BGL/include/CGAL/boost/graph/Euler_operations.h
+++ b/BGL/include/CGAL/boost/graph/Euler_operations.h
@@ -38,7 +38,7 @@ typename boost::graph_traits<Graph>::halfedge_descriptor
 join_face(typename boost::graph_traits<Graph>::halfedge_descriptor h,
           Graph& g)
 {
- typedef typename boost::graph_traits<Graph> Traits;
+  typedef typename boost::graph_traits<Graph> Traits;
   typedef typename Traits::halfedge_descriptor           halfedge_descriptor;
 
   typedef typename Traits::face_descriptor               face_descriptor;
@@ -73,16 +73,16 @@ join_face(typename boost::graph_traits<Graph>::halfedge_descriptor h,
 
   remove_edge(edge(h, g), g);
   return hprev;
-
 }
+
 } // namespace EulerImpl
 
 /// \endcond
 
-  namespace Euler {
+namespace Euler {
+
 /// \ingroup PkgBGLEulerOperations
 /// @{
-
 
 /**
  * joins the two vertices incident to `h`, (that is `source(h, g)` and
@@ -260,8 +260,6 @@ join_face(typename boost::graph_traits<Graph>::halfedge_descriptor h,
   return EulerImpl::join_face(h,g);
 }
 
-
-
 /**
  * splits the face incident to `h1` and `h2`.  Creates the opposite
  * halfedges `h3` and `h4`, such that `next(h1,g) == h3` and `next(h2,g) == h4`.
@@ -298,6 +296,7 @@ split_face(typename boost::graph_traits<Graph>::halfedge_descriptor h1,
   internal::set_face_in_face_loop(opposite(hnew,g), fnew, g);
   set_halfedge(face(hnew,g), hnew, g);
   set_halfedge(face(opposite(hnew,g),g), opposite(hnew,g), g);
+
   return hnew;
 }
 
@@ -506,6 +505,7 @@ void remove_face(typename boost::graph_traits<Graph>::halfedge_descriptor h,
   typedef typename Traits::face_descriptor               face_descriptor;
 
   CGAL_precondition(! is_border(h,g));
+
   face_descriptor f = face(h, g);
 
   halfedge_descriptor end = h;
@@ -554,9 +554,9 @@ add_edge(typename boost::graph_traits<Graph>::vertex_descriptor s,
   typename boost::graph_traits<Graph>::edge_descriptor e = add_edge(g);
   set_target(halfedge(e, g), t, g);
   set_target(opposite(halfedge(e, g), g), s, g);
+
   return e;
 }
-
 
 /**
 * checks whether a new face defined by a range of vertices (identified by their descriptors,
@@ -1520,8 +1520,8 @@ collapse_edge(typename boost::graph_traits<Graph>::edge_descriptor e,
 template<typename Graph, typename EdgeIsConstrainedMap>
 typename boost::graph_traits<Graph>::vertex_descriptor
 collapse_edge(typename boost::graph_traits<Graph>::edge_descriptor v0v1,
-              Graph& g
-              , EdgeIsConstrainedMap Edge_is_constrained_map)
+              Graph& g,
+              EdgeIsConstrainedMap Edge_is_constrained_map)
 {
   typedef boost::graph_traits< Graph > Traits;
   typedef typename Traits::vertex_descriptor          vertex_descriptor;
@@ -1798,9 +1798,8 @@ does_satisfy_link_condition(typename boost::graph_traits<Graph>::edge_descriptor
 #ifndef CGAL_NO_DEPRECATED_CODE
 /// \cond SKIP_IN_MANUAL
 template<typename Graph>
-bool
-  satisfies_link_condition(typename boost::graph_traits<Graph>::edge_descriptor e,
-                           const Graph& g)
+bool satisfies_link_condition(typename boost::graph_traits<Graph>::edge_descriptor e,
+                              const Graph& g)
 {
   return does_satisfy_link_condition(e, g);
 }
@@ -1808,9 +1807,8 @@ bool
 #endif
 /// @}
 
-} // CGAL
+} // namespace Euler
 
-} // CGAL
-
+} // namespace CGAL
 
 #endif /* CGAL_EULER_OPERATIONS_H */

--- a/BGL/include/CGAL/boost/graph/IO/Generic_facegraph_builder.h
+++ b/BGL/include/CGAL/boost/graph/IO/Generic_facegraph_builder.h
@@ -151,7 +151,7 @@ public:
         put(fcm, f, face_colors[i]);
     }
 
-    return is_valid(g);
+    return is_valid_face_graph(g);
   }
 
 protected:

--- a/BGL/include/CGAL/boost/graph/IO/Generic_facegraph_builder.h
+++ b/BGL/include/CGAL/boost/graph/IO/Generic_facegraph_builder.h
@@ -151,7 +151,7 @@ public:
         put(fcm, f, face_colors[i]);
     }
 
-    return is_valid_face_graph(g);
+    return is_valid(g);
   }
 
 protected:

--- a/BGL/include/CGAL/boost/graph/generators.h
+++ b/BGL/include/CGAL/boost/graph/generators.h
@@ -195,6 +195,11 @@ make_quad(typename boost::graph_traits<Graph>::vertex_descriptor v0,
           typename boost::graph_traits<Graph>::vertex_descriptor v3,
           Graph& g)
 {
+  CGAL_precondition(is_valid_vertex_descriptor(v0, g) &&
+                    is_valid_vertex_descriptor(v1, g) &&
+                    is_valid_vertex_descriptor(v2, g) &&
+                    is_valid_vertex_descriptor(v3, g));
+
   typedef typename boost::graph_traits<Graph>::halfedge_descriptor halfedge_descriptor;
   typedef typename boost::graph_traits<Graph>::face_descriptor face_descriptor;
   halfedge_descriptor h0 = halfedge(add_edge(g), g);

--- a/BGL/include/CGAL/boost/graph/helpers.h
+++ b/BGL/include/CGAL/boost/graph/helpers.h
@@ -75,213 +75,6 @@ is_border(typename boost::graph_traits<FaceGraph>::vertex_descriptor vd,
   return boost::optional<typename boost::graph_traits<FaceGraph>::halfedge_descriptor>();
 }
 
-
- /*!
-   \ingroup PkgBGLHelperFct
-    returns `true` if there are no border edges.
-  */
-template <typename FaceGraph>
-bool is_closed(const FaceGraph& g)
-{
-  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
-  for(halfedge_descriptor hd : halfedges(g)){
-    if(is_border(hd,g)){
-      return false;
-    }
-  }
-  return true;
-}
-
-  /*!
-   \ingroup PkgBGLHelperFct
-    returns `true` if the target of `hd` has exactly two incident edges.
-  */
-template <typename FaceGraph>
-bool is_bivalent(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd, const FaceGraph& g)
-{
-  return hd == opposite(next(opposite(next(hd,g),g),g),g);
-}
-
-  /*!
-   \ingroup PkgBGLHelperFct
-    returns `true` if all vertices have exactly two incident edges.
-  */
-template <typename FaceGraph>
-  bool is_bivalent_mesh(const FaceGraph& g)
-{
-  typedef typename boost::graph_traits<FaceGraph>::vertex_descriptor vertex_descriptor;
-  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
-  for(vertex_descriptor vd : vertices(g)){
-    halfedge_descriptor hd = halfedge(vd,g);
-    if((hd == boost::graph_traits<FaceGraph>::null_halfedge()) ||
-       (! is_bivalent(hd,g))){
-      return false;
-    }
-  }
-  return true;
-}
-
-  /*!
-   \ingroup PkgBGLHelperFct
-    returns `true` if the target of `hd` has exactly three incident edges.
-  */
-template <typename FaceGraph>
-bool is_trivalent(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd, const FaceGraph& g)
-{
-  return hd == opposite(next(opposite(next(opposite(next(hd,g),g),g),g),g),g);
-}
-
-  /*!
-   \ingroup PkgBGLHelperFct
-    returns `true` if all
-    vertices have exactly three incident edges.
-  */
-template <typename FaceGraph>
-  bool is_trivalent_mesh(const FaceGraph& g)
-{
-  typedef typename boost::graph_traits<FaceGraph>::vertex_descriptor vertex_descriptor;
-  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
-  for(vertex_descriptor vd : vertices(g)){
-    halfedge_descriptor hd = halfedge(vd,g);
-    if((hd == boost::graph_traits<FaceGraph>::null_halfedge()) ||
-       (! is_trivalent(halfedge(hd,g),g))){
-      return false;
-    }
-  }
-  return true;
-}
-
- /*!
-   \ingroup PkgBGLHelperFct
-    returns `true` iff the connected component denoted by `hd` is a triangle.
-    \pre `g` must be valid.
-  */
-template <typename FaceGraph>
-  bool is_isolated_triangle(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd, const FaceGraph& g)
-{
-  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
-  halfedge_descriptor beg = hd;
-  if(is_border(hd,g)) return false;
-  for(int i=0; i<3;i++){
-    if(! is_border(opposite(hd,g),g)) return false;
-    hd = next(hd,g);
-  }
-  return hd == beg;
-}
-
- /*!
-   \ingroup PkgBGLHelperFct
-    returns `true` iff the face denoted by `hd` is a triangle, that is it has three incident halfedges.
- */
-template <typename FaceGraph>
-bool is_triangle(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd, const FaceGraph& g)
-{
-  return hd == next(next(next(hd,g),g),g);
-}
-
-  /*!
-   \ingroup PkgBGLHelperFct
-    returns `true` if all faces are triangles.
-  */
-template <typename FaceGraph>
-  bool is_triangle_mesh(const FaceGraph& g)
-{
-  typedef typename boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
-  for(face_descriptor fd : faces(g)){
-    if(! is_triangle(halfedge(fd,g),g)){
-      return false;
-    }
-  }
-  return true;
-}
-
-/*!
-   \ingroup PkgBGLHelperFct
-    returns `true` iff the connected component denoted by `hd` is a quadrilateral.
-  */
-template <typename FaceGraph>
-bool is_isolated_quad(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd, const FaceGraph& g)
-{
- typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
-  halfedge_descriptor beg = hd;
-  if(is_border(hd,g)) return false;
-  for(int i=0; i<4;i++){
-    if(! is_border(opposite(hd,g),g)) return false;
-    hd = next(hd,g);
-  }
-  return hd == beg;
-}
-
-
- /*!
-   \ingroup PkgBGLHelperFct
-    returns `true` iff the face denoted by `hd` is a quad, that is it has four incident halfedges.
- */
-template <typename FaceGraph>
-bool is_quad(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd, const FaceGraph& g)
-{
-  return hd == next(next(next(next(hd,g),g),g),g);
-}
-
-  /*!
-   \ingroup PkgBGLHelperFct
-    returns `true` if all faces are quadrilaterals.
-  */
-template <typename FaceGraph>
-  bool is_quad_mesh(const FaceGraph& g)
-{
-    typedef typename boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
-  for(face_descriptor fd : faces(g)){
-    if(! is_quad(halfedge(fd,g),g)){
-      return false;
-    }
-  }
-  return true;
-}
-
-  /*!
-   \ingroup PkgBGLHelperFct
-    returns `true` iff the connected component denoted by `hd` is a tetrahedron.
-  */
-template <typename FaceGraph>
-bool is_tetrahedron( typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd, const FaceGraph& g)
-{
-  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
-
-  halfedge_descriptor h1 = hd;
-  if(is_border(h1,g)) return false;
-  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
-  halfedge_descriptor h2 = next(h1,g);
-  halfedge_descriptor h3 = next(h2,g);
-  halfedge_descriptor h4 = next(opposite(h1,g),g );
-  halfedge_descriptor h5 = next(opposite(h2,g),g );
-  halfedge_descriptor h6 = next(opposite(h3,g),g );
-  // check halfedge combinatorics.
-  // at least three edges at vertices 1, 2, 3.
-  if ( h4 == opposite(h3,g) ) return false;
-  if ( h5 == opposite(h1,g) ) return false;
-  if ( h6 == opposite(h2,g) ) return false;
-  // exact three edges at vertices 1, 2, 3.
-  if ( next(opposite(h4,g),g) != opposite(h3,g) ) return false;
-  if ( next(opposite(h5,g),g) != opposite(h1,g) ) return false;
-  if ( next(opposite(h6,g),g) != opposite(h2,g) ) return false;
-  // three edges at v4.
-  if ( opposite(next(h4,g),g) != h5 ) return false;
-  if ( opposite(next(h5,g),g) != h6 ) return false;
-  if ( opposite(next(h6,g),g) != h4 ) return false;
-  // All facets are triangles.
-  if ( next(next(next(h1,g),g),g) != h1 ) return false;
-  if ( next(next(next(h4,g),g),g) != h4 ) return false;
-  if ( next(next(next(h5,g),g),g) != h5 ) return false;
-  if ( next(next(next(h6,g),g),g) != h6 ) return false;
-  // all edges are non-border edges.
-  if ( is_border(h1,g) ) return false;  // implies h2 and h3
-  if ( is_border(h4,g) ) return false;
-  if ( is_border(h5,g) ) return false;
-  if ( is_border(h6,g) ) return false;
-  return true;
-}
-
 namespace BGL {
 
 template <typename Graph>
@@ -409,7 +202,6 @@ bool is_valid_edge_descriptor(typename boost::graph_traits<FaceGraph>::edge_desc
   bool valid = true;
 
   // there is no null_edge() in the Graph concepts
-
 
   // Pointer integrity.
   const halfedge_descriptor h = halfedge(e, g);
@@ -770,6 +562,234 @@ bool is_valid_polygon_mesh(const Mesh& g, bool verb = false)
   }
 
   verr << "Polygon Mesh Structure is valid." << std::endl;
+  return true;
+}
+
+ /*!
+   \ingroup PkgBGLHelperFct
+    returns `true` if there are no border edges.
+  */
+template <typename FaceGraph>
+bool is_closed(const FaceGraph& g)
+{
+  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
+  for(halfedge_descriptor hd : halfedges(g)){
+    if(is_border(hd,g)){
+      return false;
+    }
+  }
+  return true;
+}
+
+  /*!
+   \ingroup PkgBGLHelperFct
+    returns `true` if the target of `hd` has exactly two incident edges.
+  */
+template <typename FaceGraph>
+bool is_bivalent(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd, const FaceGraph& g)
+{
+  CGAL_precondition(is_valid_halfedge_descriptor(hd, g));
+
+  return hd == opposite(next(opposite(next(hd,g),g),g),g);
+}
+
+  /*!
+   \ingroup PkgBGLHelperFct
+    returns `true` if all vertices have exactly two incident edges.
+  */
+template <typename FaceGraph>
+bool is_bivalent_mesh(const FaceGraph& g)
+{
+  typedef typename boost::graph_traits<FaceGraph>::vertex_descriptor vertex_descriptor;
+  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
+  for(vertex_descriptor vd : vertices(g)){
+    halfedge_descriptor hd = halfedge(vd,g);
+    if((hd == boost::graph_traits<FaceGraph>::null_halfedge()) ||
+       (! is_bivalent(hd,g))){
+      return false;
+    }
+  }
+  return true;
+}
+
+  /*!
+   \ingroup PkgBGLHelperFct
+    returns `true` if the target of `hd` has exactly three incident edges.
+  */
+template <typename FaceGraph>
+bool is_trivalent(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd, const FaceGraph& g)
+{
+  CGAL_precondition(is_valid_halfedge_descriptor(hd, g));
+
+  return hd == opposite(next(opposite(next(opposite(next(hd,g),g),g),g),g),g);
+}
+
+  /*!
+   \ingroup PkgBGLHelperFct
+    returns `true` if all
+    vertices have exactly three incident edges.
+  */
+template <typename FaceGraph>
+bool is_trivalent_mesh(const FaceGraph& g)
+{
+  typedef typename boost::graph_traits<FaceGraph>::vertex_descriptor vertex_descriptor;
+  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
+  for(vertex_descriptor vd : vertices(g)){
+    halfedge_descriptor hd = halfedge(vd,g);
+    if((hd == boost::graph_traits<FaceGraph>::null_halfedge()) ||
+       (! is_trivalent(halfedge(hd,g),g))){
+      return false;
+    }
+  }
+  return true;
+}
+
+ /*!
+   \ingroup PkgBGLHelperFct
+    returns `true` iff the connected component denoted by `hd` is a triangle.
+    \pre `g` must be valid.
+  */
+template <typename FaceGraph>
+bool is_isolated_triangle(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd,
+                          const FaceGraph& g)
+{
+  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
+
+  CGAL_precondition(is_valid_halfedge_descriptor(hd, g));
+
+  halfedge_descriptor beg = hd;
+  if(is_border(hd,g)) return false;
+  for(int i=0; i<3;i++){
+    if(! is_border(opposite(hd,g),g)) return false;
+    hd = next(hd,g);
+  }
+  return hd == beg;
+}
+
+ /*!
+   \ingroup PkgBGLHelperFct
+    returns `true` iff the face denoted by `hd` is a triangle, that is it has three incident halfedges.
+ */
+template <typename FaceGraph>
+bool is_triangle(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd,
+                 const FaceGraph& g)
+{
+  CGAL_precondition(is_valid_halfedge_descriptor(hd, g));
+
+  return hd == next(next(next(hd,g),g),g);
+}
+
+  /*!
+   \ingroup PkgBGLHelperFct
+    returns `true` if all faces are triangles.
+  */
+template <typename FaceGraph>
+bool is_triangle_mesh(const FaceGraph& g)
+{
+  typedef typename boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
+  for(face_descriptor fd : faces(g)){
+    if(! is_triangle(halfedge(fd,g),g)){
+      return false;
+    }
+  }
+  return true;
+}
+
+/*!
+   \ingroup PkgBGLHelperFct
+    returns `true` iff the connected component denoted by `hd` is a quadrilateral.
+  */
+template <typename FaceGraph>
+bool is_isolated_quad(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd,
+                      const FaceGraph& g)
+{
+  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
+
+  CGAL_precondition(is_valid_halfedge_descriptor(hd, g));
+
+  halfedge_descriptor beg = hd;
+  if(is_border(hd,g)) return false;
+  for(int i=0; i<4;i++){
+    if(! is_border(opposite(hd,g),g)) return false;
+    hd = next(hd,g);
+  }
+  return hd == beg;
+}
+
+
+ /*!
+   \ingroup PkgBGLHelperFct
+    returns `true` iff the face denoted by `hd` is a quad, that is it has four incident halfedges.
+ */
+template <typename FaceGraph>
+bool is_quad(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd,
+             const FaceGraph& g)
+{
+  CGAL_precondition(is_valid_halfedge_descriptor(hd, g));
+
+  return hd == next(next(next(next(hd,g),g),g),g);
+}
+
+  /*!
+   \ingroup PkgBGLHelperFct
+    returns `true` if all faces are quadrilaterals.
+  */
+template <typename FaceGraph>
+bool is_quad_mesh(const FaceGraph& g)
+{
+  typedef typename boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
+
+  for(face_descriptor fd : faces(g)){
+    if(! is_quad(halfedge(fd,g),g)){
+      return false;
+    }
+  }
+  return true;
+}
+
+  /*!
+   \ingroup PkgBGLHelperFct
+    returns `true` iff the connected component denoted by `hd` is a tetrahedron.
+  */
+template <typename FaceGraph>
+bool is_tetrahedron(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd,
+                    const FaceGraph& g)
+{
+  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
+
+  CGAL_precondition(is_valid_halfedge_descriptor(hd, g));
+
+  halfedge_descriptor h1 = hd;
+  if(is_border(h1,g)) return false;
+  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
+  halfedge_descriptor h2 = next(h1,g);
+  halfedge_descriptor h3 = next(h2,g);
+  halfedge_descriptor h4 = next(opposite(h1,g),g );
+  halfedge_descriptor h5 = next(opposite(h2,g),g );
+  halfedge_descriptor h6 = next(opposite(h3,g),g );
+  // check halfedge combinatorics.
+  // at least three edges at vertices 1, 2, 3.
+  if ( h4 == opposite(h3,g) ) return false;
+  if ( h5 == opposite(h1,g) ) return false;
+  if ( h6 == opposite(h2,g) ) return false;
+  // exact three edges at vertices 1, 2, 3.
+  if ( next(opposite(h4,g),g) != opposite(h3,g) ) return false;
+  if ( next(opposite(h5,g),g) != opposite(h1,g) ) return false;
+  if ( next(opposite(h6,g),g) != opposite(h2,g) ) return false;
+  // three edges at v4.
+  if ( opposite(next(h4,g),g) != h5 ) return false;
+  if ( opposite(next(h5,g),g) != h6 ) return false;
+  if ( opposite(next(h6,g),g) != h4 ) return false;
+  // All facets are triangles.
+  if ( next(next(next(h1,g),g),g) != h1 ) return false;
+  if ( next(next(next(h4,g),g),g) != h4 ) return false;
+  if ( next(next(next(h5,g),g),g) != h5 ) return false;
+  if ( next(next(next(h6,g),g),g) != h6 ) return false;
+  // all edges are non-border edges.
+  if ( is_border(h1,g) ) return false;  // implies h2 and h3
+  if ( is_border(h4,g) ) return false;
+  if ( is_border(h5,g) ) return false;
+  if ( is_border(h6,g) ) return false;
   return true;
 }
 

--- a/BGL/include/CGAL/boost/graph/helpers.h
+++ b/BGL/include/CGAL/boost/graph/helpers.h
@@ -803,6 +803,8 @@ bool is_hexahedron(typename boost::graph_traits<FaceGraph>::halfedge_descriptor 
 {
   typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
 
+  CGAL_precondition(is_valid_halfedge_descriptor(hd, g));
+
   halfedge_descriptor h1 = hd;
   if(is_border(h1,g)) return false;
   typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
@@ -863,6 +865,8 @@ void swap_vertices(typename boost::graph_traits<FaceGraph>::vertex_descriptor& p
 {
  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
 
+  CGAL_precondition(is_valid_vertex_descriptor(p, g) && is_valid_vertex_descriptor(q, g));
+
   halfedge_descriptor hq=halfedge(q, g);
   halfedge_descriptor hp=halfedge(p, g);
   for(halfedge_descriptor h : halfedges_around_target(hq, g))
@@ -881,6 +885,9 @@ void swap_edges(const typename boost::graph_traits<FaceGraph>::halfedge_descript
   typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
   typedef typename boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
   typedef typename boost::graph_traits<FaceGraph>::vertex_descriptor vertex_descriptor;
+
+  CGAL_precondition(is_valid_halfedge_descriptor(h1, g) && is_valid_halfedge_descriptor(h2, g));
+
   const halfedge_descriptor oh1 = opposite(h1, g), oh2 = opposite(h2, g);
 
   // backup vertex pointers
@@ -1010,6 +1017,8 @@ int vertex_index_in_face(const typename boost::graph_traits<Graph>::vertex_descr
 {
   typedef typename boost::graph_traits<Graph>::halfedge_descriptor halfedge_descriptor;
 
+  CGAL_precondition(is_valid_vertex_descriptor(vd, g) && is_valid_face_descriptor(fd, g));
+
   halfedge_descriptor start = halfedge(fd, g);
   halfedge_descriptor current = start;
   int counter = 0;
@@ -1050,7 +1059,7 @@ int halfedge_index_in_face(typename boost::graph_traits<Graph>::halfedge_descrip
   typedef typename boost::graph_traits<Graph>::halfedge_descriptor halfedge_descriptor;
   typedef typename boost::graph_traits<Graph>::face_descriptor     face_descriptor;
 
-  CGAL_precondition(he != boost::graph_traits<Graph>::null_halfedge());
+  CGAL_precondition(is_valid_halfedge_descriptor(he, g));
   CGAL_precondition(!is_border(he, g));
 
   face_descriptor f = face(he, g);

--- a/BGL/include/CGAL/boost/graph/helpers.h
+++ b/BGL/include/CGAL/boost/graph/helpers.h
@@ -798,7 +798,8 @@ bool is_tetrahedron(typename boost::graph_traits<FaceGraph>::halfedge_descriptor
     returns `true` iff the connected component denoted by `hd` is a hexahedron.
   */
 template <typename FaceGraph>
-bool is_hexahedron( typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd, const FaceGraph& g)
+bool is_hexahedron(typename boost::graph_traits<FaceGraph>::halfedge_descriptor hd,
+                   const FaceGraph& g)
 {
   typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
 
@@ -856,10 +857,9 @@ clear_impl(FaceGraph& g)
 }
 
 template <class FaceGraph>
-void swap_vertices(
-  typename boost::graph_traits<FaceGraph>::vertex_descriptor& p,
-  typename boost::graph_traits<FaceGraph>::vertex_descriptor& q,
-  FaceGraph& g)
+void swap_vertices(typename boost::graph_traits<FaceGraph>::vertex_descriptor& p,
+                   typename boost::graph_traits<FaceGraph>::vertex_descriptor& q,
+                   FaceGraph& g)
 {
  typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
 
@@ -874,10 +874,9 @@ void swap_vertices(
 }
 
 template <class FaceGraph>
-void swap_edges(
-  const typename boost::graph_traits<FaceGraph>::halfedge_descriptor& h1,
-  const typename boost::graph_traits<FaceGraph>::halfedge_descriptor& h2,
-  FaceGraph& g)
+void swap_edges(const typename boost::graph_traits<FaceGraph>::halfedge_descriptor& h1,
+                const typename boost::graph_traits<FaceGraph>::halfedge_descriptor& h2,
+                FaceGraph& g)
 {
   typedef typename boost::graph_traits<FaceGraph>::halfedge_descriptor halfedge_descriptor;
   typedef typename boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;

--- a/BGL/include/CGAL/boost/graph/helpers.h
+++ b/BGL/include/CGAL/boost/graph/helpers.h
@@ -82,8 +82,6 @@ bool is_valid_vertex_descriptor(typename boost::graph_traits<Graph>::vertex_desc
                                 const Graph& g,
                                 const bool verb = false)
 {
-  typedef typename boost::graph_traits<Graph>::halfedge_descriptor   halfedge_descriptor;
-
   Verbose_ostream verr(verb);
   bool valid = true;
 

--- a/BGL/include/CGAL/boost/graph/internal/helpers.h
+++ b/BGL/include/CGAL/boost/graph/internal/helpers.h
@@ -168,7 +168,7 @@ exact_num_faces(const Graph& g)
 template<typename Graph>
 bool
 is_isolated(typename boost::graph_traits<Graph>::vertex_descriptor v,
-            Graph& g)
+            const Graph& g)
 {
   return halfedge(v, g) == boost::graph_traits<Graph>::null_halfedge();
 }

--- a/BGL/include/CGAL/boost/graph/internal/helpers.h
+++ b/BGL/include/CGAL/boost/graph/internal/helpers.h
@@ -11,13 +11,14 @@
 #ifndef CGAL_BOOST_GRAPH_INTERNAL_HELPERS_H
 #define CGAL_BOOST_GRAPH_INTERNAL_HELPERS_H
 
-#include <boost/graph/graph_traits.hpp>
-#include <boost/optional.hpp>
 #include <CGAL/iterator.h>
 #include <CGAL/property_map.h>
 #include <CGAL/boost/graph/iterator.h>
 #include <CGAL/Named_function_parameters.h>
+
 #include <boost/iterator/function_output_iterator.hpp>
+
+#include <tuple>
 
 namespace CGAL {
 
@@ -133,7 +134,7 @@ std::size_t
 exact_num_vertices(const Graph& g)
 {
   typename boost::graph_traits<Graph>::vertex_iterator beg, end;
-  boost::tie(beg,end) = vertices(g);
+  std::tie(beg,end) = vertices(g);
   return std::distance(beg,end);
  }
 
@@ -142,7 +143,7 @@ std::size_t
 exact_num_halfedges(const Graph& g)
 {
   typename boost::graph_traits<Graph>::halfedge_iterator beg, end;
-  boost::tie(beg,end) = halfedges(g);
+  std::tie(beg,end) = halfedges(g);
   return std::distance(beg,end);
  }
 
@@ -151,7 +152,7 @@ std::size_t
 exact_num_edges(const Graph& g)
 {
   typename boost::graph_traits<Graph>::edge_iterator beg, end;
-  boost::tie(beg,end) = edges(g);
+  std::tie(beg,end) = edges(g);
   return std::distance(beg,end);
  }
 
@@ -160,7 +161,7 @@ std::size_t
 exact_num_faces(const Graph& g)
 {
   typename boost::graph_traits<Graph>::face_iterator beg, end;
-  boost::tie(beg,end) = faces(g);
+  std::tie(beg,end) = faces(g);
   return std::distance(beg,end);
 }
 

--- a/BGL/include/CGAL/boost/graph/iterator.h
+++ b/BGL/include/CGAL/boost/graph/iterator.h
@@ -815,6 +815,7 @@ Iterator_range<Halfedge_around_source_iterator<Graph> >
 halfedges_around_source(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Halfedge_around_source_iterator<Graph> I;
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -826,6 +827,7 @@ template<typename Graph>
 Iterator_range<Halfedge_around_source_iterator<Graph> >
 halfedges_around_source(typename boost::graph_traits<Graph>::vertex_descriptor v, const Graph& g)
 {
+  CGAL_precondition(is_valid_vertex_descriptor(v, g));
   return halfedges_around_source(opposite(halfedge(v,g),g),g);
 }
 
@@ -838,6 +840,7 @@ Iterator_range<Halfedge_around_target_iterator<Graph> >
 halfedges_around_target(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Halfedge_around_target_iterator<Graph> I;
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -849,6 +852,7 @@ template<typename Graph>
 Iterator_range<Halfedge_around_target_iterator<Graph> >
 halfedges_around_target(typename boost::graph_traits<Graph>::vertex_descriptor v, const Graph& g)
 {
+  CGAL_precondition(is_valid_vertex_descriptor(v, g));
   return halfedges_around_target(halfedge(v,g),g);
 }
 
@@ -861,6 +865,7 @@ Iterator_range<Halfedge_around_face_iterator<Graph> >
 halfedges_around_face(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Halfedge_around_face_iterator<Graph> I;
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -965,6 +970,7 @@ Iterator_range<Face_around_target_iterator<Graph> >
 faces_around_target(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Face_around_target_iterator<Graph> I;
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -977,6 +983,7 @@ Iterator_range<Face_around_face_iterator<Graph> >
 faces_around_face(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Face_around_face_iterator<Graph> I;
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -1117,6 +1124,7 @@ Iterator_range<Opposite_edge_around_face_iterator<Graph> >
 opposite_edges_around_face(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Opposite_edge_around_face_iterator<Graph> I;
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -1152,10 +1160,9 @@ Iterator_range<Edge_around_face_iterator<Graph> >
 edges_around_face(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Edge_around_face_iterator<Graph> I;
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
-
-
 
 /**
  * \ingroup PkgBGLIterators
@@ -1273,15 +1280,16 @@ Iterator_range<Vertex_around_target_iterator<Graph> >
 adjacent_vertices(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Vertex_around_target_iterator<Graph> I;
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
-
 
 template <typename Graph>
 Iterator_range<Vertex_around_target_iterator<Graph> >
 adjacent_vertices(typename boost::graph_traits<Graph>::vertex_descriptor v, const Graph& g)
 {
   typedef Vertex_around_target_iterator<Graph> I;
+  CGAL_precondition(is_valid_vertex_descriptor(v, g));
   return make_range(I(halfedge(v,g),g), I(halfedge(v,g),g,1));
 }
 
@@ -1294,6 +1302,7 @@ Iterator_range<Vertex_around_target_iterator<Graph> >
 vertices_around_target(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Vertex_around_target_iterator<Graph> I;
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -1302,6 +1311,7 @@ Iterator_range<Vertex_around_target_iterator<Graph> >
 vertices_around_target(typename boost::graph_traits<Graph>::vertex_descriptor v, const Graph& g)
 {
   typedef Vertex_around_target_iterator<Graph> I;
+  CGAL_precondition(is_valid_vertex_descriptor(v, g));
   return make_range(I(halfedge(v,g),g), I(halfedge(v,g),g,1));
 }
 /**
@@ -1313,6 +1323,7 @@ Iterator_range<Vertex_around_face_iterator<Graph> >
 vertices_around_face(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Vertex_around_face_iterator<Graph> I;
+  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -1355,9 +1366,6 @@ private:
   typename  boost::graph_traits<Graph>::edge_descriptor dereference() const { return opp(*this->base_reference()); }
 };
 
-
-
-
 template <class Graph>
 class In_edge_iterator
   : public boost::iterator_adaptor<
@@ -1396,12 +1404,6 @@ public:
   typename  boost::graph_traits<Graph>::edge_descriptor dereference() const { return fct(*this->base_reference()); }
 };
 
-
-
-
-
-
 } // CGAL
-
 
 #endif /* CGAL_BGL_ITERATORS_H */

--- a/BGL/include/CGAL/boost/graph/iterator.h
+++ b/BGL/include/CGAL/boost/graph/iterator.h
@@ -815,7 +815,6 @@ Iterator_range<Halfedge_around_source_iterator<Graph> >
 halfedges_around_source(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Halfedge_around_source_iterator<Graph> I;
-  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -827,7 +826,6 @@ template<typename Graph>
 Iterator_range<Halfedge_around_source_iterator<Graph> >
 halfedges_around_source(typename boost::graph_traits<Graph>::vertex_descriptor v, const Graph& g)
 {
-  CGAL_precondition(is_valid_vertex_descriptor(v, g));
   return halfedges_around_source(opposite(halfedge(v,g),g),g);
 }
 
@@ -840,7 +838,6 @@ Iterator_range<Halfedge_around_target_iterator<Graph> >
 halfedges_around_target(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Halfedge_around_target_iterator<Graph> I;
-  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -852,7 +849,6 @@ template<typename Graph>
 Iterator_range<Halfedge_around_target_iterator<Graph> >
 halfedges_around_target(typename boost::graph_traits<Graph>::vertex_descriptor v, const Graph& g)
 {
-  CGAL_precondition(is_valid_vertex_descriptor(v, g));
   return halfedges_around_target(halfedge(v,g),g);
 }
 
@@ -865,7 +861,6 @@ Iterator_range<Halfedge_around_face_iterator<Graph> >
 halfedges_around_face(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Halfedge_around_face_iterator<Graph> I;
-  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -970,7 +965,6 @@ Iterator_range<Face_around_target_iterator<Graph> >
 faces_around_target(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Face_around_target_iterator<Graph> I;
-  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -983,7 +977,6 @@ Iterator_range<Face_around_face_iterator<Graph> >
 faces_around_face(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Face_around_face_iterator<Graph> I;
-  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -1124,7 +1117,6 @@ Iterator_range<Opposite_edge_around_face_iterator<Graph> >
 opposite_edges_around_face(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Opposite_edge_around_face_iterator<Graph> I;
-  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -1160,9 +1152,10 @@ Iterator_range<Edge_around_face_iterator<Graph> >
 edges_around_face(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Edge_around_face_iterator<Graph> I;
-  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
+
+
 
 /**
  * \ingroup PkgBGLIterators
@@ -1280,16 +1273,15 @@ Iterator_range<Vertex_around_target_iterator<Graph> >
 adjacent_vertices(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Vertex_around_target_iterator<Graph> I;
-  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
+
 
 template <typename Graph>
 Iterator_range<Vertex_around_target_iterator<Graph> >
 adjacent_vertices(typename boost::graph_traits<Graph>::vertex_descriptor v, const Graph& g)
 {
   typedef Vertex_around_target_iterator<Graph> I;
-  CGAL_precondition(is_valid_vertex_descriptor(v, g));
   return make_range(I(halfedge(v,g),g), I(halfedge(v,g),g,1));
 }
 
@@ -1302,7 +1294,6 @@ Iterator_range<Vertex_around_target_iterator<Graph> >
 vertices_around_target(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Vertex_around_target_iterator<Graph> I;
-  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -1311,7 +1302,6 @@ Iterator_range<Vertex_around_target_iterator<Graph> >
 vertices_around_target(typename boost::graph_traits<Graph>::vertex_descriptor v, const Graph& g)
 {
   typedef Vertex_around_target_iterator<Graph> I;
-  CGAL_precondition(is_valid_vertex_descriptor(v, g));
   return make_range(I(halfedge(v,g),g), I(halfedge(v,g),g,1));
 }
 /**
@@ -1323,7 +1313,6 @@ Iterator_range<Vertex_around_face_iterator<Graph> >
 vertices_around_face(typename boost::graph_traits<Graph>::halfedge_descriptor h, const Graph& g)
 {
   typedef Vertex_around_face_iterator<Graph> I;
-  CGAL_precondition(is_valid_halfedge_descriptor(h, g));
   return make_range(I(h,g), I(h,g,1));
 }
 
@@ -1366,6 +1355,9 @@ private:
   typename  boost::graph_traits<Graph>::edge_descriptor dereference() const { return opp(*this->base_reference()); }
 };
 
+
+
+
 template <class Graph>
 class In_edge_iterator
   : public boost::iterator_adaptor<
@@ -1404,6 +1396,12 @@ public:
   typename  boost::graph_traits<Graph>::edge_descriptor dereference() const { return fct(*this->base_reference()); }
 };
 
+
+
+
+
+
 } // CGAL
+
 
 #endif /* CGAL_BGL_ITERATORS_H */

--- a/BGL/test/BGL/test_test_face.cpp
+++ b/BGL/test/BGL/test_test_face.cpp
@@ -23,9 +23,9 @@ int main()
     vertex_descriptor vs = CGAL::add_vertex(sm);
     std::array<vertex_descriptor,0> face0;
     assert( ! CGAL::Euler::can_add_face(face0,sm) );
-    std::array<vertex_descriptor,1> face1;
+    std::array<vertex_descriptor,1> face1 = { vp };
     assert( ! CGAL::Euler::can_add_face(face1,sm) );
-    std::array<vertex_descriptor,2> face2;
+    std::array<vertex_descriptor,2> face2 = { vp, vq };
     assert( ! CGAL::Euler::can_add_face(face2,sm) );
 
     std::array<vertex_descriptor,3> face = { vp, vq, vr };
@@ -55,6 +55,8 @@ int main()
     std::swap(face[0],face[1]);
     assert( ! CGAL::Euler::can_add_face(face,sm) );
   }
+
+  std::cout << "Done" << std::endl;
 
   return 0;
 }

--- a/Heat_method_3/doc/Heat_method_3/PackageDescription.txt
+++ b/Heat_method_3/doc/Heat_method_3/PackageDescription.txt
@@ -1,13 +1,12 @@
 // The Heat Method
 
-/// \defgroup PkgHeatMethod Heat Method Reference
+/// \defgroup PkgHeatMethodRef Heat Method Reference
 
 /// \defgroup PkgHeatMethodConcepts Concepts
-/// \ingroup PkgHeatMethod
-
+/// \ingroup PkgHeatMethodRef
 
 /*!
-\addtogroup PkgHeatMethod
+\addtogroup PkgHeatMethodRef
 
 \cgalPkgDescriptionBegin{The Heat Method,PkgHeatMethod}
 \cgalPkgPicture{heat-method-small.png}
@@ -17,8 +16,8 @@
 \cgalPkgDesc{The package provides an algorithm that solves the single- or
 multiple-source shortest path problem by returning an approximation of the geodesic distance
 for all vertices of a triangle mesh to the closest vertex in a given set of
-source vertices. }
-\cgalPkgManuals{Chapter_HeatMethod,PkgHeatMethod}
+source vertices.}
+\cgalPkgManuals{Chapter_HeatMethod,PkgHeatMethodRef}
 \cgalPkgSummaryEnd
 \cgalPkgShortInfoBegin
 \cgalPkgSince{4.14}

--- a/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
@@ -487,13 +487,16 @@ private:
     }
     m_source_change_flag = false;
 
-    CGAL_precondition(is_triangle_mesh(tm));
     Index i = 0;
     for(vertex_descriptor vd : vertices(tm)){
       put(vertex_id_map, vd, i++);
     }
     Index face_i = 0;
     for(face_descriptor fd : faces(tm)){
+      // Do not use BGL's version because `tm` is not a valid halfedge graph due to its weird vertex descriptor:
+      // it fails checks such as halfedge(target(h, g), g) == h
+      CGAL_assertion_code(halfedge_descriptor hd = halfedge(fd, tm);)
+      CGAL_assertion(hd == next(next(next(hd,tm),tm),tm));
       put(face_id_map, fd, face_i++);
     }
     dimension = static_cast<int>(num_vertices(tm));

--- a/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
@@ -90,7 +90,6 @@ protected:
   Face_id_map face_id_map;
 
 public:
-
   /*!
     \brief Constructor
   */
@@ -99,7 +98,6 @@ public:
   {
     build();
   }
-
 
   /*!
     \brief Constructor
@@ -110,23 +108,20 @@ public:
     build();
   }
 
-
   /**
    * returns the triangle mesh the algorithm is running on.
    */
-  const TriangleMesh& triangle_mesh() const{
+  const TriangleMesh& triangle_mesh() const
+  {
     return tm;
   }
 
-
 private:
-
   const Matrix&
   mass_matrix() const
   {
     return m_mass_matrix;
   }
-
 
   const Matrix&
   cotan_matrix() const
@@ -134,13 +129,11 @@ private:
     return m_cotan_matrix;
   }
 
-
   const VertexPointMap&
   vertex_point_map() const
   {
     return vpm;
   }
-
 
   const Vertex_id_map&
   get_vertex_id_map() const
@@ -149,7 +142,6 @@ private:
   }
 
 public:
-
   /**
    * adds `vd` to the source set, returning `false` iff `vd` is already in the set.
    */
@@ -176,7 +168,6 @@ public:
     }
   }
 
-
   /**
    * removes `vd` from the source set, returning `true` iff `vd` was in the set.
    */
@@ -187,7 +178,6 @@ public:
     m_source_change_flag = true;
     return (m_sources.erase(v2v(vd)) == 1);
   }
-
 
   /**
    * clears the current source set.
@@ -203,7 +193,6 @@ public:
   /**
    * returns the set of  source vertices.
    */
-
   const Vertex_const_range&
   sources() const
   {
@@ -211,7 +200,6 @@ public:
   }
 
 private:
-
   double
   summation_of_edges() const
   {
@@ -237,13 +225,11 @@ private:
     return edge_sum;
   }
 
-
   double
   time_step() const
   {
     return m_time_step;
   }
-
 
   void
   update_kronecker_delta()
@@ -263,13 +249,11 @@ private:
     m_kronecker.swap(K);
   }
 
-
   const Matrix&
   kronecker_delta() const
   {
     return m_kronecker;
   }
-
 
   void factor_cotan_laplace()
   {
@@ -292,7 +276,6 @@ private:
       CGAL_error_msg("Eigen Solving in cotan failed");
     }
   }
-
 
   void
   compute_unit_gradient()
@@ -352,7 +335,6 @@ private:
     }
   }
 
-
   void
   compute_divergence()
   {
@@ -400,7 +382,6 @@ private:
     indexD.swap(m_index_divergence);
   }
 
-
   // modifies m_solved_phi
   void
   value_at_source_set(const Vector& phi)
@@ -432,7 +413,6 @@ private:
     m_solved_phi.swap(source_set_val);
   }
 
-
   void
   factor_phi()
   {
@@ -442,7 +422,6 @@ private:
       CGAL_error_msg("Eigen Decomposition in solve_phi() failed");
     }
   }
-
 
   void
   solve_phi()
@@ -456,7 +435,6 @@ private:
     value_at_source_set(phi);
   }
 
-
   // this function returns a (number of vertices)x1 vector where
   // the ith index has the distance from the first vertex to the ith vertex
   const Vector&
@@ -466,7 +444,6 @@ private:
   }
 
 public:
-
   /**
    *  Updates the distance property map after changes in the source set.
    **/
@@ -494,7 +471,6 @@ public:
   }
 
 private:
-
   void
   build()
   {
@@ -788,6 +764,7 @@ class Surface_mesh_geodesic_distances_3
   typedef typename Default::Get<
     VertexPointMap,
     typename boost::property_map< TriangleMesh, vertex_point_t>::const_type>::type Vertex_point_map;
+
   typedef
     typename Default::Get<Traits,
                           typename Kernel_traits<
@@ -808,7 +785,6 @@ class Surface_mesh_geodesic_distances_3
   }
 
 public:
-
   /// Vertex descriptor type
   typedef typename boost::graph_traits<TriangleMesh>::vertex_descriptor vertex_descriptor;
   #ifndef DOXYGEN_RUNNING

--- a/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
@@ -21,6 +21,7 @@
 #include <CGAL/property_map.h>
 #include <CGAL/double.h>
 #include <CGAL/boost/graph/properties.h>
+#include <CGAL/Default.h>
 #include <CGAL/Dynamic_property_map.h>
 #include <CGAL/squared_distance_3.h>
 #include <CGAL/number_utils.h>

--- a/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
@@ -92,8 +92,13 @@ public:
   /*!
     \brief Constructor
   */
-  Surface_mesh_geodesic_distances_3(const TriangleMesh& tm)
-    : vertex_id_map(get(Vertex_property_tag(),tm)), face_id_map(get(Face_property_tag(),tm)), v2v(tm), tm(tm), vpm(get(vertex_point,tm))
+  Surface_mesh_geodesic_distances_3(const TriangleMesh& tm,
+                                    VertexPointMap vpm)
+    : vertex_id_map(get(Vertex_property_tag(), tm)),
+      face_id_map(get(Face_property_tag(), tm)),
+      v2v(tm),
+      tm(tm),
+      vpm(vpm)
   {
     build();
   }
@@ -101,8 +106,8 @@ public:
   /*!
     \brief Constructor
   */
-  Surface_mesh_geodesic_distances_3(const TriangleMesh& tm, VertexPointMap vpm)
-    : vertex_id_map(get(Vertex_property_tag(),tm)), face_id_map(get(Face_property_tag(),tm)), v2v(tm), tm(tm), vpm(vpm)
+  Surface_mesh_geodesic_distances_3(const TriangleMesh& tm)
+    : Surface_mesh_geodesic_distances_3(tm, get(vertex_point, tm))
   {
     build();
   }

--- a/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
@@ -714,7 +714,7 @@ struct Base_helper<TriangleMesh, Traits, Intrinsic_Delaunay, LA, VertexPointMap>
 
 
 /**
- * \ingroup PkgHeatMethod
+ * \ingroup PkgHeatMethodRef
  *
  * Class `Surface_mesh_geodesic_distances_3` computes estimated geodesic distances for a set of source vertices where sources can be added and removed.
  * The class performs a preprocessing step that only depends on the mesh, so that the distance computation takes less
@@ -906,7 +906,7 @@ public:
 };
 
 #if defined(DOXYGEN_RUNNING) || defined(CGAL_EIGEN3_ENABLED)
-/// \ingroup PkgHeatMethod
+/// \ingroup PkgHeatMethodRef
 /// computes for each vertex of the triangle mesh `tm` the estimated geodesic distance to a given source vertex.
 /// This function is provided only if \ref thirdpartyEigen "Eigen" 3.3 (or greater) is available and `CGAL_EIGEN3_ENABLED` is defined.
 /// \tparam TriangleMesh a triangulated surface mesh, model of `FaceListGraph` and `HalfedgeListGraph`.
@@ -947,7 +947,7 @@ estimate_geodesic_distances(const TriangleMesh& tm,
 #endif
 
 
-/// \ingroup PkgHeatMethod
+/// \ingroup PkgHeatMethodRef
 /// computes for each vertex  of the triangle mesh `tm` the estimated geodesic distance to a given set of source vertices.
 /// This function is provided only if \ref thirdpartyEigen "Eigen" 3.3 (or greater) is available and `CGAL_EIGEN3_ENABLED` is defined.
 /// \tparam TriangleMesh a triangulated surface mesh, model of `FaceListGraph` and `HalfedgeListGraph`

--- a/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/Surface_mesh_geodesic_distances_3.h
@@ -23,7 +23,6 @@
 #include <CGAL/boost/graph/properties.h>
 #include <CGAL/Dynamic_property_map.h>
 #include <CGAL/squared_distance_3.h>
-#include <CGAL/Polygon_mesh_processing/measure.h>
 #include <CGAL/number_utils.h>
 #ifdef CGAL_EIGEN3_ENABLED
 #include <CGAL/Eigen_solver_traits.h>

--- a/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
@@ -66,13 +66,16 @@ bool has_degenerate_faces(const TriangleMesh& tm, const Traits& traits)
   typename Traits::Construct_cross_product_vector_3
     cross_product = traits.construct_cross_product_vector_3_object();
 
-  typename boost::property_map< TriangleMesh, boost::vertex_point_t>::const_type
-    vpm = get(boost::vertex_point, tm);
+  typedef typename boost::property_map< TriangleMesh, boost::vertex_point_t>::const_type VPM;
+  typedef typename boost::property_traits<VPM>::reference Point_ref;
+
+  VPM vpm = get(boost::vertex_point, tm);
+
   for (typename boost::graph_traits<TriangleMesh>::face_descriptor f : faces(tm))
   {
-    const Point p1 = get(vpm, target(halfedge(f, tm), tm));
-    const Point p2 = get(vpm, target(next(halfedge(f, tm), tm), tm));
-    const Point p3 = get(vpm, target(next(next(halfedge(f, tm), tm), tm), tm));
+    const Point_ref p1 = get(vpm, target(halfedge(f, tm), tm));
+    const Point_ref p2 = get(vpm, target(next(halfedge(f, tm), tm), tm));
+    const Point_ref p3 = get(vpm, target(next(next(halfedge(f, tm), tm), tm), tm));
     Vector_3 v = cross_product(construct_vector(p1, p2), construct_vector(p1, p3));
     if(scalar_product(v, v) == 0.)
       return true;
@@ -278,7 +281,7 @@ private:
   }
 
 
-  //returns true if edge is locally Delaunay (opposing angles are less than pi):
+  //returns `true` if edge is locally Delaunay (opposing angles are less than pi):
   //Two ways of doing this: taking angles directly (not good with virtual edges)
   //OR: taking edge length and using law of cosines,
   //The second way checks cotan weights
@@ -797,11 +800,11 @@ struct IDT_vertex_distance_property_map {
 
   friend void put(IDT_vertex_distance_property_map<IDT,PM> idtpm,
                   key_type vd,
-                  value_type v)
+                  value_type val)
   {
     typename boost::graph_traits<TM>::vertex_descriptor tm_vd = target(vd.hd, idtpm.idt.triangle_mesh());
 
-    put(idtpm.pm, idtpm.idt.v2v.at(tm_vd), v);
+    put(idtpm.pm, idtpm.idt.v2v.at(tm_vd), val);
   }
 };
 

--- a/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
@@ -57,7 +57,6 @@ namespace internal {
 template<typename TriangleMesh, typename Traits>
 bool has_degenerate_faces(const TriangleMesh& tm, const Traits& traits)
 {
-  typedef typename Traits::Point_3  Point;
   typedef typename Traits::Vector_3 Vector_3;
   typename Traits::Construct_vector_3
     construct_vector = traits.construct_vector_3_object();

--- a/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
@@ -82,7 +82,8 @@ bool has_degenerate_faces(const TriangleMesh& tm, const Traits& traits)
 }
 
 template <class TriangleMesh>
-struct Intrinsic_Delaunay_triangulation_3_vertex_descriptor {
+struct Intrinsic_Delaunay_triangulation_3_vertex_descriptor
+{
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor halfedge_descriptor;
   typedef typename boost::graph_traits<TriangleMesh>::vertex_descriptor vertex_descriptor;
   halfedge_descriptor hd;
@@ -99,6 +100,16 @@ struct Intrinsic_Delaunay_triangulation_3_vertex_descriptor {
   explicit Intrinsic_Delaunay_triangulation_3_vertex_descriptor(const vertex_descriptor vd, const TriangleMesh& tm)
     : hd(halfedge(vd,tm))
   {}
+
+  bool operator==(const Intrinsic_Delaunay_triangulation_3_vertex_descriptor& other) const
+  {
+    return hd == other.hd;
+  }
+
+  bool operator!=(const Intrinsic_Delaunay_triangulation_3_vertex_descriptor& other) const
+  {
+    return ! (*this == other);
+  }
 };
 
 template <class TriangleMesh>
@@ -549,6 +560,8 @@ struct graph_traits<CGAL::Heat_method_3::Intrinsic_Delaunay_triangulation_3<TM,T
 
   typedef typename boost::graph_traits<TM>::vertices_size_type vertices_size_type;
 
+  static vertex_descriptor null_vertex() { return vertex_descriptor(boost::graph_traits<TM>::null_halfedge()); }
+  static halfedge_descriptor null_halfedge() { return boost::graph_traits<TM>::null_halfedge(); }
   static face_descriptor null_face() { return boost::graph_traits<TM>::null_face(); }
 };
 
@@ -589,7 +602,7 @@ template <typename TM,
           typename T>
 Iterator_range<typename boost::graph_traits<Intrinsic_Delaunay_triangulation_3<TM,T> >::vertex_iterator>
 vertices(const Intrinsic_Delaunay_triangulation_3<TM,T>& idt)
- {
+{
    std::pair<typename boost::graph_traits<TM>::vertex_iterator,
              typename boost::graph_traits<TM>::vertex_iterator> p = vertices(idt.triangle_mesh());
 
@@ -597,7 +610,7 @@ vertices(const Intrinsic_Delaunay_triangulation_3<TM,T>& idt)
   Fct fct(idt.triangle_mesh());
   return make_range(boost::make_transform_iterator(p.first, fct),
                     boost::make_transform_iterator(p.second,fct));
- }
+}
 
 
 template <typename TM,
@@ -622,9 +635,9 @@ template <typename TM,
           typename T>
 Iterator_range<typename boost::graph_traits<TM>::face_iterator>
 faces(const Intrinsic_Delaunay_triangulation_3<TM,T>& idt)
- {
-   return make_range( faces(idt.triangle_mesh()) );
- }
+{
+  return make_range( faces(idt.triangle_mesh()) );
+}
 
 template <typename TM,
           typename T>
@@ -659,7 +672,7 @@ template <typename TM,
           typename T>
 typename boost::graph_traits<Intrinsic_Delaunay_triangulation_3<TM,T> >::halfedge_descriptor
 halfedge(typename boost::graph_traits<Intrinsic_Delaunay_triangulation_3<TM,T> >::edge_descriptor ed,
-       const Intrinsic_Delaunay_triangulation_3<TM,T>& idt)
+         const Intrinsic_Delaunay_triangulation_3<TM,T>& idt)
 {
   return halfedge(ed, idt.triangle_mesh());
 }
@@ -684,6 +697,23 @@ next(typename boost::graph_traits<Intrinsic_Delaunay_triangulation_3<TM,T> >::ha
   return next(hd, idt.triangle_mesh());
 }
 
+template <typename TM,
+          typename T>
+typename boost::graph_traits<Intrinsic_Delaunay_triangulation_3<TM,T> >::halfedge_descriptor
+prev(typename boost::graph_traits<Intrinsic_Delaunay_triangulation_3<TM,T> >::halfedge_descriptor hd,
+     const Intrinsic_Delaunay_triangulation_3<TM,T>& idt)
+{
+  return prev(hd, idt.triangle_mesh());
+}
+
+template <typename TM,
+          typename T>
+typename boost::graph_traits<Intrinsic_Delaunay_triangulation_3<TM,T> >::edge_descriptor
+edge(typename boost::graph_traits<Intrinsic_Delaunay_triangulation_3<TM,T> >::halfedge_descriptor hd,
+     const Intrinsic_Delaunay_triangulation_3<TM,T>& idt)
+{
+  return edge(hd, idt.triangle_mesh());
+}
 
 template <typename TM,
           typename T>

--- a/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
@@ -404,7 +404,8 @@ private:
   void
   build(VertexPointMap vpm)
   {
-    CGAL_precondition(is_triangle_mesh(m_intrinsic_tm));
+    CGAL_precondition(is_empty(m_intrinsic_tm));
+    CGAL_precondition(is_triangle_mesh(m_input_tm));
 
     typename Traits::Compute_squared_distance_3 squared_distance = Traits().compute_squared_distance_3_object();
 

--- a/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
@@ -132,7 +132,7 @@ struct Intrinsic_Delaunay_triangulation_3_vertex_iterator_functor
 };
 
 /**
- * \ingroup PkgHeatMethod
+ * \ingroup PkgHeatMethodRef
  *
  * Class `Intrinsic_Delaunay_triangulation_3` is a remeshing algorithm to improve the approximation of the `Surface_mesh_geodesic_distances_3`.
  * It internally makes a copy of the triangle mesh, performs edge flips, and computes 2D vertex coordinates per face

--- a/Heat_method_3/package_info/Heat_method_3/dependencies
+++ b/Heat_method_3/package_info/Heat_method_3/dependencies
@@ -11,7 +11,6 @@ Interval_support
 Kernel_23
 Modular_arithmetic
 Number_types
-Polygon_mesh_processing
 Profiling_tools
 Property_map
 Random_numbers

--- a/Heat_method_3/package_info/Heat_method_3/dependencies
+++ b/Heat_method_3/package_info/Heat_method_3/dependencies
@@ -4,7 +4,6 @@ Cartesian_kernel
 Circulator
 Distance_2
 Distance_3
-Filtered_kernel
 Heat_method_3
 Installation
 Interval_support

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -179,6 +179,8 @@ namespace CGAL {
       using parameters::choose_parameter;
       using parameters::get_parameter;
 
+      CGAL_precondition(is_valid_edge_descriptor(ed, pmesh));
+
       typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
         vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                                get_const_property_map(CGAL::vertex_point, pmesh));
@@ -233,6 +235,8 @@ namespace CGAL {
     {
       using parameters::choose_parameter;
       using parameters::get_parameter;
+
+      CGAL_precondition(is_valid_face_descriptor(fd, pmesh));
 
       typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
         vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -89,6 +89,8 @@ void sum_normals(const PM& pmesh,
 
   typedef typename boost::property_traits<VertexPointMap>::reference    Point_ref;
 
+  CGAL_precondition(is_valid_face_descriptor(f, pmesh));
+
   halfedge_descriptor he = halfedge(f, pmesh);
   vertex_descriptor v = source(he, pmesh);
   vertex_descriptor the = target(he,pmesh);
@@ -171,6 +173,8 @@ compute_face_normal(typename boost::graph_traits<PolygonMesh>::face_descriptor f
 {
   using parameters::choose_parameter;
   using parameters::get_parameter;
+
+  CGAL_precondition(is_valid_face_descriptor(f, pmesh));
 
   typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type               GT;
   GT traits = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
@@ -664,6 +668,8 @@ compute_vertex_normal(typename boost::graph_traits<PolygonMesh>::vertex_descript
   using parameters::choose_parameter;
   using parameters::is_default_parameter;
   using parameters::get_parameter;
+
+  CGAL_precondition(is_valid_vertex_descriptor(v, pmesh));
 
   typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor      halfedge_descriptor;
   typedef typename boost::graph_traits<PolygonMesh>::face_descriptor          face_descriptor;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/detect_features.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/detect_features.h
@@ -57,6 +57,8 @@ is_sharp(const typename boost::graph_traits<PolygonMesh>::halfedge_descriptor h,
 
   typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor       halfedge_descriptor;
 
+  CGAL_precondition(is_valid_halfedge_descriptor(h, pmesh));
+
   if(is_border_edge(h, pmesh))
     return false;
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/refine_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/refine_impl.h
@@ -103,7 +103,7 @@ private:
   {
     for(face_descriptor fd : faces)
     {
-      CGAL_assertion(fd  != boost::graph_traits<PolygonMesh>::null_face());
+      CGAL_assertion(is_valid_face_descriptor(fd, pmesh));
 
       vertex_descriptor vi = target(halfedge(fd,pmesh),pmesh);
       vertex_descriptor vj = target(next(halfedge(fd,pmesh),pmesh),pmesh);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/locate.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/locate.h
@@ -1307,7 +1307,6 @@ locate_in_common_face(std::pair<typename boost::graph_traits<TriangleMesh>::face
   else
   {
     const face_descriptor fd = boost::get<face_descriptor>(dv);
-
     CGAL_precondition(fd != boost::graph_traits<TriangleMesh>::null_face());
 
     query_location = locate_in_face(query, fd, tm, np);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -112,7 +112,7 @@ edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descriptor h,
   using parameters::choose_parameter;
   using parameters::get_parameter;
 
-  CGAL_precondition(boost::graph_traits<PolygonMesh>::null_halfedge() != h);
+  CGAL_precondition(is_valid_halfedge_descriptor(h, pmesh));
 
   typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
@@ -132,6 +132,8 @@ edge_length(typename boost::graph_traits<PolygonMesh>::edge_descriptor e,
             const PolygonMesh& pmesh,
             const NamedParameters& np = parameters::default_values())
 {
+  CGAL_precondition(is_valid_edge_descriptor(e, pmesh));
+
   return edge_length(halfedge(e, pmesh), pmesh, np);
 }
 
@@ -187,7 +189,7 @@ squared_edge_length(typename boost::graph_traits<PolygonMesh>::halfedge_descript
   using parameters::choose_parameter;
   using parameters::get_parameter;
 
-  CGAL_precondition(boost::graph_traits<PolygonMesh>::null_halfedge() != h);
+  CGAL_precondition(is_valid_halfedge_descriptor(h, pmesh));
 
   typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
@@ -208,6 +210,8 @@ squared_edge_length(typename boost::graph_traits<PolygonMesh>::edge_descriptor e
                     const PolygonMesh& pmesh,
                     const NamedParameters& np = parameters::default_values())
 {
+  CGAL_precondition(is_valid_edge_descriptor(e, pmesh));
+
   return squared_edge_length(halfedge(e, pmesh), pmesh, np);
 }
 
@@ -415,7 +419,7 @@ face_area(typename boost::graph_traits<TriangleMesh>::face_descriptor f,
 
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor halfedge_descriptor;
 
-  CGAL_precondition(boost::graph_traits<TriangleMesh>::null_face() != f);
+  CGAL_precondition(is_valid_face_descriptor(f, tmesh));
 
   typename GetVertexPointMap<TriangleMesh, CGAL_NP_CLASS>::const_type
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
@@ -486,7 +490,7 @@ squared_face_area(typename boost::graph_traits<TriangleMesh>::face_descriptor f,
 
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor halfedge_descriptor;
 
-  CGAL_precondition(boost::graph_traits<TriangleMesh>::null_face() != f);
+  CGAL_precondition(is_valid_face_descriptor(f, tmesh));
 
   typename GetVertexPointMap<TriangleMesh, CGAL_NP_CLASS>::const_type
       vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
@@ -741,7 +745,7 @@ face_aspect_ratio(typename boost::graph_traits<TriangleMesh>::face_descriptor f,
                   const TriangleMesh& tmesh,
                   const CGAL_NP_CLASS& np = parameters::default_values())
 {
-  CGAL_precondition(f != boost::graph_traits<TriangleMesh>::null_face());
+  CGAL_precondition(is_valid_face_descriptor(f, tmesh));
   CGAL_precondition(is_triangle(halfedge(f, tmesh), tmesh));
 
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor           halfedge_descriptor;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/merge_border_vertices.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/merge_border_vertices.h
@@ -292,6 +292,8 @@ void merge_duplicated_vertices_in_boundary_cycle(typename boost::graph_traits<Po
   using parameters::get_parameter;
   using parameters::choose_parameter;
 
+  CGAL_precondition(is_valid_halfedge_descriptor(h, pm));
+
   Vpm vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                              get_const_property_map(vertex_point, pm));
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h
@@ -127,9 +127,8 @@ public:
       for(std::size_t j = 0; j < size; ++j)
         vr[j] = vertices[polygon[j] ];
 
-      typename boost::graph_traits<PolygonMesh>::face_descriptor fd =
-          CGAL::Euler::add_face(vr, pmesh);
-      CGAL_assertion(fd != boost::graph_traits<PolygonMesh>::null_face());
+      typename boost::graph_traits<PolygonMesh>::face_descriptor fd = CGAL::Euler::add_face(vr, pmesh);
+      CGAL_postcondition(is_valid_face_descriptor(fd, pmesh));
       *i2f++ = std::make_pair(i, fd);
     }
   }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/shape_predicates.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/shape_predicates.h
@@ -80,6 +80,8 @@ bool is_degenerate_edge(typename boost::graph_traits<PolygonMesh>::edge_descript
   using parameters::get_parameter;
   using parameters::choose_parameter;
 
+  CGAL_precondition(is_valid_edge_descriptor(e, pm));
+
   typedef typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type VertexPointMap;
   VertexPointMap vpmap = choose_parameter(get_parameter(np, internal_np::vertex_point),
                                           get_const_property_map(vertex_point, pm));
@@ -190,10 +192,11 @@ bool is_degenerate_triangle_face(typename boost::graph_traits<TriangleMesh>::fac
                                  const TriangleMesh& tm,
                                  const NamedParameters& np = parameters::default_values())
 {
-  CGAL_precondition(CGAL::is_triangle(halfedge(f, tm), tm));
-
   using parameters::get_parameter;
   using parameters::choose_parameter;
+
+  CGAL_precondition(is_valid_face_descriptor(f, tm));
+  CGAL_precondition(CGAL::is_triangle(halfedge(f, tm), tm));
 
   typedef typename GetVertexPointMap<TriangleMesh, NamedParameters>::const_type VertexPointMap;
   VertexPointMap vpmap = choose_parameter(get_parameter(np, internal_np::vertex_point),
@@ -396,14 +399,14 @@ is_needle_triangle_face(typename boost::graph_traits<TriangleMesh>::face_descrip
                         const double threshold,
                         const NamedParameters& np = parameters::default_values())
 {
-  CGAL_precondition(threshold >= 1.);
-  CGAL_precondition(f != boost::graph_traits<TriangleMesh>::null_face());
-  CGAL_precondition(CGAL::is_triangle(halfedge(f, tm), tm));
+  typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor       halfedge_descriptor;
 
   using parameters::get_parameter;
   using parameters::choose_parameter;
 
-  typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor       halfedge_descriptor;
+  CGAL_precondition(is_valid_face_descriptor(f, tm));
+  CGAL_precondition(CGAL::is_triangle(halfedge(f, tm), tm));
+  CGAL_precondition(threshold >= 1.);
 
   typedef typename GetVertexPointMap<TriangleMesh, NamedParameters>::const_type VertexPointMap;
   VertexPointMap vpmap = choose_parameter(get_parameter(np, internal_np::vertex_point),
@@ -545,15 +548,15 @@ is_cap_triangle_face(typename boost::graph_traits<TriangleMesh>::face_descriptor
                      const double threshold,
                      const NamedParameters& np = parameters::default_values())
 {
-  CGAL_precondition(f != boost::graph_traits<TriangleMesh>::null_face());
-  CGAL_precondition(CGAL::is_triangle(halfedge(f, tm), tm));
-  CGAL_precondition(threshold >= -1.);
-  CGAL_precondition(threshold <= 0.);
+  typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor   halfedge_descriptor;
 
   using parameters::get_parameter;
   using parameters::choose_parameter;
 
-  typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor   halfedge_descriptor;
+  CGAL_precondition(is_valid_face_descriptor(f, tm));
+  CGAL_precondition(CGAL::is_triangle(halfedge(f, tm), tm));
+  CGAL_precondition(threshold >= -1.);
+  CGAL_precondition(threshold <= 0.);
 
   typedef typename GetVertexPointMap<TriangleMesh, NamedParameters>::const_type VertexPointMap;
   VertexPointMap vpmap = choose_parameter(get_parameter(np, internal_np::vertex_point),

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -1063,7 +1063,7 @@ std::size_t stitch_boundary_cycle(const typename boost::graph_traits<PolygonMesh
   typedef typename boost::graph_traits<PolygonMesh>::halfedge_descriptor           halfedge_descriptor;
   typedef typename std::pair<halfedge_descriptor, halfedge_descriptor>             halfedges_pair;
 
-  CGAL_precondition(h != boost::graph_traits<PolygonMesh>::null_halfedge());
+  CGAL_precondition(is_valid_halfedge_descriptor(h, pmesh));
   CGAL_precondition(is_border(h, pmesh));
   CGAL_precondition(is_valid(pmesh));
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangle.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangle.h
@@ -66,6 +66,8 @@ triangle(typename boost::graph_traits<TriangleMesh>::face_descriptor fd,
   using CGAL::parameters::choose_parameter;
   using CGAL::parameters::get_parameter;
 
+  CGAL_precondition(is_valid_face_descriptor(fd, tmesh));
+
   typename GetVertexPointMap<TriangleMesh, CGAL_NP_CLASS>::const_type
     vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                            get_const_property_map(CGAL::vertex_point, tmesh));

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -474,6 +474,8 @@ bool triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descriptor
   using parameters::choose_parameter;
   using parameters::get_parameter;
 
+  CGAL_precondition(is_valid_face_descriptor(f, pmesh));
+
   //VertexPointMap
   typedef typename GetVertexPointMap<PolygonMesh, NamedParameters>::type VPMap;
   VPMap vpmap = choose_parameter(get_parameter(np, internal_np::vertex_point),

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
@@ -468,6 +468,8 @@ namespace Polygon_mesh_processing {
     using parameters::choose_parameter;
     using parameters::get_parameter_reference;
 
+    CGAL_precondition(is_valid_halfedge_descriptor(border_halfedge, pmesh));
+
     std::vector<typename boost::graph_traits<PolygonMesh>::vertex_descriptor> patch;
     face_out = triangulate_and_refine_hole
       (pmesh, border_halfedge, face_out, std::back_inserter(patch), np).first;

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -1467,7 +1467,7 @@ public:
 
     /// perform an expensive validity check on the data structure and
     /// print found errors to `std::cerr` when `verbose == true`.
-    bool is_valid(bool verbose = true) const
+    bool is_valid(bool verbose = false) const
     {
         bool valid = true;
         size_type vcount = 0, hcount = 0, fcount = 0;
@@ -1580,12 +1580,15 @@ public:
 
     /// performs a validity check on a single vertex.
     bool is_valid(Vertex_index v,
-                  bool verbose = true) const
+                  bool verbose = false) const
     {
         Verbose_ostream verr(verbose);
 
         if(!has_valid_index(v))
-         return false;
+        {
+          verr << "Vertex has invalid index: " << (size_type)v << std::endl;
+          return false;
+        }
 
         Halfedge_index h = vconn_[v].halfedge_;
         if(h != null_halfedge() && (!has_valid_index(h) || is_removed(h))) {
@@ -1598,12 +1601,15 @@ public:
 
     /// performs a validity check on a single halfedge.
     bool is_valid(Halfedge_index h,
-                  bool verbose = true) const
+                  bool verbose = false) const
     {
         Verbose_ostream verr(verbose);
 
         if(!has_valid_index(h))
+        {
+          verr << "Halfedge has invalid index: " << (size_type)h << std::endl;
           return false;
+        }
 
         Face_index f = hconn_[h].face_;
         Vertex_index v = hconn_[h].vertex_;
@@ -1646,10 +1652,15 @@ public:
 
     /// performs a validity check on a single edge.
     bool is_valid(Edge_index e,
-                  bool verbose = true) const
+                  bool verbose = false) const
     {
+      Verbose_ostream verr(verbose);
+
       if(!has_valid_index(e))
+      {
+        verr << "Edge has invalid index: " << (size_type)e << std::endl;
         return false;
+      }
 
       Halfedge_index h = halfedge(e);
       return is_valid(h, verbose) && is_valid(opposite(h), verbose);
@@ -1658,12 +1669,15 @@ public:
 
     /// performs a validity check on a single face.
     bool is_valid(Face_index f,
-                  bool verbose = true) const
+                  bool verbose = false) const
     {
         Verbose_ostream verr(verbose);
 
         if(!has_valid_index(f))
+        {
+          verr << "Face has invalid index: " << (size_type)f << std::endl;
           return false;
+        }
 
         Halfedge_index h = fconn_[f].halfedge_;
         if(!has_valid_index(h) || is_removed(h)) {

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -29,6 +29,7 @@
 #include <CGAL/Named_function_parameters.h>
 #include <CGAL/circulator.h>
 #include <CGAL/Handle_hash_function.h>
+#include <CGAL/IO/Verbose_ostream.h>
 #include <CGAL/Iterator_range.h>
 #include <CGAL/property_map.h>
 
@@ -1466,7 +1467,7 @@ public:
 
     /// perform an expensive validity check on the data structure and
     /// print found errors to `std::cerr` when `verbose == true`.
-  bool is_valid(bool verbose = true) const
+    bool is_valid(bool verbose = true) const
     {
         bool valid = true;
         size_type vcount = 0, hcount = 0, fcount = 0;
@@ -1578,21 +1579,29 @@ public:
     }
 
     /// performs a validity check on a single vertex.
-    bool is_valid(Vertex_index v) const {
+    bool is_valid(Vertex_index v,
+                  bool verbose = true) const
+    {
+        Verbose_ostream verr(verbose);
+
         if(!has_valid_index(v))
          return false;
 
         Halfedge_index h = vconn_[v].halfedge_;
-        if(h!= null_halfedge() && (!has_valid_index(h) || is_removed(h))) {
-          std::cerr << "Vertex connectivity halfedge error in " << (size_type)v
-                    << " with " << (size_type)h << std::endl;
-            return false;
+        if(h != null_halfedge() && (!has_valid_index(h) || is_removed(h))) {
+          verr << "Vertex connectivity halfedge error: Vertex " << (size_type)v
+               << " with " << (size_type)h << std::endl;
+          return false;
         }
         return true;
     }
 
     /// performs a validity check on a single halfedge.
-    bool is_valid(Halfedge_index h) const {
+    bool is_valid(Halfedge_index h,
+                  bool verbose = true) const
+    {
+        Verbose_ostream verr(verbose);
+
         if(!has_valid_index(h))
           return false;
 
@@ -1605,30 +1614,30 @@ public:
         // don't validate the face if this is a border halfedge
         if(!is_border(h)) {
             if(!has_valid_index(f) || is_removed(f)) {
-                std::cerr << "Halfedge connectivity Face "
-                          << (!has_valid_index(f) ? "invalid" : "removed")
-                          << " in " << (size_type)h << std::endl;
+                verr << "Halfedge connectivity error: Face "
+                     << (!has_valid_index(f) ? "invalid" : "removed")
+                     << " in " << (size_type)h << std::endl;
                 valid = false;
             }
         }
 
         if(!has_valid_index(v) || is_removed(v)) {
-            std::cerr << "Halfedge connectivity Vertex "
-                      << (!has_valid_index(v) ? "invalid" : "removed")
-                      << " in " << (size_type)h << std::endl;
+            verr << "Halfedge connectivity error: Vertex "
+                 << (!has_valid_index(v) ? "invalid" : "removed")
+                 << " in " << (size_type)h << std::endl;
             valid = false;
         }
 
         if(!has_valid_index(hn) || is_removed(hn)) {
-            std::cerr << "Halfedge connectivity hnext "
-                      << (!has_valid_index(hn) ? "invalid" : "removed")
-                      << " in " << (size_type)h << std::endl;
+            verr << "Halfedge connectivity error: hnext "
+                 << (!has_valid_index(hn) ? "invalid" : "removed")
+                 << " in " << (size_type)h << std::endl;
             valid = false;
         }
         if(!has_valid_index(hp) || is_removed(hp)) {
-            std::cerr << "Halfedge connectivity hprev "
-                      << (!has_valid_index(hp) ? "invalid" : "removed")
-                      << " in " << (size_type)h << std::endl;
+            verr << "Halfedge connectivity error: hprev "
+                 << (!has_valid_index(hp) ? "invalid" : "removed")
+                 << " in " << (size_type)h << std::endl;
             valid = false;
         }
         return valid;
@@ -1636,25 +1645,31 @@ public:
 
 
     /// performs a validity check on a single edge.
-    bool is_valid(Edge_index e) const {
+    bool is_valid(Edge_index e,
+                  bool verbose = true) const
+    {
       if(!has_valid_index(e))
         return false;
 
       Halfedge_index h = halfedge(e);
-      return is_valid(h) && is_valid(opposite(h));
+      return is_valid(h, verbose) && is_valid(opposite(h), verbose);
     }
 
 
     /// performs a validity check on a single face.
-    bool is_valid(Face_index f) const {
+    bool is_valid(Face_index f,
+                  bool verbose = true) const
+    {
+        Verbose_ostream verr(verbose);
+
         if(!has_valid_index(f))
           return false;
 
         Halfedge_index h = fconn_[f].halfedge_;
         if(!has_valid_index(h) || is_removed(h)) {
-          std::cerr << "Face connectivity halfedge error in " << (size_type)f
-                      << " with " << (size_type)h << std::endl;
-            return false;
+          verr << "Face connectivity halfedge error: Face " << (size_type)f
+               << " with " << (size_type)h << std::endl;
+          return false;
         }
         return true;
     }

--- a/Surface_mesh/include/CGAL/boost/graph/graph_traits_Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/boost/graph/graph_traits_Surface_mesh.h
@@ -528,6 +528,51 @@ template<typename P>
 void normalize_border(const CGAL::Surface_mesh<P>&)
 {}
 
+
+template <typename P>
+bool is_valid_vertex_descriptor(typename boost::graph_traits<CGAL::Surface_mesh<P> >::vertex_descriptor v,
+                                const CGAL::Surface_mesh<P>& g,
+                                const bool verbose = false)
+{
+  if(!g.is_valid(v, verbose))
+    return false;
+
+  return BGL::is_valid_vertex_descriptor(v, g, verbose);
+}
+
+template <typename P>
+bool is_valid_halfedge_descriptor(typename boost::graph_traits<CGAL::Surface_mesh<P> >::halfedge_descriptor h,
+                                  const CGAL::Surface_mesh<P>& g,
+                                  const bool verbose = false)
+{
+  if(!g.is_valid(h, verbose))
+    return false;
+
+  return BGL::is_valid_halfedge_descriptor(h, g, verbose);
+}
+
+template <typename P>
+bool is_valid_edge_descriptor(typename boost::graph_traits<CGAL::Surface_mesh<P> >::edge_descriptor e,
+                              const CGAL::Surface_mesh<P>& g,
+                              const bool verbose = false)
+{
+  if(!g.is_valid(e, verbose))
+    return false;
+
+  return BGL::is_valid_edge_descriptor(e, g, verbose);
+}
+
+template <typename P>
+bool is_valid_face_descriptor(typename boost::graph_traits<CGAL::Surface_mesh<P> >::face_descriptor f,
+                              const CGAL::Surface_mesh<P>& g,
+                              const bool verbose = false)
+{
+  if(!g.is_valid(f, verbose))
+    return false;
+
+  return BGL::is_valid_face_descriptor(f, g, verbose);
+}
+
 } // namespace CGAL
 
 #endif // DOXYGEN_RUNNING

--- a/Surface_mesh_topology/doc/Surface_mesh_topology/PackageDescription.txt
+++ b/Surface_mesh_topology/doc/Surface_mesh_topology/PackageDescription.txt
@@ -1,10 +1,10 @@
-/// \defgroup PkgSurfaceMeshTopology Surface Mesh Topology Reference
+/// \defgroup PkgSurfaceMeshTopologyRef Surface Mesh Topology Reference
 
 /// \defgroup PkgSurfaceMeshTopologyConcepts Concepts
-/// \ingroup PkgSurfaceMeshTopology
+/// \ingroup PkgSurfaceMeshTopologyRef
 
 /// \defgroup PkgSurfaceMeshTopologyClasses Classes
-/// \ingroup PkgSurfaceMeshTopology
+/// \ingroup PkgSurfaceMeshTopologyRef
 
 /*!
   \code
@@ -12,17 +12,17 @@
   \endcode
 */
 /// \defgroup PkgDrawFaceGraphWithPaths Draw a Mesh with Paths
-/// \ingroup PkgSurfaceMeshTopology
+/// \ingroup PkgSurfaceMeshTopologyRef
 
 
 /*!
-\addtogroup PkgSurfaceMeshTopology
+\addtogroup PkgSurfaceMeshTopologyRef
 \cgalPkgDescriptionBegin{Surface Mesh Topology,PkgSurfaceMeshTopology}
 \cgalPkgPicture{surface-mesh-topology-logo.png}
 \cgalPkgSummaryBegin
 \cgalPkgAuthor{Guillaume Damiand, Francis Lazarus}
 \cgalPkgDesc{This package provides a toolbox for manipulating curves on a combinatorial surface from the topological point of view. Two main functionalities are proposed. One is the computation of shortest curves that cannot be continuously deformed to a point. This includes the computation of the so-called edge width and face width of the vertex-edge graph of a combinatorial surface. The other functionality is the homotopy test for deciding if two given curves on a combinatorial surface can be continuously deformed one into the other.}
-\cgalPkgManuals{Chapter_Surface_Mesh_Topology,PkgSurfaceMeshTopology}
+\cgalPkgManuals{Chapter_Surface_Mesh_Topology,PkgSurfaceMeshTopologyRef}
 \cgalPkgSummaryEnd
 \cgalPkgShortInfoBegin
 \cgalPkgSince{5.1}


### PR DESCRIPTION
## Summary of Changes

Motivated by losing a bit of time because I was calling Euler operations on removed descriptors.

This PR:
- moves code from `is_valid_xxx_graph` into `is_valid_xxx_descriptor` (which were completely unused)
- actually calls these in preconditions in `BGL` and `PMP`
- fixes a couple of doc issues in `is_valid_xxx_graph` functions
- add overloads of `is_valid_xxx_descriptor` for `Surface_mesh` (to call `Surface_mesh::is_valid(descriptor)`
- some misc minor cleaning and improvements.

Runtime in debug in PMP tests was unchanged.

## Release Management

* Affected package(s): `BGL`, `Polygon_mesh_processing`, `Surface_mesh`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

