### PR TITLE
Largest Empty Iso Rectangle: Ignore points on the border

### DIFF
--- a/Inscribed_areas/doc/Inscribed_areas/CGAL/Largest_empty_iso_rectangle_2.h
+++ b/Inscribed_areas/doc/Inscribed_areas/CGAL/Largest_empty_iso_rectangle_2.h
@@ -142,9 +142,11 @@ Iso_rectangle_2 get_bounding_box();
 /// @{
 
 /*!
-Inserts point `p` in the point set, if it is not already in the set.
+Inserts point `p` in the point set, if it is not already in the set
+and on the bounded side of the bounding rectangle.
+\note Points on the boundary can be ignored as they lead to the same result.
 */
-void
+bool
 insert(const Point_2& p);
 
 /*!

--- a/Inscribed_areas/examples/Inscribed_areas/largest_empty_rectangle.cpp
+++ b/Inscribed_areas/examples/Inscribed_areas/largest_empty_rectangle.cpp
@@ -1,8 +1,7 @@
 #include <CGAL/Simple_cartesian.h>
-#include <CGAL/Iso_rectangle_2.h>
 #include <CGAL/Largest_empty_iso_rectangle_2.h>
 
-#include <fstream>
+#include <iostream>
 
 typedef double                                 Number_Type;
 typedef CGAL::Simple_cartesian<Number_Type>    K;

--- a/Inscribed_areas/include/CGAL/Largest_empty_iso_rectangle_2.h
+++ b/Inscribed_areas/include/CGAL/Largest_empty_iso_rectangle_2.h
@@ -762,7 +762,7 @@ bool
 Largest_empty_iso_rectangle_2<T>::insert(const Point_2& _p)
 {
   // check that the point is inside the bounding box
-  if(bbox_p.has_on_unbounded_side(_p)) {
+  if(! bbox_p.has_on_bounded_side(_p)) {
     return(false);
   }
 


### PR DESCRIPTION
## Summary of Changes

Points that are on the boundary of the bounding iso rectangle led to wrong results. As such points have no influence on the result we can just ignore them.   

## Release Management

* Affected package(s): Inscribed_areas
* Issue(s) solved (if any): fix #7183
* License and copyright ownership: unchanged

