### PR TITLE
add missing partial specialization

### DIFF
--- a/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_interior_point_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_interior_point_3.h
@@ -180,7 +180,7 @@ halfspace_intersection_interior_point_3(PlaneIterator begin, PlaneIterator end)
   typedef typename Kernel_traits<typename std::iterator_traits<PlaneIterator>::value_type>::Kernel K;
 
   // choose exact integral type
-  typedef typename internal::Exact_field_selector<void*>::Type ET;
+  typedef typename internal::Exact_field_selector<typename K::FT>::Type ET;
 
   // find a point inside the intersection
   internal::Interior_polyhedron_3<K, ET> interior;

--- a/Intersections_2/test/Intersections_2/test_intersections_2.cpp
+++ b/Intersections_2/test/Intersections_2/test_intersections_2.cpp
@@ -924,9 +924,9 @@ int main()
 {
   CGAL::Set_ieee_double_precision pfr;
 
-  Test< CGAL::Simple_cartesian<CGAL::internal::Exact_field_selector<void*>::Type > >().run();
+  Test< CGAL::Simple_cartesian<CGAL::internal::Exact_field_selector<double>::Type > >().run();
   Test< CGAL::Cartesian<double>   >().run();
-  Test< CGAL::Homogeneous<CGAL::internal::Exact_field_selector<void*>::Type > >().run();
+  Test< CGAL::Homogeneous<CGAL::internal::Exact_field_selector<double>::Type > >().run();
   Test< CGAL::Exact_predicates_inexact_constructions_kernel >().run();
   Test< CGAL::Exact_predicates_exact_constructions_kernel >().run();
 }

--- a/Number_types/include/CGAL/Exact_integer.h
+++ b/Number_types/include/CGAL/Exact_integer.h
@@ -40,7 +40,7 @@ typedef unspecified_type Exact_integer;
 
 #else // not DOXYGEN_RUNNING
 
-using Exact_integer = Exact_NT_backend<Default_exact_nt_backend>::Integer;
+using Exact_integer = internal::Exact_NT_backend<Default_exact_nt_backend>::Integer;
 
 #endif // not DOXYGEN_RUNNING
 

--- a/Number_types/include/CGAL/Exact_integer.h
+++ b/Number_types/include/CGAL/Exact_integer.h
@@ -40,7 +40,7 @@ typedef unspecified_type Exact_integer;
 
 #else // not DOXYGEN_RUNNING
 
-typedef internal::Exact_ring_selector<int>::Type Exact_integer;
+using Exact_integer = Exact_NT_backend<Default_exact_nt_backend>::Integer;
 
 #endif // not DOXYGEN_RUNNING
 

--- a/Number_types/include/CGAL/Exact_integer.h
+++ b/Number_types/include/CGAL/Exact_integer.h
@@ -40,7 +40,7 @@ typedef unspecified_type Exact_integer;
 
 #else // not DOXYGEN_RUNNING
 
-using Exact_integer = internal::Exact_NT_backend<Default_exact_nt_backend>::Integer;
+using Exact_integer = internal::Exact_NT_backend<internal::Default_exact_nt_backend>::Integer;
 
 #endif // not DOXYGEN_RUNNING
 

--- a/Number_types/include/CGAL/Exact_rational.h
+++ b/Number_types/include/CGAL/Exact_rational.h
@@ -42,7 +42,7 @@ typedef unspecified_type Exact_rational;
 
 #else // not DOXYGEN_RUNNING
 
-using Exact_rational = internal::Exact_NT_backend<Default_exact_nt_backend>::Rational;
+using Exact_rational = internal::Exact_NT_backend<internal::Default_exact_nt_backend>::Rational;
 
 #endif
 

--- a/Number_types/include/CGAL/Exact_rational.h
+++ b/Number_types/include/CGAL/Exact_rational.h
@@ -42,7 +42,7 @@ typedef unspecified_type Exact_rational;
 
 #else // not DOXYGEN_RUNNING
 
-using Exact_rational = Exact_NT_backend<Default_exact_nt_backend>::Rational;
+using Exact_rational = internal::Exact_NT_backend<Default_exact_nt_backend>::Rational;
 
 #endif
 

--- a/Number_types/include/CGAL/Exact_rational.h
+++ b/Number_types/include/CGAL/Exact_rational.h
@@ -42,7 +42,7 @@ typedef unspecified_type Exact_rational;
 
 #else // not DOXYGEN_RUNNING
 
-typedef internal::Exact_field_selector<double>::Type Exact_rational;
+using Exact_rational = Exact_NT_backend<Default_exact_nt_backend>::Rational;
 
 #endif
 

--- a/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
+++ b/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
@@ -256,6 +256,10 @@ struct Exact_ring_selector<leda_rational>
 template <>
 struct Exact_field_selector<leda_real>
 { typedef leda_real  Type; };
+
+template <>
+struct Exact_ring_selector<leda_real>
+{ typedef leda_real  Type; };
 #endif
 
 #ifdef CGAL_USE_CORE

--- a/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
+++ b/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
@@ -162,23 +162,22 @@ struct Exact_field_selector;
 template < typename >
 struct Exact_ring_selector;
 
-template <>
-struct Exact_ring_selector<double>
-{
-  using Type = typename Exact_NT_backend<Default_exact_nt_backend>::Ring_for_float;
+#define CGAL_EXACT_SELECTORS_SPECS(X) \
+template <> \
+struct Exact_ring_selector<X> \
+{ \
+  using Type = typename Exact_NT_backend<Default_exact_nt_backend>::Ring_for_float; \
+}; \
+\
+template <> \
+struct Exact_field_selector<X> \
+{ \
+  using Type = typename Exact_NT_backend<Default_exact_nt_backend>::Rational; \
 };
 
-template <>
-struct Exact_field_selector<double>
-{
-  using Type = typename Exact_NT_backend<Default_exact_nt_backend>::Rational;
-};
-
-template <>
-struct Exact_ring_selector<float> : Exact_ring_selector<double> { };
-
-template <>
-struct Exact_field_selector<float> : Exact_field_selector<double> { };
+CGAL_EXACT_SELECTORS_SPECS(double)
+CGAL_EXACT_SELECTORS_SPECS(float)
+CGAL_EXACT_SELECTORS_SPECS(int)
 
 template <>
 struct Exact_field_selector<MP_Float>
@@ -329,5 +328,7 @@ struct Exact_type_selector : Exact_field_selector< ET > {};
 #endif
 
 } } // namespace CGAL::internal
+
+#undef CGAL_EXACT_SELECTORS_SPECS
 
 #endif // CGAL_INTERNAL_EXACT_TYPE_SELECTOR_H

--- a/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
+++ b/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
@@ -169,7 +169,16 @@ struct Exact_ring_selector<double>
 };
 
 template <>
+struct Exact_field_selector<double>
+{
+  using Type = typename Exact_NT_backend<Default_exact_nt_backend>::Rational;
+};
+
+template <>
 struct Exact_ring_selector<float> : Exact_ring_selector<double> { };
+
+template <>
+struct Exact_field_selector<float> : Exact_field_selector<double> { };
 
 template <>
 struct Exact_field_selector<MP_Float>

--- a/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
+++ b/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
@@ -187,6 +187,10 @@ struct Exact_ring_selector<MP_Float>
 
 template <>
 struct Exact_field_selector<Quotient<MP_Float> >
+{ typedef Quotient<MP_Float> Type; }
+
+template <>
+struct Exact_ring_selector<Quotient<MP_Float> >
 { typedef Quotient<MP_Float> Type; };
 
 // And we specialize for the following types :

--- a/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
+++ b/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
@@ -157,16 +157,10 @@ constexpr ENT_backend_choice Default_exact_nt_backend = static_cast<ENT_backend_
 #endif
 
 template < typename >
-struct Exact_field_selector
-{
-  using Type = typename Exact_NT_backend<Default_exact_nt_backend>::Rational;
-};
+struct Exact_field_selector;
 
 template < typename >
-struct Exact_ring_selector
-{
-  using Type = typename Exact_NT_backend<Default_exact_nt_backend>::Integer;
-};
+struct Exact_ring_selector;
 
 template <>
 struct Exact_ring_selector<double>

--- a/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
+++ b/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
@@ -181,7 +181,7 @@ struct Exact_ring_selector<MP_Float>
 
 template <>
 struct Exact_field_selector<Quotient<MP_Float> >
-{ typedef Quotient<MP_Float> Type; }
+{ typedef Quotient<MP_Float> Type; };
 
 template <>
 struct Exact_ring_selector<Quotient<MP_Float> >

--- a/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
+++ b/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
@@ -278,6 +278,26 @@ struct Exact_field_selector<Exact_NT_backend<BOOST_BACKEND>::Rational>
 template <>
 struct Exact_ring_selector<Exact_NT_backend<BOOST_BACKEND>::Rational>
 { typedef Exact_NT_backend<BOOST_BACKEND>::Rational  Type; };
+
+
+#ifdef CGAL_USE_GMP
+template <>
+struct Exact_field_selector<Exact_NT_backend<BOOST_GMP_BACKEND>::Integer>
+{ typedef Exact_NT_backend<BOOST_GMP_BACKEND>::Rational  Type; };
+
+template <>
+struct Exact_ring_selector<Exact_NT_backend<BOOST_GMP_BACKEND>::Integer>
+{ typedef Exact_NT_backend<BOOST_GMP_BACKEND>::Integer  Type; };
+
+template <>
+struct Exact_field_selector<Exact_NT_backend<BOOST_GMP_BACKEND>::Rational>
+{ typedef Exact_NT_backend<BOOST_GMP_BACKEND>::Rational  Type; };
+
+template <>
+struct Exact_ring_selector<Exact_NT_backend<BOOST_GMP_BACKEND>::Rational>
+{ typedef Exact_NT_backend<BOOST_GMP_BACKEND>::Rational  Type; };
+#endif
+
 #endif
 
 template < typename ET >


### PR DESCRIPTION
Add missing partial specialization for boost's gmp wrapper.


Fixes https://github.com/CGAL/cgal/issues/7577

