### PR TITLE
Mesh_3: Add Real_timer

### DIFF
--- a/Mesh_3/test/Mesh_3/test_criteria.cpp
+++ b/Mesh_3/test/Mesh_3/test_criteria.cpp
@@ -21,6 +21,7 @@
 #include "test_utilities.h"
 #include <CGAL/Polyhedral_mesh_domain_3.h>
 #include <CGAL/Polyhedron_3.h>
+#include <CGAL/Real_timer.h>
 
 #include <CGAL/Mesh_criteria_3.h>
 
@@ -340,6 +341,7 @@ struct Tester
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   std::cerr << "TESTING WITH Exact_predicates_inexact_constructions_kernel...\n";
   Tester<K_e_i> test_epic;
   test_epic.test_cell();
@@ -350,5 +352,6 @@ int main()
   test_epec.test_cell();
   test_epec.test_facet();
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_domain_with_polyline_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_domain_with_polyline_features.cpp
@@ -16,7 +16,7 @@
 
 #include <CGAL/Mesh_domain_with_polyline_features_3.h>
 #include "test_utilities.h"
-
+#include <CGAL/Real_timer.h>
 #include <vector>
 #include <list>
 #include <utility>
@@ -228,6 +228,7 @@ private:
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   std::cout << "Test corners" << std::endl;
   Domain_with_polyline_tester domain_corner_tester;
   domain_corner_tester.build_corners();
@@ -248,6 +249,6 @@ int main()
   domain_cycle_tester.test_cycle_corners();
   domain_cycle_tester.test_cycles();
   domain_cycle_tester.test_geodesic_distance();
-
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_implicit_multi_domain_to_labeling_function_wrapper.cpp
+++ b/Mesh_3/test/Mesh_3/test_implicit_multi_domain_to_labeling_function_wrapper.cpp
@@ -1,6 +1,6 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Implicit_to_labeling_function_wrapper.h>
-
+#include <CGAL/Real_timer.h>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K_e_i;
 typedef K_e_i::Point_3 Point_3;
@@ -134,8 +134,11 @@ void test_constructor_vfunc_vstr ()
 
 int main ()
 {
+  CGAL::Real_timer rt; rt.start(); {
+  std::cout << "Start test_implicit_multi_domain_to_labeling_function_wrapper" << std::endl;
   test_constructor_vfunc();
   test_constructor_vfunc_vvpos();
   test_constructor_vfunc_vstr();
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return 0;
 }

--- a/Mesh_3/test/Mesh_3/test_labeled_mesh_domain_3.cpp
+++ b/Mesh_3/test/Mesh_3/test_labeled_mesh_domain_3.cpp
@@ -17,7 +17,7 @@
 #include "test_meshing_utilities.h"
 #include <CGAL/Labeled_mesh_domain_3.h>
 #include <CGAL/Implicit_to_labeling_function_wrapper.h>
-
+#include <CGAL/Real_timer.h>
 
 template <typename K>
 struct LM3_tester
@@ -256,8 +256,11 @@ private:
 
 int main ()
 {
+  CGAL::Real_timer rt; rt.start(); {
+    std::cout << "Start test_labeled_mesh_domain_3" << std::endl;
   LM3_tester<K_e_i> test_epic;
   test_epic();
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_mesh_3_issue_1554.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_3_issue_1554.cpp
@@ -10,6 +10,7 @@
 
 #include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
 #include <CGAL/make_mesh_3.h>
+#include <CGAL/Real_timer.h>
 
 #include <fstream>
 
@@ -48,6 +49,9 @@ Tr::Bare_point wc_circumcenter(const Tr& tr,
 
 int main(int argc, char*argv[])
 {
+  int return_code = 0;
+  CGAL::Real_timer rt; rt.start(); {
+  std::cout << "Start test__mesh_3_issue_1554"<< std::endl;
   const char* fname = (argc>1)?argv[1]:"data/fandisk.off";
   // Create domain
   std::ifstream in(fname);
@@ -71,7 +75,7 @@ int main(int argc, char*argv[])
   Gt::Construct_weighted_circumcenter_3 w_circumcenter =
       c3t3.triangulation().geom_traits().construct_weighted_circumcenter_3_object();
 
-  int return_code = 0;
+
   for(C3t3::Cells_in_complex_iterator cit = c3t3.cells_in_complex_begin();
       cit != c3t3.cells_in_complex_end();
       ++cit)
@@ -102,5 +106,6 @@ int main(int argc, char*argv[])
   }
   std::cout << c3t3.triangulation().number_of_vertices() << std::endl;
   // Output
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return return_code;
 }

--- a/Mesh_3/test/Mesh_3/test_mesh_capsule_var_distance_bound.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_capsule_var_distance_bound.cpp
@@ -6,6 +6,7 @@
 
 #include <CGAL/Labeled_mesh_domain_3.h>
 #include <CGAL/make_mesh_3.h>
+#include <CGAL/Real_timer.h>
 
 #include <boost/version.hpp>
 
@@ -49,6 +50,8 @@ auto field = [](const Point& p, const int, const Mesh_domain::Index)
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
+  std::cout << "Start test_mesh_capsule_var_distance_bound"<< std::endl;
   Mesh_domain domain =
     Mesh_domain::create_implicit_mesh_domain(function = capsule_function,
                                              bounding_object = K::Sphere_3(CGAL::ORIGIN, 49.));
@@ -65,6 +68,6 @@ int main()
 //  CGAL::IO::write_MEDIT(medit_file, c3t3);
 //  medit_file.close();
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return 0;
 }
-

--- a/Mesh_3/test/Mesh_3/test_mesh_cell_base_3.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_cell_base_3.cpp
@@ -8,6 +8,7 @@
 #include <CGAL/Mesh_3/Robust_intersection_traits_3.h>
 #include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
 #include <CGAL/Mesh_cell_base_3.h>
+#include <CGAL/Real_timer.h>
 
 #include <CGAL/tags.h>
 
@@ -16,6 +17,8 @@
 #include <cassert>
 
 int main (int argc, char** argv){
+  CGAL::Real_timer rt; rt.start(); {
+  std::cout << "Start test_mesh_cell_base_3"<< std::endl;
   typedef CGAL::Exact_predicates_inexact_constructions_kernel                 K;
   typedef CGAL::Polyhedral_mesh_domain_with_features_3<K>                     Polyhedral_mesh_domain;
 
@@ -97,5 +100,6 @@ int main (int argc, char** argv){
   out << poly;
 
   assert(is_valid(poly));
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_mesh_criteria_creation.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_criteria_creation.cpp
@@ -2,6 +2,7 @@
 #include <CGAL/Mesh_triangulation_3.h>
 #include <CGAL/Mesh_criteria_3.h>
 #include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
+#include <CGAL/Real_timer.h>
 
 // Domain
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
@@ -23,6 +24,8 @@ using namespace CGAL::parameters;
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
+    std::cout << "Start test_mesh_criteria_creation"<< std::endl;
   Tr::Point p1(0,0,0);
   Tr::Point p2(1,0,0);
   Tr::Point p3(0,1,0);
@@ -210,4 +213,5 @@ int main()
   Mc cc12(cell_sizing_field = 12);
   Mc cc12b(cell_sizing_field = 12, cell_min_size = 2);
   Mc cc13(sizing_field = 13);
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
 }

--- a/Mesh_3/test/Mesh_3/test_mesh_polyhedral_domain_with_features_deprecated.cpp
+++ b/Mesh_3/test/Mesh_3/test_mesh_polyhedral_domain_with_features_deprecated.cpp
@@ -8,6 +8,7 @@
 
 #include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
 #include <CGAL/make_mesh_3.h>
+#include <CGAL/Real_timer.h>
 
 // Domain
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
@@ -30,6 +31,8 @@ using namespace CGAL::parameters;
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
+  std::cout << "Start test_mesh_polyhedral_domain_with_features_deprecated"<< std::endl;
   // Create domain
   Mesh_domain domain(CGAL::data_file_path("meshes/cube.off"));
 
@@ -49,5 +52,6 @@ int main()
 //  CGAL::IO::write_MEDIT(medit_file, c3t3);
 //  medit_file.close();
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_3D_gray_image.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_3D_gray_image.cpp
@@ -17,6 +17,7 @@
 #include <CGAL/Image_3.h>
 #include <CGAL/Labeled_mesh_domain_3.h>
 #include <CGAL/use.h>
+#include <CGAL/Real_timer.h>
 
 #include <functional>
 
@@ -97,6 +98,7 @@ public:
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   Image_tester<> test_epic;
   std::cerr << "Mesh generation from a 3D image:\n";
   test_epic.image();
@@ -107,5 +109,6 @@ int main()
   test_epic_p.image();
 #endif
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_3D_gray_image_deprecated.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_3D_gray_image_deprecated.cpp
@@ -5,6 +5,7 @@
 #include <CGAL/Image_3.h>
 #include <CGAL/Gray_image_mesh_domain_3.h>
 #include <CGAL/use.h>
+#include <CGAL/Real_timer.h>
 
 #include <functional>
 
@@ -89,6 +90,7 @@ public:
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   Image_tester<> test_epic;
   std::cerr << "Mesh generation from a 3D image:\n";
   test_epic.image();
@@ -99,5 +101,6 @@ int main()
   test_epic_p.image();
 #endif
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_3D_image.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_3D_image.cpp
@@ -1,4 +1,4 @@
-#define CGAL_MESH_3_VERBOSE 1
+//#define CGAL_MESH_3_VERBOSE 1
 // Copyright (c) 2009 INRIA Sophia-Antipolis (France).
 // All rights reserved.
 //
@@ -19,6 +19,7 @@
 #include <CGAL/Image_3.h>
 #include <CGAL/Labeled_mesh_domain_3.h>
 #include <CGAL/use.h>
+#include <CGAL/Real_timer.h>
 
 template <typename Concurrency_tag = CGAL::Sequential_tag>
 struct Image_tester : public Tester<K_e_i>
@@ -79,6 +80,7 @@ public:
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   std::cerr.precision(17);
   Image_tester<> test_epic;
   std::cerr << "Mesh generation from a 3D image:\n";
@@ -90,5 +92,6 @@ int main()
   test_epic_p.image();
 #endif
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_3D_image_deprecated.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_3D_image_deprecated.cpp
@@ -1,4 +1,4 @@
-#define CGAL_MESH_3_VERBOSE 1
+//#define CGAL_MESH_3_VERBOSE 1
 #include <CGAL/Installation/internal/disable_deprecation_warnings_and_errors.h>
 
 #include "test_meshing_utilities.h"
@@ -6,6 +6,7 @@
 #include <CGAL/Image_3.h>
 #include <CGAL/Labeled_image_mesh_domain_3.h>
 #include <CGAL/use.h>
+#include <CGAL/Real_timer.h>
 
 template <typename Concurrency_tag = CGAL::Sequential_tag>
 struct Image_tester : public Tester<K_e_i>
@@ -59,6 +60,7 @@ public:
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   Image_tester<> test_epic;
   std::cerr << "Mesh generation from a 3D image:\n";
   test_epic.image();
@@ -69,5 +71,6 @@ int main()
   test_epic_p.image();
 #endif
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_3D_image_with_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_3D_image_with_features.cpp
@@ -21,6 +21,7 @@
 #include <CGAL/Mesh_3/Detect_features_in_image.h>
 #include <CGAL/Mesh_3/Detect_features_on_image_bbox.h>
 #include <CGAL/use.h>
+#include <CGAL/Real_timer.h>
 #include <vector>
 
 #include <cstddef>
@@ -165,6 +166,7 @@ public:
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   Image_tester<> test_epic;
   std::cerr << "Mesh generation from a 3D image"
             << " with detection of triple lines:\n";
@@ -195,5 +197,6 @@ int main()
   test_epic_p.image_with_input_features();
 #endif
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_determinism.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_determinism.cpp
@@ -10,6 +10,7 @@
 #include <CGAL/perturb_mesh_3.h>
 #include <CGAL/exude_mesh_3.h>
 #include <CGAL/facets_in_complex_3_to_triangle_mesh.h>
+#include <CGAL/Real_timer.h>
 
 #include <cassert>
 #include <fstream>
@@ -156,6 +157,7 @@ void test()
 
 int main(int, char*[])
 {
+  CGAL::Real_timer rt; rt.start(); {
   std::cout << "Sequential test" << std::endl;
   test<CGAL::Sequential_tag>();
 
@@ -164,4 +166,5 @@ int main(int, char*[])
   tbb::global_control c(tbb::global_control::max_allowed_parallelism, 1);
   test<CGAL::Parallel_tag>();
 #endif
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_implicit_function.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_implicit_function.cpp
@@ -3,6 +3,7 @@
 #include <CGAL/Labeled_mesh_domain_3.h>
 
 #include <CGAL/disable_warnings.h>
+#include <CGAL/Real_timer.h>
 
 template <typename K, typename Concurrency_tag = CGAL::Sequential_tag>
 struct Implicit_tester : public Tester<K>
@@ -91,6 +92,7 @@ struct Implicit_tester : public Tester<K>
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   Implicit_tester<K_e_i> test_epic;
   std::cerr << "Mesh generation from an implicit function:\n";
   test_epic.implicit();
@@ -100,5 +102,6 @@ int main()
   std::cerr << "Parallel mesh generation from an implicit function:\n";
   test_epic_p.implicit();
 #endif
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_implicit_function_deprecated.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_implicit_function_deprecated.cpp
@@ -1,5 +1,6 @@
 #include <CGAL/Installation/internal/disable_deprecation_warnings_and_errors.h>
 #include <CGAL/disable_warnings.h>
+#include <CGAL/Real_timer.h>
 
 #include "test_meshing_utilities.h"
 
@@ -89,6 +90,7 @@ struct Implicit_tester : public Tester<K>
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   Implicit_tester<K_e_i> test_epic;
   std::cerr << "Mesh generation from an implicit function:\n";
   test_epic.implicit();
@@ -98,5 +100,6 @@ int main()
   std::cerr << "Parallel mesh generation from an implicit function:\n";
   test_epic_p.implicit();
 #endif
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedral_complex.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedral_complex.cpp
@@ -20,6 +20,7 @@
 #include <CGAL/make_mesh_3.h>
 
 #include <CGAL/IO/File_binary_mesh_3.h>
+#include <CGAL/Real_timer.h>
 
 #include <fstream>
 
@@ -110,6 +111,7 @@ struct Polyhedral_complex_tester : public Tester<K>
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   Polyhedral_complex_tester<K_e_i> test_epic;
   std::cerr << "Mesh generation from a polyhedral complex:\n";
   test_epic();
@@ -120,5 +122,6 @@ int main()
   test_epic_p();
 #endif
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedron.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedron.cpp
@@ -19,6 +19,7 @@
 #include "test_meshing_utilities.h"
 #include <CGAL/Polyhedral_mesh_domain_3.h>
 #include <CGAL/IO/Polyhedron_iostream.h>
+#include <CGAL/Real_timer.h>
 
 #include <CGAL/SMDS_3/Dump_c3t3.h>
 
@@ -109,6 +110,7 @@ struct Polyhedron_tester : public Tester<K>
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   Polyhedron_tester<K_e_i> test_epic;
   std::cerr << "Mesh generation from a polyhedron:\n";
   test_epic.polyhedron();
@@ -122,5 +124,6 @@ int main()
             << "The parallel version cannot be tested.\n";
 #endif
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polyhedron_with_features.cpp
@@ -21,6 +21,7 @@
 #include <CGAL/IO/File_tetgen.h>
 #include <CGAL/IO/File_binary_mesh_3.h>
 #include <CGAL/use.h>
+#include <CGAL/Real_timer.h>
 
 #include <fstream>
 #include <sstream>
@@ -153,6 +154,7 @@ struct Polyhedron_with_features_tester : public Tester<K>
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   {
     std::cerr << "Mesh generation from a polyhedron with edges:\n";
     Polyhedron_with_features_tester<K_e_i> test_epic("sequential");
@@ -166,5 +168,6 @@ int main()
   }
 #endif
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_polylines_only.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_polylines_only.cpp
@@ -9,6 +9,7 @@
 #include <CGAL/make_mesh_3.h>
 
 #include <CGAL/IO/File_binary_mesh_3.h>
+#include <CGAL/Real_timer.h>
 
 #include <cassert>
 
@@ -33,6 +34,8 @@ using namespace CGAL::parameters;
 
 int main(int argc, char** argv)
 {
+  CGAL::Real_timer rt; rt.start(); {
+  std::cout << "Start test_meshing_polylines_only" << std::endl;
   if(argc != 2) {
     std::cerr << "This test needs a filename as argument.\n";
     return 1;
@@ -99,4 +102,5 @@ int main(int argc, char** argv)
             << c3t3.triangulation().number_of_vertices() << std::endl;
   assert(c3t3.triangulation().number_of_vertices() > 900);
   assert(c3t3.triangulation().number_of_vertices() < 1100);
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_unit_tetrahedron.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_unit_tetrahedron.cpp
@@ -7,6 +7,7 @@
 #include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
 #include <CGAL/make_mesh_3.h>
 #include <CGAL/SMDS_3/Dump_c3t3.h>
+#include <CGAL/Real_timer.h>
 
 #include <sstream>
 
@@ -86,6 +87,7 @@ struct Polyhedron_tester : public Tester<K>
 };
 
 int main() {
+  CGAL::Real_timer rt; rt.start(); {
   typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
   Polyhedron_tester<K> test_epic;
   std::cerr << "Mesh generation from a polyhedron:\n";
@@ -97,5 +99,6 @@ int main() {
   test_epic_p.polyhedron();
 #endif
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_with_one_step.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_with_one_step.cpp
@@ -1,4 +1,4 @@
-#define CGAL_MESH_3_VERBOSE 1
+//#define CGAL_MESH_3_VERBOSE 1
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Mesh_triangulation_3.h>
@@ -9,6 +9,7 @@
 #include <CGAL/Polyhedral_mesh_domain_3.h>
 #include <CGAL/make_mesh_3.h>
 #include <CGAL/refine_mesh_3.h>
+#include <CGAL/Real_timer.h>
 
 // Domain
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
@@ -36,6 +37,7 @@ using namespace CGAL::parameters;
 
 int main(int argc, char*argv[])
 {
+  CGAL::Real_timer rt; rt.start(); {
   const char* fname = (argc>1)?argv[1]:"data/sphere.off";
   // Create input polyhedron
   Polyhedron polyhedron;
@@ -77,5 +79,6 @@ int main(int argc, char*argv[])
 //  CGAL::IO::write_MEDIT(medit_file, c3t3);
 //  medit_file.close();
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_without_features_determinism.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_without_features_determinism.cpp
@@ -158,6 +158,6 @@ int main(int, char*[])
   std::cout << "\n\nParallel with 1 thread test" << std::endl;
   tbb::global_control c(tbb::global_control::max_allowed_parallelism, 1);
   test<CGAL::Parallel_tag>();
-  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
 #endif
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
 }

--- a/Mesh_3/test/Mesh_3/test_meshing_without_features_determinism.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_without_features_determinism.cpp
@@ -11,6 +11,7 @@
 #include <CGAL/perturb_mesh_3.h>
 #include <CGAL/exude_mesh_3.h>
 #include <CGAL/facets_in_complex_3_to_triangle_mesh.h>
+#include <CGAL/Real_timer.h>
 
 #include <cassert>
 #include <fstream>
@@ -149,6 +150,7 @@ void test()
 
 int main(int, char*[])
 {
+  CGAL::Real_timer rt; rt.start(); {
   std::cout << "Sequential test" << std::endl;
   test<CGAL::Sequential_tag>();
 
@@ -156,5 +158,6 @@ int main(int, char*[])
   std::cout << "\n\nParallel with 1 thread test" << std::endl;
   tbb::global_control c(tbb::global_control::max_allowed_parallelism, 1);
   test<CGAL::Parallel_tag>();
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
 #endif
 }

--- a/Mesh_3/test/Mesh_3/test_min_edge_length.cpp
+++ b/Mesh_3/test/Mesh_3/test_min_edge_length.cpp
@@ -9,6 +9,7 @@
 #include <CGAL/make_mesh_3.h>
 
 #include <CGAL/Sizing_field_with_aabb_tree.h>
+#include <CGAL/Real_timer.h>
 
 
 template <typename K,
@@ -70,6 +71,8 @@ struct Tester
 
 int main(int argc, char* argv[])
 {
+  CGAL::Real_timer rt; rt.start(); {
+  std::cout << "Start test_min_edge_length"<< std::endl;
   const std::string fname = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/dragknob.off");
 
   typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
@@ -82,5 +85,6 @@ int main(int argc, char* argv[])
   Tester<K, Surface_mesh, CGAL::Parallel_tag>()(fname, "out-dragknob-parallel");
 #endif
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_min_size_criteria.cpp
+++ b/Mesh_3/test/Mesh_3/test_min_size_criteria.cpp
@@ -21,6 +21,7 @@
 #include <CGAL/Labeled_mesh_domain_3.h>
 #include <CGAL/use.h>
 #include <CGAL/Mesh_criteria_3.h>
+#include <CGAL/Real_timer.h>
 
 template <typename Concurrency_tag = CGAL::Sequential_tag>
 struct Image_tester : public Tester<K_e_i>
@@ -134,6 +135,7 @@ public:
 
 int main()
 {
+  CGAL::Real_timer rt; rt.start(); {
   Image_tester<> test_epic;
   std::cerr << "Mesh generation from a 3D image:\n";
   test_epic.image();
@@ -144,5 +146,6 @@ int main()
   test_epic_p.image();
 #endif
 
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/test/Mesh_3/test_without_detect_features.cpp
+++ b/Mesh_3/test/Mesh_3/test_without_detect_features.cpp
@@ -62,13 +62,19 @@ struct Tester {
 
 int main(int argc, char*argv[])
 {
+    int res = 0;
+  CGAL::Real_timer rt; rt.start(); {
+    std::cout << "Start test_without_detect_features" << std::endl;
   const std::string fname = (argc>1)?argv[1]:CGAL::data_file_path("meshes/cube.off");
 
   typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
   typedef CGAL::Mesh_polyhedron_3<K>::type                    Polyhedron;
   typedef CGAL::Surface_mesh<K::Point_3>                      Surface_mesh;
 
-  return
-    Tester<K, Polyhedron>()(fname, "out-polyhedron.mesh") |
+  res =
+     Tester<K, Polyhedron>()(fname, "out-polyhedron.mesh") |
     Tester<K, Surface_mesh>()(fname, "out-surface_mesh.mesh");
+
+  } std::cout << "Execution took " << rt.time() << " sec." << std::endl;
+  return res;
 }


### PR DESCRIPTION
## Summary of Changes

In an effort to understand why we have timeouts I add a `Real_timer` to each test program.
I also switched `VERBOSE` off for some test cases.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

