### PR TITLE
Installation: Workaround for boost::mp / Eigen problem

### DIFF
--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -652,6 +652,6 @@ namespace boost {
     }
 }
 
-#endif
+#endif // BOOST_VERSION < 107900
 
 #endif // CGAL_CONFIG_H

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -608,6 +608,11 @@ namespace Eigen{
   template <class A, int B, class C>
   class Ref;
 
+  template <class A, class B, int C = 0>
+  class Product;
+
+  template<typename BinaryOp, typename Lhs, typename Rhs>  class CwiseBinaryOp;
+
 }
 
 namespace boost {
@@ -625,6 +630,18 @@ namespace boost {
 
             template <class A, int B, class C>
             struct is_byte_container< Eigen::Ref<A, B, C>>
+            {
+                static const bool value = false;
+            };
+
+            template <class A, class B, int C>
+            struct is_byte_container< Eigen::Product<A, B, C>>
+            {
+                static const bool value = false;
+            };
+
+            template <class A, class B, class C>
+            struct is_byte_container< Eigen::CwiseBinaryOp<A, B, C>>
             {
                 static const bool value = false;
             };

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -598,6 +598,8 @@ inline std::string data_file_path(const std::string& filename)
 } // end namespace CGAL
 
 
+#if BOOST_VERSION < 107900
+
 // Workaround for an accidental enable if of Eigen::Matrix in the
 // boost::multiprecision::cpp_int constructor for some versions of
 // boost
@@ -649,5 +651,7 @@ namespace boost {
         }
     }
 }
+
+#endif
 
 #endif // CGAL_CONFIG_H

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -597,4 +597,40 @@ inline std::string data_file_path(const std::string& filename)
 
 } // end namespace CGAL
 
+
+// Workaround for an accidental enable if of Eigen::Matrix in the
+// boost::multiprecision::cpp_int constructor for some versions of
+// boost
+
+namespace Eigen{
+  template <class A, int B, int C, int D, int E, int F>
+  class Matrix;
+  template <class A, int B, class C>
+  class Ref;
+
+}
+
+namespace boost {
+    namespace multiprecision {
+        namespace detail {
+            template <typename T>
+            struct is_byte_container;
+
+
+            template <class A, int B, int C, int D, int E, int F>
+            struct is_byte_container< Eigen::Matrix<A, B, C, D, E, F>>
+            {
+                static const bool value = false;
+            };
+
+            template <class A, int B, class C>
+            struct is_byte_container< Eigen::Ref<A, B, C>>
+            {
+                static const bool value = false;
+            };
+
+        }
+    }
+}
+
 #endif // CGAL_CONFIG_H

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -608,7 +608,7 @@ namespace Eigen{
   template <class A, int B, class C>
   class Ref;
 
-  template <class A, class B, int C = 0>
+  template <class A, class B, int C>
   class Product;
 
   template<typename BinaryOp, typename Lhs, typename Rhs>  class CwiseBinaryOp;

--- a/Principal_component_analysis/include/CGAL/PCA_util.h
+++ b/Principal_component_analysis/include/CGAL/PCA_util.h
@@ -391,7 +391,7 @@ assemble_covariance_matrix_3(InputIterator first,
                    0.0, radius, 0.0,
                    0.0, 0.0, radius};
     Matrix transformation = init_matrix<FT>(3,delta);
-    FT volume = (FT)(4.0/3.0) * radius * t.squared_radius();
+    FT volume = radius * t.squared_radius();
 
                 // skip zero measure primitives
     if(volume == (FT)0.0)
@@ -400,8 +400,9 @@ assemble_covariance_matrix_3(InputIterator first,
     // Find the 2nd order moment for the sphere wrt to the origin by an affine transformation.
 
     // Transform the standard 2nd order moment using the transformation matrix
-    transformation = (3.0/4.0) * volume * transformation * moment * LA::transpose(transformation);
+    transformation = volume * transformation * moment * LA::transpose(transformation);
 
+    volume *= FT(4.0/3.0);
     // Translate the 2nd order moment to the center of the sphere.
     FT x0 = t.center().x();
     FT y0 = t.center().y();
@@ -476,7 +477,7 @@ assemble_covariance_matrix_3(InputIterator first,
                    0.0,    radius, 0.0,
                    0.0,    0.0,    radius};
     Matrix transformation = init_matrix<FT>(3,delta);
-    FT area = (FT)4.0 * t.squared_radius();
+    FT area = t.squared_radius();
 
                 // skip zero measure primitives
     if(area == (FT)0.0)
@@ -485,8 +486,9 @@ assemble_covariance_matrix_3(InputIterator first,
     // Find the 2nd order moment for the sphere wrt to the origin by an affine transformation.
 
     // Transform the standard 2nd order moment using the transformation matrix
-    transformation = (1.0/4.0) * area * transformation * moment * LA::transpose(transformation);
+    transformation = area * transformation * moment * LA::transpose(transformation);
 
+    area *= FT(4.0);
     // Translate the 2nd order moment to the center of the sphere.
     FT x0 = t.center().x();
     FT y0 = t.center().y();

--- a/Principal_component_analysis/include/CGAL/PCA_util_Eigen.h
+++ b/Principal_component_analysis/include/CGAL/PCA_util_Eigen.h
@@ -368,7 +368,7 @@ assemble_covariance_matrix_3(InputIterator first,
     transformation << radius, 0.0, 0.0,
                       0.0, radius, 0.0,
                       0.0, 0.0, radius;
-    FT volume = (FT)(4.0/3.0) * radius * t.squared_radius();
+    FT volume =  radius * t.squared_radius();
 
     // skip zero measure primitives
     if(volume == (FT)0.0)
@@ -377,8 +377,9 @@ assemble_covariance_matrix_3(InputIterator first,
     // Find the 2nd order moment for the sphere wrt to the origin by an affine transformation.
 
     // Transform the standard 2nd order moment using the transformation matrix
-    transformation = (3.0/4.0) * volume * transformation * moment * transformation.transpose();
+    transformation = volume * transformation * moment * transformation.transpose();
 
+    volume *= FT(4.0 / 3.0);
     // Translate the 2nd order moment to the center of the sphere.
     FT x0 = t.center().x();
     FT y0 = t.center().y();
@@ -453,7 +454,7 @@ assemble_covariance_matrix_3(InputIterator first,
     transformation << radius, 0.0,    0.0,
                       0.0,    radius, 0.0,
                       0.0,    0.0,    radius;
-    FT area = (FT)4.0 * t.squared_radius();
+    FT area = t.squared_radius();
 
     // skip zero measure primitives
     if(area == (FT)0.0)
@@ -462,8 +463,9 @@ assemble_covariance_matrix_3(InputIterator first,
     // Find the 2nd order moment for the sphere wrt to the origin by an affine transformation.
 
     // Transform the standard 2nd order moment using the transformation matrix
-    transformation = (1.0/4.0) * area * transformation * moment * transformation.transpose();
+    transformation = area * transformation * moment * transformation.transpose();
 
+    area *= FT(4.0);
     // Translate the 2nd order moment to the center of the sphere.
     FT x0 = t.center().x();
     FT y0 = t.center().y();


### PR DESCRIPTION
## Summary of Changes

The [PCA testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.6-Ic-211/Principal_component_analysis/TestReport_Christo_MSVC2017-Debug-64bits.gz) reveals a compilation problem when multiplying a  `boost::mp` with an Eigen matrix or expression.

## Release Management

* Affected package(s): Principal_component_analysis 

