### PR TITLE
Surface Mesh Simplification: Improve Examples

### DIFF
--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_bounded_normal_change.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_bounded_normal_change.cpp
@@ -52,7 +52,7 @@ int main(int argc, char** argv)
   // This is a stop predicate (defines when the algorithm terminates).
   // In this example, the simplification stops when the number of undirected edges
   // left in the surface mesh drops below the specified number
-  const std::size_t stop_n = (argc > 2) ? std::stoi(argv[2]) : num_halfedges(surface_mesh)/2 - 1;
+  const std::size_t stop_n = (argc > 2) ? std::stoi(argv[2]) : num_edges(surface_mesh)/2 - 1;
   SMS::Edge_count_stop_predicate<Surface_mesh> stop(stop_n);
 
   typedef SMS::LindstromTurk_placement<Surface_mesh> Placement;


### PR DESCRIPTION
## Summary of Changes

The first improvement is to collapse half of the edges and not just one, as consequence of a typo.

We should also switch from `operator>>()`   to functions that can read formats different from `.off`.

## Release Management

* Affected package(s): Surface_mesh_simplification

