### PR TITLE
CMake: allow spaces in git working directory

### DIFF
--- a/Installation/cmake/modules/CGALConfigVersion_binary_header_only.cmake.in
+++ b/Installation/cmake/modules/CGALConfigVersion_binary_header_only.cmake.in
@@ -2,4 +2,4 @@
 # This file points to the CGALConfigVersion.cmake for header-only CGAL.
 #
 
-include(@CGAL_INSTALLATION_PACKAGE_DIR@/lib/cmake/CGAL/CGALConfigVersion.cmake)
+include("@CGAL_INSTALLATION_PACKAGE_DIR@/lib/cmake/CGAL/CGALConfigVersion.cmake")

--- a/Installation/cmake/modules/CGALConfig_binary_header_only.cmake.in
+++ b/Installation/cmake/modules/CGALConfig_binary_header_only.cmake.in
@@ -2,4 +2,4 @@
 # This file points to the CGALConfig.cmake for header-only CGAL.
 #
 
-include(@CGAL_INSTALLATION_PACKAGE_DIR@/lib/cmake/CGAL/CGALConfig.cmake)
+include("@CGAL_INSTALLATION_PACKAGE_DIR@/lib/cmake/CGAL/CGALConfig.cmake")


### PR DESCRIPTION
## Summary of Changes

Imagine you have cloned CGAL in a local directory named `C:\Users\Laurent Rineau\cgal`, before this patch CMake would fail..., because of the space in the full path. Now it works.

## Release Management

* Affected package(s): CGAL (CMake)
* License and copyright ownership: na

