### PR TITLE
Polyhedron demo - fix dihedral angles histogram

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -705,6 +705,9 @@ create_histogram(const T3& triangulation, double& min_value, double& max_value)
     cit != triangulation.finite_cells_end();
     ++cit)
   {
+    if(cit->subdomain_index() == 0)
+      continue;
+
 #ifdef CGAL_MESH_3_DEMO_DONT_COUNT_TETS_ADJACENT_TO_SHARP_FEATURES_FOR_HISTOGRAM
     if (triangulation.in_dimension(cit->vertex(0)) <= 1
       || triangulation.in_dimension(cit->vertex(1)) <= 1


### PR DESCRIPTION
## Summary of Changes

Before this PR, the histogram of dihedral angles displayed in the demo was the histogram of all angles of all tetrahedra.
With this PR, only the angles of tetrahedra with a non-zero Subdomain_index will be computed and used to build the histogram.
Note that the tetrahedra with Subdomain_index zero
* are not displayed at all, so it is made consistent
* are not treated (on purpose) by Delaunay refinement, so they usually are of bad quality

## Release Management

* Affected package(s): Polyhedron demo

