### PR TITLE
PSP: wlop_simplify() performance improvement

### DIFF
--- a/Point_set_processing_3/include/CGAL/wlop_simplify_and_regularize_point_set.h
+++ b/Point_set_processing_3/include/CGAL/wlop_simplify_and_regularize_point_set.h
@@ -525,6 +525,7 @@ wlop_simplify_and_regularize_point_set(
 
   if (require_uniform_sampling)//default value is false
   {
+    original_density_weights.reserve(number_of_original);
     //todo: this part could also be parallelized if needed
     for (it = first_original_iter, i = 0; it != points.end() ; ++it, ++i)
     {
@@ -552,6 +553,7 @@ wlop_simplify_and_regularize_point_set(
 
     // Compute sample density weight for sample points
     std::vector<FT> sample_density_weights;
+    sample_density_weights.reserve(number_of_sample);
 
     for (sample_iter = sample_points.begin();
          sample_iter != sample_points.end(); ++sample_iter)
@@ -602,9 +604,7 @@ wlop_simplify_and_regularize_point_set(
     if (interrupted)
       return output;
 
-    sample_iter = sample_points.begin();
-    for (std::size_t i = 0; i < sample_points.size(); ++ i)
-      sample_points[i] = update_sample_points[i];
+    sample_points.swap(update_sample_points);
   }
 
   // final output


### PR DESCRIPTION
## Summary of Changes

While reading code so that I could answer #7421 I noticed that we should call `vector<T>::reserve()` and `vector<T>swap()`.

## Release Management

* Affected package(s): Point Set Processing
* License and copyright ownership:  unchanged

