### PR TITLE
CGAL 3D demo: fix USBAN warnings

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -799,6 +799,8 @@ Scene_triangulation_3_item::build_histogram()
   {
     max_size = (std::max)(max_size, *it);
   }
+  if(max_size == 0)
+    return;
 
   // colored histogram
   int j = 0;

--- a/Polyhedron/demo/Polyhedron/Triangle_container.cpp
+++ b/Polyhedron/demo/Polyhedron/Triangle_container.cpp
@@ -6,19 +6,13 @@ typedef Viewer_interface VI;
 using namespace CGAL::Three;
 
 struct Tri_d{
-
-  Tri_d():
-    shrink_factor(1.0f),
-    plane(QVector4D()),
-    alpha(1.0f)
-  {}
-  Triangle_container* container;
-  float shrink_factor;
-  QVector4D plane;
-  bool is_surface;
-  float alpha;
-  QMatrix4x4 f_matrix;
-  QMatrix4x4 mv_matrix;
+  Triangle_container* container{nullptr};
+  float shrink_factor{1.f};
+  QVector4D plane{};
+  bool is_surface{false};
+  float alpha{1.f};
+  QMatrix4x4 f_matrix{};
+  QMatrix4x4 mv_matrix{};
 };
 
 Triangle_container::Triangle_container(int program, bool indexed)

--- a/Polyhedron/demo/Polyhedron/Viewer.cpp
+++ b/Polyhedron/demo/Polyhedron/Viewer.cpp
@@ -67,7 +67,7 @@ public:
 
   // M e s s a g e s
   QString message;
-  bool _displayMessage;
+  bool _displayMessage = false;
   QTimer messageTimer;
   QOpenGLFunctions_4_3_Core* _recentFunctions;
   bool is_2d_selection_mode;

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -1691,7 +1691,7 @@ protected:
 
   struct Fill_auxiliary_return_type {
     Vertex_handle_unique_hash_map vmap;
-    bool vertex_is_incident_to_infinity;
+    bool vertex_is_incident_to_infinity = false;
   };
 
   template < class Triangulation >


### PR DESCRIPTION
## Summary of Changes

In order to improve the quality of the code, I have decided to always compile with `-fsanitize=address -fsanitize=undefined` (ASAN+UBSAN) when I compile in `Debug`. And the polyhedron demo triggers several UBSAN warnings. Here are the fixes.

## Release Management

* Affected package(s): Polyhedron/demo
