### PR TITLE
Classification: Write to different files and change degree of fair()

### DIFF
--- a/Classification/examples/Classification/example_ethz_random_forest.cpp
+++ b/Classification/examples/Classification/example_ethz_random_forest.cpp
@@ -140,7 +140,7 @@ int main (int argc, char** argv)
   classifier.save_configuration(fconfig);
 
   // Write result
-  std::ofstream f ("classification.ply");
+  std::ofstream f ("classification_ethz_random_forest.ply");
   f.precision(18);
   f << pts;
 

--- a/Classification/examples/Classification/example_opencv_random_forest.cpp
+++ b/Classification/examples/Classification/example_opencv_random_forest.cpp
@@ -128,7 +128,7 @@ int main (int argc, char** argv)
   }
 
   // Write result
-  std::ofstream f ("classification.ply");
+  std::ofstream f ("classification_opencv_random_forest.ply");
   f.precision(18);
   f << pts;
 

--- a/Classification/examples/Classification/gis_tutorial_example.cpp
+++ b/Classification/examples/Classification/gis_tutorial_example.cpp
@@ -736,7 +736,7 @@ int main (int argc, char** argv)
                                             points.range(label_map)).mean_intersection_over_union() << std::endl;
 
     // Save the classified point set
-    std::ofstream classified_ofile ("classified.ply");
+    std::ofstream classified_ofile ("classified_gis_tutorial.ply");
     CGAL::IO::set_binary_mode (classified_ofile);
     classified_ofile << points;
     classified_ofile.close();

--- a/Classification/examples/Classification/gis_tutorial_example.cpp
+++ b/Classification/examples/Classification/gis_tutorial_example.cpp
@@ -474,7 +474,8 @@ int main (int argc, char** argv)
   for (Mesh::Halfedge_index hi : holes)
     if (hi != outer_hull)
       CGAL::Polygon_mesh_processing::triangulate_refine_and_fair_hole
-        (dtm_mesh, hi, CGAL::Emptyset_iterator(), CGAL::Emptyset_iterator());
+        (dtm_mesh, hi, CGAL::Emptyset_iterator(), CGAL::Emptyset_iterator(),
+         CGAL::parameters::fairing_continuity(0));
 
   // Save DTM with holes filled
   std::ofstream dtm_filled_ofile ("dtm_filled.ply", std::ios_base::binary);
@@ -657,8 +658,6 @@ int main (int argc, char** argv)
   for (const std::vector<Point_3>& poly : polylines)
     ctp.insert_constraint (poly.begin(), poly.end());
 
-  std::cout << "before simplify" << std::endl;
-
   // Simplification algorithm with limit on distance
   PS::simplify (ctp, PS::Squared_distance_cost(), PS::Stop_above_cost_threshold (16 * spacing * spacing));
 
@@ -738,7 +737,7 @@ int main (int argc, char** argv)
                                             points.range(label_map)).mean_intersection_over_union() << std::endl;
 
     // Save the classified point set
-    std::ofstream classified_ofile ("classified_gis_tutorial.ply");
+    std::ofstream classified_ofile ("classification_gis_tutorial.ply");
     CGAL::IO::set_binary_mode (classified_ofile);
     classified_ofile << points;
     classified_ofile.close();

--- a/Classification/examples/Classification/gis_tutorial_example.cpp
+++ b/Classification/examples/Classification/gis_tutorial_example.cpp
@@ -657,6 +657,8 @@ int main (int argc, char** argv)
   for (const std::vector<Point_3>& poly : polylines)
     ctp.insert_constraint (poly.begin(), poly.end());
 
+  std::cout << "before simplify" << std::endl;
+
   // Simplification algorithm with limit on distance
   PS::simplify (ctp, PS::Squared_distance_cost(), PS::Stop_above_cost_threshold (16 * spacing * spacing));
 


### PR DESCRIPTION
## Summary of Changes

We have several examples that write the result in the same file. In case they are executed in parallel in a testsuite that may be a problem.

Reading the diff while creating this pull request I notice that the first two names were equal, but the third one (where we have the issue #7120) was not. So this won't fix the issue, but the PR makes nevertheless sense.  

It finally turned out that the real problem is that the fairing step done by filling a hole of a terrain led to a mesh that is no longer a terrain. We had to reduce the degree of the fairing continuity. 

## Release Management

* Affected package(s): Classification


