### PR TITLE
Replace use of boost::lexical_cast<std::string> with std::to_string

### DIFF
--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/overlay_unbounded.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/overlay_unbounded.cpp
@@ -2,7 +2,6 @@
 // A face overlay of two arrangements with unbounded faces.
 
 #include <string>
-#include <boost/lexical_cast.hpp>
 
 #include <CGAL/basic.h>
 #include <CGAL/Arr_extended_dcel.h>
@@ -14,7 +13,7 @@
 // Define a functor for creating a label from a character and an integer.
 struct Overlay_label {
   std::string operator()(char c, unsigned int i) const
-  { return c + boost::lexical_cast<std::string>(i); }
+  { return c + std::to_string(i); }
 };
 
 typedef CGAL::Arr_face_extended_dcel<Traits, char>         Dcel_dlue;

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/Traits_base_test.h
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/Traits_base_test.h
@@ -10,7 +10,6 @@
 #include <map>
 // #include <cstdlib>
 
-#include <boost/lexical_cast.hpp>
 
 #include <CGAL/exceptions.h>
 #include <CGAL/Arr_tags.h>
@@ -123,8 +122,8 @@ protected:
     typename Traits::Equal_2 equal = this->m_geom_traits.equal_2_object();
     if (equal(exp_answer, real_answer)) return true;
 
-    std::string exp_answer_str = boost::lexical_cast<std::string>(exp_answer);
-    std::string real_answer_str = boost::lexical_cast<std::string>(real_answer);
+    std::string exp_answer_str = std::to_string(exp_answer);
+    std::string real_answer_str = std::to_string(real_answer);
     this->print_answer(exp_answer_str, real_answer_str, "point");
     return false;
   }
@@ -136,8 +135,8 @@ protected:
     typename Traits::Equal_2 equal = this->m_geom_traits.equal_2_object();
     if (equal(exp_answer, real_answer)) return true;
 
-    std::string exp_answer_str = boost::lexical_cast<std::string>(exp_answer);
-    std::string real_answer_str = boost::lexical_cast<std::string>(real_answer);
+    std::string exp_answer_str = std::to_string(exp_answer);
+    std::string real_answer_str = std::to_string(real_answer);
     this->print_answer(exp_answer_str, real_answer_str, "x-monotone curve");
     return false;
   }
@@ -149,8 +148,8 @@ protected:
                const char* str = "result")
   {
     if (exp_answer == real_answer) return true;
-    std::string exp_answer_str = boost::lexical_cast<std::string>(exp_answer);
-    std::string real_answer_str = boost::lexical_cast<std::string>(real_answer);
+    std::string exp_answer_str = std::to_string(exp_answer);
+    std::string real_answer_str = std::to_string(real_answer);
     this->print_answer(exp_answer_str, real_answer_str, str);
     return false;
   }

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/Traits_base_test.h
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/Traits_base_test.h
@@ -10,6 +10,7 @@
 #include <map>
 // #include <cstdlib>
 
+#include <boost/lexical_cast.hpp>
 
 #include <CGAL/exceptions.h>
 #include <CGAL/Arr_tags.h>
@@ -122,8 +123,8 @@ protected:
     typename Traits::Equal_2 equal = this->m_geom_traits.equal_2_object();
     if (equal(exp_answer, real_answer)) return true;
 
-    std::string exp_answer_str = std::to_string(exp_answer);
-    std::string real_answer_str = std::to_string(real_answer);
+    std::string exp_answer_str = boost::lexical_cast<std::string>(exp_answer);
+    std::string real_answer_str = boost::lexical_cast<std::string>(real_answer);
     this->print_answer(exp_answer_str, real_answer_str, "point");
     return false;
   }
@@ -135,8 +136,8 @@ protected:
     typename Traits::Equal_2 equal = this->m_geom_traits.equal_2_object();
     if (equal(exp_answer, real_answer)) return true;
 
-    std::string exp_answer_str = std::to_string(exp_answer);
-    std::string real_answer_str = std::to_string(real_answer);
+    std::string exp_answer_str = boost::lexical_cast<std::string>(exp_answer);
+    std::string real_answer_str = boost::lexical_cast<std::string>(real_answer);
     this->print_answer(exp_answer_str, real_answer_str, "x-monotone curve");
     return false;
   }
@@ -148,8 +149,8 @@ protected:
                const char* str = "result")
   {
     if (exp_answer == real_answer) return true;
-    std::string exp_answer_str = std::to_string(exp_answer);
-    std::string real_answer_str = std::to_string(real_answer);
+    std::string exp_answer_str = boost::lexical_cast<std::string>(exp_answer);
+    std::string real_answer_str = boost::lexical_cast<std::string>(real_answer);
     this->print_answer(exp_answer_str, real_answer_str, str);
     return false;
   }

--- a/Cone_spanners_2/examples/Cone_spanners_2/theta_io.cpp
+++ b/Cone_spanners_2/examples/Cone_spanners_2/theta_io.cpp
@@ -4,7 +4,6 @@
 #include <iterator>
 #include <string>
 #include <vector>
-#include <boost/lexical_cast.hpp>
 #include <CGAL/Exact_predicates_exact_constructions_kernel_with_root_of.h>
 #include <CGAL/Construct_theta_graph_2.h>
 #include <CGAL/gnuplot_output_2.h>
@@ -79,7 +78,7 @@ int main(int argc, char ** argv)
   // obtain the number of vertices in the constructed graph
   boost::graph_traits<Graph>::vertices_size_type n = boost::num_vertices(g);
   // generate gnuplot files for plotting this graph
-  std::string file_prefix = "t" + boost::lexical_cast<std::string>(k) + "n" + boost::lexical_cast<std::string>(n);
+  std::string file_prefix = "t" + std::to_string(k) + "n" + std::to_string(n);
   CGAL::gnuplot_output_2(g, file_prefix);
 
   return 0;

--- a/Cone_spanners_2/test/Cone_spanners_2/theta_exact.cpp
+++ b/Cone_spanners_2/test/Cone_spanners_2/theta_exact.cpp
@@ -10,7 +10,6 @@
 #include <iterator>
 #include <string>
 #include <vector>
-#include <boost/lexical_cast.hpp>
 #include <CGAL/Exact_predicates_exact_constructions_kernel_with_root_of.h>
 #include <CGAL/Construct_theta_graph_2.h>
 #include <CGAL/gnuplot_output_2.h>
@@ -70,7 +69,7 @@ int main(int argc, char ** argv)
   // obtain the number of vertices in the constructed graph
   boost::graph_traits<Graph>::vertices_size_type n = boost::num_vertices(g);
   // generate gnuplot files for plotting this graph
-  std::string file_prefix = "t" + boost::lexical_cast<std::string>(k) + "n" + boost::lexical_cast<std::string>(n);
+  std::string file_prefix = "t" + std::to_string(k) + "n" + std::to_string(n);
   CGAL::gnuplot_output_2(g, file_prefix);
 
   return 0;

--- a/Cone_spanners_2/test/Cone_spanners_2/theta_inexact.cpp
+++ b/Cone_spanners_2/test/Cone_spanners_2/theta_inexact.cpp
@@ -11,7 +11,6 @@
 #include <iterator>
 #include <string>
 #include <vector>
-#include <boost/lexical_cast.hpp>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Construct_theta_graph_2.h>
 #include <CGAL/gnuplot_output_2.h>
@@ -71,7 +70,7 @@ int main(int argc, char ** argv)
   // obtain the number of vertices in the constructed graph
   boost::graph_traits<Graph>::vertices_size_type n = boost::num_vertices(g);
   // generate gnuplot files for plotting this graph
-  std::string file_prefix = "t" + boost::lexical_cast<std::string>(k) + "n" + boost::lexical_cast<std::string>(n);
+  std::string file_prefix = "t" + std::to_string(k) + "n" + std::to_string(n);
   CGAL::gnuplot_output_2(g, file_prefix);
 
   return 0;

--- a/Cone_spanners_2/test/Cone_spanners_2/yao_exact.cpp
+++ b/Cone_spanners_2/test/Cone_spanners_2/yao_exact.cpp
@@ -12,7 +12,6 @@
 #include <iterator>
 #include <string>
 #include <vector>
-#include <boost/lexical_cast.hpp>
 #include <CGAL/Exact_predicates_exact_constructions_kernel_with_root_of.h>
 #include <CGAL/Construct_yao_graph_2.h>
 #include <CGAL/gnuplot_output_2.h>
@@ -72,7 +71,7 @@ int main(int argc, char ** argv)
   boost::graph_traits<Graph>::vertices_size_type n = boost::num_vertices(g);
 
   // generate gnuplot files for plotting this graph
-  std::string fileprefix = "y" + boost::lexical_cast<std::string>(k) + "n" + boost::lexical_cast<std::string>(n);
+  std::string fileprefix = "y" + std::to_string(k) + "n" + std::to_string(n);
   CGAL::gnuplot_output_2(g, fileprefix);
 
   return 0;

--- a/Cone_spanners_2/test/Cone_spanners_2/yao_inexact.cpp
+++ b/Cone_spanners_2/test/Cone_spanners_2/yao_inexact.cpp
@@ -12,7 +12,6 @@
 #include <iterator>
 #include <string>
 #include <vector>
-#include <boost/lexical_cast.hpp>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Construct_yao_graph_2.h>
 #include <CGAL/gnuplot_output_2.h>
@@ -72,7 +71,7 @@ int main(int argc, char ** argv)
   boost::graph_traits<Graph>::vertices_size_type n = boost::num_vertices(g);
 
   // generate gnuplot files for plotting this graph
-  std::string fileprefix = "y" + boost::lexical_cast<std::string>(k) + "n" + boost::lexical_cast<std::string>(n);
+  std::string fileprefix = "y" + std::to_string(k) + "n" + std::to_string(n);
   CGAL::gnuplot_output_2(g, fileprefix);
 
   return 0;

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Plane_3_Triangle_3_intersection.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Plane_3_Triangle_3_intersection.h
@@ -18,6 +18,7 @@
 
 #include <CGAL/enum.h>
 #include <CGAL/kernel_assertions.h>
+#include <iterator>
 
 namespace CGAL {
 namespace Intersections {
@@ -141,7 +142,7 @@ intersection(const typename K::Plane_3& plane,
   CGAL_kernel_assertion(pts.size() == 2);
 
   return intersection_return<typename K::Intersect_3, typename K::Plane_3, typename K::Triangle_3>(
-           k.construct_segment_3_object()(*pts.begin(), *boost::prior(pts.end())));
+           k.construct_segment_3_object()(*pts.begin(), *std::prev(pts.end())));
 }
 
 template <class K>

--- a/STL_Extension/include/CGAL/exceptions.h
+++ b/STL_Extension/include/CGAL/exceptions.h
@@ -14,21 +14,8 @@
 #ifndef CGAL_EXCEPTIONS_H
 #define CGAL_EXCEPTIONS_H
 
-#include <CGAL/config.h>
 #include <stdexcept>
 #include <string>
-
-// Address the warning C4003: not enough actual parameters for macro 'BOOST_PP_SEQ_DETAIL_IS_NOT_EMPTY'
-// lexical_cast.hpp includes files from boost/preprocessor
-// This concerns boost 1_67_0
-#if defined(BOOST_MSVC)
-#  pragma warning(push)
-#  pragma warning(disable: 4003)
-#endif
-#include <boost/lexical_cast.hpp>
-#if defined(BOOST_MSVC)
-#  pragma warning(pop)
-#endif
 
 
 namespace CGAL {
@@ -87,7 +74,7 @@ public:
     std::logic_error( lib + std::string( " ERROR: ") + kind + std::string( "!")
         + ((expr.empty()) ? (std::string("")) : (std::string("\nExpr: ")+expr))
         + std::string( "\nFile: ") + file
-        + std::string( "\nLine: ") + boost::lexical_cast<std::string>(line)
+        + std::string( "\nLine: ") + std::to_string(line)
         + ((msg.empty()) ? (std::string(""))
                          : (std::string("\nExplanation: ") + msg))),
     m_lib( lib),


### PR DESCRIPTION
## Summary of Changes

- Replace use of lexical_cast&lt;std::string&gt; with std::to_string

- use std::prev in Plane_3_Triangle_3_intersection.h due to lack of implicit header include.


## Release Management

* Affected package(s): Arrangement_on_surface_2,Cone_spanners_2, Intersections_3, STL_Extension
* Issue(s) solved (if any): C++11 modernisation.
* License and copyright ownership: CGAL Authors

