### PR TITLE
[Barycentric_coordinates_2] BigO notation consistency

### DIFF
--- a/Barycentric_coordinates_2/doc/Barycentric_coordinates_2/Barycentric_coordinates_2.txt
+++ b/Barycentric_coordinates_2/doc/Barycentric_coordinates_2/Barycentric_coordinates_2.txt
@@ -563,7 +563,7 @@ After the normalization of these weights as before
 \f$b_i = \frac{w_i}{W^{mv}}\qquad\f$ with \f$\qquad W^{mv} = \sum_{j=1}^n w_j\f$
 </center>
 
-we obtain the max precision \f$O(n^2)\f$ algorithm. The max speed O(n) algorithm computes the
+we obtain the max precision \f$O(n^2)\f$ algorithm. The max speed \f$O(n)\f$ algorithm computes the
 weights \f$w_i\f$ using the pseudocode from <a href="https://www.inf.usi.ch/hormann/nsfworkshop/presentations/Hormann.pdf">here</a>.
 These weights
 


### PR DESCRIPTION
Making the BigO notation consistent in the Barycentric_coordinates_2 package.

