### PR TITLE
Spelling corrections

### DIFF
--- a/AABB_tree/include/CGAL/AABB_halfedge_graph_segment_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_halfedge_graph_segment_primitive.h
@@ -33,7 +33,7 @@ namespace CGAL {
 
 /*!
  * \ingroup PkgAABBTreeRef
- * Primitive type for a edge of a polyhedral surface.
+ * Primitive type for an edge of a polyhedral surface.
  * It wraps an `edge_descriptor` into a 3D segment.
  * The class model of `HalfedgeGraph` from which the primitive is built should not be deleted
  * while the AABB tree holding the primitive is in use.

--- a/BGL/include/CGAL/boost/graph/Face_filtered_graph.h
+++ b/BGL/include/CGAL/boost/graph/Face_filtered_graph.h
@@ -42,7 +42,7 @@ namespace CGAL {
    * <a href="https://www.boost.org/doc/libs/release/libs/graph/doc/filtered_graph.html"><code>boost::filtered_graph</code></a>,
    * this class only requires a way to access the selected faces and will automatically select the
    * edges/halfedges and vertices present in the adapted graph. A vertex is selected if it is incident to at least one
-   * selected face. A edge is selected if it is incident to at least a selected face. A halfedge is selected if its edge
+   * selected face. An edge is selected if it is incident to at least a selected face. A halfedge is selected if its edge
    * is selected.
    *
    * Since this class is a model of the `FaceGraph` concept, there is a restriction on the set of selected faces:

--- a/Linear_cell_complex/benchmark/Linear_cell_complex_2/surface_mesh/Surface_mesh.h
+++ b/Linear_cell_complex/benchmark/Linear_cell_complex_2/surface_mesh/Surface_mesh.h
@@ -1103,7 +1103,7 @@ public: //--------------------------------------------------- property handling
     {
         return Halfedge_property<T>(hprops_.add<T>(name, t));
     }
-    /** add a edge property of type \c T with name \c name and default value \c t.
+    /** add an edge property of type \c T with name \c name and default value \c t.
      fails if a property named \c name exists already, since the name has to be unique.
      in this case it returns an invalid property */
     template <class T> Edge_property<T> add_edge_property(const std::string& name, const T t=T())

--- a/Nef_2/include/CGAL/Nef_2/PM_point_locator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_point_locator.h
@@ -159,7 +159,7 @@ public:
     const Direction& d, bool& collinear) const
   /*{\Xop returns a halfedge |e| bounding a wedge in between two
   neighbored edges in the adjacency list of |v| which contains |d|.
-  If |d| extends along a edge then |e| is this edge. If |d| extends
+  If |d| extends along an edge then |e| is this edge. If |d| extends
   into the interior of such a wedge then |e| is the first edge hit
   when |d| is rotated clockwise. \precond |v| is not isolated.}*/
   { CGAL_NEF_TRACEN("out_wedge "<<PV(v));

--- a/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_simplify.h
@@ -169,7 +169,7 @@ class SNC_simplify_base : public SNC_decorator<SNC_structure> {
   }
 
   bool is_part_of_edge(Vertex_handle v) {
-    /* determines if a vertex v is part of a edge, checking at its local
+    /* determines if a vertex v is part of an edge, checking at its local
        graph for exactly two antipodal vertices  */
 
     SM_decorator SD(&*v);

--- a/Nef_S2/include/CGAL/Nef_S2/SM_point_locator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_point_locator.h
@@ -119,7 +119,7 @@ public:
                              bool& collinear) const
   /*{\Xop returns a halfedge |e| bounding a wedge in between two
   neighbored edges in the adjacency list of |v| which contains |d|.
-  If |d| extends along a edge then |e| is this edge. If |d| extends
+  If |d| extends along an edge then |e| is this edge. If |d| extends
   into the interior of such a wedge then |e| is the first edge hit
   when |d| is rotated clockwise. \precond |v| is not isolated.}*/
   { CGAL_NEF_TRACEN("out_wedge "<<PH(v));

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -21,7 +21,7 @@ given in Botsch et al.'s book on polygon mesh processing \cgalCite{botsch2010PMP
 A \a polygon \a mesh is a consistent and orientable surface mesh, that can have
 one or more boundaries.
 The \a faces are simple polygons.
-The \a edges are segments. Each edge connects two \a vertices,
+The \an edges are segments. Each edge connects two \a vertices,
 and is shared by two faces (including the \a null \a face for boundary edges).
 A polygon mesh can have any number of connected components, and also some self-intersections.
 In this package, a polygon mesh is considered to have the topology of a 2-manifold.

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
@@ -344,7 +344,7 @@ void Straight_skeleton_builder_2<Gt,Ss,V>::CollectNewEvents( Vertex_handle aNode
   // or vertex events (or edge events of course).
   //
   // Each vertex wavefront (reflex or not) results in one and only one event from a set of possible events.
-  // It can result in a edge event against the vertex wavefronts emerging from the adjacent vertices (in the current polygon, not
+  // It can result in an edge event against the vertex wavefronts emerging from the adjacent vertices (in the current polygon, not
   // in the input polygon); or it can result in a split event (or vertex event) against any other wavefront in the rest of
   // current polygon.
 

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
@@ -697,7 +697,7 @@ is_constrained(const vertex_descriptor v) const
 }
 
 // Some edges are NOT collapsible: doing so would break the topological consistency of the mesh.
-// This function returns true if a edge 'p->q' can be collapsed.
+// This function returns true if an edge 'p->q' can be collapsed.
 //
 // An edge p->q can be collapsed iff it satisfies the "link condition"
 // (as described in the "Mesh Optimization" article of Hoppe et al (1993))


### PR DESCRIPTION
Spelling correction `a edge` to `an edge`

