### PR TITLE
STL_extension: Doc Improvements

### DIFF
--- a/Generator/doc/Generator/Generator.txt
+++ b/Generator/doc/Generator/Generator.txt
@@ -18,7 +18,7 @@ Two kinds of point generators are provided: first, random point
 generators and second deterministic point generators. Most random
 point generators and a few deterministic point generators are provided
 as input iterators. The input iterators model an infinite sequence of
-points. The function `CGAL::copy_n()` can be used to copy a
+points. The algorithm `std::copy_n` can be used to copy a
 finite sequence. The iterator adaptor
 `Counting_iterator` can be used to create finite iterator
 ranges.

--- a/STL_Extension/doc/STL_Extension/CGAL/algorithm.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/algorithm.h
@@ -125,7 +125,6 @@ the result of `operator++()` on a forward iterator.
 
 \sa `CGAL::predecessor()`
 
-\returns `it`.
 */
 template <class ForwardIterator>
 ForwardIterator successor(ForwardIterator it);

--- a/STL_Extension/doc/STL_Extension/CGAL/algorithm.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/algorithm.h
@@ -7,7 +7,7 @@ namespace CGAL {
 /*!
 \ingroup STLAlgos
 
-\deprecated This function is deprecated, std::copy_n should be
+\deprecated This function is deprecated, `std::copy_n()` should be
 used instead.
 
 Copies the first `n` items from `first` to `result`.
@@ -36,15 +36,15 @@ namespace CGAL {
 
 Computes the minimal and the
 maximal element of a range. It is modeled after the STL functions
-`std::min_element` and `std::max_element`. The advantage of
-`min_max_element` compared to calling both STL functions is that
+`std::min_element()` and `std::max_element()`. The advantage of
+`min_max_element()` compared to calling both STL functions is that
 one only iterates once over the sequence. This is more efficient
 especially for large and/or complex sequences.
 
 \cgalHeading{Example}
 
 The following example program computes the minimal and
-maximal element of the sequence ` (3,\,6,\,5)`. Hence the output is
+maximal element of the sequence `(3,\,6,\,5)`. Hence the output is
 `min = 3, max = 6`.
 
 \cgalExample{STL_Extension/min_max_element_example.cpp}
@@ -65,8 +65,8 @@ first, ForwardIterator last);
 
 Computes the minimal and the
 maximal element of a range. It is modeled after the STL functions
-`std::min_element` and `std::max_element`. The advantage of
-`min_max_element` compared to calling both STL functions is that
+`std::min_element()` and `std::max_element()`. The advantage of
+`min_max_element()` compared to calling both STL functions is that
 one only iterates once over the sequence. This is more efficient
 especially for large and/or complex sequences.
 
@@ -95,11 +95,11 @@ namespace CGAL {
 /*!
 \ingroup STLAlgos
 
-\deprecated This function is deprecated. `std::prev` should be used
+\deprecated This function is deprecated. `std::prev()` should be used
 instead.
 
 Returns the previous iterator,
-i.e.\ the result of `operator--` on a bidirectional iterator.
+i.e.\ the result of `operator--()` on a bidirectional iterator.
 
 \sa `CGAL::successor()`
 
@@ -115,17 +115,17 @@ namespace CGAL {
 /*!
 \ingroup STLAlgos
 
-\deprecated This function is deprecated. `std::next` should be used
+\deprecated This function is deprecated. `std::next()` should be used
 instead.
 
 
-Returns the next iterator, i.e.
-the result of `operator++` on a forward iterator.
+Returns the next iterator, i.e.,
+the result of `operator++()` on a forward iterator.
 
 
 \sa `CGAL::predecessor()`
 
-\returns `++it`.
+\returns `it`.
 */
 template <class ForwardIterator>
 ForwardIterator successor(ForwardIterator it);

--- a/STL_Extension/doc/STL_Extension/CGAL/algorithm.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/algorithm.h
@@ -7,37 +7,12 @@ namespace CGAL {
 /*!
 \ingroup STLAlgos
 
-\deprecated This function is deprecated, `std::copy_n()` should be
-used instead.
-
-Copies the first `n` items from `first` to `result`.
-
-\returns the value of `result` after inserting the `n` items.
-
-\note The \stl release June 13, 1997, from SGI contains an equivalent
-function, but it is not part of the ISO standard.
-
-\sa `CGAL::Counting_iterator<Iterator, Value>`
-
-copies
-
-*/
-template <class InputIterator, class Size, class
-OutputIterator> OutputIterator copy_n(InputIterator first, Size n,
-OutputIterator result);
-
-} /* namespace CGAL */
-
-namespace CGAL {
-
-/*!
-\ingroup STLAlgos
-
 
 Computes the minimal and the
-maximal element of a range. It is modeled after the STL functions
-`std::min_element()` and `std::max_element()`. The advantage of
-`min_max_element()` compared to calling both STL functions is that
+maximal element of a range. It is modeled after the \stl functions
+<a href="https://en.cppreference.com/w/cpp/algorithm/min_element">`std::min_element`</a>
+and <a href="https://en.cppreference.com/w/cpp/algorithm/max_element">`std::max_element`</a>.
+The advantage of `min_max_element()` compared to calling both \stl functions is that
 one only iterates once over the sequence. This is more efficient
 especially for large and/or complex sequences.
 
@@ -64,9 +39,11 @@ first, ForwardIterator last);
 \ingroup STLAlgos
 
 Computes the minimal and the
-maximal element of a range. It is modeled after the STL functions
-`std::min_element()` and `std::max_element()`. The advantage of
-`min_max_element()` compared to calling both STL functions is that
+maximal element of a range. It is modeled after the \stl functions
+<a href="https://en.cppreference.com/w/cpp/algorithm/min_element">`std::min_element`</a>
+and <a
+href="https://en.cppreference.com/w/cpp/algorithm/maxelement">`std::max_element`</a>.
+The advantage of `min_max_element()` compared to calling both \stl functions is that
 one only iterates once over the sequence. This is more efficient
 especially for large and/or complex sequences.
 
@@ -90,53 +67,18 @@ CompareMin comp_min, CompareMax comp_max);
 
 } /* namespace CGAL */
 
-namespace CGAL {
-
-/*!
-\ingroup STLAlgos
-
-\deprecated This function is deprecated. `std::prev()` should be used
-instead.
-
-Returns the previous iterator,
-i.e.\ the result of `operator--()` on a bidirectional iterator.
-
-\sa `CGAL::successor()`
-
-\returns `--it`.
-*/
-template <class BidirectionalIterator>
-BidirectionalIterator predecessor(BidirectionalIterator it);
-
-} /* namespace CGAL */
 
 namespace CGAL {
 
-/*!
-\ingroup STLAlgos
-
-\deprecated This function is deprecated. `std::next()` should be used
-instead.
-
-
-Returns the next iterator, i.e.,
-the result of `operator++()` on a forward iterator.
-
-
-\sa `CGAL::predecessor()`
-
-*/
-template <class ForwardIterator>
-ForwardIterator successor(ForwardIterator it);
 
 namespace cpp98 {
 
 /*!
 \ingroup STLAlgos
 
-Replacement for <a href="https://en.cppreference.com/w/cpp/algorithm/random_shuffle">`std::random_shuffle()`</a>
+Replacement for <a href="https://en.cppreference.com/w/cpp/algorithm/random_shuffle">`std::random_shuffle`</a>
 which was deprecated in C++14, and removed by C++17.
-In the \stl it was replaced by `std::shuffle()`.
+In the \stl it was replaced by `std::shuffle`.
 
 \note The implementation in \cgal produces the same order on all platforms.
 */
@@ -148,9 +90,9 @@ random_shuffle(RandomAccessIterator begin, RandomAccessIterator end,
 /*!
 \ingroup STLAlgos
 
-Replacement for <a href="https://en.cppreference.com/w/cpp/algorithm/random_shuffle">`std::random_shuffle()`</a>
+Replacement for <a href="https://en.cppreference.com/w/cpp/algorithm/random_shuffle">`std::random_shuffle`</a>
 which was deprecated in C++14, and removed by C++17.
-In the \stl it was replaced by `std::shuffle()`.
+In the \stl it was replaced by `std::shuffle`.
 
 \note The implementation in \cgal produces the same order on all platforms.
 */
@@ -160,4 +102,3 @@ random_shuffle(RandomAccessIterator begin, RandomAccessIterator end);
 } // namespace cpp98
 
 } /* namespace CGAL */
-

--- a/STL_Extension/doc/STL_Extension/CGAL/iterator.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/iterator.h
@@ -61,8 +61,6 @@ from input iterators.
 `Iterator` is a model for
 `InputIterator`.
 
-\sa `CGAL::copy_n()`
-
 
 */
 template< typename Iterator, typename Value >

--- a/STL_Extension/doc/STL_Extension/PackageDescription.txt
+++ b/STL_Extension/doc/STL_Extension/PackageDescription.txt
@@ -41,10 +41,8 @@
 - `CGAL::Multiset<Type,Compare,Allocator>`
 
 \cgalCRPSection{Generic Algorithms}
-- `CGAL::copy_n`
 - `CGAL::min_max_element`
-- `CGAL::predecessor`
-- `CGAL::successor`
+- `CGAL::cpp98::random_shuffle`
 
 \cgalCRPSection{Iterators and Iterator/Circulator Adaptors}
 - `CGAL::Dispatch_output_iterator<V,O>`


### PR DESCRIPTION
## Summary of Changes

Replace #6889.      I do not put `()` behind functions from the STL, but stick to the convention for CGAL functions.  I removed the documentation of deprecated functions.

## Release Management

* Affected package(s): STL_extensions
* License and copyright ownership: unchanged

