### PR TITLE
Added missing reference to a paper in Heat method 

### DIFF
--- a/Documentation/doc/biblio/cgal_manual.bib
+++ b/Documentation/doc/biblio/cgal_manual.bib
@@ -2049,6 +2049,15 @@ ABSTRACT = {We present the first complete, exact and efficient C++ implementatio
   update        = "09.11 penarand"
 }
 
+@article{ cgal:sc-lntm-20
+  ,author        = {Nicholas Sharp and Keenan Crane}
+  ,title         = {{A Laplacian for Nonmanifold Triangle Meshes}}
+  ,journal       = {Computer Graphics Forum (SGP)}
+  ,volume        = {39}
+  ,number        = {5}
+  ,year          = {2020}
+}
+
 @inproceedings{cgal:ssgh-tmpm-01,
   title={Texture mapping progressive meshes},
   author={Sander, Pedro V and Snyder, John and Gortler, Steven J and Hoppe, Hugues},

--- a/Documentation/doc/biblio/cgal_manual.bib
+++ b/Documentation/doc/biblio/cgal_manual.bib
@@ -2053,6 +2053,7 @@ ABSTRACT = {We present the first complete, exact and efficient C++ implementatio
   ,author        = {Nicholas Sharp and Keenan Crane}
   ,title         = {{A Laplacian for Nonmanifold Triangle Meshes}}
   ,journal       = {Computer Graphics Forum (SGP)}
+  ,url           = "https://www.cs.cmu.edu/~kmcrane/Projects/NonmanifoldLaplace/NonmanifoldLaplace.pdf"
   ,volume        = {39}
   ,number        = {5}
   ,year          = {2020}

--- a/Heat_method_3/doc/Heat_method_3/Heat_method_3.txt
+++ b/Heat_method_3/doc/Heat_method_3/Heat_method_3.txt
@@ -41,7 +41,7 @@ the mathematical theory of the Heat method. The last section is about the \ref s
 
 Note that this package depends on the third party \ref thirdpartyEigen library (3.3 or greater), or another
 model of the concept `SparseLinearAlgebraWithFactorTraits_d`.
-This implementation is based on \cgalCite{cgal:cww-ghnac-13} and \cgalCite{cgal:fsbs-acidt-06}
+This implementation is based on \cgalCite{cgal:cww-ghnac-13} , \cgalCite{cgal:fsbs-acidt-06} , and \cgalCite{cgal:sc-lntm-20}
 
 This package is related to the package \ref PkgSurfaceMeshShortestPath. Both deal with geodesic distances.
 The heat method package computes for every vertex of a mesh an approximate distance to one or several source vertices.


### PR DESCRIPTION
## Summary of Changes

A mollification function was added to the Heat method implementation in an earlier PR #5037 based on [A Laplacian for Nonmanifold Triangle Meshes](https://www.cs.cmu.edu/~kmcrane/Projects/NonmanifoldLaplace/index.html). 

A citation to this paper was missing. In this PR it has been added to `cgal_manual.bib` and a simple reference to this has been added to the documentation.

## Release Management

* Affected package(s): Heat_method_3
* Link to compiled documentation: [doc](https://cgal.github.io/7688/v0/Manual/index.html)

