### PR TITLE
CGAL: Fixes for cmake 3.25

### DIFF
--- a/Barycentric_coordinates_2/examples/Barycentric_coordinates_2/CMakeLists.txt
+++ b/Barycentric_coordinates_2/examples/Barycentric_coordinates_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script.
 # This is the CMake script for compiling a CGAL application.
 
-project(Barycentric_coordinates_2_Examples)
-
 cmake_minimum_required(VERSION 3.1...3.22)
+
+project(Barycentric_coordinates_2_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Barycentric_coordinates_2/test/Barycentric_coordinates_2/CMakeLists.txt
+++ b/Barycentric_coordinates_2/test/Barycentric_coordinates_2/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script.
 # This is the CMake script for compiling a CGAL application.
 
-project(Barycentric_coordinates_2_Tests)
-
 cmake_minimum_required(VERSION 3.1...3.22)
+
+project(Barycentric_coordinates_2_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/CMakeLists.txt
+++ b/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-project(Polygonal_surface_reconstruction_Examples)
-
 cmake_minimum_required(VERSION 3.1...3.22)
+
+project(Polygonal_surface_reconstruction_Examples)
 
 # CGAL and its components
 find_package(CGAL REQUIRED)

--- a/Polygonal_surface_reconstruction/test/Polygonal_surface_reconstruction/CMakeLists.txt
+++ b/Polygonal_surface_reconstruction/test/Polygonal_surface_reconstruction/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-project(Polygonal_surface_reconstruction_Tests)
-
 cmake_minimum_required(VERSION 3.1...3.22)
+
+project(Polygonal_surface_reconstruction_Tests)
 
 # CGAL and its components
 find_package(CGAL REQUIRED)

--- a/Scripts/developer_scripts/test_merge_of_branch
+++ b/Scripts/developer_scripts/test_merge_of_branch
@@ -117,6 +117,30 @@ if [ -n "${project_name_demo}" ]; then
   exit 1
 fi
 
+# check minimal version is the first instruction in cmake scripts
+echo '.. Checking if all CMakeLists.txt starts with cmake_minimum_required...'
+cmr_tests=$(for i in ^build*/test/*/CMakeLists.txt;     do pkg=$(echo $i | awk -F "/" '{print $3}'); res=$(egrep -v "^\s*#" $i  | grep -v "^\s*$" | head -n 1 | grep -v cmake_minimum_required); if [ -n "${res}" ]; then echo $pkg; fi; done)
+cmr_examples=$(for i in ^build*/examples/*/CMakeLists.txt; do pkg=$(echo $i | awk -F "/" '{print $3}'); res=$(egrep -v "^s*#" $i  | grep -v "^\s*$" | head -n 1 | grep -v cmake_minimum_required); if [ -n "${res}" ]; then echo $pkg; fi; done)
+cmr_demo=$(for i in ^build*/demo/*/CMakeLists.txt;     do pkg=$(echo $i | awk -F "/" '{print $3}'); res=$(egrep -v "^s*#" $i  | grep -v "^\s*$" | head -n 1 | grep -v cmake_minimum_required); if [ -n "${res}" ]; then echo $pkg; fi; done)
+
+if [ -n "${cmr_tests}" ]; then
+  echo "CMakeLists in test with issues:"
+  echo ${cmr_tests}
+  exit 1
+fi
+
+if [ -n "${cmr_examples}" ]; then
+  echo "CMakeLists in examples with issues:"
+  echo ${cmr_examples}
+  exit 1
+fi
+
+if [ -n "${cmr_demo}" ]; then
+  echo "CMakeLists in demo with issues:"
+  echo ${cmr_demo}
+  exit 1
+fi
+
 #check header files without SPDX license identifier
 echo '.. Checking SPDX license identifier presence in header files...'
 file_without_SPDX_identifiers=$(for pkg in `find */package_info -name 'license.txt' | awk -F "/" '{print $1}'`; do if [ -e ${pkg}/include ]; then find ${pkg}/include -type f \( -name '*.h' -o -name '*.hpp' \) | xargs -r grep -L "SPDX-License-Identifier"; fi; done)

--- a/Shape_regularization/examples/Shape_regularization/CMakeLists.txt
+++ b/Shape_regularization/examples/Shape_regularization/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_CMakeLists.
 # This is the CMake script for compiling a set of CGAL applications.
 
-project(Shape_regularization_Examples)
-
 cmake_minimum_required(VERSION 3.1...3.22)
+
+project(Shape_regularization_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Shape_regularization/test/Shape_regularization/CMakeLists.txt
+++ b/Shape_regularization/test/Shape_regularization/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_CMakeLists.
 # This is the CMake script for compiling a set of CGAL applications.
 
-project(Shape_regularization_Tests)
-
 cmake_minimum_required(VERSION 3.1...3.22)
+
+project(Shape_regularization_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Weights/examples/Weights/CMakeLists.txt
+++ b/Weights/examples/Weights/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script.
 # This is the CMake script for compiling a CGAL application.
 
-project(Weights_Examples)
-
 cmake_minimum_required(VERSION 3.1...3.22)
+
+project(Weights_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Weights/test/Weights/CMakeLists.txt
+++ b/Weights/test/Weights/CMakeLists.txt
@@ -1,9 +1,9 @@
 # Created by the script cgal_create_cmake_script.
 # This is the CMake script for compiling a CGAL application.
 
-project(Weights_Tests)
-
 cmake_minimum_required(VERSION 3.1...3.22)
+
+project(Weights_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 


### PR DESCRIPTION
## Summary of Changes

Address the warning that a `CMakeLists.txt` file's first command must be `cmake_minimum_required()`
In the testsuite of `Installation` is also a warning, but that concerns probably the setup of testsuites
```
CMake Warning:
  Manually-specified variables were not used by the project:

    CMAKE_POLICY_DEFAULT_CMP0053
    LEDA_INCLUDE_DIR
    WITH_CGAL_Qt3
```

## Release Management

* Affected package(s): several 


