### PR TITLE
Add missing AppendedData closing tag, so vtu binary file contains valid xml

### DIFF
--- a/SMDS_3/include/CGAL/IO/output_to_vtu.h
+++ b/SMDS_3/include/CGAL/IO/output_to_vtu.h
@@ -333,7 +333,7 @@ void output_to_vtu_with_attributes(std::ostream& os,
     os << "<AppendedData encoding=\"raw\">\n_";
     write_c3t3_points(os,tr,V); // fills V if the mode is BINARY
     write_cells(os,c3t3,V);
-    for(std::size_t i = 0; i< attributes.size(); ++i)
+    for(std::size_t i = 0; i< attributes.size(); ++i) {
       switch(attributes[i].second.which()){
       case 0:
         write_attributes(os, *boost::get<const std::vector<double>* >(attributes[i].second));
@@ -345,6 +345,8 @@ void output_to_vtu_with_attributes(std::ostream& os,
         write_attributes(os, *boost::get<const std::vector<std::size_t>* >(attributes[i].second));
         break;
       }
+    }
+    os << "\n</AppendedData>\n";
   }
   os << "</VTKFile>\n";
 }


### PR DESCRIPTION
## Summary of Changes

Currently the binary vtu file written out by CGAL doesn't contain a closing XML tag for AppendedData. Meshio is unable to parse the vtu file, failing instead with an xml.etree.ElementTree.ParseError. Once the missing tag is added, meshio is able to parse the file correctly.

This bug doesn't affect the ascii vtu, only the binary version.
