### PR TITLE
Mesh 3 for labeled images - avoid vertex clusters on surfaces

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h
@@ -33,6 +33,7 @@ struct Get_point
 {
   const double vx, vy, vz;
   const double tx, ty, tz;
+  const std::size_t xdim, ydim, zdim;
   Get_point(const CGAL::Image_3* image)
     : vx(image->vx())
     , vy(image->vy())
@@ -40,15 +41,27 @@ struct Get_point
     , tx(image->tx())
     , ty(image->ty())
     , tz(image->tz())
+    , xdim(image->xdim())
+    , ydim(image->ydim())
+    , zdim(image->zdim())
   {}
 
   Point operator()(const std::size_t i,
                    const std::size_t j,
                    const std::size_t k) const
   {
-    return Point(double(i) * vx + tx,
-                 double(j) * vy + ty,
-                 double(k) * vz + tz);
+    double x = double(i) * vx + tx;
+    double y = double(j) * vy + ty;
+    double z = double(k) * vz + tz;
+
+    if (i == 0)              x += 1. / 6. * vx;
+    else if (i == xdim - 1)  x -= 1. / 6. * vx;
+    if (j == 0)              y += 1. / 6. * vy;
+    else if (j == ydim - 1)  y -= 1. / 6. * vy;
+    if (k == 0)              z += 1. / 6. * vz;
+    else if (k == zdim - 1)  z -= 1. / 6. * vz;
+
+    return Point(x, y, z);
   }
 };
 template<class C3T3, class MeshDomain, class MeshCriteria>

--- a/Mesh_3/include/CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h
@@ -24,7 +24,6 @@
 #include <CGAL/iterator.h>
 #include <CGAL/point_generators_3.h>
 #include <CGAL/Image_3.h>
-#include <CGAL/ImageIO.h>
 
 #include <iostream>
 #include <queue>

--- a/Mesh_3/include/CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h
@@ -132,7 +132,6 @@ void initialize_triangulation_from_labeled_image(C3T3& c3t3,
     std::size_t radius;
   };
   using Seeds = std::vector<Seed>;
-  using Subdomain_index = typename Mesh_domain::Subdomain_index;
   using Subdomain = typename Mesh_domain::Subdomain;
 
   Seeds seeds;

--- a/Mesh_3/include/CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h
@@ -154,8 +154,10 @@ void initialize_triangulation_from_labeled_image(C3T3& c3t3,
     const boost::optional<Subdomain_index> seed_label
       = domain.is_in_domain_object()(seed_point);
     const boost::optional<Subdomain_index> seed_cell_label
-      = domain.is_in_domain_object()(
-          seed_cell->weighted_circumcenter(tr.geom_traits()));
+      = (seed_cell == Cell_handle()) //seed_point is OUTSIDE_AFFINE_HULL
+        ? boost::none
+        : domain.is_in_domain_object()(
+            seed_cell->weighted_circumcenter(tr.geom_traits()));
 
     if ( seed_label != boost::none
       && seed_cell_label != boost::none

--- a/Mesh_3/include/CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h
@@ -152,8 +152,8 @@ void initialize_triangulation_from_labeled_image(C3T3& c3t3,
     const Subdomain seed_label
       = domain.is_in_domain_object()(seed_point);
     const Subdomain seed_cell_label
-      = (seed_cell == Cell_handle()) //seed_point is OUTSIDE_AFFINE_HULL
-        ? Subdomain()
+      = (seed_cell == Cell_handle() || tr.is_infinite(seed_cell))
+        ? Subdomain()  //seed_point is OUTSIDE_AFFINE_HULL
         : domain.is_in_domain_object()(
             seed_cell->weighted_circumcenter(tr.geom_traits()));
 

--- a/Mesh_3/include/CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h
@@ -157,8 +157,8 @@ void initialize_triangulation_from_labeled_image(C3T3& c3t3,
         : domain.is_in_domain_object()(
             seed_cell->weighted_circumcenter(tr.geom_traits()));
 
-    if ( seed_label.has_value()
-      && seed_cell_label.has_value()
+    if ( seed_label != boost::none
+      && seed_cell_label != boost::none
       && *seed_label == *seed_cell_label)
         continue; //this means the connected component has already been initialized
 

--- a/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
@@ -34,14 +34,12 @@
 template <typename PointsOutputIterator,
           typename DomainsOutputIterator,
           typename TransformOperator,
-          typename Construct_point,
           typename Image_word_type>
 void
 search_for_connected_components_in_labeled_image(const CGAL::Image_3& image,
                                                  PointsOutputIterator it,
                                                  DomainsOutputIterator dom_it,
                                                  TransformOperator transform,
-                                                 Construct_point point,
                                                  Image_word_type)
 {
   const std::size_t nx = image.xdim();
@@ -210,7 +208,7 @@ search_for_connected_components_in_labeled_image(const CGAL::Image_3& image,
             {
 //               if(nb_voxels >= 100)
               {
-                *it++ = std::make_pair(point(i, j, k),
+                *it++ = std::make_pair(std::make_tuple(i, j, k),
                                        depth+1);
 #if CGAL_MESH_3_SEARCH_FOR_CONNECTED_COMPONENTS_IN_LABELED_IMAGE_VERBOSE > 1
                 std::cerr << boost::format("Found seed %5%, which is voxel "

--- a/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/search_for_connected_components_in_labeled_image.h
@@ -208,8 +208,7 @@ search_for_connected_components_in_labeled_image(const CGAL::Image_3& image,
             {
 //               if(nb_voxels >= 100)
               {
-                *it++ = std::make_pair(std::make_tuple(i, j, k),
-                                       depth+1);
+                *it++ = { i, j, k, std::size_t(depth + 1) };
 #if CGAL_MESH_3_SEARCH_FOR_CONNECTED_COMPONENTS_IN_LABELED_IMAGE_VERBOSE > 1
                 std::cerr << boost::format("Found seed %5%, which is voxel "
                                            "(%1%, %2%, %3%), value=%4%\n")


### PR DESCRIPTION
## Summary of Changes

When meshing from labeled images

* without detection of connected components
<img src="https://user-images.githubusercontent.com/11311305/197203172-05d791c0-49e1-426e-a0d3-457f87e62cda.png" width="300">

* with detection of connected components and random shooting from a seed that is too close to the surface (master)
<img src="https://user-images.githubusercontent.com/11311305/197203317-2bdf8283-e61a-41dd-8d5d-4ec0fe2fb74b.png" width="300">

* with detection of connected components and random shooting from a better chosen seed (commit de9fbdb in this PR) 
<img src="https://user-images.githubusercontent.com/11311305/197203577-ced6833c-0a57-49f0-8c0f-5cffffbd6179.png" width="300">

* with detection of connected components that have not been already detected/initialized by feature protection
<img src="https://user-images.githubusercontent.com/11311305/197203734-fb1e4fa2-4f77-43c1-a13f-b17689ce327c.png" width="300">

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

