### PR TITLE
Add example of printing vertex coordinates

### DIFF
--- a/Surface_mesh/examples/Surface_mesh/sm_iterators.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_iterators.cpp
@@ -46,7 +46,8 @@ int main()
 
     // or with boost::tie, as the CGAL range derives from std::pair
     for(boost::tie(vb, ve) = m.vertices(); vb != ve; ++vb){
-            std::cout << *vb << std::endl;
+            // Print vertex index and vertex coordinates
+            std::cout << *vb << " " << m.point(*vb) << std::endl;
     }
 
     // Instead of the classical for loop one can use


### PR DESCRIPTION
## Summary of Changes

This adds a very basic example how how to access the coordinates of a vertex. 

## Release Management

* Affected package(s):

Latest source code.

* Issue(s) solved (if any): https://github.com/CGAL/cgal/discussions/7341
* Feature/Small Feature (if any):
* License and copyright ownership: Freely released in the public domain. 

