### PR TITLE
Use CGAL_assertion_code()

### DIFF
--- a/Nef_2/include/CGAL/Nef_2/PM_checker.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_checker.h
@@ -220,7 +220,7 @@ check_boundary_is_clockwise_weakly_polygon() const
   } while (hvit != hend);
   // now e_boundary_at_v_min is highest starting edge in bundle!!
 
-  int winding_around_globally=0;
+  CGAL_assertion_code(int winding_around_globally=0);
   Halfedge_around_face_const_circulator
     hfit(e_boundary_at_v_min),hstart(hfit);
   Halfedge_const_handle e_prev = next(e_boundary_at_v_min);
@@ -229,7 +229,7 @@ check_boundary_is_clockwise_weakly_polygon() const
   Direction d_prev = direction(e_prev);
   CGAL_For_all_backwards(hstart,hfit) {
     Direction d_curr = direction(hfit);
-    if ( d_curr < d_prev ) ++winding_around_globally;
+    CGAL_assertion_code(if ( d_curr < d_prev ) ++winding_around_globally);
     d_prev = d_curr;
   }
   CGAL_assertion(winding_around_globally == 1);
@@ -262,10 +262,10 @@ check_is_triangulation() const
   for( eit = this->halfedges_begin(); eit != this->halfedges_end(); ++eit) {
     if (on_boundary[eit]) continue;
     hit = hend = eit;
-    int edges_in_face_cycle=0;
+    CGAL_assertion_code(int edges_in_face_cycle=0);
     CGAL_For_all(hit,hend) {
       error_status << PE(hit);
-      ++edges_in_face_cycle;
+      CGAL_assertion_code(++edges_in_face_cycle);
     }
     CGAL_assertion_msg(edges_in_face_cycle==3,error_status.str().c_str());
     CGAL_assertion_msg(

--- a/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
@@ -299,13 +299,13 @@ check_integrity_and_topological_planarity(bool faces) const
     EI(shalfedges_begin(),shalfedges_end(),'e');
 #endif
   SVertex_const_handle v;
-  int iso_vert_num=0;
+  CGAL_assertion_code(int iso_vert_num=0);
   /* check the source links of out edges and count isolated vertices */
   CGAL_forall_svertices(v,*this) {
     if ( is_isolated(v) ) {
       if ( faces )
         CGAL_assertion_msg(v->incident_sface() != SFace_const_handle(), get_svertex_index(v).c_str());
-      ++iso_vert_num;
+      CGAL_assertion_code(++iso_vert_num);
     } else {
       CGAL_assertion_code(SHalfedge_const_handle e=first_out_edge(v));
       CGAL_assertion_msg(e != SHalfedge_const_handle(), get_svertex_index(v).c_str());

--- a/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/scene.h
+++ b/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/scene.h
@@ -432,10 +432,10 @@ public:
 
     m_pwsrec->list_output(std::back_inserter(isolated_points), std::back_inserter(edges));
 
-    int vertex_count = 0;
+    CGAL_assertion_code(int vertex_count = 0);
     for (std::vector<Point>::iterator it = isolated_points.begin();
       it != isolated_points.end(); it++) {
-      vertex_count++;
+      CGAL_assertion_code(vertex_count++);
       std::cout << *it << std::endl;
     }
     CGAL_assertion(vertex_count == 18);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Snapping/snap.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Snapping/snap.h
@@ -112,7 +112,9 @@ void simplify_range(HalfedgeRange& halfedge_range,
 
   std::set<halfedge_descriptor> edges_to_test(halfedge_range.begin(), halfedge_range.end());
 
+#ifdef CGAL_PMP_SNAP_DEBUG
   int collapsed_n = 0;
+#endif
   while(!edges_to_test.empty())
   {
     const halfedge_descriptor h = *(edges_to_test.begin());
@@ -165,8 +167,9 @@ void simplify_range(HalfedgeRange& halfedge_range,
           edges_to_test.insert(prev_h);
         if(next_h!=opoh && get(range_halfedges, next_h))
           edges_to_test.insert(next_h);
-
+#ifdef CGAL_PMP_SNAP_DEBUG
         ++collapsed_n;
+#endif
       }
     }
   }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Snapping/snap.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Snapping/snap.h
@@ -112,9 +112,8 @@ void simplify_range(HalfedgeRange& halfedge_range,
 
   std::set<halfedge_descriptor> edges_to_test(halfedge_range.begin(), halfedge_range.end());
 
-#ifdef CGAL_PMP_SNAP_DEBUG
   int collapsed_n = 0;
-#endif
+
   while(!edges_to_test.empty())
   {
     const halfedge_descriptor h = *(edges_to_test.begin());
@@ -167,13 +166,11 @@ void simplify_range(HalfedgeRange& halfedge_range,
           edges_to_test.insert(prev_h);
         if(next_h!=opoh && get(range_halfedges, next_h))
           edges_to_test.insert(next_h);
-#ifdef CGAL_PMP_SNAP_DEBUG
         ++collapsed_n;
-#endif
       }
     }
   }
-
+  CGAL_USE(collapsed_n);
 #ifdef CGAL_PMP_SNAP_DEBUG
   std::cout << "collapsed " << collapsed_n << " edges" << std::endl;
 #endif

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -1313,7 +1313,7 @@ void dump_surface_off(const Tr& tr, const char* filename)
   }
 
   //write facets
-  std::size_t nbf_print = 0;
+  CGAL_assertion_code(std::size_t nbf_print = 0);
   for (Finite_facets_iterator fit = tr.finite_facets_begin();
        fit != tr.finite_facets_end(); ++fit)
   {
@@ -1324,7 +1324,7 @@ void dump_surface_off(const Tr& tr, const char* filename)
       ofs << "3  " << vertices.left.at(c->vertex((i + 1) % 4)) << " "
           << vertices.left.at(c->vertex((i + 2) % 4)) << " "
           << vertices.left.at(c->vertex((i + 3) % 4)) << std::endl;
-      ++nbf_print;
+      CGAL_assertion_code(++nbf_print);
     }
   }
   CGAL_assertion(nbf == nbf_print);
@@ -1581,7 +1581,7 @@ void dump_facets_in_complex(const C3t3& c3t3, const char* filename)
   }
 
   //write facets
-  std::size_t nbf_print = 0;
+  CGAL_assertion_code(std::size_t nbf_print = 0);
   for (Facets_in_complex_iterator fit = c3t3.facets_in_complex_begin();
        fit != c3t3.facets_in_complex_end(); ++fit)
   {
@@ -1590,7 +1590,7 @@ void dump_facets_in_complex(const C3t3& c3t3, const char* filename)
     ofs << "3  " << vertices.left.at(c->vertex((i + 1) % 4)) << " "
         << vertices.left.at(c->vertex((i + 2) % 4)) << " "
         << vertices.left.at(c->vertex((i + 3) % 4)) << std::endl;
-    ++nbf_print;
+    CGAL_assertion_code(++nbf_print);
   }
   CGAL_assertion(nbf == nbf_print);
 


### PR DESCRIPTION
## Summary of Changes

Address warnings in several packages in this [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/results-5.6-Ic-175.shtml) all similar to:
`include/CGAL/Nef_S2/SM_const_decorator.h:302:7: warning: variable 'iso_vert_num' set but not used [-Wunused-but-set-variable]`

Concerning SLS it is already fixed in another PR.

## Release Management

* Affected package(s):  Nef_2, Nef_S2,  Optimal_transport, PMP, Tetrahedral_remeshing, 
