### PR TITLE
Fix the Kernel concept being weaker than TriangulationTraits_23 requirements

### DIFF
--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -5975,8 +5975,8 @@ public:
 
     \note It is advised to return a const reference to `p` to avoid useless copies.
 
-    \note This peculiar requirement is necessary because some CGAL structures such as triangulations
-    internally manipulate points whose type might `Point_2` or `Weighted_point_2`.
+    \note This peculiar requirement is necessary because some \cgal structures such as triangulations
+    internally manipulate points whose type might be `Point_2` or `Weighted_point_2`.
   */
   Kernel::Point_2 operator()(const Kernel::Point_2& p);
 
@@ -6015,8 +6015,8 @@ public:
 
     \note It is advised to return a const reference to `p` to avoid useless copies.
 
-    \note This peculiar requirement is necessary because some CGAL structures such as triangulations
-    internally manipulate points whose type might `Point_3` or `Weighted_point_3`.
+    \note This peculiar requirement is necessary because some \cgal structures such as triangulations
+    internally manipulate points whose type might be `Point_3` or `Weighted_point_3`.
   */
   Kernel::Point_3 operator()(const Kernel::Point_3& p);
 

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -5964,12 +5964,21 @@ public:
   /// A model of this concept must provide:
   /// @{
 
-
   /*!
     introduces a variable with Cartesian coordinates
     \f$ (0,0)\f$.
   */
   Kernel::Point_2 operator()(const CGAL::Origin &CGAL::ORIGIN);
+
+  /*!
+    returns `p`.
+
+    \note It is advised to return a const reference to `p` to avoid useless copies.
+
+    \note This peculiar requirement is necessary because some CGAL structures such as triangulations
+    internally manipulate points whose type might `Point_2` or `Weighted_point_2`.
+  */
+  Kernel::Point_2 operator()(const Kernel::Point_2& p);
 
  /*!
     extracts the bare point from the weighted point.
@@ -6000,6 +6009,16 @@ public:
     introduces a point with Cartesian coordinates\f$ (0,0,0)\f$.
   */
   Kernel::Point_3 operator()(const CGAL::Origin &CGAL::ORIGIN);
+
+  /*!
+    returns `p`.
+
+    \note It is advised to return a const reference to `p` to avoid useless copies.
+
+    \note This peculiar requirement is necessary because some CGAL structures such as triangulations
+    internally manipulate points whose type might `Point_3` or `Weighted_point_3`.
+  */
+  Kernel::Point_3 operator()(const Kernel::Point_3& p);
 
  /*!
     extracts the bare point from the weighted point.


### PR DESCRIPTION
## Summary of Changes

During Weighted_point_23 -> Point_23 implicit conversion removal (https://github.com/CGAL/cgal/pull/2102), and more precisely in the commit https://github.com/CGAL/cgal/commit/42506237b212593bc105fdc95c58118633f5afc0 I have added `Construct_point_23`, I have added the overload `Point_23 Construct_point_23(Point_23)` to the requirements of the `TriangulationTraits_23` concepts.

However, I forgot to also add it to the `Kernel` concept, which needs to also contain these requirements since we claim that any model of `Kernel` is a model of `TriangulationTraits_23`.

## Release Management

* Affected package(s): `Kernel_23`
* Feature/Small Feature (if any): n/a
* License and copyright ownership: no change
