### PR TITLE
Triangulation_2: Document mark_domain_in_triangulation on entry page

### DIFF
--- a/Triangulation_2/doc/Triangulation_2/PackageDescription.txt
+++ b/Triangulation_2/doc/Triangulation_2/PackageDescription.txt
@@ -103,6 +103,10 @@ are described in Chapter \ref PkgTDS2Ref "2D Triangulation Data Structure".
 
 - `CGAL::Triangulation_cw_ccw_2`
 
+\cgalCRPSection{Functions}
+
+- `CGAL::mark_domain_in_triangulation()`
+
 \cgalCRPSection{Enum}
 - \link CGAL::Triangulation_2::Locate_type `CGAL::Triangulation_2<Traits,Tds>::Locate_type` \endlink
 


### PR DESCRIPTION
## Summary of Changes

Add function to Reference Manual entry page.

## Release Management

* Affected package(s): Triangulation_2
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:  unchanged

