### PR TITLE
Polygon: Fix erase(Vertex_circulator)

### DIFF
--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -238,8 +238,11 @@ class Polygon_2 {
     /// Erases the vertex pointed to by `i`.
     Vertex_circulator erase(Vertex_circulator i)
       {
-        return Vertex_circulator(&d_container,
-                                 d_container.erase(i.mod_iterator()));
+        auto it = d_container.erase(i.mod_iterator());
+        if(it == d_container.end()){
+          it = d_container.begin();
+        }
+        return Vertex_circulator(&d_container, it);
       }
 
     /// Erases the vertices in the range `[first, last)`.

--- a/Polygon/test/Polygon/issue7228.cpp
+++ b/Polygon/test/Polygon/issue7228.cpp
@@ -8,7 +8,7 @@
 typedef CGAL::Simple_cartesian<double> K;
 typedef K::Point_2 Point;
 typedef CGAL::Polygon_2<K> Polygon_2;
-typedef Polygon::Vertex_circulator Vertex_circulator;
+typedef Polygon_2::Vertex_circulator Vertex_circulator;
 
 int main()
 {

--- a/Polygon/test/Polygon/issue7228.cpp
+++ b/Polygon/test/Polygon/issue7228.cpp
@@ -7,13 +7,13 @@
 
 typedef CGAL::Simple_cartesian<double> K;
 typedef K::Point_2 Point;
-typedef CGAL::Polygon_2<K> Polygon;
+typedef CGAL::Polygon_2<K> Polygon_2;
 typedef Polygon::Vertex_circulator Vertex_circulator;
 
 int main()
 {
   std::array<Point,4> points =  { Point(0,0), Point(1,0), Point(1,1), Point(0,1) };
-  Polygon poly(points.begin(), points.end());
+  Polygon_2 poly(points.begin(), points.end());
 
   Vertex_circulator vc = poly.vertices_circulator();
 

--- a/Polygon/test/Polygon/issue7228.cpp
+++ b/Polygon/test/Polygon/issue7228.cpp
@@ -1,0 +1,29 @@
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Polygon_2.h>
+
+#include <vector>
+#include <array>
+#include <cassert>
+
+typedef CGAL::Simple_cartesian<double> K;
+typedef K::Point_2 Point;
+typedef CGAL::Polygon_2<K> Polygon;
+typedef Polygon::Vertex_circulator Vertex_circulator;
+
+int main()
+{
+  std::array<Point,4> points =  { Point(0,0), Point(1,0), Point(1,1), Point(0,1) };
+  Polygon poly(points.begin(), points.end());
+
+  Vertex_circulator vc = poly.vertices_circulator();
+
+  ++vc;
+  ++vc;
+  ++vc;
+
+  vc = poly.erase(vc);
+
+  assert(*vc == Point(0,0));
+
+  return 0;
+}


### PR DESCRIPTION
## Summary of Changes

When a vertex circulator pointing on the last element gets erased the erase function must return the circulator pointing to the first element.

## Release Management

* Affected package(s): Polygon
* Issue(s) solved (if any): fix #7228
