### PR TITLE
Arrangement_on_surface_2 fixes

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_counting_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_counting_traits_2.h
@@ -85,18 +85,17 @@ public:
   typedef Arr_counting_traits_2<Base>           Self;
 
   /*! Construct default */
-  Arr_counting_traits_2() : Base()
+  template<typename ... Args>
+  Arr_counting_traits_2(Args ... args) :
+    Base(args...)
   {
     clear_counters();
     increment();
   }
 
-  /*! Construct copy */
-  Arr_counting_traits_2(const Arr_counting_traits_2& other) : Base(other)
-  {
-    clear_counters();
-    increment();
-  }
+  /*! Disable copy constructor.
+   */
+  Arr_counting_traits_2(const Arr_counting_traits_2&) = delete;
 
   /*! Obtain the counter of the given operation */
   size_t count(Operation_id id) const

--- a/Arrangement_on_surface_2/include/CGAL/Arr_topology_traits/Arr_unb_planar_construction_helper.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_topology_traits/Arr_unb_planar_construction_helper.h
@@ -272,6 +272,21 @@ before_handle_event(Event* event)
     if (m_prev_minus_inf_x_event != nullptr)
       m_prev_minus_inf_x_event->set_halfedge_handle(m_lh->next());
     m_prev_minus_inf_x_event = event;
+
+    // If the event lies also on the top boundary, associate all curve indices
+    // of subcurves that "see" m_th from below with the top fictitious halfedge
+    // (m_th->next()).
+    if (ps_y == ARR_TOP_BOUNDARY) {
+      if (m_he_ind_map_p != nullptr) {
+        Indices_list& list_ref = (*m_he_ind_map_p)[m_th];
+        list_ref.clear();
+        list_ref.splice(list_ref.end(), m_subcurves_at_ubf);
+      }
+      else {
+        m_subcurves_at_ubf.clear();
+      }
+      CGAL_assertion(m_subcurves_at_ubf.empty());
+    }
     return;
 
    case ARR_RIGHT_BOUNDARY:

--- a/Arrangement_on_surface_2/include/CGAL/Arr_tracing_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_tracing_traits_2.h
@@ -163,8 +163,9 @@ private:
 
 public:
   /*! Default constructor */
-  Arr_tracing_traits_2() :
-    Base()
+  template<typename ... Args>
+  Arr_tracing_traits_2(Args ... args) :
+    Base(args...)
   {
     enable_all_traces();
   }
@@ -650,13 +651,13 @@ public:
   /*! A functor that tests whether two x-monotone curves can be merged. */
   class Are_mergeable_2 {
   private:
-    typename Base::Are_mergeable_2 m_object;
+    const Base& m_base_traits;
     bool m_enabled;
 
   public:
     /*! Construct */
-    Are_mergeable_2(const Base* base, bool enabled = true) :
-      m_object(base->are_mergeable_2_object()), m_enabled(enabled) {}
+    Are_mergeable_2(const Base& base, bool enabled = true) :
+      m_base_traits(base), m_enabled(enabled) {}
 
     /*! Operate
      * \param xcv1 the first curve
@@ -667,14 +668,32 @@ public:
      */
     bool operator()(const X_monotone_curve_2& xcv1,
                     const X_monotone_curve_2& xcv2) const
-    {
-      if (!m_enabled) return m_object(xcv1, xcv2);
+    { return are_mergable_2_impl<Base>(xcv1, xcv2, 0); }
+
+  private:
+    /*! The base does not have Are_mergable_2
+     */
+    template <typename T>
+    bool are_mergable_2_impl(const X_monotone_curve_2& xcv1,
+                             const X_monotone_curve_2& xcv2, long) const {
+      CGAL_error();
+      return false;
+    }
+
+    /*! The base does have Are_mergable_2
+     */
+    template <typename T>
+    auto are_mergable_2_impl(const X_monotone_curve_2& xcv1,
+                             const X_monotone_curve_2& xcv2, int) const ->
+    decltype(m_base_traits.are_mergeable_2_object().operator()(xcv1, xcv2)) {
+      auto are_mergeable = m_base_traits.are_mergeable_2_object();
+      if (! m_enabled) return are_mergeable(xcv1, xcv2);
       std::cout << "are_mergeable" << std::endl
                 << "  xcv1: " << xcv1 << std::endl
                 << "  xcv2: " << xcv2 << std::endl;
-      bool are_mergeable = m_object(xcv1, xcv2);
-      std::cout << "  result: " << are_mergeable << std::endl;
-      return are_mergeable;
+      bool mergeable = are_mergeable(xcv1, xcv2);
+      std::cout << "  result: " << mergeable << std::endl;
+      return mergeable;
     }
   };
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_tracing_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_tracing_traits_2.h
@@ -162,13 +162,17 @@ private:
   { return m_flags & (0x1 << COMPARE_X_NEAR_BOUNDARY_OP); }
 
 public:
-  /*! Default constructor */
+  /*! Construct default */
   template<typename ... Args>
   Arr_tracing_traits_2(Args ... args) :
     Base(args...)
   {
     enable_all_traces();
   }
+
+  /*! Disable copy constructor.
+   */
+  Arr_tracing_traits_2(const Arr_tracing_traits_2&) = delete;
 
   /*! Enable the trace of a traits operation
    * \param id the operation identifier

--- a/Arrangement_on_surface_2/include/CGAL/Arr_tracing_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_tracing_traits_2.h
@@ -678,8 +678,8 @@ public:
     /*! The base does not have Are_mergable_2
      */
     template <typename T>
-    bool are_mergable_2_impl(const X_monotone_curve_2& xcv1,
-                             const X_monotone_curve_2& xcv2, long) const {
+    bool are_mergable_2_impl(const X_monotone_curve_2& /* xcv1 */,
+                             const X_monotone_curve_2& /* xcv2 */, long) const {
       CGAL_error();
       return false;
     }

--- a/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arr_traits_adaptor_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arr_traits_adaptor_2.h
@@ -3060,7 +3060,7 @@ public:
      */
     Comparison_result operator()(const Point_2& p1, const Point_2& p2) const
     {
-      Base base(m_self);
+      const Base& base = m_self;
       return base.compare_xy_2_object()(p1, p2);
     }
 

--- a/Arrangement_on_surface_2/include/CGAL/IO/Arr_text_formatter.h
+++ b/Arrangement_on_surface_2/include/CGAL/IO/Arr_text_formatter.h
@@ -549,56 +549,56 @@ public:
   typedef typename Base::Face_const_handle           Face_const_handle;
 
   /*! Default constructor.*/
-  Arr_extended_dcel_text_formatter() :
-    Base()
-  {}
+  Arr_extended_dcel_text_formatter() : Base() {}
 
   /*! Construct an output formatter. */
-  Arr_extended_dcel_text_formatter(std::ostream& os) :
-    Base(os)
-  {}
+  Arr_extended_dcel_text_formatter(std::ostream& os) : Base(os) {}
 
   /*! Construct an input formatter. */
-  Arr_extended_dcel_text_formatter(std::istream& is) :
-    Base(is)
-  {}
+  Arr_extended_dcel_text_formatter(std::istream& is) : Base(is) {}
 
   /*! Write the auxiliary data associated with the given vertex. */
   virtual void write_vertex_data(Vertex_const_handle v)
-  {
-    this->out() << '\n' << v->data();
-  }
+  { this->out() << '\n' << v->data(); }
 
   /*! Read a vertex-data object and attach it to the given vertex. */
-  virtual void read_vertex_data(Vertex_handle v)
-  {
-    this->in() >> v->data();
+  virtual void read_vertex_data(Vertex_handle v) {
+    using Vertex = typename Arrangement_2::Vertex;
+    using Type = decltype(std::declval<Vertex>().data());
+    using Data_type = typename std::remove_reference<Type>::type;
+    Data_type data;
+    this->in() >> data;
+    v->set_data(data);
     this->_skip_until_EOL();
   }
 
   /*! Write the auxiliary data associated with the given halfedge. */
   virtual void write_halfedge_data(Halfedge_const_handle he)
-  {
-    this->out() << '\n' << he->data();
-  }
+  { this->out() << '\n' << he->data(); }
 
   /*! Read a halfedge-data object and attach it to the given halfedge. */
-  virtual void read_halfedge_data(Halfedge_handle he)
-  {
-    this->in() >> he->data();
+  virtual void read_halfedge_data(Halfedge_handle he) {
+    using Halfedge = typename Arrangement_2::Halfedge;
+    using Type = decltype(std::declval<Halfedge>().data());
+    using Data_type = typename std::remove_reference<Type>::type;
+    Data_type data;
+    this->in() >> data;
+    he->set_data(data);
     this->_skip_until_EOL();
   }
 
   /*! Write the auxiliary data associated with the given face. */
   virtual void write_face_data(Face_const_handle f)
-  {
-    this->out() << f->data() << '\n';
-  }
+  { this->out() << f->data() << '\n'; }
 
   /*! Read a face-data object and attach it to the given face. */
-  virtual void read_face_data(Face_handle f)
-  {
-    this->in() >> f->data();
+  virtual void read_face_data(Face_handle f) {
+    using Face = typename Arrangement_2::Face;
+    using Type = decltype(std::declval<Face>().data());
+    using Data_type = typename std::remove_reference<Type>::type;
+    Data_type data;
+    this->in() >> data;
+    f->set_data(data);
     this->_skip_until_EOL();
   }
 };


### PR DESCRIPTION
## Summary of Changes

Several fixes:
1. Fix of issue #7311: Fixed handling unbounded curves that are both infinite on the left and infinite at the top
2. Tracing and counting traits: Added a parameter pack to the constructor and passed it to the underlying traits; also disabled the copy constructors.
3. Replaced copy-constructor of traits with simple conversion in Arr_traits_adaptor_2
4. Properly set the data of extended records using setters in Arr_text_formatter.h

## Release Management

* Affected package(s): Arrangement_on_surface_2
* Issue(s) solved (if any): fix #7311
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

