### PR TITLE
Converter to qpolygon

### DIFF
--- a/GraphicsView/doc/GraphicsView/CGAL/Qt/Converter.h
+++ b/GraphicsView/doc/GraphicsView/CGAL/Qt/Converter.h
@@ -42,6 +42,11 @@ Converts a point.
 QPointF operator()(K::Point_2);
 
 /*!
+Converts a circular arc point.
+*/
+QPointF operator()(K::Circular_arc_point_2);
+
+/*!
 Converts a segment.
 */
 QLineF operator()(K::Segment_2);
@@ -94,7 +99,7 @@ K::Iso_rectangle_2 operator()(QRectF);
 /*!
 Converts a polygon to a list of points.
 */
-std::list<K::Point_2> operator()(QPolygonF);
+void operator()(std::list<K::Point_2>&, QPolygonF);
 
 /// @}
 

--- a/GraphicsView/include/CGAL/Qt/Converter.h
+++ b/GraphicsView/include/CGAL/Qt/Converter.h
@@ -167,6 +167,15 @@ public:
     return qp;
   }
 
+  QPolygonF operator()(const std::list< CGAL_Point_2 >& p) const
+  {
+    QPolygonF qp;
+    for(int i = 0; i < p.size(); i++){
+      qp << operator()(p[i]);
+    }
+    return qp;
+  }
+
 
   void operator()(std::list< CGAL_Point_2 >& p, const QPolygonF& qp) const
   {


### PR DESCRIPTION
## Summary of Changes

Adds converter from `std::list<K::Point_2>` to `QPolygonF` that was documented but not implemented. Also fixes documentation for the converter in the opposite direction to match the actual implementation and adds documentation for the converter from `K::Circular_arc_point_2` to `QPointF`.

## Release Management

* Affected package(s): Qt