### PR TITLE
Installation - add new possible GMP lib name for MSVC

### DIFF
--- a/Installation/cmake/modules/FindGMP.cmake
+++ b/Installation/cmake/modules/FindGMP.cmake
@@ -26,22 +26,25 @@ if( NOT GMP_in_cache )
             NAMES gmp.h
             HINTS ENV GMP_INC_DIR
                   ENV GMP_DIR
+                  $ENV{GMP_DIR}/include
                   ${CGAL_INSTALLATION_PACKAGE_DIR}/auxiliary/gmp/include
             PATH_SUFFIXES include
   	        DOC "The directory containing the GMP header files"
            )
 
-  find_library(GMP_LIBRARY_RELEASE NAMES gmp libgmp-10 mpir
+  find_library(GMP_LIBRARY_RELEASE NAMES gmp libgmp-10 gmp-10 mpir
     HINTS ENV GMP_LIB_DIR
           ENV GMP_DIR
+          $ENV{GMP_DIR}/lib
           ${CGAL_INSTALLATION_PACKAGE_DIR}/auxiliary/gmp/lib
     PATH_SUFFIXES lib
     DOC "Path to the Release GMP library"
     )
 
-  find_library(GMP_LIBRARY_DEBUG NAMES gmpd gmp libgmp-10 mpir
+  find_library(GMP_LIBRARY_DEBUG NAMES gmpd gmp libgmp-10 gmp-10 mpir
     HINTS ENV GMP_LIB_DIR
           ENV GMP_DIR
+          $ENV{GMP_DIR}/include
           ${CGAL_INSTALLATION_PACKAGE_DIR}/auxiliary/gmp/lib
     PATH_SUFFIXES lib
     DOC "Path to the Debug GMP library"

--- a/Installation/cmake/modules/FindMPFR.cmake
+++ b/Installation/cmake/modules/FindMPFR.cmake
@@ -25,6 +25,7 @@ if (NOT MPFR_in_cache)
             NAMES mpfr.h
             HINTS ENV MPFR_INC_DIR
                   ENV MPFR_DIR
+                  $ENV{MPFR_DIR}/include
                   ${CGAL_INSTALLATION_PACKAGE_DIR}/auxiliary/gmp/include
             PATH_SUFFIXES include
   	        DOC "The directory containing the MPFR header files"
@@ -33,6 +34,7 @@ if (NOT MPFR_in_cache)
   find_library(MPFR_LIBRARIES NAMES mpfr libmpfr-4 libmpfr-1
     HINTS ENV MPFR_LIB_DIR
           ENV MPFR_DIR
+          $ENV{MPFR_DIR}/lib
           ${CGAL_INSTALLATION_PACKAGE_DIR}/auxiliary/gmp/lib
     PATH_SUFFIXES lib
     DOC "Path to the MPFR library"

--- a/Installation/test/Installation/test_gmp_mpfr_dll.cpp
+++ b/Installation/test/Installation/test_gmp_mpfr_dll.cpp
@@ -33,6 +33,9 @@ bool get_version_info(const LPCTSTR name,
     std::cerr << name << " is not loaded!\n";
     return false;
   }
+  else
+    std::cerr << name << " is loaded.\n";
+
   char fileName[_MAX_PATH];
   DWORD size = GetModuleFileName(g_dllHandle, fileName, _MAX_PATH);
   fileName[size] = NULL;

--- a/Installation/test/Installation/test_gmp_mpfr_dll.cpp
+++ b/Installation/test/Installation/test_gmp_mpfr_dll.cpp
@@ -10,9 +10,6 @@ int main() {
 #define GMP_SONAME_BACKUP "gmp"
 #define GMP_SONAME_BACKUP_2 "gmp-10"
 #define MPFR_SONAME_BACKUP "mpfr-6"
-#define GMP_MAJOR 5
-#define MPFR_MAJOR 3
-
 
 #include <iostream>
 #include <cassert>

--- a/Installation/test/Installation/test_gmp_mpfr_dll.cpp
+++ b/Installation/test/Installation/test_gmp_mpfr_dll.cpp
@@ -8,6 +8,7 @@ int main() {
 #define GMP_SONAME "libgmp-10"
 #define MPFR_SONAME "libmpfr-4"
 #define GMP_SONAME_BACKUP "gmp"
+#define GMP_SONAME_BACKUP_2 "gmp-10"
 #define MPFR_SONAME_BACKUP "mpfr-6"
 #define GMP_MAJOR 5
 #define MPFR_MAJOR 3
@@ -66,7 +67,9 @@ int main() {
   int major, minor, patch, build;
   if(!get_version_info(GMP_SONAME, major, minor, patch, build)) {
     if(!get_version_info(GMP_SONAME_BACKUP, major, minor, patch, build)) {
-      return 1;
+      if (!get_version_info(GMP_SONAME_BACKUP_2, major, minor, patch, build)) {
+        return 1;
+      }
     }
   }
 

--- a/Installation/test/Installation/test_gmp_mpfr_dll.cpp
+++ b/Installation/test/Installation/test_gmp_mpfr_dll.cpp
@@ -42,6 +42,12 @@ bool get_version_info(const LPCTSTR name,
   std::cerr << "Query FileVersion of \"" << fileName << "\"\n";
   DWORD handle = 0;
   size = GetFileVersionInfoSize(fileName, &handle);
+
+  DWORD err = GetLastError();
+  if (size == 0) {
+    std::cerr << "GetFileVersionInfoSize failed with error " << err << std::endl;
+  }
+
   BYTE* versionInfo = new BYTE[size];
   if (!GetFileVersionInfo(fileName, handle, size, versionInfo))
   {


### PR DESCRIPTION
## Summary of Changes

`gmp-10.dll` is the name of the library built by vcpkg for MSVC and installed on Christo MSVC 2019 testsuite.

## Release Management

* Affected package(s): Installation
* License and copyright ownership: unchanged

