### PR TITLE
Mesh 3 - fix initialization

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -1167,7 +1167,7 @@ private:
      * @brief Updates cell \c ch in c3t3
      * @param ch the cell to update
      * @param update if set to \c false, checking only is done
-     * @return true if \c ch is in c3t3
+     * @return a boost::optional<Subdomain_index>, valid iff \c ch is in c3t3
      */
     Subdomain operator()(const Cell_handle& ch, const bool update = true) const
     {

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.h
@@ -6,11 +6,8 @@
 #endif
 #include "Kernel_type.h"
 #include "Meshing_thread.h"
-#include "Scene_surface_mesh_item.h"
 #include <CGAL/facets_in_complex_3_to_triangle_mesh.h>
 #include <QList>
-
-class Scene_surface_mesh_item;
 
 struct Mesh_parameters;
 namespace CGAL { namespace Three {

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
@@ -316,6 +316,11 @@ launch()
 #endif
 
 #if CGAL_MESH_3_MESHER_STATUS_ACTIVATED
+  // First we have to ensure that no old cell will be left in c3t3
+  // Second, the c3t3 object could have been corrupted,
+  // for example by inserting new vertices in the triangulation.
+  c3t3_.clear_cells_and_facets_from_c3t3();
+
   mesher_->initialize();
   while ( ! mesher_->is_algorithm_done() && ! stop_ )
   {


### PR DESCRIPTION
## Summary of Changes

PR #7280 highlighted the fact that the mesh refinement `one_step()` loop may crash if the C3T3 had been corrupted during the initialization step.
Now both `refine_mesh()` and the `one_step()` loop have the exact same behaviour.

This crash was first met in the demo :
- open cube.off
- "Tetrahedral mesh generation -> Generate surface mesh"
- keep all default parameters
- OK

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

