### PR TITLE
Undocument non-existent P4HT2 operators

### DIFF
--- a/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/CGAL/Periodic_4_hyperbolic_triangulation_2.h
+++ b/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/CGAL/Periodic_4_hyperbolic_triangulation_2.h
@@ -150,20 +150,6 @@ public:
                         Deletes all faces and vertices of the triangulation.
                 */
                 void clear();
-
-                /*!
-                        Equality operator.
-                        \todo implement
-                */
-                bool operator==(const Periodic_4_hyperbolic_triangulation_2<GT, TDS>& tr1,
-                                                const Periodic_4_hyperbolic_triangulation_2<GT, TDS>& tr2);
-
-                /*!
-                        Inequality operator.
-                        \todo implement
-                */
-                bool operator!=(const Periodic_4_hyperbolic_triangulation_2<GT, TDS>& tr1,
-                                                const Periodic_4_hyperbolic_triangulation_2<GT, TDS>& tr2);
         /// @}
 
 


### PR DESCRIPTION
## Release Management

* Affected package(s): `Periodic_4_hyperbolic_triangulation_2`
* Issue(s) solved (if any): fix #6899 
* Feature/Small Feature (if any): n/a
* License and copyright ownership: no change
