### PR TITLE
Changing namespace of set_pretty_mode() from CGAL::IO to CGAL - issue…

### DIFF
--- a/Algebraic_foundations/examples/Algebraic_foundations/fraction_traits.cpp
+++ b/Algebraic_foundations/examples/Algebraic_foundations/fraction_traits.cpp
@@ -17,7 +17,7 @@ int main(){
     CGAL::Gmpq fraction(4,5);
     FT::Decompose()(fraction,numerator,denominator);
 
-    CGAL::IO::set_pretty_mode(std::cout);
+    CGAL::set_pretty_mode(std::cout);
     std::cout << "decompose fraction: "<< std::endl;
     std::cout << "fraction   : " << fraction << std::endl;
     std::cout << "numerator  : " << numerator<< std::endl;

--- a/Algebraic_foundations/examples/Algebraic_foundations/implicit_interoperable_dispatch.cpp
+++ b/Algebraic_foundations/examples/Algebraic_foundations/implicit_interoperable_dispatch.cpp
@@ -31,7 +31,7 @@ binary_func(const A& a , const B& b){
 }
 
 int main(){
-    CGAL::IO::set_pretty_mode(std::cout);
+    CGAL::set_pretty_mode(std::cout);
 
     // Function call for ImplicitInteroperable types
     std::cout<< binary_func(double(3), int(5)) << std::endl;


### PR DESCRIPTION
## Summary of Changes

Changing namespace of set_pretty_mode() from ```CGAL::IO::set_pretty_mode()``` to ```CGAL::set_pretty_mode()``` for examples : fraction_traits.cpp and implicit_interoperable_dispatch.cpp under Algebraic_foundations

Path : Algebraic_foundations/examples/Algebraic_foundations

## Release Management

* Issue solved : fix #7240 ,


