### PR TITLE
Triangulation_3: the testsuite of the simplex traverser needs C++17

### DIFF
--- a/Triangulation_3/test/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/test/Triangulation_3/CMakeLists.txt
@@ -22,15 +22,16 @@ create_single_source_cgal_program("test_regular_traits_3.cpp")
 create_single_source_cgal_program("test_RT_cell_base_with_weighted_circumcenter_3.cpp")
 create_single_source_cgal_program("test_robust_weighted_circumcenter.cpp")
 create_single_source_cgal_program("test_simplex_3.cpp")
-create_single_source_cgal_program("test_simplex_iterator_3.cpp" )
-create_single_source_cgal_program("test_segment_cell_traverser_3.cpp" )
 create_single_source_cgal_program("test_segment_simplex_traverser_3.cpp" )
 if(cxx_std_17 IN_LIST CMAKE_CXX_COMPILE_FEATURES)
+  create_single_source_cgal_program("test_simplex_iterator_3.cpp" )
+  create_single_source_cgal_program("test_segment_cell_traverser_3.cpp" )
+  target_compile_features(test_simplex_iterator_3 PRIVATE cxx_std_17)
   target_compile_features(test_segment_simplex_traverser_3 PRIVATE cxx_std_17)
 else()
   message(
   STATUS
-    "NOTICE: test_segment_simplex_traverser_3.cpp requires C++17 and will not be compiled."
+    "NOTICE: test_simplex_iterator_3.cpp and test_segment_simplex_traverser_3.cpp require C++17 and will not be compiled."
   )
 endif()
 create_single_source_cgal_program("test_static_filters.cpp")


### PR DESCRIPTION
## Summary of Changes

The files `test_simplex_iterator_3.cpp` and `test_segment_simplex_traverser_3.cpp` require C++17. This pull-request fixes the CMake logic so that they are only compiled if the compiler is able to use C++17.

Fix Triangulation_3 test suite on a few compilers:
https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-5.6-I-277/Triangulation_3/TestReport_Christo_MSVC2017-Debug-64bits.gz

## Release Management

Not a blocker in my option.

* Affected package(s): Triangulation_3
* License and copyright ownership: n/a

