### PR TITLE
Possibility to disable special CGAL documentation setting

### DIFF
--- a/Documentation/doc/CMakeLists.txt
+++ b/Documentation/doc/CMakeLists.txt
@@ -241,6 +241,18 @@ else()
       "#EXTRACT_ALL_NO_DETAILED_IF_EMPTY = NO")
 endif()
 
+option(CGAL_NO_ADDITIONAL_DETAILS
+       "Use CGAL special doxygen setting NO_ADDITIONAL_DETAILS." ON)
+if(CGAL_NO_ADDITIONAL_DETAILS)
+  set(CGAL_OPT_NO_ADDITIONAL_DETAILS
+      "NO_ADDITIONAL_DETAILS = YES")
+else()
+  # The default is NO, so we could leave it out, but it is better to have a commented out placeholder
+  # this will work for versions with and without the setting.
+  set(CGAL_OPT_NO_ADDITIONAL_DETAILS
+      "#NO_ADDITIONAL_DETAILS = NO")
+endif()
+
 #we use two directories for the generation/reading of tag files to prevent issues
 #if the targets are built in parallel
 set(CGAL_DOC_TAG_GEN_DIR "${CMAKE_BINARY_DIR}/doc_gen_tags")

--- a/Documentation/doc/resources/1.8.13/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.13/BaseDoxyfile.in
@@ -262,7 +262,7 @@ EXTRACT_ALL            = YES
 # the EXTRACT_ALL tag is set to NO.
 # The default value is: NO.
 
-EXTRACT_ALL_NO_DETAILED_IF_EMPTY                                        = YES
+${CGAL_OPT_EXTRACT_ALL_NO_DETAILED_IF_EMPTY}
 
 # If the EXTRACT_STATIC tag is set to YES, all static members of a file will be
 # included in the documentation.

--- a/Documentation/doc/resources/1.9.6/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.9.6/BaseDoxyfile.in
@@ -791,5 +791,5 @@ GENERATE_LEGEND        = NO
 # NO_ADDITIONAL_DETAILS tag is set to YES. This tag has no effect if
 # the EXTRACT_ALL tag is set to NO.
 # The default value is: NO.
-NO_ADDITIONAL_DETAILS = YES
+${CGAL_OPT_NO_ADDITIONAL_DETAILS}
 


### PR DESCRIPTION
In the past it was possible by means of the option `-DCGAL_EXTRACT_ALL_NO_DETAILED_IF_EMPTY=OFF` with CMake to disable the specific CGAL setting though currently with the 1.8.13 version this didn't work (anymore). Also the setting has been renamed for the 1.9.6 version (and newer) to `NO_ADDITIONAL_DETAILS` this has now been made more flexible as well.


