### PR TITLE
Nef_S2: Skip running assertion code when runtime assertions are disabled

### DIFF
--- a/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
@@ -297,6 +297,8 @@ check_integrity_and_topological_planarity(bool faces) const
 #ifdef CGAL_USE_TRACE
   Object_index<SHalfedge_const_iterator>
     EI(shalfedges_begin(),shalfedges_end(),'e');
+#else
+  CGAL_assertion_code( if( !CGAL::get_use_assertions()) return; )
 #endif
   SVertex_const_handle v;
   int iso_vert_num=0;


### PR DESCRIPTION
## Summary of Changes

Since CGAL_assertion_code ignores the state of `CGAL::get_use_assertions()` some assertion code in SM_const_decorator.h gets unnecessarily run. The only sensible thing to me seems to be to add some additional CGAL_assertion_code to skip everything when runtime assertions are disabled.

## Release Management

* Affected package(s): Nef_3/Nef_S2
* Issue(s) solved (if any): performance/bugfix
* License and copyright ownership: CGAL authors

