### PR TITLE
Projection_traits_xy_3: Enable structural filtering

### DIFF
--- a/Kernel_23/include/CGAL/Projection_traits_xy_3.h
+++ b/Kernel_23/include/CGAL/Projection_traits_xy_3.h
@@ -14,6 +14,7 @@
 #define CGAL_PROJECTION_TRAITS_XY_3_H
 
 #include <CGAL/Kernel_23/internal/Projection_traits_3.h>
+#include <CGAL/Triangulation_structural_filtering_traits.h>
 
 namespace CGAL {
 
@@ -21,6 +22,11 @@ template < class R >
 class Projection_traits_xy_3
   : public internal::Projection_traits_3<R,2>
 {};
+
+template < class R >
+struct Triangulation_structural_filtering_traits<Projection_traits_xy_3<R> > {
+  typedef typename Triangulation_structural_filtering_traits<R>::Use_structural_filtering_tag  Use_structural_filtering_tag;
+};
 
 } //namespace CGAL
 

--- a/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -269,12 +269,14 @@ public:
     const Point& p0 = *first;
     Point p = p0;
     Vertex_handle v0 = insert(p0), v(v0), w(v0);
+    Face_handle hint = v0->face();
     ++first;
     for(; first!=last; ++first){
       const Point& q = *first;
       if(p != q){
-        w = insert(q);
+        w = insert(q,hint);
         insert_constraint(v,w);
+        hint = w->face();
         v = w;
         p = q;
       }

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -428,12 +428,14 @@ insert_constraint(Vertex_handle  vaa, Vertex_handle vbb, OutputIterator out)
     const Point& p0 = *first;
     Point p = p0;
     Vertex_handle v0 = insert(p0), v(v0), w(v0);
+    Face_handle hint = v0->face();
     ++first;
     for(; first!=last; ++first){
       const Point& q = *first;
       if(p != q){
-        w = insert(q);
+        w = insert(q,hint);
         insert_constraint(v,w);
+        hint = w->face();
         v = w;
         p = q;
       }


### PR DESCRIPTION
## Summary of Changes

We can enable `Triangulation_2::inexact_locate()` out of the box for the projection in the xy-plane. 

We should have a look if it is also trivial for the projections in the xz and yz plane. 

## Release Management

* Affected package(s): Kernel_23, Triangulation_2

