### PR TITLE
Remove use of the safe-bool idiom, replace with explicit operator bool

### DIFF
--- a/BGL/include/CGAL/boost/graph/iterator.h
+++ b/BGL/include/CGAL/boost/graph/iterator.h
@@ -213,16 +213,10 @@ public:
   {}
 
 #ifndef DOXYGEN_RUNNING
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (Halfedge_around_source_iterator::*bool_type)() const;
 
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (this->base() == nullptr)) ?
-      &Halfedge_around_source_iterator::this_type_does_not_support_comparisons : 0;
+    return (! (this->base() == nullptr));
   }
 
   bool operator==( const Self& i) const {
@@ -313,16 +307,10 @@ public:
   {}
 
 #ifndef DOXYGEN_RUNNING
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (Halfedge_around_target_iterator::*bool_type)() const;
 
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (this->base() == nullptr)) ?
-      &Halfedge_around_target_iterator::this_type_does_not_support_comparisons : 0;
+    return (! (this->base() == nullptr));
   }
 
   bool operator==( const Self& i) const {
@@ -412,16 +400,9 @@ public:
   pointer           operator -> ( )       { return &pos; }
   const value_type* operator -> ( ) const { return &pos; }
 
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (Halfedge_around_face_iterator::*bool_type)() const;
-
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (this->base() == nullptr)) ?
-      &Halfedge_around_face_iterator::this_type_does_not_support_comparisons : 0;
+    return (! (this->base() == nullptr));
   }
 
   bool operator==( const Self& i) const {
@@ -522,16 +503,10 @@ public:
   Halfedge_around_source_circulator(vertex_descriptor vd, const Graph& g)
     : Halfedge_around_source_circulator::iterator_adaptor_(Halfedge_around_target_circulator<Graph>(halfedge(vd,g),g)), opp(g)
   {}
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (Halfedge_around_source_circulator::*bool_type)() const;
 
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (this->base_reference() == nullptr)) ?
-      &Halfedge_around_source_circulator::this_type_does_not_support_comparisons : 0;
+    return (! (this->base_reference() == nullptr));
   }
 
   bool operator== (void*) const
@@ -580,16 +555,9 @@ public:
 #ifndef DOXYGEN_RUNNING
   typedef std::size_t size_type;
 
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (Face_around_target_circulator::*bool_type)() const;
-
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (this->base_reference() == nullptr)) ?
-      &Face_around_target_circulator::this_type_does_not_support_comparisons : 0;
+    return (! (this->base_reference() == nullptr));
   }
 
   bool operator== (void*) const
@@ -654,17 +622,9 @@ public:
   bool       operator == ( const Self& other) const { return  g == other.g && pos == other.pos; }
   bool       operator != ( const Self& other) const { return  g != other.g || pos != other.pos; }
 
-
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (Halfedge_around_target_circulator::*bool_type)() const;
-
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (g == nullptr)) ?
-      &Halfedge_around_target_circulator::this_type_does_not_support_comparisons : 0;
+    return (! (g == nullptr));
   }
 
 
@@ -751,17 +711,9 @@ public:
   bool       operator == ( const Self& other) const { return  g == other.g && pos == other.pos; }
   bool       operator != ( const Self& other) const { return  g != other.g || pos != other.pos; }
 
-
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (Halfedge_around_face_circulator::*bool_type)() const;
-
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (g == nullptr)) ?
-      &Halfedge_around_face_circulator::this_type_does_not_support_comparisons : 0;
+    return (! (g == nullptr));
   }
 
   bool operator== (void* ) const
@@ -1008,16 +960,10 @@ public:
   {}
 
 #ifndef DOXYGEN_RUNNING
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (Vertex_around_face_circulator::*bool_type)() const;
 
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (this->base_reference() == nullptr)) ?
-      &Vertex_around_face_circulator::this_type_does_not_support_comparisons : 0;
+    return (! (this->base_reference() == nullptr));
   }
 
   bool operator== (void*) const
@@ -1062,16 +1008,10 @@ public:
   {}
 
 #ifndef DOXYGEN_RUNNING
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (Vertex_around_face_iterator::*bool_type)() const;
 
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (this->base_reference() == nullptr)) ?
-      &Vertex_around_face_iterator::this_type_does_not_support_comparisons : 0;
+    return (! (this->base_reference() == nullptr));
   }
 
   bool operator== (void*) const
@@ -1192,16 +1132,10 @@ public:
   {}
 
 #ifndef DOXYGEN_RUNNING
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (Vertex_around_target_circulator::*bool_type)() const;
 
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (this->base_reference() == nullptr)) ?
-      &Vertex_around_target_circulator::this_type_does_not_support_comparisons : 0;
+    return (! (this->base_reference() == nullptr));
   }
 
   bool operator== (void*) const
@@ -1250,16 +1184,10 @@ public:
   {}
 
 #ifndef DOXYGEN_RUNNING
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (Vertex_around_target_iterator::*bool_type)() const;
 
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (this->base_reference() == nullptr)) ?
-      &Vertex_around_target_iterator::this_type_does_not_support_comparisons : 0;
+    return (! (this->base_reference() == nullptr));
   }
 private:
   friend class boost::iterator_core_access;
@@ -1337,16 +1265,9 @@ public:
   Out_edge_iterator(halfedge_descriptor h, const Graph& g, int n = 0)
     : Out_edge_iterator::iterator_adaptor_(Halfedge_around_target_iterator<Graph>(h,g,(h==halfedge_descriptor())?1:n)), opp(g) {}
 
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (Out_edge_iterator::*bool_type)() const;
-
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (this->base_reference() == nullptr)) ?
-      &Out_edge_iterator::this_type_does_not_support_comparisons : 0;
+    return (! (this->base_reference() == nullptr));
   }
 
 
@@ -1379,16 +1300,9 @@ public:
     : In_edge_iterator::iterator_adaptor_(Halfedge_around_target_iterator<Graph>(h,g,(h==halfedge_descriptor())?1:n)), fct(g)
   {}
 
-  // design pattern: "safe bool"
-  // will be replaced by explicit operator bool with C++11
-  typedef void (In_edge_iterator::*bool_type)() const;
-
-  void this_type_does_not_support_comparisons() const {}
-
-  operator bool_type() const
+  explicit operator bool() const
   {
-    return (! (this->base_reference() == nullptr)) ?
-      &In_edge_iterator::this_type_does_not_support_comparisons : 0;
+    return (! (this->base_reference() == nullptr));
   }
 
  private:

--- a/BGL/include/CGAL/boost/graph/iterator.h
+++ b/BGL/include/CGAL/boost/graph/iterator.h
@@ -514,6 +514,11 @@ public:
     return this->base_reference() == nullptr;
   }
 
+  bool operator!= (void*) const
+  {
+    return this->base_reference() != nullptr;
+  }
+
 private:
   friend class boost::iterator_core_access;
   typename  boost::graph_traits<Graph>::halfedge_descriptor dereference() const { return opp(*this->base_reference()); }
@@ -563,6 +568,11 @@ public:
   bool operator== (void*) const
   {
     return this->base_reference() == nullptr;
+  }
+
+  bool operator!= (void*) const
+  {
+    return this->base_reference() != nullptr;
   }
 
 
@@ -631,6 +641,11 @@ public:
   bool operator== (void* ) const
   {
     return g == nullptr;
+  }
+
+  bool operator!= (void* ) const
+  {
+    return g != nullptr;
   }
 
 
@@ -719,6 +734,11 @@ public:
   bool operator== (void* ) const
   {
     return g == nullptr;
+  }
+
+  bool operator!= (void* ) const
+  {
+    return g != nullptr;
   }
 
   Self& operator++()
@@ -970,6 +990,12 @@ public:
   {
     return this->base_reference()== nullptr;
   }
+
+  bool operator!= (void*) const
+  {
+    return this->base_reference()!= nullptr;
+  }
+
 private:
   friend class boost::iterator_core_access;
   typename  boost::graph_traits<Graph>::vertex_descriptor dereference() const { return fct(*this->base_reference()); }
@@ -1141,6 +1167,11 @@ public:
   bool operator== (void*) const
   {
     return this->base_reference()== nullptr;
+  }
+
+  bool operator!= (void*) const
+  {
+    return this->base_reference()!= nullptr;
   }
 
 private:

--- a/STL_Extension/include/CGAL/Object.h
+++ b/STL_Extension/include/CGAL/Object.h
@@ -52,8 +52,6 @@ class Object
     template<class T>
     friend T object_cast(const Object & o);
 
-    typedef void (Object::*bool_type)() const;
-    void this_type_does_not_support_comparisons() const {}
   public:
 
     struct private_tag{};
@@ -97,8 +95,8 @@ class Object
     }
 
     // safe-bool conversion
-    operator bool_type() const {
-      return empty() == false ? &Object::this_type_does_not_support_comparisons : 0;
+    explicit operator bool() const {
+      return !empty();
     }
 
 

--- a/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
@@ -538,8 +538,6 @@ class Property_map_base
            CRTP_derived_class>
 /// @endcond
 {
-    typedef void (Property_map_base::*bool_type)() const;
-    void this_type_does_not_support_comparisons() const {}
 public:
     typedef I key_type;
     typedef T value_type;
@@ -596,9 +594,8 @@ public:
     /// can be used, and \c false otherwise.
   operator bool () const;
 #else
-    operator bool_type() const {
-        return parray_ != nullptr ?
-            &Property_map_base::this_type_does_not_support_comparisons : 0;
+    explicit operator bool() const {
+        return parray_ != nullptr;
     }
 #endif
     /// Access the property associated with the key \c i.

--- a/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
@@ -598,6 +598,11 @@ public:
         return parray_ != nullptr;
     }
 #endif
+
+    bool operator!=(const Property_map_base& pm) const {
+      return parray_ != pm.parray_;
+    }
+
     /// Access the property associated with the key \c i.
     reference operator[](const I& i)
     {

--- a/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
@@ -599,6 +599,10 @@ public:
     }
 #endif
 
+    bool operator==(const Property_map_base& pm) const {
+      return parray_ == pm.parray_;
+    }
+
     bool operator!=(const Property_map_base& pm) const {
       return parray_ != pm.parray_;
     }


### PR DESCRIPTION
## Summary of Changes

Replace safe-bool idiom with C++11 explicit operator bool.

logical checks:

`0` is `false`
`&this_type_does_not_support_comparisons` is `true`
 `e ? true : false`  is the same as `e` 
 `b == false` is the same as `!b`


## Release Management

* Affected package(s): BGL, Surface_mesh, STL_ext, 
* Issue(s) solved (if any): Modernisation C++11
* License and copyright ownership: CGAL authors

