### PR TITLE
Qt5::Svg is now only optional for CGAL_Qt5

### DIFF
--- a/AABB_tree/demo/AABB_tree/CMakeLists.txt
+++ b/AABB_tree/demo/AABB_tree/CMakeLists.txt
@@ -24,7 +24,7 @@ include_directories(BEFORE ./ ./include)
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
 # Find Qt5 itself
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Gui Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets OpenGL)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
 
@@ -53,7 +53,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
     #${CGAL_Qt5_MOC_FILES}
   )
   # Link with Qt libraries
-  target_link_libraries(AABB_demo PRIVATE Qt5::OpenGL Qt5::Gui
+  target_link_libraries(AABB_demo PRIVATE Qt5::Widgets Qt5::OpenGL
                                           CGAL::CGAL CGAL::CGAL_Qt5)
 
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS AABB_demo)

--- a/Alpha_shapes_3/demo/Alpha_shapes_3/CMakeLists.txt
+++ b/Alpha_shapes_3/demo/Alpha_shapes_3/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets OpenGL)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
 
@@ -40,7 +40,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Alpha_shape_3)
 
   target_link_libraries(Alpha_shape_3 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                              Qt5::OpenGL Qt5::Gui)
+                                              Qt5::Widgets Qt5::OpenGL)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Alpha_shape_3)

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CMakeLists.txt
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CMakeLists.txt
@@ -13,7 +13,7 @@ if(POLICY CMP0071)
 endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Core Qt5)
-find_package(Qt5 QUIET COMPONENTS Gui Widgets)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 
 if (CGAL_Qt5_FOUND AND Qt5_FOUND)
   include(${CGAL_USE_FILE})
@@ -110,7 +110,7 @@ if (CGAL_Qt5_FOUND AND Qt5_FOUND)
                  ${CGAL_Qt5_RESOURCE_FILES}
                  ${CGAL_Qt5_MOC_FILES})
 
-  target_link_libraries(arrangement_2 PRIVATE Qt5::Core Qt5::Gui Qt5::Widgets)
+  target_link_libraries(arrangement_2 PRIVATE Qt5::Widgets)
   target_link_libraries(arrangement_2 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5)
   if(CGAL_Core_FOUND)
     target_link_libraries(arrangement_2 PRIVATE CGAL::CGAL_Core)

--- a/CGAL_ipelets/demo/CGAL_ipelets/mesh_2.cpp
+++ b/CGAL_ipelets/demo/CGAL_ipelets/mesh_2.cpp
@@ -108,8 +108,8 @@ void IpeletMesh2::protected_run(int fn)
     mesher.refine_mesh();
   }
   else
-    CGAL::refine_Delaunay_mesh_2(cdt,list_of_seeds.begin(), list_of_seeds.end(),
-      Criteria(0.125, alpha));
+    CGAL::refine_Delaunay_mesh_2(cdt,
+        CGAL::parameters::criteria(Criteria(0.125, alpha)).seeds(list_of_seeds));
 
 
   for (CDT::Finite_edges_iterator it=cdt.finite_edges_begin(); it!=cdt.finite_edges_end();++it)

--- a/Circular_kernel_3/demo/Circular_kernel_3/CMakeLists.txt
+++ b/Circular_kernel_3/demo/Circular_kernel_3/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL)
+find_package(Qt5 QUIET COMPONENTS Widgets OpenGL)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
 
@@ -23,7 +23,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Circular_kernel_3)
 
   target_link_libraries(Circular_kernel_3 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                                  Qt5::OpenGL Qt5::Gui)
+                                                  Qt5::Widgets Qt5::OpenGL)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Circular_kernel_3)

--- a/GraphicsView/demo/Alpha_shapes_2/CMakeLists.txt
+++ b/GraphicsView/demo/Alpha_shapes_2/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 include_directories(BEFORE ./include)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
@@ -37,7 +37,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Alpha_shapes_2)
 
   target_link_libraries(Alpha_shapes_2 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                               Qt5::Gui)
+                                               Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Alpha_shapes_2)

--- a/GraphicsView/demo/Apollonius_graph_2/CMakeLists.txt
+++ b/GraphicsView/demo/Apollonius_graph_2/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_definitions(-DQT_NO_KEYWORDS)
@@ -38,7 +38,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Apollonius_graph_2)
 
   target_link_libraries(Apollonius_graph_2 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                                   Qt5::Gui)
+                                                   Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Apollonius_graph_2)

--- a/GraphicsView/demo/Bounding_volumes/CMakeLists.txt
+++ b/GraphicsView/demo/Bounding_volumes/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 include_directories(BEFORE ./include)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
@@ -40,7 +40,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Bounding_volumes)
 
   target_link_libraries(Bounding_volumes PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                                 Qt5::Gui)
+                                                 Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Bounding_volumes)

--- a/GraphicsView/demo/Circular_kernel_2/CMakeLists.txt
+++ b/GraphicsView/demo/Circular_kernel_2/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_definitions(-DQT_NO_KEYWORDS)
@@ -38,7 +38,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Circular_kernel_2)
 
   target_link_libraries(Circular_kernel_2 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                                  Qt5::Gui)
+                                                  Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Circular_kernel_2)

--- a/GraphicsView/demo/Generator/CMakeLists.txt
+++ b/GraphicsView/demo/Generator/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
 
@@ -36,7 +36,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
 
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Generator_2)
 
-  target_link_libraries(Generator_2 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Gui)
+  target_link_libraries(Generator_2 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Generator_2)

--- a/GraphicsView/demo/GraphicsView/CMakeLists.txt
+++ b/GraphicsView/demo/GraphicsView/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
 
@@ -25,7 +25,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
 
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS min)
 
-  target_link_libraries(min PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Gui)
+  target_link_libraries(min PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(min)

--- a/GraphicsView/demo/L1_Voronoi_diagram_2/CMakeLists.txt
+++ b/GraphicsView/demo/L1_Voronoi_diagram_2/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 include_directories(BEFORE ./include)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
@@ -38,7 +38,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS L1_voronoi_diagram_2)
 
   target_link_libraries(L1_voronoi_diagram_2 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                                     Qt5::Gui)
+                                                     Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(L1_voronoi_diagram_2)

--- a/GraphicsView/demo/Largest_empty_rect_2/CMakeLists.txt
+++ b/GraphicsView/demo/Largest_empty_rect_2/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
 
@@ -37,7 +37,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Largest_empty_rectangle_2)
 
   target_link_libraries(Largest_empty_rectangle_2
-                        PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Gui)
+                        PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Largest_empty_rectangle_2)

--- a/GraphicsView/demo/Periodic_2_triangulation_2/CMakeLists.txt
+++ b/GraphicsView/demo/Periodic_2_triangulation_2/CMakeLists.txt
@@ -12,7 +12,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 include_directories(BEFORE ./include)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
@@ -49,7 +49,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
                      Periodic_2_Delaunay_triangulation_2)
 
   target_link_libraries(Periodic_2_Delaunay_triangulation_2
-                        PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Gui)
+                        PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Periodic_2_Delaunay_triangulation_2)

--- a/GraphicsView/demo/Polygon/CMakeLists.txt
+++ b/GraphicsView/demo/Polygon/CMakeLists.txt
@@ -22,7 +22,7 @@ if(NOT TARGET CGAL::Eigen3_support)
   return()
 endif()
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   include(${CGAL_USE_FILE})
@@ -49,7 +49,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Polygon_2)
 
   target_link_libraries(Polygon_2 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                          CGAL::Eigen3_support Qt5::Gui)
+                                          CGAL::Eigen3_support Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Polygon_2)

--- a/GraphicsView/demo/Segment_Delaunay_graph_2/CMakeLists.txt
+++ b/GraphicsView/demo/Segment_Delaunay_graph_2/CMakeLists.txt
@@ -20,7 +20,7 @@ set(QT_USE_QTMAIN TRUE)
 set(QT_USE_QTSCRIPT TRUE)
 set(QT_USE_QTOPENGL TRUE)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 include_directories(BEFORE ./include)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
@@ -43,7 +43,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Segment_voronoi_2)
 
   target_link_libraries(Segment_voronoi_2 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                                  Qt5::Gui)
+                                                  Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Segment_voronoi_2)

--- a/GraphicsView/demo/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
+++ b/GraphicsView/demo/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
@@ -20,7 +20,7 @@ set(QT_USE_QTMAIN TRUE)
 set(QT_USE_QTSCRIPT TRUE)
 set(QT_USE_QTOPENGL TRUE)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 include_directories(BEFORE ./include)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
@@ -42,7 +42,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Segment_voronoi_linf_2)
 
   target_link_libraries(Segment_voronoi_linf_2 PRIVATE CGAL::CGAL
-                                                       CGAL::CGAL_Qt5 Qt5::Gui)
+                                                       CGAL::CGAL_Qt5 Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Segment_voronoi_linf_2)

--- a/GraphicsView/demo/Snap_rounding_2/CMakeLists.txt
+++ b/GraphicsView/demo/Snap_rounding_2/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   set(CMAKE_AUTOMOC ON)
@@ -36,7 +36,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Snap_rounding_2)
 
   target_link_libraries(Snap_rounding_2 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                                Qt5::Gui)
+                                                Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Snap_rounding_2)

--- a/GraphicsView/demo/Spatial_searching_2/CMakeLists.txt
+++ b/GraphicsView/demo/Spatial_searching_2/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
 
@@ -37,7 +37,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Spatial_searching_2)
 
   target_link_libraries(Spatial_searching_2 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                                    Qt5::Gui)
+                                                    Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Spatial_searching_2)

--- a/GraphicsView/demo/Stream_lines_2/CMakeLists.txt
+++ b/GraphicsView/demo/Stream_lines_2/CMakeLists.txt
@@ -15,7 +15,7 @@ endif()
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
 
@@ -37,7 +37,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Stream_lines_2)
 
   target_link_libraries(Stream_lines_2 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                               Qt5::Gui)
+                                               Qt5::Widgets)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Stream_lines_2)

--- a/GraphicsView/include/CGAL/Qt/DemosMainWindow.h
+++ b/GraphicsView/include/CGAL/Qt/DemosMainWindow.h
@@ -93,8 +93,9 @@ protected Q_SLOTS:
   void popupAboutCGAL();
   void popupAboutDemo();
 
+#if QT_SVG_LIB
   void exportSVG();
-
+#endif
   void openRecentFile_aux();
   void addToRecentFiles(QString fileName);
   void updateRecentFileActions();

--- a/GraphicsView/include/CGAL/Qt/DemosMainWindow_impl.h
+++ b/GraphicsView/include/CGAL/Qt/DemosMainWindow_impl.h
@@ -38,7 +38,9 @@
 #include <QUrl>
 #include <QDesktopWidget>
 #include <QRegExp>
-#include <QSvgGenerator>
+#if QT_SVG_LIB
+#  include <QSvgGenerator>
+#endif
 #include <QtCore>
 #include <QtOpenGL>
 
@@ -159,6 +161,7 @@ DemosMainWindow::setupOptionsMenu(QMenu* menuOptions)
   actionUse_Antialiasing->setChecked(true);
 }
 
+#if QT_SVG_LIB
 CGAL_INLINE_FUNCTION
 void
 DemosMainWindow::setupExportSVG(QAction* action, QGraphicsView* view)
@@ -189,6 +192,7 @@ void DemosMainWindow::exportSVG()
   this->view->render(&painter);
   painter.end();
 }
+#endif // QT_SVG_LIB
 
 CGAL_INLINE_FUNCTION
 void

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -15,7 +15,7 @@ find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Core Qt5)
 find_package(LEDA QUIET)
 
 # Find Qt5 itself
-find_package(Qt5 QUIET COMPONENTS OpenGL Gui)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 
 if(CGAL_Qt5_FOUND
    AND Qt5_FOUND

--- a/Installation/cmake/modules/CGAL_SetupCGAL_Qt5Dependencies.cmake
+++ b/Installation/cmake/modules/CGAL_SetupCGAL_Qt5Dependencies.cmake
@@ -9,7 +9,7 @@
 #
 # .. code-block:: cmake
 #
-#    find_package(Qt5 QUIET COMPONENTS OpenGL Svg)
+#    find_package(Qt5 QUIET COMPONENTS OpenGL Widgets)
 #
 # and defines the variable :variable:`CGAL_Qt5_FOUND` and the function
 # :command:`CGAL_setup_CGAL_Qt5_dependencies`.
@@ -24,14 +24,14 @@ set(CGAL_SetupCGAL_Qt5Dependencies_included TRUE)
 # Used Modules
 # ^^^^^^^^^^^^
 #   - :module:`Qt5Config`
-find_package(Qt5 QUIET COMPONENTS OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS OpenGL Widgets OPTIONAL_COMPONENTS Svg)
 
 set(CGAL_Qt5_MISSING_DEPS "")
 if(NOT Qt5OpenGL_FOUND)
   set(CGAL_Qt5_MISSING_DEPS "Qt5OpenGL")
 endif()
-if(NOT Qt5Svg_FOUND)
-  set(CGAL_Qt5_MISSING_DEPS "${CGAL_Qt5_MISSING_DEPS} Qt5Svg")
+if(NOT Qt5Widgets_FOUND)
+  set(CGAL_Qt5_MISSING_DEPS "${CGAL_Qt5_MISSING_DEPS} Qt5Widgets")
 endif()
 if(NOT Qt5_FOUND)
   set(CGAL_Qt5_MISSING_DEPS "${CGAL_Qt5_MISSING_DEPS} Qt5")
@@ -75,8 +75,10 @@ if(NOT CGAL_Qt5_MISSING_DEPS)
       POSITION_INDEPENDENT_CODE TRUE
       EXCLUDE_FROM_ALL TRUE
       AUTOMOC TRUE)
-    target_link_libraries(CGAL_Qt5_moc_and_resources CGAL::CGAL Qt5::Widgets Qt5::OpenGL Qt5::Svg )
-
+    target_link_libraries(CGAL_Qt5_moc_and_resources PUBLIC CGAL::CGAL Qt5::Widgets Qt5::OpenGL )
+    if(Qt5Svg_FOUND)
+      target_link_libraries(CGAL_Qt5_moc_and_resources PUBLIC Qt5::Svg)
+    endif()
     add_library(CGAL::CGAL_Qt5_moc_and_resources ALIAS CGAL_Qt5_moc_and_resources)
     add_library(CGAL::Qt5_moc_and_resources ALIAS CGAL_Qt5_moc_and_resources)
   endif()
@@ -112,7 +114,7 @@ function(CGAL_setup_CGAL_Qt5_dependencies target)
   endif()
   target_link_libraries( ${target} INTERFACE CGAL::CGAL)
   target_link_libraries( ${target} INTERFACE CGAL::Qt5_moc_and_resources)
-  target_link_libraries( ${target} INTERFACE Qt5::OpenGL Qt5::Svg )
+  target_link_libraries( ${target} INTERFACE Qt5::OpenGL Qt5::Widgets )
 
   # Remove -Wdeprecated-copy, for g++ >= 9.0, because Qt5, as of
   # version 5.12, has a lot of [-Wdeprecated-copy] warnings.

--- a/Linear_cell_complex/demo/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/demo/Linear_cell_complex/CMakeLists.txt
@@ -42,11 +42,9 @@ add_definitions(-DCMAP_WITH_INDEX) # to use cc with index (handle otherwise)
 ##################
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Svg)
+find_package(Qt5 COMPONENTS Widgets OpenGL)
 
-if(NOT
-   (CGAL_Qt5_FOUND
-    AND Qt5_FOUND))
+if(NOT CGAL_Qt5_FOUND OR NOT Qt5_FOUND)
 
   message("NOTICE: This demo requires CGAL and Qt5, and will not be compiled.")
 
@@ -79,7 +77,7 @@ else()
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Linear_cell_complex_3_demo)
 
   target_link_libraries(Linear_cell_complex_3_demo
-                        PUBLIC CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Gui Qt5::OpenGL)
+                        PUBLIC CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Widgets Qt5::OpenGL)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Linear_cell_complex_3_demo)

--- a/Linear_cell_complex/demo/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/demo/Linear_cell_complex/CMakeLists.txt
@@ -42,7 +42,7 @@ add_definitions(-DCMAP_WITH_INDEX) # to use cc with index (handle otherwise)
 ##################
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 COMPONENTS Widgets OpenGL)
+find_package(Qt5 QUIET COMPONENTS Widgets OpenGL)
 
 if(NOT CGAL_Qt5_FOUND OR NOT Qt5_FOUND)
 

--- a/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/CMakeLists.txt
+++ b/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/CMakeLists.txt
@@ -19,7 +19,7 @@ include_directories(BEFORE ./ ./include)
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
 # Find Qt5 itself
-find_package(Qt5 5.4 QUIET COMPONENTS OpenGL)
+find_package(Qt5 5.4 QUIET COMPONENTS Widgets)
 if(Qt5_FOUND)
   add_definitions(-DQT_NO_KEYWORDS)
   set(CMAKE_INCLUDE_CURRENT_DIR ON)
@@ -68,8 +68,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_executable(Otr2_demo ${SRCS} ${CGAL_Qt5_MOC_FILES} ${UI_FILES}
                            ${CGAL_Qt5_RESOURCE_FILES})
 
-  target_link_libraries(Otr2_demo PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Gui
-                                          Qt5::OpenGL)
+  target_link_libraries(Otr2_demo PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Widgets)
 
   # Link with pthread if necessary
   if(CIMG_INCLUDE_DIR)

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
@@ -17,7 +17,7 @@ endif()
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
 # Find Qt5 itself
-find_package(Qt5 QUIET COMPONENTS OpenGL Help Core)
+find_package(Qt5 QUIET COMPONENTS Widgets OpenGL Help)
 
 if(Qt5_FOUND)
   add_definitions(-DQT_NO_KEYWORDS)
@@ -73,7 +73,7 @@ if(CGAL_Qt5_FOUND
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS periodic_3_triangulation_3_demo)
 
   target_link_libraries(periodic_3_triangulation_3_demo
-                        PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::OpenGL)
+                        PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Widgets Qt5::OpenGL)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(periodic_3_triangulation_3_demo)

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/CMakeLists.txt
@@ -19,7 +19,7 @@ set(CMAKE_AUTOMOC ON)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS Script Help OpenGL Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets OpenGL Help)
 
 if(Qt5Help_VERSION VERSION_LESS 5.12)
   set(CGAL_QCOLLECTIONGENERATOR_TARGET Qt5::qcollectiongenerator)
@@ -68,7 +68,7 @@ if(CGAL_Qt5_FOUND
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Periodic_Lloyd_3)
 
   target_link_libraries(Periodic_Lloyd_3 PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                                 Qt5::OpenGL)
+                                                 Qt5::Widgets Qt5::OpenGL)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test(Periodic_Lloyd_3)

--- a/Polyline_simplification_2/demo/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/demo/Polyline_simplification_2/CMakeLists.txt
@@ -17,7 +17,7 @@ find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
 set(CMAKE_INCLUDE_CURRENT_DIR ON)
 
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Widgets Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets)
 
 include_directories(BEFORE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
@@ -39,7 +39,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
     ${CGAL_Qt5_RESOURCE_FILES} ${CGAL_Qt5_MOC_FILES})
 
   target_link_libraries(Polyline_simplification_2
-                        PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Gui)
+                        PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::Widgets)
 
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS Polyline_simplification_2)
 

--- a/Principal_component_analysis/demo/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/demo/Principal_component_analysis/CMakeLists.txt
@@ -25,7 +25,7 @@ if(NOT TARGET CGAL::Eigen3_support)
 endif()
 
 # Find Qt5 itself
-find_package(Qt5 QUIET COMPONENTS Script OpenGL)
+find_package(Qt5 QUIET COMPONENTS Widgets OpenGL)
 
 if(CGAL_Qt5_FOUND AND Qt5_FOUND)
 
@@ -51,7 +51,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
                           ${CGAL_Qt5_MOC_FILES})
 
   target_link_libraries(PCA_demo PRIVATE CGAL::CGAL CGAL::CGAL_Qt5
-                                         CGAL::Eigen3_support Qt5::Gui)
+                                         CGAL::Eigen3_support Qt5::Widgets Qt5::OpenGL)
 
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS PCA_demo)
 

--- a/Triangulation_3/demo/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/demo/Triangulation_3/CMakeLists.txt
@@ -20,7 +20,7 @@ set(CMAKE_AUTOMOC ON)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
-find_package(Qt5 QUIET COMPONENTS OpenGL)
+find_package(Qt5 QUIET COMPONENTS Widgets OpenGL)
 
 if(Qt5_FOUND)
   add_definitions(-DQT_NO_KEYWORDS)
@@ -70,7 +70,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS T3_demo)
 
   target_link_libraries(T3_demo PRIVATE CGAL::CGAL CGAL::CGAL_Qt5)
-  target_link_libraries(T3_demo PRIVATE Qt5::OpenGL)
+  target_link_libraries(T3_demo PRIVATE Qt5::Widgets Qt5::OpenGL)
   if(TARGET CGAL::TBB_support)
     target_link_libraries(T3_demo PUBLIC CGAL::TBB_support)
   endif()

--- a/Triangulation_on_sphere_2/demo/Triangulation_on_sphere_2/CMakeLists.txt
+++ b/Triangulation_on_sphere_2/demo/Triangulation_on_sphere_2/CMakeLists.txt
@@ -24,7 +24,7 @@ endif()
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt5)
 
 # Find Qt5 itself
-find_package(Qt5 QUIET COMPONENTS Script OpenGL Gui Svg)
+find_package(Qt5 QUIET COMPONENTS Widgets OpenGL)
 
 find_package(Eigen3 3.1.0 QUIET) #(requires 3.1.0 or greater)
 include(CGAL_Eigen3_support)
@@ -42,7 +42,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND AND TARGET CGAL::Eigen3_support)
 
   add_to_cached_list( CGAL_EXECUTABLE_TARGETS Triangulation_on_sphere_2_Demo )
 
-  target_link_libraries( Triangulation_on_sphere_2_Demo PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 CGAL::Eigen3_support)
+  target_link_libraries( Triangulation_on_sphere_2_Demo PRIVATE CGAL::CGAL CGAL::CGAL_Qt5 Qt5::OpenGL Qt5::Widgets CGAL::Eigen3_support)
 
   include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
   cgal_add_compilation_test( Triangulation_on_sphere_2_Demo )


### PR DESCRIPTION
## Summary of Changes

- `Qt5::Svg` is now only optional for CGAL_Qt5
- And cleanup all the usages of Qt5 in CMake scripts of CGAL:
  - 2D demos need `Qt5::Widgets` (that includes `Core` and `Gui`), and
  - 3D demos need `Qt5::Widgets` and `Qt5::OpenGL`.

## Release Management

* Affected package(s): CGAL
* It is a blocker for CGAL-5.6-beta
