### PR TITLE
PMP: Test with class derived from Surface_mesh

### DIFF
--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_bool_op.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_bool_op.cpp
@@ -1,5 +1,6 @@
 // #define CGAL_COREFINEMENT_POLYHEDRA_DEBUG
 // #define CGAL_COREFINEMENT_DEBUG
+#define  CGAL_USE_DERIVED_SURFACE_MESH
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
@@ -13,9 +14,17 @@
 #include <CGAL/iterator.h>
 #include <CGAL/array.h>
 
+#include <CGAL/Testsuite/DerivedSurfaceMesh.h>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel              Kernel;
-typedef CGAL::Surface_mesh<Kernel::Point_3> Surface_mesh;
+typedef Kernel::Point_3 Point_3;
+
+
+#ifdef CGAL_USE_DERIVED_SURFACE_MESH
+typedef CGAL::Testsuite::DerivedSurfaceMesh<Point_3> Surface_mesh;
+#else
+typedef CGAL::Surface_mesh<Point_3> Surface_mesh;
+#endif
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 namespace CFR = PMP::Corefinement;

--- a/Testsuite/include/CGAL/Testsuite/DerivedSurfaceMesh.h
+++ b/Testsuite/include/CGAL/Testsuite/DerivedSurfaceMesh.h
@@ -1,0 +1,33 @@
+// Copyright (c) 2023   GeometryFactory Sophia-Antipolis (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Andreas Fabri
+
+#ifndef CGAL_TESTSUITE_DERIVED_SURFACE_MESH_H
+#define CGAL_TESTSUITE_DERIVED_SURFACE_MESH_H
+
+namespace CGAL { namespace Testsuite {
+
+  template <typename P>
+  struct DerivedSurfaceMesh: public CGAL::Surface_mesh<P> {
+    typedef CGAL::Surface_mesh<P> Base;
+    std::string name;
+  };
+
+
+  } // namespace Testsuite
+} // namespace CGAL
+
+
+#define CGAL_GRAPH_TRAITS_INHERITANCE_TEMPLATE_PARAMS typename P
+#define CGAL_GRAPH_TRAITS_INHERITANCE_CLASS_NAME CGAL::Testsuite::DerivedSurfaceMesh<P>
+#define CGAL_GRAPH_TRAITS_INHERITANCE_BASE_CLASS_NAME CGAL::Surface_mesh<P>
+#include <CGAL/boost/graph/graph_traits_inheritance_macros.h>
+
+#endif CGAL_TESTSUITE_DERIVED_SURFACE_MESH_H


### PR DESCRIPTION
## Summary of Changes

Add the class `CGAL::Testsuite::DerivedSurfaceMesh`  that will enable us to check if a class derived from ` CGAL::Surface_mesh` passes the Polygon Mesh Processing testsuite (and others).    To get started and early feedback this is currently only used in a single testcase.  

This is related to PR #7418 as we would have detected the issue.

## Release Management

* Affected package(s): PMP

* License and copyright ownership: unchanged

