### PR TITLE
STL Extensions: Correct spelling

### DIFF
--- a/Combinatorial_map/include/CGAL/Compact_container_with_index.h
+++ b/Combinatorial_map/include/CGAL/Compact_container_with_index.h
@@ -752,7 +752,10 @@ public:
     return false;
   }
 
-  bool owns_dereferencable(const_iterator cit) const
+  bool owns_dereferenceable(const_iterator cit) const
+  { return cit!=end() && owns(cit); }
+
+  CGAL_DEPRECATED bool owns_dereferencable(const_iterator cit) const
   { return cit!=end() && owns(cit); }
 
   /** Reserve method to ensure that the capacity of the Compact_container be

--- a/Combinatorial_map/include/CGAL/Compact_container_with_index.h
+++ b/Combinatorial_map/include/CGAL/Compact_container_with_index.h
@@ -756,7 +756,7 @@ public:
   { return cit!=end() && owns(cit); }
 
   CGAL_DEPRECATED bool owns_dereferencable(const_iterator cit) const
-  { return cit!=end() && owns(cit); }
+  { return owns_dereferenceable(cit); }
 
   /** Reserve method to ensure that the capacity of the Compact_container be
    * greater or equal than a given value n.

--- a/Documentation/doc/Documentation/Developer_manual/Chapter_iterators_and_circulators.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_iterators_and_circulators.txt
@@ -42,7 +42,7 @@ Thus we will not give a full description of these concept here
 but only a few hints about how to use and write handle, iterators and circulators in \cgal.  Developers should consult the above-mentioned references to become
 familiar with the iterator, circulator and handle concepts. In
 particular,  the notions of iterator and circulator ranges,
-dereferencable and past-the-end values,
+dereferenceable and past-the-end values,
  mutable and constant iterators and circulators,
 and the different categories (forward, bidirectional, random-access, etc.)
 of iterators and circulators, are fundamental.

--- a/STL_Extension/doc/STL_Extension/CGAL/Compact_container.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/Compact_container.h
@@ -672,7 +672,7 @@ bool owns(const_iterator pos);
 /*!
  * returns whether `pos` is in the range `[cc.begin(), cc`.end())` (`cc.end()` excluded).
  */
-bool owns_dereferencable(const_iterator pos);
+bool owns_dereferenceable(const_iterator pos);
 
 /// @}
 

--- a/STL_Extension/doc/STL_Extension/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/Concurrent_compact_container.h
@@ -294,7 +294,7 @@ complexity. No exception is thrown.
   /// returns whether `pos` is in the range `[ccc.begin(),  ccc.end()]` (`ccc.end()` included).
   bool owns(const_iterator pos);
   /// returns whether `pos` is in the range `[ccc.begin(), ccc`.end())` (`ccc.end()` excluded).
-  bool owns_dereferencable(const_iterator pos);
+  bool owns_dereferenceable(const_iterator pos);
 
 /// @}
 

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -545,7 +545,7 @@ public:
 
   CGAL_DEPRECATED bool owns_dereferencable(const_iterator cit) const
   {
-    return cit != end() && owns(cit);
+    return owns_dereferenceable(cit);
   }
 
   /** Reserve method to ensure that the capacity of the Compact_container be

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -537,7 +537,13 @@ public:
     return false;
   }
 
-  bool owns_dereferencable(const_iterator cit) const
+  bool owns_dereferenceable(const_iterator cit) const
+  {
+    return cit != end() && owns(cit);
+  }
+
+
+  CGAL_DEPRECATED bool owns_dereferencable(const_iterator cit) const
   {
     return cit != end() && owns(cit);
   }

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -542,11 +542,15 @@ public:
     return false;
   }
 
-  bool owns_dereferencable(const_iterator cit) const
+  bool owns_dereferenceable(const_iterator cit) const
   {
     return cit != end() && owns(cit);
   }
 
+  CGAL_DEPRECATED bool owns_dereferencable(const_iterator cit) const
+  {
+    return cit != end() && owns(cit);
+  }
   /** Reserve method to ensure that the capacity of the Concurrent_compact_container be
    * greater or equal than a given value n.
    */

--- a/STL_Extension/include/CGAL/Concurrent_compact_container.h
+++ b/STL_Extension/include/CGAL/Concurrent_compact_container.h
@@ -549,8 +549,9 @@ public:
 
   CGAL_DEPRECATED bool owns_dereferencable(const_iterator cit) const
   {
-    return cit != end() && owns(cit);
+    return owns_dereferenceable(cit);
   }
+
   /** Reserve method to ensure that the capacity of the Concurrent_compact_container be
    * greater or equal than a given value n.
    */

--- a/STL_Extension/test/STL_Extension/test_Compact_container.cpp
+++ b/STL_Extension/test/STL_Extension/test_Compact_container.cpp
@@ -242,15 +242,15 @@ void test(const Cont &)
   assert(c11.size() == v1.size());
   assert(c10 == c11);
 
-  // owns() and owns_dereferencable().
+  // owns() and owns_dereferenceable().
   for(typename Cont::const_iterator it = c9.begin(), end = c9.end(); it != end; ++it) {
     assert(c9.owns(it));
-    assert(c9.owns_dereferencable(it));
+    assert(c9.owns_dereferenceable(it));
     assert(! c10.owns(it));
-    assert(! c10.owns_dereferencable(it));
+    assert(! c10.owns_dereferenceable(it));
   }
   assert(c9.owns(c9.end()));
-  assert(! c9.owns_dereferencable(c9.end()));
+  assert(! c9.owns_dereferenceable(c9.end()));
 
 
   c9.erase(c9.begin(), c9.end());

--- a/STL_Extension/test/STL_Extension/test_Concurrent_compact_container.cpp
+++ b/STL_Extension/test/STL_Extension/test_Concurrent_compact_container.cpp
@@ -322,15 +322,15 @@ void test(const Cont &)
   assert(c11.size() == v1.size());
   assert(c10 == c11);*/
 
-  // owns() and owns_dereferencable().
+  // owns() and owns_dereferenceable().
   for(typename Cont::const_iterator it = c9.begin(), end = c9.end(); it != end; ++it) {
     assert(c9.owns(it));
-    assert(c9.owns_dereferencable(it));
+    assert(c9.owns_dereferenceable(it));
     assert(! c10.owns(it));
-    assert(! c10.owns_dereferencable(it));
+    assert(! c10.owns_dereferenceable(it));
   }
   assert(c9.owns(c9.end()));
-  assert(! c9.owns_dereferencable(c9.end()));
+  assert(! c9.owns_dereferenceable(c9.end()));
 
 
   c9.erase(c9.begin(), c9.end());

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -2049,7 +2049,7 @@ bool
 Triangulation_data_structure_3<Vb,Cb,Ct>::
 is_vertex(Vertex_handle v) const
 {
-    return vertices().owns_dereferencable(v);
+    return vertices().owns_dereferenceable(v);
 }
 
 template <class Vb, class Cb, class Ct>
@@ -2102,7 +2102,7 @@ is_edge(Cell_handle c, int i, int j) const
   if ( (dimension() == 2) && ((i>2) || (j>2)) ) return false;
   if ((i>3) || (j>3)) return false;
 
-  return cells().owns_dereferencable(c);
+  return cells().owns_dereferenceable(c);
 }
 
 template <class Vb, class Cb, class Ct>
@@ -2149,7 +2149,7 @@ is_facet(Cell_handle c, int i) const
     if ( (dimension() == 2) && (i!=3) )
         return false;
 
-    return cells().owns_dereferencable(c);
+    return cells().owns_dereferenceable(c);
 }
 
 template <class Vb, class Cb, class Ct>
@@ -2161,7 +2161,7 @@ is_cell( Cell_handle c ) const
     if (dimension() < 3)
         return false;
 
-    return cells().owns_dereferencable(c);
+    return cells().owns_dereferenceable(c);
 }
 
 template <class Vb, class Cb, class Ct>


### PR DESCRIPTION
## Summary of Changes

dereferencable -> dereferenceable     

I deprecated the function but kept it. I do not test the deprecated version, and I do not put it into the changelog. 

## Release Management

* Affected package(s): STL_extension
* Issue(s) solved (if any): fix #6834


