### PR TITLE
PMP: Fix for a -Wmaybe-uninitialized

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polyhedral_envelope.h
+++ b/Polygon_mesh_processing/include/CGAL/Polyhedral_envelope.h
@@ -864,7 +864,11 @@ private:
   Implicit_Seg_Facet_interpoint_Out_Prism_return_local_id(const ePoint_3 &ip,
                                                           const std::vector<unsigned int> &prismindex, const unsigned int &jump, int &id) const
   {
-    Oriented_side ori;
+    Oriented_side ori = ON_POSITIVE_SIDE; // The compiler sees the
+                                          // possibility that the
+                                          // nested for loop body is
+                                          // not executed and warns that
+                                          // ori may not be initialized
 
     for (unsigned int i = 0; i < prismindex.size(); i++){
       if (prismindex[i] == jump){


### PR DESCRIPTION
## Summary of Changes

Initialize a variable. This is not really needed, because we know that the inner body of the nested for loop will be executed, but the compiler doesn't because it has never read the paper. See this [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.6-Ic-129/Polygon_mesh_processing/TestReport_lrineau_Debian-stable-Release.gz)

## Release Management

* Affected package(s): PMP:  Polyhedral_envelope

