### PR TITLE
Scale_space_reconstruction: Cleanup

### DIFF
--- a/Documentation/doc/Documentation/Tutorials/Tutorial_reconstruction.txt
+++ b/Documentation/doc/Documentation/Tutorials/Tutorial_reconstruction.txt
@@ -290,7 +290,7 @@ by the user at runtime with the second argument.
 
 \section TutorialsReconstruction_pipeline Full Pipeline Images
 
-The following figure an example of a full reconstruction pipeline
+The following figures show a full reconstruction pipeline
 applied to a bear statue (courtesy _EPFL Computer Graphics and
 Geometry Laboratory_ \cgalCite{cgal:e-esmr}). Two mesh processing
 algorithms (hole filling and isotropic remeshing) are also applied

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/tutorial_example.cpp
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/tutorial_example.cpp
@@ -210,7 +210,7 @@ int main(int argc, char*argv[])
     for (Point_set::Index idx : points)
       f << points.point (idx) << std::endl;
     for (const auto& facet : CGAL::make_range (reconstruct.facets_begin(), reconstruct.facets_end()))
-      f << "3 "<< facet << std::endl;
+      f << "3 "<< facet[0] << " " << facet[1] << " " << facet[2] << std::endl;
     f.close ();
 
     //! [Output scale space]

--- a/Scale_space_reconstruction_3/examples/Scale_space_reconstruction_3/scale_space_incremental.cpp
+++ b/Scale_space_reconstruction_3/examples/Scale_space_reconstruction_3/scale_space_incremental.cpp
@@ -1,6 +1,7 @@
 #include <CGAL/Scale_space_surface_reconstruction_3.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/IO/read_points.h>
+#include <CGAL/IO/OFF.h>
 
 #include <algorithm>
 #include <fstream>
@@ -16,19 +17,6 @@ typedef Reconstruction::Point                                   Point;
 
 typedef Reconstruction::Facet_const_iterator                   Facet_iterator;
 
-// function for writing the reconstruction output in the off format
-void dump_reconstruction(const Reconstruction& reconstruct, std::string name)
-{
-  std::ofstream output(name.c_str());
-  output << "OFF " << reconstruct.number_of_points() << " "
-         << reconstruct.number_of_facets() << " 0\n";
-
-  std::copy(reconstruct.points_begin(),
-            reconstruct.points_end(),
-            std::ostream_iterator<Point>(output,"\n"));
-  for( Facet_iterator it = reconstruct.facets_begin(); it != reconstruct.facets_end(); ++it )
-      output << "3 " << *it << std::endl;
-}
 
 int main(int argc, char* argv[])
 {
@@ -70,14 +58,18 @@ int main(int argc, char* argv[])
       if (i == 0)
       {
         std::cout << "First reconstruction done." << std::endl;
-        // Write the reconstruction.
-        dump_reconstruction(reconstruct, "reconstruction1.off");
+        CGAL::IO::write_OFF("reconstruction1.off",
+                            reconstruct.points(),
+                            reconstruct.facets(),
+                            CGAL::parameters::stream_precision(17));
       }
       else
       {
         std::cout << "Second reconstruction done." << std::endl;
-        // Write the reconstruction.
-        dump_reconstruction(reconstruct, "reconstruction2.off");
+        CGAL::IO::write_OFF("reconstruction2.off",
+                            reconstruct.points(),
+                            reconstruct.facets(),
+                            CGAL::parameters::stream_precision(17));
       }
     }
 

--- a/Scale_space_reconstruction_3/examples/Scale_space_reconstruction_3/scale_space_manifold.cpp
+++ b/Scale_space_reconstruction_3/examples/Scale_space_reconstruction_3/scale_space_manifold.cpp
@@ -21,7 +21,7 @@ typedef Mesher::Facet_const_iterator                            Mesher_iterator;
 typedef CGAL::Timer Timer;
 
 int main(int argc, char* argv[]) {
-  // Read the dat
+  // Read the data
   std::string fname = argc==1?CGAL::data_file_path("points_3/kitten.off"):argv[1];
 
   std::cerr << "Reading " << std::flush;
@@ -49,22 +49,18 @@ int main(int argc, char* argv[]) {
   reconstruct.reconstruct_surface(mesher);
 
   std::cerr << "Reconstruction done in " << t.time() << " sec." << std::endl;
-  t.reset();
+
   std::ofstream out("out.off");
   // Write the reconstruction.
   for(Facet_iterator it = reconstruct.facets_begin(); it != reconstruct.facets_end(); ++it )
-    out << "3 "<< *it << '\n'; // We write a '3' in front so that it can be assembled into an OFF file
-
-  std::cerr << "Writing result in " << t.time() << " sec." << std::endl;
-
+    // We write a '3' in front so that it can be assembled into an OFF file
+    out << "3 " << (*it)[0] << " " << (*it)[1] << " " << (*it)[2] << '\n';
   out.close();
 
-  t.reset();
   std::ofstream garbage("garbage.off");
   // Write facets that were removed to force manifold output
   for(Mesher_iterator it = mesher.garbage_begin(); it != mesher.garbage_end(); ++it )
-    garbage << "3 "<< *it << '\n'; // We write a '3' in front so that it can be assembled into an OFF file
-  std::cerr << "Writing garbage facets in " << t.time() << " sec." << std::endl;
+    garbage << "3 " << (*it)[0] << " " << (*it)[1] << " " << (*it)[2] << '\n';
 
   std::cerr << "Done." << std::endl;
 

--- a/Scale_space_reconstruction_3/include/CGAL/Scale_space_surface_reconstruction_3.h
+++ b/Scale_space_reconstruction_3/include/CGAL/Scale_space_surface_reconstruction_3.h
@@ -53,6 +53,7 @@ public:
   typedef std::array<std::size_t, 3> Facet;                           ///< defines a facet of the surface (triple of point indices).
 
 #ifdef DOXYGEN_RUNNING
+  typedef unspecified_type                      Point_range;            ///< defines a range points.
   typedef unspecified_type                      Point_iterator;         ///< defines an iterator over the points.
   typedef const unspecified_type                Point_const_iterator;   ///< defines a constant iterator over the points.
 #else
@@ -62,6 +63,7 @@ public:
 #endif
 
 #ifdef DOXYGEN_RUNNING
+  typedef unspecified_type                      Facet_range;            ///< defines a range of facets
   typedef unspecified_type                      Facet_iterator;         ///< defines an iterator over the facets.
   typedef const unspecified_type                Facet_const_iterator;   ///< defines a constant iterator over the facets.
 #else
@@ -233,6 +235,9 @@ public:
   /// gives the number of points of the surface.
   std::size_t number_of_points() const { return m_points.size(); }
 
+  /// gives the range of points
+  const Point_range points() const { return m_points; }
+
   /// gives an iterator to the first point at the current scale.
   /** \warning Changes to the scale-space do not cause an automatic update to
    *  the surface.
@@ -253,6 +258,9 @@ public:
 
   /// gives the number of facets of the surface.
   std::size_t number_of_facets() const { return m_facets.size(); }
+
+  /// gives the range of facets
+  const Facet_range facets() const { return m_facets; }
 
   /// gives an iterator to the first triple in the surface.
   /** \warning Changes to the surface may change its topology.
@@ -291,17 +299,5 @@ std::ostream& operator<< (std::ostream& os, const CGAL::Scale_space_surface_reco
 }
 
 } // namespace CGAL
-
-template< typename T >
-std::ostream&
-operator<<( std::ostream& os, const std::array< T, 3 >& t ) {
-    return os << t[0] << " " << t[1] << " " << t[2];
-}
-
-template< typename T >
-std::istream&
-operator>>( std::istream& is, std::array< T, 3 >& t ) {
-    return is >> get<0>(t) >> get<1>(t) >> get<2>(t);
-}
 
 #endif // CGAL_SCALE_SPACE_SURFACE_RECONSTRUCTION_3_H


### PR DESCRIPTION
## Summary of Changes

Remove generic function for inserting a `std::array` of three elements into a `std::ostream`.  Use `write_OFF()`.
Added functions returning a range of points and a range of facets (for `write_OFF`).
We might add an example where we orient a triangle soup and create a `Surface_mesh. 

## Release Management

* Affected package(s): Scale_space_reconstruction_3
* License and copyright ownership: unchanged

