### PR TITLE
Add Workflow to remove the 'Tested' label

### DIFF
--- a/.github/workflows/Remove_labels.yml
+++ b/.github/workflows/Remove_labels.yml
@@ -1,0 +1,32 @@
+name: remove_labels
+on:
+  pull_request_target:
+    types: [synchronize]
+jobs:
+  remove_label:
+    runs-on: ubuntu-latest
+    if: contains(github.event.pull_request.labels.*.name, 'Tested')
+    name: remove label
+    steps:
+      - name: removelabel
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              name: "Tested",
+            });
+      - name: Post address
+        uses: actions/github-script@v6
+        if: ${{ success() && github.event_name == 'pull_request_target' }}
+        with:
+          script: |
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body: "This pull-request was previously marked with the label `Tested`, but has been modified with new commits. That label has been removed."
+              })

--- a/.github/workflows/Remove_labels.yml
+++ b/.github/workflows/Remove_labels.yml
@@ -21,7 +21,7 @@ jobs:
             });
       - name: Post address
         uses: actions/github-script@v6
-        if: ${{ success() && github.event_name == 'pull_request_target' }}
+        if: ${{ success() }}
         with:
           script: |
             github.rest.issues.createComment({


### PR DESCRIPTION
## Summary of Changes

Added a workflow that removes the `Tested` labels during a new commit in a pull request

## Release Management

* Affected package(s): -
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -

