### PR TITLE
Skeletonization: Make it deterministic

### DIFF
--- a/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
+++ b/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
@@ -234,6 +234,10 @@ public:
   typedef typename boost::graph_traits<mTriangleMesh>::edge_descriptor         edge_descriptor;
   typedef typename boost::graph_traits<mTriangleMesh>::edge_iterator           edge_iterator;
 
+  struct Less_id {
+    bool operator()(const edge_descriptor& x, const edge_descriptor& y) const { return x.id() < y.id(); }
+  };
+
   // Get weight from the weight interface.
   typedef CGAL::Weights::Cotangent_weight<mTriangleMesh, mVertexPointMap, Traits> Weight_calculator;
 
@@ -1425,7 +1429,7 @@ std::size_t Mean_curvature_flow_skeletonization<TriangleMesh, Traits_, VertexPoi
 {
   std::size_t cnt=0, prev_cnt=0;
 
-  std::set<edge_descriptor> edges_to_collapse, non_topologically_valid_collapses;
+  std::set<edge_descriptor,Less_id> edges_to_collapse, non_topologically_valid_collapses;
 
   for(edge_descriptor ed : edges(m_tmesh))
     if ( edge_should_be_collapsed(ed) )


### PR DESCRIPTION
## Summary of Changes

For the `less`  of a `std::set` use the `id`  of the halfedge instead of the pointer.

## Release Management

* Affected package(s): Surface_mesh_skeletonization
* Issue(s) solved (if any): fix #7511


