### PR TITLE
Nef_3: Use the skipVEL parameter to ensure result is always an SFace

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SNC_const_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_const_decorator.h
@@ -269,7 +269,7 @@ public:
     sp = Infi_box::simplify(sp);
     CGAL_NEF_TRACEN( "Locating "<<sp <<" in "<<v->point());
     SM_point_locator L(&*v);
-    Object_handle o = L.locate(sp);
+    Object_handle o = L.locate(sp, true);
 
     SFace_handle sf;
     if(!CGAL::assign(sf,o)) {


### PR DESCRIPTION
## Summary of Changes

This sets the skipVEL (Skip SVertices SEdges and SLoops) parameter to true, when calling the locate method in `get_visible_facet` of SNC_const_decorator.  Since it's trying to locate an Sface, it makes no sense for locate to match SVertices, SEdges or SLoops, and if it does the assertion in get_visible_facet will fail.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): #7271 
* Feature/Small Feature (if any): bugfix
* License and copyright ownership: CGAL authors

