### PR TITLE
CGAL 3D demo: Fix current context in the destroy of the Scene

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -1928,6 +1928,7 @@ void Scene::removeViewer(Viewer_interface *viewer)
   if(viewer->property("is_destroyed").toBool())
     return;
 
+  viewer->makeCurrent();
   vaos[viewer]->destroy();
   vaos[viewer]->deleteLater();
   vaos.remove(viewer);


### PR DESCRIPTION
## Summary of Changes

Fix current context in the destroy of the Scene. Fixes the error:
> QOpenGLVertexArrayObject::destroy() failed to restore current context

that we can see at the exit of the demo.

## Release Management

* Affected package(s): Polyhedron demo


