### PR TITLE
3D Demo: Fix statistics on angles

### DIFF
--- a/Polyhedron/demo/Polyhedron/include/CGAL/statistics_helpers.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/statistics_helpers.h
@@ -11,6 +11,7 @@
 #include <boost/accumulators/statistics/min.hpp>
 #include <boost/accumulators/statistics/max.hpp>
 #include <boost/accumulators/statistics/median.hpp>
+#include <boost/algorithm/clamp.hpp>
 #include <boost/property_map/property_map.hpp>
 
 #include <cmath>
@@ -71,7 +72,7 @@ void compute_angles(Mesh* poly,Tester tester , double& mini, double& maxi, doubl
     typename Traits::Vector_3 bc(b, c);
     double cos_angle = (ba * bc)
       / std::sqrt(ba.squared_length() * bc.squared_length());
-
+    cos_angle = boost::algorithm::clamp<double>(cos_angle, -1.0, 1.0);
     acc(std::acos(cos_angle) * rad_to_deg);
   }
 
@@ -281,4 +282,3 @@ void faces_aspect_ratio(Mesh* poly,
   faces_aspect_ratio(poly, faces(*poly), min_altitude,  mini, maxi, mean);
 }
 #endif // POLYHEDRON_DEMO_STATISTICS_HELPERS_H
-

--- a/Polyhedron/demo/Polyhedron/include/CGAL/statistics_helpers.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/statistics_helpers.h
@@ -11,7 +11,6 @@
 #include <boost/accumulators/statistics/min.hpp>
 #include <boost/accumulators/statistics/max.hpp>
 #include <boost/accumulators/statistics/median.hpp>
-#include <boost/algorithm/clamp.hpp>
 #include <boost/property_map/property_map.hpp>
 
 #include <cmath>
@@ -68,12 +67,8 @@ void compute_angles(Mesh* poly,Tester tester , double& mini, double& maxi, doubl
     typename Traits::Point_3 b = get(vpmap, target(h, *poly));
     typename Traits::Point_3 c = get(vpmap, target(next(h, *poly), *poly));
 
-    typename Traits::Vector_3 ba(b, a);
-    typename Traits::Vector_3 bc(b, c);
-    double cos_angle = (ba * bc)
-      / std::sqrt(ba.squared_length() * bc.squared_length());
-    cos_angle = boost::algorithm::clamp<double>(cos_angle, -1.0, 1.0);
-    acc(std::acos(cos_angle) * rad_to_deg);
+    typename Traits::FT ang = CGAL::approximate_angle(b,a,c);
+    acc(CGAL::to_double(ang));
   }
 
   mini = extract_result< tag::min >(acc);

--- a/Polyhedron/demo/Polyhedron/include/CGAL/statistics_helpers.h
+++ b/Polyhedron/demo/Polyhedron/include/CGAL/statistics_helpers.h
@@ -50,7 +50,6 @@ void compute_angles(Mesh* poly,Tester tester , double& mini, double& maxi, doubl
   typedef typename boost::graph_traits<Mesh>::face_descriptor face_descriptor;
   typedef typename boost::property_map<Mesh, CGAL::vertex_point_t>::type VPMap;
   typedef typename CGAL::Kernel_traits< typename boost::property_traits<VPMap>::value_type >::Kernel Traits;
-  double rad_to_deg = 180. / CGAL_PI;
 
   accumulator_set< double,
     features< tag::min, tag::max, tag::mean > > acc;


### PR DESCRIPTION
## Summary of Changes

Clamp as `acos()` operates on `[-1,1]`.   Without that a single `nan` ruins the mean value.

## Release Management

* Affected package(s): Polyhedron_3

