### PR TITLE
Triangulation_2: Clarify what happens with degenerate constraints

### DIFF
--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -191,8 +191,6 @@ Inserts the line segment between the points `c.first` and `c.second` as  a const
 /*!
 Inserts the line segment whose endpoints are the vertices `va` and
 `vb` as a constraint in the triangulation.
-\pre `va` != `vb`.
-
 */
 void insert_constraint(Vertex_handle va, Vertex_handle vb);
 
@@ -224,7 +222,10 @@ std::size_t insert_constraints(ConstraintIterator first, ConstraintIterator last
 Same as above except that each constraints is given as a pair of indices of the points
 in the range [points_first, points_last). The indices must go from 0 to `std::distance(points_first, points_last)`
 \tparam PointIterator is an `InputIterator` with the value type `Point`.
-\tparam IndicesIterator is an `InputIterator` with `std::pair<Int, Int>` where `Int` is an integral type implicitly convertible to `std::size_t`
+\tparam IndicesIterator is an `InputIterator` with `std::pair<Int,Int>`
+where `Int` is an integral type implicitly convertible to `std::size_t`
+\return the number of inserted points.
+\note points are inserted even if they are not endpoint of a constraint.
 */
 template <class PointIterator, class IndicesIterator>
 std::size_t insert_constraints(PointIterator points_first, PointIterator points_last,

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -224,8 +224,8 @@ in the range [points_first, points_last). The indices must go from 0 to `std::di
 \tparam PointIterator is an `InputIterator` with the value type `Point`.
 \tparam IndicesIterator is an `InputIterator` with `std::pair<Int,Int>`
 where `Int` is an integral type implicitly convertible to `std::size_t`
-\return the number of inserted points.
 \note points are inserted even if they are not endpoint of a constraint.
+\return the number of inserted points.
 */
 template <class PointIterator, class IndicesIterator>
 std::size_t insert_constraints(PointIterator points_first, PointIterator points_last,

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -294,8 +294,10 @@ Once endpoints have been inserted, the segments are inserted in the order of the
 using the vertex handles of its endpoints.
 In case the constraints are degenerate the points are inserted, but no
 constraints.
-\return the number of inserted points.
+
 \tparam ConstraintIterator must be an `InputIterator` with the value type `std::pair<Point,Point>` or `Segment`.
+
+\return the number of inserted points.
 */
 template <class ConstraintIterator>
 std::size_t insert_constraints(ConstraintIterator first, ConstraintIterator last);
@@ -307,8 +309,8 @@ in the range [points_first, points_last). The indices must go from 0 to `std::di
 \tparam IndicesIterator is an `InputIterator` with `std::pair<Int,
 Int>` where `Int` is an integral type implicitly convertible to
 `std::size_t`
-\return the number of inserted points.
 \note points are inserted even if they are not endpoint of a constraint.
+\return the number of inserted points.
 */
 template <class PointIterator, class IndicesIterator>
 std::size_t insert_constraints(PointIterator points_first, PointIterator points_last,

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -22,11 +22,17 @@ point.
 
 
 The data structure maintains for each input constraint
-the sequence of vertices on this constraint. These vertices are
+the sequence of vertices on this constraint. Note that there is
+not a one-to-one correspondence between an input constraint and
+the sequence of vertices. These vertices are
 either vertices of the input constraint or intersection points.
+Also consecutive identical points in the input constraint
+result in a single vertex in the sequence if vertices on this
+constrain. In case of an input constraint being degenerate
+to a point, this point is inserted but there will not be a
+zero length constraint.
 
-\todo The following description does not match the code
-Two consecutive vertices of an input constraint form a *subconstraint*.
+Two consecutive vertices of a constraint form a *subconstraint*.
 A subconstraint is a pair of vertex handles and corresponds to a constrained edge of the
 triangulation, which is a pair of a face handle and an index.
 
@@ -36,7 +42,8 @@ It further enables the retrieval of the set of input constraints that induce a s
 As it is straightforward to obtain a subconstraint from a constrained edge `e`,
 one can obtain the input constraints which induce `e`.
 
-\tparam Tr must be either a CGAL::Constrained_triangulation_2 or a CGAL::Constrained_Delaunay_triangulation_2
+
+\tparam Tr must be either a `CGAL::Constrained_triangulation_2` or a `CGAL::Constrained_Delaunay_triangulation_2`
 
 \sa `CGAL::Constrained_triangulation_2<Traits,Tds>`
 \sa `CGAL::Constrained_Delaunay_triangulation_2<Traits,Tds>`
@@ -242,12 +249,14 @@ insert(PointIterator first, PointIterator last);
 /*!
 inserts the constraint segment `ab` in the triangulation.
 If the two points are equal the point is inserted but no constraint,
-and the default constructed `Constraint_id` is returned.
+and a default constructed `Constraint_id` is returned.
 */
 Constraint_id insert_constraint(Point a, Point b);
 
 /*!
-inserts the constraint `c`.
+inserts the constraint `c` in the triangulation.
+If the two points are equal the point is inserted but no constraint,
+and a default constructed `Constraint_id` is returned.
 */
   void push_back(const std::pair<Point,Point>& c);
 
@@ -255,7 +264,7 @@ inserts the constraint `c`.
 inserts a constraint whose endpoints are the vertices
 pointed by `va` and `vb` in the triangulation.
 If the two vertex handles are equal no constraint is inserted,
-and the default constructed `Constraint_id` is returned.
+and a default constructed `Constraint_id` is returned.
 */
 Constraint_id insert_constraint(Vertex_handle va, Vertex_handle vb);
 
@@ -264,10 +273,13 @@ inserts a polyline defined by the points in the range `[first,last)`
 and returns the constraint id.
 The polyline is considered as a closed curve if the first and last point are equal or if  `close == true`. This enables for example passing the vertex range of a `Polygon_2`.
 When traversing the vertices of a closed polyline constraint with a  `Vertices_in_constraint_iterator` the first and last vertex are the same.
-In case the range is empty `Constraint_id()` is returned.
-In case all points are equal the point is inserted but no constraint,
-and `Constraint_id()` is returned.
+In case the range is empty a default constructed `Constraint_id` is returned.
+In case the range contains only one point or all points are equal the point is inserted but no constraint,
+and a default constructed `Constraint_id` is returned.
+
 \tparam PointIterator must be an `InputIterator` with the value type `Point`.
+
+\note
 */
 template < class PointIterator>
 Constraint_id insert_constraint(PointIterator first, PointIterator last, bool close=false);
@@ -280,7 +292,8 @@ is used to improve efficiency.
 More precisely, all endpoints are inserted prior to the segments and according to the order provided by the spatial sort.
 Once endpoints have been inserted, the segments are inserted in the order of the input iterator,
 using the vertex handles of its endpoints.
-
+In case the constraints are degenerate the points are inserted, but no
+constraints.
 \return the number of inserted points.
 \tparam ConstraintIterator must be an `InputIterator` with the value type `std::pair<Point,Point>` or `Segment`.
 */
@@ -291,7 +304,11 @@ std::size_t insert_constraints(ConstraintIterator first, ConstraintIterator last
 Same as above except that each constraint is given as a pair of indices of the points
 in the range [points_first, points_last). The indices must go from 0 to `std::distance(points_first, points_last)`
 \tparam PointIterator is an `InputIterator` with the value type `Point`.
-\tparam IndicesIterator is an `InputIterator` with `std::pair<Int, Int>` where `Int` is an integral type implicitly convertible to `std::size_t`
+\tparam IndicesIterator is an `InputIterator` with `std::pair<Int,
+Int>` where `Int` is an integral type implicitly convertible to
+`std::size_t`
+\return the number of inserted points.
+\note points are inserted even if they are not endpoint of a constraint.
 */
 template <class PointIterator, class IndicesIterator>
 std::size_t insert_constraints(PointIterator points_first, PointIterator points_last,

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -27,8 +27,8 @@ not a one-to-one correspondence between an input constraint and
 the sequence of vertices. These vertices are
 either vertices of the input constraint or intersection points.
 Also consecutive identical points in the input constraint
-result in a single vertex in the sequence if vertices on this
-constrain. In case of an input constraint being degenerate
+result in a single vertex in the sequence of vertices on this
+constraint. In case of an input constraint being degenerate
 to a point, this point is inserted but there will not be a
 zero length constraint.
 
@@ -278,8 +278,6 @@ In case the range contains only one point or all points are equal the point is i
 and a default constructed `Constraint_id` is returned.
 
 \tparam PointIterator must be an `InputIterator` with the value type `Point`.
-
-\note
 */
 template < class PointIterator>
 Constraint_id insert_constraint(PointIterator first, PointIterator last, bool close=false);

--- a/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -431,6 +431,9 @@ public:
                                  IndicesIterator indices_first,
                                  IndicesIterator indices_beyond)
   {
+    if(indices_first == indices_beyond){
+      return insert(points_first, points_beyond);
+    }
     std::vector<Point> points(points_first, points_beyond);
     return internal::insert_constraints(*this,points, indices_first, indices_beyond);
   }

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -828,6 +828,9 @@ insert_constraint(Vertex_handle  vaa, Vertex_handle vbb)
 // if a vertex vc of t lies on segment ab
 // or if ab intersect some constrained edges
 {
+  if(vaa == vbb){
+    return;
+  }
   std::stack<std::pair<Vertex_handle, Vertex_handle> > stack;
   stack.push(std::make_pair(vaa,vbb));
 

--- a/Triangulation_2/include/CGAL/Triangulation_2/insert_constraints.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/insert_constraints.h
@@ -34,7 +34,7 @@ namespace CGAL {
                                     IndicesIterator indices_beyond )
   {
     if(indices_first == indices_beyond){
-      return 0;
+      return t.insert(points.begin(), points.end());
     }
     typedef typename T::Vertex_handle Vertex_handle;
     typedef typename T::Face_handle Face_handle;


### PR DESCRIPTION
## Summary of Changes

Improve the documentation of  the constrained triangulation classes to make clear what happens 
- when degenerate constraints are inserted, 
- when a sequence of points and index pairs are inserted.

## Release Management

* Affected package(s): Triangulation_2
* Issue(s) solved (if any): fix #7336
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:  unchanged

