### PR TITLE
EPECK Triangulation serialization

### DIFF
--- a/Alpha_shapes_2/include/CGAL/Alpha_shape_vertex_base_2.h
+++ b/Alpha_shapes_2/include/CGAL/Alpha_shape_vertex_base_2.h
@@ -19,6 +19,7 @@
 #include <utility>
 #include <CGAL/Triangulation_vertex_base_2.h>
 #include <CGAL/Alpha_shapes_2/internal/Lazy_alpha_nt_2.h>
+#include <CGAL/Default.h>
 
 //-------------------------------------------------------------------
 namespace CGAL {

--- a/Alpha_shapes_2/package_info/Alpha_shapes_2/dependencies
+++ b/Alpha_shapes_2/package_info/Alpha_shapes_2/dependencies
@@ -2,7 +2,6 @@ Algebraic_foundations
 Alpha_shapes_2
 Arithmetic_kernel
 Cartesian_kernel
-Filtered_kernel
 Hash_map
 Homogeneous_kernel
 Installation

--- a/Convex_hull_3/include/CGAL/Convex_hull_vertex_base_2.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_vertex_base_2.h
@@ -18,6 +18,7 @@
 #include <CGAL/license/Convex_hull_3.h>
 
 #include <CGAL/Triangulation_ds_vertex_base_2.h>
+#include <CGAL/IO/io.h>
 
 #include <iostream>
 

--- a/Convex_hull_3/include/CGAL/Convex_hull_vertex_base_2.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_vertex_base_2.h
@@ -77,7 +77,7 @@ template <typename GT, typename Vb>
 std::ostream&
 operator<<(std::ostream &os, const Convex_hull_vertex_base_2<GT, Vb>& v)
 {
-  return os << static_cast<const Vb&>(v) << v.point();
+  return os << static_cast<const Vb&>(v) << IO::serialize(v.point());
 }
 
 } //namespace CGAL

--- a/Filtered_kernel/include/CGAL/Filtered_kernel.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel.h
@@ -21,8 +21,6 @@
 #include <CGAL/Kernel/Type_equality_wrapper.h>
 #include <CGAL/Exact_kernel_selector.h>
 
-#include <CGAL/Lazy_exact_nt.h>
-
 #include <CGAL/Filtered_kernel/internal/Static_filters/Static_filters.h>
 #include <boost/type_traits.hpp>
 

--- a/Filtered_kernel/include/CGAL/Filtered_kernel.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel.h
@@ -21,9 +21,7 @@
 #include <CGAL/Kernel/Type_equality_wrapper.h>
 #include <CGAL/Exact_kernel_selector.h>
 
-#include <CGAL/MP_Float.h>
-#include <CGAL/Quotient.h>
-#include <CGAL/Number_types/internal/Exact_type_selector.h>
+#include <CGAL/Lazy_exact_nt.h>
 
 #include <CGAL/Filtered_kernel/internal/Static_filters/Static_filters.h>
 #include <boost/type_traits.hpp>

--- a/Filtered_kernel/include/CGAL/Lazy_kernel.h
+++ b/Filtered_kernel/include/CGAL/Lazy_kernel.h
@@ -31,6 +31,7 @@
 #include <boost/mpl/or.hpp>
 #include <boost/type_traits/remove_reference.hpp>
 #include <boost/type_traits/remove_cv.hpp>
+#include <CGAL/Lazy_exact_nt.h>
 
 #if defined(BOOST_MSVC)
 #  pragma warning(push)

--- a/NewKernel_d/include/CGAL/NewKernel_d/Lazy_cartesian.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Lazy_cartesian.h
@@ -15,6 +15,7 @@
 #include <CGAL/basic.h>
 #include <CGAL/algorithm.h>
 #include <CGAL/Lazy.h>
+#include <CGAL/Lazy_exact_nt.h>
 #include <CGAL/Default.h>
 #include <CGAL/NewKernel_d/Filtered_predicate2.h>
 #include <CGAL/iterator_from_indices.h>

--- a/Number_types/include/CGAL/Lazy_exact_nt.h
+++ b/Number_types/include/CGAL/Lazy_exact_nt.h
@@ -34,6 +34,8 @@
 #include <CGAL/Kernel/mpl.h>
 #include <CGAL/tss.h>
 #include <CGAL/type_traits.h>
+#include <CGAL/Number_types/internal/Exact_type_selector.h>
+
 
 #include<type_traits>
 
@@ -1427,7 +1429,24 @@ class Modular_traits<Lazy_exact_nt<ET> >
 #undef CGAL_int
 #undef CGAL_To_interval
 
-} //namespace CGAL
+namespace internal {
+
+template < typename ET >
+struct Exact_field_selector<Lazy_exact_nt<ET> >
+: Exact_field_selector<ET>
+{
+  // We have a choice here :
+  // - using ET gets rid of the DAG computation as well as redoing the interval
+  // - using Lazy_exact_nt<ET> might use sharper intervals.
+  // typedef ET  Type;
+  // typedef Lazy_exact_nt<ET>  Type;
+};
+template < typename ET >
+struct Exact_ring_selector<Lazy_exact_nt<ET> >
+: Exact_ring_selector<ET>
+{};
+
+} } //namespace CGAL::internal
 
 namespace Eigen {
   template<class> struct NumTraits;

--- a/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
+++ b/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
@@ -22,7 +22,6 @@
 #include <CGAL/number_type_basic.h>
 #include <CGAL/MP_Float.h>
 #include <CGAL/Quotient.h>
-#include <CGAL/Lazy_exact_nt.h>
 
 #include <CGAL/boost_mp.h>
 
@@ -279,21 +278,6 @@ template <>
 struct Exact_ring_selector<Exact_NT_backend<BOOST_BACKEND>::Rational>
 { typedef Exact_NT_backend<BOOST_BACKEND>::Rational  Type; };
 #endif
-
-template < typename ET >
-struct Exact_field_selector<Lazy_exact_nt<ET> >
-: Exact_field_selector<ET>
-{
-  // We have a choice here :
-  // - using ET gets rid of the DAG computation as well as redoing the interval
-  // - using Lazy_exact_nt<ET> might use sharper intervals.
-  // typedef ET  Type;
-  // typedef Lazy_exact_nt<ET>  Type;
-};
-template < typename ET >
-struct Exact_ring_selector<Lazy_exact_nt<ET> >
-: Exact_ring_selector<ET>
-{};
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 // Added for backward compatibility

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_traits_2_aux.h
@@ -25,6 +25,7 @@
 #include <CGAL/tags.h>
 #include <CGAL/Uncertain.h>
 #include <CGAL/Unfiltered_predicate_adaptor.h>
+#include <CGAL/Lazy_exact_nt.h>
 
 #include <boost/tuple/tuple.hpp>
 #include <boost/optional/optional.hpp>

--- a/Stream_support/include/CGAL/IO/io.h
+++ b/Stream_support/include/CGAL/IO/io.h
@@ -698,6 +698,25 @@ inline const char* mode_name( IO::Mode m )
   return names[m];
 }
 
+namespace internal {
+
+template <class P> constexpr auto has_exact(int) -> decltype(exact(P()), bool()) { return true; }
+template <class P> constexpr bool has_exact(...) { return false; }
+
+}
+
+template <class P>
+auto
+serialize(const P& p) {
+  if constexpr (internal::has_exact<P>(0)) {
+    return exact(p);
+  } else {
+    return p;
+  }
+}
+
+
+
 } // IO namespace
 
 #ifndef CGAL_NO_DEPRECATED_CODE

--- a/Surface_mesher/test/Surface_mesher/implicit_surface_mesher_test.cpp
+++ b/Surface_mesher/test/Surface_mesher/implicit_surface_mesher_test.cpp
@@ -1,6 +1,7 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Cartesian.h>
 #include <CGAL/Filtered_kernel.h>
+#include <CGAL/Lazy_exact_nt.h>
 
 #include <CGAL/make_surface_mesh.h>
 

--- a/Triangulation_2/include/CGAL/Regular_triangulation_vertex_base_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_vertex_base_2.h
@@ -16,8 +16,8 @@
 
 #include <CGAL/license/Triangulation_2.h>
 
-
 #include <CGAL/Triangulation_ds_vertex_base_2.h>
+#include <CGAL/IO/io.h>
 
 namespace CGAL {
 

--- a/Triangulation_2/include/CGAL/Regular_triangulation_vertex_base_2.h
+++ b/Triangulation_2/include/CGAL/Regular_triangulation_vertex_base_2.h
@@ -81,7 +81,7 @@ operator<<(std::ostream &os,
            const Regular_triangulation_vertex_base_2<GT, Vb> &v)
   // non combinatorial information. Default = point
 {
-  return os << static_cast<const Vb&>(v) << v.point();
+  return os << static_cast<const Vb&>(v) << IO::serialize(v.point());
 }
 
 } //namespace CGAL

--- a/Triangulation_2/include/CGAL/Triangulation_vertex_base_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_vertex_base_2.h
@@ -18,6 +18,7 @@
 
 #include <CGAL/config.h>
 #include <CGAL/Triangulation_ds_vertex_base_2.h>
+#include <CGAL/IO/io.h>
 
 namespace CGAL {
 

--- a/Triangulation_2/include/CGAL/Triangulation_vertex_base_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_vertex_base_2.h
@@ -109,7 +109,7 @@ std::ostream&
 operator<<(std::ostream &os, const Triangulation_vertex_base_2<GT, Vb> &v)
   // non combinatorial information. Default = point
 {
-  return os << static_cast<const Vb&>(v) << v.point();
+  return os << static_cast<const Vb&>(v) << IO::serialize(v.point());
 }
 
 #ifndef CGAL_NO_DEPRECATED_CODE

--- a/Triangulation_3/include/CGAL/Regular_triangulation_vertex_base_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_vertex_base_3.h
@@ -18,6 +18,7 @@
 #include <CGAL/basic.h>
 #include <CGAL/Triangulation_vertex_base_3.h>
 #include <CGAL/Triangulation_ds_vertex_base_3.h>
+#include <CGAL/IO/io.h>
 
 namespace CGAL {
 

--- a/Triangulation_3/include/CGAL/Regular_triangulation_vertex_base_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_vertex_base_3.h
@@ -75,7 +75,7 @@ std::ostream&
 operator<<(std::ostream &os, const Regular_triangulation_vertex_base_3<GT, DSVb> &v)
   // non combinatorial information. Default = point
 {
-  return os << static_cast<const DSVb&>(v) << v.point();
+  return os << static_cast<const DSVb&>(v) << IO::serialize(v.point());
 }
 
 } //namespace CGAL

--- a/Triangulation_3/include/CGAL/Triangulation_vertex_base_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_vertex_base_3.h
@@ -61,6 +61,7 @@ private:
   Point _p;
 };
 
+
 template < class GT, class DSVb >
 std::istream&
 operator>>(std::istream &is, Triangulation_vertex_base_3<GT, DSVb> &v)
@@ -74,7 +75,7 @@ std::ostream&
 operator<<(std::ostream &os, const Triangulation_vertex_base_3<GT, DSVb> &v)
   // non combinatorial information. Default = point
 {
-  return os << static_cast<const DSVb&>(v) << v.point();
+  return os << static_cast<const DSVb&>(v) << IO::serialize(v.point());
 }
 
 } //namespace CGAL

--- a/Triangulation_3/include/CGAL/Triangulation_vertex_base_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_vertex_base_3.h
@@ -17,6 +17,7 @@
 
 #include <CGAL/basic.h>
 #include <CGAL/Triangulation_ds_vertex_base_3.h>
+#include <CGAL/IO/io.h>
 
 namespace CGAL {
 

--- a/Triangulation_3/test/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/test/Triangulation_3/CMakeLists.txt
@@ -28,6 +28,7 @@ create_single_source_cgal_program("test_segment_simplex_traverser_3.cpp" )
 create_single_source_cgal_program("test_static_filters.cpp")
 create_single_source_cgal_program("test_triangulation_3.cpp")
 create_single_source_cgal_program("test_io_triangulation_3.cpp")
+create_single_source_cgal_program("test_triangulation_serialization_3.cpp")
 
 if(TARGET CGAL::TBB_support)
   message(STATUS "Found TBB")

--- a/Triangulation_3/test/Triangulation_3/test_triangulation_serialization_3.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_triangulation_serialization_3.cpp
@@ -1,0 +1,44 @@
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Exact_rational.h>
+
+#include <CGAL/Delaunay_triangulation_3.h>
+
+#include <CGAL/Random.h>
+
+
+#include <sstream>
+
+template <class K>
+void test()
+{
+  typedef typename K::FT FT;
+  CGAL::Delaunay_triangulation_3<K> dt3;
+
+
+  // create a bunch of points
+  CGAL::Random random;
+  FT x,y,z;
+  for (int n=0;n<50;++n)
+  {
+    x=random.get_int(-500,500);
+    y=random.get_int(-500,500);
+    z=random.get_int(-500,500);
+    dt3.insert(typename K::Point_3(x/FT(3),y/FT(5),z/FT(7)));
+  }
+
+  std::stringstream buffer;
+  buffer << std::setprecision(17) << dt3;
+  decltype(dt3) dt3_bis;
+  buffer >> dt3_bis;
+
+  assert(dt3==dt3_bis);
+}
+
+int main()
+{
+  test<CGAL::Simple_cartesian<CGAL::Exact_rational>>();
+  test<CGAL::Exact_predicates_exact_constructions_kernel>();
+  test<CGAL::Exact_predicates_inexact_constructions_kernel>();
+}


### PR DESCRIPTION
Before the patch the points were written in double.

