### PR TITLE
Three, and Polyhedron Demo: Add an #include and remove deprecated code

### DIFF
--- a/GraphicsView/include/CGAL/Qt/camera.h
+++ b/GraphicsView/include/CGAL/Qt/camera.h
@@ -13,6 +13,7 @@
 
 #ifndef QGLVIEWER_CAMERA_H
 #define QGLVIEWER_CAMERA_H
+#include <array>
 #include <QMap>
 #include <CGAL/Qt/vec.h>
 #include <CGAL/Qt/quaternion.h>

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.1...3.23)
 project( Polyhedron_Demo )
 include(FeatureSummary)
 
+
+add_definitions ( -DCGAL_NO_DEPRECATED_CODE )
+
 # Find includes in corresponding build directories
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/triangulation_3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/triangulation_3_io_plugin.cpp
@@ -1,3 +1,4 @@
+#include <CGAL/IO/io.h>
 #include <CGAL/Three/Three.h>
 #include <CGAL/Three/Polyhedron_demo_io_plugin_interface.h>
 #include "T3_type.h"
@@ -34,7 +35,7 @@ public:
     T3 tr;;
 
     if(fileinfo.absoluteFilePath().endsWith(".binary.cgal"))
-      CGAL::set_binary_mode(ifs);
+      CGAL::IO::set_binary_mode(ifs);
     ifs >> tr;
     if(ifs.fail() || !tr.is_valid(false)) {
       std::cerr << "Error! Cannot open file " << (const char*)fileinfo.filePath().toUtf8() << std::endl;
@@ -71,11 +72,11 @@ public:
       std::ofstream out(fileinfo.filePath().toUtf8());
       if(path.endsWith(".binary.cgal"))
       {
-        CGAL::set_binary_mode(out);
+        CGAL::IO::set_binary_mode(out);
       }
       else
       {
-        CGAL::set_ascii_mode(out);
+        CGAL::IO::set_ascii_mode(out);
       }
       out << t3_item->triangulation();
       if( out.fail())

--- a/Polyhedron/demo/Polyhedron/Plugins/PMP/Smoothing_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PMP/Smoothing_plugin.cpp
@@ -220,7 +220,7 @@ public Q_SLOTS:
         CGAL::Polygon_mesh_processing::tangential_relaxation(
           vset,
           pmesh,
-          CGAL::Polygon_mesh_processing::parameters::number_of_iterations(nb_iter)
+          CGAL::parameters::number_of_iterations(nb_iter)
           .edge_is_constrained_map(selection_item->constrained_edges_pmap())
           .vertex_is_constrained_map(selection_item->constrained_vertices_pmap())
           .relax_constraints(smooth_features));
@@ -234,7 +234,7 @@ public Q_SLOTS:
         CGAL::Polygon_mesh_processing::tangential_relaxation(
           vertices(pmesh),
           pmesh,
-          CGAL::Polygon_mesh_processing::parameters::number_of_iterations(nb_iter));
+          CGAL::parameters::number_of_iterations(nb_iter));
 
         poly_item->invalidateOpenGLBuffers();
         Q_EMIT poly_item->itemChanged();
@@ -277,7 +277,7 @@ public Q_SLOTS:
 
     if(poly_item)
     {
-      angle_and_area_smoothing(pmesh, parameters::do_project(projection)
+      angle_and_area_smoothing(pmesh, CGAL::parameters::do_project(projection)
                                     .number_of_iterations(nb_iter)
                                     .vertex_is_constrained_map(vcmap)
                                     .use_safety_constraints(use_safety_measures)
@@ -295,7 +295,7 @@ public Q_SLOTS:
       // No faces selected --> use all faces
       if(std::begin(selection_item->selected_facets) == std::end(selection_item->selected_facets))
       {
-        angle_and_area_smoothing(pmesh, parameters::do_project(projection)
+        angle_and_area_smoothing(pmesh, CGAL::parameters::do_project(projection)
                                       .number_of_iterations(nb_iter)
                                       .vertex_is_constrained_map(vcmap)
                                       .edge_is_constrained_map(selection_item->constrained_edges_pmap())
@@ -306,7 +306,7 @@ public Q_SLOTS:
       }
       else // some faces exist in the selection
       {
-        angle_and_area_smoothing(selection_item->selected_facets, pmesh, parameters::do_project(projection)
+        angle_and_area_smoothing(selection_item->selected_facets, pmesh, CGAL::parameters::do_project(projection)
                                                                        .number_of_iterations(nb_iter)
                                                                        .vertex_is_constrained_map(vcmap)
                                                                        .edge_is_constrained_map(selection_item->constrained_edges_pmap())
@@ -350,7 +350,7 @@ public Q_SLOTS:
 
     if(poly_item)
     {
-      smooth_shape(pmesh, time_step, parameters::number_of_iterations(nb_iter)
+      smooth_shape(pmesh, time_step, CGAL::parameters::number_of_iterations(nb_iter)
                                                 .vertex_is_constrained_map(vcmap));
 
       poly_item->invalidateOpenGLBuffers();
@@ -362,13 +362,13 @@ public Q_SLOTS:
 
       if(std::begin(selection_item->selected_facets) == std::end(selection_item->selected_facets))
       {
-        smooth_shape(pmesh, time_step, parameters::number_of_iterations(nb_iter)
+        smooth_shape(pmesh, time_step, CGAL::parameters::number_of_iterations(nb_iter)
                                                   .vertex_is_constrained_map(vcmap));
       }
       else
       {
         smooth_shape(selection_item->selected_facets, pmesh, time_step,
-                     parameters::number_of_iterations(nb_iter)
+                     CGAL::parameters::number_of_iterations(nb_iter)
                                 .vertex_is_constrained_map(vcmap));
       }
 

--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -30,6 +30,7 @@
 
 #include <boost/iterator/function_output_iterator.hpp>
 
+#include <CGAL/IO/io.h>
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 #include <CGAL/AABB_triangulation_3_cell_primitive.h>
@@ -276,7 +277,7 @@ void Scene_c3t3_item::show_cnc(bool b)
 
 bool Scene_c3t3_item::load_binary(std::istream& is)
 {
-  if(!CGAL::Mesh_3::load_binary_file(is, c3t3())) return false;
+  if(!CGAL::IO::load_binary_file(is, c3t3())) return false;
   resetCutPlane();
   if(is.good()) {
     c3t3_changed();

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -38,6 +38,7 @@
 #include <CGAL/AABB_traits.h>
 #include <CGAL/AABB_triangulation_3_cell_primitive.h>
 #include <CGAL/facets_in_complex_3_to_triangle_mesh.h>
+#include <CGAL/IO/Color.h>
 
 #include "Scene_polygon_soup_item.h"
 
@@ -188,7 +189,7 @@ public :
   }
 
   void addTriangle(const Tr::Bare_point& pa, const Tr::Bare_point& pb,
-                   const Tr::Bare_point& pc, const CGAL::Color color)
+                   const Tr::Bare_point& pc, const CGAL::IO::Color color)
   {
     const CGAL::qglviewer::Vec offset = Three::mainViewer()->offset();
     Geom_traits::Vector_3 n = cross_product(pb - pa, pc - pa);
@@ -1253,7 +1254,7 @@ void Scene_triangulation_3_item_priv::computeIntersection(const Primitive& cell)
   const Tr::Bare_point& pc = wp2p(ch->vertex(2)->point());
   const Tr::Bare_point& pd = wp2p(ch->vertex(3)->point());
 
-  CGAL::Color color(UC(c.red()), UC(c.green()), UC(c.blue()));
+  CGAL::IO::Color color(UC(c.red()), UC(c.green()), UC(c.blue()));
 
   if(is_filterable)
   {
@@ -1355,7 +1356,7 @@ void Scene_triangulation_3_item_priv::computeSpheres()
     typedef unsigned char UC;
     tr_vertices.push_back(*vit);
     spheres->add_sphere(Geom_traits::Sphere_3(center, radius),s_id++,
-                        CGAL::Color(UC(c.red()), UC(c.green()), UC(c.blue())));
+                        CGAL::IO::Color(UC(c.red()), UC(c.green()), UC(c.blue())));
 
   }
   spheres->invalidateOpenGLBuffers();

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -18,7 +18,7 @@
 
 #include <list>
 #include <vector>
-#include <map>
+#include <unordered_map>
 #include <algorithm>
 #include <utility>
 #include <iostream>


### PR DESCRIPTION
## Summary of Changes

When compiling the Polyhedron demo with  `add_definitions ( -DCGAL_NO_DEPRECATED_CODE )`    there is an error message for `std::array` being not defined.

I would also consider it as a good idea to add the above mention `#define`  in the CMakeLists.txt flle of the demo. What do you think @sloriot ?

## Release Management

* Affected package(s): Polyhedron_3

