### PR TITLE
Bounding volumes fix 3center

### DIFF
--- a/Bounding_volumes/examples/Rectangular_p_center_2/rectangular_p_center_2.cpp
+++ b/Bounding_volumes/examples/Rectangular_p_center_2/rectangular_p_center_2.cpp
@@ -19,7 +19,7 @@ typedef CGAL::Ostream_iterator<Point,std::ostream>  OIterator;
 int main()
 {
   int n = 10;
-  int p = 2;
+  int p = 3;
   OIterator cout_ip(std::cout);
   CGAL::IO::set_pretty_mode(std::cout);
 
@@ -31,7 +31,7 @@ int main()
   FT p_radius;
   std::cout << "\n\n" << p << "-centers:\n";
   CGAL::rectangular_p_center_2(
-    points.begin(), points.end(), cout_ip, p_radius, 3);
+    points.begin(), points.end(), cout_ip, p_radius, p);
   std::cout << "\n\n" << p << "-radius = " << p_radius << std::endl;
 
   return 0;

--- a/Bounding_volumes/include/CGAL/rectangular_3_center_2.h
+++ b/Bounding_volumes/include/CGAL/rectangular_3_center_2.h
@@ -1371,9 +1371,8 @@ CGAL_3CENTER_REPEAT_CHECK:
 
   // try rho_min
   CGAL_assertion(rho_min <= rho_max);
-  CGAL_assertion(rho_min >= 0);
   FT rad_2 = q_t_q_r_cover_at_rho_min;
-  if (s_at_rho_min != e_at_rho_min) {
+  if (rho_min >= 0 && s_at_rho_min != e_at_rho_min) {
     auto mydist = [&q_t_at_rho_min, &q_r_at_rho_min, &op](const Point& p)
                   { return Min<FT>()( op.distance()(q_t_at_rho_min, p),
                                       op.distance()(q_r_at_rho_min, p)); };

--- a/Bounding_volumes/test/Bounding_volumes/issue_2836.cpp
+++ b/Bounding_volumes/test/Bounding_volumes/issue_2836.cpp
@@ -1,0 +1,39 @@
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/point_generators_2.h>
+#include <CGAL/rectangular_p_center_2.h>
+#include <CGAL/IO/Ostream_iterator.h>
+#include <CGAL/algorithm.h>
+#include <iostream>
+#include <algorithm>
+#include <vector>
+
+typedef double                                      FT;
+
+typedef CGAL::Simple_cartesian<FT>                  Kernel;
+
+typedef Kernel::Point_2                             Point;
+typedef std::vector<Point>                          Cont;
+typedef CGAL::Random_points_in_square_2<Point>      Generator;
+typedef CGAL::Ostream_iterator<Point,std::ostream>  OIterator;
+
+int main()
+{
+  CGAL::get_default_random() = CGAL::Random(1518508913);
+  int n = 10;
+  int p = 3;
+  OIterator cout_ip(std::cout);
+  CGAL::IO::set_pretty_mode(std::cout);
+
+  Cont points;
+  std::copy_n(Generator(1), n, std::back_inserter(points));
+  std::cout << "Generated Point Set:\n";
+  std::copy(points.begin(), points.end(), cout_ip);
+
+  FT p_radius;
+  std::cout << "\n\n" << p << "-centers:\n";
+  CGAL::rectangular_p_center_2(
+    points.begin(), points.end(), cout_ip, p_radius, p);
+  std::cout << "\n\n" << p << "-radius = " << p_radius << std::endl;
+
+  return 0;
+}


### PR DESCRIPTION

## Summary of Changes
Fix issue in 3center brute-force base case: Don't check `rho_min` if `s == t`.
Make parameters consistent in example
## Release Management
* Affected package(s): Bounding_volumes
* Issue(s) solved (if any): fix #2836

