### PR TITLE
Nef_2: Deal with isolated vertices

### DIFF
--- a/Nef_2/include/CGAL/Nef_2/PM_checker.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_checker.h
@@ -203,7 +203,7 @@ check_boundary_is_clockwise_weakly_polygon() const
   for (vit = v_min = this->vertices_begin() ; vit != this->vertices_end(); ++vit)
     if ( K.compare_xy(point(vit), point(v_min))<0 ) v_min = vit;
   CGAL_assertion_msg(!is_isolated(v_min),"Minimal vertex not connected.");
-  Point p_min = point(v_min);
+  const Point& p_min = point(v_min);
   // determine boundary edge incident to v_min:
   Halfedge_const_handle e_boundary_at_v_min = first_out_edge(v_min);
   // all out edges are forward oriented due to minimality
@@ -211,8 +211,8 @@ check_boundary_is_clockwise_weakly_polygon() const
     hvit(e_boundary_at_v_min), hend(hvit);
   do {
     --hvit;
-    Point p1 = point(target(e_boundary_at_v_min));
-    Point p2 = point(target(hvit));
+    const Point& p1 = point(target(e_boundary_at_v_min));
+    const Point& p2 = point(target(hvit));
     if ( K.orientation(p_min,p1,p2) > 0 ) { // left_turn
       e_boundary_at_v_min = hvit;
       break;

--- a/Nef_2/include/CGAL/Nef_2/PM_const_decorator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_const_decorator.h
@@ -434,9 +434,10 @@ check_integrity_and_topological_planarity(bool faces) const
   /* check the source links of out edges and count isolated vertices */
   for (vit = vertices_begin() ; vit != vend; ++vit) {
     if ( is_isolated(vit) ) {
-      if ( faces )
-        CGAL_assertion_msg( vit->face() != Face_const_handle(),
-                            VI(vit).c_str());
+        if (faces) {
+            CGAL_assertion_msg(vit->face() != Face_const_handle(),
+                VI(vit).c_str());
+        }
       ++iso_vert_num;
     } else {
       CGAL_assertion_msg( vit->halfedge() != Halfedge_const_handle(),

--- a/Nef_2/include/CGAL/Nef_2/PM_const_decorator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_const_decorator.h
@@ -481,6 +481,8 @@ check_integrity_and_topological_planarity(bool faces) const
     first=false;
   }
 
+  CGAL_assertion(iso_vert_num == iv_num);
+
   std::size_t v_num = number_of_vertices() - iso_vert_num;
   std::size_t e_num = number_of_edges();
   std::size_t c_num = number_of_connected_components() - iso_vert_num;

--- a/Nef_2/include/CGAL/Nef_2/PM_decorator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_decorator.h
@@ -799,7 +799,7 @@ void PM_decorator<HDS>::clone(const HDS& H) const
   CGAL::Unique_hash_map<Vertex_const_iterator,Vertex_handle>     Vnew;
   CGAL::Unique_hash_map<Halfedge_const_iterator,Halfedge_handle> Hnew;
   CGAL::Unique_hash_map<Face_const_iterator,Face_handle>         Fnew;
- 
+
   /* First clone all objects and store correspondence in three maps.*/
   Vertex_const_iterator vit, vend = H.vertices_end();
   for (vit = H.vertices_begin(); vit != vend; ++vit) {

--- a/Nef_2/include/CGAL/Nef_2/PM_decorator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_decorator.h
@@ -799,11 +799,13 @@ void PM_decorator<HDS>::clone(const HDS& H) const
   CGAL::Unique_hash_map<Vertex_const_iterator,Vertex_handle>     Vnew;
   CGAL::Unique_hash_map<Halfedge_const_iterator,Halfedge_handle> Hnew;
   CGAL::Unique_hash_map<Face_const_iterator,Face_handle>         Fnew;
-
+ 
   /* First clone all objects and store correspondence in three maps.*/
   Vertex_const_iterator vit, vend = H.vertices_end();
-  for (vit = H.vertices_begin(); vit!=vend; ++vit)
-    Vnew[vit] = this->phds->vertices_push_back(Vertex_base());
+  for (vit = H.vertices_begin(); vit != vend; ++vit) {
+      Vnew[vit] = this->phds->vertices_push_back(Vertex_base());
+      assert(Vnew[vit] != Vertex_handle());
+  }
   Halfedge_const_iterator eit, eend = H.halfedges_end();
   for (eit = H.halfedges_begin(); eit!=eend; ++(++eit)) {
     Hnew[eit] = this->phds->edges_push_back(Halfedge_base(),Halfedge_base());
@@ -820,8 +822,12 @@ void PM_decorator<HDS>::clone(const HDS& H) const
        vit2!=vend2; ++vit, ++vit2) {
     mark(vit2) = DC.mark(vit);
     point(vit2) = DC.point(vit);
-    if ( DC.is_isolated(vit) ) vit2->set_face(Fnew[vit->face()]);
-    else vit2->set_halfedge(Hnew[vit->halfedge()]);
+    if (DC.is_isolated(vit)) {
+      vit2->set_face(Fnew[vit->face()]);
+    }
+    else {
+      vit2->set_halfedge(Hnew[vit->halfedge()]);
+    }
   }
   Halfedge_iterator eit2, eend2 = this->phds->halfedges_end();
   for (eit = H.halfedges_begin(), eit2 = halfedges_begin();
@@ -843,9 +849,10 @@ void PM_decorator<HDS>::clone(const HDS& H) const
       fit2->store_fc(Hnew[fcit]);
     } // hole face cycles
     Isolated_vertex_const_iterator ivit;
-    for (ivit = isolated_vertices_begin(fit);
-         ivit != isolated_vertices_end(fit); ++ivit)
+    for (ivit = DC.isolated_vertices_begin(fit);
+        ivit != DC.isolated_vertices_end(fit); ++ivit) {
       fit2->store_iv(Vnew[ivit]);
+    }
       // isolated vertices in the interior
     mark(fit2) = DC.mark(fit);
   }

--- a/Nef_2/include/CGAL/Nef_2/PM_overlayer.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_overlayer.h
@@ -626,8 +626,11 @@ avoid the simplification for edge pairs referenced by |e|.}*/
   for(v = this->vertices_begin(); v != vend; v=vn) { CGAL_NEF_TRACEN("at vertex "<<PV(v));
     vn=v; ++vn;
     if ( is_isolated(v) ) {
-      if ( mark(v) == mark(face(v)) ) delete_vertex_only(v);
-      else set_isolated_vertex(face(v),v);
+      if (mark(v) == mark(face(v))) {
+        delete_vertex_only(v);
+      } else {
+        set_isolated_vertex(face(v), v);
+      }
     } else { // v not isolated
       Halfedge_handle e2 = first_out_edge(v), e1 = previous(e2);
       Point p1 = point(source(e1)), p2 = point(v),
@@ -643,7 +646,14 @@ avoid the simplification for edge pairs referenced by |e|.}*/
   for (f = this->faces_begin(); f != fend; f=fn) {
     fn=f; ++fn;
     Union_find_handle pit = Pitem[f];
-    if ( unify_faces.find(pit) != pit ) delete_face(f);
+    if (unify_faces.find(pit) != pit) {
+      Union_find_handle root = unify_faces.find(pit);
+      for(Isolated_vertex_iterator ivi = isolated_vertices_begin(f); ivi != isolated_vertices_end(f); ++ivi){
+        v->set_face(*root);
+        link_as_isolated_vertex(*root,v);
+      }
+      delete_face(f);
+    }
   }
 
 

--- a/Nef_2/include/CGAL/Nef_2/PM_overlayer.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_overlayer.h
@@ -646,8 +646,9 @@ avoid the simplification for edge pairs referenced by |e|.}*/
   for (f = this->faces_begin(); f != fend; f=fn) {
     fn=f; ++fn;
     Union_find_handle pit = Pitem[f];
-    if (unify_faces.find(pit) != pit) {
       Union_find_handle root = unify_faces.find(pit);
+      if (root != pit) {
+
       for(Isolated_vertex_iterator ivi = isolated_vertices_begin(f); ivi != isolated_vertices_end(f); ++ivi){
         ivi->set_face(*root);
         link_as_isolated_vertex(*root,ivi);

--- a/Nef_2/include/CGAL/Nef_2/PM_overlayer.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_overlayer.h
@@ -649,8 +649,8 @@ avoid the simplification for edge pairs referenced by |e|.}*/
     if (unify_faces.find(pit) != pit) {
       Union_find_handle root = unify_faces.find(pit);
       for(Isolated_vertex_iterator ivi = isolated_vertices_begin(f); ivi != isolated_vertices_end(f); ++ivi){
-        v->set_face(*root);
-        link_as_isolated_vertex(*root,v);
+        ivi->set_face(*root);
+        link_as_isolated_vertex(*root,ivi);
       }
       delete_face(f);
     }

--- a/Nef_2/include/CGAL/Nef_2/PM_overlayer.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_overlayer.h
@@ -336,6 +336,8 @@ public:
   using Base::set_isolated_vertex;
   using Base::has_outdeg_two;
   using Base::merge_halfedge_pairs_at_target;
+  using Base::isolated_vertices_begin;
+  using Base::isolated_vertices_end;
 
   // C++ is really friendly:
   #define USECMARK(t) const Mark& mark(t h) const { return Base::mark(h); }

--- a/Nef_2/include/CGAL/Nef_2/PM_overlayer.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_overlayer.h
@@ -605,18 +605,18 @@ avoid the simplification for edge pairs referenced by |e|.}*/
     CGAL_For_all(hfc,hend) {
       set_face(hfc,f);
       if(target(hfc) == target(e_min)) {
-        Point p1 = point(source(hfc)),
-          p2 = point(target(hfc)),
-          p3 = point(target(next(hfc)));
+        const Point& p1 = point(source(hfc));
+        const Point&  p2 = point(target(hfc));
+        const Point&  p3 = point(target(next(hfc)));
         if (!K.left_turn(p1,p2,p3) )
           e_min = hfc;
       } else if ( K.compare_xy(point(target(hfc)), point(target(e_min))) < 0 )
         e_min = hfc;
       linked[hfc]=true;
     }
-    Point p1 = point(source(e_min)),
-          p2 = point(target(e_min)),
-          p3 = point(target(next(e_min)));
+    const Point& p1 = point(source(e_min));
+    const Point& p2 = point(target(e_min));
+    const Point& p3 = point(target(next(e_min)));
     if ( K.orientation(p1,p2,p3) > 0 ) set_halfedge(f,e_min); // outer
     else set_hole(f,e_min); // store as inner
   }
@@ -633,8 +633,8 @@ avoid the simplification for edge pairs referenced by |e|.}*/
       }
     } else { // v not isolated
       Halfedge_handle e2 = first_out_edge(v), e1 = previous(e2);
-      Point p1 = point(source(e1)), p2 = point(v),
-            p3 = point(target(e2));
+      const Point& p1 = point(source(e1)), p2 = point(v);
+      const Point& p3 = point(target(e2));
       if ( has_outdeg_two(v) &&
            mark(v) == mark(e1) && mark(v) == mark(e2) &&
            (K.orientation(p1,p2,p3) == 0) )
@@ -838,9 +838,9 @@ void create_face_objects(const Below_info& D) const
     CGAL_For_all(hfc,hend) {
       FaceCycle[hfc]=i; // assign face cycle number
       if(target(hfc) == target(e_min)) {
-        Point p1 = point(source(hfc)),
-          p2 = point(target(hfc)),
-          p3 = point(target(next(hfc)));
+        const Point& p1 = point(source(hfc));
+        const Point&p2 = point(target(hfc));
+        const Point&p3 = point(target(next(hfc)));
         if (!K.left_turn(p1,p2,p3) )
           e_min = hfc;
       } else if ( K.compare_xy(point(target(hfc)), point(target(e_min))) < 0 )
@@ -854,10 +854,10 @@ void create_face_objects(const Below_info& D) const
   Face_handle f_outer = this->new_face();
   for (int j=0; j<i; ++j) {
     Halfedge_handle e = MinimalHalfedge[j];
-      CGAL_NEF_TRACEN("  face cycle "<<j);CGAL_NEF_TRACEN("  minimal halfedge "<<PE(e));
-    Point p1 = point(source(e)),
-          p2 = point(target(e)),
-          p3 = point(target(next(e)));
+    CGAL_NEF_TRACEN("  face cycle "<<j);CGAL_NEF_TRACEN("  minimal halfedge "<<PE(e));
+    const Point& p1 = point(source(e));
+    const Point& p2 = point(target(e));
+    const Point& p3 = point(target(next(e)));
     if ( K.left_turn(p1,p2,p3) ) { // left_turn => outer face cycle
       CGAL_NEF_TRACEN("  creating new face object");
       Face_handle f = this->new_face();
@@ -899,9 +899,9 @@ void create_face_objects_pl(const Below_info& D) const
     CGAL_For_all(hfc,hend) {
       FaceCycle[hfc]=i; // assign face cycle number
       if(target(hfc) == target(e_min)) {
-        Point p1 = point(source(hfc)),
-          p2 = point(target(hfc)),
-          p3 = point(target(next(hfc)));
+        const Point& p1 = point(source(hfc));
+        const Point& p2 = point(target(hfc));
+        const Point& p3 = point(target(next(hfc)));
         if (!K.left_turn(p1,p2,p3) )
           e_min = hfc;
       } else if ( K.compare_xy(point(target(hfc)), point(target(e_min))) < 0 )
@@ -915,10 +915,10 @@ void create_face_objects_pl(const Below_info& D) const
   (void)/* Face_handle f_outer = */ this->new_face();
   for (int j=0; j<i; ++j) {
     Halfedge_handle e = MinimalHalfedge[j];
-      CGAL_NEF_TRACEN("  face cycle "<<j);CGAL_NEF_TRACEN("  minimal halfedge "<<PE(e));
-    Point p1 = point(source(e)),
-          p2 = point(target(e)),
-          p3 = point(target(next(e)));
+    CGAL_NEF_TRACEN("  face cycle "<<j);CGAL_NEF_TRACEN("  minimal halfedge "<<PE(e));
+    const Point& p1 = point(source(e));
+    const Point& p2 = point(target(e));
+    const Point& p3 = point(target(next(e)));
     if ( K.left_turn(p1,p2,p3) ) { // left_turn => outer face cycle
       CGAL_NEF_TRACEN("  creating new face object");
       Face_handle f = this->new_face();
@@ -963,8 +963,8 @@ Segment segment(const Const_decorator& N,
 
 bool is_forward_edge(const Const_decorator& N,
                      Halfedge_const_iterator hit) const
-{ Point p1 = N.point(N.source(hit));
-  Point p2 = N.point(N.target(hit));
+{ const Point& p1 = N.point(N.source(hit));
+  const Point& p2 = N.point(N.target(hit));
   return (K.compare_xy(p1,p2) < 0); }
 
 void assert_type_precondition() const

--- a/Nef_2/include/CGAL/Nef_2/PM_persistent_PL.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_persistent_PL.h
@@ -72,8 +72,8 @@ struct PM_persistent_PL_traits
 
   EdgeCategory ClassifyEdge(const Graph& G, const Edge& e, const Node& u)
   {
-    Point p_u = G.point(u);
-    Point p_v = G.point(opposite(G,e,u));
+    const Point& p_u = G.point(u);
+    const Point& p_v = G.point(opposite(G,e,u));
 
     int cmpX = pK->compare_x(p_u, p_v);
     if ( cmpX < 0 ) return StartingNonVertical;
@@ -111,7 +111,8 @@ struct PM_persistent_PL_traits
   Curve makeCurve(const Graph& G, const Node& n) const
   { return makeCurve(G.point(n)); }
   Curve makeCurve(const Graph& G, const Edge& e) const
-  { Point ps = G.point(G.source(e)), pt = G.point(G.target(e));
+  { const Point& ps = G.point(G.source(e));
+    const Point& pt = G.point(G.target(e));
     Curve res(G.point(G.source(e)),G.point(G.target(e)));
     if ( pK->compare_xy(ps,pt) < 0 ) res = pK->construct_segment(ps,pt);
     else                             res = pK->construct_segment(pt,ps);
@@ -135,10 +136,10 @@ struct PM_persistent_PL_traits
 
    int operator()(const Curve& s1, const Curve& s2) const
    {
-     Point a = pK->source(s1);
-     Point b = pK->target(s1);
-     Point c = pK->source(s2);
-     Point d = pK->target(s2);
+     const Point& a = pK->source(s1);
+     const Point& b = pK->target(s1);
+     const Point& c = pK->source(s2);
+     const Point& d = pK->target(s2);
      if ( a==b )
        if ( c==d ) return pK->compare_y(a,c);
        else        return  cmppntseg(a, s2);

--- a/Nef_2/include/CGAL/Nef_2/PM_point_locator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_point_locator.h
@@ -165,7 +165,7 @@ public:
   { CGAL_NEF_TRACEN("out_wedge "<<PV(v));
     CGAL_assertion(!is_isolated(v));
     collinear=false;
-    Point p = point(v);
+    const Point& p = point(v);
     Halfedge_const_handle e_res = first_out_edge(v);
     Direction d_res = direction(e_res);
     Halfedge_around_vertex_const_circulator el(e_res),ee(el);
@@ -219,7 +219,7 @@ public:
   { CGAL_NEF_TRACEN("locate naivly "<<s);
     if (this->number_of_vertices() == 0)
       CGAL_error_msg("PM_naive_point_locator: plane map is empty.");
-    Point p = K.source(s);
+    const Point& p = K.source(s);
     Vertex_const_iterator vit;
     for(vit = this->vertices_begin(); vit != this->vertices_end(); ++vit) {
       if ( p == point(vit) ) return make_object(vit);
@@ -236,7 +236,7 @@ public:
     Direction dso = K.construct_direction(K.target(s),p), d_res;
     CGAL::Unique_hash_map<Halfedge_const_handle,bool> visited(false);
     for(vit = this->vertices_begin(); vit != this->vertices_end(); ++vit) {
-      Point p_res, vp = point(vit);
+      const Point& vp = point(vit);
       if ( K.contains(ss,vp) ) {
         CGAL_NEF_TRACEN(" location via vertex at "<<vp);
         ss = K.construct_segment(p,vp); // we shrink the segment
@@ -260,8 +260,8 @@ public:
 
     for (eit = this->halfedges_begin(); eit != this->halfedges_end(); ++eit) {
       if ( visited[eit] ) continue;
-      Point se = point(source(eit)),
-            te = point(target(eit));
+      const Point& se = point(source(eit));
+      const Point& te = point(target(eit));
       int o1 = K.orientation(ss,se);
       int o2 = K.orientation(ss,te);
       if ( o1 == -o2 && // internal intersection
@@ -298,7 +298,7 @@ public:
   along |s| does not hit any object |h| of |P| with |M(h)|.}*/
   { CGAL_NEF_TRACEN("naive ray_shoot "<<s);
     CGAL_assertion( !K.is_degenerate(s) );
-    Point p = K.source(s);
+    const Point& p = K.source(s);
     Segment ss(s);
     Direction d = K.construct_direction(K.source(s),K.target(s));
     Object_handle h = locate(s);
@@ -311,7 +311,7 @@ public:
     h = Object_handle();
     CGAL_NEF_TRACEN("not contained");
     for (v = this->vertices_begin(); v != this->vertices_end(); ++v) {
-      Point pv = point(v);
+      const Point& pv = point(v);
       if ( !K.contains(ss,pv) ) continue;
       CGAL_NEF_TRACEN("candidate "<<pv);
       if ( M(v) ) {
@@ -643,10 +643,10 @@ protected:
       Halfedge_handle e3 = next(e);
       // e1,e3: edges of quadrilateral with diagonal e
 
-      Point a = point(source(e1));
-      Point b = point(target(e1));
-      Point c = point(source(e3));
-      Point d = point(target(e3));
+      const Point& a = point(source(e1));
+      const Point& b = point(target(e1));
+      const Point& c = point(source(e3));
+      const Point& d = point(target(e3));
 
       if (! (this->K.orientation(b,d,a) > 0 && // left_turn
              this->K.orientation(b,d,c) < 0) ) // right_turn
@@ -731,7 +731,7 @@ public:
                                   Halfedge_const_handle& e,
                                   const Tag_false& ) const {
     CGAL_NEF_TRACEN("target on outer facet");
-    Point p = this->K.source(s);
+    const Point& p = this->K.source(s);
     Vertex_const_handle v1 = CT.vertices_begin();
     Halfedge_const_handle e1 = CT.twin(CT.first_out_edge(v1));
     Halfedge_around_face_const_circulator circ(e1), end(circ);
@@ -782,7 +782,7 @@ public:
   { Segment s(ss);
     CGAL_NEF_TRACEN("ray_shoot "<<s);
     CGAL_assertion( !this->K.is_degenerate(s) );
-    Point p = this->K.source(s);
+    const Point& p = this->K.source(s);
     Direction d = this->K.construct_direction(p,s.target());
     Vertex_const_handle v;
     Halfedge_const_handle e;
@@ -813,9 +813,9 @@ public:
         if ( M(input_face(e)) ) // face mark
           return make_object(input_face(e));
 
-        Point p1 = CT.point(CT.source(e)),
-              p2 = CT.point(CT.target(e)),
-              p3 = CT.point(CT.target(next(e)));
+        const Point& p1 = CT.point(CT.source(e));
+        const Point& p2 = CT.point(CT.target(e));
+        const Point& p3 = CT.point(CT.target(next(e)));
         int or1 = this->K.orientation(p,s.target(),p1);
         int or2 = this->K.orientation(p,s.target(),p2);
         int or3 = this->K.orientation(p,s.target(),p3);
@@ -999,7 +999,7 @@ PM_point_locator<PMD,GEO>::walk_in_triangulation(const Point& q) const
       return Object_handle();
 
   Halfedge_const_handle e;
-  Point p = CT.point(v);
+  const Point& p = CT.point(v);
   if ( p == q ) return make_object(v);
   //  Segment s = this->K.construct_segment(p,q);
   Direction dir = this->K.construct_direction(p,q);

--- a/Nef_2/include/CGAL/Nef_2/PM_point_locator.h
+++ b/Nef_2/include/CGAL/Nef_2/PM_point_locator.h
@@ -165,7 +165,6 @@ public:
   { CGAL_NEF_TRACEN("out_wedge "<<PV(v));
     CGAL_assertion(!is_isolated(v));
     collinear=false;
-    const Point& p = point(v);
     Halfedge_const_handle e_res = first_out_edge(v);
     Direction d_res = direction(e_res);
     Halfedge_around_vertex_const_circulator el(e_res),ee(el);

--- a/Nef_2/include/CGAL/Nef_2/Segment_overlay_traits.h
+++ b/Nef_2/include/CGAL/Nef_2/Segment_overlay_traits.h
@@ -167,7 +167,7 @@ public:
   Point_2 target(const ISegment& is) const
   { return K.target(is->first()); }
 
-  ITERATOR original(xonst ISegment& s) const
+  ITERATOR original(const ISegment& s) const
   { return s->second(); }
 
   int orientation(ST_item sit, const Point_2& p) const

--- a/Nef_2/include/CGAL/Nef_2/Segment_overlay_traits.h
+++ b/Nef_2/include/CGAL/Nef_2/Segment_overlay_traits.h
@@ -161,11 +161,13 @@ public:
   }
 
 
-  Point_2 source(ISegment is) const
+  Point_2 source(const ISegment& is) const
   { return K.source(is->first()); }
-  Point_2 target(ISegment is) const
+
+  Point_2 target(const ISegment& is) const
   { return K.target(is->first()); }
-  ITERATOR original(ISegment s) const
+
+  ITERATOR original(xonst ISegment& s) const
   { return s->second(); }
 
   int orientation(ST_item sit, const Point_2& p) const
@@ -474,7 +476,7 @@ public:
 
   public:
     compare_segs_at_sweepline(const Point_2& pi,
-                         ISegment s1, ISegment s2,
+                              ISegment s1, ISegment s2,
                               const GEOMETRY& k)
      : p(pi), s_bottom(s1), s_top(s2), K(k)
     {}
@@ -673,6 +675,7 @@ public:
 
   Point_2 source(ISegment is) const
   { return K.source(is->first); }
+
   Point_2 target(ISegment is) const
   { return K.target(is->first); }
 
@@ -687,7 +690,8 @@ public:
         *sit1 == &sh ||
         *sit2 == &sl ||
         *sit2 == &sh) return false;
-    Point_2 ps = source(*sit2), pt = target(*sit2);
+    const Point_2& ps = source(*sit2);
+    const Point_2& pt = target(*sit2);
     return ( orientation(sit1,ps)==0 &&
              orientation(sit1,pt)==0 );
   }
@@ -758,8 +762,8 @@ public:
         continue;  // ignore zero-length segments regarding YS
       }
 
-      Point_2 p = *it1;
-      Point_2 q = *it2;
+      const Point_2& p = *it1;
+      const Point_2& q = *it2;
 
       Segment_2 s1;
       if ( K.compare_xy(p,q) < 0 )

--- a/Nef_2/test/Nef_2/issue7662.cpp
+++ b/Nef_2/test/Nef_2/issue7662.cpp
@@ -39,5 +39,7 @@ int main(int argc, char *argv[])
   Nef_polyhedron intersect = poly1.intersection(poly2);
   intersect.explorer().check_integrity_and_topological_planarity();
 
+  Nef_polyhedron comp = intersect.complement();  //leads to crash/exception since topological plane map of intersect is not correct!
+  comp.explorer().check_integrity_and_topological_planarity();
   return 0;
 }

--- a/Nef_2/test/Nef_2/issue7662.cpp
+++ b/Nef_2/test/Nef_2/issue7662.cpp
@@ -1,0 +1,43 @@
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Lazy_exact_nt.h>
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Bounded_kernel.h>
+#include <CGAL/Nef_polyhedron_2.h>
+#include <CGAL/Polygon_2.h>
+
+typedef CGAL::Lazy_exact_nt<CGAL::Exact_rational> FT;
+typedef CGAL::Simple_cartesian<FT> Kernel;
+typedef CGAL::Bounded_kernel<Kernel> Bounded_kernel;
+typedef CGAL::Nef_polyhedron_2<Bounded_kernel> Nef_polyhedron;
+typedef Nef_polyhedron::Point Point;
+
+
+int main(int argc, char *argv[])
+{
+  Point p1[] = {
+    Point(0,0),
+    Point(100,100),
+    Point(0,100)
+  };
+
+  Point p2[] = {
+    Point(100, 100),
+    Point(110, 100),
+    Point(100, 110)
+  };
+
+
+  std::list<std::pair<Point*, Point*> > polygons1;
+  polygons1.push_back(std::make_pair(p1, p1 + sizeof(p1) / sizeof(Point)));
+
+  Nef_polyhedron poly1(polygons1.begin(), polygons1.end(), Nef_polyhedron::POLYGONS);
+  poly1.explorer().check_integrity_and_topological_planarity();
+
+  Nef_polyhedron poly2(p2, p2 + sizeof(p2) / sizeof(Point));
+  poly2.explorer().check_integrity_and_topological_planarity();
+
+  Nef_polyhedron intersect = poly1.intersection(poly2);
+  intersect.explorer().check_integrity_and_topological_planarity();
+
+  return 0;
+}

--- a/Nef_2/test/Nef_2/issue7662.cpp
+++ b/Nef_2/test/Nef_2/issue7662.cpp
@@ -81,7 +81,7 @@ void print(const Nef_polyhedron& poly, bool exact = false)
 
 
 
-int main(int argc, char *argv[])
+int main()
 {
   Point p1[] = {
     Point(0,0),


### PR DESCRIPTION
## Summary of Changes

Show issue #7662 

Two fixes were needed: 

1. When merging faces in `simplify()`  at the end of the overlay, isolated vertices were lost.
2. When cloning, we did not iterate over the isolated vertices of the source object.

## Release Management

* Affected package(s): Nef_2
* Issue(s) solved (if any): fix #7662
* License and copyright ownership: unchanged

