### PR TITLE
Classification: Workaround for VC++/std17/boost bug

### DIFF
--- a/Classification/include/CGAL/Classification/Image.h
+++ b/Classification/include/CGAL/Classification/Image.h
@@ -16,6 +16,7 @@
 
 #include <map>
 #include <memory>
+#include <CGAL/assertions.h>
 
 #define CGAL_CLASSIFICATION_IMAGE_SIZE_LIMIT 100000000
 
@@ -38,12 +39,15 @@ class Image
   std::shared_ptr<Map> m_sparse;
   Type m_default;
 
-  // Forbid using copy constructor
-  Image (const Image&)
-  {
-  }
 
 public:
+  // Forbid using copy constructor
+  // Make it public for a strange VC++ std17 boost-1_82 error
+  // https://github.com/boostorg/core/issues/148
+  Image(const Image&)
+  {
+      CGAL_assertion(false);
+  }
 
   Image () : m_width(0), m_height(0), m_depth(0)
   {


### PR DESCRIPTION
## Summary of Changes

VC2022   with std17 and boost 1_82_0 have a `N`  in the Classification testsuite.
We reported an issue at [`boost/core`](https://github.com/boostorg/core/issues/148) 
The workaround is to make the copy constructor public.

See also the discussion on the [issue  ](https://github.com/boostorg/core/issues/148)in boost/core

## Release Management

* Affected package(s): Classification
