### PR TITLE
STL_Extension/Triangulation_2: improve CDT_2 debug messages

### DIFF
--- a/Circulator/include/CGAL/circulator.h
+++ b/Circulator/include/CGAL/circulator.h
@@ -701,7 +701,13 @@ typedef Iterator_from_circulator< C, const_reference, const_pointer>
 template <class Container>
 class Circulator_from_container {
     typedef Circulator_from_container<Container>      Self;
-    typedef typename Container::iterator              iterator;
+    typedef typename Container::iterator              container_iterator;
+    typedef typename Container::const_iterator        container_const_iterator;
+    typedef std::conditional_t<
+        std::is_const<Container>::value,
+        container_const_iterator,
+        container_iterator
+        >                                             iterator;
     typedef std::iterator_traits<iterator>            iterator_traits;
 public:
     typedef typename iterator_traits::value_type      value_type;

--- a/STL_Extension/include/CGAL/Base_with_time_stamp.h
+++ b/STL_Extension/include/CGAL/Base_with_time_stamp.h
@@ -1,0 +1,48 @@
+// Copyright (c) 2023  GeometryFactory Sarl (France).
+// All rights reserved.
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Laurent Rineau
+
+#ifndef CGAL_BASE_WITH_TIME_STAMP_H
+#define CGAL_BASE_WITH_TIME_STAMP_H
+
+#include <CGAL/tags.h> // for Tag_true
+#include <cstdint>     // for std::size_t
+#include <utility>     // for std::forward
+
+namespace CGAL {
+
+template <typename Base>
+class Base_with_time_stamp : public Base {
+  std::size_t time_stamp_ = -1;
+public:
+  using Base::Base;
+
+  Base_with_time_stamp(const Base_with_time_stamp& other) :
+    Base(other),
+    time_stamp_(other.time_stamp_)
+  {}
+
+  typedef CGAL::Tag_true Has_timestamp;
+
+  std::size_t time_stamp() const {
+    return time_stamp_;
+  }
+  void set_time_stamp(const std::size_t& ts) {
+    time_stamp_ = ts;
+  }
+
+  template < class TDS >
+  struct Rebind_TDS {
+    typedef typename Base::template Rebind_TDS<TDS>::Other Base2;
+    typedef Base_with_time_stamp<Base2> Other;
+  };
+};
+
+} // namespace CGAL
+
+#endif // CGAL_BASE_WITH_TIME_STAMP_H

--- a/STL_Extension/include/CGAL/Base_with_time_stamp.h
+++ b/STL_Extension/include/CGAL/Base_with_time_stamp.h
@@ -20,13 +20,6 @@ template <typename Base>
 class Base_with_time_stamp : public Base {
   std::size_t time_stamp_ = -1;
 public:
-  using Base::Base;
-
-  Base_with_time_stamp(const Base_with_time_stamp& other) :
-    Base(other),
-    time_stamp_(other.time_stamp_)
-  {}
-
   typedef CGAL::Tag_true Has_timestamp;
 
   std::size_t time_stamp() const {

--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -33,6 +33,7 @@
 #include <CGAL/Time_stamper.h>
 #include <CGAL/Has_member.h>
 #include <CGAL/assertions.h>
+#include <CGAL/IO/io.h>
 
 #include <boost/mpl/if.hpp>
 
@@ -1152,6 +1153,20 @@ namespace handle {
 } // namespace handle
 
 } // namespace internal
+
+template <class DSC, bool Const >
+class Output_rep<CGAL::internal::CC_iterator<DSC, Const> > {
+protected:
+  using CC_iterator = CGAL::internal::CC_iterator<DSC, Const>;
+  using Compact_container = typename CC_iterator::CC;
+  using Time_stamper = typename Compact_container::Time_stamper;
+  CC_iterator it;
+public:
+  Output_rep( const CC_iterator it) : it(it) {}
+  std::ostream& operator()( std::ostream& out) const {
+    return (out << Time_stamper::display_id(it.operator->()));
+  }
+};
 
 } //namespace CGAL
 

--- a/STL_Extension/include/CGAL/Time_stamper.h
+++ b/STL_Extension/include/CGAL/Time_stamper.h
@@ -13,6 +13,7 @@
 #define CGAL_TIME_STAMPER_H
 
 #include <CGAL/Has_timestamp.h>
+#include <string>
 
 namespace CGAL {
 
@@ -66,6 +67,11 @@ struct Time_stamper
     return pt->time_stamp();
   }
 
+  static auto display_id(const T* pt)
+  {
+    return std::string("#") + std::to_string(pt->time_stamp());
+  }
+
   static std::size_t hash_value(const T* p) {
     if(nullptr == p)
       return std::size_t(-1);
@@ -99,6 +105,11 @@ public:
   static std::size_t time_stamp(const T*)
   {
     return 0;
+  }
+
+  static auto display_id(const T* pt)
+  {
+    return static_cast<const void*>(pt);
   }
 
   static std::size_t hash_value(const T* p) {

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -622,6 +622,7 @@ public:
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   auto display_vertex(Vertex_handle v) const {
     With_point_tag point_tag;
+    using CGAL::IO::oformat;
     return oformat(v, point_tag);
   }
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -38,6 +38,28 @@
 #include <boost/mpl/has_xxx.hpp>
 #include <boost/iterator/filter_iterator.hpp>
 
+#ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
+#  include <CGAL/IO/io.h>
+#  include <CGAL/Compact_container.h>
+#  include <iostream>
+namespace CGAL {
+
+struct With_point_tag {};
+
+template <class DSC, bool Const>
+struct Output_rep<CGAL::internal::CC_iterator<DSC, Const>, With_point_tag>
+  : public Output_rep<CGAL::internal::CC_iterator<DSC, Const>>
+{
+  using Base = Output_rep<CGAL::internal::CC_iterator<DSC, Const>>;
+  using Base::Base;
+
+  std::ostream& operator()(std::ostream& out) const {
+    return Base::operator()(out) << "= " << this->it->point();
+  }
+};
+} // namespace CGAL
+#endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
+
 namespace CGAL {
 
 struct No_constraint_intersection_tag{};
@@ -597,6 +619,12 @@ public:
       return are_there;
     }
 
+#ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
+  auto display_vertex(Vertex_handle v) const {
+    With_point_tag point_tag;
+    return oformat(v, point_tag);
+  }
+#endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
 
  template<class OutputItEdges>
  OutputItEdges  incident_constraints(Vertex_handle v,
@@ -804,8 +832,8 @@ insert_constraint(Vertex_handle  vaa, Vertex_handle vbb)
 
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_2::insert_constraint( #" << vaa->time_stamp() << "= " << vaa->point()
-            << " , #" << vbb->time_stamp() << "= " << vbb->point()
+            << "CT_2::insert_constraint( " << display_vertex(vaa)
+            << " , " << display_vertex(vbb)
             << " )\n";
   internal::Indentation_level::Exit_guard exit_guard = CGAL::internal::cdt_2_indent_level.open_new_scope();
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
@@ -815,8 +843,8 @@ insert_constraint(Vertex_handle  vaa, Vertex_handle vbb)
     CGAL_precondition( vaa != vbb);
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
     std::cerr << CGAL::internal::cdt_2_indent_level
-              << "CT_2::insert_constraint, stack pop=( #" << vaa->time_stamp() << "= " << vaa->point()
-              << " , #" << vbb->time_stamp() << "= " << vbb->point()
+              << "CT_2::insert_constraint, stack pop=( " << display_vertex(vaa)
+              << " , " << display_vertex(vbb)
               << " ) remaining stack size: "
               << stack.size() << '\n';
     CGAL_assertion(this->is_valid());
@@ -858,12 +886,12 @@ insert_constraint(Vertex_handle  vaa, Vertex_handle vbb)
       if (vi != vaa && vi != vbb) {
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_2::insert_constraint stack push [vaa, vi] ( #" << vaa->time_stamp() << "= " << vaa->point()
-            << " , #" << vi->time_stamp() << "= " << vi->point()
+            << "CT_2::insert_constraint stack push [vaa, vi] ( " << display_vertex(vaa)
+            << " , " << display_vertex(vi)
             << " )\n";
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_2::insert_constraint stack push [vi, vbb] ( #" << vi->time_stamp() << "= " << vi->point()
-            << " , #" << vbb->time_stamp() << "= " << vbb->point()
+            << "CT_2::insert_constraint stack push [vi, vbb] ( " << display_vertex(vi)
+            << " , " << display_vertex(vbb)
             << " )\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
         stack.push(std::make_pair(vaa,vi));
@@ -872,8 +900,8 @@ insert_constraint(Vertex_handle  vaa, Vertex_handle vbb)
       else{
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_2::insert_constraint stack push [vaa, vbb]( #" << vaa->time_stamp() << "= " << vaa->point()
-            << " , #" << vbb->time_stamp() << "= " << vbb->point()
+            << "CT_2::insert_constraint stack push [vaa, vbb]( " << display_vertex(vaa)
+            << " , " << display_vertex(vbb)
             << " )\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
         stack.push(std::make_pair(vaa,vbb));
@@ -921,8 +949,8 @@ find_intersected_faces(Vertex_handle vaa,
   // is constrained
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_2::find_intersected_faces ( #" << vaa->time_stamp() << "= " << vaa->point()
-            << " , #" << vbb->time_stamp() << "= " << vbb->point()
+            << "CT_2::find_intersected_faces ( " << display_vertex(vaa)
+            << " , " << display_vertex(vbb)
             << " )\n"
             << CGAL::internal::cdt_2_indent_level
             << "> current constrained edges are:\n";
@@ -1220,7 +1248,7 @@ insert_intersection(Face_handle f, int i,
   }
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_2::insert_intersection, `vi` is ( #" << vi->time_stamp() << "= " << vi->point()
+            << "CT_2::insert_intersection, `vi` is ( " << display_vertex(vi)
             << " )\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   return vi;
@@ -1245,16 +1273,16 @@ intersect(Face_handle f, int i,
 
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_2::intersect segment ( #" << vaa->time_stamp() << "= " << vaa->point()
-            << " , #" << vbb->time_stamp() << "= " << vbb->point()
-            << " ) with edge ( #"<< vcc->time_stamp() << "= " << vcc->point()
-            << " , #" << vdd->time_stamp() << "= " << vdd->point()
+            << "CT_2::intersect segment ( " << display_vertex(vaa)
+            << " , " << display_vertex(vbb)
+            << " ) with edge ( " << display_vertex(vcc)
+            << " , " << display_vertex(vdd)
             << " )\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   Vertex_handle vi = insert_intersection(f, i, vaa, vbb, vcc, vdd, pa, pb, pc, pd, itag);
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_2::intersect, `vi` is ( #" << vi->time_stamp() << "= " << vi->point()
+            << "CT_2::intersect, `vi` is ( " << display_vertex(vi)
             << " )\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
 

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -129,6 +129,10 @@ public:
   using Triangulation::is_infinite;
   using Triangulation::number_of_vertices;
 #endif
+#ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
+  using Triangulation::display_vertex;
+#endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
+
 
   typedef typename Triangulation::Edge             Edge;
   typedef typename Triangulation::Vertex           Vertex;
@@ -275,8 +279,8 @@ public:
   {
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_plus_2::insert_constraint( #" << va->time_stamp() << "= " << va->point()
-            << " , #" << vb->time_stamp() << "= " << vb->point()
+            << "CT_plus_2::insert_constraint( " << display_vertex(va)
+            << " , " << display_vertex(vb)
             << " )\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
     // protects against inserting a zero length constraint
@@ -883,13 +887,13 @@ insert_subconstraint(Vertex_handle vaa,
 {
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_plus_2::insert_subconstraint( #" << vaa->time_stamp() << "= " << vaa->point()
-            << " , #" << vbb->time_stamp() << "= " << vbb->point()
+            << "CT_plus_2::insert_subconstraint( " << display_vertex(vaa)
+            << " , " << display_vertex(vbb)
             << " )\n";
   internal::Indentation_level::Exit_guard exit_guard = CGAL::internal::cdt_2_indent_level.open_new_scope();
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_plus_2::insert_constraint stack push [va, vb] ( #" << vaa->time_stamp() << "= " << vaa->point()
-            << " , #" << vbb->time_stamp() << "= " << vbb->point()
+            << "CT_plus_2::insert_constraint stack push [va, vb] ( " << display_vertex(vaa)
+            << " , " << display_vertex(vbb)
             << " )\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::stack<std::pair<Vertex_handle, Vertex_handle> > stack;
@@ -901,8 +905,8 @@ insert_subconstraint(Vertex_handle vaa,
     CGAL_precondition( vaa != vbb);
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
     std::cerr << CGAL::internal::cdt_2_indent_level
-              << "CT_plus_2::insert_subconstraint, stack pop=( #" << vaa->time_stamp() << "= " << vaa->point()
-              << " , #" << vbb->time_stamp() << "= " << vbb->point()
+              << "CT_plus_2::insert_subconstraint, stack pop=( " << display_vertex(vaa)
+              << " , " << display_vertex(vbb)
               << " ) remaining stack size: "
               << stack.size() << '\n';
     CGAL_assertion(this->is_valid());
@@ -914,8 +918,8 @@ insert_subconstraint(Vertex_handle vaa,
     if(this->includes_edge(vaa,vbb,vi,fr,i)) {
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
     std::cerr << CGAL::internal::cdt_2_indent_level
-              << "CT_plus_2::insert_subconstraint, the segment ( #" << vaa->time_stamp() << "= " << vaa->point()
-              << " , #" << vbb->time_stamp() << "= " << vbb->point()
+              << "CT_plus_2::insert_subconstraint, the segment ( " << display_vertex(vaa)
+              << " , " << display_vertex(vbb)
               << " ) is an edge with #"
               << vi->time_stamp() << "= " << vi->point()
               << '\n';
@@ -925,8 +929,8 @@ insert_subconstraint(Vertex_handle vaa,
         hierarchy.split_constraint(vaa,vbb,vi);
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_plus_2::insert_constraint (includes_edge) stack push [vi, vbb] ( #" << vi->time_stamp() << "= " << vi->point()
-            << " , #" << vbb->time_stamp() << "= " << vbb->point()
+            << "CT_plus_2::insert_constraint (includes_edge) stack push [vi, vbb] ( " << display_vertex(vi)
+            << " , " << display_vertex(vbb)
             << " )\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
         stack.push(std::make_pair(vi,vbb));
@@ -949,12 +953,12 @@ insert_subconstraint(Vertex_handle vaa,
         hierarchy.split_constraint(vaa,vbb,vi);
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_plus_2::insert_constraint stack push [vaa, vi] ( #" << vaa->time_stamp() << "= " << vaa->point()
-            << " , #" << vi->time_stamp() << "= " << vi->point()
+            << "CT_plus_2::insert_constraint stack push [vaa, vi] ( " << display_vertex(vaa)
+            << " , " << display_vertex(vi)
             << " )\n";
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_plus_2::insert_constraint stack push [vi, vbb] ( #" << vi->time_stamp() << "= " << vi->point()
-            << " , #" << vbb->time_stamp() << "= " << vbb->point()
+            << "CT_plus_2::insert_constraint stack push [vi, vbb] ( " << display_vertex(vi)
+            << " , " << display_vertex(vbb)
             << " )\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
         stack.push(std::make_pair(vaa,vi));
@@ -963,8 +967,8 @@ insert_subconstraint(Vertex_handle vaa,
       else {
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_plus_2::insert_constraint stack push [vaa, vbb]( #" << vaa->time_stamp() << "= " << vaa->point()
-            << " , #" << vbb->time_stamp() << "= " << vbb->point()
+            << "CT_plus_2::insert_constraint stack push [vaa, vbb]( " << display_vertex(vaa)
+            << " , " << display_vertex(vbb)
             << " )\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
         stack.push(std::make_pair(vaa,vbb));
@@ -1180,10 +1184,10 @@ intersect(Face_handle f, int i,
   const Point& pd = vd->point();
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_plus_2::intersect segment ( #" << va->time_stamp() << "= " << va->point()
-            << " , #" << vb->time_stamp() << "= " << vb->point()
+            << "CT_plus_2::intersect segment ( " << display_vertex(va)
+            << " , " << display_vertex(vb)
             << " ) with edge ( #"<< vc->time_stamp() << "= " << vc->point()
-            << " , #" << vd->time_stamp() << "= " << vd->point()
+            << " , " << display_vertex(vd)
             << " , Exact_intersections_tag)\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   Point pi(ORIGIN); // initialize although we are sure that it will be
@@ -1196,7 +1200,7 @@ intersect(Face_handle f, int i,
   Vertex_handle vi = insert(pi, Triangulation::EDGE, f, i);
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_plus_2::intersect, `vi` is ( #" << vi->time_stamp() << "= " << vi->point()
+            << "CT_plus_2::intersect, `vi` is ( " << display_vertex(vi)
             << " )\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   return vi;
@@ -1220,10 +1224,10 @@ intersect(Face_handle f, int i,
   const Point& pd = vdd->point();
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "CT_plus_2::intersect segment ( #" << vaa->time_stamp() << "= " << vaa->point()
-            << " , #" << vbb->time_stamp() << "= " << vbb->point()
+            << "CT_plus_2::intersect segment ( " << display_vertex(vaa)
+            << " , " << display_vertex(vbb)
             << " ) with edge ( #"<< vcc->time_stamp() << "= " << vcc->point()
-            << " , #" << vdd->time_stamp() << "= " << vdd->point()
+            << " , " << display_vertex(vdd)
             << " , Exact_predicates_tag)\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
 

--- a/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
@@ -25,7 +25,9 @@
 #include <CGAL/assertions.h>
 
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
+#  include <CGAL/IO/io.h>
 #  include <CGAL/Constrained_triangulation_2.h>
+#  include <iostream>
 #endif
 
 namespace CGAL {
@@ -861,11 +863,8 @@ insert_constraint(T va, T vb){
 
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "C_hierachy.insert_constraint( #"
-              << va->time_stamp()
-              << ", #"
-              << vb->time_stamp()
-              << ")\n";
+            << "C_hierachy.insert_constraint( "
+            << oformat(va) << ", " << oformat(vb) << ")\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   typename Sc_to_c_map::iterator scit = sc_to_c_map.find(he);
   if(scit == sc_to_c_map.end()){
@@ -898,11 +897,8 @@ insert_constraint_old_API(T va, T vb){
 
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "C_hierachy.insert_constraint_old_API( #"
-              << va->time_stamp()
-              << ", #"
-              << vb->time_stamp()
-              << ")\n";
+            << "C_hierachy.insert_constraint_old_API( "
+            << oformat(va) << ", " << oformat(vb) << ")\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   typename Sc_to_c_map::iterator scit = sc_to_c_map.find(he);
   if(scit == sc_to_c_map.end()){
@@ -933,11 +929,8 @@ append_constraint(Constraint_id cid, T va, T vb){
 
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "C_hierachy.append_constraint( ..., #"
-              << va->time_stamp()
-              << ", #"
-              << vb->time_stamp()
-              << ")\n";
+            << "C_hierachy.append_constraint( ..., "
+            << oformat(va) << ", " << oformat(vb) << ")\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   typename Sc_to_c_map::iterator scit = sc_to_c_map.find(he);
   if(scit == sc_to_c_map.end()){
@@ -1052,13 +1045,9 @@ Polyline_constraint_hierarchy_2<T,Compare,Point>::
 add_Steiner(T va, T vb, T vc){
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
   std::cerr << CGAL::internal::cdt_2_indent_level
-            << "C_hierachy.add_Steinter( #"
-              << va->time_stamp()
-              << ", #"
-              << vb->time_stamp()
-              << ", #"
-              << vc->time_stamp()
-              << ")\n";
+            << "C_hierachy.add_Steinter( "
+            << oformat(va) << ", " << oformat(vb) << ", " << oformat(vc)
+            << ")\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   Context_list* hcl=nullptr;
   if(!get_contexts(va,vb,hcl)) {

--- a/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
@@ -862,6 +862,7 @@ insert_constraint(T va, T vb){
   Context_list* fathers;
 
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
+  using CGAL::IO::oformat;
   std::cerr << CGAL::internal::cdt_2_indent_level
             << "C_hierachy.insert_constraint( "
             << oformat(va) << ", " << oformat(vb) << ")\n";
@@ -896,6 +897,7 @@ insert_constraint_old_API(T va, T vb){
   Context_list* fathers;
 
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
+  using CGAL::IO::oformat;
   std::cerr << CGAL::internal::cdt_2_indent_level
             << "C_hierachy.insert_constraint_old_API( "
             << oformat(va) << ", " << oformat(vb) << ")\n";
@@ -928,6 +930,7 @@ append_constraint(Constraint_id cid, T va, T vb){
   Context_list* fathers;
 
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
+  using CGAL::IO::oformat;
   std::cerr << CGAL::internal::cdt_2_indent_level
             << "C_hierachy.append_constraint( ..., "
             << oformat(va) << ", " << oformat(vb) << ")\n";
@@ -1044,6 +1047,7 @@ void
 Polyline_constraint_hierarchy_2<T,Compare,Point>::
 add_Steiner(T va, T vb, T vc){
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
+  using CGAL::IO::oformat;
   std::cerr << CGAL::internal::cdt_2_indent_level
             << "C_hierachy.add_Steinter( "
             << oformat(va) << ", " << oformat(vb) << ", " << oformat(vc)

--- a/Triangulation_2/test/Triangulation_2/issue_4405.cpp
+++ b/Triangulation_2/test/Triangulation_2/issue_4405.cpp
@@ -4,39 +4,12 @@
 #include <CGAL/Projection_traits_xy_3.h>
 #include <CGAL/Triangulation_face_base_with_info_2.h>
 #include <CGAL/Triangulation_vertex_base_with_id_2.h>
+#include <CGAL/Base_with_time_stamp.h>
 
 typedef CGAL::Epick Kernel;
 typedef Kernel::FT FieldNumberType;
 typedef Kernel::Point_2 Point2;
 typedef Kernel::Point_3 Point3;
-
-template <typename Vb>
-class My_vertex_base : public Vb {
-  std::size_t time_stamp_;
-public:
-  My_vertex_base() : Vb(), time_stamp_(-1) {
-  }
-
-  My_vertex_base(const My_vertex_base& other) :
-    Vb(other),
-    time_stamp_(other.time_stamp_)
-  {}
-
-  typedef CGAL::Tag_true Has_timestamp;
-
-  std::size_t time_stamp() const {
-    return time_stamp_;
-  }
-  void set_time_stamp(const std::size_t& ts) {
-    time_stamp_ = ts;
-  }
-
-  template < class TDS >
-  struct Rebind_TDS {
-    typedef typename Vb::template Rebind_TDS<TDS>::Other Vb2;
-    typedef My_vertex_base<Vb2> Other;
-  };
-};
 
 struct FaceInfo2
 {
@@ -44,7 +17,7 @@ struct FaceInfo2
 };
 typedef CGAL::Projection_traits_xy_3<Kernel> TriangulationTraits;
 typedef CGAL::Triangulation_vertex_base_with_id_2<TriangulationTraits> VertexBaseWithId;
-typedef My_vertex_base<VertexBaseWithId> Vb2;
+typedef CGAL::Base_with_time_stamp<VertexBaseWithId> Vb2;
 typedef CGAL::Triangulation_vertex_base_2<TriangulationTraits, Vb2> VertexBase;
 typedef CGAL::Triangulation_face_base_with_info_2<FaceInfo2, Kernel> FaceBaseWithInfo;
 typedef CGAL::Constrained_triangulation_face_base_2<TriangulationTraits, FaceBaseWithInfo> FaceBase;

--- a/Triangulation_2/test/Triangulation_2/test_cdt_degenerate_case.cpp
+++ b/Triangulation_2/test/Triangulation_2/test_cdt_degenerate_case.cpp
@@ -2,41 +2,14 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Constrained_Delaunay_triangulation_2.h>
 #include <CGAL/Constrained_triangulation_plus_2.h>
+#include <CGAL/Base_with_time_stamp.h>
 #include <iostream>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel EPIC;
 typedef EPIC::Point_2 Point_2;
 
-template <typename Vb>
-class My_vertex_base : public Vb {
-  std::size_t time_stamp_;
-public:
-  My_vertex_base() : Vb(), time_stamp_(-1) {
-  }
-
-  My_vertex_base(const My_vertex_base& other) :
-    Vb(other),
-    time_stamp_(other.time_stamp_)
-  {}
-
-  typedef CGAL::Tag_true Has_timestamp;
-
-  std::size_t time_stamp() const {
-    return time_stamp_;
-  }
-  void set_time_stamp(const std::size_t& ts) {
-    time_stamp_ = ts;
-  }
-
-  template < class TDS >
-  struct Rebind_TDS {
-    typedef typename Vb::template Rebind_TDS<TDS>::Other Vb2;
-    typedef My_vertex_base<Vb2> Other;
-  };
-};
-
 #ifdef CGAL_CDT_2_DEBUG_INTERSECTIONS
-typedef My_vertex_base<CGAL::Triangulation_vertex_base_2<EPIC> > Vb;
+typedef CGAL::Base_with_time_stamp<CGAL::Triangulation_vertex_base_2<EPIC> > Vb;
 #else
 typedef CGAL::Triangulation_vertex_base_2<K> Vb;
 #endif


### PR DESCRIPTION
## Summary of Changes

This pull-request has three commits:
  - Introduce `Base_with_time_stamp`, that introduces a real vertex base template class, instead of various ad-hoc solutions in various places.
  - Use `Output_rep` to display debug info, that introduces a nice way to display the debug information about vertices in CDT_2 debug messages.
  - `Circulator_from_container<const Container>` now works... because otherwise that was a hamper against adding `const`.

## Release Management

* Affected package(s): STL_Extension, Circulator (that should be merged into `STL_Extension`), and `Triangulation_2`
* License and copyright ownership: maintenance by GeometryFactory, ownership unchanged.

