### PR TITLE
AW3: Move some input named parameters to in_np

### DIFF
--- a/Alpha_wrap_3/examples/Alpha_wrap_3/wrap_from_cavity.cpp
+++ b/Alpha_wrap_3/examples/Alpha_wrap_3/wrap_from_cavity.cpp
@@ -47,15 +47,8 @@ int main(int argc, char** argv)
   const double offset = diag_length / relative_offset;
 
   // Construct the wrap
-  using Oracle = CGAL::Alpha_wraps_3::internal::Triangle_mesh_oracle<K>;
-  Oracle oracle;
-  oracle.add_triangle_mesh(input);
-
   CGAL::Real_timer t;
   t.start();
-
-  Mesh wrap;
-  CGAL::Alpha_wraps_3::internal::Alpha_wrap_3<Oracle> aw3(oracle);
 
   // There is no limit on how many seeds can be used.
   // However, the algorithm automatically determines whether a seed can be used
@@ -66,7 +59,8 @@ int main(int argc, char** argv)
     Point_3(0, 50, 0) // a point within the armadillo surface
   };
 
-  aw3(alpha, offset, wrap, CGAL::parameters::seed_points(std::ref(seeds)));
+  Mesh wrap;
+  alpha_wrap_3(input, alpha, offset, wrap, CGAL::parameters::seed_points(std::ref(seeds)));
 
   t.stop();
   std::cout << "Result: " << num_vertices(wrap) << " vertices, " << num_faces(wrap) << " faces" << std::endl;

--- a/Alpha_wrap_3/include/CGAL/Alpha_wrap_3/internal/Alpha_wrap_3.h
+++ b/Alpha_wrap_3/include/CGAL/Alpha_wrap_3/internal/Alpha_wrap_3.h
@@ -229,11 +229,14 @@ private:
   }
 
 public:
-  template <typename OutputMesh, typename NamedParameters>
+  template <typename OutputMesh,
+            typename InputNamedParameters = parameters::Default_named_parameters,
+            typename OutputNamedParameters = parameters::Default_named_parameters>
   void operator()(const double alpha, // = default_alpha()
                   const double offset, // = alpha / 30.
                   OutputMesh& output_mesh,
-                  const NamedParameters& np)
+                  const InputNamedParameters& in_np = parameters::default_values(),
+                  const OutputNamedParameters& out_np = parameters::default_values())
   {
     namespace PMP = Polygon_mesh_processing;
 
@@ -241,25 +244,25 @@ public:
     using parameters::get_parameter_reference;
     using parameters::choose_parameter;
 
-    using OVPM = typename CGAL::GetVertexPointMap<OutputMesh, NamedParameters>::type;
-    OVPM ovpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
+    using OVPM = typename CGAL::GetVertexPointMap<OutputMesh, OutputNamedParameters>::type;
+    OVPM ovpm = choose_parameter(get_parameter(out_np, internal_np::vertex_point),
                                  get_property_map(vertex_point, output_mesh));
 
     typedef typename internal_np::Lookup_named_param_def <
       internal_np::visitor_t,
-      NamedParameters,
+      InputNamedParameters,
       Wrapping_default_visitor // default
     >::reference                                                                 Visitor;
 
     Wrapping_default_visitor default_visitor;
-    Visitor visitor = choose_parameter(get_parameter_reference(np, internal_np::visitor), default_visitor);
+    Visitor visitor = choose_parameter(get_parameter_reference(in_np, internal_np::visitor), default_visitor);
 
     std::vector<Point_3> no_seeds;
     using Seeds = typename internal_np::Lookup_named_param_def<
-                    internal_np::seed_points_t, NamedParameters, std::vector<Point_3> >::reference;
-    Seeds seeds = choose_parameter(get_parameter_reference(np, internal_np::seed_points), no_seeds);
+                    internal_np::seed_points_t, InputNamedParameters, std::vector<Point_3> >::reference;
+    Seeds seeds = choose_parameter(get_parameter_reference(in_np, internal_np::seed_points), no_seeds);
 
-    const bool do_enforce_manifoldness = choose_parameter(get_parameter(np, internal_np::do_enforce_manifoldness), true);
+    const bool do_enforce_manifoldness = choose_parameter(get_parameter(in_np, internal_np::do_enforce_manifoldness), true);
 
 #ifdef CGAL_AW3_TIMER
     CGAL::Real_timer t;
@@ -360,14 +363,6 @@ public:
   }
 
   // Convenience overloads
-  template <typename OutputMesh>
-  void operator()(const double alpha,
-                  const double offset,
-                  OutputMesh& output_mesh)
-  {
-    return operator()(alpha, offset, output_mesh, parameters::default_values());
-  }
-
   template <typename OutputMesh>
   void operator()(const double alpha,
                   OutputMesh& output_mesh)

--- a/Alpha_wrap_3/include/CGAL/alpha_wrap_3.h
+++ b/Alpha_wrap_3/include/CGAL/alpha_wrap_3.h
@@ -112,7 +112,7 @@ void alpha_wrap_3(const PointRange& points,
   Oracle oracle(alpha, gt);
   oracle.add_triangle_soup(points, faces, in_np);
   AW3 alpha_wrap_builder(oracle);
-  alpha_wrap_builder(alpha, offset, alpha_wrap, out_np);
+  alpha_wrap_builder(alpha, offset, alpha_wrap, in_np, out_np);
 }
 
 // Convenience overloads
@@ -261,7 +261,7 @@ void alpha_wrap_3(const TriangleMesh& tmesh,
   Oracle oracle(alpha, gt);
   oracle.add_triangle_mesh(tmesh, in_np);
   AW3 alpha_wrap_builder(oracle);
-  alpha_wrap_builder(alpha, offset, alpha_wrap, out_np);
+  alpha_wrap_builder(alpha, offset, alpha_wrap, in_np, out_np);
 }
 
 // The convenience overloads are the same for triangle mesh & point set
@@ -357,7 +357,7 @@ void alpha_wrap_3(const PointRange& points,
   Oracle oracle(gt);
   oracle.add_point_set(points, in_np);
   AW3 alpha_wrap_builder(oracle);
-  alpha_wrap_builder(alpha, offset, alpha_wrap, out_np);
+  alpha_wrap_builder(alpha, offset, alpha_wrap, in_np, out_np);
 }
 
 // Convenience overloads, common to both mesh and point set

--- a/Alpha_wrap_3/test/Alpha_wrap_3/test_AW3_manifoldness.cpp
+++ b/Alpha_wrap_3/test/Alpha_wrap_3/test_AW3_manifoldness.cpp
@@ -45,7 +45,6 @@ void alpha_wrap_triangle_manifoldness(Mesh& input_mesh,
 
   Mesh nm_wrap;
   CGAL::alpha_wrap_3(input_mesh, alpha, offset, nm_wrap,
-                     CGAL::parameters::default_values(),
                      CGAL::parameters::do_enforce_manifoldness(false));
 
   std::cout << "Result: " << vertices(nm_wrap).size() << " vertices, " << faces(nm_wrap).size() << " faces" << std::endl;
@@ -67,7 +66,6 @@ void alpha_wrap_triangle_manifoldness(Mesh& input_mesh,
 
   Mesh m_wrap;
   CGAL::alpha_wrap_3(input_mesh, alpha, offset, m_wrap,
-                     CGAL::parameters::default_values(),
                      CGAL::parameters::do_enforce_manifoldness(true));
 
 //  CGAL::IO::write_polygon_mesh("last.off", wrap, CGAL::parameters::stream_precision(17));

--- a/Alpha_wrap_3/test/Alpha_wrap_3/test_alpha_wrap_3_mesh.cpp
+++ b/Alpha_wrap_3/test/Alpha_wrap_3/test_alpha_wrap_3_mesh.cpp
@@ -47,7 +47,6 @@ void alpha_wrap_triangle_mesh(Mesh& input_mesh,
 
   Mesh wrap;
   CGAL::alpha_wrap_3(input_mesh, alpha, offset, wrap,
-                     CGAL::parameters::default_values(),
                      CGAL::parameters::do_enforce_manifoldness(enforce_manifoldness));
 
   std::cout << "Result: " << vertices(wrap).size() << " vertices, " << faces(wrap).size() << " faces" << std::endl;


### PR DESCRIPTION
## Summary of Changes

Moving some internal named parameters to the input NP rather than the output NP.

## Release Management

* Affected package(s):
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): n/a
* License and copyright ownership: no change

