### PR TITLE
Fixing dangling reference issue with tmesh

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_slicer.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_slicer.h
@@ -294,7 +294,7 @@ class Polygon_mesh_slicer
 
 /// member variables
   const AABBTree* m_tree_ptr;
-  TriangleMesh& m_tmesh;
+  TriangleMesh m_tmesh;
   VertexPointMap m_vpmap;
   Traits m_traits;
   bool m_own_tree;
@@ -397,15 +397,13 @@ public:
   * Constructor using `edges(tmesh)` to initialize the
   * internal `AABB_tree`.
   * @param tmesh the triangulated surface mesh to be sliced.
-  *              It must be valid and non modified as long
-  *              as the functor is used.
   * @param vpmap an instance of the vertex point property map associated to `tmesh`
   * @param traits a traits class instance, can be omitted
   */
   Polygon_mesh_slicer(const TriangleMesh& tmesh,
                       VertexPointMap vpmap,
                       const Traits& traits = Traits())
-  : m_tmesh(const_cast<TriangleMesh&>(tmesh))
+  : m_tmesh(tmesh)
   , m_vpmap(vpmap)
   , m_traits(traits)
   , m_own_tree(true)
@@ -419,8 +417,6 @@ public:
   /**
   * Constructor using a pre-built `AABB_tree` of edges provided by the user.
   * @param tmesh the triangulated surface mesh to be sliced.
-  *              It must be valid and non modified as long
-  *              as the functor is used.
   * @param tree must be initialized with all the edges of `tmesh`
   * @param vpmap an instance of the vertex point property map associated to `tmesh`
   * @param traits a traits class instance, can be omitted
@@ -430,7 +426,7 @@ public:
                       VertexPointMap vpmap,
                       const Traits& traits = Traits())
     : m_tree_ptr(&tree)
-    , m_tmesh(const_cast<TriangleMesh&>(tmesh))
+    , m_tmesh(tmesh)
     , m_vpmap(vpmap)
     , m_traits(traits)
     , m_own_tree(false)
@@ -441,13 +437,11 @@ public:
   * internal `AABB_tree`. The vertex point property map used
   * is `get(CGAL::vertex_point, tmesh)`
   * @param tmesh the triangulated surface mesh to be sliced.
-  *              It must be valid and non modified as long
-  *              as the functor is used.
   * @param traits a traits class instance, can be omitted
   */
   Polygon_mesh_slicer(const TriangleMesh& tmesh,
                       const Traits& traits = Traits())
-  : m_tmesh(const_cast<TriangleMesh&>(tmesh))
+  : m_tmesh(tmesh)
   , m_vpmap(get(boost::vertex_point, m_tmesh))
   , m_traits(traits)
   , m_own_tree(true)
@@ -462,8 +456,6 @@ public:
   * Constructor using a `AABB_tree` provided by the user.
   * The vertex point property map used is `get(CGAL::vertex_point, tmesh)`
   * @param tmesh the triangulated surface mesh to be sliced.
-  *              It must be valid and non modified as long
-  *              as the functor is used.
   * @param tree must be initialized with all the edges of `tmesh`
   * @param traits a traits class instance, can be omitted
   */
@@ -471,7 +463,7 @@ public:
                       const AABBTree& tree,
                       const Traits& traits = Traits())
     : m_tree_ptr(&tree)
-    , m_tmesh(const_cast<TriangleMesh&>(tmesh))
+    , m_tmesh(tmesh)
     , m_vpmap(get(boost::vertex_point, m_tmesh))
     , m_traits(traits)
     , m_own_tree(false)


### PR DESCRIPTION
## Summary of Changes

This pull request addresses the issue of a dangling reference with the “tmesh” TriangleMesh object in the Polygon_mesh_slicer class, ensuring its validity throughout the lifetime of the object.

Modified the Polygon_mesh_slicer constructor to store a copy of the "tmesh" TriangleMesh object instead of a reference.
Ensured that the m_tmesh copy remains valid even if the original "tmesh" TriangleMesh object is modified or destroyed.

## Additional Notes
When I was using the Polygon mesh_slicer constructor, I discovered a potential problem with local variable references. I found that very subtle bugs occur when the constructor is passed in with parameters that are local variables.
Finally, I note that during the lifetime of the Polygon_mesh_slicer object, if the "tmesh" is modified or destroyed externally, the object referenced via m_tmesh will reflect these changes or become a dangling reference. 
I think that using a copy instead of a stored reference here is less efficient, but less error-prone.

## My Code
```cpp
//==============================In one cpp file as follows:======================================
             Mesh mesh_cgal;//local variable here------> Dangling reference problem in the constructor of the instance object 
                                         // CuttingPlaneCal of the sw_dis class
            if (!CGAL::IO::read_polygon_mesh(input, mesh_cgal))
            {
                std::cerr << "Invalid input." << std::endl;
                assert(false&&" invalid input for CGAL");
            }
            CuttingPlaneCal.reset(new sw_dis(mesh_cgal));// sw_dis::Ptr CuttingPlaneCal; 
//==============================In another hpp file as follows:======================================
#ifndef _SW_HPP
#define _SW_HPP
#include <iostream>
#include <fstream>
#include <CGAL/Projection_traits_3.h>
#include <CGAL/Constrained_Delaunay_triangulation_2.h>
#include <CGAL/Triangulation_face_base_with_info_2.h>
#include <CGAL/Qt/Basic_viewer_qt.h>
#include <CGAL/Point_set_3.h>
#include <CGAL/Polygon_set_2.h>
#include <CGAL/Polygon_2.h>
#include <CGAL/draw_point_set_3.h>
#include <CGAL/draw_surface_mesh.h>
#include <CGAL/draw_polyhedron.h>
#include <CGAL/draw_polygon_set_2.h>
#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
#include <CGAL/Surface_mesh.h>
#include <CGAL/Polygon_mesh_slicer.h>
#include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
#include <CGAL/AABB_halfedge_graph_segment_primitive.h>
#include <CGAL/AABB_tree.h>
#include <CGAL/AABB_traits.h>
#include <CGAL/Polygon_2.h>
#include <CGAL/Simple_cartesian.h>
#include <CGAL/Point_2.h>

#include <iostream>
#include <list>
#include <string>
#include <vector>
#include <chrono>
#include <random>
#include <Eigen/Eigen>
#include <Eigen/Core>
#include <memory>
using RowMatrixXd = Eigen::Matrix<double, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
using RowMatrixXi = Eigen::Matrix<int, Eigen::Dynamic, Eigen::Dynamic, Eigen::RowMajor>;
using Kernel = CGAL::Exact_predicates_inexact_constructions_kernel;
using Mesh = CGAL::Surface_mesh<Kernel::Point_3>;
using Polyline = std::vector<Kernel::Point_3>;
using Polylines = std::list<Polyline>;
using Polygon_set_2 = CGAL::Polygon_set_2<Kernel>;
using Polygon_2 = CGAL::Polygon_2<Kernel>;
using Point_2 = Kernel::Point_2;
using Point_3 = Kernel::Point_3;
using Vector_3 = typename Kernel::Vector_3;
using Mesh = typename CGAL::Surface_mesh<Point_3>;
using Point_set_3 = typename CGAL::Point_set_3<Point_3>;
using Projection_traits_3 = typename CGAL::Projection_traits_3<Kernel>;
using namespace Eigen;
class sw_dis
{
private:
    Mesh mesh;
    Polylines polylines;
    CGAL::Polygon_mesh_slicer<Mesh, Kernel> plane_slicer;
    std::back_insert_iterator<Polylines> slices_lines;
    Kernel::Plane_3 cutting_plane;
    Point_set_3 ps;

public:
    typedef std::shared_ptr<sw_dis> Ptr;
    //here is the problem  (_mesh would become a a dangling reference for the Polygon_mesh_slicer object plane_slicer)
    sw_dis(const Mesh &_mesh) : mesh(_mesh), polylines(Polylines()), plane_slicer(_mesh), slices_lines(polylines)
    {
    }
    ~sw_dis()
    {
    }

    inline double dis_calculate(const Vector3d &point, const Vector3d &dir)
    {

        polylines.clear();
        ps.clear();
        cutting_plane = Kernel::Plane_3(Kernel::Point_3(point[0], point[1], point[2]), Kernel::Vector_3(dir[0], dir[1], dir[2]));

        plane_slicer(cutting_plane, slices_lines);

        return 0;
    }
};

#endif
```
Please review the changes made in this pull request. Thanks for your feedback and suggestions for improvement.


