### PR TITLE
Nef_3: performance in binop_intersection_tests

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/Binary_operation.h
+++ b/Nef_3/include/CGAL/Nef_3/Binary_operation.h
@@ -74,6 +74,7 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
   typedef typename SNC_structure::Items                Items;
   typedef typename Map::Sphere_map                     Sphere_map;
   typedef CGAL::SNC_decorator<SNC_structure>           SNC_decorator;
+  typedef CGAL::SNC_const_decorator<SNC_structure>     SNC_const_decorator;
   typedef SNC_decorator                                Base;
   typedef CGAL::SNC_constructor<Items, SNC_structure>  SNC_constructor;
   typedef CGAL::SNC_external_structure<Items, SNC_structure>
@@ -85,7 +86,9 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
 
   typedef typename SNC_structure::Vertex_handle Vertex_handle;
   typedef typename SNC_structure::Halfedge_handle Halfedge_handle;
+  typedef typename SNC_structure::Halfedge_const_handle Halfedge_const_handle;
   typedef typename SNC_structure::Halffacet_handle Halffacet_handle;
+  typedef typename SNC_structure::Halffacet_const_handle Halffacet_const_handle;
   typedef typename SNC_structure::Volume_handle Volume_handle;
   typedef typename SNC_structure::SVertex_handle SVertex_handle;
   typedef typename SNC_structure::SHalfedge_handle SHalfedge_handle;
@@ -144,12 +147,12 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
     return v01;
   }
 
-  Vertex_handle create_local_view_on( const Point_3& p, Halfedge_handle e) {
+  Vertex_handle create_local_view_on( const Point_3& p, Halfedge_const_handle e) {
     SNC_constructor C(*this->sncp());
     return C.create_from_edge( e, p);
   }
 
-  Vertex_handle create_local_view_on( const Point_3& p, Halffacet_handle f) {
+  Vertex_handle create_local_view_on( const Point_3& p, Halffacet_const_handle f) {
     SNC_constructor C(*this->sncp());
     return C.create_from_facet( f, p);
   }
@@ -167,14 +170,14 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
             typename Selection,
             typename Association>
   class Intersection_call_back :
-    public SNC_point_locator::Intersection_call_back
+    public CGAL::SNC_point_locator<SNC_decorator>::Intersection_call_back
   {
     typedef typename SNC_decorator::Decorator_traits Decorator_traits;
     typedef typename Decorator_traits::Halfedge_handle Halfedge_handle;
     typedef typename Decorator_traits::Halffacet_handle Halffacet_handle;
 
   public:
-    Intersection_call_back( SNC_structure& s0, SNC_structure& s1,
+    Intersection_call_back( const SNC_structure& s0, const SNC_structure& s1,
                             const Selection& _bop, SNC_structure& r,
                             bool invert_order, Association& Ain) :
       snc0(s0), snc1(s1), bop(_bop), result(r),
@@ -456,12 +459,10 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
 
     // CGAL_NEF_SETDTHREAD(19*509*43*131);
 
-    Intersection_call_back<SNC_decorator, Selection, Association> call_back0
-      ( const_cast<SNC_structure&>(snc1), const_cast<SNC_structure&>(snc2),
-        BOP, *this->sncp(), false, A);
-    Intersection_call_back<SNC_decorator, Selection, Association> call_back1
-      ( const_cast<SNC_structure&>(snc2), const_cast<SNC_structure&>(snc2),
-        BOP, *this->sncp(), true, A);
+    Intersection_call_back<SNC_const_decorator, Selection, Association> call_back0
+      ( snc1, snc2, BOP, *this->sncp(), false, A);
+    Intersection_call_back<SNC_const_decorator, Selection, Association> call_back1
+      ( snc2, snc2, BOP, *this->sncp(), true, A);
 
 #ifdef CGAL_NEF3_TIMER_INTERSECTION
     double split_intersection = timer_overlay.time();
@@ -503,10 +504,8 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
                     << this->sncp()->number_of_vertices());
 #else
     CGAL_NEF_TRACEN("intersection by fast box intersection");
-        binop_intersection_test_segment_tree<SNC_decorator> binop_box_intersection;
-        binop_box_intersection(call_back0, call_back1,
-                               const_cast<SNC_structure&>(snc1),
-                               const_cast<SNC_structure&>(snc2));
+        binop_intersection_test_segment_tree<SNC_const_decorator> binop_box_intersection;
+        binop_box_intersection(call_back0, call_back1, snc1, snc2);
 #endif
 
 #ifdef CGAL_NEF3_TIMER_INTERSECTION

--- a/Nef_3/include/CGAL/Nef_3/Binary_operation.h
+++ b/Nef_3/include/CGAL/Nef_3/Binary_operation.h
@@ -84,6 +84,7 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
   typedef CGAL::SNC_SM_overlayer<Items, SM_decorator>  SM_overlayer;
   typedef CGAL::SM_point_locator<SM_decorator>         SM_point_locator;
   typedef CGAL::SNC_point_locator<SNC_decorator>       SNC_point_locator;
+  typedef CGAL::SNC_point_locator<SNC_const_decorator> SNC_const_point_locator;
 
   typedef typename SNC_structure::Vertex_handle Vertex_handle;
   typedef typename SNC_structure::Halfedge_handle Halfedge_handle;
@@ -171,7 +172,7 @@ class Binary_operation : public CGAL::SNC_decorator<Map> {
             typename Selection,
             typename Association>
   class Intersection_call_back :
-    public CGAL::SNC_point_locator<SNC_decorator>::Intersection_call_back
+    public SNC_const_point_locator::Intersection_call_back
   {
     typedef typename SNC_decorator::Decorator_traits Decorator_traits;
     typedef typename Decorator_traits::Halfedge_handle Halfedge_handle;

--- a/Nef_3/include/CGAL/Nef_3/Binary_operation.h
+++ b/Nef_3/include/CGAL/Nef_3/Binary_operation.h
@@ -23,6 +23,7 @@
 #include <CGAL/Nef_S2/Normalizing.h>
 #include <CGAL/Unique_hash_map.h>
 #include <CGAL/Nef_3/SNC_decorator.h>
+#include <CGAL/Nef_3/SNC_const_decorator.h>
 #include <CGAL/Nef_S2/SM_decorator.h>
 #include <CGAL/Nef_S2/SM_point_locator.h>
 #include <CGAL/Nef_3/SNC_SM_overlayer.h>

--- a/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
+++ b/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
@@ -40,21 +40,6 @@ struct binop_intersection_test_segment_tree {
   struct Bop_edge0_face1_callback {
     Callback           &cb;
 
-    struct Pair_hash_function {
-      typedef std::size_t result_type;
-
-      template <class H>
-      std::size_t
-      operator() (const H& h) const {
-        return
-          std::size_t(&*(h.first)) / sizeof
-          (typename std::iterator_traits<typename H::first_type>::value_type)
-              +
-          std::size_t(&*(h.second)) / sizeof
-          (typename std::iterator_traits<typename H::second_type>::value_type);
-      }
-    };
-
     Bop_edge0_face1_callback(Callback &cb)
     : cb(cb)
     {}

--- a/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
+++ b/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
@@ -126,8 +126,8 @@ struct binop_intersection_test_segment_tree {
   template<class Callback>
   void operator()(Callback& cb0,
                   Callback& cb1,
-                  SNC_structure& sncp,
-                  SNC_structure& snc1i)
+                  const SNC_structure& sncp,
+                  const SNC_structure& snc1i)
   {
     Halfedge_iterator e0, e1;
     Halffacet_iterator f0, f1;

--- a/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
+++ b/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
@@ -114,31 +114,34 @@ struct binop_intersection_test_segment_tree {
   {
     Halfedge_iterator e0, e1;
     Halffacet_iterator f0, f1;
-    std::vector<Nef_box> a, b;
+    std::vector<Nef_box> e0boxes, e1boxes, f0boxes, f1boxes;
+
+    e0boxes.reserve(snc0.number_of_halfedges());
+    e1boxes.reserve(snc1.number_of_halfedges());
+    f0boxes.reserve(snc0.number_of_halffacets());
+    f1boxes.reserve(snc1.number_of_halffacets());
+
+    CGAL_forall_edges( e0, snc0) e0boxes.push_back( Nef_box( e0 ) );
+    CGAL_forall_edges( e1, snc1) e1boxes.push_back( Nef_box( e1 ) );
+    CGAL_forall_facets( f0, snc0) f0boxes.push_back( Nef_box( f0 ) );
+    CGAL_forall_facets( f1, snc1) f1boxes.push_back( Nef_box( f1 ) );
 
     CGAL_NEF_TRACEN("start edge0 edge1");
     Bop_edge0_edge1_callback<Callback> callback_edge0_edge1( cb0 );
-    CGAL_forall_edges( e0, snc0) a.push_back( Nef_box( e0 ) );
-    CGAL_forall_edges( e1, snc1) b.push_back( Nef_box( e1 ) );
-    box_intersection_d( a.begin(), a.end(), b.begin(), b.end(),
+    box_intersection_d( e0boxes.begin(), e0boxes.end(),
+                        e1boxes.begin(), e1boxes.end(),
                         callback_edge0_edge1);
-    a.clear();
-    b.clear();
 
     CGAL_NEF_TRACEN("start edge0 face1");
     Bop_edge0_face1_callback<Callback> callback_edge0_face1( cb0 );
-    CGAL_forall_edges( e0, snc0)  a.push_back( Nef_box( e0 ) );
-    CGAL_forall_facets( f1, snc1) b.push_back( Nef_box( f1 ) );
-    box_intersection_d( a.begin(), a.end(), b.begin(), b.end(),
+    box_intersection_d( e0boxes.begin(), e0boxes.end(),
+                        f1boxes.begin(), f1boxes.end(),
                         callback_edge0_face1);
-    a.clear();
-    b.clear();
 
     CGAL_NEF_TRACEN("start edge1 face0");
     Bop_edge1_face0_callback<Callback> callback_edge1_face0( cb1 );
-    CGAL_forall_edges( e1, snc1)  a.push_back( Nef_box( e1 ) );
-    CGAL_forall_facets( f0, snc0) b.push_back( Nef_box( f0 ) );
-    box_intersection_d( a.begin(), a.end(), b.begin(), b.end(),
+    box_intersection_d( e1boxes.begin(), e1boxes.end(),
+                        f0boxes.begin(), f0boxes.end(),
                         callback_edge1_face0);
   }
 };

--- a/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
+++ b/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
@@ -137,14 +137,8 @@ struct binop_intersection_test_segment_tree {
     Bop_edge0_edge1_callback<Callback> callback_edge0_edge1( cb0 );
     CGAL_forall_edges( e0, sncp)  a.push_back( Nef_box( e0 ) );
     CGAL_forall_edges( e1, snc1i) b.push_back( Nef_box( e1 ) );
-#ifdef CGAL_NEF3_BOX_INTERSECTION_CUTOFF
-    box_intersection_d( a.begin(), a.end(), b.begin(), b.end(),
-                        callback_edge0_edge1,
-                        CGAL_NEF3_BOX_INTERSECTION_CUTOFF,);
-#else
     box_intersection_d( a.begin(), a.end(), b.begin(), b.end(),
                         callback_edge0_edge1);
-#endif
     a.clear();
     b.clear();
 
@@ -152,14 +146,8 @@ struct binop_intersection_test_segment_tree {
     Bop_edge0_face1_callback<Callback> callback_edge0_face1( cb0 );
     CGAL_forall_edges( e0, sncp ) a.push_back( Nef_box( e0 ) );
     CGAL_forall_facets( f1, snc1i)    b.push_back( Nef_box( f1 ) );
-#ifdef CGAL_NEF3_BOX_INTERSECTION_CUTOFF
-    box_intersection_d( a.begin(), a.end(), b.begin(), b.end(),
-                        callback_edge0_face1,
-                        CGAL_NEF3_BOX_INTERSECTION_CUTOFF);
-#else
     box_intersection_d( a.begin(), a.end(), b.begin(), b.end(),
                         callback_edge0_face1);
-#endif
     a.clear();
     b.clear();
 
@@ -167,14 +155,8 @@ struct binop_intersection_test_segment_tree {
     Bop_edge1_face0_callback<Callback> callback_edge1_face0( cb1 );
     CGAL_forall_edges( e1, snc1i)  a.push_back( Nef_box( e1 ) );
     CGAL_forall_facets( f0, sncp ) b.push_back( Nef_box( f0 ) );
-#ifdef CGAL_NEF3_BOX_INTERSECTION_CUTOFF
-    box_intersection_d( a.begin(), a.end(), b.begin(), b.end(),
-                        callback_edge1_face0,
-                        CGAL_NEF3_BOX_INTERSECTION_CUTOFF);
-#else
     box_intersection_d( a.begin(), a.end(), b.begin(), b.end(),
                         callback_edge1_face0);
-#endif
   }
 };
 

--- a/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
+++ b/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
@@ -126,8 +126,8 @@ struct binop_intersection_test_segment_tree {
   template<class Callback>
   void operator()(Callback& cb0,
                   Callback& cb1,
-                  const SNC_structure& sncp,
-                  const SNC_structure& snc1i)
+                  const SNC_structure& snc0,
+                  const SNC_structure& snc1)
   {
     Halfedge_iterator e0, e1;
     Halffacet_iterator f0, f1;
@@ -135,8 +135,8 @@ struct binop_intersection_test_segment_tree {
 
     CGAL_NEF_TRACEN("start edge0 edge1");
     Bop_edge0_edge1_callback<Callback> callback_edge0_edge1( cb0 );
-    CGAL_forall_edges( e0, sncp)  a.push_back( Nef_box( e0 ) );
-    CGAL_forall_edges( e1, snc1i) b.push_back( Nef_box( e1 ) );
+    CGAL_forall_edges( e0, snc0) a.push_back( Nef_box( e0 ) );
+    CGAL_forall_edges( e1, snc1) b.push_back( Nef_box( e1 ) );
     box_intersection_d( a.begin(), a.end(), b.begin(), b.end(),
                         callback_edge0_edge1);
     a.clear();
@@ -144,8 +144,8 @@ struct binop_intersection_test_segment_tree {
 
     CGAL_NEF_TRACEN("start edge0 face1");
     Bop_edge0_face1_callback<Callback> callback_edge0_face1( cb0 );
-    CGAL_forall_edges( e0, sncp ) a.push_back( Nef_box( e0 ) );
-    CGAL_forall_facets( f1, snc1i)    b.push_back( Nef_box( f1 ) );
+    CGAL_forall_edges( e0, snc0)  a.push_back( Nef_box( e0 ) );
+    CGAL_forall_facets( f1, snc1) b.push_back( Nef_box( f1 ) );
     box_intersection_d( a.begin(), a.end(), b.begin(), b.end(),
                         callback_edge0_face1);
     a.clear();
@@ -153,8 +153,8 @@ struct binop_intersection_test_segment_tree {
 
     CGAL_NEF_TRACEN("start edge1 face0");
     Bop_edge1_face0_callback<Callback> callback_edge1_face0( cb1 );
-    CGAL_forall_edges( e1, snc1i)  a.push_back( Nef_box( e1 ) );
-    CGAL_forall_facets( f0, sncp ) b.push_back( Nef_box( f0 ) );
+    CGAL_forall_edges( e1, snc1)  a.push_back( Nef_box( e1 ) );
+    CGAL_forall_facets( f0, snc0) b.push_back( Nef_box( f0 ) );
     box_intersection_d( a.begin(), a.end(), b.begin(), b.end(),
                         callback_edge1_face0);
   }

--- a/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
+++ b/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h
@@ -17,9 +17,8 @@
 
 #include <CGAL/Nef_3/Nef_box.h>
 #include <CGAL/Nef_3/Infimaximal_box.h>
+#include <CGAL/Nef_3/SNC_const_decorator.h>
 #include <vector>
-#include <iostream>
-#include <CGAL/Timer.h>
 
 namespace CGAL {
 
@@ -75,7 +74,6 @@ struct binop_intersection_test_segment_tree {
       }
     }
   };
-
 
   template<class Callback>
   struct Bop_edge1_face0_callback {


### PR DESCRIPTION
## Summary of Changes

Within `Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h`, the current code calculates bounding boxes for intersecting elements multiple times when performing intersection tests. While calculating the bounding boxes is typically a very fast operation, it does impact performance, particularly when the number of elements is large. The current code implements two `std::vector<Nef_box>` called `a` and `b` which are repeatedly cleared and recomputed.

At first, it was considered it might be intentional to re-calculate because the SNC structure is updated via the callbacks. However, in the binary operation, the source operands are const, and the result is a new value. The code uses a `const_cast` to cast away constness from the parameters.  The first step was to make the necessary changes to ensure that the parameters and callbacks are const, thus removing the undesirable `const_cast`'s

The current pair of nef box vectors could then be replaced with four nef box vectors that persist for the function scope and are reused. Reserving the size of the vectors improves allocation speed.

Some redundant code and headers were removed. The code relating to CGAL_NEF3_BOX_INTERSECTION_CUTOFF was removed since it cannot compile because of the typo made in https://github.com/CGAL/cgal/commit/97769c439e16db569089f0a5147916a6c3680e65 where a trailing comma was added on line 220:

https://github.com/CGAL/cgal/blob/97769c439e16db569089f0a5147916a6c3680e65/Packages/Nef_3/include/CGAL/Nef_3/binop_intersection_tests.h#L218-L220

I will provide some benchmark results in upcoming comments.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): performance
* Feature/Small Feature (if any):
* License and copyright ownership: Returned to CGAL authors.

