### PR TITLE
Use deduced type for source/target of a segment

### DIFF
--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -305,11 +305,11 @@ public:
 
 #if 1
   template <class Segment_2>
-  static const Point& get_source(const Segment_2& segment){
+  static decltype(auto) get_source(const Segment_2& segment){
     return segment.source();
   }
   template <class Segment_2>
-  static const Point& get_target(const Segment_2& segment){
+  static decltype(auto) get_target(const Segment_2& segment){
     return segment.target();
   }
 

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_const_Del_triangulation_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_const_Del_triangulation_2.h
@@ -57,7 +57,6 @@ _test_cls_const_Del_triangulation(const Triangul&)
   typedef std::list<Constraint>               list_constraints;
 
   CGAL_USE_TYPE(Gt);
-  CGAL_USE_TYPE(Segment);
   CGAL_USE_TYPE(Triangle);
   CGAL_USE_TYPE(Locate_type);
 
@@ -80,6 +79,19 @@ _test_cls_const_Del_triangulation(const Triangul&)
    assert( T2.dimension() == 2 );
    assert( T2.number_of_vertices() == 20);
    assert( T2.is_valid() );
+
+{
+   // alternative build method
+   std::vector<Segment> l;
+   for (int m=0; m<19;  m++)
+     l.push_back(Segment(lpt[m],lpt[m+1]));
+
+   Triangul T2_bis;
+   T2_bis.insert_constraints(l.begin(), l.end());
+   assert( T2_bis.dimension() == 2 );
+   assert( T2_bis.number_of_vertices() == 20);
+   assert( T2_bis.is_valid() );
+}
 
    // test get_conflicts
   std:: cout << "    get conflicts" << std::endl;

--- a/Triangulation_2/test/Triangulation_2/test_const_del_triangulation_2.cpp
+++ b/Triangulation_2/test/Triangulation_2/test_const_del_triangulation_2.cpp
@@ -22,6 +22,7 @@
 
 #include <CGAL/_test_types.h>
 
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>
 #include <CGAL/_test_cls_const_Del_triangulation_2.h>
 
@@ -33,8 +34,10 @@ int main()
   std::cout << "Testing constrained_Delaunay_triangulation "<< std::endl;
   std::cout << " with No_constraint_intersection_requiring_constructions_tag : " << std::endl;
   typedef CGAL::Constrained_Delaunay_triangulation_2<TestK>        CDt2;
+  typedef CGAL::Constrained_Delaunay_triangulation_2<CGAL::Epeck>  EPECK_CDt2;
 
   _test_cls_const_Del_triangulation(CDt2());
+  _test_cls_const_Del_triangulation(EPECK_CDt2());
 
   //Testing insertion of a range of constraints
   std::vector<TestK::Point_2> points;


### PR DESCRIPTION
EPECK does not return a ref for example.