### PR TITLE
Modify flipping criteria in PMP::isotropic_remeshing and PMP::refine

### DIFF
--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_example.cpp
@@ -43,7 +43,7 @@ int main(int argc, char* argv[])
   }
 
   double target_edge_length = (argc > 2) ? std::stod(std::string(argv[2])) : 0.04;
-  unsigned int nb_iter = 3;
+  unsigned int nb_iter = (argc > 3) ? std::stoi(std::string(argv[3])) : 10;
 
   std::cout << "Split border...";
 
@@ -58,6 +58,8 @@ int main(int argc, char* argv[])
   PMP::isotropic_remeshing(faces(mesh), target_edge_length, mesh,
                            CGAL::parameters::number_of_iterations(nb_iter)
                                             .protect_constraints(true)); //i.e. protect border, here
+
+  CGAL::IO::write_polygon_mesh("out.off", mesh, CGAL::parameters::stream_precision(17));
 
   std::cout << "Remeshing done." << std::endl;
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/refine_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/refine_impl.h
@@ -259,8 +259,7 @@ private:
       Halfedge_around_face_circulator<PolygonMesh> circ(halfedge(fd,pmesh),pmesh), done(circ);
       do {
         vertex_descriptor v = target(*circ,pmesh);
-        std::pair<typename std::map<vertex_descriptor, double>::iterator, bool> v_insert
-          = scale_attribute.insert(std::make_pair(v, 0));
+        auto v_insert = scale_attribute.emplace(v, 0);
         if(!v_insert.second) { continue; } // already calculated
         v_insert.first->second = average_length(v, interior_map, accept_internal_facets);
       } while(++circ != done);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/refine_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/refine_impl.h
@@ -15,12 +15,6 @@
 
 #include <CGAL/license/Polygon_mesh_processing/meshing_hole_filling.h>
 
-
-#include <cmath>
-#include <map>
-#include <set>
-#include <list>
-
 #include <CGAL/assertions.h>
 #ifdef CGAL_PMP_FAIR_DEBUG
 #include <CGAL/Timer.h>
@@ -30,7 +24,13 @@
 #include <CGAL/boost/graph/iterator.h>
 #include <CGAL/boost/graph/Euler_operations.h>
 #include <CGAL/boost/graph/properties.h>
+#include <CGAL/Polygon_mesh_processing/repair_degeneracies.h>
 #include <CGAL/property_map.h>
+
+#include <cmath>
+#include <map>
+#include <set>
+#include <list>
 
 namespace CGAL {
 
@@ -49,15 +49,28 @@ class Refine_Polyhedron_3 {
   typedef Halfedge_around_face_circulator<PolygonMesh>    Halfedge_around_facet_circulator;
   typedef Halfedge_around_target_circulator<PolygonMesh>  Halfedge_around_vertex_circulator;
 
+  typedef typename CGAL::Kernel_traits<Point_3>::type                     Traits;
+
 private:
   PolygonMesh& pmesh;
   VertexPointMap vpmap;
+  Traits traits = {};
 
-  bool flippable(halfedge_descriptor h) {
+  bool flippable(halfedge_descriptor h)
+  {
     // this check is added so that edge flip does not break manifoldness
     // it might happen when there is an edge where flip_edge(h) will be placed (i.e. two edges collide after flip)
     vertex_descriptor v_tip_0 = target(next(h,pmesh),pmesh);
     vertex_descriptor v_tip_1 = target(next(opposite(h,pmesh),pmesh),pmesh);
+
+#ifdef CGAL_PMP_REFINE_DEBUG_PP
+    std::cout << "flippable() " << h << std::endl;
+    std::cout << "\t" << source(h, pmesh) << ": " << pmesh.point(source(h, pmesh)) << std::endl;
+    std::cout << "\t" << target(h, pmesh) << ": " << pmesh.point(target(h, pmesh)) << std::endl;
+    std::cout << "\t" << v_tip_0 << ": " << pmesh.point(v_tip_0) << std::endl;
+    std::cout << "\t" << v_tip_1 << ": " << pmesh.point(v_tip_1) << std::endl;
+#endif
+
     Halfedge_around_vertex_circulator v_cir(next(h,pmesh), pmesh), v_end(v_cir);
     do {
       if(target(opposite(*v_cir, pmesh),pmesh) == v_tip_1) { return false; }
@@ -74,13 +87,21 @@ private:
 
   bool relax(halfedge_descriptor h)
   {
+#ifdef CGAL_PMP_REFINE_DEBUG_PP
     typedef typename boost::property_traits<VertexPointMap>::reference Point_3_ref;
-    Point_3_ref p = get(vpmap, target(h,pmesh));
-    Point_3_ref q = get(vpmap, target(opposite(h,pmesh),pmesh));
+    Point_3_ref p = get(vpmap, source(h,pmesh));
+    Point_3_ref q = get(vpmap, target(h,pmesh));
     Point_3_ref r = get(vpmap, target(next(h,pmesh),pmesh));
     Point_3_ref s = get(vpmap, target(next(opposite(h,pmesh),pmesh),pmesh));
-    if( (CGAL::ON_UNBOUNDED_SIDE  != CGAL::side_of_bounded_sphere(p,q,r,s)) ||
-        (CGAL::ON_UNBOUNDED_SIDE  != CGAL::side_of_bounded_sphere(p,q,s,r)) )
+
+    std::cout << "relax() " << h << std::endl;
+    std::cout << "\t" << source(h, pmesh) << ": " << p << std::endl;
+    std::cout << "\t" << target(h, pmesh) << ": " << q << std::endl;
+    std::cout << "\t" << target(next(h,pmesh),pmesh) << ": " << r << std::endl;
+    std::cout << "\t" << target(next(opposite(h,pmesh),pmesh),pmesh) << ": " << s << std::endl;
+#endif
+
+    if(internal::should_flip(edge(h, pmesh), pmesh, vpmap, traits))
     {
       if(flippable(h)) {
         Euler::flip_edge(h,pmesh);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -315,9 +315,9 @@ bool should_flip(typename boost::graph_traits<TriangleMesh>::edge_descriptor e,
   const Point_ref p2 = get(vpm, source(h, tmesh));
   const Point_ref p3 = get(vpm, target(next(opposite(h, tmesh), tmesh), tmesh));
 
-  const double ap1 = angle(p0,p1,p2);
-  const double ap3 = angle(p2,p3,p0);
-  return (ap1 + ap3 > 180);
+  const typename Traits::FT ap1 = to_double(angle(p0,p1,p2));
+  const typename Traits::FT ap3 = to_double(angle(p2,p3,p0));
+  return (ap1 + ap3 > typename Traits::FT(180.));
 }
 
 template <class TriangleMesh, class VPM, class Traits, class Functor>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -302,6 +302,7 @@ bool should_flip(typename boost::graph_traits<TriangleMesh>::edge_descriptor e,
 {
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor halfedge_descriptor;
 
+  typedef typename Traits:: FT                                            FT;
   typedef typename boost::property_traits<VPM>::reference                 Point_ref;
 
   CGAL_precondition(!is_border(e, tmesh));
@@ -315,9 +316,9 @@ bool should_flip(typename boost::graph_traits<TriangleMesh>::edge_descriptor e,
   const Point_ref p2 = get(vpm, source(h, tmesh));
   const Point_ref p3 = get(vpm, target(next(opposite(h, tmesh), tmesh), tmesh));
 
-  const typename Traits::FT ap1 = to_double(angle(p0,p1,p2));
-  const typename Traits::FT ap3 = to_double(angle(p2,p3,p0));
-  return (ap1 + ap3 > typename Traits::FT(180.));
+  const FT ap1 = angle(p0,p1,p2);
+  const FT ap3 = angle(p2,p3,p0);
+  return (ap1 + ap3 > FT(180));
 }
 
 template <class TriangleMesh, class VPM, class Traits, class Functor>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -302,9 +302,7 @@ bool should_flip(typename boost::graph_traits<TriangleMesh>::edge_descriptor e,
 {
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor halfedge_descriptor;
 
-  typedef typename Traits::FT                                             FT;
   typedef typename boost::property_traits<VPM>::reference                 Point_ref;
-  typedef typename Traits::Vector_3                                       Vector_3;
 
   CGAL_precondition(!is_border(e, tmesh));
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -294,7 +294,6 @@ get_best_edge_orientation(typename boost::graph_traits<TriangleMesh>::edge_descr
   return boost::graph_traits<TriangleMesh>::null_halfedge();
 }
 
-// adapted from triangulate_faces
 template <typename TriangleMesh, typename VPM, typename Traits>
 bool should_flip(typename boost::graph_traits<TriangleMesh>::edge_descriptor e,
                  const TriangleMesh& tmesh,
@@ -309,43 +308,18 @@ bool should_flip(typename boost::graph_traits<TriangleMesh>::edge_descriptor e,
 
   CGAL_precondition(!is_border(e, tmesh));
 
-  halfedge_descriptor h = halfedge(e, tmesh);
+  typename Traits::Compute_approximate_angle_3 angle = gt.compute_approximate_angle_3_object();
 
-  Point_ref p0 = get(vpm, target(h, tmesh));
-  Point_ref p1 = get(vpm, target(next(h, tmesh), tmesh));
-  Point_ref p2 = get(vpm, source(h, tmesh));
-  Point_ref p3 = get(vpm, target(next(opposite(h, tmesh), tmesh), tmesh));
+  const halfedge_descriptor h = halfedge(e, tmesh);
 
-  /* Chooses the diagonal that will split the quad in two triangles that maximize
-   * the scalar product of of the un-normalized normals of the two triangles.
-   * The lengths of the un-normalized normals (computed using cross-products of two vectors)
-   *  are proportional to the area of the triangles.
-   * Maximize the scalar product of the two normals will avoid skinny triangles,
-   * and will also taken into account the cosine of the angle between the two normals.
-   * In particular, if the two triangles are oriented in different directions,
-   * the scalar product will be negative.
-   */
+  const Point_ref p0 = get(vpm, target(h, tmesh));
+  const Point_ref p1 = get(vpm, target(next(h, tmesh), tmesh));
+  const Point_ref p2 = get(vpm, source(h, tmesh));
+  const Point_ref p3 = get(vpm, target(next(opposite(h, tmesh), tmesh), tmesh));
 
-//  CGAL::cross_product(p2-p1, p3-p2) * CGAL::cross_product(p0-p3, p1-p0);
-//  CGAL::cross_product(p1-p0, p1-p2) * CGAL::cross_product(p3-p2, p3-p0);
-
-  const Vector_3 v01 = gt.construct_vector_3_object()(p0, p1);
-  const Vector_3 v12 = gt.construct_vector_3_object()(p1, p2);
-  const Vector_3 v23 = gt.construct_vector_3_object()(p2, p3);
-  const Vector_3 v30 = gt.construct_vector_3_object()(p3, p0);
-
-  const FT p1p3 = gt.compute_scalar_product_3_object()(
-                    gt.construct_cross_product_vector_3_object()(v12, v23),
-                    gt.construct_cross_product_vector_3_object()(v30, v01));
-
-  const Vector_3 v21 = gt.construct_opposite_vector_3_object()(v12);
-  const Vector_3 v03 = gt.construct_opposite_vector_3_object()(v30);
-
-  const FT p0p2 = gt.compute_scalar_product_3_object()(
-                    gt.construct_cross_product_vector_3_object()(v01, v21),
-                    gt.construct_cross_product_vector_3_object()(v23, v03));
-
-  return p0p2 <= p1p3;
+  const double ap1 = angle(p0,p1,p2);
+  const double ap3 = angle(p2,p3,p0);
+  return (ap1 + ap3 > 180);
 }
 
 template <class TriangleMesh, class VPM, class Traits, class Functor>


### PR DESCRIPTION
## Summary of Changes

### Criterion in `PMP::isotropic_remeshing()`

The criterion that takes the scalar_product of the cross products  is maybe adapted to minimize the curvature when triangulating faces,  but should_flip() is used in `PMP::isotropic_remeshing()`, `PMP::refine()`, and `PMP::remove_almost_degenerate_faces()`. These algorithms aim to produce well-shaped elements. The criterion is not adapted to these algorithms: for example, on a flat mesh the scalar product is meaningless so it will pick the diagonal which maximizes the product of the lengths and product of sines, but this might create very anisotropic elements since the sine of obtuse angles is still positive. In `PMP::isotropic_remeshing()`, we actually do not notice how bad the flip is because other operations (smoothing, collapsing, splitting) counter balance it.
 
The "new" criterion is simply the criterion used in mesh smoothing and the typical Delaunay criterion for surfaces. The old criterion is still used in `PMP::triangulate_faces()` since we care for a nice surface and not nice elements.

Below is an example of `PMP::isotropic_remeshing()` without collapse (left - input, middle - master, right - new flip criterion)

![image](https://user-images.githubusercontent.com/5074170/208135032-af586afb-41eb-4c08-9a4d-7dc643d9f38d.png)

### Criterion in `PMP::refine()`

The current criterion is some kind of Delaunay ball (it calls `side_of_bounded_sphere()`), which might work OK for flat regions, but can produce super thin wedges (see issue: https://github.com/CGAL/cgal/issues/6982) when the mesh is not flat.

The criterion used instead is the one used in `PMP::isotropic_remeshing()` and `PMP::remove_almost_degenerate_faces()`, which is the typical angle-based surface Delaunay criterion.

Below is input, hole filling with old refine criterion, old filling with new refine criterion.

![image](https://user-images.githubusercontent.com/5074170/208141681-85585924-dc4b-43bc-b4e7-3d67ae9cfa56.png)

## Release Management

* Affected package(s): `PMP`
* Issue(s) solved (if any): fix #6982
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

