### PR TITLE
Shortest Path: Add a default parameter so that the test does something

### DIFF
--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/TestMesh.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/TestMesh.cpp
@@ -264,7 +264,7 @@ void run_program_instance(po::variables_map& vm)
 
   if (vm.count("randomseed"))
   {
-    programInstance.randomizer = new CGAL::Random(vm["randomSeed"].as<unsigned int>());
+    programInstance.randomizer = new CGAL::Random(vm["randomseed"].as<unsigned int>());
   }
 
   programInstance.debugMode = vm["debugmode"].as<bool>();
@@ -310,7 +310,7 @@ int main(int argc, char** argv)
     ("help,h", "Display help message")
     ("polyhedron,p", po::value<std::string>()->default_value("./data/test_mesh_6.off"), "Polyhedron input file")
     ("debugmode,d", po::value<bool>()->default_value(false), "Enable debug output")
-    ("randomseed,r", po::value<unsigned int>(), "Randomization seed value")
+    ("randomseed,r", po::value<unsigned int>()->default_value(0), "Randomization seed value")
     ("trials,t", po::value<size_t>()->default_value(1), "Number of trials to run")
     ("kernel,k", po::value<std::string>()->default_value("epick"), "Kernel to use.  One of \'ipick\', \'epick\', \'epeck\'")
     ;

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/TestMesh.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/TestMesh.cpp
@@ -72,6 +72,12 @@ struct TestMeshProgramInstance
     numIterations = 1;
   }
 
+  ~TestMeshProgramInstance()
+  {
+    if (randomizer)
+      delete randomizer;
+  }
+
   size_t numIterations;
   std::string meshName;
   bool debugMode;

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/TestMesh.cpp
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/TestMesh.cpp
@@ -308,7 +308,7 @@ int main(int argc, char** argv)
 
   options.add_options()
     ("help,h", "Display help message")
-    ("polyhedron,p", po::value<std::string>(), "Polyhedron input file")
+    ("polyhedron,p", po::value<std::string>()->default_value("./data/test_mesh_6.off"), "Polyhedron input file")
     ("debugmode,d", po::value<bool>()->default_value(false), "Enable debug output")
     ("randomseed,r", po::value<unsigned int>(), "Randomization seed value")
     ("trials,t", po::value<size_t>()->default_value(1), "Number of trials to run")


### PR DESCRIPTION
## Summary of Changes

TestMesh.cpp uses boost program options, and currently has no default for a mesh.

## Release Management

* Affected package(s): Surface_mesh_shortest_path

