### PR TITLE
Fix initialisation issues in Mesh_3

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -633,6 +633,13 @@ insert_point(const Bare_point& p, const Weight& w, int dim, const Index& index,
 {
   using CGAL::Mesh_3::internal::weight_modifier;
 
+#if CGAL_MESH_3_PROTECTION_DEBUG & 1
+  std::cerr << "insert_point( (" << p
+            << "), w=" << w
+            << ", dim=" << dim
+            << ", index=" << CGAL::IO::oformat(index) << ")\n";
+#endif
+
   // Convert the dimension if it was set to a negative value (marker for special balls).
   if(dim < 0)
     dim = -1 - dim;
@@ -709,6 +716,7 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
             << "), w=" << w
             << ", dim=" << dim
             << ", index=" << CGAL::IO::oformat(index) << ")\n";
+  std::cerr << "triangulation dimension is " << c3t3_.triangulation().dimension() << std::endl;
 #endif
   const Tr& tr = c3t3_.triangulation();
 
@@ -877,10 +885,12 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
       }
     }
 
+    // Change w in order to be sure that no existing point will be included in (p,w)
     FT min_sq_d = w;
+#if CGAL_MESH_3_PROTECTION_DEBUG & 1
     typename Tr::Point nearest_point;
-    // Change w in order to be sure that no existing point will be included
-    // in (p,w)
+#endif
+
     for ( typename Tr::Finite_vertices_iterator it = tr.finite_vertices_begin(),
          end = tr.finite_vertices_end() ; it != end ; ++it )
     {
@@ -888,7 +898,9 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
       FT sq_d = tr.min_squared_distance(p, cp(it_wp));
       if(sq_d < min_sq_d) {
         min_sq_d = sq_d;
+#if CGAL_MESH_3_PROTECTION_DEBUG & 1
         nearest_point = c3t3_.triangulation().point(it);
+#endif
       }
     }
 
@@ -916,6 +928,11 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
   }
 
   if( w < minimal_weight_) {
+#if CGAL_MESH_3_PROTECTION_DEBUG & 1
+    std::cerr << "smart_insert_point: weight " << w
+              << " was smaller than minimal weight (" << minimal_weight_ << ")\n";
+#endif
+
     w = minimal_weight_;
     insert_a_special_ball = true;
   }

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -854,33 +854,25 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
   else // tr.dimension() <= 2
   {
     // change size of existing balls which include p
-    bool restart = true;
-    while ( restart )
+    for ( typename Tr::Finite_vertices_iterator it = tr.finite_vertices_begin(),
+          end = tr.finite_vertices_end() ; it != end ; ++it )
     {
-      restart = false;
-      for ( typename Tr::Finite_vertices_iterator it = tr.finite_vertices_begin(),
-           end = tr.finite_vertices_end() ; it != end ; ++it )
+      const Weighted_point& it_wp = tr.point(it);
+      FT sq_d = tr.min_squared_distance(p, cp(it_wp));
+      if ( cwsr(it_wp, - sq_d) == CGAL::SMALLER )
       {
-        const Weighted_point& it_wp = tr.point(it);
-        FT sq_d = tr.min_squared_distance(p, cp(it_wp));
-        if ( cwsr(it_wp, - sq_d) == CGAL::SMALLER )
+        bool special_ball = false;
+        if(minimal_weight_ != Weight() && sq_d < minimal_weight_)
         {
-          bool special_ball = false;
-          if(minimal_weight_ != Weight() && sq_d < minimal_weight_)
-          {
-            sq_d = minimal_weight_;
-            w = minimal_weight_;
-            special_ball = true;
-            insert_a_special_ball = true;
-          }
+          sq_d = minimal_weight_;
+          w = minimal_weight_;
+          special_ball = true;
+          insert_a_special_ball = true;
+        }
 
-          if( ! is_special(it) ) {
-            *out++ = it;
-            change_ball_size(it, sq_d, special_ball);
-            restart = true;
-          }
-
-          break;
+        if( ! is_special(it) ) {
+          *out++ = it;
+          change_ball_size(it, sq_d, special_ball);
         }
       }
     }

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -743,8 +743,8 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
 #endif
 
     // if sq_d < nearest_vh's weight
-    while ( cwsr(c3t3_.triangulation().point(nearest_vh), - sq_d) == CGAL::SMALLER &&
-            ! is_special(nearest_vh) )
+    while ( ! is_special(nearest_vh) &&
+            cwsr(c3t3_.triangulation().point(nearest_vh), - sq_d) == CGAL::SMALLER )
     {
       CGAL_assertion( minimal_size_ > 0 || sq_d > 0 );
 

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -578,7 +578,7 @@ insert_corners()
     Index p_index = domain_.index_from_corner_index(cit->first);
 
 #if CGAL_MESH_3_PROTECTION_DEBUG & 1
-      std::cerr << "** treat corner #" << CGAL::IO::oformat(p_index) << std::endl;
+      std::cerr << "\n** treat corner #" << CGAL::IO::oformat(p_index) << std::endl;
 #endif
 
     // Get weight (the ball radius is given by the 'query_size' function)
@@ -833,7 +833,7 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
 #if CGAL_MESH_3_PROTECTION_DEBUG & 1
       std::cerr << "smart_insert_point: weight " << w
                 << " reduced to " << min_sq_d
-                << "\n (near existing point: " << nearest_point << " )\n";
+                << " (near existing point: " << nearest_point << " )\n";
 #endif
       w = min_sq_d;
       add_handle_to_unchecked = true;
@@ -873,11 +873,13 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
             special_ball = true;
             insert_a_special_ball = true;
           }
+
           if( ! is_special(it) ) {
             *out++ = it;
             change_ball_size(it, sq_d, special_ball);
             restart = true;
           }
+
           break;
         }
       }
@@ -903,7 +905,7 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
 #if CGAL_MESH_3_PROTECTION_DEBUG & 1
       std::cerr << "smart_insert_point: weight " << w
                 << " reduced to " << min_sq_d
-                << "\n (near existing point: " << nearest_point << " )\n";
+                << " (near existing point: " << nearest_point << " )\n";
 #endif
       w = min_sq_d;
       add_handle_to_unchecked = true;
@@ -957,7 +959,7 @@ insert_balls_on_edges()
     if ( ! is_treated(curve_index) )
     {
 #if CGAL_MESH_3_PROTECTION_DEBUG & 1
-      std::cerr << "** treat curve #" << curve_index << std::endl;
+      std::cerr << "\n** treat curve #" << curve_index << std::endl;
 #endif
       const Bare_point& p = std::get<1>(*fit).first;
       const Bare_point& q = std::get<2>(*fit).first;

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -866,7 +866,8 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
         if ( cwsr(it_wp, - sq_d) == CGAL::SMALLER )
         {
           bool special_ball = false;
-          if(minimal_weight_ != Weight() && sq_d > minimal_weight_) {
+          if(minimal_weight_ != Weight() && sq_d < minimal_weight_)
+          {
             sq_d = minimal_weight_;
             w = minimal_weight_;
             special_ball = true;

--- a/Mesh_3/include/CGAL/Mesh_3/Robust_intersection_traits_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Robust_intersection_traits_3.h
@@ -418,14 +418,14 @@ tr_intersection(const typename K::Triangle_3  &t,
 
   typedef typename K::Point_3 Point_3;
 
-  typename K::Construct_vertex_3 vertex_on =
-    k.construct_vertex_3_object();
-
+  typename K::Do_intersect_3 do_intersect =
+    k.do_intersect_3_object();
   typename K::Orientation_3 orientation =
     k.orientation_3_object();
-
   typename K::Construct_point_on_3 point_on =
     k.construct_point_on_3_object();
+  typename K::Construct_vertex_3 vertex_on =
+    k.construct_vertex_3_object();
 
   typename Mesh_3::Vector_plane_orientation_3_static_filter<K> vector_plane_orient;
 
@@ -439,17 +439,24 @@ tr_intersection(const typename K::Triangle_3  &t,
   const Point_3& q = point_on(r,1);
 
   const Orientation ray_direction = vector_plane_orient(p, q, a, b, c);
-
-  if(ray_direction == COPLANAR) return result_type();
+  if(ray_direction == COPLANAR)
+    return result_type();
 
   const Orientation abcp = orientation(a,b,c,p);
+  if(abcp == COPLANAR) // p belongs to the triangle's supporting plane
+  {
+    if(do_intersect(t, p))
+      return result_type(p);
+    else
+      return result_type();
+  }
 
-  if(abcp == COPLANAR) return result_type(); // p belongs to the triangle's
-                                        // supporting plane
-
-  if(ray_direction == abcp) return result_type();
-  // The ray lies entirely in one of the two open halfspaces defined by the
-  // triangle's supporting plane.
+  if(ray_direction == abcp)
+  {
+    // The ray lies entirely in one of the two open halfspaces defined by the
+    // triangle's supporting plane.
+    return result_type();
+  }
 
   // Here we know that the ray crosses the plane (abc)
 

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -692,13 +692,14 @@ Construct_initial_points::operator()(OutputIterator pts,
   typename IGT::Construct_vector_3 vector = IGT().construct_vector_3_object();
 
   const Bounding_box bbox = r_domain_.tree_.bbox();
-  const Point_3 center( FT( (bbox.xmin() + bbox.xmax()) / 2),
-                        FT( (bbox.ymin() + bbox.ymax()) / 2),
-                        FT( (bbox.zmin() + bbox.zmax()) / 2) );
+  Point_3 center( FT( (bbox.xmin() + bbox.xmax()) / 2),
+                  FT( (bbox.ymin() + bbox.ymax()) / 2),
+                  FT( (bbox.zmin() + bbox.zmax()) / 2) );
 
   CGAL::Random& rng = *(r_domain_.p_rng_ != 0 ?
                         r_domain_.p_rng_ :
                         new Random(0));
+
   Random_points_on_sphere_3<Point_3> random_point(1., rng);
 
   int i = n;
@@ -728,6 +729,15 @@ Construct_initial_points::operator()(OutputIterator pts,
         % (n - i)
         % n;
 # endif
+
+      // If the source of the ray is on the surface, every ray will return its source
+      // so change the source to a random point in the bounding box
+      if(std::get<0>(intersection) == ray_shot.source())
+      {
+        center = Point_3(rng.get_double(bbox.xmin(), bbox.xmax()),
+                         rng.get_double(bbox.ymin(), bbox.ymax()),
+                         rng.get_double(bbox.zmin(), bbox.zmax()));
+      }
     }
     ++random_point;
   }

--- a/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_3/Protect_edges_sizing_field.h
+++ b/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_3/Protect_edges_sizing_field.h
@@ -1683,8 +1683,8 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
 #endif
 
   // This will never happen for a dummy point
-  while(cwsr(c3t3_.triangulation().point(nearest_vh), - sq_d) == CGAL::SMALLER &&
-        ! is_special(nearest_vh))
+  while(! is_special(nearest_vh) &&
+        cwsr(c3t3_.triangulation().point(nearest_vh), - sq_d) == CGAL::SMALLER)
   {
     CGAL_assertion(minimal_size_ > 0 || sq_d > 0);
 


### PR DESCRIPTION
## Summary of Changes

- Issue 1 (fbecb18): bad comparison in minimal weight clamping in 2D case, caused protection balls to become hidden.
- Issue 2 (39c0a9f): robust intersection traits returned no intersection for a ray spawned within a triangle, so the `init_c3t3()` could not insert initial points.
- Issue 3 (49bb14b): in the 2D case, the code was exiting too early while adjusting ball sizes before a new point insertion.
- Issue 4 (1f258bc): after 39c0a9f, initialization did not work anymore if the source is on the domain.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): -
* Feature/Small Feature (if any):  -
* License and copyright ownership: no change

