### PR TITLE
Added type cast to preprocess_weights() to avoid compilation error

### DIFF
--- a/Straight_skeleton_extrusion_2/include/CGAL/extrude_skeleton.h
+++ b/Straight_skeleton_extrusion_2/include/CGAL/extrude_skeleton.h
@@ -955,7 +955,7 @@ preprocess_weights(WeightRange& weights)
   // Since the max value might not be very close to 90°, take the max between of the large-% weight
   // and the weight corresponding to an angle of 89.9999999°
   const FT weight_of_89d9999999 = 572957787.3425436; // tan(89.9999999°)
-  const FT scaled_max = (std::max)(weight_of_89d9999999, 1e3 * max_value);
+  const FT scaled_max = (std::max)(weight_of_89d9999999, FT(1e3) * max_value);
 
   for(auto& contour_weights : weights)
   {


### PR DESCRIPTION
## Summary of Changes

A faced with an compilation error while using CGAL::extrude_skeleton() with float kernel. The error was caused by std::max() function getting arguments of different types. My improvement should fix this problem.

## Release Management

* Affected package(s): Straight Skeleton
* License and copyright ownership: unchanged

