### PR TITLE
patch to support Windows 32 bits

### DIFF
--- a/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
+++ b/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
@@ -119,6 +119,11 @@ function(CGAL_setup_CGAL_dependencies target)
     target_link_options(${target} INTERFACE -fsanitize=address)
   endif()
   # Now setup compilation flags
+  if(WIN32 AND CMAKE_SIZEOF_VOID_P EQUAL 4)
+    message(STATUS "Boost MP is turned off for all Windows 32 bits architectures!")
+    target_compile_options(${target} INTERFACE "-DCGAL_DO_NOT_USE_BOOST_MP")
+  endif()
+
   if(MSVC)
     target_compile_options(${target} INTERFACE
       "-D_SCL_SECURE_NO_DEPRECATE;-D_SCL_SECURE_NO_WARNINGS")


### PR DESCRIPTION
## Summary of Changes

Patch required for the acceptance of CGAL-5.6 in vcpkg. The CI system tests on `x86_windows` (32 bits), and there was an error:
```
D:\installed\x86-windows\include\CGAL/cpp_float.h(30): error C3861: '_BitScanForward64': identifier not found
D:\installed\x86-windows\include\CGAL/cpp_float.h(42): error C3861: '_BitScanReverse64': identifier not found
```
See https://github.com/microsoft/vcpkg/pull/32896#issuecomment-1662117705

The solution is do disable support for Boost MP on Windows 32 bits. That patch has been tested with the vcpkg CI, and it worked.

## Release Management

* Affected package(s): Installation (CMake)
* Issue(s) solved (if any): patch required by https://github.com/microsoft/vcpkg/pull/32896


