### PR TITLE
Number_types: Fix VC2017 bug with boost::mp

### DIFF
--- a/Number_types/include/CGAL/Sqrt_extension/Sqrt_extension_type.h
+++ b/Number_types/include/CGAL/Sqrt_extension/Sqrt_extension_type.h
@@ -662,12 +662,6 @@ CGAL::Comparison_result
   // NT
   friend bool operator == (const Sqrt_extension& p, const NT& num)
     { return (p-num).is_zero();}
-#if 0
-  friend bool operator <  (const Sqrt_extension& p, const NT& num)
-    { return ( p.compare(num) == CGAL::SMALLER ); }
-  friend bool operator >  (const Sqrt_extension& p, const NT& num)
-    { return ( p.compare(num) == CGAL::LARGER ); }
-#endif
 
   //CGAL_int(NT)
   friend bool operator == (const Sqrt_extension& p, CGAL_int(NT) num)

--- a/Number_types/include/CGAL/Sqrt_extension/Sqrt_extension_type.h
+++ b/Number_types/include/CGAL/Sqrt_extension/Sqrt_extension_type.h
@@ -672,7 +672,7 @@ CGAL::Comparison_result
     { return ( p.compare(num) == CGAL::LARGER ); }
 };
 
-// The two operators are moved out of the class scope (where they were friends) 
+// The two operators are moved out of the class scope (where they were friends)
 // in order to work around a VC2017 compilation problem
 template <class NT, class ROOT_, class ACDE_TAG_, class FP_TAG >
 bool operator <  (const Sqrt_extension<NT, ROOT_, ACDE_TAG_, FP_TAG>& p, const NT& num)

--- a/Number_types/include/CGAL/Sqrt_extension/Sqrt_extension_type.h
+++ b/Number_types/include/CGAL/Sqrt_extension/Sqrt_extension_type.h
@@ -662,10 +662,12 @@ CGAL::Comparison_result
   // NT
   friend bool operator == (const Sqrt_extension& p, const NT& num)
     { return (p-num).is_zero();}
+#if 0
   friend bool operator <  (const Sqrt_extension& p, const NT& num)
     { return ( p.compare(num) == CGAL::SMALLER ); }
   friend bool operator >  (const Sqrt_extension& p, const NT& num)
     { return ( p.compare(num) == CGAL::LARGER ); }
+#endif
 
   //CGAL_int(NT)
   friend bool operator == (const Sqrt_extension& p, CGAL_int(NT) num)
@@ -676,6 +678,17 @@ CGAL::Comparison_result
     { return ( p.compare(num) == CGAL::LARGER ); }
 };
 
+template <class NT, class ROOT_, class ACDE_TAG_, class FP_TAG >
+inline bool operator <  (const Sqrt_extension<NT, ROOT_, ACDE_TAG_, FP_TAG>& p, const NT& num)
+{
+    return (p.compare(num) == CGAL::SMALLER);
+}
+
+template <class NT, class ROOT_, class ACDE_TAG_, class FP_TAG >
+inline bool operator >  (const Sqrt_extension<NT, ROOT_, ACDE_TAG_, FP_TAG>& p, const NT& num)
+{
+    return (p.compare(num) == CGAL::LARGER);
+}
 /*!
  * Compute the square of a one-root number.
  */

--- a/Number_types/include/CGAL/Sqrt_extension/Sqrt_extension_type.h
+++ b/Number_types/include/CGAL/Sqrt_extension/Sqrt_extension_type.h
@@ -672,14 +672,16 @@ CGAL::Comparison_result
     { return ( p.compare(num) == CGAL::LARGER ); }
 };
 
+// The two operators are moved out of the class scope (where they were friends) 
+// in order to work around a VC2017 compilation problem
 template <class NT, class ROOT_, class ACDE_TAG_, class FP_TAG >
-inline bool operator <  (const Sqrt_extension<NT, ROOT_, ACDE_TAG_, FP_TAG>& p, const NT& num)
+bool operator <  (const Sqrt_extension<NT, ROOT_, ACDE_TAG_, FP_TAG>& p, const NT& num)
 {
     return (p.compare(num) == CGAL::SMALLER);
 }
 
 template <class NT, class ROOT_, class ACDE_TAG_, class FP_TAG >
-inline bool operator >  (const Sqrt_extension<NT, ROOT_, ACDE_TAG_, FP_TAG>& p, const NT& num)
+bool operator >  (const Sqrt_extension<NT, ROOT_, ACDE_TAG_, FP_TAG>& p, const NT& num)
 {
     return (p.compare(num) == CGAL::LARGER);
 }


### PR DESCRIPTION
## Summary of Changes

We have a compilation error in the [Number_type testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/results-5.6-I-195.shtml#Number_types) for VC2017 and VC2015.   It compiles locally with VC2017 when I move a friend function out of the scope of the class, Also no need to be friend.     Also I first I thought it is only in boost 1.70, but it it also in boost 1.74. 

## Release Management

* Affected package(s): Number_types


