### PR TITLE
Fix seed computation in SLS offset computation

### DIFF
--- a/Boolean_set_operations_2/examples/Boolean_set_operations_2/bezier_traits_adapter2.cpp
+++ b/Boolean_set_operations_2/examples/Boolean_set_operations_2/bezier_traits_adapter2.cpp
@@ -168,11 +168,11 @@ bool read_bezier(char const* aFileName, Bezier_polygon_set& rSet)
       }
     }
     catch(std::exception const& x) {
-      std::cout << "An exception ocurred during reading of Bezier polygon set:"
+      std::cout << "An exception occurred during reading of Bezier polygon set:"
                 << x.what() << std::endl;
     }
     catch(...) {
-      std::cout << "An exception ocurred during reading of Bezier polygon set."
+      std::cout << "An exception occurred during reading of Bezier polygon set."
                 << std::endl;
     }
   }

--- a/Polyline_simplification_2/demo/Polyline_simplification_2/Polyline_simplification_2.cpp
+++ b/Polyline_simplification_2/demo/Polyline_simplification_2/Polyline_simplification_2.cpp
@@ -321,7 +321,7 @@ void MainWindow::on_actionSimplify_triggered()
   }
   catch(...)
   {
-    statusBar()->showMessage(QString("Exception ocurred"));
+    statusBar()->showMessage(QString("Exception occurred"));
   }
 
    // default cursor
@@ -478,7 +478,7 @@ void MainWindow::loadOSM(QString fileName)
   }
   catch(...)
   {
-    statusBar()->showMessage(QString("Exception ocurred"));
+    statusBar()->showMessage(QString("Exception occurred"));
   }
 
   Q_EMIT( changed());

--- a/Straight_skeleton_2/include/CGAL/Polygon_offset_builder_2.h
+++ b/Straight_skeleton_2/include/CGAL/Polygon_offset_builder_2.h
@@ -137,43 +137,14 @@ private:
     return K().construct_segment_2_object()(s,t);
   }
 
-  Trisegment_2_ptr CreateTrisegment ( Triedge const& aTriedge ) const
-  {
-    CGAL_precondition( aTriedge.is_valid() ) ;
-
-    if ( aTriedge.is_skeleton() )
-    {
-      return Construct_ss_trisegment_2(mTraits)(CreateSegment(aTriedge.e0())
-                                               ,CreateSegment(aTriedge.e1())
-                                               ,CreateSegment(aTriedge.e2())
-                                               );
-    }
-    else
-    {
-      return Trisegment_2_ptr() ;
-    }
-  }
-
-  Trisegment_2_ptr CreateTrisegment ( Vertex_const_handle aNode ) const ;
-
-  Vertex_const_handle GetSeedVertex ( Vertex_const_handle   aNode
-                                    , Halfedge_const_handle aBisector
-                                    , Halfedge_const_handle aEa
-                                    , Halfedge_const_handle aEb
-                                    ) const ;
-
-  bool Is_bisector_defined_by ( Halfedge_const_handle aBisector, Halfedge_const_handle aEa, Halfedge_const_handle aEb ) const
-  {
-    return    ( aBisector->defining_contour_edge() == aEa && aBisector->opposite()->defining_contour_edge() == aEb )
-           || ( aBisector->defining_contour_edge() == aEb && aBisector->opposite()->defining_contour_edge() == aEa ) ;
-  }
+  Trisegment_2_ptr GetTrisegment ( Vertex_const_handle aNode ) const ;
 
   Comparison_result Compare_offset_against_event_time( FT aT, Vertex_const_handle aNode ) const
   {
     CGAL_precondition( aNode->is_skeleton() ) ;
 
     Comparison_result r = aNode->has_infinite_time() ? SMALLER
-                                                     : static_cast<Comparison_result>(Compare_offset_against_event_time_2(mTraits)(aT,CreateTrisegment(aNode)));
+                                                     : static_cast<Comparison_result>(Compare_offset_against_event_time_2(mTraits)(aT,GetTrisegment(aNode)));
 
     return r ;
   }
@@ -199,8 +170,7 @@ public:
       CGAL_assertion ( lNodeT->is_skeleton() ) ;
 
       Vertex_const_handle lSeedNode = aBisector->slope() == POSITIVE ? lNodeS : lNodeT ;
-
-      lSeedEvent = CreateTrisegment(lSeedNode) ;
+      lSeedEvent = GetTrisegment(lSeedNode) ;
 
       CGAL_POLYOFFSET_TRACE(3,"Seed node for " << e2str(*aBisector) << " is " << v2str(*lSeedNode) << " event=" << lSeedEvent ) ;
     }

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Polygon_offset_builder_2_impl.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Polygon_offset_builder_2_impl.h
@@ -66,7 +66,7 @@ Polygon_offset_builder_2<Ss,Gt,Cont,Visitor>::LocateHook( FT                    
     Halfedge_const_handle lNext = aBisector->next();
 
     CGAL_POLYOFFSET_TRACE(2,"Testing hook on " << e2str(*aBisector) ) ;
-    CGAL_POLYOFFSET_TRACE(4, "Next: " << e2str(*lNext) << " - Prev: " << e2str(*lPrev) ) ;
+    CGAL_POLYOFFSET_TRACE(4, "Next: " << e2str(*lNext) << " ; Prev: " << e2str(*lPrev) ) ;
 
     if ( !IsVisited(aBisector) )
     {
@@ -82,6 +82,9 @@ Polygon_offset_builder_2<Ss,Gt,Cont,Visitor>::LocateHook( FT                    
 
         Comparison_result lTimeWrtSrcTime = lPrev->is_bisector() ? Compare_offset_against_event_time(aTime,lPrev    ->vertex()) : LARGER ;
         Comparison_result lTimeWrtTgtTime = lNext->is_bisector() ? Compare_offset_against_event_time(aTime,aBisector->vertex()) : LARGER ;
+        CGAL_POLYOFFSET_TRACE(3,"  lPrev->is_bisector(): " << lPrev->is_bisector() << " lNext->is_bisector(): " << lNext->is_bisector());
+        CGAL_POLYOFFSET_TRACE(3,"  lPrev->vertex()->time(): " << lPrev->vertex()->time());
+        CGAL_POLYOFFSET_TRACE(3,"  aBisector->vertex()->time(): " << aBisector->vertex()->time());
         CGAL_POLYOFFSET_TRACE(3,"  TimeWrtSrcTime: " << lTimeWrtSrcTime << " TimeWrtTgtTime: " << lTimeWrtTgtTime ) ;
 
         //

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Polygon_offset_builder_2_impl.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Polygon_offset_builder_2_impl.h
@@ -327,96 +327,23 @@ OutputIterator Polygon_offset_builder_2<Ss,Gt,Cont,Visitor>::construct_offset_co
 
 template<class Ss, class Gt, class Cont, class Visitor>
 typename Polygon_offset_builder_2<Ss,Gt,Cont,Visitor>::Trisegment_2_ptr
-Polygon_offset_builder_2<Ss,Gt,Cont,Visitor>::CreateTrisegment ( Vertex_const_handle aNode ) const
+Polygon_offset_builder_2<Ss,Gt,Cont,Visitor>::GetTrisegment ( Vertex_const_handle aNode ) const
 {
   CGAL_precondition(handle_assigned(aNode));
 
   Trisegment_2_ptr r ;
 
-  CGAL_POLYOFFSET_TRACE(3,"Creating Trisegment for " << v2str(*aNode) ) ;
+  CGAL_POLYOFFSET_TRACE(3,"Getting Trisegment for " << v2str(*aNode) ) ;
 
   if ( aNode->is_skeleton() )
   {
-    Triedge const& lEventTriedge =  aNode->event_triedge() ;
-
-    r = CreateTrisegment(lEventTriedge) ;
-
-    CGAL_stskel_intrinsic_test_assertion
-    (
-      !CGAL_SS_i::is_possibly_inexact_distance_clearly_not_equal_to( Construct_ss_event_time_and_point_2(mTraits)(r)->get<0>()
-                                                                   , aNode->time()
-                                                                   )
-    ) ;
-
-    CGAL_POLYOFFSET_TRACE(3,"Event triedge=" << lEventTriedge ) ;
-
-    if ( r->degenerate_seed_id() == Trisegment_2::LEFT )
-    {
-     CGAL_POLYOFFSET_TRACE(3,"Left seed is degenerate." ) ;
-
-      Vertex_const_handle lLeftSeed = GetSeedVertex(aNode
-                                                   ,aNode->primary_bisector()->prev()->opposite()
-                                                   ,lEventTriedge.e0()
-                                                   ,lEventTriedge.e1()
-                                                   ) ;
-      if ( handle_assigned(lLeftSeed) )
-        r->set_child_l( CreateTrisegment(lLeftSeed) ) ; // Recursive call
-    }
-    else if ( ! aNode->is_split() && r->degenerate_seed_id() == Trisegment_2::RIGHT )
-    {
-      CGAL_POLYOFFSET_TRACE(3,"Right seed is degenerate." ) ;
-
-      Vertex_const_handle lRightSeed = GetSeedVertex(aNode
-                                                    ,aNode->primary_bisector()->opposite()->next()
-                                                    ,lEventTriedge.e1()
-                                                    ,lEventTriedge.e2()
-                                                    ) ;
-      if ( handle_assigned(lRightSeed) )
-        r->set_child_r( CreateTrisegment(lRightSeed) ) ; // Recursive call
-    }
+    r = aNode->trisegment() ;
+    CGAL_assertion(bool(r));
   }
 
   return r ;
 }
 
-template<class Ss, class Gt, class Cont, class Visitor>
-typename Polygon_offset_builder_2<Ss,Gt,Cont,Visitor>::Vertex_const_handle
-Polygon_offset_builder_2<Ss,Gt,Cont,Visitor>::GetSeedVertex ( Vertex_const_handle   aNode
-                                                            , Halfedge_const_handle aBisector
-                                                            , Halfedge_const_handle aEa
-                                                            , Halfedge_const_handle aEb
-                                                            ) const
-{
-  Vertex_const_handle rSeed ;
+} // namespace CGAL
 
-  if ( Is_bisector_defined_by(aBisector,aEa,aEb) )
-  {
-    rSeed = aBisector->vertex();
-
-    CGAL_POLYOFFSET_TRACE(3,"Seed of N" << aNode->id() << " for vertex (E" << aEa->id() << ",E" << aEb->id() << ") directly found: " << v2str(*rSeed) ) ;
-  }
-  else
-  {
-    typedef typename Vertex::Halfedge_around_vertex_const_circulator Halfedge_around_vertex_const_circulator ;
-
-    Halfedge_around_vertex_const_circulator cb = aNode->halfedge_around_vertex_begin() ;
-    Halfedge_around_vertex_const_circulator c  = cb ;
-    do
-    {
-      Halfedge_const_handle lBisector = *c ;
-      if ( Is_bisector_defined_by(lBisector,aEa,aEb) )
-      {
-        rSeed = lBisector->opposite()->vertex();
-        CGAL_POLYOFFSET_TRACE(3,"Seed of N" << aNode->id() << " for vertex (E" << aEa->id() << ",E" << aEb->id() << ") indirectly found: V" << rSeed->id() ) ;
-      }
-    }
-    while ( !handle_assigned(rSeed) && ++ c != cb ) ;
-  }
-
-  return rSeed ;
-}
-
-} // end namespace CGAL
-
-#endif // CGAL_POLYGON_OFFSET_BUILDER_2_IMPL_H //
-// EOF //
+#endif // CGAL_POLYGON_OFFSET_BUILDER_2_IMPL_H

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_aux.h
@@ -43,6 +43,23 @@ struct Has_inexact_constructions
                                   >::type type ;
 } ;
 
+template <class K>
+struct Segment_2_with_ID
+  : public K::Segment_2
+{
+  typedef typename K::Segment_2 Base;
+  typedef typename K::Point_2 Point_2;
+
+public:
+  Segment_2_with_ID() : Base(), mID(-1) { }
+  Segment_2_with_ID(Base const& aS) : Base(aS), mID(-1) { }
+  Segment_2_with_ID(Base const& aS, const std::size_t aID) : Base(aS), mID(aID) { }
+  Segment_2_with_ID(Point_2 const& aP, Point_2 const& aQ, const std::size_t aID) : Base(aP, aQ), mID(aID) { }
+
+public:
+  std::size_t mID;
+};
+
 //
 // This record encapsulates the defining contour halfedges for a node (both contour and skeleton)
 //

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_aux.h
@@ -30,7 +30,8 @@ namespace CGAL {
 
 namespace CGAL_SS_i {
 
-template<class K> struct Has_inexact_constructions
+template<class K>
+struct Has_inexact_constructions
 {
   typedef typename K::FT FT ;
 
@@ -176,10 +177,7 @@ public:
 
 inline void intrusive_ptr_add_ref( Ref_counted_base const* p ) { p->AddRef(); }
 inline void intrusive_ptr_release( Ref_counted_base const* p ) { p->Release(); }
+
 } // namespace CGAL
 
-
-
-#endif // CGAL_STRAIGHT_SKELETON_AUX_H //
-// EOF //
-
+#endif // CGAL_STRAIGHT_SKELETON_AUX_H

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
@@ -581,7 +581,7 @@ void Straight_skeleton_builder_2<Gt,Ss,V>::CreateContourBisectors()
 
     Vertex_handle lInfNode = mSSkel->SSkel::Base::vertices_push_back( Vertex( mVertexID++ ) ) ;
     InitVertexData(lInfNode);
-    CGAL_assertion(lInfNode->has_null_point());
+    CGAL_assertion(lInfNode->has_infinite_time());
 
     lRBisector->HBase_base::set_next( lLBisector  );
     lLBisector->HBase_base::set_prev( lRBisector );
@@ -1212,7 +1212,7 @@ void Straight_skeleton_builder_2<Gt,Ss,V>::HandleSplitEvent( EventPtr aEvent, Ve
     Vertex_handle lNewFicNode = mSSkel->SSkel::Base::vertices_push_back( Vertex( mVertexID++ ) ) ;
 
     InitVertexData(lNewFicNode);
-    CGAL_assertion(lNewFicNode->has_null_point());
+    CGAL_assertion(lNewFicNode->has_infinite_time());
     CrossLink(lNOBisector_R,lNewFicNode);
 
     SetBisectorSlope(lNOBisector_L,POSITIVE);

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
@@ -1045,10 +1045,7 @@ void Straight_skeleton_builder_2<Gt,Ss,V>::HandleEdgeEvent( EventPtr aEvent )
     Halfedge_handle lDefiningBorderB = lNewNode->halfedge()->opposite()->prev()->opposite()->defining_contour_edge();
     Halfedge_handle lDefiningBorderC = lNewNode->halfedge()->opposite()->prev()->defining_contour_edge();
 
-    lNewNode->VBase::set_event_triedge( lEvent.triedge() ) ;
-
     Triedge lTri(lDefiningBorderA,lDefiningBorderB,lDefiningBorderC);
-
     SetVertexTriedge( lNewNode, lTri ) ;
 
     SetBisectorSlope(lLSeed,lNewNode);
@@ -1228,9 +1225,6 @@ void Straight_skeleton_builder_2<Gt,Ss,V>::HandleSplitEvent( EventPtr aEvent, Ve
     Halfedge_handle lNewNode_R_DefiningBorderA = lNewNode_R->halfedge()->defining_contour_edge();
     Halfedge_handle lNewNode_R_DefiningBorderB = lNewNode_R->halfedge()->opposite()->prev()->opposite()->defining_contour_edge();
     Halfedge_handle lNewNode_R_DefiningBorderC = lNewNode_R->halfedge()->opposite()->prev()->defining_contour_edge();
-
-    lNewNode_L->VBase::set_event_triedge( lEvent.triedge() ) ;
-    lNewNode_R->VBase::set_event_triedge( lEvent.triedge() ) ;
 
     Triedge lTriL( lNewNode_L_DefiningBorderA,lNewNode_L_DefiningBorderB,lNewNode_L_DefiningBorderC ) ;
     Triedge lTriR( lNewNode_R_DefiningBorderA,lNewNode_R_DefiningBorderB,lNewNode_R_DefiningBorderC ) ;
@@ -1456,9 +1450,6 @@ void Straight_skeleton_builder_2<Gt,Ss,V>::HandlePseudoSplitEvent( EventPtr aEve
     Halfedge_handle lNewNode_R_DefiningBorderA = lNewNode_R->halfedge()->defining_contour_edge();
     Halfedge_handle lNewNode_R_DefiningBorderB = lNewNode_R->halfedge()->next()->opposite()->defining_contour_edge();
     Halfedge_handle lNewNode_R_DefiningBorderC = lNewNode_R->halfedge()->opposite()->prev()->defining_contour_edge();
-
-    lNewNode_L->VBase::set_event_triedge( lEvent.triedge() ) ;
-    lNewNode_R->VBase::set_event_triedge( lEvent.triedge() ) ;
 
     Triedge lTriL( lNewNode_L_DefiningBorderA, lNewNode_L_DefiningBorderB, lNewNode_L_DefiningBorderC ) ;
     Triedge lTriR( lNewNode_R_DefiningBorderA, lNewNode_R_DefiningBorderB, lNewNode_R_DefiningBorderC ) ;

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
@@ -113,9 +113,9 @@ Straight_skeleton_builder_2<Gt,Ss,V>::FindEdgeEvent( Vertex_handle aLNode, Verte
 
       if ( GetEdgeEndingAt(lPrevNode) == lTriedge.e2() )
       {
-        // Note that this can be a contour node and in that case GetTrisegment is null and we get
-        // the middle point, but in that case e2 and e0 are consecutive in the input
-        // and the middle point is the common extremity and things are fine.
+        // Note that this can be a contour node and in that case GetTrisegment returns null
+        // and we get the middle point as a seed, but in that case e2 and e0 are consecutive
+        // in the input and the middle point is the common extremity thus things are fine.
         lTrisegment->set_child_t( GetTrisegment(lPrevNode) ) ;
       }
       else

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
@@ -367,7 +367,7 @@ void Straight_skeleton_builder_2<Gt,Ss,V>::CollectNewEvents( Vertex_handle aNode
 
 // Handles the special case of two simultaneous edge events, that is, two edges
 // collapsing along the line/point were they meet at the same time.
-// This ocurrs when the bisector emerging from vertex 'aA' is defined by the same pair of
+// This occurs when the bisector emerging from vertex 'aA' is defined by the same pair of
 // contour edges as the bisector emerging from vertex 'aB' (but in opposite order).
 //
 template<class Gt, class Ss, class V>

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
@@ -190,23 +190,6 @@ class Rational
     NT mN, mD ;
 } ;
 
-template <class K>
-struct Segment_2_with_ID
-  : public Segment_2<K>
-{
-  typedef Segment_2<K> Base;
-  typedef typename K::Point_2 Point_2;
-
-public:
-  Segment_2_with_ID() : Base(), mID(-1) { }
-  Segment_2_with_ID(Base const& aS) : Base(aS), mID(-1) { }
-  Segment_2_with_ID(Base const& aS, const std::size_t aID) : Base(aS), mID(aID) { }
-  Segment_2_with_ID(Point_2 const& aP, Point_2 const& aQ, const std::size_t aID) : Base(aP, aQ), mID(aID) { }
-
-public:
-  std::size_t mID;
-};
-
 template <class Info>
 struct No_cache
 {

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/debug.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/debug.h
@@ -187,8 +187,8 @@ inline std::string e2str( E const& e )
     ss << "B" << e.id()
        << "[E" << e.defining_contour_edge()->id()
        << ",E" << e.opposite()->defining_contour_edge()->id() << "]"
-       << " (/" << ( e.slope() == CGAL::ZERO ? "·" : ( e.slope() == CGAL::NEGATIVE ? "-" : "+" ) )
-       << " " << e.opposite()->vertex()->time() << "->" << e.vertex()->time() << ")" ;
+       << " (S " << ( e.slope() == CGAL::ZERO ? "0" : ( e.slope() == CGAL::NEGATIVE ? "-" : "+" ) )
+       << "; T " << e.opposite()->vertex()->time() << " -> " << e.vertex()->time() << ")" ;
   }
   else
   {
@@ -263,7 +263,7 @@ inline std::string newn2str( char const* name, VH const& v, Triedge const& aTrie
 #endif
 
 #ifdef CGAL_STRAIGHT_SKELETON_TRAITS_ENABLE_TRACE
-bool sEnableTraitsTrace = false;
+bool sEnableTraitsTrace = true;
 #  define CGAL_STSKEL_TRAITS_ENABLE_TRACE sEnableTraitsTrace = true ;
 #  define CGAL_STSKEL_TRAITS_ENABLE_TRACE_IF(cond) if ((cond)) sEnableTraitsTrace = true ;
 #  define CGAL_STSKEL_TRAITS_DISABLE_TRACE sEnableTraitsTrace = false;

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_builder_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_builder_2.h
@@ -633,7 +633,10 @@ private :
 
   void SetTrisegment ( Vertex_handle aV, Trisegment_2_ptr const& aTrisegment )
   {
+    // @todo could get rid of the 'mTrisegment' in vertex data
+    // since it's also stored in the vertex directly (to be used during offset construction...)
     GetVertexData(aV).mTrisegment = aTrisegment ;
+    aV->set_trisegment(aTrisegment) ;
   }
 
   // Null if aV is a contour node

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_converter_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_converter_2.h
@@ -19,6 +19,7 @@
 #include <CGAL/Cartesian_converter.h>
 
 #include <boost/shared_ptr.hpp>
+#include <boost/intrusive_ptr.hpp>
 
 #include <vector>
 
@@ -40,6 +41,22 @@ struct Straight_skeleton_items_converter_2: Cartesian_converter< typename Source
 
   typedef typename Source_skeleton::Traits Source_traits ;
   typedef typename Target_skeleton::Traits Target_traits ;
+
+  typedef CGAL_SS_i::Segment_2_with_ID<Source_traits> Source_segment_2_with_ID;
+  typedef CGAL_SS_i::Segment_2_with_ID<Target_traits> Target_segment_2_with_ID;
+
+  typedef typename Source_traits::Segment_2 Source_segment_2;
+  typedef typename Target_traits::Segment_2 Target_segment_2;
+  typedef Trisegment_2<Source_traits, Source_segment_2> Source_trisegment_2;
+  typedef Trisegment_2<Target_traits, Target_segment_2> Target_trisegment_2;
+  typedef boost::intrusive_ptr<Source_trisegment_2> Source_trisegment_2_ptr;
+  typedef boost::intrusive_ptr<Target_trisegment_2> Target_trisegment_2_ptr;
+
+  // Same as above, but for Segment with IDs...
+  typedef Trisegment_2<Source_traits, Source_segment_2_with_ID> Source_trisegment_2_with_ID;
+  typedef Trisegment_2<Target_traits, Target_segment_2_with_ID> Target_trisegment_2_with_ID;
+  typedef boost::intrusive_ptr<Source_trisegment_2_with_ID> Source_trisegment_2_with_ID_ptr;
+  typedef boost::intrusive_ptr<Target_trisegment_2_with_ID> Target_trisegment_2_with_ID_ptr;
 
   typedef Cartesian_converter<Source_traits,Target_traits> Base ;
 
@@ -76,6 +93,63 @@ struct Straight_skeleton_items_converter_2: Cartesian_converter< typename Source
 
     return Target_face( aF->id() );
   }
+
+  Target_segment_2_with_ID operator() ( const Source_segment_2_with_ID& aS ) const
+  {
+    return Target_segment_2_with_ID(this->Base::operator()(
+      static_cast<const typename Source_segment_2_with_ID::Base&>(aS)), aS.mID);
+  }
+
+  Target_trisegment_2_ptr operator() ( const Source_trisegment_2_ptr& aT ) const
+  {
+    const auto& lSe0 = aT->e0();
+    const auto& lSe1 = aT->e1();
+    const auto& lSe2 = aT->e2();
+
+    Trisegment_collinearity lCollinearity = aT->collinearity();
+    std::size_t lId = aT->id();
+
+    Target_trisegment_2_ptr rT = Target_trisegment_2_ptr(
+                                   new Target_trisegment_2(this->operator()(lSe0),
+                                                           this->operator()(lSe1),
+                                                           this->operator()(lSe2),
+                                                           lCollinearity, lId));
+
+    if ( aT->child_l() )
+      rT->set_child_l(this->operator()(aT->child_l()));
+    if ( aT->child_r() )
+      rT->set_child_r(this->operator()(aT->child_r()));
+    if ( aT->child_t() )
+      rT->set_child_t(this->operator()(aT->child_t()));
+
+    return rT;
+  }
+
+  Target_trisegment_2_with_ID_ptr operator() ( const Source_trisegment_2_with_ID_ptr& aT ) const
+  {
+    const auto& lSe0 = aT->e0();
+    const auto& lSe1 = aT->e1();
+    const auto& lSe2 = aT->e2();
+
+    Trisegment_collinearity lCollinearity = aT->collinearity();
+    std::size_t lId = aT->id();
+
+    Target_trisegment_2_with_ID_ptr rT = Target_trisegment_2_with_ID_ptr(
+                                           new Target_trisegment_2_with_ID(this->operator()(lSe0),
+                                                                           this->operator()(lSe1),
+                                                                           this->operator()(lSe2),
+                                                                           lCollinearity, lId));
+
+    if ( aT->child_l() )
+      rT->set_child_l(this->operator()(aT->child_l()));
+    if ( aT->child_r() )
+      rT->set_child_r(this->operator()(aT->child_r()));
+    if ( aT->child_t() )
+      rT->set_child_t(this->operator()(aT->child_t()));
+
+    return rT;
+  }
+
 } ;
 
 template<class Source_skeleton_, class Target_skeleton_, class Items_converter_>
@@ -201,20 +275,8 @@ private :
       CGAL_assertion( handle_assigned(tgt_halfedge) ) ;
       tvit->VBase::set_halfedge(tgt_halfedge);
 
-      Target_halfedge_handle tgt_striedge_e0, tgt_striedge_e1, tgt_striedge_e2 ;
-
-      Source_triedge const& stri = svit->event_triedge() ;
-
-      if ( handle_assigned(stri.e0()) )
-        tgt_striedge_e0 = Target_halfedges.at(stri.e0()->id());
-
-      if ( handle_assigned(stri.e1()) )
-        tgt_striedge_e1 = Target_halfedges.at(stri.e1()->id());
-
-      if ( handle_assigned(stri.e2()) )
-        tgt_striedge_e2 = Target_halfedges.at(stri.e2()->id());
-
-      tvit->VBase::set_event_triedge( Target_triedge(tgt_striedge_e0, tgt_striedge_e1, tgt_striedge_e2) ) ;
+      if(svit->trisegment()) // contour nodes do not have trisegments
+        tvit->set_trisegment(cvt(svit->trisegment()));
     }
 
     Target_halfedge_iterator thit = aTarget.halfedges_begin();

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_converter_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_converter_2.h
@@ -14,6 +14,7 @@
 #include <CGAL/license/Straight_skeleton_2.h>
 
 #include <CGAL/Straight_skeleton_2/Straight_skeleton_aux.h>
+#include <CGAL/Trisegment_2.h>
 
 #include <CGAL/assertions.h>
 #include <CGAL/Cartesian_converter.h>

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_converter_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_converter_2.h
@@ -13,7 +13,7 @@
 
 #include <CGAL/license/Straight_skeleton_2.h>
 
-#include <CGAL/Straight_skeleton_2.h>
+#include <CGAL/Straight_skeleton_2/Straight_skeleton_aux.h>
 
 #include <CGAL/assertions.h>
 #include <CGAL/Cartesian_converter.h>

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_halfedge_base_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_halfedge_base_2.h
@@ -62,8 +62,6 @@ public:
     return !this->vertex()->is_contour() && !this->opposite()->vertex()->is_contour();
   }
 
-  bool has_null_segment() const { return this->vertex()->has_null_point() ; }
-
   bool has_infinite_time() const { return this->vertex()->has_infinite_time() ; }
 
   Halfedge_const_handle defining_contour_edge() const { return this->face()->halfedge() ; }

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_vertex_base_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_vertex_base_2.h
@@ -197,8 +197,6 @@ public:
 
   bool has_infinite_time() const { return ( mFlags & HasInfiniteTimeBit ) == HasInfiniteTimeBit ; }
 
-  bool has_null_point() const { return has_infinite_time(); }
-
   bool is_split() const { return ( mFlags & IsSplitBit ) == IsSplitBit ; }
 
   Halfedge_const_handle primary_bisector() const { return halfedge()->next(); }
@@ -285,14 +283,9 @@ public:
 
   Straight_skeleton_vertex_base_2 ( int aID, Point_2 const& aP ) : Base(aID,aP) {}
 
-  Straight_skeleton_vertex_base_2 ( int aID, Point_2 const& aP, FT aTime, bool aIsSplit, bool aHasInfiniteTime ) : Base(aID,aP,aTime,aIsSplit,aHasInfiniteTime) {}
-
-private:
-
-  void set_halfedge     ( Halfedge_handle aHE )     { Base::set_halfedge(aHE) ; }
-  void set_event_triedge( Triedge const& aTriedge ) { Base::set_event_triedge( aTriedge); }
-  void reset_id         ( int aID )                 { Base::reset_id(aID) ; }
-
+  Straight_skeleton_vertex_base_2 ( int aID, Point_2 const& aP, FT aTime, bool aIsSplit, bool aHasInfiniteTime )
+    : Base(aID, aP, aTime, aIsSplit, aHasInfiniteTime)
+  {}
 } ;
 
 } // end namespace CGAL

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_vertex_base_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_vertex_base_2.h
@@ -231,9 +231,6 @@ public:
     return Defining_contour_halfedges_circulator(halfedge());
   }
 
-
-  std::size_t degree() const { return CGAL::circulator_size(halfedge_around_vertex_begin()); }
-
   bool is_skeleton() const { return  halfedge()->is_bisector() ; }
   bool is_contour () const { return !halfedge()->is_bisector() ; }
 

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_vertex_base_2.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_vertex_base_2.h
@@ -15,6 +15,8 @@
 
 #include <CGAL/Straight_skeleton_2/Straight_skeleton_aux.h>
 #include <CGAL/Straight_skeleton_halfedge_base_2.h>
+#include <CGAL/Trisegment_2.h>
+
 #include <CGAL/circulator.h>
 #include <CGAL/Origin.h>
 #include <CGAL/use.h>
@@ -155,6 +157,12 @@ public:
 
   typedef CGAL_SS_i::Triedge<Halfedge_handle> Triedge ;
 
+  typedef typename CGAL::Kernel_traits<P>::type K ;
+  typedef CGAL_SS_i::Segment_2_with_ID<K> Segment_2 ;
+  typedef CGAL_SS_i::Segment_2_with_ID<K> Segment_2_with_ID ; // for BOOST_MPL_HAS_XXX_TRAIT_DEF
+  typedef CGAL::Trisegment_2<K, Segment_2_with_ID> Trisegment_2 ;
+  typedef boost::intrusive_ptr<Trisegment_2> Trisegment_2_ptr;
+
 public:
 
   Straight_skeleton_vertex_base_base_2() : mID(-1), mTime(0.0), mFlags(0) {}
@@ -236,10 +244,18 @@ public:
 
   void set_halfedge( Halfedge_handle aHE)  { mHE = aHE; }
 
-  Triedge const& event_triedge() const { return mEventTriedge ; }
-
-  void set_event_triedge( Triedge const& aTriedge ) { mEventTriedge = aTriedge ; }
-
+  // Store a pointer to the trisegment, which also includes its potential children.
+  // This is done to keep in memory the history of each node as to be able to
+  // recompute its geometric position and time during offset polygon construction.
+  //
+  // Note: the trisegment stored was constructed in the straight skeleton builder.
+  // When FinishUp() is called, multinodes are processed but as nodes are merged,
+  // the trisegments of these nodes are *not* updated. Thus, the combinatorial trees
+  // of these trisegments will become incoherent with the straight skeleton, but
+  // that's OK because it is still valid to compute purely geometrical information
+  // such as the node position and its time, which is all that is required for offset tracing.
+  Trisegment_2_ptr trisegment() const { return mTrisegment ; }
+  void set_trisegment( Trisegment_2_ptr const& aTrisegment ) { mTrisegment = aTrisegment ; }
 
 public :
 
@@ -248,12 +264,13 @@ public :
 
 private:
 
-  int             mID ;
-  Halfedge_handle mHE;
-  Triedge         mEventTriedge ;
-  Point_2         mP;
-  FT              mTime ;
-  unsigned char   mFlags ;
+  int              mID ;
+  Halfedge_handle  mHE ;
+  Triedge          mEventTriedge ;
+  Trisegment_2_ptr mTrisegment ;
+  Point_2          mP;
+  FT               mTime ;
+  unsigned char    mFlags ;
 };
 
 template < class Refs, class P, class N >
@@ -275,7 +292,8 @@ public:
 
   typedef Straight_skeleton_vertex_base_base_2<Refs,P,N> Base ;
 
-  typedef typename Base::Triedge Triedge ;
+  typedef typename Base::Triedge               Triedge ;
+  typedef typename Base::Trisegment_2_ptr      Trisegment_2_ptr ;
 
   Straight_skeleton_vertex_base_2() {}
 

--- a/Straight_skeleton_2/include/CGAL/Trisegment_2.h
+++ b/Straight_skeleton_2/include/CGAL/Trisegment_2.h
@@ -60,7 +60,7 @@ struct Minmax_traits< Trisegment_collinearity >
   static const Trisegment_collinearity max = TRISEGMENT_COLLINEARITY_ALL;
 };
 
-}
+} // namespace internal
 
 template<class K, typename Segment>
 class Trisegment_2
@@ -181,10 +181,22 @@ public:
       os << *aTriPtr ;
 
       if ( aTriPtr->child_l() )
+      {
+        os << " \nleft child:" ;
         recursive_print(os,aTriPtr->child_l(),aDepth+1);
+      }
 
       if ( aTriPtr->child_r() )
+      {
+        os << " \nright child:" ;
         recursive_print(os,aTriPtr->child_r(),aDepth+1);
+      }
+
+      if ( aTriPtr->child_t() )
+      {
+        os << " \nthird child:" ;
+        recursive_print(os,aTriPtr->child_t(),aDepth+1);
+      }
     }
     else
     {

--- a/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/constructions/Straight_skeleton_cons_ftC2.h
@@ -385,10 +385,10 @@ boost::optional< Point_2<K> > compute_oriented_midpoint ( Segment_2_with_ID<K> c
 // If you ask for the right child point for a trisegment tree corresponding to a split event you will just get e1.target()
 // which is nonsensical for a non initial split event.
 //
-// NOTE: There is an abnormal collinearity case which ocurrs when e0 and e2 are collinear.
+// NOTE: There is an abnormal collinearity case which occurs when e0 and e2 are collinear.
 // In this case, these lines do not correspond to an offset vertex (because e0* and e2* are never consecutive before the event),
 // so the degenerate seed is neither the left or the right seed. In this case, the SEED ID for the degenerate pseudo seed is UNKOWN.
-// If you request the point of such degenerate pseudo seed the oriented midpoint bettwen e0 and e2 is returned.
+// If you request the point of such degenerate pseudo seed the oriented midpoint between e0 and e2 is returned.
 //
 template <class K, class CoeffCache>
 boost::optional< Point_2<K> >

--- a/Straight_skeleton_2/include/CGAL/predicates/Straight_skeleton_pred_ftC2.h
+++ b/Straight_skeleton_2/include/CGAL/predicates/Straight_skeleton_pred_ftC2.h
@@ -368,7 +368,7 @@ is_edge_facing_offset_lines_isecC2 ( boost::intrusive_ptr< Trisegment_2<K, Segme
 // If the opposite edge is 'e' and its previous/next edges are "preve"/"nexte" then the split point is inside the offset
 // edge if it is NOT to the positive side of [preve,e] *and* NOT to the negative side o [e,nexte].
 // (so this predicate answer half the question, at one and other side independenty).
-// If the split point is exacty over any of this bisectors then the split point ocurres exactly and one (or both) endpoints
+// If the split point is exacty over any of this bisectors then the split point occurs exactly and one (or both) endpoints
 // of the opposite edge (so it is a pseudo-split event since the opposite edge is not itself split in two halfeves)
 // When this predicate is called to test (prev,e), e is the primary edge but since it is  pass as e1, primary_is_0=false.
 // This causes the case of parallel but not collinear edges to return positive when the split point is before the source point of e*

--- a/Straight_skeleton_2/test/Straight_skeleton_2/CMakeLists.txt
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/CMakeLists.txt
@@ -4,7 +4,7 @@
 cmake_minimum_required(VERSION 3.1...3.22)
 project(Straight_skeleton_2_Tests)
 
-find_package(CGAL REQUIRED COMPONENTS Core)
+find_package(CGAL REQUIRED COMPONENTS Qt5 Core)
 
 include_directories(BEFORE "include")
 
@@ -16,3 +16,7 @@ file(
 foreach(cppfile ${cppfiles})
   create_single_source_cgal_program("${cppfile}")
 endforeach()
+
+if(CGAL_Qt5_FOUND)
+  target_link_libraries(issue7149 PUBLIC CGAL::CGAL_Basic_viewer)
+endif()

--- a/Straight_skeleton_2/test/Straight_skeleton_2/issue7149.cpp
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/issue7149.cpp
@@ -1,0 +1,203 @@
+// #define CGAL_SLS_TEST_ISSUE_7149_DEBUG
+#ifdef CGAL_SLS_TEST_ISSUE_7149_DEBUG
+
+#include <string>
+#include <iostream>
+#include <iomanip>
+#include <fstream>
+
+bool lAppToLog = false ;
+
+void Straight_skeleton_external_trace ( std::string m )
+{
+  std::ofstream out("sls_log.txt", ( lAppToLog ? std::ios::app | std::ios::ate : std::ios::trunc | std::ios::ate ) );
+  out << std::setprecision(19) << m << std::endl << std::flush ;
+  lAppToLog = true ;
+}
+void Straight_skeleton_traits_external_trace ( std::string m )
+{
+  std::ofstream out("sls_log.txt", ( lAppToLog ? std::ios::app | std::ios::ate : std::ios::trunc | std::ios::ate ) ) ;
+  out << std::setprecision(19) << m << std::endl << std::flush ;
+  lAppToLog = true ;
+}
+
+void error_handler ( char const* what, char const* expr, char const* file, int line, char const* msg )
+{
+  std::cerr << "CGAL error: " << what << " violation!" << std::endl
+       << "Expr: " << expr << std::endl
+       << "File: " << file << std::endl
+       << "Line: " << line << std::endl;
+  if ( msg != nullptr)
+      std::cerr << "Explanation:" << msg << std::endl;
+
+  std::exit(1);
+}
+
+#define CGAL_STRAIGHT_SKELETON_ENABLE_TRACE 4
+#define CGAL_STRAIGHT_SKELETON_TRAITS_ENABLE_TRACE
+#define CGAL_POLYGON_OFFSET_ENABLE_TRACE 4
+
+#endif
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel_with_sqrt.h>
+
+#include <CGAL/create_straight_skeleton_2.h>
+#include <CGAL/create_offset_polygons_2.h>
+
+#include <CGAL/draw_straight_skeleton_2.h>
+#include <CGAL/draw_polygon_2.h>
+
+#include <CGAL/Polygon_2.h>
+#include <CGAL/Random.h>
+
+#include <array>
+#include <iostream>
+
+template <typename K, typename PointRange>
+void test(const PointRange& points,
+          typename K::FT offset)
+{
+  using FT = typename K::FT;
+  using Polygon_2 = CGAL::Polygon_2<K>;
+
+  std::cout << "== Test Kernel: " << typeid(K).name() << ", offset: " << offset << std::endl;
+
+  Polygon_2 pol{std::cbegin(points), std::cend(points)};
+  std::cout << "Input polygon is " << (pol.is_simple() ? "simple" : "not simple") << std::endl;
+
+  // For EPICK, construction errors can create polygons with consecutive equal points
+  constexpr bool test_output_simplicity =
+    (CGAL::is_same_or_derived<CGAL::Field_with_sqrt_tag,
+                             typename CGAL::Algebraic_structure_traits<FT>::Algebraic_category>::value &&
+     !std::is_floating_point<FT>::value);
+
+  std::vector<Polygon_2> no_holes;
+  auto ss_ptr = CGAL::CGAL_SS_i::create_partial_interior_straight_skeleton_2(
+                  FT(offset),
+                  CGAL::CGAL_SS_i::vertices_begin(pol),
+                  CGAL::CGAL_SS_i::vertices_end(pol),
+                  no_holes.begin(),
+                  no_holes.end(),
+                  K());
+  assert(ss_ptr);
+
+  std::vector<boost::shared_ptr<Polygon_2> > offset_polygons_ptrs =
+    CGAL::create_offset_polygons_2<Polygon_2>(FT(offset), CGAL::CGAL_SS_i::dereference(ss_ptr), K());
+
+  std::cout << offset_polygons_ptrs.size() << " polygon(s)" << std::endl;
+
+  if(offset == FT(0.48))
+    assert(offset_polygons_ptrs.size() == 1);
+
+  for(const auto& offset_polygon_ptr : offset_polygons_ptrs)
+  {
+    std::cout << offset_polygon_ptr->size() << " vertices in offset polygon" << std::endl;
+    std::cout << "Offset polygon is " << (offset_polygon_ptr->is_simple() ? "simple" : "not simple") << std::endl;
+    for(const auto& p : *offset_polygon_ptr)
+      std::cout << p << std::endl;
+
+    // CGAL::draw(*offset_polygon_ptr);
+
+    if(test_output_simplicity)
+      assert(offset_polygon_ptr->is_simple());
+    if(offset == FT(0.48))
+      assert(offset_polygon_ptr->size() == 23);
+  }
+}
+
+template <typename K>
+void test(CGAL::Random& r)
+{
+  using FT = typename K::FT;
+  using Polygon_2 = CGAL::Polygon_2<K>;
+  using Point_2 = typename K::Point_2;
+
+  // Input
+  const std::array<Point_2, 41> points = {{{131.6610, 51.1444},
+                                           {132.0460, 50.9782},
+                                           {132.0840, 50.9678},
+                                           {132.1210, 50.9678},
+                                           {132.1480, 50.9574},
+                                           {132.2830, 50.9574},
+                                           {132.3060, 50.9678},
+                                           {132.3800, 50.9678},
+                                           {132.6670, 51.0924},
+                                           {132.8060, 51.2170},
+                                           {132.8040, 51.2274},
+                                           {132.8270, 51.2378},
+                                           {132.9220, 51.4040},
+                                           {132.9940, 51.6324},
+                                           {133.0010, 51.6636},
+                                           {133.0010, 51.7363},
+                                           {133.0080, 51.7674},
+                                           {133.0080, 51.8401},
+                                           {133.0010, 51.8817},
+                                           {133.0010, 51.9544},
+                                           {132.9960, 51.9855},
+                                           {132.9840, 52.0582},
+                                           {132.9770, 52.0998},
+                                           {132.9590, 52.1309},
+                                           {132.9520, 52.1725},
+                                           {132.9300, 52.2348},
+                                           {132.9100, 52.2763},
+                                           {132.8860, 52.3490},
+                                           {132.8680, 52.3802},
+                                           {132.7660, 52.5463},
+                                           {132.7490, 52.5775},
+                                           {132.7210, 52.5982},
+                                           {132.7030, 52.6294},
+                                           {132.6730, 52.6605},
+                                           {132.6280, 52.7125},
+                                           {132.5980, 52.7436},
+                                           {132.5700, 52.7644},
+                                           {132.4830, 52.8371},
+                                           {132.4550, 52.8579},
+                                           {131.8930, 53.0552},
+                                           {131.7120, 53.0344}}};
+
+  Polygon_2 pol(std::cbegin(points), std::cend(points));
+  auto ss_ptr = CGAL::create_interior_straight_skeleton_2(pol, K());
+  assert(ss_ptr);
+  // CGAL::draw(*ss_ptr);
+
+  // get some interesting offset values
+  std::set<FT> offsets {{0.48}};
+
+  for(auto it=ss_ptr->vertices_begin(); it!=ss_ptr->vertices_end(); ++it)
+  {
+    if(it->time() > 0)
+    {
+      std::cout << "Offset " << it->time() << " at " << it->point() << std::endl;
+      offsets.insert(it->time());
+    }
+  }
+
+  // a couple random values
+  for(int i=0; i<10; ++i)
+    offsets.insert(FT(r.get_double((std::numeric_limits<double>::min)(),
+                      CGAL::to_double(*(offsets.rbegin())))));
+
+  for(FT offset : offsets)
+    test<K>(points, offset);
+}
+
+int main(int, char**)
+{
+  std::cout.precision(17);
+  std::cerr.precision(17);
+
+  CGAL::Random r;
+  std::cout << "random seed = " << r.get_seed() << std::endl;
+
+#ifdef CGAL_SLS_TEST_ISSUE_7149_DEBUG
+  sEnableTrace = true;
+#endif
+
+  test<CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt>(r);
+  test<CGAL::Exact_predicates_exact_constructions_kernel>(r);
+  test<CGAL::Exact_predicates_inexact_constructions_kernel>(r);
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary of Changes

When inputs have some collinear segments and an e0-e2 collinearity configuration appears, seed computation was wrongly assumed to simply always be the middle point between the two (collinear) segments.

A first fix was done https://github.com/CGAL/cgal/pull/5213.

Once the seed is known and the node has been created, the trisegment history takes care of reproducing the correct geometrical position during construction of the skeleton. However, when constructing an offset, we previously lost trisegment trees and only kept triedge information. Without the trisegment history, the code wrongly took the middle point again as seed.

This PR makes it so we keep this history in mind (it's simply a boost intrusive pointer) rather than just the triedge.

## Release Management

* Affected package(s): `Straight_skeleton_2`
* Issue(s) solved (if any): fix #7149
* Feature/Small Feature (if any): N/A
* License and copyright ownership: no change

