### PR TITLE
Fix implicit conversion from `std::size_t` to `bool` creating ambiguous calls

### DIFF
--- a/BGL/include/CGAL/boost/graph/selection.h
+++ b/BGL/include/CGAL/boost/graph/selection.h
@@ -543,7 +543,7 @@ regularize_face_selection_borders(
                             (face_index_map));
 
   for (mesh_face_descriptor fd : faces(mesh))
-    put(is_selected, fd, graph.labels[get(face_index_map,fd)]);
+    put(is_selected, fd, (graph.labels[get(face_index_map,fd)] != 0));
 }
 
 /// \cond SKIP_IN_MANUAL


### PR DESCRIPTION
## Summary of Changes

`is_selected` is documented to be a `face_descriptor` -> `bool` property map.

## Release Management

* Affected package(s): `BGL`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

