### PR TITLE
Be more permissive in Compare_dihedral_angle_3

### DIFF
--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -246,6 +246,8 @@ namespace CommonKernelFunctors {
       const Vector_3 abad1 = xproduct(ab1, ad1);
       const FT sc_prod_1 = abac1 * abad1;
 
+      if (abac1==NULL_VECTOR || abad1==NULL_VECTOR) return SMALLER;
+
       CGAL_kernel_assertion_msg( abac1 != NULL_VECTOR,
                                  "ab1 and ac1 are collinear" );
       CGAL_kernel_assertion_msg( abad1 != NULL_VECTOR,

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -244,9 +244,8 @@ namespace CommonKernelFunctors {
 
       const Vector_3 abac1 = xproduct(ab1, ac1);
       const Vector_3 abad1 = xproduct(ab1, ad1);
-      const FT sc_prod_1 = abac1 * abad1;
-
       if (abac1==NULL_VECTOR || abad1==NULL_VECTOR) return SMALLER;
+      const FT sc_prod_1 = abac1 * abad1;
 
       CGAL_kernel_assertion_msg( abac1 != NULL_VECTOR,
                                  "ab1 and ac1 are collinear" );


### PR DESCRIPTION
Do not throw an error but return SMALLER
The collinearity check being already done in the predicate it would be more expensive to do it also before calling the predicate

