### PR TITLE
Improve warning on GitHub

### DIFF
--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -160,7 +160,7 @@ jobs:
           script: |
             const error = process.env.ERRORMSG
             const job_url = `${context.serverUrl}/CGAL/cgal/actions/runs/${context.runId}`
-            const msg = "There was an error while building the doc: \n"+error + "\n" + job_url
+            const msg = "There was an error while building the doc: \n```\n"+error + "\n```\n" + job_url
             github.rest.issues.createComment({
               owner: "CGAL",
               repo: "cgal",


### PR DESCRIPTION
When the documentation is generated by GitHub Actions and the result is published on GitHub the warnings are not well / not easy readable. Placing them in a "fenced code" will improve this. (see e.g. https://github.com/CGAL/cgal/pull/7445#issuecomment-1549305160)



