### PR TITLE
Polygonal Surface Reconstruction: Remapping of plane_indices in input data to range [0..n-1]

### DIFF
--- a/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/point_set_with_planes.h
+++ b/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/point_set_with_planes.h
@@ -146,11 +146,13 @@ namespace CGAL {
                                         Base_class::m_normals[idx] = get(normal_map, *it);
                                         int plane_index = get(plane_index_map, *it);
                                         if (plane_index != -1) {
-                                          if (plane_index_remap.find(plane_index) == plane_index_remap.end()) {
+                                          auto it = plane_index_remap.find(plane_index);
+                                          if (it == plane_index_remap.end()) {
                                             plane_index_remap[plane_index] = planar_segments_.size();
                                             planar_segments_.push_back(new Planar_segment(this));
+                                            planar_segments_.back()->push_back(idx);
                                           }
-                                          planar_segments_[plane_index_remap[plane_index]]->push_back(idx);
+                                          else planar_segments_[it->second]->push_back(idx);
                                         }
                                         idx++;
                                 }

--- a/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/point_set_with_planes.h
+++ b/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/point_set_with_planes.h
@@ -139,7 +139,6 @@ namespace CGAL {
                                 std::map<int, std::size_t> plane_index_remap;
 
                                 // Gets to know the number of plane from the plane indices
-                                int max_plane_index = 0;
                                 std::size_t idx = 0;
                                 for (typename PointRange::const_iterator it = points.begin(); it != points.end(); ++it) {
                                         Base_class::m_points[idx] = get(point_map, *it);

--- a/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/point_set_with_planes.h
+++ b/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/point_set_with_planes.h
@@ -136,29 +136,23 @@ namespace CGAL {
                                 Base_class::resize(points.size());
                                 Base_class::add_normal_map();
 
+                                std::map<int, std::size_t> plane_index_remap;
+
                                 // Gets to know the number of plane from the plane indices
                                 int max_plane_index = 0;
-                                for (typename PointRange::const_iterator it = points.begin(); it != points.end(); ++it) {
-                                        int plane_index = get(plane_index_map, *it);
-                                        if (plane_index > max_plane_index)
-                                                max_plane_index = plane_index;
-                                }
-                                std::size_t num_plane = max_plane_index + 1; // the first one has index 0
-
-                                for (std::size_t i = 0; i < num_plane; ++i)
-                                        planar_segments_.push_back(new Planar_segment(this));
-
                                 std::size_t idx = 0;
                                 for (typename PointRange::const_iterator it = points.begin(); it != points.end(); ++it) {
                                         Base_class::m_points[idx] = get(point_map, *it);
                                         Base_class::m_normals[idx] = get(normal_map, *it);
                                         int plane_index = get(plane_index_map, *it);
                                         if (plane_index != -1) {
-                                                Planar_segment* ps = planar_segments_[plane_index];
-                                                ps->push_back(idx);
+                                          if (plane_index_remap.find(plane_index) == plane_index_remap.end()) {
+                                            plane_index_remap[plane_index] = planar_segments_.size();
+                                            planar_segments_.push_back(new Planar_segment(this));
+                                          }
+                                          planar_segments_[plane_index_remap[plane_index]]->push_back(idx);
                                         }
-
-                                        ++idx;
+                                        idx++;
                                 }
                         }
 

--- a/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/point_set_with_planes.h
+++ b/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/point_set_with_planes.h
@@ -146,13 +146,12 @@ namespace CGAL {
                                         Base_class::m_normals[idx] = get(normal_map, *it);
                                         int plane_index = get(plane_index_map, *it);
                                         if (plane_index != -1) {
-                                          auto it = plane_index_remap.find(plane_index);
-                                          if (it == plane_index_remap.end()) {
-                                            plane_index_remap[plane_index] = planar_segments_.size();
+                                          auto it_and_bool = plane_index_remap.emplace(plane_index, planar_segments_.size());
+                                          if (it_and_bool.second) {
                                             planar_segments_.push_back(new Planar_segment(this));
                                             planar_segments_.back()->push_back(idx);
                                           }
-                                          else planar_segments_[it->second]->push_back(idx);
+                                          else planar_segments_[it_and_bool.first->second]->push_back(idx);
                                         }
                                         idx++;
                                 }


### PR DESCRIPTION
## Summary of Changes

Remapping of plane_indices in input data to range [0..n-1] as required by method.

## Release Management

* Affected package(s): Polygonal Surface Reconstruction
* Issue(s) solved (if any): fix #7433

