### PR TITLE
Shape_detection: Removed unused parameter

### DIFF
--- a/Shape_detection/doc/Shape_detection/Concepts/RegionType.h
+++ b/Shape_detection/doc/Shape_detection/Concepts/RegionType.h
@@ -37,16 +37,14 @@ public:
   typedef unspecified_type Region_index_map;
 
   /*!
-    checks if the item `to`, which is a neighbor of the item
-    `from`, can be added to the region represented by `region`.
+    checks if the item `i` can be added to the region represented by `region`.
 
     `CGAL::Shape_detection::Region_growing` calls this function each time when
     trying to add a new item to a region. If this function returns `true`, the
-    item with the index `to`, is added to the region, otherwise ignored.
+    item with the index `i`, is added to the region, otherwise ignored.
   */
   bool is_part_of_region(
-    const Item from,
-    const Item to,
+    const Item i,
     const Region &region) {
   }
 

--- a/Shape_detection/examples/Shape_detection/region_growing_with_custom_classes.cpp
+++ b/Shape_detection/examples/Shape_detection/region_growing_with_custom_classes.cpp
@@ -78,7 +78,6 @@ namespace Custom {
     }
 
     bool is_part_of_region(
-      const Item,
       const Item query,
       const Region& region) const {
 

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_circle_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_circle_fit_region.h
@@ -253,8 +253,6 @@ namespace Point_set {
       \param region
       inlier items of the region
 
-      The first parameter is not used in this implementation.
-
       \return Boolean `true` or `false`
 
     */

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_circle_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_circle_fit_region.h
@@ -259,7 +259,6 @@ namespace Point_set {
 
     */
     bool is_part_of_region(
-      const Item,
       const Item query,
       const Region& region) const {
 

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_cylinder_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_cylinder_fit_region.h
@@ -252,8 +252,6 @@ namespace Point_set {
       \param region
       inlier items of the region
 
-      The first parameter is not used in this implementation.
-
       \return Boolean `true` or `false`
 
     */

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_cylinder_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_cylinder_fit_region.h
@@ -258,7 +258,6 @@ namespace Point_set {
 
     */
     bool is_part_of_region(
-      const Item,
       const Item query,
       const Region& region) const {
 

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_line_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_line_fit_region.h
@@ -222,7 +222,6 @@ namespace Point_set {
       \return Boolean `true` or `false`
     */
     bool is_part_of_region(
-      const Item,
       const Item query,
       const Region&) const {
 

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_line_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_line_fit_region.h
@@ -217,7 +217,7 @@ namespace Point_set {
       \param query
       item of the query point
 
-      The first and third parameters are not used in this implementation.
+      The last parameter is not used in this implementation.
 
       \return Boolean `true` or `false`
     */

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_plane_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_plane_fit_region.h
@@ -224,7 +224,6 @@ namespace Point_set {
 
     */
     bool is_part_of_region(
-      const Item,
       const Item query,
       const Region&) const {
 

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_plane_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_plane_fit_region.h
@@ -218,7 +218,7 @@ namespace Point_set {
       \param query
       `Item` of the query point
 
-      The first and third parameters are not used in this implementation.
+      The last parameter is not used in this implementation.
 
       \return Boolean `true` or `false`
 

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_sphere_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_sphere_fit_region.h
@@ -249,7 +249,6 @@ namespace Point_set {
       \return Boolean `true` or `false`
     */
     bool is_part_of_region(
-      const Item,
       const Item query,
       const Region& region) const {
 

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_sphere_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_sphere_fit_region.h
@@ -244,8 +244,6 @@ namespace Point_set {
       \param region
       inlier items of the region
 
-      The first parameter is not used in this implementation.
-
       \return Boolean `true` or `false`
     */
     bool is_part_of_region(

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Polygon_mesh/Least_squares_plane_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Polygon_mesh/Least_squares_plane_fit_region.h
@@ -219,7 +219,7 @@ namespace Polygon_mesh {
       \param query
       `Item` of the query face
 
-      The first and third parameters are not used in this implementation.
+      The last parameter is not used in this implementation.
 
       \return Boolean `true` or `false`
 

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Polygon_mesh/Least_squares_plane_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Polygon_mesh/Least_squares_plane_fit_region.h
@@ -226,7 +226,6 @@ namespace Polygon_mesh {
       \pre `query` is a valid const_iterator of `input_range`
     */
     bool is_part_of_region(
-      const Item,
       const Item query,
       const Region&) const {
 

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Region_growing.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Region_growing.h
@@ -555,13 +555,11 @@ namespace internal {
 
           // Verify that associated elements are still within the tolerance.
           bool fits = true;
-          Item former = region.front();
           for (Item item : region) {
             if (!m_region_type.is_part_of_region(item, region)) {
               fits = false;
               break;
             }
-            former = item;
           }
 
           // The refitted primitive does not fit all elements of the region, so the growing stops here.

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Region_growing.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Region_growing.h
@@ -528,7 +528,7 @@ namespace internal {
             for (Item neighbor : neighbors) {
 
               if (!get(m_visited, neighbor)) {
-                if (m_region_type.is_part_of_region(item, neighbor, region)) {
+                if (m_region_type.is_part_of_region(neighbor, region)) {
 
                   // Add this neighbor to the other queue so that we can visit it later.
                   put(m_visited, neighbor, true);
@@ -557,7 +557,7 @@ namespace internal {
           bool fits = true;
           Item former = region.front();
           for (Item item : region) {
-            if (!m_region_type.is_part_of_region(former, item, region)) {
+            if (!m_region_type.is_part_of_region(item, region)) {
               fits = false;
               break;
             }
@@ -574,7 +574,7 @@ namespace internal {
 
           // Try to continue growing the region by considering formerly rejected elements.
           for (const std::pair<const Item, const Item>& p : rejected) {
-            if (m_region_type.is_part_of_region(p.first, p.second, region)) {
+            if (m_region_type.is_part_of_region(p.second, region)) {
 
               // Add this neighbor to the other queue so that we can visit it later.
               put(m_visited, p.second, true);

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Segment_set/Least_squares_line_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Segment_set/Least_squares_line_fit_region.h
@@ -229,7 +229,6 @@ namespace Segment_set {
 
     */
     bool is_part_of_region(
-      const Item,
       const Item query,
       const Region&) const {
 

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Segment_set/Least_squares_line_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Segment_set/Least_squares_line_fit_region.h
@@ -223,7 +223,7 @@ namespace Segment_set {
       \param query
       `Item` of the query segment
 
-      The first and third parameters are not used in this implementation.
+      The last parameter is not used in this implementation.
 
       \return Boolean `true` or `false`
 


### PR DESCRIPTION
## Summary of Changes

Removed first unused parameter from X_region::is_part_of_region().

## Release Management

Small leftover from https://github.com/CGAL/cgal/pull/6702.

* Affected package(s): Shape_detection
* Issue(s) solved (if any):
* Feature/Small Feature (if any):
* License and copyright ownership:

