### PR TITLE
Number_types:  Cleanup concerning Quotient

### DIFF
--- a/Number_types/doc/Number_types/CGAL/Quotient.h
+++ b/Number_types/doc/Number_types/CGAL/Quotient.h
@@ -8,8 +8,7 @@ An object of the class `Quotient<NT>` is an element of the
 field of quotients of the integral domain type `NT`.
 If `NT` behaves like an integer, `Quotient<NT>`
 behaves like a rational number.
-\leda's class `rational` (see Section \ref ledant)
-has been the basis for `Quotient<NT>`.
+
 A `Quotient<NT>` `q` is represented as a pair of
 `NT`s, representing numerator and denominator.
 

--- a/Number_types/doc/Number_types/NumberTypeSupport.txt
+++ b/Number_types/doc/Number_types/NumberTypeSupport.txt
@@ -210,6 +210,7 @@ This package was naturally one of the first packages implemented in \cgal.
 It initially contained the `Quotient`, `Gmpz` and `Gmpq` classes,
 together with the interfaces to the number types provided by \leda, which were
 implemented by Stefan Schirra and Andreas Fabri.
+\leda's class `rational` has been the basis for `Quotient`.
 
 Later, around 1998-2002, Sylvain Pion implemented `Interval_nt`,
 `MP_Float` and `Lazy_exact_nt`, together with the interfaces to
@@ -231,4 +232,3 @@ Luis Pe&ntilde;aranda and Sylvain Lazard contributed the `Gmpfi` and
 
 */
 } /* namespace CGAL */
-


### PR DESCRIPTION
## Summary of Changes

Move the implementation history of  `Quotient`  to the subsection in the User Manual 

## Release Management

* Affected package(s):  Number_types
* License and copyright ownership:  unchanged

