### PR TITLE
Regular_triangulation_3: fix another race-condition

### DIFF
--- a/STL_Extension/include/CGAL/Spatial_lock_grid_3.h
+++ b/STL_Extension/include/CGAL/Spatial_lock_grid_3.h
@@ -209,7 +209,7 @@ public:
     int index_x = static_cast<int>( (CGAL::to_double(point.x()) - m_bbox.xmin()) * m_resolution_x);
     //index_x = std::max( 0, std::min(index_x, m_num_grid_cells_per_axis - 1) );
     index_x =
-      (index_x < 0 ?
+      (index_x < 0 ? /// @TODO: use std::clamp
         0
         : (index_x >= m_num_grid_cells_per_axis ?
             m_num_grid_cells_per_axis - 1

--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -2584,8 +2584,17 @@ remove(Vertex_handle v, bool *could_lock_zone)
     if(!vertex_validity_check(v, tds()))
       return true; // vertex is already gone from the TDS, nothing to do
 
-    Vertex_handle hint = v->cell()->vertex(0) == v ? v->cell()->vertex(1) : v->cell()->vertex(0);
-
+#ifndef CGAL_LINKED_WITH_TBB
+    using Vertex_handle_and_point = Vertex_handle;
+#endif // not CGAL_LINKED_WITH_TBB
+    Vertex_handle_and_point hint_and_point{v->cell()->vertex(0) == v ? v->cell()->vertex(1) : v->cell()->vertex(0)};
+#ifdef CGAL_LINKED_WITH_TBB
+    const Vertex_handle& hint = hint_and_point.vh;
+    const Weighted_point& hint_point_mem = hint_and_point.wpt;
+#else // not CGAL_LINKED_WITH_TBB
+    const Vertex_handle& hint = hint_and_point;
+    const Weighted_point& hint_point_mem = hint_and_point->point();
+#endif // not CGAL_LINKED_WITH_TBB
     Self tmp;
     Vertex_remover<Self> remover(tmp);
     removed = Tr_Base::remove(v, remover, could_lock_zone);
@@ -2612,13 +2621,12 @@ remove(Vertex_handle v, bool *could_lock_zone)
           // the hint.
           if(!vertex_validity_check(hint, tds()))
           {
-            hint = finite_vertices_begin();
+            hint_and_point = finite_vertices_begin();
             continue;
           }
 
           // We need to make sure that while are locking the position P1 := hint->point(), 'hint'
           // does not get its position changed to P2 != P1.
-          const Weighted_point hint_point_mem = hint->point();
 
           if(this->try_lock_point(hint_point_mem) && this->try_lock_point(wp))
           {
@@ -2628,7 +2636,7 @@ remove(Vertex_handle v, bool *could_lock_zone)
             if(!vertex_validity_check(hint, tds()) ||
                hint->point() != hint_point_mem)
             {
-              hint = finite_vertices_begin();
+              hint_and_point = finite_vertices_begin();
               this->unlock_all_elements();
               continue;
             }
@@ -2639,7 +2647,7 @@ remove(Vertex_handle v, bool *could_lock_zone)
             {
               success = true;
               if(hv != Vertex_handle())
-                hint = hv;
+                hint_and_point = hv;
             }
           }
 


### PR DESCRIPTION
(Followup to the PR #7448.)

## Summary of Changes

During the insert or removal of points, in a regular triangulation, vertices can be destroy in the operation. During the removal of a range of vertices, that is obvious, but because of hidden points, even the insertion of new points can trigger the removal of vertices.

If the code keeps a `Vertex_handle hint` during the algorithm, that vertex can be destroyed, by another thread, and in particular its points can be destroyed. As the locking uses points, one have store store the points alongside the `Vertex_handle`, because the code `this->try_lock_point(hint->point())` accesses the point via an indirection *before* the lock.

With `Epick`, that was not detected, because the destruction of a point from `Epick` does nothing (the coordinates stay in memory). But with `Epeck`, a destruction of a point means that the `Handle` is assigned to a null pointer.

I have fixed one source of race-condition, and I have executed more that 10k runs without any assertion. But I have the impression that the code is still not correct, around those lines: 

https://github.com/lrineau/cgal/blob/8cd8bc7b0604d03511bb318ab2dc4c050e214562/Triangulation_3/include/CGAL/Regular_triangulation_3.h#L2622-L2626

The call to `finite_vertices_begin()` is not thread-safe: the first vertex might be under destruction by another thread. Or maybe destroyed between that call and the access to `hint->point()`. @MaelRL @sloriot I would like to discuss the issue.

## Release Management

* Affected package(s): Triangulation_3
* Issue(s) solved (if any): fix #7295
* License and copyright ownership: maintenance by GeometryFactory

