### PR TITLE
Polyhedron demo - fix the bbox of `scene_c3t3_item`

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -29,6 +29,7 @@
 #include <CGAL/Qt/qglviewer.h>
 
 #include <boost/iterator/function_output_iterator.hpp>
+#include <boost/range/empty.hpp>
 
 #include <CGAL/IO/io.h>
 #include <CGAL/AABB_tree.h>
@@ -304,6 +305,17 @@ void Scene_c3t3_item::compute_bbox() const
     }
     _bbox = Bbox(result.xmin(), result.ymin(), result.zmin(),
                  result.xmax(), result.ymax(), result.zmax());
+
+    if (boost::empty(c3t3().cells_in_complex()))
+    {
+      for (Tr::Vertex_handle v : c3t3().triangulation().finite_vertex_handles())
+      {
+        if(v->in_dimension() != -1) //skip far points
+          result += v->point().bbox();
+      }
+      _bbox = Bbox(result.xmin(), result.ymin(), result.zmin(),
+                   result.xmax(), result.ymax(), result.zmax());
+    }
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

Even if the c3t3 has no complex cells, there may be facets in complex, edges in complex, vertices in complex, or even just vertices of the underlying triangulation, possibly with weights.
Hence, the bbox should not be the default when `cells_in_complex()` is empty. This PR adds a fallback to the bbox of the underlying triangulation vertices.

## Release Management

* Affected package(s): Demo
* License and copyright ownership: unchanged

