### PR TITLE
Mesh_3 - fix default parameters of `CGAL::exude_mesh_3(c3t3)`

### DIFF
--- a/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
@@ -485,7 +485,7 @@ public:
 
 
 #ifndef CGAL_NO_DEPRECATED_CODE
-  template<typename Function, typename Bounding_object, typename CGAL_NP_TEMPLATE_PARAMETERS>
+  template<typename Function, typename Bounding_object>
 #if !defined(BOOST_MSVC)
   CGAL_DEPRECATED
 #endif

--- a/Mesh_3/include/CGAL/exude_mesh_3.h
+++ b/Mesh_3/include/CGAL/exude_mesh_3.h
@@ -102,8 +102,9 @@ Mesh_optimization_return_code exude_mesh_3(C3T3& c3t3,const CGAL_NP_CLASS& np = 
 }
 
 #ifndef CGAL_NO_DEPRECATED_CODE
-template<typename C3T3, typename CGAL_NP_TEMPLATE_PARAMETERS>
-Mesh_optimization_return_code exude_mesh_3(C3T3& c3t3, double time_limit = 0, double sliver_bound = 0)
+template<typename C3T3>
+CGAL_DEPRECATED
+Mesh_optimization_return_code exude_mesh_3(C3T3& c3t3, double time_limit, double sliver_bound = 0)
 {
   return exude_mesh_3(c3t3, CGAL::parameters::time_limit(time_limit).sliver_bound(sliver_bound));
 }


### PR DESCRIPTION
## Summary of Changes

This PR fixes an ambiguous match between different versions (NP and deprecated versions) of the default parameters in `CGAL::exude_mesh_3(c3t3)`.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

