### PR TITLE
Point_set_3 - `NP_helper::has_normal_map()` should not always return true

### DIFF
--- a/BGL/include/CGAL/boost/graph/named_params_helper.h
+++ b/BGL/include/CGAL/boost/graph/named_params_helper.h
@@ -336,7 +336,7 @@ struct Point_set_processing_3_np_helper
     return parameters::choose_parameter<Geom_traits>(parameters::get_parameter(np, internal_np::geom_traits));
   }
 
-  static constexpr bool has_normal_map()
+  static constexpr bool has_normal_map(const PointRange&, const NamedParameters&)
   {
     using CGAL::parameters::is_default_parameter;
     return !(is_default_parameter<NamedParameters, internal_np::normal_t>::value);

--- a/BGL/include/CGAL/boost/graph/named_params_helper.h
+++ b/BGL/include/CGAL/boost/graph/named_params_helper.h
@@ -336,10 +336,10 @@ struct Point_set_processing_3_np_helper
     return parameters::choose_parameter<Geom_traits>(parameters::get_parameter(np, internal_np::geom_traits));
   }
 
-  static constexpr bool has_normal_map()
+  static constexpr bool has_normal_map(const PointRange&, const NamedParameters&)
   {
-    return !boost::is_same< typename internal_np::Get_param<typename NamedParameters::base, internal_np::normal_t>::type,
-                            internal_np::Param_not_found> ::value;
+    using CGAL::parameters::is_default_parameter;
+    return !(is_default_parameter<NamedParameters, internal_np::normal_t>::value);
   }
 };
 

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -466,7 +466,8 @@ public:
     are initialized to their default value.
 
     \note If not already added, a normal property is automatically
-    added to the point set when using this method.
+    added to the point set when using this method. The default value
+    for normal vectors is `CGAL::NULL_VECTOR`.
 
     \note If a reallocation happens, all iterators, pointers and
     references related to the container are invalidated.  Otherwise,

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -1343,17 +1343,11 @@ struct Point_set_processing_3_np_helper<Point_set_3<Point, Vector>, NamedParamet
 
   static const Normal_map get_normal_map(const Point_set_3<Point, Vector>& ps, const NamedParameters& np)
   {
-    CGAL_assertion_code(
-      if (!(parameters::is_default_parameter<NamedParameters, internal_np::normal_t>::value)))
-        CGAL_assertion(!!ps.normal_map());
     return parameters::choose_parameter(parameters::get_parameter(np, internal_np::normal_map), ps.normal_map());
   }
 
   static Normal_map get_normal_map(Point_set_3<Point, Vector>& ps, const NamedParameters& np)
   {
-    CGAL_assertion_code(
-      if (!(parameters::is_default_parameter<NamedParameters, internal_np::normal_t>::value)))
-        CGAL_assertion(!!ps.normal_map());
     return parameters::choose_parameter(parameters::get_parameter(np, internal_np::normal_map), ps.normal_map());
   }
 
@@ -1362,11 +1356,9 @@ struct Point_set_processing_3_np_helper<Point_set_3<Point, Vector>, NamedParamet
     return parameters::choose_parameter<Geom_traits>(parameters::get_parameter(np, internal_np::geom_traits));
   }
 
-  static constexpr bool has_normal_map(const Point_set_3<Point, Vector>& ps, const NamedParameters& np)
+  static constexpr bool has_normal_map(const Point_set_3<Point, Vector>&, const NamedParameters&)
   {
-    using CGAL::parameters::is_default_parameter;
-    const bool np_has_normals = !(is_default_parameter<NamedParameters, internal_np::normal_t>::value);
-    return np_has_normals || !!ps.normal_map();
+    return true;//either available in np, or in point set
   }
 
 };

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -219,11 +219,9 @@ public:
     added. If `false` (default value), the normal map can still be
     added later on (see `add_normal_map()`).
    */
-  Point_set_3 (bool with_normal_map = false) : m_base()
+  Point_set_3 () : m_base()
   {
     clear();
-    if (with_normal_map)
-      add_normal_map();
   }
 
   /*!
@@ -1341,11 +1339,17 @@ struct Point_set_processing_3_np_helper<Point_set_3<Point, Vector>, NamedParamet
 
   static const Normal_map get_normal_map(const Point_set_3<Point, Vector>& ps, const NamedParameters& np)
   {
+    CGAL_assertion_code(
+      if (!(parameters::is_default_parameter<NamedParameters, internal_np::normal_t>::value)))
+        CGAL_assertion(!!ps.normal_map());
     return parameters::choose_parameter(parameters::get_parameter(np, internal_np::normal_map), ps.normal_map());
   }
 
   static Normal_map get_normal_map(Point_set_3<Point, Vector>& ps, const NamedParameters& np)
   {
+    CGAL_assertion_code(
+      if (!(parameters::is_default_parameter<NamedParameters, internal_np::normal_t>::value)))
+        CGAL_assertion(!!ps.normal_map());
     return parameters::choose_parameter(parameters::get_parameter(np, internal_np::normal_map), ps.normal_map());
   }
 
@@ -1354,9 +1358,11 @@ struct Point_set_processing_3_np_helper<Point_set_3<Point, Vector>, NamedParamet
     return parameters::choose_parameter<Geom_traits>(parameters::get_parameter(np, internal_np::geom_traits));
   }
 
-  static constexpr bool has_normal_map()
+  static constexpr bool has_normal_map(const Point_set_3<Point, Vector>& ps, const NamedParameters& np)
   {
-    return true;
+    using CGAL::parameters::is_default_parameter;
+    const bool np_has_normals = !(is_default_parameter<NamedParameters, internal_np::normal_t>::value);
+    return np_has_normals || !!ps.normal_map();
   }
 
 };

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -1365,7 +1365,7 @@ struct Point_set_processing_3_np_helper<Point_set_3<Point, Vector>, NamedParamet
     return !(is_default_parameter<NamedParameters, internal_np::normal_t>::value);
   }
 
-  static constexpr bool has_normal_map(Point_set_3<Point, Vector>& ps, const NamedParameters&)
+  static constexpr bool has_normal_map(Point_set_3<Point, Vector>&, const NamedParameters&)
   {
     return true; // either available in named parameters, and always available in Point_set_3 otherwise
   }

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -465,8 +465,8 @@ public:
     \note Properties of the added point other than its normal vector
     are initialized to their default value.
 
-    \note A normal property must have been added to the point set
-    before using this method.
+    \note If not already added, a normal property is automatically
+    added to the point set when using this method.
 
     \note If a reallocation happens, all iterators, pointers and
     references related to the container are invalidated.  Otherwise,
@@ -479,8 +479,7 @@ public:
   iterator insert (const Point& p, const Vector& n)
   {
     iterator out = insert (p);
-    CGAL_assertion(has_normal_map());
-    m_normals[size()-1] = n;
+    normal_map()[size()-1] = n;
     return out;
   }
 
@@ -550,17 +549,17 @@ public:
   /*!
     \brief returns a reference to the normal corresponding to `index`.
 
-    \note The normal property must have been added to the point set
-    before calling this method (see `add_normal_map()`).
+    \note If not already added, a normal property is automatically
+    added to the point set (see `add_normal_map()`).
   */
-  Vector& normal (const Index& index) { return m_normals[index]; }
+  Vector& normal (const Index& index) { return normal_map()[index]; }
   /*!
     \brief returns a constant reference to the normal corresponding to `index`.
 
-    \note The normal property must have been added to the point set
-    before calling this method (see `add_normal_map()`).
+    \note If not already added, a normal property is automatically
+    added to the point set (see `add_normal_map()`).
   */
-  const Vector& normal (const Index& index) const { return m_normals[index]; }
+  const Vector& normal (const Index& index) const { return normal_map()[index]; }
 
   /// @}
 
@@ -869,11 +868,14 @@ public:
   /*!
     \brief returns the property map of the normal property.
 
-    \note The normal property must have been added to the point set
-    before calling this method (see `add_normal_map()`).
+    \note If the normal property has not been added yet to the point set
+    before calling this method, the property map is automatically added
+    with `add_normal_map()`.
   */
   Vector_map normal_map ()
   {
+    if (!m_normals)
+      add_normal_map();
     return m_normals;
   }
   /*!
@@ -982,7 +984,7 @@ public:
   inline parameters() const
   {
     return CGAL::parameters::point_map (m_points).
-      normal_map (m_normals).
+      normal_map (normal_map()).
       geom_traits (typename Kernel_traits<Point>::Kernel());
   }
 
@@ -1036,7 +1038,7 @@ public:
   */
   Vector_range normals () const
   {
-    return this->range<Vector> (m_normals);
+    return this->range<Vector> (normal_map());
   }
 
   /// @}

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -1357,11 +1357,18 @@ struct Point_set_processing_3_np_helper<Point_set_3<Point, Vector>, NamedParamet
     return parameters::choose_parameter<Geom_traits>(parameters::get_parameter(np, internal_np::geom_traits));
   }
 
-  static constexpr bool has_normal_map()
+  static bool has_normal_map(const Point_set_3<Point, Vector>& ps, const NamedParameters&)
+  {
+    if (ps.has_normal_map())
+      return true;
+    using CGAL::parameters::is_default_parameter;
+    return !(is_default_parameter<NamedParameters, internal_np::normal_t>::value);
+  }
+
+  static constexpr bool has_normal_map(Point_set_3<Point, Vector>& ps, const NamedParameters&)
   {
     return true; // either available in named parameters, and always available in Point_set_3 otherwise
   }
-
 };
 /// \endcond
 

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -219,9 +219,11 @@ public:
     added. If `false` (default value), the normal map can still be
     added later on (see `add_normal_map()`).
    */
-  Point_set_3 () : m_base()
+  Point_set_3 (bool with_normal_map = false) : m_base()
   {
     clear();
+    if (with_normal_map)
+      add_normal_map();
   }
 
   /*!

--- a/Point_set_processing_3/include/CGAL/IO/read_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_off_points.h
@@ -98,8 +98,6 @@ bool read_OFF(std::istream& is,
   typedef typename NP_helper::Geom_traits Kernel;
   typedef typename Kernel::FT FT;
 
-  //the default value for normal map, if not provided in the np,
-  // is a dummy Constant_property_map
   PointMap point_map = NP_helper::get_point_map(np);
   NormalMap normal_map = NP_helper::get_normal_map(np);
 

--- a/Point_set_processing_3/include/CGAL/IO/read_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_off_points.h
@@ -98,8 +98,8 @@ bool read_OFF(std::istream& is,
   typedef typename NP_helper::Geom_traits Kernel;
   typedef typename Kernel::FT FT;
 
-  bool has_normals = NP_helper::has_normal_map();
-
+  //the default value for normal map, if not provided in the np,
+  // is a dummy Constant_property_map
   PointMap point_map = NP_helper::get_point_map(np);
   NormalMap normal_map = NP_helper::get_normal_map(np);
 
@@ -183,8 +183,7 @@ bool read_OFF(std::istream& is,
 
         Enriched_point pwn;
         put(point_map,  pwn, point);  // point_map[&pwn] = point
-        if (has_normals)
-          put(normal_map, pwn, normal); // normal_map[&pwn] = normal
+        put(normal_map, pwn, normal); // normal_map[&pwn] = normal
 
         *output++ = pwn;
         ++pointsRead;

--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -258,17 +258,14 @@ bool read_PLY(std::istream& is,
   typedef typename NP_helper::Point_map PointMap;
   typedef typename NP_helper::Normal_map NormalMap;
 
-  bool has_normals = NP_helper::has_normal_map();
-
+  //the default value for normal map, if not provided in the np,
+  // is a dummy Constant_property_map
   PointMap point_map = NP_helper::get_point_map(np);
   NormalMap normal_map = NP_helper::get_normal_map(np);
 
-  if(has_normals)
-    return read_PLY_with_properties(is, output,
+  return read_PLY_with_properties(is, output,
                                     make_ply_point_reader(point_map),
                                     make_ply_normal_reader(normal_map));
-  // else
-  return read_PLY_with_properties(is, output, make_ply_point_reader(point_map));
 }
 
 /**

--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -258,8 +258,6 @@ bool read_PLY(std::istream& is,
   typedef typename NP_helper::Point_map PointMap;
   typedef typename NP_helper::Normal_map NormalMap;
 
-  //the default value for normal map, if not provided in the np,
-  // is a dummy Constant_property_map
   PointMap point_map = NP_helper::get_point_map(np);
   NormalMap normal_map = NP_helper::get_normal_map(np);
 

--- a/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
@@ -90,8 +90,8 @@ bool read_XYZ(std::istream& is,
   typedef typename NP_helper::Normal_map NormalMap;
   typedef typename NP_helper::Geom_traits Kernel;
 
-  bool has_normals = NP_helper::has_normal_map();
-
+  //the default value for normal map, if not provided in the np,
+  // is a dummy Constant_property_map
   PointMap point_map = NP_helper::get_point_map(np);
   NormalMap normal_map = NP_helper::get_normal_map(np);
 
@@ -156,8 +156,7 @@ bool read_XYZ(std::istream& is,
         Enriched_point pwn;
         put(point_map,  pwn, point);  // point_map[pwn] = point
 
-        if (has_normals)
-          put(normal_map, pwn, normal); // normal_map[pwn] = normal
+        put(normal_map, pwn, normal); // normal_map[pwn] = normal
 
         *output++ = pwn;
         continue;

--- a/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
@@ -90,8 +90,6 @@ bool read_XYZ(std::istream& is,
   typedef typename NP_helper::Normal_map NormalMap;
   typedef typename NP_helper::Geom_traits Kernel;
 
-  //the default value for normal map, if not provided in the np,
-  // is a dummy Constant_property_map
   PointMap point_map = NP_helper::get_point_map(np);
   NormalMap normal_map = NP_helper::get_normal_map(np);
 

--- a/Point_set_processing_3/include/CGAL/IO/write_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_off_points.h
@@ -46,7 +46,7 @@ bool write_OFF_PSP(std::ostream& os,
   typedef typename NP_helper::Const_point_map PointMap;
   typedef typename NP_helper::Normal_map NormalMap;
 
-  const bool has_normals = NP_helper::has_normal_map();
+  const bool has_normals = NP_helper::has_normal_map(points, np);
 
   PointMap point_map = NP_helper::get_const_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/IO/write_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_off_points.h
@@ -46,7 +46,7 @@ bool write_OFF_PSP(std::ostream& os,
   typedef typename NP_helper::Const_point_map PointMap;
   typedef typename NP_helper::Normal_map NormalMap;
 
-  const bool has_normals = !(is_default_parameter<CGAL_NP_CLASS, internal_np::normal_t>::value);
+  bool has_normals = NP_helper::has_normal_map(points, np);
 
   PointMap point_map = NP_helper::get_const_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/IO/write_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_off_points.h
@@ -46,7 +46,7 @@ bool write_OFF_PSP(std::ostream& os,
   typedef typename NP_helper::Const_point_map PointMap;
   typedef typename NP_helper::Normal_map NormalMap;
 
-  bool has_normals = NP_helper::has_normal_map();
+  const bool has_normals = NP_helper::has_normal_map();
 
   PointMap point_map = NP_helper::get_const_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/IO/write_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_ply_points.h
@@ -201,7 +201,7 @@ bool write_PLY(std::ostream& os,
   typedef typename NP_helper::Const_point_map PointMap;
   typedef typename NP_helper::Normal_map NormalMap;
 
-  const bool has_normals = NP_helper::has_normal_map();
+  const bool has_normals = NP_helper::has_normal_map(points, np);
 
   PointMap point_map = NP_helper::get_const_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/IO/write_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_ply_points.h
@@ -201,7 +201,7 @@ bool write_PLY(std::ostream& os,
   typedef typename NP_helper::Const_point_map PointMap;
   typedef typename NP_helper::Normal_map NormalMap;
 
-  bool has_normals = NP_helper::has_normal_map();
+  const bool has_normals = NP_helper::has_normal_map();
 
   PointMap point_map = NP_helper::get_const_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/IO/write_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_ply_points.h
@@ -201,7 +201,7 @@ bool write_PLY(std::ostream& os,
   typedef typename NP_helper::Const_point_map PointMap;
   typedef typename NP_helper::Normal_map NormalMap;
 
-  bool has_normals = NP_helper::has_normal_map();
+  bool has_normals = NP_helper::has_normal_map(points, np);
 
   PointMap point_map = NP_helper::get_const_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/IO/write_xyz_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_xyz_points.h
@@ -47,7 +47,7 @@ bool write_XYZ_PSP(std::ostream& os,
   typedef typename NP_helper::Const_point_map PointMap;
   typedef typename NP_helper::Normal_map NormalMap;
 
-  const bool has_normals = NP_helper::has_normal_map();
+  const bool has_normals = NP_helper::has_normal_map(points, np);
 
   PointMap point_map = NP_helper::get_const_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/IO/write_xyz_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_xyz_points.h
@@ -47,7 +47,7 @@ bool write_XYZ_PSP(std::ostream& os,
   typedef typename NP_helper::Const_point_map PointMap;
   typedef typename NP_helper::Normal_map NormalMap;
 
-  bool has_normals = NP_helper::has_normal_map();
+  const bool has_normals = NP_helper::has_normal_map();
 
   PointMap point_map = NP_helper::get_const_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/IO/write_xyz_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_xyz_points.h
@@ -47,7 +47,7 @@ bool write_XYZ_PSP(std::ostream& os,
   typedef typename NP_helper::Const_point_map PointMap;
   typedef typename NP_helper::Normal_map NormalMap;
 
-  bool has_normals = NP_helper::has_normal_map();
+  bool has_normals = NP_helper::has_normal_map(points, np);
 
   PointMap point_map = NP_helper::get_const_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/bilateral_smooth_point_set.h
+++ b/Point_set_processing_3/include/CGAL/bilateral_smooth_point_set.h
@@ -278,7 +278,7 @@ bilateral_smooth_point_set(
   typedef typename Kernel::Point_3 Point_3;
   typedef typename Kernel::Vector_3 Vector_3;
 
-  CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+  CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
   typedef typename Kernel::FT FT;
 

--- a/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
+++ b/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
@@ -367,7 +367,7 @@ edge_aware_upsample_point_set(
   typedef typename NP_helper::Geom_traits Kernel;
 
 
-  CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+  CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
   typedef typename Kernel::Point_3 Point;
   typedef typename Kernel::Vector_3 Vector;

--- a/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
+++ b/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
@@ -367,7 +367,7 @@ edge_aware_upsample_point_set(
   typedef typename NP_helper::Geom_traits Kernel;
 
 
-  CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+  CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
   typedef typename Kernel::Point_3 Point;
   typedef typename Kernel::Vector_3 Vector;

--- a/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
+++ b/Point_set_processing_3/include/CGAL/edge_aware_upsample_point_set.h
@@ -367,7 +367,7 @@ edge_aware_upsample_point_set(
   typedef typename NP_helper::Geom_traits Kernel;
 
 
-  CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
+  CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
   typedef typename Kernel::Point_3 Point;
   typedef typename Kernel::Vector_3 Vector;

--- a/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
@@ -196,7 +196,7 @@ jet_estimate_normals(
   typedef typename Kernel::FT FT;
   typedef typename GetSvdTraits<NamedParameters>::type SvdTraits;
 
-  CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
+  CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
   CGAL_static_assertion_msg(!(boost::is_same<SvdTraits,
                               typename GetSvdTraits<NamedParameters>::NoTraits>::value),
                             "Error: no SVD traits");

--- a/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
@@ -196,7 +196,7 @@ jet_estimate_normals(
   typedef typename Kernel::FT FT;
   typedef typename GetSvdTraits<NamedParameters>::type SvdTraits;
 
-  CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+  CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
   CGAL_static_assertion_msg(!(boost::is_same<SvdTraits,
                               typename GetSvdTraits<NamedParameters>::NoTraits>::value),
                             "Error: no SVD traits");

--- a/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
@@ -196,7 +196,7 @@ jet_estimate_normals(
   typedef typename Kernel::FT FT;
   typedef typename GetSvdTraits<NamedParameters>::type SvdTraits;
 
-  CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+  CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
   CGAL_static_assertion_msg(!(boost::is_same<SvdTraits,
                               typename GetSvdTraits<NamedParameters>::NoTraits>::value),
                             "Error: no SVD traits");

--- a/Point_set_processing_3/include/CGAL/mst_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/mst_orient_normals.h
@@ -631,7 +631,7 @@ mst_orient_normals(
     typedef typename NP_helper::Geom_traits Kernel;
     typedef typename Point_set_processing_3::GetIsConstrainedMap<PointRange, NamedParameters>::type ConstrainedMap;
 
-    CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+    CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
     PointMap point_map = NP_helper::get_point_map(points, np);
     NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/mst_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/mst_orient_normals.h
@@ -631,7 +631,7 @@ mst_orient_normals(
     typedef typename NP_helper::Geom_traits Kernel;
     typedef typename Point_set_processing_3::GetIsConstrainedMap<PointRange, NamedParameters>::type ConstrainedMap;
 
-    CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
+    CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
     PointMap point_map = NP_helper::get_point_map(points, np);
     NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/mst_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/mst_orient_normals.h
@@ -631,7 +631,7 @@ mst_orient_normals(
     typedef typename NP_helper::Geom_traits Kernel;
     typedef typename Point_set_processing_3::GetIsConstrainedMap<PointRange, NamedParameters>::type ConstrainedMap;
 
-    CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+    CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
     PointMap point_map = NP_helper::get_point_map(points, np);
     NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
@@ -168,7 +168,7 @@ pca_estimate_normals(
   typedef typename NP_helper::Geom_traits Kernel;
   typedef typename Kernel::FT FT;
 
-  CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+  CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
   PointMap point_map = NP_helper::get_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
@@ -168,7 +168,7 @@ pca_estimate_normals(
   typedef typename NP_helper::Geom_traits Kernel;
   typedef typename Kernel::FT FT;
 
-  CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
+  CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
   PointMap point_map = NP_helper::get_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
@@ -168,7 +168,7 @@ pca_estimate_normals(
   typedef typename NP_helper::Geom_traits Kernel;
   typedef typename Kernel::FT FT;
 
-  CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+  CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
   PointMap point_map = NP_helper::get_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/scanline_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/scanline_orient_normals.h
@@ -478,7 +478,7 @@ void scanline_orient_normals (PointRange& points, const NamedParameters& np = pa
     <internal_np::scanline_id_t, NamedParameters, No_map>::type;
   using Fallback_scanline_ID = Boolean_tag<std::is_same<ScanlineIDMap, No_map>::value>;
 
-  CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+  CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
   PointMap point_map = NP_helper::get_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/scanline_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/scanline_orient_normals.h
@@ -478,7 +478,7 @@ void scanline_orient_normals (PointRange& points, const NamedParameters& np = pa
     <internal_np::scanline_id_t, NamedParameters, No_map>::type;
   using Fallback_scanline_ID = Boolean_tag<std::is_same<ScanlineIDMap, No_map>::value>;
 
-  CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+  CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
   PointMap point_map = NP_helper::get_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/scanline_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/scanline_orient_normals.h
@@ -478,7 +478,7 @@ void scanline_orient_normals (PointRange& points, const NamedParameters& np = pa
     <internal_np::scanline_id_t, NamedParameters, No_map>::type;
   using Fallback_scanline_ID = Boolean_tag<std::is_same<ScanlineIDMap, No_map>::value>;
 
-  CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
+  CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
   PointMap point_map = NP_helper::get_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/structure_point_set.h
+++ b/Point_set_processing_3/include/CGAL/structure_point_set.h
@@ -234,7 +234,7 @@ public:
     typedef typename Point_set_processing_3::GetPlaneMap<PlaneRange, NamedParameters>::type PlaneMap;
     typedef typename Point_set_processing_3::GetPlaneIndexMap<NamedParameters>::type PlaneIndexMap;
 
-    CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+    CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
     CGAL_static_assertion_msg((!is_default_parameter<NamedParameters, internal_np::plane_index_t>::value),
                               "Error: no plane index map");
 

--- a/Point_set_processing_3/include/CGAL/structure_point_set.h
+++ b/Point_set_processing_3/include/CGAL/structure_point_set.h
@@ -234,7 +234,7 @@ public:
     typedef typename Point_set_processing_3::GetPlaneMap<PlaneRange, NamedParameters>::type PlaneMap;
     typedef typename Point_set_processing_3::GetPlaneIndexMap<NamedParameters>::type PlaneIndexMap;
 
-    CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
+    CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
     CGAL_static_assertion_msg((!is_default_parameter<NamedParameters, internal_np::plane_index_t>::value),
                               "Error: no plane index map");
 

--- a/Point_set_processing_3/include/CGAL/structure_point_set.h
+++ b/Point_set_processing_3/include/CGAL/structure_point_set.h
@@ -234,7 +234,7 @@ public:
     typedef typename Point_set_processing_3::GetPlaneMap<PlaneRange, NamedParameters>::type PlaneMap;
     typedef typename Point_set_processing_3::GetPlaneIndexMap<NamedParameters>::type PlaneIndexMap;
 
-    CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+    CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
     CGAL_static_assertion_msg((!is_default_parameter<NamedParameters, internal_np::plane_index_t>::value),
                               "Error: no plane index map");
 

--- a/Point_set_processing_3/include/CGAL/vcm_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/vcm_estimate_normals.h
@@ -321,7 +321,7 @@ vcm_estimate_normals_internal (PointRange& points,
     typedef typename NP_helper::Geom_traits Kernel;
     typedef typename GetDiagonalizeTraits<NamedParameters, double, 3>::type DiagonalizeTraits;
 
-    CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+    CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
     PointMap point_map = NP_helper::get_point_map(points, np);
     NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/vcm_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/vcm_estimate_normals.h
@@ -321,7 +321,7 @@ vcm_estimate_normals_internal (PointRange& points,
     typedef typename NP_helper::Geom_traits Kernel;
     typedef typename GetDiagonalizeTraits<NamedParameters, double, 3>::type DiagonalizeTraits;
 
-    CGAL_static_assertion_msg(NP_helper::has_normal_map(), "Error: no normal map");
+    CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
     PointMap point_map = NP_helper::get_point_map(points, np);
     NormalMap normal_map = NP_helper::get_normal_map(points, np);

--- a/Point_set_processing_3/include/CGAL/vcm_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/vcm_estimate_normals.h
@@ -321,7 +321,7 @@ vcm_estimate_normals_internal (PointRange& points,
     typedef typename NP_helper::Geom_traits Kernel;
     typedef typename GetDiagonalizeTraits<NamedParameters, double, 3>::type DiagonalizeTraits;
 
-    CGAL_assertion(NP_helper::has_normal_map(points, np), "Error: no normal map");
+    CGAL_assertion_msg(NP_helper::has_normal_map(points, np), "Error: no normal map");
 
     PointMap point_map = NP_helper::get_point_map(points, np);
     NormalMap normal_map = NP_helper::get_normal_map(points, np);


### PR DESCRIPTION
## Summary of Changes

Instead of returning `true`, look for a normal pmap in the point set, and in the named parameters.

## Release Management

* Affected package(s): Point_set_3, PSP_3
* License and copyright ownership: unchanged

