### PR TITLE
CGAL: Enable user to provide set_use_assertions()

### DIFF
--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -59,7 +59,7 @@ inline void set_use_assertions(bool b)
 }
 }
 
-#else
+#elif !defined(CGAL_USER_DEFINED_USE_ASSERTIONS)
 
 namespace CGAL{
 inline void set_use_assertions(bool){}


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes

As suggested by @GilesBathgate we give the (undocumented) possibility to a user provided function.

## Release Management

* Affected package(s): STL_Extension
* License and copyright ownership: unchanged

