### PR TITLE
Github Action build_doc Add URL to job log in case of an error

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -159,7 +159,8 @@ jobs:
         with:
           script: |
             const error = process.env.ERRORMSG
-            const msg = "There was an error while building the doc: \n"+error
+            const job_url = `${context.serverUrl}/cgal/cgal/actions/runs/${context.runId}`
+            const msg = "There was an error while building the doc: \n"+error + "\n" + job_url
             github.rest.issues.createComment({
               owner: "CGAL",
               repo: "cgal",

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -159,7 +159,7 @@ jobs:
         with:
           script: |
             const error = process.env.ERRORMSG
-            const job_url = `${context.serverUrl}/cgal/cgal/actions/runs/${context.runId}`
+            const job_url = `${context.serverUrl}/CGAL/cgal/actions/runs/${context.runId}`
             const msg = "There was an error while building the doc: \n"+error + "\n" + job_url
             github.rest.issues.createComment({
               owner: "CGAL",


### PR DESCRIPTION
## Summary of Changes
add the url to the job log in case of an error during build_doc

## Release Management

* Issue(s) solved (if any): cgal#7227

