### PR TITLE
Convex_hull_2: Use of 2D Delaunay

### DIFF
--- a/Convex_hull_2/doc/Convex_hull_2/Convex_hull_2.txt
+++ b/Convex_hull_2/doc/Convex_hull_2/Convex_hull_2.txt
@@ -143,6 +143,10 @@ check whether a given sequence of 2D points forms a (counter)clockwise strongly
 convex polygon. These are used in postcondition
 testing of the two-dimensional convex hull functions.
 
+In case you want to keep collinear points you can use the 2D Delaunay triangulation as
+in the following example. This sequence is then <em>not</em> strongly convex.
+
+\cgalExample{Convex_hull_2/ch_delaunay_2.cpp}
+
 */
 } /* namespace CGAL */
-

--- a/Convex_hull_2/doc/Convex_hull_2/examples.txt
+++ b/Convex_hull_2/doc/Convex_hull_2/examples.txt
@@ -6,4 +6,5 @@
 \example Convex_hull_2/ch_timing.cpp
 \example Convex_hull_2/iostream_convex_hull_2.cpp
 \example Convex_hull_2/vector_convex_hull_2.cpp
+\example Convex_hull_2/ch_delaunay_2.cpp
 */

--- a/Convex_hull_2/examples/Convex_hull_2/ch_delaunay_2.cpp
+++ b/Convex_hull_2/examples/Convex_hull_2/ch_delaunay_2.cpp
@@ -1,0 +1,27 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Delaunay_triangulation_2.h>
+#include <list>
+#include <iostream>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+typedef K::Point_2 Point_2;
+typedef CGAL::Delaunay_triangulation_2<K> Delaunay_triangulation_2;
+
+
+int main()
+{
+  std::vector<Point_2> input = { Point_2(0, 0), Point_2(1,1), Point_2(2,0), Point_2(2,2), Point_2(1,2), Point_2(0,2) };
+
+  Delaunay_triangulation_2 dt(input.begin(), input.end());
+
+  std::list<Point_2> result;
+  Delaunay_triangulation_2::Vertex_circulator vc = dt.incident_vertices(dt.infinite_vertex()), done(vc);
+  do{
+    std ::cout << vc->point() << std::endl;
+    // push_front in order to obtain the counterclockwise sequence
+    result.push_front(vc->point());
+    ++vc;
+  }while(vc != done);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary of Changes

Add an example where we extract the not necessarily strong convex hull from a triangulation.

## Release Management

* Affected package(s): CH2 
* Issue(s) solved (if any): fix #7113

