### PR TITLE
Kernel_d: Address -Wmaybe-uninitialized warning

### DIFF
--- a/Kernel_d/include/CGAL/Kernel_d/Sphere_d.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Sphere_d.h
@@ -47,6 +47,7 @@ class  Sphere_d_rep  {
 public:
   Sphere_d_rep() : cp(0) {}
   Sphere_d_rep(int d)  : P(d), cp(0) {}
+  Sphere_d_rep(int d, Orientation orient)  : P(d), orient(orient), cp(0) {}
 
   template <class ForwardIterator>
   Sphere_d_rep(int d, ForwardIterator first, ForwardIterator last) :
@@ -109,14 +110,13 @@ typedef typename std::vector< Point_d >::const_iterator point_iterator;
 
 /*{\Mcreation 4}*/
 
-Sphere_d(int d = 0) : Base( Rep(d+1) )
+  Sphere_d(int d = 0) : Base( Rep(d+1, ZERO) )
 /*{\Mcreate introduces a variable |\Mvar| of type |\Mname|. |\Mvar|
 is initialized to the empty sphere centered at the origin of
 $d$-dimensional space. }*/
 {
   Point_d p(d);
   for (int i = 0; i <= d; i++) ptr()->P[i] = p;
-  ptr()->orient = ZERO;
   ptr()->cp = new Point_d(p);
 }
 


### PR DESCRIPTION
## Summary of Changes

Address warning in [this ](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.6-Ic-99/Kernel_d/TestReport_lrineau_Fedora-with-LEDA.gz) testsuite.

Instead of creating a `Rep` and right afterwards setting a data member, add a parameter to the Rep constructor for initialization. 

## Release Management

* Affected package(s): Kernel_d 

