### PR TITLE
Mesh_3: Improve Sizing_field_with_aabb_tree speed

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/experimental/AABB_filtered_projection_traits.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/AABB_filtered_projection_traits.h
@@ -79,6 +79,35 @@ public:
   }
 
   template <typename IndexToIgnoreIterator>
+  Filtered_projection_traits(const Point_and_primitive_id& hint,
+                             IndexToIgnoreIterator begin,
+                             IndexToIgnoreIterator end,
+                             const AABBTraits& aabb_traits,
+                             IndexPropertyMap index_map = IndexPropertyMap())
+    : m_closest_point(hint.first),
+      m_closest_primitive(hint.second),
+      m_closest_point_initialized(true),
+      set_of_indices(begin, end),
+      aabb_traits(aabb_traits),
+      index_map(index_map)
+  {
+  }
+
+  Filtered_projection_traits(const Point_and_primitive_id& hint,
+                             Index_type index,
+                             const AABBTraits& aabb_traits,
+                             IndexPropertyMap index_map = IndexPropertyMap())
+    : m_closest_point(hint.first),
+      m_closest_primitive(hint.second),
+      m_closest_point_initialized(true),
+      set_of_indices(),
+      aabb_traits(aabb_traits),
+      index_map(index_map)
+  {
+    set_of_indices.insert(index);
+  }
+
+  template <typename IndexToIgnoreIterator>
   Filtered_projection_traits(IndexToIgnoreIterator begin,
                              IndexToIgnoreIterator end,
                              const AABBTraits& aabb_traits,

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/AABB_filtered_projection_traits.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/AABB_filtered_projection_traits.h
@@ -57,25 +57,20 @@ public:
                              IndexToIgnoreIterator end,
                              const AABBTraits& aabb_traits,
                              IndexPropertyMap index_map = IndexPropertyMap())
-    : m_closest_point(hint),
-      m_closest_point_initialized(true),
-      set_of_indices(begin, end),
-      aabb_traits(aabb_traits),
-      index_map(index_map)
+    : Filtered_projection_traits(begin, end, aabb_traits, index_map)
   {
+    m_closest_point = hint;
+    m_closest_point_initialized = true;
   }
 
   Filtered_projection_traits(const Point_3& hint,
                              Index_type index,
                              const AABBTraits& aabb_traits,
                              IndexPropertyMap index_map = IndexPropertyMap())
-    : m_closest_point(hint),
-      m_closest_point_initialized(true),
-      set_of_indices(),
-      aabb_traits(aabb_traits),
-      index_map(index_map)
+    : Filtered_projection_traits(index, aabb_traits, index_map)
   {
-    set_of_indices.insert(index);
+    m_closest_point = hint;
+    m_closest_point_initialized = true;
   }
 
   template <typename IndexToIgnoreIterator>
@@ -84,27 +79,18 @@ public:
                              IndexToIgnoreIterator end,
                              const AABBTraits& aabb_traits,
                              IndexPropertyMap index_map = IndexPropertyMap())
-    : m_closest_point(hint.first),
-      m_closest_primitive(hint.second),
-      m_closest_point_initialized(true),
-      set_of_indices(begin, end),
-      aabb_traits(aabb_traits),
-      index_map(index_map)
+    : Filtered_projection_traits(hint.first, begin, end, aabb_traits, index_map)
   {
+    m_closest_primitive = hint.second;
   }
 
   Filtered_projection_traits(const Point_and_primitive_id& hint,
                              Index_type index,
                              const AABBTraits& aabb_traits,
                              IndexPropertyMap index_map = IndexPropertyMap())
-    : m_closest_point(hint.first),
-      m_closest_primitive(hint.second),
-      m_closest_point_initialized(true),
-      set_of_indices(),
-      aabb_traits(aabb_traits),
-      index_map(index_map)
+    : Filtered_projection_traits(hint.first, index, aabb_traits, index_map)
   {
-    set_of_indices.insert(index);
+    m_closest_primitive = hint.second;
   }
 
   template <typename IndexToIgnoreIterator>
@@ -112,8 +98,7 @@ public:
                              IndexToIgnoreIterator end,
                              const AABBTraits& aabb_traits,
                              IndexPropertyMap index_map = IndexPropertyMap())
-    : m_closest_point_initialized(false),
-      set_of_indices(begin, end),
+    : set_of_indices(begin, end),
       aabb_traits(aabb_traits),
       index_map(index_map)
   {
@@ -122,12 +107,10 @@ public:
   Filtered_projection_traits(Index_type index,
                              const AABBTraits& aabb_traits,
                              IndexPropertyMap index_map = IndexPropertyMap())
-    : m_closest_point_initialized(false),
-      set_of_indices(),
+    : set_of_indices({index}),
       aabb_traits(aabb_traits),
       index_map(index_map)
   {
-    set_of_indices.insert(index);
   }
 
   bool go_further() const { return true; }
@@ -180,7 +163,7 @@ public:
 private:
   Point_3 m_closest_point;
   typename Primitive::Id m_closest_primitive;
-  bool m_closest_point_initialized;
+  bool m_closest_point_initialized = false;
   Set_of_indices set_of_indices;
   const AABBTraits& aabb_traits;
   IndexPropertyMap index_map;

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
@@ -376,7 +376,7 @@ struct Sizing_field_with_aabb_tree
       if(!d_ptr->aabb_tree.empty()) {
         //Compute distance to surface patches
         const auto closest_point_and_primitive = closest_point_on_surfaces(p, ids);
-        if(closest_point_and_primitive != boost::none) {
+        if(closest_point_and_primitive == boost::none) {
 #ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
           std::cerr << result << " (projection not found)\n";
 #endif // CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
@@ -84,9 +84,9 @@ struct Sizing_field_with_aabb_tree
     Facet_patch_id_map index_map{};
 
     bool go_further() const { return true; }
-    bool do_intersect(std::nullptr_t, const auto&) { return true; }
+    template <typename T> bool do_intersect(std::nullptr_t, const T&) { return true; }
 
-    void intersection(std::nullptr_t, const auto& primitive) {
+    template <typename P> void intersection(std::nullptr_t, const P& primitive) {
       const Patch_index id = get(index_map, primitive.id());
       if (id < min) min = id;
       if (id > max) max = id;

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
@@ -129,12 +129,12 @@ struct Sizing_field_with_aabb_tree
       };
 
       struct Visit_all_primitives {
-        decltype(push_vertex) push_vertex;
+        decltype(push_vertex) register_vertex;
         bool go_further() const { return true; }
         bool do_intersect(std::nullptr_t, const Node&) { return true; }
         void intersection(std::nullptr_t, const Primitive& primitive)
         {
-          push_vertex(primitive);
+          register_vertex(primitive);
         }
       } visit_all_primitives{push_vertex};
       d_ptr->aabb_tree.traversal(nullptr, visit_all_primitives);

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
@@ -232,7 +232,7 @@ struct Sizing_field_with_aabb_tree
     boost::optional<Point_and_primitive_id> result{};
     if(d_ptr->aabb_tree.empty()) return result;
     for(std::size_t i = 0; i < d_ptr->kd_trees_ptrs.size(); ++i) {
-      const auto patch_id = i + d_ptr->min_patch_id;
+      const auto patch_id = static_cast<Patch_index>(i + d_ptr->min_patch_id);
       if(patch_ids_to_ignore.find(patch_id) != patch_ids_to_ignore.end()) continue;
       if(d_ptr->kd_trees_ptrs[i]) {
         const Kd_tree& kd_tree = *d_ptr->kd_trees_ptrs[i];

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
@@ -120,11 +120,11 @@ struct Sizing_field_with_aabb_tree
       // possible.
       for(Curve_index curve_index : incident_curves) {
         if(domain.is_loop(curve_index)) {
-          FT curve_lenght = d_ptr->domain.curve_length(curve_index);
+          FT curve_length = d_ptr->domain.curve_length(curve_index);
           Point_3 other_point =
             d_ptr->domain.construct_point_on_curve(pair.first,
                                                    curve_index,
-                                                   curve_lenght / 2);
+                                                   curve_length / 2);
           d_ptr->dt.insert(other_point);
         }
       }
@@ -420,12 +420,12 @@ struct Sizing_field_with_aabb_tree
           if (const Point_3* pp = boost::get<Point_3>(&*int_res))
           {
             FT new_sqd = CGAL::squared_distance(p, *pp);
-            FT gdist = CGAL::abs(d_ptr->domain.signed_geodesic_distance(p, *pp, curve_id));
+            FT dist = CGAL::abs(d_ptr->domain.signed_geodesic_distance(p, *pp, curve_id));
 
 #ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
             std::cerr << "Intersection point : Point_3(" << *pp << ") ";
             std::cerr << "\n  new_sqd = " << new_sqd ;
-            std::cerr << "\n  gdist = " << gdist << "\n";
+            std::cerr << "\n  dist = " << dist << "\n";
 #endif
             if (new_sqd * 1e10 < CGAL::squared_distance(curr_segment.source(),
                                                         curr_segment.target()))
@@ -436,7 +436,7 @@ struct Sizing_field_with_aabb_tree
 #endif
               continue;
             }
-            if (CGAL_NTS sqrt(new_sqd) > 0.9 * gdist)
+            if (CGAL_NTS sqrt(new_sqd) > 0.9 * dist)
               continue;
             if (sqd_intersection == -1 || new_sqd < sqd_intersection)
             {

--- a/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
+++ b/Mesh_3/include/CGAL/Mesh_3/experimental/Sizing_field_with_aabb_tree.h
@@ -111,6 +111,9 @@ struct Sizing_field_with_aabb_tree
       //  - First compute the number of patches and min/max patch ids
       Face_ids_traversal_traits traversal_traits;
       d_ptr->aabb_tree.traversal(nullptr, traversal_traits);
+#ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
+      std::cerr << "min: " << traversal_traits.min << ", max: " << traversal_traits.max << '\n';
+#endif // CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
       d_ptr->min_patch_id = traversal_traits.min;
       d_ptr->kd_trees_ptrs.resize(traversal_traits.max - d_ptr->min_patch_id + 1);
 
@@ -378,7 +381,12 @@ struct Sizing_field_with_aabb_tree
         const auto closest_point_and_primitive = closest_point_on_surfaces(p, ids);
         if(closest_point_and_primitive == boost::none) {
 #ifdef CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
-          std::cerr << result << " (projection not found)\n";
+          std::cerr << result << " (projection not found) ids:";
+          for(Patch_index i : ids) {
+            std::cerr << " " << CGAL::IO::oformat(i);
+          }
+          std::cerr << "\n";
+
 #endif // CGAL_MESH_3_PROTECTION_HIGH_VERBOSITY
           return result;
         }


### PR DESCRIPTION
## Summary of Changes

- Make `Sizing_field_with_aabb_tree` a lightweight object carrying a `shared_ptr`
- Use per-patch kd-trees to speed up distance queries

## Release Management

Note that `Sizing_field_with_aabb_tree` is for the moment an undocumented class from `<Mesh_3/experimental/Sizing_field_with_aabb_tree.h>`.

* Affected package(s): Mesh_3
* License and copyright ownership: maintenance by GeometryFactory, unchanged

