### PR TITLE
Tet remeshing - `cell_is_selected_map` should be a property map

### DIFF
--- a/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/tetrahedral_remeshing_of_one_subdomain.cpp
+++ b/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/tetrahedral_remeshing_of_one_subdomain.cpp
@@ -10,19 +10,34 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Tetrahedral_remeshing::Remeshing_triangulation_3<K> Remeshing_triangulation;
 
 
-struct Cells_of_subdomain
+template<typename Tr>
+struct Cells_of_subdomain_pmap
 {
 private:
+  using Cell_handle = typename Tr::Cell_handle;
+
   const int m_subdomain;
 
 public:
-  Cells_of_subdomain(const int& subdomain)
+  using key_type = Cell_handle;
+  using value_type = bool;
+  using reference = bool;
+  using category = boost::read_write_property_map_tag;
+
+  Cells_of_subdomain_pmap(const int& subdomain)
     : m_subdomain(subdomain)
   {}
 
-  bool operator()(Remeshing_triangulation::Cell_handle c) const
+  friend value_type get(const Cells_of_subdomain_pmap& map,
+                        const key_type& c)
   {
-    return m_subdomain == c->subdomain_index();
+    return (map.m_subdomain == c->subdomain_index());
+  }
+  friend void put(Cells_of_subdomain_pmap&,
+                  const key_type&,
+                  const value_type)
+  {
+    ; //nothing to do : subdomain indices are updated in remeshing
   }
 };
 
@@ -35,7 +50,8 @@ int main(int argc, char* argv[])
   CGAL::Tetrahedral_remeshing::generate_input_two_subdomains(nbv, tr);
 
   CGAL::tetrahedral_isotropic_remeshing(tr, target_edge_length,
-      CGAL::parameters::cell_is_selected_map(Cells_of_subdomain(2)));
+      CGAL::parameters::cell_is_selected_map(
+        Cells_of_subdomain_pmap<Remeshing_triangulation>(2)));
 
   return EXIT_SUCCESS;
 }

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
@@ -744,10 +744,11 @@ void merge_surface_patch_indices(const typename C3t3::Facet& f1,
   }
 }
 
-template<typename C3t3>
+template<typename C3t3, typename CellSelector>
 typename C3t3::Vertex_handle
 collapse(const typename C3t3::Cell_handle ch,
          const int to, const int from,
+         CellSelector& cell_selector,
          C3t3& c3t3)
 {
   typedef typename C3t3::Triangulation Tr;
@@ -913,8 +914,7 @@ collapse(const typename C3t3::Cell_handle ch,
   for (Cell_handle cell_to_remove : cells_to_remove)
   {
     // remove cell
-    if (c3t3.is_in_complex(cell_to_remove))
-      c3t3.remove_from_complex(cell_to_remove);
+    treat_before_delete(cell_to_remove, cell_selector, c3t3);
     c3t3.triangulation().tds().delete_cell(cell_to_remove);
   }
 
@@ -927,9 +927,10 @@ collapse(const typename C3t3::Cell_handle ch,
 }
 
 
-template<typename C3t3>
+template<typename C3t3, typename CellSelector>
 typename C3t3::Vertex_handle collapse(typename C3t3::Edge& edge,
                                       const Collapse_type& collapse_type,
+                                      CellSelector& cell_selector,
                                       C3t3& c3t3)
 {
   typedef typename C3t3::Vertex_handle Vertex_handle;
@@ -953,7 +954,7 @@ typename C3t3::Vertex_handle collapse(typename C3t3::Edge& edge,
     vh0->set_point(new_position);
     vh1->set_point(new_position);
 
-    vh = collapse(edge.first, edge.second, edge.third, c3t3);
+    vh = collapse(edge.first, edge.second, edge.third, cell_selector, c3t3);
     c3t3.set_dimension(vh, (std::min)(dim_vh0, dim_vh1));
   }
   else //Collapse at vertex
@@ -961,7 +962,7 @@ typename C3t3::Vertex_handle collapse(typename C3t3::Edge& edge,
     if (collapse_type == TO_V1)
     {
       vh0->set_point(p1);
-      vh = collapse(edge.first, edge.third, edge.second, c3t3);
+      vh = collapse(edge.first, edge.third, edge.second, cell_selector, c3t3);
       c3t3.set_dimension(vh, (std::min)(dim_vh0, dim_vh1));
     }
     else //Collapse at v0
@@ -969,7 +970,7 @@ typename C3t3::Vertex_handle collapse(typename C3t3::Edge& edge,
       if (collapse_type == TO_V0)
       {
         vh1->set_point(p0);
-        vh = collapse(edge.first, edge.second, edge.third, c3t3);
+        vh = collapse(edge.first, edge.second, edge.third, cell_selector, c3t3);
         c3t3.set_dimension(vh, (std::min)(dim_vh0, dim_vh1));
       }
       else
@@ -1133,7 +1134,7 @@ typename C3t3::Vertex_handle collapse_edge(typename C3t3::Edge& edge,
       if (in_cx)
         nb_valid_collapse++;
 #endif
-      return collapse(edge, collapse_type, c3t3);
+      return collapse(edge, collapse_type, cell_selector, c3t3);
     }
   }
 #ifdef CGAL_DEBUG_TET_REMESHING_IN_PLUGIN

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/compute_c3t3_statistics.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/compute_c3t3_statistics.h
@@ -63,7 +63,7 @@ void compute_statistics(const Triangulation& tr,
   {
     const Cell_handle cell = fit->first;
     const int& index = fit->second;
-    if (!cell_selector(cell) || !cell_selector(cell->neighbor(index)))
+    if (!get(cell_selector, cell) || !get(cell_selector, cell->neighbor(index)))
       continue;
 
     const Point& pa = point(cell->vertex((index + 1) & 3)->point());
@@ -96,7 +96,7 @@ void compute_statistics(const Triangulation& tr,
        ++cit)
   {
     const Subdomain_index& si = cit->subdomain_index();
-    if (si == Subdomain_index() || !cell_selector(cit))
+    if (si == Subdomain_index() || !get(cell_selector, cit))
       continue;
 
     ++nb_tets;

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/flip_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/flip_edges.h
@@ -867,7 +867,7 @@ Sliver_removal_result flip_n_to_m(C3t3& c3t3,
 
   //Subdomain index?
   typename C3t3::Subdomain_index subdomain = to_remove[0]->subdomain_index();
-  bool selected = get(m_cell_selector, to_remove[0]);
+  bool selected = get(cell_selector, to_remove[0]);
   visitor.before_flip(to_remove[0]);
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
@@ -1015,12 +1015,13 @@ Sliver_removal_result flip_n_to_m(C3t3& c3t3,
 }
 
 
-template<typename C3t3, typename IncCellsVectorMap, typename Visitor>
+template<typename C3t3, typename IncCellsVectorMap, typename CellSelector, typename Visitor>
 Sliver_removal_result flip_n_to_m(typename C3t3::Edge& edge,
                                   C3t3& c3t3,
                                   const std::vector<typename C3t3::Vertex_handle>& boundary_vertices,
                                   const Flip_Criterion& criterion,
                                   IncCellsVectorMap& inc_cells,
+                                  CellSelector& cell_selector,
                                   Visitor& visitor)
 {
   typedef typename C3t3::Vertex_handle Vertex_handle;
@@ -1069,7 +1070,8 @@ Sliver_removal_result flip_n_to_m(typename C3t3::Edge& edge,
       if (curr_max_cosdh <= curr_cost_vpair.first)
         return NO_BEST_CONFIGURATION;
 
-      result = flip_n_to_m(c3t3, edge, curr_cost_vpair.second.first, inc_cells, visitor);
+      result = flip_n_to_m(c3t3, edge, curr_cost_vpair.second.first, inc_cells,
+                           cell_selector, visitor);
 
       if (result != NOT_FLIPPABLE)
         flip_performed = true;
@@ -1231,7 +1233,7 @@ std::size_t flip_all_edges(const std::vector<VertexPair>& edges,
 template<typename C3T3, typename CellSelector, typename Visitor>
 void flip_edges(C3T3& c3t3,
                 const bool protect_boundaries,
-                CellSelector cell_selector,
+                CellSelector& cell_selector,
                 Visitor& visitor)
 {
   CGAL_USE(protect_boundaries);

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/flip_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/flip_edges.h
@@ -87,12 +87,13 @@ void update_c3t3_facets(C3t3& c3t3,
   }
 }
 
-template<typename C3t3, typename IncCellsVectorMap>
+template<typename C3t3, typename IncCellsVectorMap, typename Cell_selector>
 Sliver_removal_result flip_3_to_2(typename C3t3::Edge& edge,
                                   C3t3& c3t3,
                                   const std::vector<typename C3t3::Vertex_handle>& vertices_around_edge,
                                   const Flip_Criterion& criterion,
-                                  IncCellsVectorMap& inc_cells)
+                                  IncCellsVectorMap& inc_cells,
+                                  Cell_selector& cell_selector)
 {
   typedef typename C3t3::Triangulation Tr;
   typedef typename C3t3::Facet         Facet;
@@ -323,7 +324,7 @@ Sliver_removal_result flip_3_to_2(typename C3t3::Edge& edge,
   // Update c3t3
   update_c3t3_facets(c3t3, cells_to_update, outer_mirror_facets);
 
-  c3t3.remove_from_complex(cell_to_remove);
+  treat_before_delete(cell_to_remove, cell_selector, c3t3);
   tr.tds().delete_cell(cell_to_remove);
 
   /********************VALIDITY CHECK***************************/
@@ -703,11 +704,15 @@ void find_best_flip_to_improve_dh(C3t3& c3t3,
   }
 }
 
-template<typename C3t3, typename IncCellsVectorMap, typename Visitor>
+template<typename C3t3,
+         typename IncCellsVectorMap,
+         typename Cell_selector,
+         typename Visitor>
 Sliver_removal_result flip_n_to_m(C3t3& c3t3,
                                   typename C3t3::Edge& edge,
                                   typename C3t3::Vertex_handle vh,
                                   IncCellsVectorMap& inc_cells,
+                                  Cell_selector& cell_selector,
                                   Visitor& visitor,
                                   bool check_validity = false)
 {
@@ -862,6 +867,7 @@ Sliver_removal_result flip_n_to_m(C3t3& c3t3,
 
   //Subdomain index?
   typename C3t3::Subdomain_index subdomain = to_remove[0]->subdomain_index();
+  bool selected = get(m_cell_selector, to_remove[0]);
   visitor.before_flip(to_remove[0]);
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
@@ -882,7 +888,8 @@ Sliver_removal_result flip_n_to_m(C3t3& c3t3,
 
     new_cell->set_vertex(fi.second, vh);
 
-    c3t3.add_to_complex(new_cell, subdomain);
+    treat_new_cell(new_cell, subdomain, cell_selector, selected, c3t3);
+
     visitor.after_flip(new_cell);
     cells_to_update.push_back(new_cell);
   }
@@ -951,7 +958,7 @@ Sliver_removal_result flip_n_to_m(C3t3& c3t3,
   //Remove cells
   for (Cell_handle ch : to_remove)
   {
-    c3t3.remove_from_complex(ch);
+    treat_before_delete(ch, cell_selector, c3t3);
     tr.tds().delete_cell(ch);
   }
 
@@ -1072,11 +1079,12 @@ Sliver_removal_result flip_n_to_m(typename C3t3::Edge& edge,
   return result;
 }
 
-template<typename C3t3, typename IncCellsVectorMap, typename Visitor>
+template<typename C3t3, typename IncCellsVectorMap, typename Cell_selector, typename Visitor>
 Sliver_removal_result find_best_flip(typename C3t3::Edge& edge,
                                      C3t3& c3t3,
                                      const Flip_Criterion& criterion,
                                      IncCellsVectorMap& inc_cells,
+                                     Cell_selector& cell_selector,
                                      Visitor& visitor)
 {
   typedef typename C3t3::Triangulation        Tr;
@@ -1139,7 +1147,7 @@ Sliver_removal_result find_best_flip(typename C3t3::Edge& edge,
     {
       std::vector<Vertex_handle> vertices;
       vertices.insert(vertices.end(), vertices_around_edge.begin(), vertices_around_edge.end());
-      res = flip_3_to_2(edge, c3t3, vertices, criterion, inc_cells);
+      res = flip_3_to_2(edge, c3t3, vertices, criterion, inc_cells, cell_selector);
     }
   }
   else
@@ -1151,7 +1159,7 @@ Sliver_removal_result find_best_flip(typename C3t3::Edge& edge,
     {
       std::vector<Vertex_handle> vertices;
       vertices.insert(vertices.end(), boundary_vertices.begin(), boundary_vertices.end());
-      res = flip_n_to_m(edge, c3t3, vertices, criterion, inc_cells, visitor);
+      res = flip_n_to_m(edge, c3t3, vertices, criterion, inc_cells, cell_selector, visitor);
       //return n_to_m_flip(edge, boundary_vertices, flip_criterion);
     }
   }
@@ -1160,10 +1168,11 @@ Sliver_removal_result find_best_flip(typename C3t3::Edge& edge,
 }
 
 
-template<typename VertexPair, typename C3t3, typename Visitor>
+template<typename VertexPair, typename C3t3, typename Cell_selector, typename Visitor>
 std::size_t flip_all_edges(const std::vector<VertexPair>& edges,
                            C3t3& c3t3,
                            const Flip_Criterion& criterion,
+                           Cell_selector& cell_selector,
                            Visitor& visitor)
 {
   typedef typename C3t3::Triangulation Tr;
@@ -1194,7 +1203,8 @@ std::size_t flip_all_edges(const std::vector<VertexPair>& edges,
     {
       Edge edge(ch, i0, i1);
 
-      Sliver_removal_result res = find_best_flip(edge, c3t3, criterion, inc_cells, visitor);
+      Sliver_removal_result res
+        = find_best_flip(edge, c3t3, criterion, inc_cells, cell_selector, visitor);
       if (res == INVALID_CELL || res == INVALID_VERTEX || res == INVALID_ORIENTATION)
       {
         std::cout << "FLIP PROBLEM!!!!" << std::endl;
@@ -1237,8 +1247,6 @@ void flip_edges(C3T3& c3t3,
 
   //const Flip_Criterion criterion = VALENCE_MIN_DH_BASED;
 
-  //collect long edges
-
   //compute vertices normals map?
 
   // typedef typename C3T3::Surface_patch_index Surface_patch_index;
@@ -1272,7 +1280,7 @@ void flip_edges(C3T3& c3t3,
 #ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
   nb_flips =
 #endif
-    flip_all_edges(inside_edges, c3t3, MIN_ANGLE_BASED, visitor);
+    flip_all_edges(inside_edges, c3t3, MIN_ANGLE_BASED, cell_selector, visitor);
   //}
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
@@ -451,7 +451,7 @@ public:
     inc_cells(nbv, boost::container::small_vector<Cell_handle, 40>());
     for (const Cell_handle c : tr.finite_cell_handles())
     {
-      const bool cell_is_selected = cell_selector(c);
+      const bool cell_is_selected = get(cell_selector, c);
 
       for (int i = 0; i < 4; ++i)
       {

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
@@ -281,7 +281,8 @@ private:
     for (auto& kv : ons_map)
     {
       std::ostringstream oss;
-      oss << "dump_normals_normalized_" << kv.first << ".polylines.txt";
+      oss << "dump_normals_normalized_["
+        << kv.first.first << "_" << kv.first.second << "].polylines.txt";
       std::ofstream ons(oss.str());
       for (auto s : kv.second)
         ons << "2 " << s.source() << " " << s.target() << std::endl;

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
@@ -140,6 +140,20 @@ private:
     return n;
   }
 
+  template<typename Patch_index>
+  std::string debug_to_string(const Patch_index i)
+  {
+    return std::to_string(i);
+  }
+
+  template<typename Patch_index>
+  std::string debug_to_string(const std::pair<Patch_index, Patch_index>& pi)
+  {
+    std::string str = std::to_string(pi.first);
+    str.append("_").append(std::to_string(pi.second));
+    return str;
+  }
+
   template<typename VertexNormalsMap, typename CellSelector>
   void compute_vertices_normals(const C3t3& c3t3,
                                 VertexNormalsMap& normals_map,
@@ -282,7 +296,7 @@ private:
     {
       std::ostringstream oss;
       oss << "dump_normals_normalized_["
-        << kv.first.first << "_" << kv.first.second << "].polylines.txt";
+        << debug_to_string(kv.first) << "].polylines.txt";
       std::ofstream ons(oss.str());
       for (auto s : kv.second)
         ons << "2 " << s.source() << " " << s.target() << std::endl;

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/split_long_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/split_long_edges.h
@@ -32,8 +32,9 @@ namespace Tetrahedral_remeshing
 {
 namespace internal
 {
-template<typename C3t3>
+template<typename C3t3, typename CellSelector>
 typename C3t3::Vertex_handle split_edge(const typename C3t3::Edge& e,
+                                        CellSelector cell_selector,
                                         C3t3& c3t3)
 {
   typedef typename C3t3::Triangulation       Tr;
@@ -68,8 +69,16 @@ typename C3t3::Vertex_handle split_edge(const typename C3t3::Edge& e,
   }
   CGAL_assertion(dimension > 0);
 
-  boost::unordered_map<Facet, Subdomain_index> cells_info;
-  boost::unordered_map<Facet, std::pair<Vertex_handle, Surface_patch_index> > facets_info;
+  struct Cell_info {
+    Subdomain_index subdomain_index_;
+    bool selected_;
+  };
+  struct Facet_info {
+    Vertex_handle opp_vertex_;
+    Surface_patch_index patch_index_;
+  };
+  boost::unordered_map<Facet, Cell_info> cells_info;
+  boost::unordered_map<Facet, Facet_info> facets_info;
 
   // check orientation and collect incident cells to avoid circulating twice
   boost::container::small_vector<Cell_handle, 30> inc_cells;
@@ -113,23 +122,21 @@ typename C3t3::Vertex_handle split_edge(const typename C3t3::Edge& e,
     //keys are the opposite facets to the ones not containing e,
     //because they will not be modified
     const Subdomain_index subdomain = c3t3.subdomain_index(c);
+    const bool selected = get(cell_selector, c);
     const Facet opp_facet1 = tr.mirror_facet(Facet(c, index_v1));
     const Facet opp_facet2 = tr.mirror_facet(Facet(c, index_v2));
 
     // volume data
-    cells_info.insert(std::make_pair(opp_facet1, subdomain));
-    cells_info.insert(std::make_pair(opp_facet2, subdomain));
-    if (c3t3.is_in_complex(c))
-      c3t3.remove_from_complex(c);
+    cells_info.insert(std::make_pair(opp_facet1, Cell_info{subdomain, selected}));
+    cells_info.insert(std::make_pair(opp_facet2, Cell_info{subdomain, selected}));
+    treat_before_delete(c, cell_selector, c3t3);
 
     // surface data for facets of the cells to be split
     const int findex = CGAL::Triangulation_utils_3::next_around_edge(index_v1, index_v2);
     Surface_patch_index patch = c3t3.surface_patch_index(c, findex);
     Vertex_handle opp_vertex = c->vertex(findex);
-    facets_info.insert(std::make_pair(opp_facet1,
-                                      std::make_pair(opp_vertex, patch)));
-    facets_info.insert(std::make_pair(opp_facet2,
-                                      std::make_pair(opp_vertex, patch)));
+    facets_info.insert(std::make_pair(opp_facet1, Facet_info{opp_vertex, patch}));
+    facets_info.insert(std::make_pair(opp_facet2, Facet_info{opp_vertex, patch}));
 
     if(c3t3.is_in_complex(c, findex))
       c3t3.remove_from_complex(c, findex);
@@ -150,28 +157,26 @@ typename C3t3::Vertex_handle split_edge(const typename C3t3::Edge& e,
 
     //get subdomain info back
     CGAL_assertion(cells_info.find(mfi) != cells_info.end());
-    Subdomain_index n_index = cells_info.at(mfi);
-    if (Subdomain_index() != n_index)
-      c3t3.add_to_complex(new_cell, n_index);
-    else
-      new_cell->set_subdomain_index(Subdomain_index());
+    Cell_info c_info = cells_info.at(mfi);
+    treat_new_cell(new_cell, c_info.subdomain_index_,
+                   cell_selector, c_info.selected_, c3t3);
 
     // get surface info back
     CGAL_assertion(facets_info.find(mfi) != facets_info.end());
-    const std::pair<Vertex_handle, Surface_patch_index> v_and_opp_patch = facets_info.at(mfi);
+    const Facet_info v_and_opp_patch = facets_info.at(mfi);
 
     // facet opposite to new_v (status wrt c3t3 is unchanged)
     new_cell->set_surface_patch_index(new_cell->index(new_v),
                                       mfi.first->surface_patch_index(mfi.second));
 
     // new half-facet (added or not to c3t3 depending on the stored surface patch index)
-    if (Surface_patch_index() == v_and_opp_patch.second)
-      new_cell->set_surface_patch_index(new_cell->index(v_and_opp_patch.first),
+    if (Surface_patch_index() == v_and_opp_patch.patch_index_)
+      new_cell->set_surface_patch_index(new_cell->index(v_and_opp_patch.opp_vertex_),
                                         Surface_patch_index());
     else
       c3t3.add_to_complex(new_cell,
-                          new_cell->index(v_and_opp_patch.first),
-                          v_and_opp_patch.second);
+                          new_cell->index(v_and_opp_patch.opp_vertex_),
+                          v_and_opp_patch.patch_index_);
 
     // newly created internal facet
     for (int i = 0; i < 4; ++i)
@@ -301,7 +306,7 @@ void split_long_edges(C3T3& c3t3,
         continue;
 
       visitor.before_split(tr, edge);
-      Vertex_handle vh = split_edge(edge, c3t3);
+      Vertex_handle vh = split_edge(edge, cell_selector, c3t3);
 
       if(vh != Vertex_handle())
         visitor.after_split(tr, vh);

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -385,7 +385,8 @@ private:
         const Subdomain_index index = cit->subdomain_index();
         if(!input_is_c3t3())
           m_c3t3.remove_from_complex(cit);
-        m_c3t3.add_to_complex(cit, index);
+        if(Subdomain_index() != index)
+          m_c3t3.add_to_complex(cit, index);
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
         ++nbc;

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -55,6 +55,24 @@ public:
   void after_flip(CellHandle /* c */) {}
 };
 
+template<typename Tr>
+struct All_cells_selected
+{
+  using key_type = typename Tr::Cell_handle;
+  using value_type = bool;
+  using reference = bool;
+  using category = boost::read_write_property_map_tag;
+
+  friend value_type get(const All_cells_selected&, const key_type& c)
+  {
+    using SI = typename Tr::Cell::Subdomain_index;
+    return c->subdomain_index() != SI();
+  }
+  friend void put(All_cells_selected&, const key_type&, const value_type)
+  {} //nothing to do : subdomain indices are updated in remeshing};
+};
+
+
 template<typename Triangulation
          , typename SizingFunction
          , typename EdgeIsConstrainedMap

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -417,10 +417,7 @@ private:
       if (!input_is_c3t3())
       {
         for (int i = 0; i < 4; ++i)
-        {
-          if (cit->vertex(i)->in_dimension() == -1)
-            cit->vertex(i)->set_dimension(3);
-        }
+          cit->vertex(i)->set_dimension(3);
       }
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
       else if (input_is_c3t3() && m_c3t3.is_in_complex(cit))
@@ -449,8 +446,7 @@ private:
         for (int j = 0; j < 3; ++j)
         {
           Vertex_handle vij = f.first->vertex(Tr::vertex_triple_index(i, j));
-          if (vij->in_dimension() == -1 || vij->in_dimension() > 2)
-            vij->set_dimension(2);
+          vij->set_dimension(2);
         }
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
         ++nbf;
@@ -482,12 +478,10 @@ private:
         m_c3t3.add_to_complex(e, 1);
 
         Vertex_handle v = e.first->vertex(e.second);
-        if (v->in_dimension() == -1 || v->in_dimension() > 1)
-          v->set_dimension(1);
+        v->set_dimension(1);
 
         v = e.first->vertex(e.third);
-        if (v->in_dimension() == -1 || v->in_dimension() > 1)
-          v->set_dimension(1);
+        v->set_dimension(1);
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
         ++nbe;
@@ -508,8 +502,7 @@ private:
         if(!m_c3t3.is_in_complex(vit))
           m_c3t3.add_to_complex(vit, ++corner_id);
 
-        if (vit->in_dimension() == -1 || vit->in_dimension() > 0)
-          vit->set_dimension(0);
+        vit->set_dimension(0);
 
         vit->set_index(corner_id);
 

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -55,33 +55,6 @@ public:
   void after_flip(CellHandle /* c */) {}
 };
 
-template<typename Tr>
-struct All_cells_selected
-{
-  typedef typename Tr::Cell_handle argument_type;
-  typedef typename Tr::Cell::Subdomain_index Subdomain_index;
-
-  typedef bool                     result_type;
-
-  result_type operator()(const argument_type c) const
-  {
-    return c->subdomain_index() != Subdomain_index();
-  }
-};
-
-template<typename Primitive>
-struct No_constraint_pmap
-{
-public:
-  typedef Primitive                           key_type;
-  typedef bool                                value_type;
-  typedef value_type                          reference;
-  typedef boost::read_write_property_map_tag  category;
-
-  friend value_type get(No_constraint_pmap, key_type) { return false; }
-  friend void put(No_constraint_pmap, key_type, value_type) {}
-};
-
 template<typename Triangulation
          , typename SizingFunction
          , typename EdgeIsConstrainedMap
@@ -407,7 +380,7 @@ private:
     //tag cells
     for (Cell_handle cit : tr().finite_cell_handles())
     {
-      if (m_cell_selector(cit))
+      if (get(m_cell_selector, cit))
       {
         const Subdomain_index index = cit->subdomain_index();
         if(!input_is_c3t3())

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -189,6 +189,7 @@ public:
       "1-facets_in_complex_after_split.off");
     CGAL::Tetrahedral_remeshing::debug::dump_vertices_by_dimension(
       m_c3t3.triangulation(), "1-c3t3_vertices_after_split");
+    CGAL::Tetrahedral_remeshing::debug::check_surface_patch_indices(m_c3t3);
 #endif
 #ifdef CGAL_DUMP_REMESHING_STEPS
     CGAL::Tetrahedral_remeshing::debug::dump_c3t3(m_c3t3, "1-split");
@@ -210,6 +211,7 @@ public:
     CGAL_assertion(debug::are_cell_orientations_valid(tr()));
     CGAL::Tetrahedral_remeshing::debug::dump_vertices_by_dimension(
       m_c3t3.triangulation(), "2-c3t3_vertices_after_collapse");
+    CGAL::Tetrahedral_remeshing::debug::check_surface_patch_indices(m_c3t3);
 #endif
 #ifdef CGAL_DUMP_REMESHING_STEPS
     CGAL::Tetrahedral_remeshing::debug::dump_c3t3(m_c3t3, "2-collapse");
@@ -226,6 +228,7 @@ public:
     CGAL_assertion(debug::are_cell_orientations_valid(tr()));
     CGAL::Tetrahedral_remeshing::debug::dump_vertices_by_dimension(
       m_c3t3.triangulation(), "3-c3t3_vertices_after_flip");
+    CGAL::Tetrahedral_remeshing::debug::check_surface_patch_indices(m_c3t3);
 #endif
 #ifdef CGAL_DUMP_REMESHING_STEPS
     CGAL::Tetrahedral_remeshing::debug::dump_c3t3(m_c3t3, "3-flip");
@@ -241,6 +244,7 @@ public:
     CGAL_assertion(debug::are_cell_orientations_valid(tr()));
     CGAL::Tetrahedral_remeshing::debug::dump_vertices_by_dimension(
       m_c3t3.triangulation(), "4-c3t3_vertices_after_smooth");
+    CGAL::Tetrahedral_remeshing::debug::check_surface_patch_indices(m_c3t3);
 #endif
 #ifdef CGAL_DUMP_REMESHING_STEPS
     CGAL::Tetrahedral_remeshing::debug::dump_c3t3(m_c3t3, "4-smooth");
@@ -527,6 +531,7 @@ private:
 
     CGAL::Tetrahedral_remeshing::debug::dump_vertices_by_dimension(
       m_c3t3.triangulation(), "c3t3_vertices_");
+    CGAL::Tetrahedral_remeshing::debug::check_surface_patch_indices(m_c3t3);
 #endif
   }
 

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -440,7 +440,7 @@ bool is_boundary(const C3T3& c3t3,
                  const CellSelector& cell_selector)
 {
   return c3t3.is_in_complex(f)
-         || cell_selector(f.first) != cell_selector(f.first->neighbor(f.second));
+    || get(cell_selector, f.first) != get(cell_selector, f.first->neighbor(f.second));
 }
 
 template<typename C3T3, typename CellSelector>
@@ -496,7 +496,7 @@ bool is_boundary_vertex(const typename C3t3::Vertex_handle& v,
   {
     if (c3t3.is_in_complex(f))
       return true;
-    if (cell_selector(f.first) ^ cell_selector(f.first->neighbor(f.second)))
+    if (get(cell_selector, f.first) ^ get(cell_selector, f.first->neighbor(f.second)))
       return true;
   }
   return false;
@@ -766,7 +766,7 @@ bool is_outside(const typename C3t3::Edge & edge,
     if (c3t3.is_in_complex(circ))
       return false;
     // does circ belong to the selection?
-    if (cell_selector(circ))
+    if (get(cell_selector, circ))
       return false;
 
     ++circ;
@@ -788,7 +788,7 @@ bool is_selected(const typename C3t3::Vertex_handle v,
 
   for(Cell_handle c : cells)
   {
-    if (cell_selector(c))
+    if (get(cell_selector, c))
       return true;
   }
   return false;
@@ -813,7 +813,7 @@ bool is_internal(const typename C3t3::Edge& edge,
       return false;
     if (si != circ->subdomain_index())
       return false;
-    if (!cell_selector(circ))
+    if (!get(cell_selector, circ))
       return false;
     if (c3t3.is_in_complex(
           circ,
@@ -835,7 +835,7 @@ bool is_selected(const typename C3T3::Triangulation::Edge& e,
   Cell_circulator done = circ;
   do
   {
-    if (cell_selector(circ))
+    if (get(cell_selector, circ))
       return true;
   } while (++circ != done);
 

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -1134,6 +1134,38 @@ void get_edge_info(const typename C3t3::Edge& edge,
   }
 }
 
+namespace internal
+{
+  template<typename C3t3, typename CellSelector>
+  void treat_before_delete(typename C3t3::Cell_handle c,
+                           CellSelector& cell_selector,
+                           C3t3& c3t3)
+  {
+    if (c3t3.is_in_complex(c))
+      c3t3.remove_from_complex(c);
+    if (get(cell_selector, c))
+      put(cell_selector, c, false);
+  }
+
+  template<typename C3t3, typename CellSelector>
+  void treat_new_cell(typename C3t3::Cell_handle c,
+                      const typename C3t3::Subdomain_index& subdomain,
+                      CellSelector& cell_selector,
+                      const bool selected,
+                      C3t3& c3t3)
+  {
+    //update C3t3
+    using Subdomain_index = typename C3t3::Subdomain_index;
+    if (Subdomain_index() != subdomain)
+      c3t3.add_to_complex(c, subdomain);
+    else
+      c->set_subdomain_index(Subdomain_index());
+
+    //update cell_selector property map
+    put(cell_selector, c, selected);
+  }
+}
+
 namespace debug
 {
 

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -1591,11 +1591,9 @@ void dump_cells_with_small_dihedral_angle(const Tr& tr,
   std::vector<Cell_handle>     cells;
   std::vector<Subdomain_index> indices;
 
-  for (typename Tr::Finite_cells_iterator cit = tr.finite_cells_begin();
-       cit != tr.finite_cells_end(); ++cit)
+  for (Cell_handle c : tr.finite_cell_handles())
   {
-    Cell_handle c = cit;
-    if (c->subdomain_index() != Subdomain_index() && cell_select(c))
+    if (c->subdomain_index() != Subdomain_index() && get(cell_select, c))
     {
       double dh = min_dihedral_angle(tr, c);
       if (dh < angle_bound)

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -26,6 +26,8 @@
 #include <CGAL/boost/graph/Named_function_parameters.h>
 #include <CGAL/boost/graph/named_params_helper.h>
 
+#include <CGAL/property_map.h>
+
 #ifdef CGAL_DUMP_REMESHING_STEPS
 #include <sstream>
 #endif
@@ -214,34 +216,33 @@ void tetrahedral_isotropic_remeshing(
     = choose_parameter(get_parameter(np, internal_np::smooth_constrained_edges),
                        false);
 
+  typedef typename Tr::Cell_handle Cell_handle;
   typedef typename internal_np::Lookup_named_param_def <
     internal_np::cell_selector_t,
     NamedParameters,
-    Tetrahedral_remeshing::internal::All_cells_selected<Tr>//default
+    Constant_property_map<Cell_handle, bool>//default
   > ::type SelectionFunctor;
   SelectionFunctor cell_select
     = choose_parameter(get_parameter(np, internal_np::cell_selector),
-                       Tetrahedral_remeshing::internal::All_cells_selected<Tr>());
+                       Constant_property_map<Cell_handle, bool>(true));
 
   typedef std::pair<typename Tr::Vertex_handle, typename Tr::Vertex_handle> Edge_vv;
-  typedef Tetrahedral_remeshing::internal::No_constraint_pmap<Edge_vv> No_edge;
   typedef typename internal_np::Lookup_named_param_def <
     internal_np::edge_is_constrained_t,
     NamedParameters,
-    No_edge//default
+    Constant_property_map<Edge_vv, bool>//default
   > ::type ECMap;
   ECMap ecmap = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
-                                 No_edge());
+                                 Constant_property_map<Edge_vv, bool>(false));
 
   typedef typename Tr::Facet Facet;
-  typedef Tetrahedral_remeshing::internal::No_constraint_pmap<Facet> No_facet;
   typedef typename internal_np::Lookup_named_param_def <
     internal_np::facet_is_constrained_t,
     NamedParameters,
-    No_facet//default
+    Constant_property_map<Facet, bool>//default
   > ::type FCMap;
   FCMap fcmap = choose_parameter(get_parameter(np, internal_np::facet_is_constrained),
-                                 No_facet());
+                                 Constant_property_map<Facet, bool>(false));
 
   typedef typename internal_np::Lookup_named_param_def <
     internal_np::visitor_t,

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -216,7 +216,6 @@ void tetrahedral_isotropic_remeshing(
     = choose_parameter(get_parameter(np, internal_np::smooth_constrained_edges),
                        false);
 
-  typedef typename Tr::Cell_handle Cell_handle;
   typedef typename internal_np::Lookup_named_param_def <
     internal_np::cell_selector_t,
     NamedParameters,

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -410,34 +410,33 @@ void tetrahedral_isotropic_remeshing(
     = choose_parameter(get_parameter(np, internal_np::smooth_constrained_edges),
       false);
 
+  typedef typename Tr::Cell_handle Cell_handle;
   typedef typename internal_np::Lookup_named_param_def <
   internal_np::cell_selector_t,
               NamedParameters,
-              Tetrahedral_remeshing::internal::All_cells_selected<Tr>//default
+              Constant_property_map<Cell_handle, bool>//default
               > ::type SelectionFunctor;
   SelectionFunctor cell_select
     = choose_parameter(get_parameter(np, internal_np::cell_selector),
-                       Tetrahedral_remeshing::internal::All_cells_selected<Tr>());
+                       Constant_property_map<Cell_handle, bool>(true));
 
   typedef std::pair<typename Tr::Vertex_handle, typename Tr::Vertex_handle> Edge_vv;
-  typedef Tetrahedral_remeshing::internal::No_constraint_pmap<Edge_vv> No_edge;
   typedef typename internal_np::Lookup_named_param_def <
   internal_np::edge_is_constrained_t,
               NamedParameters,
-              No_edge//default
+              Constant_property_map<Edge_vv, bool>//default
               > ::type ECMap;
   ECMap ecmap = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
-                                 No_edge());
+                                 Constant_property_map<Edge_vv, bool>(false));
 
   typedef typename Tr::Facet Facet;
-  typedef Tetrahedral_remeshing::internal::No_constraint_pmap<Facet> No_facet;
   typedef typename internal_np::Lookup_named_param_def <
   internal_np::facet_is_constrained_t,
               NamedParameters,
-              No_facet//default
+              Constant_property_map<Facet, bool>//default
               > ::type FCMap;
   FCMap fcmap = choose_parameter(get_parameter(np, internal_np::facet_is_constrained),
-                                 No_facet());
+                                 Constant_property_map<Facet, bool>(false));
 
   typedef typename internal_np::Lookup_named_param_def <
               internal_np::visitor_t,

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -220,11 +220,11 @@ void tetrahedral_isotropic_remeshing(
   typedef typename internal_np::Lookup_named_param_def <
     internal_np::cell_selector_t,
     NamedParameters,
-    Constant_property_map<Cell_handle, bool>//default
+    Tetrahedral_remeshing::internal::All_cells_selected<Tr>//default
   > ::type SelectionFunctor;
   SelectionFunctor cell_select
     = choose_parameter(get_parameter(np, internal_np::cell_selector),
-                       Constant_property_map<Cell_handle, bool>(true));
+                       Tetrahedral_remeshing::internal::All_cells_selected<Tr>());
 
   typedef std::pair<typename Tr::Vertex_handle, typename Tr::Vertex_handle> Edge_vv;
   typedef typename internal_np::Lookup_named_param_def <

--- a/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_of_one_subdomain.cpp
+++ b/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_of_one_subdomain.cpp
@@ -47,20 +47,33 @@ void generate_input_two_subdomains(const std::size_t nbv, Remeshing_triangulatio
 #endif
 }
 
-struct Cells_of_subdomain
+template<typename Tr>
+struct Cells_of_subdomain_pmap
 {
 private:
+  using Cell_handle = typename Tr::Cell_handle;
+
   const int m_subdomain;
 
 public:
-  Cells_of_subdomain(const int& subdomain)
+  using key_type = Cell_handle;
+  using value_type = bool;
+  using reference = bool;
+  using category = boost::read_write_property_map_tag;
+
+  Cells_of_subdomain_pmap(const int& subdomain)
     : m_subdomain(subdomain)
   {}
 
-  bool operator()(Remeshing_triangulation::Cell_handle c) const
+  friend value_type get(
+    const Cells_of_subdomain_pmap& map, const key_type& c)
   {
-    return m_subdomain == c->subdomain_index();
+    return (map.m_subdomain == c->subdomain_index());
   }
+  friend void put(
+    Cells_of_subdomain_pmap&, const key_type&, const value_type)
+  {} //nothing to do : subdomain indices are updated in remeshing
+
 };
 
 int main(int argc, char* argv[])
@@ -74,7 +87,8 @@ int main(int argc, char* argv[])
   generate_input_two_subdomains(1000, tr);
 
   CGAL::tetrahedral_isotropic_remeshing(tr, target_edge_length,
-      CGAL::parameters::cell_is_selected_map(Cells_of_subdomain(2)));
+      CGAL::parameters::cell_is_selected_map(
+        Cells_of_subdomain_pmap<Remeshing_triangulation>(2)));
 
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary of Changes

The doc and name say that `cell_is_selected_map` is a property map, and it was not!

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged

Todo
- [x] ~~make backward compatible with operator()~~ the existing functors were actually not working, so it's better to make sure they are not used at all
- [x] make sure the pmap is updated after each atomic operation, similarly to subdomain indices
- [ ] this PR is a bug fix so it will not appear in `changes.md` but the users should be warned when the release is published. The message could be
> Breaking change in Tetrahedral remeshing : the named parameter `cell_is_selected_map` is now consistently a property map in documentation and code.