### PR TITLE
Polyhedron demo - fix Mesh_3 dialog initialization

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -685,9 +685,8 @@ void Mesh_3_plugin::mesh_3(const Mesh_type mesh_type,
   connect(ui.useWeights_checkbox, SIGNAL(toggled(bool)),
           ui.weightsSigma_label, SLOT(setEnabled(bool)));
   ui.labeledImgGroup->setVisible(input_is_labeled_img);
-  ui.weightsSigma->setValue((std::max)(image_item->image()->vx(),
-                            (std::max)(image_item->image()->vy(),
-                                       image_item->image()->vz())));
+  if(image_item != nullptr && input_is_labeled_img)
+    ui.weightsSigma->setValue(image_item->default_sigma_weights());
 
 #ifndef CGAL_USE_ITK
   if (input_is_labeled_img)

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
@@ -542,7 +542,16 @@ Scene_image_item::sigma_weights() const
 {
   return d->m_sigma_weights;
 }
-
+float
+Scene_image_item::default_sigma_weights() const
+{
+  if(!m_image)
+    return 0.f;
+  else
+    return (std::max)(m_image->image()->vx,
+           (std::max)(m_image->image()->vy,
+                      m_image->image()->vz));
+}
 
 void
 Scene_image_item::draw(Viewer_interface* viewer) const

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.h
@@ -48,6 +48,7 @@ public:
   Image* image_weights() const;
   void set_image_weights(const Image& img, const float sigma);
   float sigma_weights() const;
+  float default_sigma_weights() const;
 
   void invalidateOpenGLBuffers();
   void initializeBuffers(Viewer_interface *) const;


### PR DESCRIPTION
## Summary of Changes

Avoid trying to access a non-existing labeled image. That was crashing the demo when running the following steps :
* open a .off file
* Operations -> Tet mesh generation
* seg fault

## Release Management

* Affected package(s): Polyhedron demo

