### PR TITLE
Surface_mesh: Add example for accessing points

### DIFF
--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -706,6 +706,7 @@ user might encounter.
 - `CGAL::Halfedge_around_target_circulator`
 - `CGAL::Halfedge_around_face_circulator`
 - `CGAL::Vertex_around_target_circulator`
+- `CGAL::Vertex_around_face_circulator`
 - `CGAL::Face_around_target_circulator`
 - `CGAL::Face_around_face_circulator`
 

--- a/BGL/include/CGAL/boost/graph/iterator.h
+++ b/BGL/include/CGAL/boost/graph/iterator.h
@@ -980,6 +980,12 @@ faces_around_face(typename boost::graph_traits<Graph>::halfedge_descriptor h, co
   return make_range(I(h,g), I(h,g,1));
 }
 
+/**
+ * \ingroup PkgBGLIterators
+ * A bidirectional circulator with value type `boost::graph_traits<Graph>::%vertex_descriptor` over all vertices incident to the same face or border.
+ * \tparam Graph must be a model of the concept `HalfedgeGraph`
+ * \cgalModels `BidirectionalIterator`
+ */
 template <typename Graph>
 class Vertex_around_face_circulator
 #ifndef DOXYGEN_RUNNING

--- a/Surface_mesh/doc/Surface_mesh/Surface_mesh.txt
+++ b/Surface_mesh/doc/Surface_mesh/Surface_mesh.txt
@@ -77,11 +77,20 @@ they were created must be used to obtain this information.
 
 \subsection usage_example Example
 
-The following example shows how to create a very simple `Surface_mesh`
+The first example shows how to create a very simple `Surface_mesh`
 by adding 2 faces, and how to check that a face is correctly added
 to the mesh.
 
 \cgalExample{Surface_mesh/check_orientation.cpp}
+
+The second example shows how to access the points associated
+to the vertices, either for an individual vertex, or as
+the range of points of the entire mesh.  Such a range can
+be accessed in a for-loop or passed to functions that expect
+a range of points as input.
+
+\cgalExample{Surface_mesh/sm_points.cpp}
+
 \section sectionSurfaceMeshConnectivity Connectivity
 
 A surface mesh is an edge-centered data structure capable of

--- a/Surface_mesh/doc/Surface_mesh/dependencies
+++ b/Surface_mesh/doc/Surface_mesh/dependencies
@@ -4,6 +4,7 @@ Algebraic_foundations
 BGL
 Box_intersection_d
 Circulator
+Convex_hull_3
 HalfedgeDS
 Kernel_23
 Miscellany
@@ -11,4 +12,3 @@ Polyhedron
 Polygon_mesh_processing
 STL_Extension
 Stream_support
-

--- a/Surface_mesh/doc/Surface_mesh/examples.txt
+++ b/Surface_mesh/doc/Surface_mesh/examples.txt
@@ -1,5 +1,6 @@
 /*!
 \example Surface_mesh/check_orientation.cpp
+\example Surface_mesh/sm_points.cpp
 \example Surface_mesh/sm_iterators.cpp
 \example Surface_mesh/sm_circulators.cpp
 \example Surface_mesh/sm_properties.cpp

--- a/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
+++ b/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
@@ -12,6 +12,7 @@ project(Surface_mesh_Examples)
 #CGAL_Qt5 is needed for the drawing.
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
+create_single_source_cgal_program("sm_points.cpp")
 create_single_source_cgal_program("sm_derivation.cpp")
 create_single_source_cgal_program("sm_join.cpp")
 create_single_source_cgal_program("sm_aabbtree.cpp")

--- a/Surface_mesh/examples/Surface_mesh/sm_points.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_points.cpp
@@ -1,0 +1,35 @@
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/convex_hull_3.h>
+
+typedef CGAL::Simple_cartesian<double> K;
+typedef CGAL::Surface_mesh<K::Point_3> Mesh;
+typedef Mesh::Vertex_index vertex_descriptor;
+typedef Mesh::Face_index face_descriptor;
+
+int main()
+{
+  Mesh m;
+  vertex_descriptor v0 = m.add_vertex(K::Point_3(0,0,0));
+  vertex_descriptor v1 = m.add_vertex(K::Point_3(1,0,0));
+  vertex_descriptor v2 = m.add_vertex(K::Point_3(0,1,0));
+  vertex_descriptor v3 = m.add_vertex(K::Point_3(0,0,1));
+
+  face_descriptor fd = m.add_face(v0, v1, v2);
+  m.add_face(v1, v0, v3);
+
+  // Access the point for a given vertex
+  for(vertex_descriptor vd : vertices_around_face(m.halfedge(fd), m)){
+    std ::cout << m.point(vd) << std::endl;
+  }
+
+  // Access the range of all points of the mesh
+  for( const K::Point_3& p : m.points()){
+    std::cout << p << std::endl;
+  }
+
+  Mesh ch;
+  CGAL::convex_hull_3(m.points().begin(), m.points().end(), ch);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary of Changes

As pointed out by @oleg-alexandrov the functions to access the coordinates of a vertex are rather hidden.
This PR at the same time adds the missing documentation for `Vertex_around_face_circulator`.

This PR does not replace #7342 but complements it.

## Release Management

* Affected package(s): Surface_mesh
* Issue(s) solved (if any): fix #7341

* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: unchanged

