### PR TITLE
tag_pr_per_release: gh>=2.28 can edit multiple PRs

### DIFF
--- a/Scripts/developer_scripts/tag_pr_per_release.sh
+++ b/Scripts/developer_scripts/tag_pr_per_release.sh
@@ -44,9 +44,13 @@ echo
 if [[ $REPLY =~ ^YES$ ]]; then
 
   gh api repos/CGAL/cgal/labels -F name=Merged_in_${CURRENT_RELEASE}
-  for i in ${PR_LIST}; do
-    gh pr edit  $i --add-label Merged_in_${CURRENT_RELEASE}
-  done
+  if gh issue edit help | grep -q numbers; then 
+    gh pr edit ${PR_LIST} --add-label Merged_in_${CURRENT_RELEASE}
+  else
+    for i in ${PR_LIST}; do
+      gh pr edit  $i --add-label Merged_in_${CURRENT_RELEASE}
+    done
+  fi
 
 else
 

--- a/Scripts/developer_scripts/tag_pr_per_release.sh
+++ b/Scripts/developer_scripts/tag_pr_per_release.sh
@@ -43,9 +43,9 @@ read -p "Please confirm operation by typing YES? " -n 4 -r
 echo
 if [[ $REPLY =~ ^YES$ ]]; then
 
-  gh api repos/CGAL/cgal/labels -F name=Merged_in_${CURRENT_RELEASE}
-  if gh issue edit help | grep -q numbers; then 
-    gh pr edit ${PR_LIST} --add-label Merged_in_${CURRENT_RELEASE}
+  gh api repos/CGAL/cgal/labels -F name=Merged_in_${CURRENT_RELEASE} || true
+  if gh issue edit --help 2>&1 | grep -q numbers; then
+    gh issue edit ${PR_LIST} --add-label Merged_in_${CURRENT_RELEASE}
   else
     for i in ${PR_LIST}; do
       gh pr edit  $i --add-label Merged_in_${CURRENT_RELEASE}


### PR DESCRIPTION
## Summary of Changes

In [latest release of Github CLI](https://github.com/cli/cli/releases/tag/v2.28.0):
> `issue edit`: edit multiple issues at the same time

Use a `grep -q` of the output of `gh issue edit --help` to detect "numbers" (plural) instead of "number". And then avoid the long for-loop on all the PRs if that is possible (gh version 2.28 and above).

## Release Management

* Affected package(s): Scripts

For the moment, that is a draft-PR, because I will wait for next CGAL release to test the changes in action.
