### PR TITLE
Incorrect HTML code in relation with \cgalAdvancedEnd

### DIFF
--- a/Documentation/doc/resources/1.8.20/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.20/BaseDoxyfile.in
@@ -329,7 +329,7 @@ ALIASES                = "cgal=%CGAL" \
                          "cgalDebugEnd=\htmlonly[block] </div> \endhtmlonly" \
                          "cgalDebugFunction=This is a function for debugging purpose." \
                          "cgalAdvancedBegin=^^ \htmlonly[block] <div class=\"CGALAdvanced\"> <div>Advanced</div> \endhtmlonly ^^" \
-                         "cgalAdvancedEnd=\noop ^^ \htmlonly[block] </div> \endhtmlonly" \
+                         "cgalAdvancedEnd=^^ \noop ^^ \htmlonly[block] </div> \endhtmlonly" \
                          "cgalAdvancedFunction=This is an advanced function." \
                          "cgalAdvancedClass=This is an advanced class." \
                          "cgalAdvancedType=This is an advanced type." \

--- a/Documentation/doc/resources/1.9.3/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.9.3/BaseDoxyfile.in
@@ -336,7 +336,7 @@ ALIASES                = "cgal=%CGAL" \
                          "cgalDebugEnd=\htmlonly[block] </div> \endhtmlonly" \
                          "cgalDebugFunction=This is a function for debugging purpose." \
                          "cgalAdvancedBegin=^^ \htmlonly[block] <div class=\"CGALAdvanced\"> <div>Advanced</div> \endhtmlonly ^^" \
-                         "cgalAdvancedEnd=\noop ^^ \htmlonly[block] </div> \endhtmlonly" \
+                         "cgalAdvancedEnd=^^ \noop ^^ \htmlonly[block] </div> \endhtmlonly" \
                          "cgalAdvancedFunction=This is an advanced function." \
                          "cgalAdvancedClass=This is an advanced class." \
                          "cgalAdvancedType=This is an advanced type." \


### PR DESCRIPTION
In #5226 we already fixed a problem regarding the subtle interaction between the `cgaAdvancedEnd` command and table rows / columns. In this PR a subtle interaction between the `\cgalAdvancedEnd` and the `pre` command is solved.

xmllint gave the following type warning:
```
Periodic_2_triangulation_2/classCGAL_1_1Periodic__2__triangulation__2.html:1418: parser error : Opening and ending tag mismatch: dd line 1418 and div
"This is an advancedSurface_mesh_deformation function.">is_triangulation_in_1_sheet()</a></code>  </div>
```
this type of warning appeared for the packages:
- Periodic_2_triangulation_2
- Point_set_3
- TDS_3
- Triangulation
- Triangulation_2

for the package Surface_mesh_skeletonization we again saw a warning like:
```
Surface_mesh_skeletonization/classCGAL_1_1Mean__curvature__flow__skeletonization.html:519: parser error : Opening and ending tag mismatch: td line 519 and div
raph_traits&lt;TriangleMesh&gt;::vertex_descriptor</code> as value type.  </div>
```
this is also fixed with this PR.

