### PR TITLE
Fix issues in OBJ I/O

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h
@@ -101,7 +101,7 @@ bool read_polygon_mesh(const std::string& fname,
 
   std::vector<Point> points;
   std::vector<std::vector<std::size_t> > faces;
-  if(!CGAL::IO::read_polygon_soup(fname, points, faces))
+  if(!CGAL::IO::read_polygon_soup(fname, points, faces, CGAL::parameters::verbose(verbose)))
   {
     if(verbose)
       std::cerr << "Warning: cannot read polygon soup" << std::endl;

--- a/Stream_support/include/CGAL/IO/OBJ.h
+++ b/Stream_support/include/CGAL/IO/OBJ.h
@@ -146,7 +146,11 @@ bool read_OBJ(std::istream& is,
       }
 
       if(iss.bad())
+      {
+        if(verbose)
+          std::cerr << "error while reading OBJ face." << std::endl;
         return false;
+      }
     }
     else if(s.front() == '#')
     {
@@ -172,15 +176,15 @@ bool read_OBJ(std::istream& is,
     else
     {
       if(verbose)
-        std::cerr << "error: unrecognized line: " << s << std::endl;
+        std::cerr << "Error: unrecognized line: " << s << std::endl;
       return false;
     }
   }
 
   if(norm_found && verbose)
-    std::cout<<"NOTE: normals were found in this file, but were discarded."<<std::endl;
+    std::cout << "NOTE: normals were found in this file, but were discarded." << std::endl;
   if(tex_found && verbose)
-    std::cout<<"NOTE: textures were found in this file, but were discarded."<<std::endl;
+    std::cout << "NOTE: textures were found in this file, but were discarded." << std::endl;
 
   if(points.empty() || polygons.empty())
   {


### PR DESCRIPTION
## Summary of Changes

The previous code failed to read files with NULL-only lines, and multi lines separated by backslashes.

Running on Thingi10k, I observed (only) the expected failures :

![image](https://user-images.githubusercontent.com/5074170/232745372-99cf52f6-2898-40df-937c-3e2610ae014f.png)


## Release Management

* Affected package(s): `Stream_support`
* Issue(s) solved (if any): N/A
* Feature/Small Feature (if any): N/A
* License and copyright ownership:

