### PR TITLE
Polyhedron demo - read .nii.gz image files

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -1090,7 +1090,7 @@ QString Io_image_plugin::nameFilters() const
                  "Analyze files (*.hdr *.img *.img.gz) ;; "
                  "Stanford Exploration Project files (*.H *.HH) ;; "
                  "NRRD image files (*.nrrd) ;; "
-                 "NIFTI image files (*.nii)");
+                 "NIFTI image files (*.nii *.nii.gz)");
 }
 
 bool Io_image_plugin::canLoad(QFileInfo) const
@@ -1146,7 +1146,9 @@ Io_image_plugin::load(QFileInfo fileinfo, bool& ok, bool add_to_scene)
   }
 
   // read a NIFTI file
-  if(fileinfo.suffix() == "nii")
+  if(fileinfo.suffix() == "nii"
+    || (   fileinfo.suffix() == "gz"
+        && fileinfo.fileName().endsWith(QString(".nii.gz"), Qt::CaseInsensitive)))
   {
 #ifdef CGAL_USE_VTK
     vtkNew<vtkNIFTIImageReader> reader;


### PR DESCRIPTION
## Summary of Changes

Add the ability to read NIFTI `.nii.gz` labeled images, in addition to existing NIFTI `.nii` files.

## Release Management

* Affected package(s): Polyhedron demo
