### PR TITLE
Trailing 'l' on return statement

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Smoothing/mesh_smoothing_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Smoothing/mesh_smoothing_impl.h
@@ -468,7 +468,7 @@ public:
 //    std::cout << "y : " << initial_y << " -> " << y << "\n";
 //    std::cout << "z : " << initial_z << " -> " << z << "\n";
 
-    return Vector(FT(x - initial_x), FT(y - initial_y), FT(z - initial_z))l;
+    return Vector(FT(x - initial_x), FT(y - initial_y), FT(z - initial_z));
 #else
     CGAL_USE(v);
     return CGAL::NULL_VECTOR;


### PR DESCRIPTION
## Summary of Changes

In CERES_SOLVER mode, a trailling 'l' was causing an invalid syntax, on the Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Smoothing/mesh_smoothing_impl.h file.

## Release Management

* Affected package(s): 
  * PolygonMeshProcessing

* License and copyright ownership:
  * What do I need to do here ?

