### PR TITLE
Scripts, run_testsuite_with_ctest: CONFIG_TYPE maybe used on other platforms

### DIFF
--- a/Scripts/developer_scripts/run_testsuite_with_ctest
+++ b/Scripts/developer_scripts/run_testsuite_with_ctest
@@ -296,7 +296,7 @@ run_test_on_platform()
   echo "SET(CTEST_CUSTOM_MAXIMUM_FAILED_TEST_OUTPUT_SIZE 1000000000)" >> CTestCustom.cmake
 
   CTEST_OPTS="-T Start -T Test --timeout 1200 ${DO_NOT_TEST:+-E execution___of__}"
-  if uname | grep -q "CYGWIN"; then
+  if [ -n "$CONFIG_TYPE" ]; then
     CTEST_OPTS="-C ${CONFIG_TYPE} ${CTEST_OPTS}"
   fi
   if [ -z "${SHOW_PROGRESS}" ]; then


### PR DESCRIPTION
## Summary of Changes

So far, the config type was only used if Cygwin was detected, because implicitly it was for the Visual Studio CMake generator. But the config type maybe used on other platforms. On MacOS, with the XCode generator, the config type is required.

So, the change is that `CONFIG_TYPE` is used if and only if it is defined. Simple.

## Release Management

I have based the change on 5.4 because we need the change for the testsuite on `monet`, a MacOS test machine, and we still test 5.4.x and 5.5.x.

@sloriot This PR should be in the current batch of PRs to be tested.

* Affected package(s): Scripts, testsuite
