### PR TITLE
Mesh_3 for weighted images - fix translated labeled image case

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Image_plus_weights_to_labeled_function_wrapper.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Image_plus_weights_to_labeled_function_wrapper.h
@@ -116,9 +116,9 @@ public:
   {
     return static_cast<return_type>(transform(
       r_im_.template labellized_trilinear_interpolation<Image_word_type>(
-          CGAL::to_double(p.x()),
-          CGAL::to_double(p.y()),
-          CGAL::to_double(p.z()),
+          CGAL::to_double(p.x() - r_im_.image()->tx),
+          CGAL::to_double(p.y() - r_im_.image()->ty),
+          CGAL::to_double(p.z() - r_im_.image()->tz),
           value_outside,
           indicator_factory)));
   }


### PR DESCRIPTION
## Summary of Changes

The translation `tx, ty, tz` of a labeled image was not taken into account in the weighted image oracle, leading to an output mesh that was shifted to origin, not aligned with input image.

This PR fixes this misalignment.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

