### PR TITLE
Address -Wunused-but-set-variable

### DIFF
--- a/AABB_tree/test/AABB_tree/AABB_test_util.h
+++ b/AABB_tree/test/AABB_tree/AABB_test_util.h
@@ -527,7 +527,6 @@ private:
   {
     CGAL::Timer timer;
     timer.start();
-    int nb_test = 0;
     while ( timer.time() < duration )
     {
       Point a = random_point_in<K>(m_tree.bbox());
@@ -539,8 +538,6 @@ private:
       test(segment, m_polyhedron, m_tree, m_naive);
       test(ray, m_polyhedron, m_tree, m_naive);
       test(line, m_polyhedron, m_tree, m_naive);
-
-      ++nb_test;
     }
     timer.stop();
 

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementPainterOstream.cpp
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementPainterOstream.cpp
@@ -198,7 +198,6 @@ ArrangementPainterOstream<CGAL::Arr_conic_traits_2<
     auto p_curr = app_pts.begin();
     auto end_pts = app_pts.end();
     auto p_next = p_curr + 1;
-    int count = 0;
     do
     {
       QPointF p1(p_curr->first, p_curr->second);
@@ -206,7 +205,6 @@ ArrangementPainterOstream<CGAL::Arr_conic_traits_2<
       this->qp->drawLine(p1, p2);
       p_curr++;
       p_next++;
-      ++count;
     } while (p_next != end_pts);
   };
 

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementPainterOstream.cpp
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/ArrangementPainterOstream.cpp
@@ -48,12 +48,10 @@ ArrangementPainterOstream<CGAL::Arr_polyline_traits_2<SegmentTraits>>&
 ArrangementPainterOstream<CGAL::Arr_polyline_traits_2<SegmentTraits>>::
 operator<<(const X_monotone_curve_2& curve)
 {
-  int cnt = 0;
   for (typename X_monotone_curve_2::Subcurve_const_iterator it =
          curve.subcurves_begin();
        it != curve.subcurves_end(); ++it)
   {
-    cnt++;
     this->painterOstream << *it;
   }
 

--- a/BGL/include/CGAL/boost/graph/selection.h
+++ b/BGL/include/CGAL/boost/graph/selection.h
@@ -207,13 +207,11 @@ struct Regularization_graph
       prevent_unselection (prevent_unselection)
   {
     labels.reserve(num_faces(fg));
-    std::size_t nb_selected = 0;
     for (fg_face_descriptor fd : faces(fg))
     {
       if (get(is_selected_map,fd))
       {
         labels.push_back(1);
-        ++ nb_selected;
       }
       else
         labels.push_back(0);

--- a/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_3.h
@@ -73,7 +73,6 @@ namespace CGAL
 
 
               std::unordered_map <Facet_const_handle, vertex_descriptor> primal_vertices;
-              size_t n = 0;
 
               // First, computing the primal vertices
               for(Facet_const_handle fd : faces(_dual)){
@@ -111,7 +110,6 @@ namespace CGAL
                 vertex_descriptor vd = add_vertex(primal);
                 primal_vertices[fd] = vd;
                 put(vpm, vd, ppp);
-                ++n;
               }
 
               // Then, add facets to the primal polyhedron
@@ -283,4 +281,3 @@ namespace CGAL
 #include <CGAL/enable_warnings.h>
 
 #endif // CGAL_HALFSPACE_INTERSECTION_3_H
-

--- a/HalfedgeDS/include/CGAL/HalfedgeDS_decorator.h
+++ b/HalfedgeDS/include/CGAL/HalfedgeDS_decorator.h
@@ -795,8 +795,7 @@ public:
         Assert_compile_time_tag(Supports_vertex_halfedge(), Tag_true());
         Assert_compile_time_tag(Supports_halfedge_vertex(), Tag_true());
 
-        unsigned int nb_erased_components = 0,
-                     nb_isolated_vertices = 0;
+        unsigned int nb_erased_components = 0;
 
         // Gets list of connected components, ordered by size (i.e. number of vertices)
         std::vector<Vertex_handle> components;
@@ -818,12 +817,8 @@ public:
           else // if isolated vertex
           {
             vertices_erase(vertex);
-            nb_isolated_vertices++;
           }
         }
-
-//         if (nb_isolated_vertices > 0)
-//           std::cerr << "  Erased " << nb_isolated_vertices << " isolated vertices\n";
 
         return nb_erased_components;
     }

--- a/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
+++ b/Heat_method_3/include/CGAL/Heat_method_3/internal/Intrinsic_Delaunay_triangulation_3.h
@@ -340,7 +340,6 @@ private:
   void
   loop_over_edges(edge_stack stack, std::vector<int>& marked_edges)
   {
-    int a = 0;
     while(!stack.empty()) {
       edge_descriptor ed = stack.top();
       stack.pop();
@@ -351,7 +350,6 @@ private:
       //if the edge itself is not locally delaunay, go back
       if(!(is_edge_locally_delaunay(ed))) {
         if(!(is_border(ed,m_intrinsic_tm))) {
-          a++;
           change_edge_length(edge_i,ed);
           halfedge_descriptor hd = (halfedge(ed, m_intrinsic_tm));
           CGAL::Euler::flip_edge(hd, m_intrinsic_tm);

--- a/Linear_cell_complex/demo/Linear_cell_complex/Linear_cell_complex_3_subdivision.cpp
+++ b/Linear_cell_complex/demo/Linear_cell_complex/Linear_cell_complex_3_subdivision.cpp
@@ -134,11 +134,10 @@ subdivide_lcc_3 (LCC & m)
 
   // 2) We subdivide each facet.
   m.negate_mark (treated);  // All the darts are marked in O(1).
-  unsigned int nb = 0;
+
   for (LCC::Dart_range::iterator it (m.darts().begin ());
        m.number_of_marked_darts (treated) > 0; ++it)
   {
-    ++nb;
     if (m.is_marked (it, treated))
     {
       // We unmark the darts of the facet to process only once dart/facet.

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_cells_3.h
@@ -702,15 +702,18 @@ scan_triangulation_impl()
   {
 #if defined(CGAL_MESH_3_VERBOSE) || defined(CGAL_MESH_3_PROFILING)
     std::cerr << "Scanning triangulation for bad cells (sequential)... ";
+    int count = 0;
 #endif
 
-    int count = 0;
+
     for(Finite_cell_iterator cell_it = r_tr_.finite_cells_begin();
         cell_it != r_tr_.finite_cells_end();
         ++cell_it)
     {
       treat_new_cell(cell_it);
+#if defined(CGAL_MESH_3_VERBOSE) || defined(CGAL_MESH_3_PROFILING)
       ++count;
+#endif
     }
 #if defined(CGAL_MESH_3_VERBOSE) || defined(CGAL_MESH_3_PROFILING)
     std::cerr << count << " cells scanned, ";

--- a/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
@@ -97,9 +97,9 @@ search_for_connected_components_in_labeled_image(const CGAL::Image_3& image,
           % (long)static_evaluate<Image_word_type>(image.image(), i, j, k)
           % number_of_connected_components
           % (int)current_label;
-#endif // CGAL_MESH_3_SEARCH_FOR_CONNECTED_COMPONENTS_IN_LABELED_IMAGE_VERBOSE
 
         int nb_voxels = 0;
+#endif // CGAL_MESH_3_SEARCH_FOR_CONNECTED_COMPONENTS_IN_LABELED_IMAGE_VERBOSE
 
         Indices_queue queue;
         Indices indices(i, j ,k, 0);
@@ -137,7 +137,9 @@ search_for_connected_components_in_labeled_image(const CGAL::Image_3& image,
             {
               visited[offset] = true;
               second_pass[offset] = false;
+#if CGAL_MESH_3_SEARCH_FOR_CONNECTED_COMPONENTS_IN_LABELED_IMAGE_VERBOSE > 1
               ++nb_voxels;
+#endif
               boost::get<0>(bbox_min) = (std::min)(i, boost::get<0>(bbox_min));
               boost::get<0>(bbox_max) = (std::max)(i, boost::get<0>(bbox_max));
               boost::get<1>(bbox_min) = (std::min)(j, boost::get<1>(bbox_min));

--- a/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
@@ -137,7 +137,7 @@ search_for_connected_components_in_labeled_image(const CGAL::Image_3& image,
             {
               visited[offset] = true;
               second_pass[offset] = false;
-#if CGAL_MESH_3_SEARCH_FOR_CONNECTED_COMPONENTS_IN_LABELED_IMAGE_VERBOSE > 1
+#ifdef CGAL_MESH_3_SEARCH_FOR_CONNECTED_COMPONENTS_IN_LABELED_IMAGE_VERBOSE
               ++nb_voxels;
 #endif
               boost::get<0>(bbox_min) = (std::min)(i, boost::get<0>(bbox_min));

--- a/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_conv_2.h
+++ b/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_conv_2.h
@@ -266,7 +266,6 @@ public:
 
     // Construct the segments of the convolution cycles.
     unsigned int curr_id = 0;
-    unsigned int cycles = 0;
     Segments_list conv_segments;
     Segments_list cycle;
     Labels_set used_labels;
@@ -340,7 +339,6 @@ public:
               CGAL_assertion(cycle.empty());
             }
           }
-          ++cycles;
         }
 
         curr1 = next1;

--- a/Nef_2/include/CGAL/Nef_2/PM_const_decorator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_const_decorator.h
@@ -485,6 +485,8 @@ check_integrity_and_topological_planarity(bool faces) const
   std::size_t e_num = number_of_edges();
   std::size_t c_num = number_of_connected_components() - iso_vert_num;
   std::size_t f_num = number_of_face_cycles() - c_num + 1;
+  CGAL_USE(fc_num);
+  CGAL_USE(iv_num);
   CGAL_USE(v_num);
   CGAL_USE(e_num);
   CGAL_USE(f_num);

--- a/Nef_2/include/CGAL/Nef_2/PM_point_locator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_point_locator.h
@@ -17,6 +17,7 @@
 
 #include <CGAL/basic.h>
 #include <CGAL/Unique_hash_map.h>
+#include <CGAL/use.h>
 #include <CGAL/Nef_2/Constrained_triang_traits.h>
 #include <CGAL/Nef_2/Object_handle.h>
 #include <CGAL/Circulator_project.h>
@@ -665,6 +666,7 @@ protected:
 
 
     }
+    CGAL_USE(flip_count);
     CGAL_NEF_TRACEN("  flipped "<<flip_count);
   }
 

--- a/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
@@ -358,6 +358,8 @@ check_integrity_and_topological_planarity(bool faces) const
                       iso_vert_num
                       + number_of_sloops());
   CGAL_assertion_code(std::size_t f_num = number_of_sface_cycles() - c_num + 1);
+  CGAL_USE(fc_num);
+  CGAL_USE(iv_num);
   CGAL_assertion_code(CGAL_NEF_TRACEV(fc_num));
   CGAL_assertion_code(CGAL_NEF_TRACEV(iv_num));
   CGAL_assertion_code(CGAL_NEF_TRACEV(iso_vert_num));

--- a/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/render.cpp
+++ b/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/render.cpp
@@ -335,14 +335,13 @@ void R_s_k_2::draw_relevance(const float line_width, const int nb)
   MultiIndex mindex;
   FT min_value = (std::numeric_limits<FT>::max)();
   FT max_value = -(std::numeric_limits<FT>::max)();
-  unsigned int nb_initial = 0;
+
   for (Finite_edges_iterator ei = m_dt.finite_edges_begin(); ei != m_dt.finite_edges_end(); ++ei)
   {
     Edge edge = *ei;
     if (m_dt.is_ghost(edge)) continue;
     FT value = m_dt.get_edge_relevance(edge); // >= 0
 
-    nb_initial++;
     min_value = (std::min)(min_value, value);
     max_value = (std::max)(max_value, value);
     mindex.insert(PEdge(edge, value));

--- a/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/scene.h
+++ b/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/scene.h
@@ -440,11 +440,9 @@ public:
     }
     CGAL_assertion(vertex_count == 18);
 
-    int edge_count = 0;
     for (std::vector<Segment>::iterator it = edges.begin();
       it != edges.end(); it++) {
       std::cout << *it << std::endl;
-      edge_count++;
     }
   }
 

--- a/Periodic_2_triangulation_2/include/CGAL/Periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/Periodic_2_triangulation_2.h
@@ -2180,12 +2180,10 @@ Gt, Tds >::insert_first(const Point& p)
   CGAL_triangulation_assertion(_too_long_edge_counter == 0);
 
   // Insert all vertices as the first vertex in the _too_long_edges list
-  int k = 0;
   std::list<Vertex_handle> empty_list;
   for (Vertex_iterator vit = vertices_begin(); vit != vertices_end(); ++vit)
     {
       _too_long_edges[vit] = empty_list;
-      k++;
     }
 
   // Insert all edges as all edges are too long
@@ -3466,11 +3464,9 @@ void Periodic_2_triangulation_2<Gt, Tds>::convert_to_9_sheeted_covering()
   _cover = make_array(3, 3);
 
   // Set up too long edges data structure
-  int i = 0;
   for (Vertex_iterator vit = vertices_begin(); vit != vertices_end(); ++vit)
     {
       _too_long_edges[vit] = std::list<Vertex_handle>();
-      ++i;
     }
   _too_long_edge_counter = find_too_long_edges(_too_long_edges);
 
@@ -4434,12 +4430,10 @@ Periodic_2_triangulation_2<Gt, Tds>::load(std::istream& is)
   for (std::size_t j = 0 ; j < m; j++)
     is >> *(F[j]);
 
-  int i = 0;
   for (Vertex_iterator vi = vertices_begin();
        vi != vertices_end(); ++vi)
     {
       _too_long_edges[vi] = std::list<Vertex_handle>();
-      ++i;
     }
 
   _edge_length_threshold = FT(0.166) * (_domain.xmax() - _domain.xmin())

--- a/Periodic_4_hyperbolic_triangulation_2/include/CGAL/Periodic_4_hyperbolic_Delaunay_triangulation_2.h
+++ b/Periodic_4_hyperbolic_triangulation_2/include/CGAL/Periodic_4_hyperbolic_Delaunay_triangulation_2.h
@@ -165,15 +165,11 @@ public:
     spatial_sort(points.begin(), points.end(), geom_traits());
 
     Face_handle f;
-    int cnt = 0;
-    int cnt_good = 0;
     for(typename std::vector<Point>::const_iterator p=points.begin(), end = points.end(); p != end; ++p)
     {
-      ++cnt;
       Vertex_handle v = insert(*p, f);
       if(v != Vertex_handle())
       {
-        ++cnt_good;
         f = v->face();
       }
     }
@@ -596,8 +592,6 @@ remove(Vertex_handle v)
 
     Nbr_history failsafe;
 
-    int internb = 0;
-    int bdrynb = 0;
     for(std::size_t i=0; i<new_f.size(); ++i)
     {
       for(int k=0; k< 3; k++)
@@ -623,7 +617,6 @@ remove(Vertex_handle v)
             failsafe.push_back(hist);
 
             tds().set_adjacency(nbf, nbidx, new_f[i], k);
-            bdrynb++;
             break;
           }
         }
@@ -641,7 +634,6 @@ remove(Vertex_handle v)
                  new_f[i]->vertex(cw(k))  == new_f[l]->vertex(ccw(j)))
               {
                 tds().set_adjacency(new_f[i], k, new_f[l], j);
-                internb++;
                 break;
               }
             }

--- a/Point_set_processing_3/include/CGAL/scanline_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/scanline_orient_normals.h
@@ -20,6 +20,7 @@
 #include <CGAL/boost/graph/named_params_helper.h>
 
 #include <CGAL/linear_least_squares_fitting_3.h>
+#include <CGAL/use.h>
 
 #include <boost/iterator/transform_iterator.hpp>
 
@@ -545,6 +546,8 @@ void scanline_orient_normals (PointRange& points, const NamedParameters& np = pa
   std::cerr << nb_scanlines << " scanline(s) identified (mean length = "
             << std::size_t(points.size() / double(nb_scanlines))
             << " point(s))" << std::endl;
+#else
+  CGAL_USE(nb_scanlines);
 #endif
 }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -501,7 +501,9 @@ namespace internal {
       }
 
       //split long edges
+#ifdef CGAL_PMP_REMESHING_VERBOSE
       unsigned int nb_splits = 0;
+#endif
       while (!long_edges.empty())
       {
         //the edge with longest length

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -530,8 +530,9 @@ namespace internal {
         halfedge_descriptor hnew = CGAL::Euler::split_edge(he, mesh_);
         CGAL_assertion(he == next(hnew, mesh_));
         put(ecmap_, edge(hnew, mesh_), get(ecmap_, edge(he, mesh_)) );
+#ifdef CGAL_PMP_REMESHING_VERBOSE
         ++nb_splits;
-
+#endif
         //move refinement point
         vertex_descriptor vnew = target(hnew, mesh_);
         put(vpmap_, vnew, refinement_point);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -405,7 +405,9 @@ namespace internal {
       }
 
       //split long edges
+#ifdef CGAL_PMP_REMESHING_VERBOSE
       unsigned int nb_splits = 0;
+#endif
       while (!long_edges.empty())
       {
         //the edge with longest length
@@ -420,7 +422,9 @@ namespace internal {
         // propagate the constrained status
         put(ecmap_, edge(hnew, mesh_), get(ecmap_, edge(he, mesh_)));
         CGAL_assertion(he == next(hnew, mesh_));
+#ifdef CGAL_PMP_REMESHING_VERBOSE
         ++nb_splits;
+#endif
 
         //move refinement point
         vertex_descriptor vnew = target(hnew, mesh_);
@@ -642,7 +646,9 @@ namespace internal {
       std::cout << "done." << std::endl;
 #endif
 
+#ifdef CGAL_PMP_REMESHING_VERBOSE
       unsigned int nb_collapses = 0;
+#endif
       while (!short_edges.empty())
       {
         //the edge with shortest length
@@ -779,8 +785,9 @@ namespace internal {
           vertex_descriptor vkept = CGAL::Euler::collapse_edge(e, mesh_, ecmap_);
           CGAL_assertion(is_valid(mesh_));
           CGAL_assertion(vkept == vb);//is the constrained point still here
+#ifdef CGAL_PMP_REMESHING_VERBOSE
           ++nb_collapses;
-
+#endif
           //fix constrained case
           CGAL_assertion((is_constrained(vkept) || is_corner(vkept) || is_on_patch_border(vkept)) ==
                          (is_va_constrained || is_vb_constrained || is_va_on_constrained_polyline || is_vb_on_constrained_polyline));
@@ -842,7 +849,9 @@ namespace internal {
 
       const double cap_threshold = std::cos(160. / 180 * CGAL_PI);
 
+#ifdef CGAL_PMP_REMESHING_VERBOSE
       unsigned int nb_flips = 0;
+#endif
       for(edge_descriptor e : edges(mesh_))
       {
         //only the patch edges are allowed to be flipped
@@ -906,8 +915,9 @@ namespace internal {
         put(degree, vc, vvc);
         put(degree, vd, vvd);
 
+#ifdef CGAL_PMP_REMESHING_VERBOSE
         ++nb_flips;
-
+#endif
 #ifdef CGAL_PMP_REMESHING_VERBOSE_PROGRESS
         std::cout << "\r\t(" << nb_flips << " flips)";
         std::cout.flush();
@@ -956,8 +966,9 @@ namespace internal {
           put(degree, vc, vvc);
           put(degree, vd, vvd);
 
+#ifdef CGAL_PMP_REMESHING_VERBOSE
           --nb_flips;
-
+#endif
           CGAL_assertion_code(Halfedge_status s3 = status(he));
           CGAL_assertion(s1 == s3);
           CGAL_assertion(!is_border(he, mesh_));
@@ -1635,8 +1646,6 @@ private:
                               const double& sq_low,
                               const bool collapse_constraints)
     {
-      CGAL_assertion_code(std::size_t nb_done = 0);
-
       std::unordered_set<halfedge_descriptor> degenerate_faces;
       for(halfedge_descriptor h :
           halfedges_around_target(halfedge(v, mesh_), mesh_))
@@ -1695,7 +1704,6 @@ private:
               continue;
 
             CGAL::Euler::flip_edge(hf, mesh_);
-            CGAL_assertion_code(++nb_done);
             done = true;
 
             //update status
@@ -1891,6 +1899,11 @@ private:
         else if(is_an_isolated_constraint(h)) nb_isolated++;
         else CGAL_assertion(false);
       }
+      CGAL_USE(nb_border);
+      CGAL_USE(nb_mesh);
+      CGAL_USE(nb_patch);
+      CGAL_USE(nb_patch_border);
+      CGAL_USE(nb_isolated);
     }
 
 #ifdef CGAL_PMP_REMESHING_DEBUG

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Smoothing/mesh_smoothing_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Smoothing/mesh_smoothing_impl.h
@@ -161,8 +161,9 @@ public:
       put(marks, e, false);
     for(edge_descriptor e : edge_range)
       put(marks, e, true);
-
+#ifdef CGAL_PMP_SMOOTHING_DEBUG
     int flipped_n = 0;
+#endif
     while(!edge_range.empty())
     {
       edge_descriptor e = edge_range.back();
@@ -172,8 +173,9 @@ public:
 
       if(should_be_flipped(e))
       {
+#ifdef CGAL_PMP_SMOOTHING_DEBUG
         ++flipped_n;
-
+#endif
         halfedge_descriptor h = halfedge(e, mesh_);
 
 #ifdef CGAL_PMP_SMOOTHING_DEBUG_PP

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -1378,7 +1378,6 @@ bool remove_degenerate_edges(const EdgeRange& edge_range,
 
   typedef typename GetGeomTraits<TM, NamedParameters>::type                       Traits;
 
-  std::size_t nb_deg_faces = 0;
   bool all_removed = false;
   bool some_removed = true;
   bool preserve_genus = choose_parameter(get_parameter(np, internal_np::preserve_genus), true);
@@ -1413,7 +1412,6 @@ bool remove_degenerate_edges(const EdgeRange& edge_range,
         // remove edges that could also be set for removal
         if(face(h, tmesh) != GT::null_face())
         {
-          ++nb_deg_faces;
           const edge_descriptor prev_e = edge(prev(h, tmesh), tmesh);
           degenerate_edges_to_remove.erase(prev_e);
           local_edge_range.erase(prev_e);
@@ -1422,7 +1420,6 @@ bool remove_degenerate_edges(const EdgeRange& edge_range,
 
         if(face(opposite(h, tmesh), tmesh) != GT::null_face())
         {
-          ++nb_deg_faces;
           const edge_descriptor prev_opp_e = edge(prev(opposite(h, tmesh), tmesh), tmesh);
           degenerate_edges_to_remove.erase(prev_opp_e);
           local_edge_range.erase(prev_opp_e);
@@ -1461,7 +1458,6 @@ bool remove_degenerate_edges(const EdgeRange& edge_range,
         // remove edges that could also be set for removal
         if(face(h, tmesh) != GT::null_face())
         {
-          ++nb_deg_faces;
           const edge_descriptor prev_e = edge(prev(h, tmesh), tmesh);
           degenerate_edges_to_remove.erase(prev_e);
           local_edge_range.erase(prev_e);
@@ -1470,7 +1466,6 @@ bool remove_degenerate_edges(const EdgeRange& edge_range,
 
         if(face(opposite(h, tmesh), tmesh)!=GT::null_face())
         {
-          ++nb_deg_faces;
           const edge_descriptor prev_opp_e = edge(prev(opposite(h, tmesh), tmesh), tmesh);
           degenerate_edges_to_remove.erase(prev_opp_e);
           local_edge_range.erase(prev_opp_e);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_self_intersections.h
@@ -251,7 +251,6 @@ FaceOutputIterator replace_faces_with_patch(const std::vector<typename boost::gr
   Vertex_pair_halfedge_map halfedge_map;
 
   // register border halfedges
-  int i = 0;
   for(halfedge_descriptor h : border_hedges)
   {
     const vertex_descriptor vs = source(h, pmesh);
@@ -259,7 +258,6 @@ FaceOutputIterator replace_faces_with_patch(const std::vector<typename boost::gr
     halfedge_map.emplace(std::make_pair(vs, vt), h);
 
     set_halfedge(target(h, pmesh), h, pmesh); // update vertex halfedge pointer
-    ++i;
   }
 
   face_descriptor f = boost::graph_traits<PolygonMesh>::null_face();
@@ -1581,7 +1579,6 @@ bool fill_hole_with_constraints(std::vector<typename boost::graph_traits<Triangl
   std::set<face_descriptor> visited_faces;
   std::vector<std::vector<Point> > patch;
 
-  int cc_counter = 0;
   for(face_descriptor f : cc_faces)
   {
     if(!visited_faces.insert(f).second) // already visited that face
@@ -1593,7 +1590,6 @@ bool fill_hole_with_constraints(std::vector<typename boost::graph_traits<Triangl
                                                  CGAL::parameters::edge_is_constrained_map(eif));
 
     visited_faces.insert(sub_cc.begin(), sub_cc.end());
-    ++cc_counter;
 
 #ifdef CGAL_PMP_REMOVE_SELF_INTERSECTION_OUTPUT
     dump_cc("results/current_cc.off", sub_cc, tmesh, vpm);

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/pmp_do_intersect_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/pmp_do_intersect_test.cpp
@@ -39,10 +39,8 @@ template<class Point>
 int load_polylines(std::ifstream& input,
                    std::vector<std::vector<Point> >& points)
 {
-  int counter = 0;
   std::size_t n;
   while(input >> n) {
-    ++counter;
     std::vector<Point> new_polyline;
     points.push_back(new_polyline);
     std::vector<Point>&polyline = points.back();

--- a/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Scene_movable_sm_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/AABB_tree/Scene_movable_sm_item.cpp
@@ -203,7 +203,7 @@ void Scene_movable_sm_item::invalidateOpenGLBuffers()
 CGAL::Three::Scene_item::ManipulatedFrame* Scene_movable_sm_item::manipulatedFrame() { return d->frame; }
 const CGAL::qglviewer::Vec& Scene_movable_sm_item::center() const { return d->center_; }
 Scene_movable_sm_item::~Scene_movable_sm_item() { delete d; Q_EMIT killed(); }
-void Scene_movable_sm_item::setFMatrix(const GLdouble matrix[])
+void Scene_movable_sm_item::setFMatrix(const GLdouble matrix[16])
 {
   for (int i=0; i<16; ++i)
     d->f_matrix.data()[i] = (float)matrix[i];

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Repair_polyhedron_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Repair_polyhedron_plugin.cpp
@@ -299,12 +299,10 @@ void Polyhedron_demo_repair_polyhedron_plugin::on_actionSnapBorders_triggered()
       std::vector<halfedge_descriptor> remaining_cycles;
       CGAL::Polygon_mesh_processing::extract_boundary_cycles(tm, std::back_inserter(remaining_cycles));
 
-      int tested=0, done=0;
       for (halfedge_descriptor hc : remaining_cycles)
       {
         if (next(next(hc,tm),tm)==prev(hc,tm))
         {
-          ++tested;
           //get smallest halfedge
           halfedge_descriptor hm = hc;
           double min_l = CGAL::Polygon_mesh_processing::edge_length(hc, tm);
@@ -335,7 +333,6 @@ void Polyhedron_demo_repair_polyhedron_plugin::on_actionSnapBorders_triggered()
           std::array<vertex_descriptor,3> vr = { source(hm, tm), target(hm, tm), target(next(hm, tm), tm) };
           CGAL::Euler::add_face(vr, tm);
           CGAL::Euler::collapse_edge(edge(hm, tm), tm);
-          ++done;
         }
       }
     }

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Selection_plugin.cpp
@@ -753,7 +753,6 @@ public Q_SLOTS:
         return;
       }
       std::unordered_map<fg_face_descriptor, bool> is_selected_map;
-      int index = 0;
       for(fg_face_descriptor fh : faces(*selection_item->polyhedron()))
       {
         if(selection_item->selected_facets.find(fh)
@@ -763,7 +762,6 @@ public Q_SLOTS:
         {
           is_selected_map[fh]=true;
         }
-        ++index;
       }
       CGAL::expand_face_selection_for_removal(selection_item->selected_facets,
                                               *selection_item->polyhedron(),

--- a/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_nef_polyhedron_item.cpp
@@ -189,7 +189,6 @@ Scene_nef_polyhedron_item_priv::mark_domains(CDT& ct,
 void Scene_nef_polyhedron_item_priv::compute_normals_and_vertices(void) const
 {
     QApplication::setOverrideCursor(Qt::WaitCursor);
-    int count = 0;
     positions_facets.resize(0);
     positions_points.resize(0);
     normals.resize(0);
@@ -205,7 +204,6 @@ void Scene_nef_polyhedron_item_priv::compute_normals_and_vertices(void) const
         {
             if(f->is_twin()) continue;
             bool incident_volume_marked = f->incident_volume()->mark();
-            count++;
             Nef_polyhedron::Vector_3 v = (incident_volume_marked? -1:1) * f->plane().orthogonal_vector();
             P_traits cdt_traits(v);
             CDT cdt(cdt_traits);

--- a/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polyhedron_selection_item.cpp
@@ -461,7 +461,6 @@ void Scene_polyhedron_selection_item_priv::compute_temp_elements()const
     const CGAL::qglviewer::Vec offset = Three::mainViewer()->offset();
     color_fixed_points.clear();
     positions_fixed_points.clear();
-    int i=0;
 
     constVPmap vpm = get(CGAL::vertex_point,*polyhedron());
 
@@ -487,7 +486,6 @@ void Scene_polyhedron_selection_item_priv::compute_temp_elements()const
         color_fixed_points.push_back(0.0);
         color_fixed_points.push_back(0.0);
       }
-      i++;
     }
   }
 
@@ -509,10 +507,10 @@ void Scene_polyhedron_selection_item_priv::compute_temp_elements()const
         positions_temp_points.data(),
         static_cast<int>(positions_temp_points.size()*sizeof(float)));
 
-item->getPointContainer(Fixed_points)->allocate(
-      Pc::Vertices,
-      positions_fixed_points.data(),
-      static_cast<int>(positions_fixed_points.size()*sizeof(float)));
+  item->getPointContainer(Fixed_points)->allocate(
+        Pc::Vertices,
+        positions_fixed_points.data(),
+        static_cast<int>(positions_fixed_points.size()*sizeof(float)));
 
   item->getPointContainer(Fixed_points)->allocate(
         Pc::Colors,

--- a/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_polylines_item.cpp
@@ -602,12 +602,11 @@ void Scene_polylines_item::split_at_sharp_angles()
     typedef Polyline Bare_polyline;
     Polylines_container& bare_polylines = polylines;
 
-    int counter = 0;
     for(Bare_polyline_container::iterator
         bare_polyline_it = bare_polylines.begin();
         bare_polyline_it != bare_polylines.end(); // the end changes
-        // during the loop
-        ++counter /* bare_polyline_it is incremented in the loop */)
+                                                  // during the loop
+        /* bare_polyline_it is incremented in the loop */)
     {
         Bare_polyline_container::iterator current_polyline_it =
                 bare_polyline_it;

--- a/Polyhedron/demo/Polyhedron/Viewer.h
+++ b/Polyhedron/demo/Polyhedron/Viewer.h
@@ -84,7 +84,7 @@ public:
 
 
   TextRenderer* textRenderer() Q_DECL_OVERRIDE;
-  void enableClippingBox(QVector4D box[]) Q_DECL_OVERRIDE;
+  void enableClippingBox(QVector4D box[6]) Q_DECL_OVERRIDE;
   void disableClippingBox() Q_DECL_OVERRIDE;
   void set2DSelectionMode(bool) Q_DECL_OVERRIDE;
   void setStaticImage(QImage image) Q_DECL_OVERRIDE;

--- a/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Alpha_shape_mesher.h
+++ b/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Alpha_shape_mesher.h
@@ -559,9 +559,6 @@ private:
   {
     std::set<Cell_handle> done;
 
-    unsigned int nb_facets_removed = 0;
-
-    unsigned int nb_skipped = 0;
     for (Cell_iterator cit = _shape->cells_begin (); cit != _shape->cells_end (); ++ cit)
     {
       if (_shape->is_infinite (cit))
@@ -702,7 +699,6 @@ private:
               }
               else
               {
-                nb_facets_removed ++;
                 mark_handled (f);
                 _garbage.push_back (ordered_facet_indices (f));
               }
@@ -716,7 +712,6 @@ private:
               }
               else
               {
-                nb_facets_removed ++;
                 mark_handled (_shape->mirror_facet (f));
                 _garbage.push_back (ordered_facet_indices (_shape->mirror_facet (f)));
               }
@@ -782,7 +777,6 @@ private:
       // If number of layers is != 2, ignore volume and discard bubble
       if (layer != 1)
       {
-        nb_skipped ++;
         for (unsigned int i = 0; i < 2; ++ i)
           for (typename std::set<SFacet>::iterator fit = _bubbles.back()[i].begin ();
                fit != _bubbles.back()[i].end (); ++ fit)
@@ -790,7 +784,6 @@ private:
             mark_handled (*fit);
             _map_f2b.erase (*fit);
             _garbage.push_back (ordered_facet_indices (*fit));
-            nb_facets_removed ++;
           }
         _bubbles.pop_back ();
       }
@@ -804,10 +797,6 @@ private:
 
     typedef std::map<std::pair<VEdge, unsigned int>, std::set<Facet> > Edge_shell_map_triples;
     typedef typename Edge_shell_map_triples::iterator Edge_shell_map_triples_iterator;
-
-    unsigned int nb_facets_removed = 0;
-
-    unsigned int nb_nm_edges = 0;
 
     // Store for each pair edge/shell the incident facets
     Edge_shell_map_triples eshell_triples;
@@ -841,8 +830,6 @@ private:
       if (eit->second.size () < 3)
         continue;
 
-      ++ nb_nm_edges;
-
       Facet_iterator tit = _shells[eit->first.second];
       Facet_iterator end = (eit->first.second == _shells.size () - 1)
         ? _surface.end () : _shells[eit->first.second + 1];
@@ -863,7 +850,6 @@ private:
           _map_f2s.erase (map_t2f[*current]);
           _surface.erase (current);
 
-          ++ nb_facets_removed;
           eit->second.erase (search);
         }
 
@@ -931,14 +917,12 @@ private:
       _surface.splice(end, tmp, tmp.begin(), tmp.end());
     }
 
-    unsigned int nb_facets_removed = 0;
     unsigned int nb_nm_vertices = 0;
     // Removing facets to fix non-manifold vertices might make some other vertices
     // become non-manifold, therefore we iterate until no facet needs to be removed.
     do
     {
       nb_nm_vertices = 0;
-      nb_facets_removed = 0;
 
       // Store for each pair vertex/shell the incident facets
       Vertex_shell_map_facets vshell_facets;
@@ -1052,7 +1036,6 @@ private:
               _garbage.push_back (*current);
               _surface.erase (current);
 
-              ++ nb_facets_removed;
               ++ tindex;
             }
 

--- a/Spatial_searching/test/Spatial_searching/test_print.cpp
+++ b/Spatial_searching/test/Spatial_searching/test_print.cpp
@@ -27,10 +27,9 @@ void test_print(const std::string filename) {
   std::ifstream in(filename);
   CGAL::IO::set_ascii_mode(in);
 
-  Point_3 p; std::size_t count = 0;
+  Point_3 p;
   while (in >> p) {
     points.push_back(p);
-    ++count;
   }
   assert(points.size() > 0);
 

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h
@@ -560,7 +560,6 @@ private:
     Error_code status = OK;
 
     // compute A
-    unsigned int count = 0;
     for(vertex_descriptor vd : vertices) {
       if(!get(vpmap, vd)) { // not yet parameterized
         // Compute the line i of the matrix A
@@ -570,7 +569,6 @@ private:
       } else { // fixed vertices
         int index = get(vimap, vd);
         A.set_coef(index, index, 1, true /*new*/);
-        ++count;
       }
     }
     return status;
@@ -1079,7 +1077,6 @@ private:
     // Initialize the right hand side B in the linear system "A*X = B"
     Error_code status = OK;
 
-    unsigned int count = 0;
     for(vertex_descriptor vd : vertices) {
       if(!get(vpmap, vd)) { // not yet parameterized
         // Compute the lines i of the vectors Bu and Bv
@@ -1092,7 +1089,6 @@ private:
         const Point_2& uv = get(uvmap, vd);
         Bu.set(index, uv.x());
         Bv.set(index, uv.y());
-        ++count;
       }
     }
     return status;

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Fixed_border_parameterizer_3.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/Fixed_border_parameterizer_3.h
@@ -255,7 +255,6 @@ public:
       main_border.insert(v);
     }
 
-    int count = 0;
     for(vertex_descriptor v : vertices){
       // inner vertices only
       if(main_border.find(v) == main_border.end()){
@@ -263,8 +262,6 @@ public:
         status = setup_inner_vertex_relations(A, Bu, Bv, mesh, v, vimap);
         if(status != OK)
           return status;
-      } else {
-        count++;
       }
     }
 

--- a/Surface_mesh_topology/examples/Surface_mesh_topology/draw_facewidth.h
+++ b/Surface_mesh_topology/examples/Surface_mesh_topology/draw_facewidth.h
@@ -54,17 +54,16 @@ template<typename LCC>
 void draw_facewidth(const LCC& lcc,
                     const std::vector<typename LCC::Dart_const_descriptor>& cycle)
 {
-  int nbv=0, nbf=0;
   typename LCC::size_type vertex_mark = lcc.get_new_mark();
   typename LCC::size_type face_mark = lcc.get_new_mark();
   for (std::size_t i=0; i<cycle.size(); ++i)
   {
     // Color the vertex
     if (!lcc.is_marked(cycle[i], vertex_mark))
-    { lcc.template mark_cell<0>(cycle[i], vertex_mark); ++nbv; }
+    { lcc.template mark_cell<0>(cycle[i], vertex_mark); }
     // Color the face
     if (!lcc.is_marked(cycle[i], face_mark))
-    { lcc.template mark_cell<2>(cycle[i], face_mark); ++nbf; }
+    { lcc.template mark_cell<2>(cycle[i], face_mark); }
   }
 
   Facewidth_draw_functor<LCC> df(vertex_mark, face_mark);

--- a/Surface_mesher/include/CGAL/Surface_mesher/Surface_mesher_manifold.h
+++ b/Surface_mesher/include/CGAL/Surface_mesher/Surface_mesher_manifold.h
@@ -107,15 +107,17 @@ namespace CGAL {
       {
 #ifdef CGAL_SURFACE_MESHER_VERBOSE
         std::cerr << "scanning vertices" << std::endl;
-#endif
         int n = 0;
+#endif
         for (Finite_vertices_iterator vit = SMMBB::tr.finite_vertices_begin();
              vit != SMMBB::tr.finite_vertices_end();
              ++vit) {
           if ( (SMMBB::c2t3.face_status(vit)  // @TODO: appeler is_regular
                 == C2t3::SINGULAR) ) {
             bad_vertices.insert( vit );
+#ifdef CGAL_SURFACE_MESHER_VERBOSE
             ++n;
+#endif
           }
         }
         bad_vertices_initialized = true;

--- a/Surface_mesher/include/CGAL/Surface_mesher/Surface_mesher_regular_edges.h
+++ b/Surface_mesher/include/CGAL/Surface_mesher/Surface_mesher_regular_edges.h
@@ -213,8 +213,8 @@ namespace CGAL {
       if(withBoundary)
         std::cerr << "(boundaries allowed)";
       std::cerr << "...\n";
-#endif
       int n = 0;
+#endif
       for (Finite_edges_iterator eit = SMB::tr.finite_edges_begin(); eit !=
              SMB::tr.finite_edges_end(); ++eit) {
         if ( (SMB::c2t3.face_status(*eit)
@@ -223,7 +223,9 @@ namespace CGAL {
                (SMB::c2t3.face_status(*eit)
                 == C2t3::BOUNDARY) ) ) {
           bad_edges.insert( edge_to_edgevv(*eit) );
+#ifdef CGAL_SURFACE_MESHER_VERBOSE
           ++n;
+#endif
         }
       }
       bad_edges_initialized = true;

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
@@ -414,10 +414,11 @@ public:
 #ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
     std::cout << "Smooth vertices...";
     std::cout.flush();
-#endif
+
     std::size_t nb_done_3d = 0;
     std::size_t nb_done_2d = 0;
     std::size_t nb_done_1d = 0;
+#endif
     FT total_move = 0.;
 
     Tr& tr = c3t3.triangulation();
@@ -540,8 +541,11 @@ public:
 #endif
           // move vertex
           const typename Tr::Point new_pos(final_position.x(), final_position.y(), final_position.z());
-          if(check_inversion_and_move(v, new_pos, inc_cells[vid], tr, total_move))
+          if(check_inversion_and_move(v, new_pos, inc_cells[vid], tr, total_move)){
+#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
             nb_done_1d++;
+#endif
+          }
         }
         else if (neighbors[vid] > 0)
         {
@@ -574,8 +578,11 @@ public:
 #endif
           // move vertex
           const typename Tr::Point new_pos(final_position.x(), final_position.y(), final_position.z());
-          if(check_inversion_and_move(v, new_pos, inc_cells[vid], tr, total_move))
+          if(check_inversion_and_move(v, new_pos, inc_cells[vid], tr, total_move)){
+#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
             nb_done_1d++;
+#endif
+          }
         }
       }
     }
@@ -647,8 +654,11 @@ public:
           os_surf << "2 " << current_pos << " " << final_position << std::endl;
 #endif
           const typename Tr::Point new_pos(final_position.x(), final_position.y(), final_position.z());
-          if(check_inversion_and_move(v, new_pos, inc_cells[vid], tr, total_move))
+          if(check_inversion_and_move(v, new_pos, inc_cells[vid], tr, total_move)){
+#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
             nb_done_2d++;
+#endif
+          }
         }
         else if (neighbors[vid] > 0)
         {
@@ -660,8 +670,11 @@ public:
           if (boost::optional<Vector_3> mls_projection = project(si, current_pos))
           {
             const typename Tr::Point new_pos(CGAL::ORIGIN + *mls_projection);
-            if(check_inversion_and_move(v, new_pos, inc_cells[vid], tr, total_move))
+            if(check_inversion_and_move(v, new_pos, inc_cells[vid], tr, total_move)){
+#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
               nb_done_2d++;
+#endif
+            }
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
             os_surf0 << "2 " << current_pos << " " << new_pos << std::endl;
@@ -715,8 +728,11 @@ public:
 #endif
         const Vector_3 p = smoothed_positions[vid] / static_cast<FT>(neighbors[vid]);
         typename Tr::Point new_pos(p.x(), p.y(), p.z());
-        if(check_inversion_and_move(v, new_pos, inc_cells[vid], tr, total_move))
+        if(check_inversion_and_move(v, new_pos, inc_cells[vid], tr, total_move)){
+#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
           nb_done_3d++;
+#endif
+        }
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
         os_vol << " " << point(v->point()) << std::endl;

--- a/Triangulation_3/test/Triangulation_3/test_regular_remove_3.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_regular_remove_3.cpp
@@ -288,16 +288,14 @@ bool test_case (std::istream &is)
 
     point_set points;
     Cls T;
-    int number = 0;
 
     do {
-        ++number;
         points.insert (*pi);
         T.insert (*pi);
     } while (++pi != pend);
     assert(T.is_valid());
 
-    for (int i = 0; !points.empty(); ++i) {
+    while(! points.empty()) {
         assert(T.number_of_vertices() != 0);
         Vertex_handle v = T.finite_vertices_begin();
         set_iterator pos = points.find (v->point());
@@ -376,4 +374,3 @@ int main(int argc, char **argv)
 
     return 0;
 }
-

--- a/Visibility_2/test/Visibility_2/include/CGAL/test_utils.h
+++ b/Visibility_2/test/Visibility_2/include/CGAL/test_utils.h
@@ -858,7 +858,6 @@ typename Arrangement_2::Face_const_handle construct_biggest_arr_with_no_holes(
   Ccb_halfedge_const_circulator curr;
   Face_const_iterator fit;
 
-  int cnt(0);
   for (fit = arr_in.faces_begin() ; fit != arr_in.faces_end() ; fit++) {
     if (fit->has_outer_ccb()) {
       Ccb_halfedge_const_circulator circ = fit->outer_ccb();
@@ -868,7 +867,6 @@ typename Arrangement_2::Face_const_handle construct_biggest_arr_with_no_holes(
         curr_max_circ = circ;
       }
     }
-    cnt++;
   }
 
   std::vector<Segment_2> segments;

--- a/Voronoi_diagram_2/test/Voronoi_diagram_2/include/vda_print_report.h
+++ b/Voronoi_diagram_2/test/Voronoi_diagram_2/include/vda_print_report.h
@@ -329,6 +329,8 @@ void print_report(const VDA& vda, const Projector& project,
   std::cout << "# of Voronoi cells: " << n_all << std::endl;
   std::cout << "# of Voronoi cells with empty interior: "
             << n_empty << std::endl;
+#else
+  CGAL_USE(n_vert); CGAL_USE(n_all); CGAL_USE(n_empty);
 #endif
 
   std::cout << "is Voronoi diagram valid? "


### PR DESCRIPTION
## Summary of Changes

Several packages have variables that probably served for debugging purposes. 
Not all packages are treated but there are some in assertion code being modified in another PR.

<details><summary><h2>Note about Eigen</h2> (click for details)</summary>

There are also warnings concerning Eigen and we might make a merge request.
**Edit:** the merge request was [created and is already merged](https://gitlab.com/libeigen/eigen/-/merge_requests/1094).

[SparseCore/TriangularSolver.h](https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/SparseCore/TriangularSolver.h#L279)

`/usr/include/eigen3/Eigen/src/SparseCore/TriangularSolver.h:273:13: warning: variable 'count' set but not used [-Wunused-but-set-variable]`

[SparseLU/SparseLU_heap_relax_snode.h](https://gitlab.com/libeigen/eigen/-/blob/master/Eigen/src/SparseLU/SparseLU_heap_relax_snode.h#L80)
`/usr/include/eigen3/Eigen/src/SparseLU/SparseLU_heap_relax_snode.h:79:9: warning: variable 'nsuper_et' set but not used [-Wunused-but-set-variable]`

and the same for the other variable `nsuper_et_post`.  The increments must be removed as well.

See for example https://cgal.geometryfactory.com/CGAL/testsuite/results-5.6-I-86.shtml#Heat_method_3 at the [column `Debian-testing-clang-main`](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.6-I-86/Heat_method_3/TestReport_gimeno_Debian-testing-clang-main.gz).

</details>

## Release Management

* Affected package(s): several

* License and copyright ownership: unchanged

