### PR TITLE
Convex_hull_2: Do not assert without exact predicates

### DIFF
--- a/Convex_hull_2/test/Convex_hull_2/ch_test_CH.cpp
+++ b/Convex_hull_2/test/Convex_hull_2/ch_test_CH.cpp
@@ -56,9 +56,5 @@ main()
   CGAL::ch__batch_test( cch_H_gmp );
 #endif
 
-  CGAL::Convex_hull_constructive_traits_2< CGAL::Homogeneous<double> >
-                                                                 cch_H_double;
-  std::cout << "Homogeneous<double>: C ";
-  CGAL::ch__batch_test( cch_H_double );
   return 0;
 }

--- a/Convex_hull_2/test/Convex_hull_2/ch_test_SC.cpp
+++ b/Convex_hull_2/test/Convex_hull_2/ch_test_SC.cpp
@@ -53,8 +53,5 @@ main()
   CGAL::ch__batch_test( ch_C_Qgmp );
 #endif
 
-  CGAL::Cartesian<double>                       ch_C_double;
-  std::cout << "Cartesian<double>:     ";
-  CGAL::ch__batch_test( ch_C_double );
   return 0;
 }

--- a/Convex_hull_2/test/Convex_hull_2/ch_test_SH.cpp
+++ b/Convex_hull_2/test/Convex_hull_2/ch_test_SH.cpp
@@ -52,8 +52,5 @@ main()
   CGAL::ch__batch_test( ch_H_gmp );
 #endif
 
-  CGAL::Homogeneous<double>           ch_H_double;
-  std::cout << "Homogeneous<double>:   ";
-  CGAL::ch__batch_test( ch_H_double );
   return 0;
 }

--- a/Convex_hull_2/test/Convex_hull_2/ch_test_SS.cpp
+++ b/Convex_hull_2/test/Convex_hull_2/ch_test_SS.cpp
@@ -53,8 +53,5 @@ main()
   CGAL::ch__batch_test( ch_S_Qgmp );
 #endif
 
-  CGAL::Simple_cartesian<double>                       ch_S_double;
-  std::cout << "SimpleCartesian<double>:     ";
-  CGAL::ch__batch_test( ch_S_double );
   return 0;
 }


### PR DESCRIPTION
## Summary of Changes

Remove the tests without exact predicates. We just know that they may fail.

## Release Management

* Affected package(s): Convex_hull_2
* Issue(s) solved (if any): fix #7107

