### PR TITLE
Purge to-be-border halfedges from edges-to-collapse sets

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -710,9 +710,11 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
             edges_to_collapse.erase(h);
             next_edges_to_collapse.erase(h);
 
-            halfedge_descriptor rm_h = prev(h, tmesh);
+            // By default, prev(h) is removed. If prev(h) is constrained, then next(h) is removed.
+            // Both cannot be constrained, otherwise we would not be collapsing `h`.
+            halfedge_descriptor rm_h = prev(h, tmesh), ot_h = next(h, tmesh);
             if(get(ecm, edge(rm_h, tmesh)))
-              rm_h = next(h, tmesh);
+              std::swap(rm_h, ot_h);
 
             edges_to_flip.erase(rm_h);
             edges_to_collapse.erase(rm_h);
@@ -722,6 +724,16 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
             edges_to_flip.erase(opp_rm_h);
             edges_to_collapse.erase(opp_rm_h);
             next_edges_to_collapse.erase(opp_rm_h);
+
+            // If the third (i.e., non-removed) halfedge of the face becomes a border halfedge
+            // with the collapse, then it also needs to be removed.
+            // Pre-collapse, the corresponding halfedge is `opp_rm_h`.
+            if(is_border(opp_rm_h, tmesh))
+            {
+              edges_to_flip.erase(ot_h);
+              edges_to_collapse.erase(ot_h);
+              next_edges_to_collapse.erase(ot_h);
+            }
           }
 
           h = opposite(h, tmesh);


### PR DESCRIPTION
## Summary of Changes

In the function `PMP::remove_almost_degenerate_faces`, we need to maintain a set of to-collapse edges that correspond to badly shaped faces. These edges describe faces and thus shouldn't be border halfedges.

When an edge is collapsed, the sets need to be purged from deleted edges, but also need to be purged from non-deleted edges that will become boundary edges as these become meaningless since they do not describe a face anymore.

Here is an illustration of the configuration, `prev(h, g)` is constrained, so `rm_h` is `next(h, g)`, and `edge(next(h, g), g)` is a boundary edge.
![illustration](https://user-images.githubusercontent.com/5074170/193929098-60779326-7845-46f4-b533-f1af389c3d64.png)

## Release Management

* Affected package(s): `Polygon_mesh_processing`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): N/A
* License and copyright ownership: no change

