### PR TITLE
Snap_rounding:  cleanup

### DIFF
--- a/Snap_rounding_2/doc/Snap_rounding_2/Concepts/SnapRoundingTraits_2.h
+++ b/Snap_rounding_2/doc/Snap_rounding_2/Concepts/SnapRoundingTraits_2.h
@@ -189,7 +189,7 @@ class ConstructVertex_2
   public:
   /*!
   returns the source or target of `seg`. If `i` modulo 2 is 0,
-  the source is returned, otherwise the target is returned.}
+  the source is returned, otherwise the target is returned.
   */
   Point_2 operator()(Segment_2 seg, int i);
 };
@@ -223,7 +223,7 @@ class ConstructIsoRectangle_2
   public:
 
   /*!
-  introduces an iso-oriented rectangle fo whose minimal `x` coordinate
+  introduces an iso-oriented rectangle whose minimal `x` coordinate
   is the one of `left`, the maximal `x` coordinate is the one of
   `right`, the minimal `y` coordinate is the one of `bottom`,
   the maximal `y` coordinate is the one of `top`.}

--- a/Snap_rounding_2/doc/Snap_rounding_2/Snap_rounding_2.txt
+++ b/Snap_rounding_2/doc/Snap_rounding_2/Snap_rounding_2.txt
@@ -128,8 +128,7 @@ Polyline number 4:
 The package is supplied with a graphical demo program that opens a window,
 allows the user to edit segments dynamically, applies a selected
 snap-rounding procedures, and displays the result onto the same window
-(see `<CGAL_ROOT>/demo/Snap_rounding_2/demo.cpp`).
+(see `<CGAL_ROOT>/demo/Snap_rounding_2/Snap_rounding_2.cpp`).
 
 */
 } /* namespace CGAL */
-

--- a/Snap_rounding_2/include/CGAL/Snap_rounding_kd_2.h
+++ b/Snap_rounding_2/include/CGAL/Snap_rounding_kd_2.h
@@ -19,7 +19,6 @@
 
 #include <list>
 #include <CGAL/basic.h>
-#include <CGAL/predicates_on_points_2.h>
 #include <iostream>
 #include <CGAL/predicates_on_points_2.h>
 #include <CGAL/utility.h>


### PR DESCRIPTION
## Summary of Changes

deduplicate `#include` and fix typos in the documentation

## Release Management

* Affected package(s):  Snap_rounding 

