### PR TITLE
Nef_3: Performance SNC_external_structure Visit shell objects only once

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -255,9 +255,6 @@ public:
   typedef CGAL::Unique_hash_map<SFace_const_handle,bool> SFace_visited_hash;
   typedef CGAL::Unique_hash_map<SFace_const_handle,bool> Shell_closed_hash;
 
-  typedef std::vector<SFace_handle> SFace_list;
-  typedef std::vector<Halffacet_handle> Halffacet_list;
-
   using SNC_decorator::visit_shell_objects;
   using SNC_decorator::store_boundary_object;
   using SNC_decorator::set_volume;
@@ -269,23 +266,26 @@ public:
   using SNC_decorator::make_twins;
 
   struct Shell_entry {
+    typedef std::vector<SFace_handle> SFace_handles;
+    typedef std::vector<Halffacet_handle> Halffacet_handles;
+
     Shell_entry(SFace_handle f) : minimal_sface(f) {}
     SFace_handle minimal_sface;
-    SFace_list connected_sfaces;
-    Halffacet_list connected_halffacets;
+    SFace_handles connected_sfaces;
+    Halffacet_handles connected_halffacets;
   };
 
-  typedef std::vector<Shell_entry> Shell_entry_list;
+  typedef std::vector<Shell_entry> Shell_entries;
 
   struct Shell_explorer {
     Sface_shell_hash&   shell_lookup;
     Face_shell_hash&    facet_lookup;
-    Shell_entry_list&   shell_entries;
+    Shell_entries&      shell_entries;
     SFace_visited_hash& Done;
     int shell_number;
 
     Shell_explorer(Sface_shell_hash& s, Face_shell_hash& f,
-                   Shell_entry_list& se, SFace_visited_hash& d)
+                   Shell_entries& se, SFace_visited_hash& d)
       : shell_lookup(s), facet_lookup(f),
         shell_entries(se), Done(d), shell_number(0) {
     }
@@ -820,7 +820,7 @@ public:
     auto sface_count = this->sncp()->number_of_sfaces();
     Sface_shell_hash   shell_lookup(0, sface_count);
     Face_shell_hash    facet_lookup(0, face_count);
-    Shell_entry_list   shell_entries;
+    Shell_entries      shell_entries;
     SFace_visited_hash Done(false, sface_count);
     Shell_explorer     V(shell_lookup, facet_lookup, shell_entries, Done);
 
@@ -932,7 +932,7 @@ public:
 
   Halffacet_handle get_facet_below( Vertex_handle vi,
                                     const Sface_shell_hash& shell_lookup,
-                                    const Shell_entry_list& shell_entries) const {
+                                    const Shell_entries& shell_entries) const {
     // {\Mop determines the facet below a vertex |vi| via ray shooting. }
 
     Halffacet_handle f_below;
@@ -991,7 +991,7 @@ public:
 
   Volume_handle determine_volume( SFace_handle sf,
                                   const Sface_shell_hash& shell_lookup,
-                                  const Shell_entry_list& shell_entries) const {
+                                  const Shell_entries& shell_entries) const {
     //{\Mop determines the volume |C| that a shell |S| pointed by |sf|
     //  belongs to.  \precondition |S| separates the volume |C| from an enclosed
     //  volume.}

--- a/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_external_structure.h
@@ -191,7 +191,6 @@ struct Plane_RT_lt {
 template <typename Items_, typename SNC_structure_>
 class SNC_external_structure_base : public SNC_decorator<SNC_structure_>
 {
-public:
   typedef SNC_structure_ SNC_structure;
 
   typedef typename SNC_structure::Infi_box                   Infi_box;
@@ -258,12 +257,9 @@ public:
   using SNC_decorator::visit_shell_objects;
   using SNC_decorator::store_boundary_object;
   using SNC_decorator::set_volume;
-  using SNC_decorator::link_as_inner_shell;
   using SNC_decorator::link_as_outer_shell;
-  using SNC_decorator::link_as_prev_next_pair;
   using SNC_decorator::get_visible_facet;
   using SNC_decorator::adjacent_sface;
-  using SNC_decorator::make_twins;
 
   struct Shell_entry {
     typedef std::vector<SFace_handle> SFace_handles;
@@ -330,11 +326,23 @@ public:
     }
   };
 
+  void set_volumes( Volume_handle c, const Shell_entry& se) const {
+    for(SFace_handle h : se.connected_sfaces)
+      set_volume(h, c);
+    for(Halffacet_handle h : se.connected_halffacets)
+      set_volume(h, c);
+  }
+
+protected:
   SNC_external_structure_base( SNC_structure& W, SNC_point_locator* spl = nullptr)
     : SNC_decorator(W), pl(spl) {}
   /*{\Mcreate makes |\Mvar| a decorator of |W|.}*/
 
- public:
+  using SNC_decorator::make_twins;
+  using SNC_decorator::link_as_prev_next_pair;
+  using SNC_decorator::link_as_inner_shell;
+
+public:
   //#define CGAL_NEF_NO_HALFEDGE_KEYS
 #ifdef CGAL_NEF_NO_HALFEDGE_KEYS
   void pair_up_halfedges() const {
@@ -923,13 +931,6 @@ public:
     }
   }
 
-  void set_volumes( Volume_handle c, const Shell_entry& se) const {
-    for(SFace_handle h : se.connected_sfaces)
-      set_volume(h, c);
-    for(Halffacet_handle h : se.connected_halffacets)
-      set_volume(h, c);
-  }
-
   Halffacet_handle get_facet_below( Vertex_handle vi,
                                     const Sface_shell_hash& shell_lookup,
                                     const Shell_entries& shell_entries) const {
@@ -1116,7 +1117,6 @@ template <typename SNC_structure_>
 class SNC_external_structure<SNC_indexed_items, SNC_structure_>
   : public SNC_external_structure_base<int, SNC_structure_> {
 
-public:
   typedef SNC_structure_                                SNC_structure;
   typedef SNC_external_structure_base<int, SNC_structure>    Base;
 
@@ -1147,12 +1147,11 @@ public:
   using Base::link_as_prev_next_pair;
   using Base::link_as_inner_shell;
 
-
+public:
   SNC_external_structure( SNC_structure& W, SNC_point_locator* spl = nullptr)
     : Base(W, spl) {}
   /*{\Mcreate makes |\Mvar| a decorator of |W|.}*/
 
- public:
   void pair_up_halfedges() const {
     typedef Halfedge_key_lt4<Halfedge_handle>  Halfedge_key_lt;
     typedef std::list<Halfedge_handle>  Halfedge_list;

--- a/Nef_3/test/Nef_3/include/CGAL/test_Nef_3.h
+++ b/Nef_3/test/Nef_3/include/CGAL/test_Nef_3.h
@@ -149,6 +149,7 @@ private:
     std::string fullname = std::string(datadir) + std::string(name);
     std::ofstream out("data/temp.nef3");
     out << N;
+    out.close();
     bool b = are_files_equal("data/temp.nef3",fullname.c_str());
     return b;
   }


### PR DESCRIPTION
## Summary of Changes

Within `Nef_3/include/CGAL/Nef_3/SNC_external_structure.h`, the code makes use of the function `visit_shell_objects` four times. Firstly the minimal sface of each shell is calculated using the `Shell_explorer`. Then for all of the outer shells, all connected sfaces and facets for the shell are set to a new volume. Likewise, for all of the inner shells, these are set to a different volume, either directly or via the `determine_volume` function. Visitors are instantiated and the visit_shell_objects function is called each time to find sfaces and facets that are connected, via a closed walk.

Calling visit_shell_objects multiple times is unnecessary (and slow) since in the first pass all of the connected sfaces and facets can be stored in lists. 

A struct `Shell_entry` has been introduced, which contains a minimal sface, and the lists of connected sfaces and facets. There is one shell_entry for each shell, which themselves are stored in a `std::vector<Shell_entry>`  and indexed by the shell_number which was the way the shells were indexed previously.

The shell entries are populated during the first visit using the Shell_explorer visitor. Instead of calling the functions `link_as_inner_shell`, and `link_as_outer_shell`, the lists collected during the first visit are used to set the volumes eliminating the need to call `visit_shell_objects` the additional times. 

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): performance
* License and copyright ownership: Returned to CGAL authors.

