### PR TITLE
fix issue #7666: Sphere_3 intersection with interval arithmetic fails on 5.6

### DIFF
--- a/Circular_kernel_3/include/CGAL/Circular_kernel_3/internal_functions_on_sphere_3.h
+++ b/Circular_kernel_3/include/CGAL/Circular_kernel_3/internal_functions_on_sphere_3.h
@@ -278,6 +278,7 @@ namespace CGAL {
        typedef typename SK::Point_3  Point_3;
        typedef typename SK::Sphere_3  Sphere_3;
        typedef typename SK::Algebraic_kernel  Algebraic_kernel;
+       typedef typename SK::Boolean Bool;
        typedef typename SK3_Intersection_traits<SK, Sphere_3, Sphere_3, Sphere_3>::type result_type;
 
        CGAL_kernel_precondition(!s1.is_degenerate());
@@ -317,7 +318,7 @@ namespace CGAL {
              return res;
          }
          if(const Circle_3* c = CGAL::Intersections::internal::intersect_get<Circle_3>(v)) {
-            if(SK().has_on_3_object()(s3, *c)) {
+            if(static_cast<Bool>(SK().has_on_3_object()(s3, *c))) {
               *res++ = result_type(*c);
             }
            return res;


### PR DESCRIPTION
## Summary of Changes

There was a compilation error because the conversion from `Needs_FT<Uncertain<bool>>` to 'bool' requires two user-defined conversions. With an explicit conversion, that compiles and works.

## Release Management

* Affected package(s): Circular_kernel_3
* Issue(s) solved (if any): fix #7666

Note for @sloriot: there seems to be an unfortunate conflict with `master`, but it is quite trivial (because it only affects adjacent lines).


