### PR TITLE
Polyhedron Demo: Fix upper right corner

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Basic_generator_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Basic_generator_widget.ui
@@ -934,7 +934,7 @@ QGroupBox::title {
                  <item>
                   <widget class="QLineEdit" name="grid_lineEdit">
                    <property name="text">
-                    <string>0 0 0 1 1 1</string>
+                    <string>0 0 0 1 1 0</string>
                    </property>
                   </widget>
                  </item>


### PR DESCRIPTION
## Summary of Changes

When generating a grid in the demo it is better that it is in the xy plane.

## Release Management

* Affected package(s): Polyhedron

