### PR TITLE
Incorrect closing HTML comment

### DIFF
--- a/Triangulation/doc/Triangulation/PackageDescription.txt
+++ b/Triangulation/doc/Triangulation/PackageDescription.txt
@@ -67,7 +67,7 @@ of the underlying Euclidean space \f$ \mathbb{R}^d\f$.
 The neighbors of a full cell are also
 indexed  in such a way that the neighbor indexed by \f$ i\f$
 is opposite to the vertex with the same index.
---->
+-->
 
 \cgalClassifedRefPages
 

--- a/Triangulation/doc/Triangulation/Triangulation.txt
+++ b/Triangulation/doc/Triangulation/Triangulation.txt
@@ -41,7 +41,7 @@ that is pure, connected and without boundaries nor singularities. The
 <i>dimension</i> of the triangulation is the dimension of its maximal
 simplices.
 
-<!--- cardinality, i.e., they have the same number of vertices.--->
+<!--- cardinality, i.e., they have the same number of vertices. -->
 In the sequel, we will call these maximal simplices <I>full cells</I>.
 A <I>face</I> of a simplex is a subset of this simplex.
 A <I>proper face</I> of a simplex is a strict subset of this simplex.
@@ -136,12 +136,12 @@ Possible values of \f$d\f$ (the <I>current dimension</I> of the triangulation) i
 triangulation data structure.
 <DT><B>\f$d=-1\f$</B><DD> This corresponds to an abstract simplicial
 complex reduced to a single vertex.
- <!---  and a single full cell. In a geometric triangulation, this vertex corresponds to the vertex at infinity.--->
+ <!---  and a single full cell. In a geometric triangulation, this vertex corresponds to the vertex at infinity. -->
 <DT><B>\f$d=0\f$</B><DD> This corresponds to an abstract simplicial
 complex including two vertices, each corresponding to a full cell;
 the two full cells being neighbors of each other. This is the unique
 triangulation of the \f$ 0\f$-sphere.
-<!--- (geometrically, the finite vertex and the infinite vertex),--->
+<!--- (geometrically, the finite vertex and the infinite vertex), -->
 <DT><B>\f$ 0< d \le D\f$</B><DD> This corresponds to a triangulation of
 the sphere \f$ \mathbb{S}^d\f$.
 </DL>
@@ -260,7 +260,7 @@ Therefore, the reader will make
 the best use of this example by reading it slowly, together with the reference
 manual documentation of the methods that are called (see here:
 `TriangulationDataStructure`) and by trying to understand the various
-`assert(...)` statements.--->
+`assert(...)` statements. -->
 
 \cgalExample{triangulation_data_structure_static.cpp}
 


### PR DESCRIPTION
Newer versions of doxygen are more restrictive (and following the rules) in respect to the end comment of a HTML type of comment, i.e. `<!-- ... -->`, so parts of the paragraphs were missing (Triangulation/index.html and Triangulation/group___pkg_triangulations_ref.html)

See also https://www.w3.org/TR/2006/REC-xml11-20060816/#sec-comments



