### PR TITLE
Incorrect usage of `xmlns` in HTML headers

### DIFF
--- a/Documentation/doc/resources/1.8.13/header.html
+++ b/Documentation/doc/resources/1.8.13/header.html
@@ -1,6 +1,6 @@
 <!-- HTML header for doxygen 1.8.13-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="https://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <link rel="icon" type="image/png" href="$relpath$../Manual/g-196x196-doc.png"/>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>

--- a/Documentation/doc/resources/1.8.13/header_package.html
+++ b/Documentation/doc/resources/1.8.13/header_package.html
@@ -1,6 +1,6 @@
 <!-- HTML header for doxygen 1.8.13-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="https://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <link rel="icon" type="image/png" href="$relpath$../Manual/g-196x196-doc.png" />
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>

--- a/Documentation/doc/resources/1.8.14/header.html
+++ b/Documentation/doc/resources/1.8.14/header.html
@@ -1,6 +1,6 @@
 <!-- HTML header for doxygen 1.8.13-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="https://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <link rel="icon" type="image/png" href="$relpath$../Manual/g-196x196-doc.png"/>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>

--- a/Documentation/doc/resources/1.8.14/header_package.html
+++ b/Documentation/doc/resources/1.8.14/header_package.html
@@ -1,6 +1,6 @@
 <!-- HTML header for doxygen 1.8.13-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="https://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <link rel="icon" type="image/png" href="$relpath$../Manual/g-196x196-doc.png"/>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>

--- a/Documentation/doc/resources/1.8.20/header.html
+++ b/Documentation/doc/resources/1.8.20/header.html
@@ -1,6 +1,6 @@
 <!-- HTML header for doxygen 1.8.20-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="https://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <link rel="icon" type="image/png" href="$relpath$../Manual/g-196x196-doc.png"/>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>

--- a/Documentation/doc/resources/1.8.20/header_package.html
+++ b/Documentation/doc/resources/1.8.20/header_package.html
@@ -1,6 +1,6 @@
 <!-- HTML header for doxygen 1.8.20-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="https://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <link rel="icon" type="image/png" href="$relpath$../Manual/g-196x196-doc.png"/>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>

--- a/Documentation/doc/resources/1.8.4/header.html
+++ b/Documentation/doc/resources/1.8.4/header.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="https://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <link rel="icon" type="image/png" href="$relpath$../Manual/g-196x196-doc.png"/>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>

--- a/Documentation/doc/resources/1.8.4/header_package.html
+++ b/Documentation/doc/resources/1.8.4/header_package.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="https://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <link rel="icon" type="image/png" href="$relpath$../Manual/g-196x196-doc.png"/>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>

--- a/Documentation/doc/resources/1.9.3/header.html
+++ b/Documentation/doc/resources/1.9.3/header.html
@@ -1,6 +1,6 @@
 <!-- HTML header for doxygen 1.8.20-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="https://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <link rel="icon" type="image/png" href="$relpath$../Manual/g-196x196-doc.png"/>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>

--- a/Documentation/doc/resources/1.9.3/header_package.html
+++ b/Documentation/doc/resources/1.9.3/header_package.html
@@ -1,6 +1,6 @@
 <!-- HTML header for doxygen 1.8.20-->
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
-<html xmlns="https://www.w3.org/1999/xhtml">
+<html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 <link rel="icon" type="image/png" href="$relpath$../Manual/g-196x196-doc.png"/>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>


### PR DESCRIPTION
In #7075 the usage of `xmlns` was changed from:
```
<html xmln="https://www.w3.org/1999/xhtml">
```
into
```
<html xmlns="https://www.w3.org/1999/xhtml">
```

this is not correct, the usage has to be `http`  as in the definition https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd we see:
```
<!-- the namespace URI designates the document profile -->

<!ELEMENT html (head, body)>
<!ATTLIST html
  %i18n;
  id          ID             #IMPLIED
  xmlns       %URI;          #FIXED 'http://www.w3.org/1999/xhtml'
  >
```

_Please use the following template to help us managing pull requests._

## Summary of Changes

_Describe what your pull request changes to CGAL (this can be skipped if it solves an issue already in the tracker or if it is a Feature or Small Feature submitted to the CGAL Wiki)._

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

