### PR TITLE
CGAL Lab - disable verbosity of `.mesh` reader

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -138,7 +138,7 @@ Polyhedron_demo_c3t3_binary_io_plugin::load(
       item->set_valid(false);
 
       if(CGAL::SMDS_3::build_triangulation_from_file(in, item->c3t3().triangulation(),
-         /*verbose = */true, /*replace_subdomain_0 = */false, /*allow_non_manifold = */true))
+         /*verbose = */false, /*replace_subdomain_0 = */false, /*allow_non_manifold = */true))
       {
         update_c3t3(item->c3t3());
 


### PR DESCRIPTION
## Summary of Changes

The verbose version of  `build_triangulation_from_file` is really too verbose and slows down the file reader.

## Release Management

* Affected package(s): Polyhedron demo

