### PR TITLE
Orthtree:  Fix memory leak

### DIFF
--- a/Orthtree/include/CGAL/Orthtree.h
+++ b/Orthtree/include/CGAL/Orthtree.h
@@ -320,8 +320,21 @@ public:
   void refine(const Split_predicate& split_predicate) {
 
     // If the tree has already been refined, reset it
-    if (!m_root.is_leaf())
+    if (!m_root.is_leaf()){
+      std::queue<Node> nodes;
+      for (std::size_t i = 0; i < Degree::value; ++ i)
+            nodes.push (m_root[i]);
+      while (!nodes.empty())
+      {
+        Node node = nodes.front();
+        nodes.pop();
+        if (!node.is_leaf())
+          for (std::size_t i = 0; i < Degree::value; ++ i)
+            nodes.push (node[i]);
+        node.free();
+      }
       m_root.unsplit();
+    }
 
     // Reset the side length map, too
     m_side_per_depth.resize(1);

--- a/Orthtree/include/CGAL/Orthtree/Node.h
+++ b/Orthtree/include/CGAL/Orthtree/Node.h
@@ -345,7 +345,7 @@ public:
   }
 
   /*!
-    \brief returns the nth child fo this node.
+    \brief returns the nth child of this node.
 
     \pre `!is_null()`
     \pre `!is_leaf()`


### PR DESCRIPTION
## Summary of Changes

Fix a memory leak by freeing all nodes, right as the destructor would do, but keeping the root node.

## Release Management

* Affected package(s): Orthtree
* Issue(s) solved (if any): fix #6951
* License and copyright ownership:  unchanged

