### PR TITLE
Fix weights in ARAP parameterization's post processing

### DIFF
--- a/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/examples.txt
+++ b/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/examples.txt
@@ -1,4 +1,5 @@
 /*!
+ \example Surface_mesh_parameterization/ARAP_parameterization.cpp
  \example Surface_mesh_parameterization/discrete_authalic.cpp
  \example Surface_mesh_parameterization/lscm.cpp
  \example Surface_mesh_parameterization/orbifold.cpp

--- a/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/ARAP_parameterization.cpp
+++ b/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/ARAP_parameterization.cpp
@@ -1,0 +1,57 @@
+#include <CGAL/Simple_cartesian.h>
+
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Surface_mesh_parameterization/IO/File_off.h>
+#include <CGAL/Surface_mesh_parameterization/ARAP_parameterizer_3.h>
+#include <CGAL/Surface_mesh_parameterization/Error_code.h>
+#include <CGAL/Surface_mesh_parameterization/parameterize.h>
+
+#include <CGAL/Polygon_mesh_processing/measure.h>
+
+#include <cstdlib>
+#include <iostream>
+#include <fstream>
+
+typedef CGAL::Simple_cartesian<double>       Kernel;
+typedef Kernel::Point_2                      Point_2;
+typedef Kernel::Point_3                      Point_3;
+typedef CGAL::Surface_mesh<Kernel::Point_3>  SurfaceMesh;
+
+typedef boost::graph_traits<SurfaceMesh>::halfedge_descriptor  halfedge_descriptor;
+typedef boost::graph_traits<SurfaceMesh>::vertex_descriptor    vertex_descriptor;
+typedef boost::graph_traits<SurfaceMesh>::face_descriptor      face_descriptor;
+
+namespace SMP = CGAL::Surface_mesh_parameterization;
+
+int main(int argc, char** argv)
+{
+  const std::string filename = (argc>1) ? argv[1] : CGAL::data_file_path("meshes/head.off");
+
+  SurfaceMesh sm;
+  if(!CGAL::IO::read_polygon_mesh(filename, sm))
+  {
+    std::cerr << "Invalid input file." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  // A halfedge on the border
+  halfedge_descriptor bhd = CGAL::Polygon_mesh_processing::longest_border(sm).first;
+
+  // The 2D points of the uv parametrisation will be written into this map
+  typedef SurfaceMesh::Property_map<vertex_descriptor, Point_2>  UV_pmap;
+  UV_pmap uv_map = sm.add_property_map<vertex_descriptor, Point_2>("v:uv").first;
+
+  SMP::ARAP_parameterizer_3<SurfaceMesh> parameterizer;
+  SMP::Error_code err = SMP::parameterize(sm, parameterizer, bhd, uv_map);
+
+  if(err != SMP::OK) {
+    std::cerr << "Error: " << SMP::get_error_message(err) << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::ofstream out("result.off");
+  SMP::IO::output_uvmap_to_off(sm, bhd, uv_map, out);
+
+  return EXIT_SUCCESS;
+}

--- a/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/CMakeLists.txt
+++ b/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/CMakeLists.txt
@@ -53,6 +53,8 @@ if(TARGET CGAL::Eigen3_support)
   #   End of SuiteSparse detection
   # ------------------------------------------------------------------
 
+  create_single_source_cgal_program("ARAP_parameterization.cpp")
+  target_link_libraries(ARAP_parameterization PUBLIC CGAL::Eigen3_support)
   create_single_source_cgal_program("discrete_authalic.cpp")
   target_link_libraries(discrete_authalic PUBLIC CGAL::Eigen3_support)
   create_single_source_cgal_program("lscm.cpp")
@@ -68,6 +70,7 @@ if(TARGET CGAL::Eigen3_support)
   create_single_source_cgal_program( "iterative_authalic_parameterizer.cpp" )
   target_link_libraries(iterative_authalic_parameterizer PUBLIC CGAL::Eigen3_support)
   if(SuiteSparse_FOUND)
+    target_link_libraries(ARAP_parameterization PRIVATE ${SuiteSparse_LIBRARIES})
     target_link_libraries(orbifold PRIVATE ${SuiteSparse_LIBRARIES})
   endif()
 

--- a/Weights/include/CGAL/Weights/tangent_weights.h
+++ b/Weights/include/CGAL/Weights/tangent_weights.h
@@ -461,7 +461,7 @@ namespace Weights {
       const auto v1 = construct_vector_2(q, r);
       const auto v2 = construct_vector_2(q, p);
 
-      const auto A = internal::area_2(traits, p, q, r);
+      const auto A = internal::positive_area_2(traits, p, q, r);
       CGAL_assertion(A != FT(0)); // three points are identical!
       const auto S = scalar_product_2(v1, v2);
       m_w_base = -tangent_half_angle(m_d_r, m_d_p, A, S);


### PR DESCRIPTION
## Summary of Changes

With the introduction of the Weights package, weights were factorized away from the parameterization package, but a sign error was introduced.

## Release Management

* Affected package(s): `Surface_mesh_parameterization`, `Weights`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change
