### PR TITLE
Better showing of `#include`

### DIFF
--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/PackageDescription.txt
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/PackageDescription.txt
@@ -47,7 +47,7 @@ namespace ArrTraits {}
 /// \ingroup PkgArrangementOnSurface2Ref
 
 /*!
-  `#include <CGAL/draw_arrangement_2.h>`
+\cgalInclude{CGAL/draw_arrangement_2.h}
 */
 /// \defgroup PkgArrangementOnSurface2Draw Drawing
 /// \ingroup PkgArrangementOnSurface2Ref

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/PackageDescription.txt
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/PackageDescription.txt
@@ -47,9 +47,7 @@ namespace ArrTraits {}
 /// \ingroup PkgArrangementOnSurface2Ref
 
 /*!
-  \code
-   #include <CGAL/draw_arrangement_2.h>
-  \endcode
+  `#include <CGAL/draw_arrangement_2.h>`
 */
 /// \defgroup PkgArrangementOnSurface2Draw Drawing
 /// \ingroup PkgArrangementOnSurface2Ref

--- a/Boolean_set_operations_2/doc/Boolean_set_operations_2/PackageDescription.txt
+++ b/Boolean_set_operations_2/doc/Boolean_set_operations_2/PackageDescription.txt
@@ -7,9 +7,7 @@
 namespace ArrDirectionalTraits {}
 
 /*!
-  \code
-  #include <CGAL/draw_polygon_set_2.h>
-  \endcode
+  `#include <CGAL/draw_polygon_set_2.h>`
 */
 /// \defgroup PkgDrawPolygonSet2 Draw a 2D Polygon Set
 /// \ingroup PkgBooleanSetOperations2Ref

--- a/Boolean_set_operations_2/doc/Boolean_set_operations_2/PackageDescription.txt
+++ b/Boolean_set_operations_2/doc/Boolean_set_operations_2/PackageDescription.txt
@@ -7,7 +7,7 @@
 namespace ArrDirectionalTraits {}
 
 /*!
-  `#include <CGAL/draw_polygon_set_2.h>`
+\cgalInclude{CGAL/draw_polygon_set_2.h}
 */
 /// \defgroup PkgDrawPolygonSet2 Draw a 2D Polygon Set
 /// \ingroup PkgBooleanSetOperations2Ref

--- a/Documentation/doc/resources/1.8.13/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.8.13/BaseDoxyfile.in
@@ -190,7 +190,8 @@ ALIASES                = "cgal=%CGAL" \
                          "cgalParamSectionEnd=\cgalParamNEnd" \
                          "cgalParamPrecondition{1}=<li><b>Precondition: </b>\1</li>" \
                          "cgalBigO{1}=\f$O(\1)\f$" \
-                         "cgalBigOLarge{1}=\f$O\left(\1\right)\f$"
+                         "cgalBigOLarge{1}=\f$O\left(\1\right)\f$" \
+                         "cgalInclude{1}=\#`include<\1>`"
 
 # Doxygen selects the parser to use depending on the extension of the files it
 # parses. With this tag you can assign which parser to use for a given

--- a/Documentation/doc/resources/1.9.6/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.9.6/BaseDoxyfile.in
@@ -199,7 +199,8 @@ ALIASES                = "cgal=%CGAL" \
                          "cgalParamSectionEnd=\cgalParamNEnd" \
                          "cgalParamPrecondition{1}=<li><b>Precondition: </b>\1</li>" \
                          "cgalBigO{1}=\f$O(\1)\f$" \
-                         "cgalBigOLarge{1}=\f$O\left(\1\right)\f$"
+                         "cgalBigOLarge{1}=\f$O\left(\1\right)\f$" \
+                         "cgalInclude{1}=`#include<\1>`"
 
 # Doxygen selects the parser to use depending on the extension of the files it
 # parses. With this tag you can assign which parser to use for a given

--- a/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
@@ -12,17 +12,13 @@
 /// \ingroup PkgLinearCellComplexRef
 
 /*! High-level operations.
-  \code
-   #include <CGAL/Linear_cell_complex_operations.h>
-   \endcode
+   `#include <CGAL/Linear_cell_complex_operations.h>`
 */
 /// \defgroup PkgLinearCellComplexOperations Operations for Linear Cell Complex
 /// \ingroup PkgLinearCellComplexRef
 
 /*!
-  \code
-   #include <CGAL/draw_linear_cell_complex.h>
-  \endcode
+   `#include <CGAL/draw_linear_cell_complex.h>`
 */
 /// \defgroup PkgDrawLinearCellComplex Draw a Linear Cell Complex
 /// \ingroup PkgLinearCellComplexRef

--- a/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
@@ -12,13 +12,13 @@
 /// \ingroup PkgLinearCellComplexRef
 
 /*! High-level operations.
-   `#include <CGAL/Linear_cell_complex_operations.h>`
+\cgalInclude{CGAL/Linear_cell_complex_operations.h}
 */
 /// \defgroup PkgLinearCellComplexOperations Operations for Linear Cell Complex
 /// \ingroup PkgLinearCellComplexRef
 
 /*!
-   `#include <CGAL/draw_linear_cell_complex.h>`
+\cgalInclude{CGAL/draw_linear_cell_complex.h}
 */
 /// \defgroup PkgDrawLinearCellComplex Draw a Linear Cell Complex
 /// \ingroup PkgLinearCellComplexRef

--- a/Nef_3/doc/Nef_3/PackageDescription.txt
+++ b/Nef_3/doc/Nef_3/PackageDescription.txt
@@ -4,7 +4,7 @@
 /// \ingroup PkgNef3Ref
 
 /*! Draw.
-  `#include <CGAL/draw_nef_3.h>`
+\cgalInclude{CGAL/draw_nef_3.h}
 */
 /// \defgroup PkgDrawNef3 Draw a Nef Polyhedron
 /// \ingroup PkgNef3Ref

--- a/Nef_3/doc/Nef_3/PackageDescription.txt
+++ b/Nef_3/doc/Nef_3/PackageDescription.txt
@@ -4,9 +4,7 @@
 /// \ingroup PkgNef3Ref
 
 /*! Draw.
-  \code
-  #include <CGAL/draw_nef_3.h>
-  \endcode
+  `#include <CGAL/draw_nef_3.h>`
 */
 /// \defgroup PkgDrawNef3 Draw a Nef Polyhedron
 /// \ingroup PkgNef3Ref

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/PackageDescription.txt
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/PackageDescription.txt
@@ -16,9 +16,7 @@
 /// \ingroup PkgPeriodic2Triangulation2Ref
 
 /*! Draw.
-  \code
-   #include <CGAL/draw_periodic_2_triangulation_2.h>
-  \endcode
+   `#include <CGAL/draw_periodic_2_triangulation_2.h>`
 */
 /// \defgroup PkgDrawPeriodic2Triangulation2 Draw a 2D Periodic Triangulation
 /// \ingroup PkgPeriodic2Triangulation2Ref

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/PackageDescription.txt
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/PackageDescription.txt
@@ -16,7 +16,7 @@
 /// \ingroup PkgPeriodic2Triangulation2Ref
 
 /*! Draw.
-   `#include <CGAL/draw_periodic_2_triangulation_2.h>`
+\cgalInclude{CGAL/draw_periodic_2_triangulation_2.h}
 */
 /// \defgroup PkgDrawPeriodic2Triangulation2 Draw a 2D Periodic Triangulation
 /// \ingroup PkgPeriodic2Triangulation2Ref

--- a/Point_set_3/doc/Point_set_3/PackageDescription.txt
+++ b/Point_set_3/doc/Point_set_3/PackageDescription.txt
@@ -1,9 +1,7 @@
 /// \defgroup PkgPointSet3Ref 3D Point Set Reference
 
 /*!
-  \code
-   #include <CGAL/draw_point_set_3.h>
-  \endcode
+   `#include <CGAL/draw_point_set_3.h>`
 */
 /// \defgroup PkgDrawPointSet3D Draw a 3D Point Set
 /// \ingroup PkgPointSet3Ref

--- a/Point_set_3/doc/Point_set_3/PackageDescription.txt
+++ b/Point_set_3/doc/Point_set_3/PackageDescription.txt
@@ -1,7 +1,7 @@
 /// \defgroup PkgPointSet3Ref 3D Point Set Reference
 
 /*!
-   `#include <CGAL/draw_point_set_3.h>`
+\cgalInclude{CGAL/draw_point_set_3.h}
 */
 /// \defgroup PkgDrawPointSet3D Draw a 3D Point Set
 /// \ingroup PkgPointSet3Ref

--- a/Polygon/doc/Polygon/PackageDescription.txt
+++ b/Polygon/doc/Polygon/PackageDescription.txt
@@ -7,13 +7,13 @@
 /// \ingroup PkgPolygon2Ref
 
 /*!
-   `#include <CGAL/draw_polygon_2.h>`
+\cgalInclude{CGAL/draw_polygon_2.h}
 */
 /// \defgroup PkgDrawPolygon2 Draw a 2D Polygon
 /// \ingroup PkgPolygon2Ref
 
 /*!
-  `#include <CGAL/draw_polygon_with_holes_2.h>`
+\cgalInclude{CGAL/draw_polygon_with_holes_2.h}
 */
 /// \defgroup PkgDrawPolygonWithHoles2 Draw a 2D Polygon with Holes
 /// \ingroup PkgPolygon2Ref

--- a/Polygon/doc/Polygon/PackageDescription.txt
+++ b/Polygon/doc/Polygon/PackageDescription.txt
@@ -7,17 +7,13 @@
 /// \ingroup PkgPolygon2Ref
 
 /*!
-  \code
-   #include <CGAL/draw_polygon_2.h>
-  \endcode
+   `#include <CGAL/draw_polygon_2.h>`
 */
 /// \defgroup PkgDrawPolygon2 Draw a 2D Polygon
 /// \ingroup PkgPolygon2Ref
 
 /*!
-  \code
-  #include <CGAL/draw_polygon_with_holes_2.h>
-  \endcode
+  `#include <CGAL/draw_polygon_with_holes_2.h>`
 */
 /// \defgroup PkgDrawPolygonWithHoles2 Draw a 2D Polygon with Holes
 /// \ingroup PkgPolygon2Ref

--- a/Polyhedron/doc/Polyhedron/PackageDescription.txt
+++ b/Polyhedron/doc/Polyhedron/PackageDescription.txt
@@ -6,9 +6,7 @@
 /// \ingroup PkgPolyhedronRef
 
 /*!
-  \code
-   #include <CGAL/draw_polyhedron.h>
-  \endcode
+   `#include <CGAL/draw_polyhedron.h>`
 */
 /// \defgroup PkgDrawPolyhedron Draw a Polyhedron 3
 /// \ingroup PkgPolyhedronRef

--- a/Polyhedron/doc/Polyhedron/PackageDescription.txt
+++ b/Polyhedron/doc/Polyhedron/PackageDescription.txt
@@ -6,7 +6,7 @@
 /// \ingroup PkgPolyhedronRef
 
 /*!
-   `#include <CGAL/draw_polyhedron.h>`
+\cgalInclude{CGAL/draw_polyhedron.h}
 */
 /// \defgroup PkgDrawPolyhedron Draw a Polyhedron 3
 /// \ingroup PkgPolyhedronRef

--- a/Surface_mesh/doc/Surface_mesh/PackageDescription.txt
+++ b/Surface_mesh/doc/Surface_mesh/PackageDescription.txt
@@ -1,7 +1,7 @@
 /// \defgroup PkgSurface_mesh Surface Mesh Reference
 
 /*!
-   `#include <CGAL/draw_surface_mesh.h>`
+\cgalInclude{CGAL/draw_surface_mesh.h}
 */
 /// \defgroup PkgDrawSurfaceMesh Draw a Surface Mesh
 /// \ingroup PkgSurface_mesh

--- a/Surface_mesh/doc/Surface_mesh/PackageDescription.txt
+++ b/Surface_mesh/doc/Surface_mesh/PackageDescription.txt
@@ -1,9 +1,7 @@
 /// \defgroup PkgSurface_mesh Surface Mesh Reference
 
 /*!
-  \code
-   #include <CGAL/draw_surface_mesh.h>
-  \endcode
+   `#include <CGAL/draw_surface_mesh.h>`
 */
 /// \defgroup PkgDrawSurfaceMesh Draw a Surface Mesh
 /// \ingroup PkgSurface_mesh

--- a/Surface_mesh_topology/doc/Surface_mesh_topology/PackageDescription.txt
+++ b/Surface_mesh_topology/doc/Surface_mesh_topology/PackageDescription.txt
@@ -7,9 +7,7 @@
 /// \ingroup PkgSurfaceMeshTopologyRef
 
 /*!
-  \code
-   #include <CGAL/draw_face_graph_with_paths.h>
-  \endcode
+   `#include <CGAL/draw_face_graph_with_paths.h>`
 */
 /// \defgroup PkgDrawFaceGraphWithPaths Draw a Mesh with Paths
 /// \ingroup PkgSurfaceMeshTopologyRef

--- a/Surface_mesh_topology/doc/Surface_mesh_topology/PackageDescription.txt
+++ b/Surface_mesh_topology/doc/Surface_mesh_topology/PackageDescription.txt
@@ -7,7 +7,7 @@
 /// \ingroup PkgSurfaceMeshTopologyRef
 
 /*!
-   `#include <CGAL/draw_face_graph_with_paths.h>`
+\cgalInclude{CGAL/draw_face_graph_with_paths.h}
 */
 /// \defgroup PkgDrawFaceGraphWithPaths Draw a Mesh with Paths
 /// \ingroup PkgSurfaceMeshTopologyRef

--- a/Triangulation_2/doc/Triangulation_2/PackageDescription.txt
+++ b/Triangulation_2/doc/Triangulation_2/PackageDescription.txt
@@ -14,7 +14,7 @@
 /// \ingroup PkgTriangulation2Ref
 
 /*!
-   `#include <CGAL/draw_triangulation_2.h>`
+\cgalInclude{CGAL/draw_triangulation_2.h}
 */
 /// \defgroup PkgDrawTriangulation2 Draw a Triangulation 2
 /// \ingroup PkgTriangulation2Ref

--- a/Triangulation_2/doc/Triangulation_2/PackageDescription.txt
+++ b/Triangulation_2/doc/Triangulation_2/PackageDescription.txt
@@ -14,9 +14,7 @@
 /// \ingroup PkgTriangulation2Ref
 
 /*!
-  \code
-   #include <CGAL/draw_triangulation_2.h>
-  \endcode
+   `#include <CGAL/draw_triangulation_2.h>`
 */
 /// \defgroup PkgDrawTriangulation2 Draw a Triangulation 2
 /// \ingroup PkgTriangulation2Ref

--- a/Triangulation_3/doc/Triangulation_3/PackageDescription.txt
+++ b/Triangulation_3/doc/Triangulation_3/PackageDescription.txt
@@ -13,9 +13,7 @@
 /// \ingroup PkgTriangulation3Ref
 
 /*!
-  \code
-   #include <CGAL/draw_triangulation_3.h>
-  \endcode
+   `#include <CGAL/draw_triangulation_3.h>`
 */
 /// \defgroup PkgDrawTriangulation3 Draw a Triangulation 3
 /// \ingroup PkgTriangulation3Ref

--- a/Triangulation_3/doc/Triangulation_3/PackageDescription.txt
+++ b/Triangulation_3/doc/Triangulation_3/PackageDescription.txt
@@ -13,7 +13,7 @@
 /// \ingroup PkgTriangulation3Ref
 
 /*!
-   `#include <CGAL/draw_triangulation_3.h>`
+\cgalInclude{CGAL/draw_triangulation_3.h}
 */
 /// \defgroup PkgDrawTriangulation3 Draw a Triangulation 3
 /// \ingroup PkgTriangulation3Ref

--- a/Voronoi_diagram_2/doc/Voronoi_diagram_2/PackageDescription.txt
+++ b/Voronoi_diagram_2/doc/Voronoi_diagram_2/PackageDescription.txt
@@ -13,7 +13,7 @@
 /// \ingroup PkgVoronoiDiagram2Ref
 
 /*!
-  `#include <CGAL/draw_voronoi_diagram_2.h>`
+\cgalInclude{CGAL/draw_voronoi_diagram_2.h}
 */
 /// \defgroup PkgDrawVoronoiDiagram2 Draw a 2D Voronoi Diagram
 /// \ingroup PkgVoronoiDiagram2Ref

--- a/Voronoi_diagram_2/doc/Voronoi_diagram_2/PackageDescription.txt
+++ b/Voronoi_diagram_2/doc/Voronoi_diagram_2/PackageDescription.txt
@@ -13,9 +13,7 @@
 /// \ingroup PkgVoronoiDiagram2Ref
 
 /*!
-  \code
-  #include <CGAL/draw_voronoi_diagram_2.h>
-  \endcode
+  `#include <CGAL/draw_voronoi_diagram_2.h>`
 */
 /// \defgroup PkgDrawVoronoiDiagram2 Draw a 2D Voronoi Diagram
 /// \ingroup PkgVoronoiDiagram2Ref

--- a/Weights/doc/Weights/PackageDescription.txt
+++ b/Weights/doc/Weights/PackageDescription.txt
@@ -19,9 +19,7 @@ Models and functions that can be used to compute weights which have a simple ana
 \defgroup PkgWeightsRefUniformWeights Uniform Weight
 \ingroup PkgWeightsRefAnalytic
 
-\verbatim
-#include <CGAL/Weights/uniform_weights.h>
-\endverbatim
+`#include <CGAL/Weights/uniform_weights.h>`
 
 This weight is always equal to 1.
 
@@ -35,9 +33,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefShepardWeights Shepard Weight
 \ingroup PkgWeightsRefAnalytic
 
-\verbatim
-#include <CGAL/Weights/shepard_weights.h>
-\endverbatim
+`#include <CGAL/Weights/shepard_weights.h>`
 
 This weight is computed as
 \f$w = \frac{1}{d^a}\f$
@@ -65,9 +61,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefInverseDistanceWeights Inverse Distance Weight
 \ingroup PkgWeightsRefAnalytic
 
-\verbatim
-#include <CGAL/Weights/inverse_distance_weights.h>
-\endverbatim
+`#include <CGAL/Weights/inverse_distance_weights.h>`
 
 This weight is computed as
 \f$w = \frac{1}{d}\f$
@@ -96,9 +90,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefThreePointFamilyWeights Three Point Family Weight
 \ingroup PkgWeightsRefAnalytic
 
-\verbatim
-#include <CGAL/Weights/three_point_family_weights.h>
-\endverbatim
+`#include <CGAL/Weights/three_point_family_weights.h>`
 
 This weight is computed as
 \f$w = \frac{d_2^a A_0 - d^a B + d_0^a A_2}{A_0 A_2}\f$
@@ -137,9 +129,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefWachspressWeights Wachspress Weight
 \ingroup PkgWeightsRefAnalytic
 
-\verbatim
-#include <CGAL/Weights/wachspress_weights.h>
-\endverbatim
+`#include <CGAL/Weights/wachspress_weights.h>`
 
 This weight is computed as
 \f$w = \frac{C}{A_0 A_2}\f$
@@ -170,9 +160,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefAuthalicWeights Authalic Weight
 \ingroup PkgWeightsRefAnalytic
 
-\verbatim
-#include <CGAL/Weights/authalic_weights.h>
-\endverbatim
+`#include <CGAL/Weights/authalic_weights.h>`
 
 This weight is computed as
 \f$w = 2 \frac{\cot\beta + \cot\gamma}{d^2}\f$
@@ -202,9 +190,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefMeanValueWeights Mean Value Weight
 \ingroup PkgWeightsRefAnalytic
 
-\verbatim
-#include <CGAL/Weights/mean_value_weights.h>
-\endverbatim
+`#include <CGAL/Weights/mean_value_weights.h>`
 
 This weight is computed as
 \f$w = \pm 2 \sqrt{\frac{2 (d_0 d_2 - D)}{(d d_0 + D_0)(d d_2 + D_2)}}\f$
@@ -241,9 +227,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefTangentWeights Tangent Weight
 \ingroup PkgWeightsRefAnalytic
 
-\verbatim
-#include <CGAL/Weights/tangent_weights.h>
-\endverbatim
+`#include <CGAL/Weights/tangent_weights.h>`
 
 This weight is computed as
 \f$w = 2 \frac{t_1 + t_2}{d}\f$, where
@@ -278,9 +262,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefDiscreteHarmonicWeights Discrete Harmonic Weight
 \ingroup PkgWeightsRefAnalytic
 
-\verbatim
-#include <CGAL/Weights/discrete_harmonic_weights.h>
-\endverbatim
+`#include <CGAL/Weights/discrete_harmonic_weights.h>`
 
 This weight is computed as
 \f$w = \frac{d_2^2 A_0 - d^2 B + d_0^2 A_2}{A_0 A_2}\f$
@@ -311,9 +293,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefCotangentWeights Cotangent Weight
 \ingroup PkgWeightsRefAnalytic
 
-\verbatim
-#include <CGAL/Weights/cotangent_weights.h>
-\endverbatim
+`#include <CGAL/Weights/cotangent_weights.h>`
 
 This weight is computed as
 \f$w = 2 (\cot\beta + \cot\gamma)\f$
@@ -348,9 +328,7 @@ to polygons. These weights are then normalized in order to obtain barycentric co
 \defgroup PkgWeightsRefBarycentricWachspressWeights Wachspress Weights
 \ingroup PkgWeightsRefBarycentric
 
-\verbatim
-#include <CGAL/Weights/wachspress_weights.h>
-\endverbatim
+`#include <CGAL/Weights/wachspress_weights.h>`
 
 Wachspress weights which can be computed for a query point with respect to the
 vertices of a strictly convex polygon.
@@ -361,9 +339,7 @@ vertices of a strictly convex polygon.
 \defgroup PkgWeightsRefBarycentricMeanValueWeights Mean Value Weights
 \ingroup PkgWeightsRefBarycentric
 
-\verbatim
-#include <CGAL/Weights/mean_value_weights.h>
-\endverbatim
+`#include <CGAL/Weights/mean_value_weights.h>`
 
 Mean value weights which can be computed for a query point with respect to the
 vertices of a simple polygon.
@@ -374,9 +350,7 @@ vertices of a simple polygon.
 \defgroup PkgWeightsRefBarycentricDiscreteHarmonicWeights Discrete Harmonic Weights
 \ingroup PkgWeightsRefBarycentric
 
-\verbatim
-#include <CGAL/Weights/discrete_harmonic_weights.h>
-\endverbatim
+`#include <CGAL/Weights/discrete_harmonic_weights.h>`
 
 Discrete Harmonic weights which can be computed for a query point with respect to the
 vertices of a strictly convex polygon.
@@ -394,9 +368,7 @@ used to balance other weights.
 \defgroup PkgWeightsRefUniformRegionWeights Uniform Region Weight
 \ingroup PkgWeightsRefRegions
 
-\verbatim
-#include <CGAL/Weights/uniform_region_weights.h>
-\endverbatim
+`#include <CGAL/Weights/uniform_region_weights.h>`
 
 This weight is always equal to 1.
 
@@ -410,9 +382,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefTriangularRegionWeights Triangular Region Weight
 \ingroup PkgWeightsRefRegions
 
-\verbatim
-#include <CGAL/Weights/triangular_region_weights.h>
-\endverbatim
+`#include <CGAL/Weights/triangular_region_weights.h>`
 
 This weight is the area of the shaded region in the figure below. The region is
 the triangle `[p, q, r]`.
@@ -431,9 +401,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefBarycentricRegionWeights Barycentric Region Weight
 \ingroup PkgWeightsRefRegions
 
-\verbatim
-#include <CGAL/Weights/barycentric_region_weights.h>
-\endverbatim
+`#include <CGAL/Weights/barycentric_region_weights.h>`
 
 This weight is the area of the shaded region in the figure below. The region
 is formed by the two midpoints of the edges incident to `q` and the barycenter of
@@ -453,9 +421,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefVoronoiRegionWeights Voronoi Region Weight
 \ingroup PkgWeightsRefRegions
 
-\verbatim
-#include <CGAL/Weights/voronoi_region_weights.h>
-\endverbatim
+`#include <CGAL/Weights/voronoi_region_weights.h>`
 
 This weight is the area of the shaded region in the figure below. The region
 is formed by the two midpoints of the edges incident to `q` and the circumcenter of
@@ -477,9 +443,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefMixedVoronoiRegionWeights Mixed Voronoi Region Weight
 \ingroup PkgWeightsRefRegions
 
-\verbatim
-#include <CGAL/Weights/mixed_voronoi_region_weights.h>
-\endverbatim
+`#include <CGAL/Weights/mixed_voronoi_region_weights.h>`
 
 This weight is the area of the shaded region in the figure below. The region
 is formed by the two midpoints of the edges incident to `q` and the circumcenter of

--- a/Weights/doc/Weights/PackageDescription.txt
+++ b/Weights/doc/Weights/PackageDescription.txt
@@ -19,7 +19,7 @@ Models and functions that can be used to compute weights which have a simple ana
 \defgroup PkgWeightsRefUniformWeights Uniform Weight
 \ingroup PkgWeightsRefAnalytic
 
-`#include <CGAL/Weights/uniform_weights.h>`
+\cgalInclude{CGAL/Weights/uniform_weights.h}
 
 This weight is always equal to 1.
 
@@ -33,7 +33,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefShepardWeights Shepard Weight
 \ingroup PkgWeightsRefAnalytic
 
-`#include <CGAL/Weights/shepard_weights.h>`
+\cgalInclude{CGAL/Weights/shepard_weights.h}
 
 This weight is computed as
 \f$w = \frac{1}{d^a}\f$
@@ -61,7 +61,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefInverseDistanceWeights Inverse Distance Weight
 \ingroup PkgWeightsRefAnalytic
 
-`#include <CGAL/Weights/inverse_distance_weights.h>`
+\cgalInclude{CGAL/Weights/inverse_distance_weights.h}
 
 This weight is computed as
 \f$w = \frac{1}{d}\f$
@@ -90,7 +90,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefThreePointFamilyWeights Three Point Family Weight
 \ingroup PkgWeightsRefAnalytic
 
-`#include <CGAL/Weights/three_point_family_weights.h>`
+\cgalInclude{CGAL/Weights/three_point_family_weights.h}
 
 This weight is computed as
 \f$w = \frac{d_2^a A_0 - d^a B + d_0^a A_2}{A_0 A_2}\f$
@@ -129,7 +129,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefWachspressWeights Wachspress Weight
 \ingroup PkgWeightsRefAnalytic
 
-`#include <CGAL/Weights/wachspress_weights.h>`
+\cgalInclude{CGAL/Weights/wachspress_weights.h}
 
 This weight is computed as
 \f$w = \frac{C}{A_0 A_2}\f$
@@ -160,7 +160,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefAuthalicWeights Authalic Weight
 \ingroup PkgWeightsRefAnalytic
 
-`#include <CGAL/Weights/authalic_weights.h>`
+\cgalInclude{CGAL/Weights/authalic_weights.h}
 
 This weight is computed as
 \f$w = 2 \frac{\cot\beta + \cot\gamma}{d^2}\f$
@@ -190,7 +190,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefMeanValueWeights Mean Value Weight
 \ingroup PkgWeightsRefAnalytic
 
-`#include <CGAL/Weights/mean_value_weights.h>`
+\cgalInclude{CGAL/Weights/mean_value_weights.h}
 
 This weight is computed as
 \f$w = \pm 2 \sqrt{\frac{2 (d_0 d_2 - D)}{(d d_0 + D_0)(d d_2 + D_2)}}\f$
@@ -227,7 +227,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefTangentWeights Tangent Weight
 \ingroup PkgWeightsRefAnalytic
 
-`#include <CGAL/Weights/tangent_weights.h>`
+\cgalInclude{CGAL/Weights/tangent_weights.h}
 
 This weight is computed as
 \f$w = 2 \frac{t_1 + t_2}{d}\f$, where
@@ -262,7 +262,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefDiscreteHarmonicWeights Discrete Harmonic Weight
 \ingroup PkgWeightsRefAnalytic
 
-`#include <CGAL/Weights/discrete_harmonic_weights.h>`
+\cgalInclude{CGAL/Weights/discrete_harmonic_weights.h}
 
 This weight is computed as
 \f$w = \frac{d_2^2 A_0 - d^2 B + d_0^2 A_2}{A_0 A_2}\f$
@@ -293,7 +293,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefCotangentWeights Cotangent Weight
 \ingroup PkgWeightsRefAnalytic
 
-`#include <CGAL/Weights/cotangent_weights.h>`
+\cgalInclude{CGAL/Weights/cotangent_weights.h}
 
 This weight is computed as
 \f$w = 2 (\cot\beta + \cot\gamma)\f$
@@ -328,7 +328,7 @@ to polygons. These weights are then normalized in order to obtain barycentric co
 \defgroup PkgWeightsRefBarycentricWachspressWeights Wachspress Weights
 \ingroup PkgWeightsRefBarycentric
 
-`#include <CGAL/Weights/wachspress_weights.h>`
+\cgalInclude{CGAL/Weights/wachspress_weights.h}
 
 Wachspress weights which can be computed for a query point with respect to the
 vertices of a strictly convex polygon.
@@ -339,7 +339,7 @@ vertices of a strictly convex polygon.
 \defgroup PkgWeightsRefBarycentricMeanValueWeights Mean Value Weights
 \ingroup PkgWeightsRefBarycentric
 
-`#include <CGAL/Weights/mean_value_weights.h>`
+\cgalInclude{CGAL/Weights/mean_value_weights.h}
 
 Mean value weights which can be computed for a query point with respect to the
 vertices of a simple polygon.
@@ -350,7 +350,7 @@ vertices of a simple polygon.
 \defgroup PkgWeightsRefBarycentricDiscreteHarmonicWeights Discrete Harmonic Weights
 \ingroup PkgWeightsRefBarycentric
 
-`#include <CGAL/Weights/discrete_harmonic_weights.h>`
+\cgalInclude{CGAL/Weights/discrete_harmonic_weights.h}
 
 Discrete Harmonic weights which can be computed for a query point with respect to the
 vertices of a strictly convex polygon.
@@ -368,7 +368,7 @@ used to balance other weights.
 \defgroup PkgWeightsRefUniformRegionWeights Uniform Region Weight
 \ingroup PkgWeightsRefRegions
 
-`#include <CGAL/Weights/uniform_region_weights.h>`
+\cgalInclude{CGAL/Weights/uniform_region_weights.h}
 
 This weight is always equal to 1.
 
@@ -382,7 +382,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefTriangularRegionWeights Triangular Region Weight
 \ingroup PkgWeightsRefRegions
 
-`#include <CGAL/Weights/triangular_region_weights.h>`
+\cgalInclude{CGAL/Weights/triangular_region_weights.h}
 
 This weight is the area of the shaded region in the figure below. The region is
 the triangle `[p, q, r]`.
@@ -401,7 +401,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefBarycentricRegionWeights Barycentric Region Weight
 \ingroup PkgWeightsRefRegions
 
-`#include <CGAL/Weights/barycentric_region_weights.h>`
+\cgalInclude{CGAL/Weights/barycentric_region_weights.h}
 
 This weight is the area of the shaded region in the figure below. The region
 is formed by the two midpoints of the edges incident to `q` and the barycenter of
@@ -421,7 +421,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefVoronoiRegionWeights Voronoi Region Weight
 \ingroup PkgWeightsRefRegions
 
-`#include <CGAL/Weights/voronoi_region_weights.h>`
+\cgalInclude{CGAL/Weights/voronoi_region_weights.h}
 
 This weight is the area of the shaded region in the figure below. The region
 is formed by the two midpoints of the edges incident to `q` and the circumcenter of
@@ -443,7 +443,7 @@ a model of `AnalyticWeightTraits_3` for 3D points
 \defgroup PkgWeightsRefMixedVoronoiRegionWeights Mixed Voronoi Region Weight
 \ingroup PkgWeightsRefRegions
 
-`#include <CGAL/Weights/mixed_voronoi_region_weights.h>`
+\cgalInclude{CGAL/Weights/mixed_voronoi_region_weights.h}
 
 This weight is the area of the shaded region in the figure below. The region
 is formed by the two midpoints of the edges incident to `q` and the circumcenter of


### PR DESCRIPTION
Getting a better (and consistent) output for the include file to be used with some functions. Normally `#include` are sown as in a typewrite font, but the `#include` in these cases were shown in a code block way.

For e.g Weights/group__PkgWeightsRefUniformRegionWeights.htmlthe w`#include was shown as:
![image](https://github.com/CGAL/cgal/assets/5223533/54751c5a-ea91-4459-aec8-e9fa04a9ad0d)

and will now be shown as:
![image](https://github.com/CGAL/cgal/assets/5223533/a3d00489-e0a1-48cf-a2bb-1c37fff2ff01)
