### PR TITLE
Nef_3: Hash map sizes

### DIFF
--- a/Hash_map/include/CGAL/Hash_map/internal/chained_map.h
+++ b/Hash_map/include/CGAL/Hash_map/internal/chained_map.h
@@ -78,7 +78,7 @@ private:
    }
 
 public:
-   static constexpr std::size_t min_size = 32;
+   static constexpr std::size_t min_size = 8;
    static constexpr std::size_t default_size = 512;
    typedef chained_map_elem<T>*  Item;
 

--- a/Hash_map/include/CGAL/Unique_hash_map.h
+++ b/Hash_map/include/CGAL/Unique_hash_map.h
@@ -47,9 +47,10 @@ public:
 
 private:
     typedef internal::chained_map<Data, Allocator>   Map;
-    typedef typename Map::Item                       Item;
-
+public:
+    static constexpr std::size_t min_size = Map::min_size;
 private:
+    typedef typename Map::Item                       Item;
     Hash_function  m_hash_function;
     Map            m_map;
 

--- a/Nef_2/include/CGAL/Nef_2/Segment_overlay_traits.h
+++ b/Nef_2/include/CGAL/Nef_2/Segment_overlay_traits.h
@@ -606,8 +606,8 @@ public:
   stl_seg_overlay_traits(const INPUT& in, OUTPUT& G, const GEOMETRY& k)
     : its(in.first), ite(in.second), GO(G), K(k),
     XS(compare_pnts_xy(K)), SLcmp(p_sweep,&sl,&sh,K), YS(SLcmp),
-    y2x(XS.end()), x2y(YS.end()), x2iso(0), y2y(&sl),
-    SQ(lt_pnts_xy(K)), Edge_of(0)
+    y2x(XS.end(), Y2X::min_size), x2y(YS.end(), X2Y::min_size), x2iso(0, X2iso::min_size), y2y(&sl, Y2Y::min_size),
+    SQ(lt_pnts_xy(K)), Edge_of(0, AssocEdgeMap::min_size)
   {}
 
   std::string dump_structures()

--- a/Nef_3/include/CGAL/Nef_3/SNC_SM_overlayer.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_SM_overlayer.h
@@ -358,8 +358,8 @@ class SNC_SM_overlayer<SNC_indexed_items, SM_decorator_>
     CGAL_NEF_TRACEN("simplifying");
 
     typedef typename CGAL::Union_find<SFace_handle>::handle Union_find_handle;
-    CGAL::Unique_hash_map< SFace_handle, Union_find_handle> Pitem(nullptr);
-    CGAL::Unique_hash_map< SVertex_handle, Union_find_handle> Vitem(nullptr);
+    CGAL::Unique_hash_map< SFace_handle, Union_find_handle> Pitem(nullptr,this->number_of_sfaces());
+    CGAL::Unique_hash_map< SVertex_handle, Union_find_handle> Vitem(nullptr,this->number_of_svertices());
     CGAL::Union_find< SFace_handle> UF;
 
     SFace_iterator f;
@@ -409,7 +409,7 @@ class SNC_SM_overlayer<SNC_indexed_items, SM_decorator_>
       }
     }
 
-    CGAL::Unique_hash_map<SHalfedge_handle,bool> linked(false);
+    CGAL::Unique_hash_map<SHalfedge_handle,bool> linked(false,this->number_of_shalfedges());
     for (e = this->shalfedges_begin(); e != this->shalfedges_end(); ++e) {
       if ( linked[e] ) continue;
       SHalfedge_around_sface_circulator hfc(e),hend(hfc);

--- a/Nef_3/include/CGAL/Nef_3/SNC_SM_overlayer.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_SM_overlayer.h
@@ -142,7 +142,8 @@ public:
       }
     }
 
-    CGAL::Unique_hash_map<SHalfedge_handle,bool> linked(false);
+    typedef CGAL::Unique_hash_map<SHalfedge_handle,bool> Linked_map;
+    Linked_map linked(false, this->number_of_shalfedges());
     for (e = this->shalfedges_begin(); e != this->shalfedges_end(); ++e) {
       if ( linked[e] ) continue;
       SHalfedge_around_sface_circulator hfc(e),hend(hfc);

--- a/Nef_3/include/CGAL/Nef_3/SNC_SM_overlayer.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_SM_overlayer.h
@@ -91,8 +91,8 @@ public:
     CGAL_NEF_TRACEN("simplifying");
 
     typedef typename CGAL::Union_find<SFace_handle>::handle Union_find_handle;
-    CGAL::Unique_hash_map< SFace_handle, Union_find_handle> Pitem(nullptr);
-    CGAL::Unique_hash_map< SVertex_handle, Union_find_handle> Vitem(nullptr);
+    CGAL::Unique_hash_map< SFace_handle, Union_find_handle> Pitem(nullptr, this->number_of_sfaces());
+    CGAL::Unique_hash_map< SVertex_handle, Union_find_handle> Vitem(nullptr, this->number_of_svertices());
     CGAL::Union_find< SFace_handle> UF;
 
     SFace_iterator f;

--- a/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
@@ -436,8 +436,6 @@ public:
 
   Vertex_handle create_for_infibox_overlay(Vertex_const_handle vin) const {
 
-    Unique_hash_map<SHalfedge_handle, Mark> mark_of_right_sface;
-
     Vertex_handle v = this->sncp()->new_vertex(vin->point(), vin->mark());
     SM_decorator D(&*v);
     SM_const_decorator E(&*vin);
@@ -468,7 +466,9 @@ public:
       CGAL_NEF_TRACEN("edge is not isolated");
       SHalfedge_handle se;
       SFace_handle sf;
-
+      CGAL_assertion_code(std::vector<SHalfedge_handle> index_check);
+      typedef std::vector<Mark> Marks;
+      Marks mark_of_right_sface;
       SHalfedge_around_svertex_const_circulator ec(E.out_edges(e)), ee(ec);
       CGAL_For_all(ec,ee) {
         Sphere_segment seg(ec->source()->point(),
@@ -476,15 +476,18 @@ public:
                            ec->circle());
         se = D.new_shalfedge_pair(v1, v2);
         se->mark() = se->twin()->mark() = ec->mark();
-        mark_of_right_sface[se] = ec->incident_sface()->mark();
+        CGAL_assertion_code(index_check.push_back(se));
+        mark_of_right_sface.push_back(ec->incident_sface()->mark());
         se->circle() = ec->circle();
         se->twin()->circle() = se->circle().opposite();
       }
 
+      typename Marks::size_type mark_index=0;
       SHalfedge_around_svertex_circulator ec2(D.out_edges(v1)), ee2(ec2);
       CGAL_For_all(ec2,ee2) {
         sf = D.new_sface();
-        sf->mark() = mark_of_right_sface[ec2];
+        CGAL_assertion(index_check[mark_index]==ec2);
+        sf->mark() = mark_of_right_sface[mark_index++];
         D.link_as_face_cycle(SHalfedge_handle(ec2),sf);
       }
     }
@@ -770,8 +773,6 @@ public:
 
     CGAL_NEF_TRACEN("edge facet overlay " << p);
 
-    Unique_hash_map<SHalfedge_handle, Mark> mark_of_right_sface;
-
     SM_decorator D(&*this->sncp()->new_vertex(p, BOP(e->mark(), f->mark())));
     SM_const_decorator E(&*e->source());
 
@@ -823,7 +824,9 @@ public:
       SHalfedge_handle se2;
       SFace_handle sf;
       Sphere_circle c(f->plane());
-
+      CGAL_assertion_code(std::vector<SHalfedge_handle> index_check);
+      typedef std::vector<Mark> Marks;
+      Marks mark_of_right_sface;
       SHalfedge_handle next_edge;
       SHalfedge_around_svertex_const_circulator ec(E.out_edges(e)), ee(ec);
       CGAL_For_all(ec,ee) {
@@ -845,11 +848,13 @@ public:
         next_edge = se2->twin();
         se1->mark() = se1->twin()->mark() = BOP(ec->mark(), faces_p->incident_volume()->mark(), inv);
         se2->mark() = se2->twin()->mark() = BOP(ec->mark(), faces_p->twin()->incident_volume()->mark(), inv);
-        mark_of_right_sface[se1] = ec->incident_sface()->mark();
+        CGAL_assertion_code(index_check.push_back(se1));
+        mark_of_right_sface.push_back(ec->incident_sface()->mark());
         se1->circle() = se2->circle() = ec->circle();
         se1->twin()->circle() = se2->twin()->circle() = se1->circle().opposite();
       }
 
+      typename Marks::size_type mark_index=0;
       SHalfedge_around_svertex_circulator ec2(D.out_edges(v1)), ee2(ec2);
       CGAL_For_all(ec2,ee2) {
         SHalfedge_around_svertex_circulator en(ec2);
@@ -859,13 +864,15 @@ public:
                         " -> " << en->twin()->source()->vector());
         se1->circle() = Sphere_circle(faces_p->plane());
         se1->twin()->circle() = se1->circle().opposite();
-        se1->mark() = se1->twin()->mark() = BOP(mark_of_right_sface[ec2], faces_p->mark(), inv);
+        CGAL_assertion(mark_of_right_sface[mark_index]==ec2);
+        Mark m = mark_of_right_sface[mark_index++];
+        se1->mark() = se1->twin()->mark() = BOP(m, faces_p->mark(), inv);
 
         sf = D.new_sface();
-        sf->mark() = BOP(mark_of_right_sface[ec2], faces_p->incident_volume()->mark(), inv);
+        sf->mark() = BOP(m, faces_p->incident_volume()->mark(), inv);
         D.link_as_face_cycle(se1,sf);
         sf = D.new_sface();
-        sf->mark() = BOP(mark_of_right_sface[ec2], faces_p->twin()->incident_volume()->mark(), inv);
+        sf->mark() = BOP(m, faces_p->twin()->incident_volume()->mark(), inv);
         D.link_as_face_cycle(se1->twin(),sf);
       }
     }
@@ -1995,8 +2002,6 @@ class SNC_constructor<SNC_indexed_items, SNC_structure_>
 
     CGAL_NEF_TRACEN("edge facet overlay " << p);
 
-    Unique_hash_map<SHalfedge_handle, Mark> mark_of_right_sface;
-
     SM_decorator D(&*this->sncp()->new_vertex(p, BOP(e->mark(), f->mark())));
     SM_const_decorator E(&*e->source());
 
@@ -2054,7 +2059,9 @@ class SNC_constructor<SNC_indexed_items, SNC_structure_>
       SHalfedge_handle se2;
       SFace_handle sf;
       Sphere_circle c(CGAL::ORIGIN,f->plane());
-
+      CGAL_assertion_code(std::vector<SHalfedge_handle> index_check);
+      typedef std::vector<Mark> Marks;
+      Marks mark_of_right_sface;
       SHalfedge_handle next_edge;
       SHalfedge_around_svertex_const_circulator ec(E.out_edges(e)), ee(ec);
       CGAL_For_all(ec,ee) {
@@ -2088,7 +2095,8 @@ class SNC_constructor<SNC_indexed_items, SNC_structure_>
         next_edge = se2->twin();
         se1->mark() = se1->twin()->mark() = BOP(ec->mark(), faces_p->incident_volume()->mark(), inv);
         se2->mark() = se2->twin()->mark() = BOP(ec->mark(), faces_p->twin()->incident_volume()->mark(), inv);
-        mark_of_right_sface[se1] = ec->incident_sface()->mark();
+        CGAL_assertion_code(index_check.push_back(se1));
+        mark_of_right_sface.push_back(ec->incident_sface()->mark());
         se1->circle() = se2->circle() = ec->circle();
         se1->twin()->circle() = se2->twin()->circle() = se1->circle().opposite();
         se1->set_index(ec->get_index());
@@ -2097,6 +2105,7 @@ class SNC_constructor<SNC_indexed_items, SNC_structure_>
         se2->twin()->set_index(ec->twin()->get_index());
       }
 
+      typename Marks::size_type mark_index=0;
       SHalfedge_around_svertex_circulator ec2(D.out_edges(v1)), ee2(ec2);
       CGAL_For_all(ec2,ee2) {
         SHalfedge_around_svertex_circulator en(ec2);
@@ -2106,7 +2115,9 @@ class SNC_constructor<SNC_indexed_items, SNC_structure_>
                         " -> " << en->twin()->source()->vector());
         se1->circle() = Sphere_circle(CGAL::ORIGIN,faces_p->plane());
         se1->twin()->circle() = se1->circle().opposite();
-        se1->mark() = se1->twin()->mark() = BOP(mark_of_right_sface[ec2], faces_p->mark(), inv);
+        CGAL_assertion(mark_index<index_check.size() && index_check[mark_index] == ec2);
+        Mark m = mark_of_right_sface[mark_index++];
+        se1->mark() = se1->twin()->mark() = BOP(m, faces_p->mark(), inv);
 
         Halffacet_cycle_const_iterator fci = faces_p->facet_cycles_begin();
         SHalfedge_around_facet_const_circulator sea(fci);
@@ -2114,10 +2125,10 @@ class SNC_constructor<SNC_indexed_items, SNC_structure_>
         se1->twin()->set_index(sea->get_index());
 
         sf = D.new_sface();
-        sf->mark() = BOP(mark_of_right_sface[ec2], faces_p->incident_volume()->mark(), inv);
+        sf->mark() = BOP(m, faces_p->incident_volume()->mark(), inv);
         D.link_as_face_cycle(se1,sf);
         sf = D.new_sface();
-        sf->mark() = BOP(mark_of_right_sface[ec2], faces_p->twin()->incident_volume()->mark(), inv);
+        sf->mark() = BOP(m, faces_p->twin()->incident_volume()->mark(), inv);
         D.link_as_face_cycle(se1->twin(),sf);
       }
     }

--- a/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
@@ -486,7 +486,7 @@ public:
       SHalfedge_around_svertex_circulator ec2(D.out_edges(v1)), ee2(ec2);
       CGAL_For_all(ec2,ee2) {
         sf = D.new_sface();
-        CGAL_assertion(index_check[mark_index]==ec2);
+        CGAL_assertion(mark_index<index_check.size() && index_check[mark_index] == ec2);
         sf->mark() = mark_of_right_sface[mark_index++];
         D.link_as_face_cycle(SHalfedge_handle(ec2),sf);
       }
@@ -864,7 +864,7 @@ public:
                         " -> " << en->twin()->source()->vector());
         se1->circle() = Sphere_circle(faces_p->plane());
         se1->twin()->circle() = se1->circle().opposite();
-        CGAL_assertion(mark_of_right_sface[mark_index]==ec2);
+        CGAL_assertion(mark_index<index_check.size() && index_check[mark_index] == ec2);
         Mark m = mark_of_right_sface[mark_index++];
         se1->mark() = se1->twin()->mark() = BOP(m, faces_p->mark(), inv);
 

--- a/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_constructor.h
@@ -693,12 +693,16 @@ public:
     ++number_of_clones;
 #endif
 
-    CGAL::Unique_hash_map<SVertex_const_handle, SVertex_handle>         VM;
-    CGAL::Unique_hash_map<SHalfedge_const_handle, SHalfedge_handle>     EM;
-    CGAL::Unique_hash_map<SHalfloop_const_handle, SHalfloop_handle>     LM;
-    CGAL::Unique_hash_map<SFace_const_handle, SFace_handle>             FM;
-
     SM_const_decorator E(&*vin);
+    typedef CGAL::Unique_hash_map<SVertex_const_handle, SVertex_handle> VM_map;
+    typedef CGAL::Unique_hash_map<SHalfedge_const_handle, SHalfedge_handle> EM_map;
+    typedef CGAL::Unique_hash_map<SHalfloop_const_handle, SHalfloop_handle> LM_map;
+    typedef CGAL::Unique_hash_map<SFace_const_handle, SFace_handle> FM_map;
+    VM_map VM(SVertex_handle(), E.number_of_svertices());
+    EM_map EM(SHalfedge_handle(), E.number_of_shalfedges());
+    LM_map LM(SHalfloop_handle(), E.number_of_shalfloops());
+    FM_map FM(SFace_handle(), E.number_of_sfaces());
+
     Vertex_handle vout = this->sncp()->new_vertex(vin->point(), vin->mark());
     SM_decorator D(&*vout);
 
@@ -934,6 +938,7 @@ public:
   }
 
   bool erase_redundant_vertices() {
+    std::size_t num_vertices = this->sncp()->number_of_vertices();
 
     std::list<Vertex_handle> redundant_points;
     Vertex_iterator v;
@@ -973,7 +978,8 @@ public:
       typedef std::map< Pluecker_line_3, Halfedge_list, Pluecker_line_lt>
         Pluecker_line_map;
 
-      Unique_hash_map<Vertex_handle, bool> erase_vertex(false);
+      typedef Unique_hash_map<Vertex_handle, bool> Erase_vertex_map;
+      Erase_vertex_map erase_vertex(false, num_vertices);
       std::list<Point_3> recreate;
 
       SNC_decorator D(*this);
@@ -1917,12 +1923,16 @@ class SNC_constructor<SNC_indexed_items, SNC_structure_>
     ++number_of_clones;
 #endif
 
-    CGAL::Unique_hash_map<SVertex_const_handle, SVertex_handle>         VM;
-    CGAL::Unique_hash_map<SHalfedge_const_handle, SHalfedge_handle>     EM;
-    CGAL::Unique_hash_map<SHalfloop_const_handle, SHalfloop_handle>     LM;
-    CGAL::Unique_hash_map<SFace_const_handle, SFace_handle>             FM;
-
     SM_const_decorator E(&*vin);
+    typedef CGAL::Unique_hash_map<SVertex_const_handle, SVertex_handle> VM_map;
+    typedef CGAL::Unique_hash_map<SHalfedge_const_handle, SHalfedge_handle> EM_map;
+    typedef CGAL::Unique_hash_map<SHalfloop_const_handle, SHalfloop_handle> LM_map;
+    typedef CGAL::Unique_hash_map<SFace_const_handle, SFace_handle> FM_map;
+    VM_map VM(SVertex_handle(), E.number_of_svertices());
+    EM_map EM(SHalfedge_handle(), E.number_of_shalfedges());
+    LM_map LM(SHalfloop_handle(), E.number_of_shalfloops());
+    FM_map FM(SFace_handle(), E.number_of_sfaces());
+
     Vertex_handle vout = this->sncp()->new_vertex(vin->point(), vin->mark());
     SM_decorator D(&*vout);
 

--- a/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_decorator.h
@@ -381,9 +381,9 @@ class SNC_decorator : public SNC_const_decorator<Map> {
       valid = valid && vi->is_valid(verb, level);
 
       SM_decorator SD(&*vi);
-      Unique_hash_map<SVertex_handle, bool> SVvisited(false);
-      Unique_hash_map<SHalfedge_handle, bool> SEvisited(false);
-      Unique_hash_map<SFace_handle, bool> SFvisited(false);
+      Unique_hash_map<SVertex_handle, bool> SVvisited(false, SD.number_of_svertices());
+      Unique_hash_map<SHalfedge_handle, bool> SEvisited(false, SD.number_of_shalfedges());
+      Unique_hash_map<SFace_handle, bool> SFvisited(false, SD.number_of_sfaces());
 
       valid = valid && SD.is_valid(SVvisited,SEvisited,SFvisited, verb, level);
 
@@ -444,7 +444,7 @@ class SNC_decorator : public SNC_const_decorator<Map> {
     verr << "CGAL::SNC_decorator<...>::is_valid(): structure is "
          << ( valid ? "valid." : "NOT VALID.") << std::endl;
 
-    Unique_hash_map<SHalfedge_handle, bool> SEinUniqueFC(false);
+    Unique_hash_map<SHalfedge_handle, bool> SEinUniqueFC(false, this->number_of_shalfedges());
     Halffacet_iterator hfi;
     CGAL_forall_halffacets(hfi,*this) {
       valid = valid && hfi->is_valid(verb, level);

--- a/Nef_3/include/CGAL/Nef_3/SNC_io_parser.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_io_parser.h
@@ -2203,6 +2203,7 @@ void SNC_io_parser<EW>::add_infi_box() {
     vh->point() = Infi_box::create_extended_point(hx, hy, hz);
     vh->mark() = 1;
     vh->sncp() = this->sncp();
+    vh->update_number_of_items();
   }
 
   int seOff[3] = {0, 1, 3};

--- a/Nef_3/include/CGAL/Nef_3/SNC_io_parser.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_io_parser.h
@@ -1643,6 +1643,8 @@ read_vertex(Vertex_handle vh) {
   OK = OK && test_string("}");
   in >> vh->mark();
 
+  vh->update_number_of_items();
+
   return OK;
 }
 

--- a/Nef_3/include/CGAL/Nef_3/SNC_io_parser.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_io_parser.h
@@ -1279,7 +1279,7 @@ SNC_io_parser<EW>::SNC_io_parser(std::ostream& os, SNC_structure& W,
     SFI[*sfl] = i++;
 
   Volume_iterator ci;
-  CGAL::Unique_hash_map<SFace_handle,bool> Done(false);
+  CGAL::Unique_hash_map<SFace_handle,bool> Done(false, this->sncp()->number_of_sfaces());
   find_minimal_sface_of_shell<SNC_structure> findMinSF(*this->sncp(),Done);
   CGAL_forall_volumes(ci, *this->sncp()) {
     if(sorted) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_point_locator.h
@@ -521,7 +521,8 @@ private:
 
   void intersect_with_edges( Halfedge_handle e0,
                              const Intersection_call_back& call_back, Segment_3& s, Node_list& nodes) const {
-    Unique_hash_map<Halfedge_handle,bool> visited(false);
+    typedef Unique_hash_map<Halfedge_handle,bool> Visited_map;
+    Visited_map visited(false, Visited_map::min_size);
     for(typename Node_list::iterator ni = nodes.begin(); ni!=nodes.end(); ++ni) {
       Node_handle n(*ni);
       for(typename Halfedge_list::const_iterator e = n->edges_begin(); e!=n->edges_end(); ++e) {
@@ -545,7 +546,8 @@ private:
 
   void intersect_with_facets( Halfedge_handle e0,
                               const Intersection_call_back& call_back,Segment_3& s, Node_list& nodes) const {
-    Unique_hash_map<Halffacet_handle,bool> visited(false);
+    typedef Unique_hash_map<Halffacet_handle,bool> Visited_map;
+    Visited_map visited(false, Visited_map::min_size);
     for(typename Node_list::iterator ni = nodes.begin(); ni!=nodes.end(); ++ni) {
       Node_handle n(*ni);
       for(typename Halffacet_list::const_iterator f = n->facets_begin(); f!=n->facets_end(); ++f) {

--- a/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
@@ -319,6 +319,12 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
     return number_of_sfaces_;
   }
 
+  void update_number_of_items() {
+    number_of_svertices_ = Base::number_of_svertices();
+    number_of_shalfedges_ = Base::number_of_shalfedges();
+    number_of_sfaces_ = Base::number_of_sfaces();
+  }
+
   template <typename H>
   void make_twins(H h1, H h2) {
     h1->twin() = h2;

--- a/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
@@ -295,15 +295,7 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
       this->number_of_sfaces() == 0;
   }
 
-  /*
-  bool has_shalfloop() const {
-    return shalfloop_ != 0;
-  }
 
-  SHalfloop_handle shalfloop() const {
-    return shalfloop_;
-  }
-  */
 
   template <typename H>
   void make_twins(H h1, H h2) {
@@ -329,15 +321,7 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
     CGAL_NEF_TRACEN("new_svertex "<<&*sv);
     return sv;
   }
-  /*
-  SFace_handle new_sface() {
-    SFace_iterator sf =  this->sncp()->new_sface_only();
-    if ( this->sfaces_begin() == this->sncp()->sfaces_end()) init_range(sf);
-    else this->sfaces_last() = sf;
-    sf->center_vertex() = Vertex_handle((SNC_in_place_list_sm<Self>*) this);
-    return sf;
-  }
-  */
+
   SFace_handle new_sface() {
     SFace_iterator sf;
     if ( this->sfaces_begin() == this->sncp()->sfaces_end()) {
@@ -349,20 +333,9 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
       this->sfaces_last() = sf;
     }
     sf->center_vertex() = Vertex_handle((SNC_in_place_list_sm<Self>*) this);
+    ++number_of_sfaces_;
     return sf;
   }
-
-  /*
-  SHalfedge_handle new_shalfedge_pair() {
-    SHalfedge_iterator se = this->sncp()->new_shalfedge_only();
-    SHalfedge_iterator set = this->sncp()->new_shalfedge_only();
-    if(this->shalfedges_begin() == this->sncp()->shalfedges_end())
-      init_range(se);
-    this->shalfedges_last() = set;
-    make_twins(se,set);
-    return se;
-  }
-  */
 
   SHalfedge_handle new_shalfedge_pair() {
     SHalfedge_iterator se, set;

--- a/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_sphere_map.h
@@ -133,7 +133,11 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
   typedef Vertex_const_handle Constructor_const_parameter;
   using Base::init_range; // AF add CR
  public:
-  SNC_sphere_map(bool construct=false) : Base(), destruct(construct) {
+  SNC_sphere_map(bool construct=false) : Base(), destruct(construct),
+    number_of_svertices_(0),
+    number_of_shalfedges_(0),
+    number_of_sfaces_(0)
+  {
     if(!construct) return;
     this->sncp() = new SNC_structure;
     init_range(this->sncp()->svertices_end());
@@ -150,13 +154,21 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
 
   Self& operator=(const Self& M) {
     destruct = M.destruct;
+    number_of_svertices_ = M.number_of_svertices_;
+    number_of_shalfedges_ = M.number_of_shalfedges_;
+    number_of_sfaces_ = M.number_of_sfaces_;
     Base* b(this);
     *b = M;
     return *this;
   }
 
   void clear(bool clear_base=false) {
-    if(clear_base) Base::clear();
+    if(clear_base) {
+      Base::clear();
+      number_of_svertices_ = 0;
+      number_of_shalfedges_ = 0;
+      number_of_sfaces_ = 0;
+    }
   }
 
   template <typename H>
@@ -295,7 +307,17 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
       this->number_of_sfaces() == 0;
   }
 
+  Size_type number_of_svertices() const {
+    return number_of_svertices_;
+  }
 
+  Size_type number_of_shalfedges() const {
+    return number_of_shalfedges_;
+  }
+
+  Size_type number_of_sfaces() const {
+    return number_of_sfaces_;
+  }
 
   template <typename H>
   void make_twins(H h1, H h2) {
@@ -319,6 +341,7 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
     sv->mark() = m;
     sv->center_vertex() = Vertex_handle((SNC_in_place_list_sm<Self>*) this);
     CGAL_NEF_TRACEN("new_svertex "<<&*sv);
+    ++number_of_svertices_;
     return sv;
   }
 
@@ -350,6 +373,7 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
     }
     this->shalfedges_last() = set;
     make_twins(se,set);
+    number_of_shalfedges_+=2;
     return se;
   }
 
@@ -371,6 +395,8 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
     else if (this->svertices_begin() == v ) ++(this->svertices_begin());
     else if (this->svertices_last() == v ) --(this->svertices_last());
     this->sncp()->delete_halfedge_only(v);
+    CGAL_assertion(number_of_svertices_>0);
+    --number_of_svertices_;
   }
 
   void delete_shalfedge(SHalfedge_handle e) {
@@ -380,6 +406,8 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
     else if (this->shalfedges_begin() == e ) ++(this->shalfedges_begin());
     else if (this->shalfedges_last() == e ) --(this->shalfedges_last());
     this->sncp()->delete_shalfedge_only(e);
+    CGAL_assertion(number_of_shalfedges_>0);
+    --number_of_shalfedges_;
   }
 
   void delete_shalfedge_pair(SHalfedge_handle e) {
@@ -394,6 +422,8 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
     else if (this->sfaces_begin() == f ) ++(this->sfaces_begin());
     else if (this->sfaces_last() == f )  --(this->sfaces_last());
     this->sncp()->delete_sface_only(f);
+    CGAL_assertion(number_of_sfaces_>0);
+    --number_of_sfaces_;
   }
 
   void delete_shalfloop_pair() {
@@ -405,6 +435,10 @@ class SNC_sphere_map : public Items_::template Vertex<SNC_structure<Kernel_, Ite
 
  protected:
   bool            destruct;
+ private:
+  Size_type number_of_svertices_;
+  Size_type number_of_shalfedges_;
+  Size_type number_of_sfaces_;
 };  // SNC_sphere_map
 
 

--- a/Nef_3/include/CGAL/Nef_3/SNC_structure.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_structure.h
@@ -384,13 +384,15 @@ public:
   expensive operation.}*/
 
   SNC_structure() :
-    boundary_item_(std::nullopt), sm_boundary_item_(std::nullopt),
+    boundary_item_(std::nullopt, Boundary_item_map::min_size),
+    sm_boundary_item_(std::nullopt, Boundary_item_map::min_size),
     vertices_(), halfedges_(), halffacets_(), volumes_(),
     shalfedges_(), shalfloops_(), sfaces_() {}
   ~SNC_structure() { CGAL_NEF_TRACEN("~SNC_structure: clearing "<<this); clear(); }
 
   SNC_structure(const Self& D) :
-    boundary_item_(std::nullopt), sm_boundary_item_(std::nullopt),
+    boundary_item_(std::nullopt, Boundary_item_map::min_size),
+    sm_boundary_item_(std::nullopt, Boundary_item_map::min_size),
     vertices_(D.vertices_), halfedges_(D.halfedges_),
     halffacets_(D.halffacets_), volumes_(D.volumes_),
     shalfedges_(D.shalfedges_), shalfloops_(D.shalfloops_),
@@ -1036,9 +1038,10 @@ protected:
   void pointer_update(const Self& D);
 
   typedef std::optional<Object_iterator> Optional_object_iterator ;
+  typedef Generic_handle_map<Optional_object_iterator> Boundary_item_map;
  private:
-  Generic_handle_map<Optional_object_iterator> boundary_item_;
-  Generic_handle_map<Optional_object_iterator> sm_boundary_item_;
+  Boundary_item_map boundary_item_;
+  Boundary_item_map sm_boundary_item_;
  protected:
   Vertex_list    vertices_;
   Halfedge_list  halfedges_;

--- a/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Generic_handle_map.h
@@ -33,7 +33,7 @@ class Generic_handle_map : public
 { typedef Unique_hash_map<void*,I,Void_handle_hash_function> Base;
 public:
   Generic_handle_map() : Base() {}
-  Generic_handle_map(I i) : Base(i) {}
+  Generic_handle_map(I i, std::size_t n = Base::min_size) : Base(i, n) {}
 
   template <class H>
   const I& operator[](H h) const

--- a/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
@@ -381,7 +381,8 @@ SM_const_decorator<SM_>::
 number_of_sface_cycles() const
 {
   unsigned int fc_num=0;
-  CGAL::Unique_hash_map<SHalfedge_const_handle,bool> visited;
+  typedef CGAL::Unique_hash_map<SHalfedge_const_handle,bool> Visited_map;
+  Visited_map visited(false, this->number_of_shalfedges());
   SHalfedge_const_iterator e;
   CGAL_forall_shalfedges(e,*this) {
     if (visited[e]) continue;

--- a/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
@@ -399,7 +399,8 @@ SM_const_decorator<SM_>::
 number_of_connected_components() const
 {
   int comp_num=0;
-  CGAL::Unique_hash_map<SVertex_const_iterator,bool> visited(false);
+  typedef CGAL::Unique_hash_map<SVertex_const_iterator,bool> Visited_map;
+  Visited_map visited(false, Visited_map::min_size);
   SVertex_const_iterator v;
   CGAL_forall_svertices(v,*this) {
     if (visited[v]) continue;

--- a/Nef_S2/include/CGAL/Nef_S2/SM_overlayer.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_overlayer.h
@@ -2050,7 +2050,8 @@ create_face_objects(SHalfedge_iterator e_start, SHalfedge_iterator e_end,
 {
   CGAL_NEF_TRACEN("create_face_objects()");
   if(e_start != e_end) {
-    CGAL::Unique_hash_map<SHalfedge_handle,int> SFaceCycle(-1);
+    typedef CGAL::Unique_hash_map<SHalfedge_handle,int> SFaceCycle_map;
+    SFaceCycle_map SFaceCycle(-1, this->number_of_shalfedges());
     std::vector<SHalfedge_handle>  MinimalSHalfedge;
     SHalfedge_around_sface_circulator hfc(last_out_edge(v_start)),hend(hfc);
     CGAL_NEF_TRACEN("equator cycle "<<PH(hfc));
@@ -2313,8 +2314,10 @@ void SM_overlayer<Map>::simplify()
   CGAL_NEF_TRACEN("simplifying");
 
   typedef typename CGAL::Union_find<SFace_handle>::handle Union_find_handle;
-  CGAL::Unique_hash_map< SFace_handle, Union_find_handle> Pitem(nullptr);
-  CGAL::Unique_hash_map< SVertex_handle, Union_find_handle> Vitem(nullptr);
+  typedef CGAL::Unique_hash_map< SFace_handle, Union_find_handle> Pitem_map;
+  Pitem_map Pitem(nullptr, this->number_of_sfaces());
+  typedef CGAL::Unique_hash_map< SVertex_handle, Union_find_handle> Vitem_map;
+  Vitem_map Vitem(nullptr, this->number_of_svertices());
   CGAL::Union_find< SFace_handle> UF;
 
   SFace_iterator f;
@@ -2362,7 +2365,8 @@ void SM_overlayer<Map>::simplify()
     }
   }
 
-  CGAL::Unique_hash_map<SHalfedge_handle,bool> linked(false);
+  typedef CGAL::Unique_hash_map<SHalfedge_handle,bool> Linked_map;
+  Linked_map linked(false, this->number_of_shalfedges());
   for (e = this->shalfedges_begin(); e != this->shalfedges_end(); ++e) {
     if ( linked[e] ) continue;
     SHalfedge_around_sface_circulator hfc(e),hend(hfc);

--- a/Nef_S2/include/CGAL/Nef_S2/SM_point_locator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_point_locator.h
@@ -254,7 +254,8 @@ public:
     // s now initialized
 
     Sphere_direction dso(s.sphere_circle().opposite());
-    Unique_hash_map<SHalfedge_handle,bool> visited(false);
+    typedef Unique_hash_map<SHalfedge_handle,bool> Visited_map;
+    Visited_map visited(false, this->number_of_shalfedges());
     CGAL_forall_svertices(v,*this) {
       Sphere_point vp = v->point();
       if ( (v == v_res) || s.has_on(vp) ) {
@@ -378,7 +379,8 @@ public:
       }
     } // all vertices
 
-    CGAL::Unique_hash_map<SHalfedge_handle,bool> visited(false);
+    typedef Unique_hash_map<SHalfedge_handle,bool> Visited_map;
+    Visited_map visited(false, this->number_of_shalfedges());
     SHalfedge_iterator e_res;
     CGAL_forall_sedges(e,*this) {
       Sphere_segment se = segment(e);


### PR DESCRIPTION
## Summary of Changes

This addresses places in the Nef_3 module where the Hash map sizes are are either known at construction or can be set to the minimum size. 

To facilitate this a change is required within `SNC_sphere_map` the values for `number_of_svertices` / `number_of_shalfedges` / `number_of_sfaces` where currently these are calculated by calling the base class in Vertex.h which uses loops to calculate the number of vertices:

https://github.com/CGAL/cgal/blob/088f5c3e18b6a38510b6d457a34ba7d698903757/Nef_3/include/CGAL/Nef_3/Vertex.h#L214-L226

These can be made into a constant time `O(1)` count of the number of svertices/shalfedges/sfaces is instead of the current linear time `O(n)` loop. This is particularly relavant when allocating the size of the hashmaps `Pitem`, `Vitem` and `linked` in the `SNC_SM_overlayer.h` function  `simplify`

Since the `SNC_sphere_map` has methods to new/delete these items, member variables can be added which are incremented on new, and decremented on delete. An additional method `update_number_of_items` is needed for `SNC_io_parser` which updates the start and end pointers of the SNC_sphere_map directly.

While profiling the hashmaps it was also discovered that the hashmap `mark_of_right_sface` within `SNC_constructor` (called before simplify) only ever seems to contain two items. Furthermore, the loop in which the values of the hashmap are set indexes the edges in the same order as the loop in which the hashmap is read. Therefore the hashmap can simply be replaced with a vector. (in theory, a 2-element array could be used but I don't want to make that assumption)

`CGAL_assertion`s have been added to test assumptions in the above.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): performance
* License and copyright ownership: CGAL authors