### PR TITLE
Inconsistent return type in Kernel_d concepts

### DIFF
--- a/Kernel_d/doc/Kernel_d/Concepts/Kernel--Contained_in_affine_hull_d.h
+++ b/Kernel_d/doc/Kernel_d/Concepts/Kernel--Contained_in_affine_hull_d.h
@@ -19,7 +19,7 @@ affine hull of the points in `A = tuple [first,last)`.
 
 \tparam ForwardIterator has `Kernel_d::Point_d` as value type.
 */
-template <class ForwardIterator> Bounded_side
+template <class ForwardIterator> bool
 operator()( ForwardIterator first, ForwardIterator last, const
 Kernel_d::Point_d& p);
 

--- a/Kernel_d/doc/Kernel_d/Concepts/Kernel--Contained_in_linear_hull_d.h
+++ b/Kernel_d/doc/Kernel_d/Concepts/Kernel--Contained_in_linear_hull_d.h
@@ -18,7 +18,7 @@ linear hull of the vectors in `A = tuple [first,last)`.
 \pre The objects are of the same dimension.
 \tparam ForwardIterator has `Kernel_d::Vector_d` as value type.
 */
-template <class ForwardIterator> Bounded_side
+template <class ForwardIterator> bool
 operator()( ForwardIterator first, ForwardIterator last, const
 Kernel_d::Vector_d& v);
 

--- a/Kernel_d/doc/Kernel_d/Concepts/Kernel--Contained_in_simplex_d.h
+++ b/Kernel_d/doc/Kernel_d/Concepts/Kernel--Contained_in_simplex_d.h
@@ -19,7 +19,7 @@ simplex of the points in `A = tuple [first,last)`.
 \pre The objects in \f$ A\f$ are of the same dimension and affinely independent.
 \tparam ForwardIterator has `Kernel_d::Point_d` as value type.
 */
-template <class ForwardIterator> Bounded_side
+template <class ForwardIterator> bool
 operator()( ForwardIterator first, ForwardIterator last, const
 Kernel_d::Point_d& p);
 


### PR DESCRIPTION
## Summary of Changes

Reported by Michael Kerber: the concept https://doc.cgal.org/latest/Kernel_d/classKernel__d_1_1Contained__in__simplex__d.html documents a return type of Bounded_side but all implementations return bool instead. This is particularly confusing because Bounded_side could have made sense, and you can easily write code that compiles and gives nonsensical results.

## Release Management

* Affected package(s): Kernel_d