### PR TITLE
Fix CMAKE_NO_SYSTEM_FROM_IMPORTED

### DIFF
--- a/Installation/lib/cmake/CGAL/CGALConfig.cmake
+++ b/Installation/lib/cmake/CGAL/CGALConfig.cmake
@@ -115,6 +115,18 @@ include(${CGAL_MODULES_DIR}/CGAL_enable_end_of_configuration_hook.cmake)
 
 set(CGAL_USE_FILE ${CGAL_MODULES_DIR}/UseCGAL.cmake)
 
+include(${CGAL_CONFIG_DIR}/CGALConfigVersion.cmake)
+
+# Temporary? Change the CMAKE module path
+cgal_setup_module_path()
+
+include(${CGAL_MODULES_DIR}/CGAL_target_use_TBB.cmake)
+
+if( CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST OR CGAL_TEST_SUITE )
+  # Do not use -isystem for CGAL include paths
+  set(CMAKE_NO_SYSTEM_FROM_IMPORTED TRUE)
+endif()
+
 foreach(comp ${CGAL_FIND_COMPONENTS})
   if(NOT comp MATCHES "Core|ImageIO|Qt5")
     message(FATAL_ERROR "The requested CGAL component ${comp} does not exist!")
@@ -184,19 +196,3 @@ if (NOT TARGET CGAL::CGAL_Basic_viewer)
       INTERFACE_LINK_LIBRARIES CGAL::CGAL_Qt5)
 endif()
 
-include(${CGAL_CONFIG_DIR}/CGALConfigVersion.cmake)
-
-#
-#
-#
-
-# Temporary? Change the CMAKE module path
-cgal_setup_module_path()
-
-set(CGAL_USE_FILE ${CGAL_MODULES_DIR}/UseCGAL.cmake)
-include(${CGAL_MODULES_DIR}/CGAL_target_use_TBB.cmake)
-
-if( CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST OR CGAL_TEST_SUITE )
-  # Do not use -isystem for CGAL include paths
-  set(CMAKE_NO_SYSTEM_FROM_IMPORTED TRUE)
-endif()


### PR DESCRIPTION
## Summary of Changes

With the current `master`, if one configure all CGAL with `-DWITH_examples=ON`, `-DWITH_tests=ON`... then the compiler warnings are disable for tests (but not for examples).

This pull-request fixes the situation, until I can find a better workaround.

## Release Management

This PR is a bug-fix... but it has conflicts with CGAL-5.4.x and 5.5.x. I have decided to push it to `master` only, given that the impact is probably quite limited to myself only.

* Affected package(s): Installation

