### PR TITLE
Surface_mesh: Fix links to functions replacing deprecated ones

### DIFF
--- a/Surface_mesh/include/CGAL/Surface_mesh/IO.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO.h
@@ -30,7 +30,9 @@ namespace CGAL {
 
 /*!
   \ingroup PkgSurfaceMeshIOFuncDeprecated
-  \deprecated This function is deprecated since \cgal 5.3, `CGAL::IO::read_polygon_mesh()` should be used instead.
+  \deprecated This function is deprecated since \cgal 5.3,
+    `CGAL::IO::read_polygon_mesh(std::istream& is, Graph& g, const NamedParameters& np)`
+    should be used instead.
 */
 template <typename K>
 CGAL_DEPRECATED bool read_mesh(Surface_mesh<K>& sm, const std::string& filename)
@@ -40,7 +42,9 @@ CGAL_DEPRECATED bool read_mesh(Surface_mesh<K>& sm, const std::string& filename)
 
 /*!
   \ingroup PkgSurfaceMeshIOFuncDeprecated
-  \deprecated This function is deprecated since \cgal 5.3, `CGAL::IO::write_polygon_mesh()` should be used instead.
+  \deprecated This function is deprecated since \cgal 5.3,
+    `CGAL::IO::write_polygon_mesh(const std::string& fname, Graph& g,  const NamedParameters& np)`
+    should be used instead.
 */
 template <typename K>
 CGAL_DEPRECATED bool write_mesh(const Surface_mesh<K>& mesh, const std::string& filename)


### PR DESCRIPTION
## Summary of Changes

[Here ](https://cgal.geometryfactory.com/CGAL/doc/master/Surface_mesh/group__PkgSurfaceMeshIOFuncDeprecated.html#ga34db73ce1c76b70e97bcef45daf63468) the links for  `read_polygon_mesh()` and `write_polygon_mesh()` are missing.  Hopefully it works when we add the parameters. 

## Release Management

* Affected package(s): Surface_mesh
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: unchanged

