### PR TITLE
PMP: Document overload of angle_and_area_smoothing()

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/angle_and_area_smoothing.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/angle_and_area_smoothing.h
@@ -33,7 +33,7 @@ namespace Polygon_mesh_processing {
 *
 * \short smooths a triangulated region of a polygon mesh.
 *
-* This function attempts to make the triangle angle and area distributions as uniform as possible
+* This function aims to make the triangle angle and area distributions as uniform as possible
 * by moving (non-constrained) vertices.
 *
 * Angle-based smoothing does not change the combinatorial information of the mesh. Area-based smoothing
@@ -329,13 +329,33 @@ void angle_and_area_smoothing(const FaceRange& faces,
   }
 }
 
-///\cond SKIP_IN_MANUAL
+/*!
+* \ingroup PMP_meshing_grp
+*
+* \short smooths a polygon mesh.
+*
+* This function aims to make the triangle angle and area distributions as uniform as possible
+* by moving (non-constrained) vertices.
+*
+* Angle-based smoothing does not change the combinatorial information of the mesh. Area-based smoothing
+* might change the combinatorial information, unless specified otherwise. It is also possible
+* to make the smoothing algorithm "safer" by rejecting moves that, when applied, would worsen the
+* quality of the mesh, e.g. that would decrease the value of the smallest angle around a vertex or
+* create self-intersections.
+*
+* Optionally, the points are reprojected after each iteration.
+*
+* See the overload for a face range of this function for the template
+* parameters, parameters, and named parameters.
+*/
 template <typename TriangleMesh, typename CGAL_NP_TEMPLATE_PARAMETERS>
 void angle_and_area_smoothing(TriangleMesh& tmesh, const CGAL_NP_CLASS& np = parameters::default_values())
 {
   angle_and_area_smoothing(faces(tmesh), tmesh, np);
 }
 
+
+///\cond SKIP_IN_MANUAL
 template<typename TriangleMesh, typename GeomTraits, typename Stream>
 void angles_evaluation(TriangleMesh& tmesh, GeomTraits traits, Stream& output)
 {

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/angle_and_area_smoothing.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/angle_and_area_smoothing.h
@@ -31,7 +31,7 @@ namespace Polygon_mesh_processing {
 /*!
 * \ingroup PMP_meshing_grp
 *
-* \short smooths a triangulated region of a polygon mesh.
+* \brief smooths a triangulated region of a polygon mesh.
 *
 * This function aims to make the triangle angle and area distributions as uniform as possible
 * by moving (non-constrained) vertices.
@@ -332,7 +332,7 @@ void angle_and_area_smoothing(const FaceRange& faces,
 /*!
 * \ingroup PMP_meshing_grp
 *
-* \short smooths a polygon mesh.
+* \brief smooths a polygon mesh.
 *
 * This function aims to make the triangle angle and area distributions as uniform as possible
 * by moving (non-constrained) vertices.
@@ -345,7 +345,8 @@ void angle_and_area_smoothing(const FaceRange& faces,
 *
 * Optionally, the points are reprojected after each iteration.
 *
-* See the overload for a face range of this function for the template
+* The overload of this function which takes a face range as
+* additonal parameter documents the template
 * parameters, parameters, and named parameters.
 */
 template <typename TriangleMesh, typename CGAL_NP_TEMPLATE_PARAMETERS>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/angle_and_area_smoothing.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/angle_and_area_smoothing.h
@@ -345,9 +345,8 @@ void angle_and_area_smoothing(const FaceRange& faces,
 *
 * Optionally, the points are reprojected after each iteration.
 *
-* The overload of this function which takes a face range as
-* additonal parameter documents the template
-* parameters, parameters, and named parameters.
+* See the overload which takes a face range as additonal parameter for a comprehensive description
+* of the parameters.
 */
 template <typename TriangleMesh, typename CGAL_NP_TEMPLATE_PARAMETERS>
 void angle_and_area_smoothing(TriangleMesh& tmesh, const CGAL_NP_CLASS& np = parameters::default_values())


### PR DESCRIPTION
## Summary of Changes

Add a function documentation

## Release Management

* Affected package(s): Polygon_mesh_processing
* Issue(s) solved (if any): fix #7487 
* Feature/Small Feature (if any):
* Link to compiled documentation:  [link](https://cgal.geometryfactory.com/CGAL/Manual_doxygen_test/CGAL-5.6-Ic-264/output2/Polygon_mesh_processing/group__PMP__meshing__grp.html#ga6e971b85a933e194198218130ba98c0b) into doc testsuite
* License and copyright ownership:

