### PR TITLE
Apollonius_graph: Fix return type in the documentation

### DIFF
--- a/Apollonius_graph_2/doc/Apollonius_graph_2/CGAL/Apollonius_graph_2.h
+++ b/Apollonius_graph_2/doc/Apollonius_graph_2/CGAL/Apollonius_graph_2.h
@@ -608,24 +608,22 @@ Vertex_handle nearest_neighbor(const Point_2& p, Vertex_handle vnear) const;
 /*!
 Returns the
 dual corresponding to the face handle `f`. The returned object can
-be assignable to one of the following: `Site_2`, `Gt::Line_2`.
+be assigned to one of the following: `Site_2`, `Gt::Line_2`.
 */
 Gt::Object_2 dual(Face_handle f) const;
 
 /*!
 Returns the
 dual of the face to which `it` points to. The returned object can
-be assignable to one of the following: `Site_2`, `Gt::Line_2`.
+be assigned to one of the following: `Site_2`, `Gt::Line_2`.
 */
 Gt::Object_2 dual(All_faces_iterator it) const;
 
 /*!
 Returns
-the dual of the face to which `it` points to. The returned
-object can be assignable to one of the following: `Site_2`,
-`Gt::Line_2`.
+the dual of the face to which `it` points to.
 */
-Gt::Object_2 dual(Finite_faces_iterator it) const;
+Site dual(Finite_faces_iterator it) const;
 
 /// @}
 

--- a/Apollonius_graph_2/doc/Apollonius_graph_2/CGAL/Apollonius_graph_vertex_base_2.h
+++ b/Apollonius_graph_2/doc/Apollonius_graph_2/CGAL/Apollonius_graph_vertex_base_2.h
@@ -29,7 +29,7 @@ instantiated by `Triangulation_ds_vertex_base_2<>`.
 \sa `CGAL::Triangulation_data_structure_2<Vb,Fb>`
 \sa `CGAL::Apollonius_graph_hierarchy_vertex_base_2<Gt>`
 */
-  template< typename Gt, typename StoreHidden, typename Vb >
+template< typename Gt, typename StoreHidden, typename Vb >
 class Apollonius_graph_vertex_base_2 : public Vb {
 public:
 

--- a/Apollonius_graph_2/doc/Apollonius_graph_2/CGAL/Apollonius_graph_vertex_base_2.h
+++ b/Apollonius_graph_2/doc/Apollonius_graph_2/CGAL/Apollonius_graph_vertex_base_2.h
@@ -7,7 +7,7 @@ namespace CGAL {
 The class `Apollonius_graph_vertex_base_2` provides a model for the
 `ApolloniusGraphVertexBase_2` concept which is the vertex base
 required by the `ApolloniusGraphDataStructure_2` concept. The
-class `Apollonius_graph_vertex_base_2` has two template arguments.
+class `Apollonius_graph_vertex_base_2` has three template arguments.
 
 \tparam Gt is the geometric traits of the Apollonius graph and must be a model of the
 concept `ApolloniusGraphTraits_2`.

--- a/Apollonius_graph_2/doc/Apollonius_graph_2/CGAL/Apollonius_graph_vertex_base_2.h
+++ b/Apollonius_graph_2/doc/Apollonius_graph_2/CGAL/Apollonius_graph_vertex_base_2.h
@@ -30,7 +30,7 @@ instantiated by `Triangulation_ds_vertex_base_2<>`.
 \sa `CGAL::Apollonius_graph_hierarchy_vertex_base_2<Gt>`
 */
   template< typename Gt, typename StoreHidden, typename Vb >
-  class Apollonius_graph_vertex_base_2 : public Vb {
+class Apollonius_graph_vertex_base_2 : public Vb {
 public:
 
 /// \name Creation

--- a/Apollonius_graph_2/doc/Apollonius_graph_2/CGAL/Apollonius_graph_vertex_base_2.h
+++ b/Apollonius_graph_2/doc/Apollonius_graph_2/CGAL/Apollonius_graph_vertex_base_2.h
@@ -7,9 +7,12 @@ namespace CGAL {
 The class `Apollonius_graph_vertex_base_2` provides a model for the
 `ApolloniusGraphVertexBase_2` concept which is the vertex base
 required by the `ApolloniusGraphDataStructure_2` concept. The
-class `Apollonius_graph_vertex_base_2` has two template arguments, the first being the
-geometric traits of the Apollonius graph and should be a model of the
-concept `ApolloniusGraphTraits_2`. The second is a Boolean which
+class `Apollonius_graph_vertex_base_2` has two template arguments.
+
+\tparam Gt is the geometric traits of the Apollonius graph and must be a model of the
+concept `ApolloniusGraphTraits_2`.
+
+\tparam StoreHidden is a Boolean which
 controls whether hidden sites are actually stored. Such a
 control is important if the user is not interested in hidden sites
 and/or if only insertions are made, in which case no hidden
@@ -17,13 +20,17 @@ site can become visible. If `StoreHidden` is set to
 `true`, hidden sites are stored, otherwise they are
 discarded. By default `StoreHidden` is set to `true`.
 
+\tparam Vb must be a model of the concept `TriangulationDSVertexBase_2`
+By default this parameter is
+instantiated by `Triangulation_ds_vertex_base_2<>`.
+
 \cgalModels `ApolloniusGraphVertexBase_2`
 
 \sa `CGAL::Triangulation_data_structure_2<Vb,Fb>`
 \sa `CGAL::Apollonius_graph_hierarchy_vertex_base_2<Gt>`
 */
-template< typename Gt, typename StoreHidden >
-class Apollonius_graph_vertex_base_2 {
+  template< typename Gt, typename StoreHidden, typename Vb >
+  class Apollonius_graph_vertex_base_2 : public Vb {
 public:
 
 /// \name Creation


### PR DESCRIPTION
## Summary of Changes

Fix the return type.  Document the third template parameter of  `Apollonius_graph_vertex_base_2`.

## Release Management

* Affected package(s): `Apollonius_graph_2`
* Issue(s) solved (if any): fix #7582 and #7579
* Link to compiled documentation: [link](https://cgal.github.io/7619/v0/Apollonius_graph_2/classCGAL_1_1Apollonius__graph__2.html#a6e6e1b20ab5018c96e4b0ed2c0f0ee00) and [here ](https://cgal.github.io/7619/v0/Apollonius_graph_2/classCGAL_1_1Apollonius__graph__vertex__base__2.html#acbabb6d26d4d8938bde5bbd6c6e467eb)for the vertex base.
* License and copyright ownership:  unchanged

