### PR TITLE
Minkowski_sum_2: fix hole filter

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -106,6 +106,7 @@ extracted from labeled images.
 
 ### [2D Minkowski Sums](https://doc.cgal.org/5.6/Manual/packages.html#PkgMinkowskiSum2)
 -   Fixed a bug that made holes in the Minkowski sum disappear
+-   Fixed hole filtering. The code use to erroneously remove holes from the container of holes of polygons with holes that did not affect the mink. sum. Now it simply adds those that do affect it.
 
 [Release 5.5](https://github.com/CGAL/cgal/releases/tag/v5.5)
 -----------

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -106,7 +106,7 @@ extracted from labeled images.
 
 ### [2D Minkowski Sums](https://doc.cgal.org/5.6/Manual/packages.html#PkgMinkowskiSum2)
 -   Fixed a bug that made holes in the Minkowski sum disappear
--   Fixed hole filtering. The code use to erroneously remove holes from the container of holes of polygons with holes that did not affect the mink. sum. Now it simply adds those that do affect it.
+-   Fixed hole filtering. The code used to erroneously remove holes from the container of holes of polygons with holes that did not affect the minkowsi sum. Now it simply adds those that do affect it.
 
 [Release 5.5](https://github.com/CGAL/cgal/releases/tag/v5.5)
 -----------

--- a/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Hole_filter_2.h
+++ b/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Hole_filter_2.h
@@ -26,16 +26,12 @@ namespace CGAL {
  * to the Minkowski sum boundary.
  */
 template <typename Kernel_, typename Container_>
-class Hole_filter_2
-{
+class Hole_filter_2 {
 private:
-  typedef Kernel_               Kernel;
-  typedef Container_            Container;
-
-  typedef CGAL::Polygon_2<Kernel, Container>            Polygon_2;
-  typedef CGAL::Polygon_with_holes_2<Kernel, Container> Polygon_with_holes_2;
-  typedef typename Polygon_with_holes_2::Hole_iterator  Hole_iterator;
-  typedef std::vector<Hole_iterator>                    Hole_iterator_vector;
+  using Kernel = Kernel_;
+  using Container = Container_;
+  using Polygon_2 = CGAL::Polygon_2<Kernel, Container>;
+  using Polygon_with_holes_2 = CGAL::Polygon_with_holes_2<Kernel, Container>;
 
 public:
   /*! Filter out holes of a polygon with holes.
@@ -45,29 +41,17 @@ public:
    */
   void operator()(const Polygon_with_holes_2& pgn1,
                   const Polygon_2& pgn2,
-                  Polygon_with_holes_2& filtered_pgn1) const
-  {
-    filtered_pgn1 = pgn1;
-
-    Hole_iterator_vector to_erase;
+                  Polygon_with_holes_2& filtered_pgn1) const {
     Bbox_2 boundary_bbox = pgn2.bbox();
-
-    Hole_iterator it = filtered_pgn1.holes_begin();
-    while (it != filtered_pgn1.holes_end()) {
-      Bbox_2 hole_bbox = (*it).bbox();
-
-      if ((hole_bbox.ymax()-hole_bbox.ymin() <
-           boundary_bbox.ymax()-boundary_bbox.ymin()) ||
-          (hole_bbox.xmax()-hole_bbox.xmin() <
+    filtered_pgn1 = Polygon_with_holes_2(pgn1.outer_boundary());
+    for (const auto& h : pgn1.holes()) {
+      Bbox_2 hole_bbox = h.bbox();
+      if ((hole_bbox.ymax()-hole_bbox.ymin() >=
+           boundary_bbox.ymax()-boundary_bbox.ymin()) &&
+          (hole_bbox.xmax()-hole_bbox.xmin() >=
            boundary_bbox.xmax()-boundary_bbox.xmin()))
-      {
-        to_erase.push_back(it);
-      }
-      ++it;
+        filtered_pgn1.add_hole(h);
     }
-
-    typename Hole_iterator_vector::iterator it2 = to_erase.begin();
-    while (it2 != to_erase.end()) filtered_pgn1.erase_hole(*it2++);
   }
 
   /*! Filter out holes of a polygon with holes.


### PR DESCRIPTION
## Summary of Changes

Fixed hole filtering. The code used to erroneously remove holes from an std::deque of holes that did not affect the Minkowski sum. Now it simply adds those that do affect it.
The error could be reproduced only with clang. (Apparently, g++ tolerated the erroneous condition.)

## Release Management

* Affected package(s): Minkowski_sum_2
* Issue(s) solved (if any): none submitted
* Feature/Small Feature (if any): na
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: TAU

