### PR TITLE
Email notifications about changes to the GitHub wiki

### DIFF
--- a/.github/workflows/send_email.yml
+++ b/.github/workflows/send_email.yml
@@ -1,4 +1,4 @@
-name: Send Email 
+name: Send Email using SSH
 
 on:
   workflow_call:
@@ -7,14 +7,14 @@ on:
         description: 'Message to send'
         required: true
         type: string
-      email:
-        description: 'Email address to send to'
-        required: true
-        type: string
     secrets:
+      email:
+        required: true
       private_key:
         required: true
       user:
+        required: true
+      host:
         required: true
 
 jobs:
@@ -25,7 +25,7 @@ jobs:
       run: |
         install -m 600 -D /dev/null ~/.ssh/id_rsa
         echo "${{ secrets.private_key }}" > ~/.ssh/id_rsa
-        ssh-keyscan -H ${{ vars.CGAL_SEND_EMAIL_SSH_HOST }} > ~/.ssh/known_hosts
+        ssh-keyscan -H ${{ secrets.host }} > ~/.ssh/known_hosts
     - name: send email via ssh
       run: |
-        echo "${{ inputs.message }}" | ssh  ${{ secrets.user }}@${{ vars.CGAL_SEND_EMAIL_SSH_HOST }} "/sbin/sendmail -t ${{ inputs.email }}"
+        echo "${{ inputs.message }}" | ssh  ${{ secrets.user }}@${{ secrets.host }} "/sbin/sendmail -t ${{ secrets.email }}"

--- a/.github/workflows/send_email.yml
+++ b/.github/workflows/send_email.yml
@@ -1,0 +1,31 @@
+name: Send Email 
+
+on:
+  workflow_call:
+    inputs:
+      message:
+        description: 'Message to send'
+        required: true
+        type: string
+      email:
+        description: 'Email address to send to'
+        required: true
+        type: string
+    secrets:
+      private_key:
+        required: true
+      user:
+        required: true
+
+jobs:
+  send_email:
+    runs-on: ubuntu-latest
+    steps:
+    - name: install ssh keys
+      run: |
+        install -m 600 -D /dev/null ~/.ssh/id_rsa
+        echo "${{ secrets.private_key }}" > ~/.ssh/id_rsa
+        ssh-keyscan -H ${{ vars.CGAL_SEND_EMAIL_SSH_HOST }} > ~/.ssh/known_hosts
+    - name: send email via ssh
+      run: |
+        echo "${{ inputs.message }}" | ssh  ${{ secrets.user }}@${{ vars.CGAL_SEND_EMAIL_SSH_HOST }} "/sbin/sendmail -t ${{ inputs.email }}"

--- a/.github/workflows/wiki_notification.yml
+++ b/.github/workflows/wiki_notification.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
     - name: get informations from api and prepare email messages
       run: |
-        response=$(curl -s https://api.github.com/repos/saillantnicolas/cgal/events)
+        response=$(curl -s https://api.github.com/repos/cgal/cgal/events)
         eventcount=$(echo "$response" | jq '. | length')
         for ((i=eventcount; i>=0; i--))
         do

--- a/.github/workflows/wiki_notification.yml
+++ b/.github/workflows/wiki_notification.yml
@@ -15,12 +15,15 @@ jobs:
         result-encoding: string
         script: |
           const payload = context.payload;
-          const actor = payload.sender.login;
+          const actor = payload.sender;
           const pages = payload.pages;
-          let messages = "Subject:Updates to CGAL Wiki \n";
+          let messages = "Subject:Updates to CGAL Wiki \nContent-Type: text/html\n";
+          messages += "<html><body>";
+          messages += `<p>The following CGAL Wiki page were modified by <a href="${actor.html_url}">"${actor.login}"</a></p><ul>\n`
           for (const page of pages){
-              messages += `The CGAL Wiki page "${page.title}" was ${page.action} by ${actor}.\n`;
+              messages += `<li><a href="${page.html_url}"> ${page.title}</a></li>\n`;
           }
+          messages += "</ul></body></html>";
           console.log( messages );
           return messages;
   call_send_email:

--- a/.github/workflows/wiki_notification.yml
+++ b/.github/workflows/wiki_notification.yml
@@ -1,0 +1,45 @@
+name: Wiki Notification
+
+on: [gollum,workflow_dispatch]
+  
+
+jobs:
+  run_script:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: get informations from api and prepare email messages
+      run: |
+        response=$(curl -s https://api.github.com/repos/saillantnicolas/cgal/events)
+        eventcount=$(echo "$response" | jq '. | length')
+        for ((i=eventcount; i>=0; i--))
+        do
+            if [ "$(echo "$response" | jq -r '.['$i'].type')" == "GollumEvent" ];
+            then
+                event=$(echo "$response" | jq '.['$i']')
+            fi
+        done
+        actor=$(echo "$event" | jq '.actor.login' | tr -d '"')
+        count=$(echo "$event" | jq  '.payload.pages | length')
+        date=$(echo "$event" | jq '.created_at' | tr -d '"')
+        echo -e "Subject:Cgal wiki has been updated \n" >> messages.txt
+        for ((i=0; i<count; i++)); do
+          action=$(echo "$event" | jq '.payload.pages['$i'].action' | tr -d '"')
+          wiki_page=$(echo "$event" | jq '.payload.pages['$i'].title' | tr -d '"')
+          page_url=$(echo "$event" | jq '.payload.pages['$i'].html_url' | tr -d '"')
+          echo "Page $i" >> messages.txt
+          echo "Actor : $actor" >> messages.txt
+          echo "Action : $action" >> messages.txt
+          echo "Wiki Page : $wiki_page" >> messages.txt
+          echo "Page URL : $page_url" >> messages.txt
+          echo "History : $page_url/_history" >> messages.txt
+          echo "Date : $date" >> messages.txt
+        done
+    - name: install ssh keys
+      run: |
+        install -m 600 -D /dev/null ~/.ssh/id_rsa
+        echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
+        ssh-keyscan -H ${{ vars.SSH_HOST }} > ~/.ssh/known_hosts
+    - name: send email via ssh
+      run: |
+        cat messages.txt | ssh ${{ secrets.SSH_USER }}@${{ vars.SSH_HOST }} "/sbin/sendmail -t ${{ vars.SEND_EMAIL_TO }}"

--- a/.github/workflows/wiki_notification.yml
+++ b/.github/workflows/wiki_notification.yml
@@ -1,7 +1,7 @@
 name: Wiki Notification
 
 on: gollum
-  
+
 jobs:
   prepare_email:
     runs-on: ubuntu-latest
@@ -28,7 +28,8 @@ jobs:
     uses: ./.github/workflows/send_email.yml
     with:
       message: ${{needs.prepare_email.outputs.messages}}
-      email: ${{ vars.SEND_EMAIL_TO }}
     secrets:
-      private_key: ${{ secrets.CGAL_SEND_EMAIL_SSH_PRIVATE_KEY }}
-      user: ${{ secrets.CGAL_SEND_EMAIL_SSH_USER }}
+      email: ${{ secrets.CGAL_SEND_WIKI_EMAIL_TO }}
+      private_key: ${{ secrets.CGAL_SEND_WIKI_EMAIL_SSH_PRIVATE_KEY }}
+      user: ${{ secrets.CGAL_SEND_WIKI_EMAIL_SSH_USER }}
+      host: ${{ secrets.CGAL_SEND_WIKI_EMAIL_SSH_HOST }}

--- a/.github/workflows/wiki_notification.yml
+++ b/.github/workflows/wiki_notification.yml
@@ -1,45 +1,34 @@
 name: Wiki Notification
 
-on: [gollum,workflow_dispatch]
+on: gollum
   
-
 jobs:
-  run_script:
+  prepare_email:
     runs-on: ubuntu-latest
-
+    outputs:
+      messages: ${{ steps.set-result.outputs.result }}
     steps:
-    - name: get informations from api and prepare email messages
-      run: |
-        response=$(curl -s https://api.github.com/repos/cgal/cgal/events)
-        eventcount=$(echo "$response" | jq '. | length')
-        for ((i=eventcount; i>=0; i--))
-        do
-            if [ "$(echo "$response" | jq -r '.['$i'].type')" == "GollumEvent" ];
-            then
-                event=$(echo "$response" | jq '.['$i']')
-            fi
-        done
-        actor=$(echo "$event" | jq '.actor.login' | tr -d '"')
-        count=$(echo "$event" | jq  '.payload.pages | length')
-        date=$(echo "$event" | jq '.created_at' | tr -d '"')
-        echo -e "Subject:Cgal wiki has been updated \n" >> messages.txt
-        for ((i=0; i<count; i++)); do
-          action=$(echo "$event" | jq '.payload.pages['$i'].action' | tr -d '"')
-          wiki_page=$(echo "$event" | jq '.payload.pages['$i'].title' | tr -d '"')
-          page_url=$(echo "$event" | jq '.payload.pages['$i'].html_url' | tr -d '"')
-          echo "Page $i" >> messages.txt
-          echo "Actor : $actor" >> messages.txt
-          echo "Action : $action" >> messages.txt
-          echo "Wiki Page : $wiki_page" >> messages.txt
-          echo "Page URL : $page_url" >> messages.txt
-          echo "History : $page_url/_history" >> messages.txt
-          echo "Date : $date" >> messages.txt
-        done
-    - name: install ssh keys
-      run: |
-        install -m 600 -D /dev/null ~/.ssh/id_rsa
-        echo "${{ secrets.SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
-        ssh-keyscan -H ${{ vars.SSH_HOST }} > ~/.ssh/known_hosts
-    - name: send email via ssh
-      run: |
-        cat messages.txt | ssh ${{ secrets.SSH_USER }}@${{ vars.SSH_HOST }} "/sbin/sendmail -t ${{ vars.SEND_EMAIL_TO }}"
+    - name: get informations and prepare email
+      uses: actions/github-script@v6
+      id: set-result
+      with:
+        result-encoding: string
+        script: |
+          const payload = context.payload;
+          const actor = payload.sender.login;
+          const pages = payload.pages;
+          let messages = "Subject:Updates to CGAL Wiki \n";
+          for (const page of pages){
+              messages += `The CGAL Wiki page "${page.title}" was ${page.action} by ${actor}.\n`;
+          }
+          console.log( messages );
+          return messages;
+  call_send_email:
+    needs: prepare_email
+    uses: ./.github/workflows/send_email.yml
+    with:
+      message: ${{needs.prepare_email.outputs.messages}}
+      email: ${{ vars.SEND_EMAIL_TO }}
+    secrets:
+      private_key: ${{ secrets.CGAL_SEND_EMAIL_SSH_PRIVATE_KEY }}
+      user: ${{ secrets.CGAL_SEND_EMAIL_SSH_USER }}


### PR DESCRIPTION
## Summary of Changes

Adding a workflow to send email notifications when a change is made on the wiki.
Sometimes the action is executed before the github api updates and therefore the email information does not match the last change.

## Release Management

* Issue(s) solved (if any): https://github.com/CGAL/cgal/issues/2000

Edit by @lrineau: note that this PR, as with all modifications to `.github/`, cannot be tested in `integration`.
