### PR TITLE
Mesh 3: Fix demo tetrahedral filtering with a tetrahedral mesh having many subdomains

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Tetrahedra_filtering_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Tetrahedra_filtering_plugin.cpp
@@ -150,9 +150,9 @@ public Q_SLOTS:
     if(!tet_item)
       return;
     Scene_c3t3_item* c3t3_item = tet_item->c3t3_item();
-    if(c3t3_item->subdomain_indices().size() > 96)
+    if(c3t3_item->subdomain_indices().size() > 25)
     {
-      QMessageBox::warning(nullptr, "Warning", tr("The filtering is only available for items with less than 96 subdomains, and this one has %1").arg(c3t3_item->subdomain_indices().size()));
+      QMessageBox::warning(nullptr, "Warning", tr("The filtering is only available for items with less than 24 subdomains, and this one has %1").arg(c3t3_item->subdomain_indices().size()));
       return;
     }
     int counter = 0;

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Tetrahedra_filtering_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Tetrahedra_filtering_plugin.cpp
@@ -59,6 +59,10 @@ public :
     addDockWidget(dock_widget);
 
     connect(dock_widget->resetButton, &QPushButton::clicked, [this](){
+      if(!tet_item)
+          return;
+      tet_item->c3t3_item()->resetVisibleSubdomain();
+      tet_item->c3t3_item()->computeIntersection();
       filter();
     });
   }
@@ -130,6 +134,7 @@ public Q_SLOTS:
     connect(dock_widget->minEdit, &DoubleEdit::editingFinished, tet_item, QOverload<>::of(&Scene_tetrahedra_item::setMinThreshold));
     connect(dock_widget->maxEdit, &DoubleEdit::editingFinished, tet_item, QOverload<>::of(&Scene_tetrahedra_item::setMaxThreshold));
 
+    onFilterIndexChanged(dock_widget->filterBox->currentIndex());
     dock_widget->show();
   }
 
@@ -163,6 +168,13 @@ public Q_SLOTS:
     int counter = 0;
     int limit = static_cast<int>(std::ceil(CGAL::approximate_sqrt(EPICK::FT(c3t3_item->subdomain_indices().size()))));
     QGridLayout *layout = dock_widget->gridLayout;
+    //delete all items (see https://stackoverflow.com/questions/4272196/qt-remove-all-widgets-from-layout)
+    QLayoutItem* item;
+    while ((item = layout->takeAt(0)))
+    {
+      delete item->widget();
+      delete item;
+    }
     for (std::set<int>::iterator it = c3t3_item->subdomain_indices().begin(),
          end = c3t3_item->subdomain_indices().end(); it != end; ++it)
     {
@@ -170,7 +182,7 @@ public Q_SLOTS:
       QPushButton* button = new QPushButton(tr("%1").arg(index));
       buttons.push_back(button);
       button->setCheckable(true);
-      button->setChecked(true);
+      button->setChecked(c3t3_item->isVisibleSubdomain(index));
       QColor color = c3t3_item->getSubdomainIndexColor(index);
       QString s("QPushButton { font-weight: bold; background: #"
                 + QString::number(90,16)

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Tetrahedra_filtering_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Tetrahedra_filtering_plugin.cpp
@@ -11,6 +11,7 @@
 #include <CGAL/double.h>
 
 #include "Scene_c3t3_item.h"
+#include "Scene_triangulation_3_item.h"
 #include "Scene_tetrahedra_item.h"
 #include "Messages_interface.h"
 #include "CGAL_double_edit.h"
@@ -150,9 +151,13 @@ public Q_SLOTS:
     if(!tet_item)
       return;
     Scene_c3t3_item* c3t3_item = tet_item->c3t3_item();
-    if(c3t3_item->subdomain_indices().size() > 25)
+    unsigned int max_number_of_item = 32*Scene_triangulation_3_item::number_of_bitset-1;
+    if(c3t3_item->subdomain_indices().size() >= max_number_of_item)
     {
-      QMessageBox::warning(nullptr, "Warning", tr("The filtering is only available for items with less than 24 subdomains, and this one has %1").arg(c3t3_item->subdomain_indices().size()));
+      QString message = tr("The filtering is only available for items with less than %1 subdomains, and this one has %2")
+                            .arg(max_number_of_item)
+                            .arg(c3t3_item->subdomain_indices().size());
+      QMessageBox::warning(nullptr, "Warning", message);
       return;
     }
     int counter = 0;

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -659,7 +659,7 @@ Scene_triangulation_3_item::triangulation_changed()
   }
   const int max_subdomain_index = max;
   d->visible_subdomain.resize(max_subdomain_index+1, true);
-  d->is_filterable &=( d->subdomain_ids.size() < 96);
+  d->is_filterable &=( d->subdomain_ids.size() <= 24);
   for (Tr::Finite_facets_iterator fit = triangulation().finite_facets_begin(),
        end = triangulation().finite_facets_end(); fit != end; ++fit)
   {

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -353,6 +353,7 @@ struct Scene_triangulation_3_item_priv {
     is_aabb_tree_built = false;
     alphaSlider = NULL;
     is_filterable = true;
+    memset(visible_biteset, 0xFFFF, Scene_triangulation_3_item::number_of_bitset * sizeof(uint)); // all bits set to 1
   }
   void computeIntersection(const Primitive& facet);
   void fill_aabb_tree() {
@@ -492,7 +493,7 @@ struct Scene_triangulation_3_item_priv {
   QVector<QColor> colors;
   QVector<QColor> colors_subdomains;
   boost::dynamic_bitset<> visible_subdomain;
-  std::bitset<24> bs[4] = {16777215, 16777215, 16777215, 16777215};
+  std::bitset<32> visible_biteset[Scene_triangulation_3_item::number_of_bitset];
   bool show_tetrahedra;
   bool is_aabb_tree_built;
   bool last_intersection;
@@ -659,7 +660,7 @@ Scene_triangulation_3_item::triangulation_changed()
   }
   const int max_subdomain_index = max;
   d->visible_subdomain.resize(max_subdomain_index+1, true);
-  d->is_filterable &=( d->subdomain_ids.size() <= 24);
+  d->is_filterable &=( d->subdomain_indices_.size() < 32*number_of_bitset-1);
   for (Tr::Finite_facets_iterator fit = triangulation().finite_facets_begin(),
        end = triangulation().finite_facets_end(); fit != end; ++fit)
   {
@@ -972,8 +973,9 @@ void Scene_triangulation_3_item::draw(CGAL::Three::Viewer_interface* viewer) con
     program->bind();
     if(d->is_filterable)
     {
-      QVector4D visible_bitset(d->bs[0].to_ulong(),d->bs[1].to_ulong(),d->bs[2].to_ulong(),d->bs[3].to_ulong());
-      program->setUniformValue("is_visible_bitset", visible_bitset);
+      GLuint visible_bitset_ulong[number_of_bitset];
+      memcpy(visible_bitset_ulong, d->visible_biteset, number_of_bitset * sizeof(uint));
+      program->setUniformValueArray("is_visible_bitset", visible_bitset_ulong, number_of_bitset);
     }
     program->setUniformValue("is_filterable", d->is_filterable);
     program->release();
@@ -1051,8 +1053,9 @@ void Scene_triangulation_3_item::drawEdges(CGAL::Three::Viewer_interface* viewer
         program->bind();
         if(d->is_filterable)
         {
-          QVector4D visible_bitset(d->bs[0].to_ulong(),d->bs[1].to_ulong(),d->bs[2].to_ulong(),d->bs[3].to_ulong());
-          program->setUniformValue("is_visible_bitset", visible_bitset);
+          GLuint visible_bitset_ulong[number_of_bitset];
+          memcpy(visible_bitset_ulong, d->visible_biteset, number_of_bitset * sizeof(uint));
+          program->setUniformValueArray("is_visible_bitset", visible_bitset_ulong, number_of_bitset);
         }
         program->setUniformValue("is_filterable", d->is_filterable);
         program->release();
@@ -2050,7 +2053,7 @@ void Scene_triangulation_3_item::switchVisibleSubdomain(int id)
   int i = compact_id/32;
   int j = compact_id%32;
 
-  d->bs[i][j] = d->visible_subdomain[id];
+  d->visible_biteset[i][j] = d->visible_subdomain[id];
 }
 
 void Scene_triangulation_3_item::computeIntersection()

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -353,7 +353,7 @@ struct Scene_triangulation_3_item_priv {
     is_aabb_tree_built = false;
     alphaSlider = NULL;
     is_filterable = true;
-    memset(visible_biteset, 0xFFFF, Scene_triangulation_3_item::number_of_bitset * sizeof(uint)); // all bits set to 1
+    visible_bitset.fill(0xFFFF);
   }
   void computeIntersection(const Primitive& facet);
   void fill_aabb_tree() {
@@ -493,7 +493,7 @@ struct Scene_triangulation_3_item_priv {
   QVector<QColor> colors;
   QVector<QColor> colors_subdomains;
   boost::dynamic_bitset<> visible_subdomain;
-  std::bitset<32> visible_biteset[Scene_triangulation_3_item::number_of_bitset];
+  std::array<std::bitset<32>, Scene_triangulation_3_item::number_of_bitset> visible_bitset;
   bool show_tetrahedra;
   bool is_aabb_tree_built;
   bool last_intersection;
@@ -973,9 +973,11 @@ void Scene_triangulation_3_item::draw(CGAL::Three::Viewer_interface* viewer) con
     program->bind();
     if(d->is_filterable)
     {
-      GLuint visible_bitset_ulong[number_of_bitset];
-      memcpy(visible_bitset_ulong, d->visible_biteset, number_of_bitset * sizeof(uint));
-      program->setUniformValueArray("is_visible_bitset", visible_bitset_ulong, number_of_bitset);
+      std::array<GLuint, number_of_bitset> visible_bitset_ulong;
+      std::transform(d->visible_bitset.cbegin(), d->visible_bitset.cend(), visible_bitset_ulong.begin(),
+                     [](const std::bitset<32>& bitset) { return bitset.to_ulong(); }
+                     );
+      program->setUniformValueArray("is_visible_bitset", visible_bitset_ulong.data(), number_of_bitset);
     }
     program->setUniformValue("is_filterable", d->is_filterable);
     program->release();
@@ -1053,9 +1055,11 @@ void Scene_triangulation_3_item::drawEdges(CGAL::Three::Viewer_interface* viewer
         program->bind();
         if(d->is_filterable)
         {
-          GLuint visible_bitset_ulong[number_of_bitset];
-          memcpy(visible_bitset_ulong, d->visible_biteset, number_of_bitset * sizeof(uint));
-          program->setUniformValueArray("is_visible_bitset", visible_bitset_ulong, number_of_bitset);
+          std::array<GLuint, number_of_bitset> visible_bitset_ulong;
+          std::transform(d->visible_bitset.cbegin(), d->visible_bitset.cend(), visible_bitset_ulong.begin(),
+                         [](const std::bitset<32>& bitset) { return bitset.to_ulong(); }
+                         );
+          program->setUniformValueArray("is_visible_bitset", visible_bitset_ulong.data(), number_of_bitset);
         }
         program->setUniformValue("is_filterable", d->is_filterable);
         program->release();
@@ -2049,7 +2053,7 @@ QColor Scene_triangulation_3_item::getSubdomainIndexColor(int i) const
 void Scene_triangulation_3_item::resetVisibleSubdomain()
 {
   d->visible_subdomain.set();
-  memset(d->visible_biteset, 0xFFFF, number_of_bitset * sizeof(uint));
+  d->visible_bitset.fill(0xFFFF);
 }
 
 void Scene_triangulation_3_item::switchVisibleSubdomain(int id)
@@ -2059,7 +2063,7 @@ void Scene_triangulation_3_item::switchVisibleSubdomain(int id)
   int i = compact_id/32;
   int j = compact_id%32;
 
-  d->visible_biteset[i][j] = d->visible_subdomain[id];
+  d->visible_bitset[i][j] = d->visible_subdomain[id];
 }
 
 bool Scene_triangulation_3_item::isVisibleSubdomain(int id) const

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -2046,6 +2046,12 @@ QColor Scene_triangulation_3_item::getSubdomainIndexColor(int i) const
   return d->colors_subdomains[i];
 }
 
+void Scene_triangulation_3_item::resetVisibleSubdomain()
+{
+  d->visible_subdomain.set();
+  memset(d->visible_biteset, 0xFFFF, number_of_bitset * sizeof(uint));
+}
+
 void Scene_triangulation_3_item::switchVisibleSubdomain(int id)
 {
   d->visible_subdomain[id] = !d->visible_subdomain[id];
@@ -2054,6 +2060,11 @@ void Scene_triangulation_3_item::switchVisibleSubdomain(int id)
   int j = compact_id%32;
 
   d->visible_biteset[i][j] = d->visible_subdomain[id];
+}
+
+bool Scene_triangulation_3_item::isVisibleSubdomain(int id) const
+{
+  return d->visible_subdomain[id];
 }
 
 void Scene_triangulation_3_item::computeIntersection()

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -353,7 +353,7 @@ struct Scene_triangulation_3_item_priv {
     is_aabb_tree_built = false;
     alphaSlider = NULL;
     is_filterable = true;
-    visible_bitset.fill(0xFFFF);
+    visible_bitset.fill(0xFFFFFFFF);
   }
   void computeIntersection(const Primitive& facet);
   void fill_aabb_tree() {
@@ -2053,7 +2053,7 @@ QColor Scene_triangulation_3_item::getSubdomainIndexColor(int i) const
 void Scene_triangulation_3_item::resetVisibleSubdomain()
 {
   d->visible_subdomain.set();
-  d->visible_bitset.fill(0xFFFF);
+  d->visible_bitset.fill(0xFFFFFFFF);
 }
 
 void Scene_triangulation_3_item::switchVisibleSubdomain(int id)

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.h
@@ -142,7 +142,9 @@ public:
 
   QColor get_histogram_color(const double v) const;
 
+  void resetVisibleSubdomain();
   void switchVisibleSubdomain(int);
+  bool isVisibleSubdomain(int) const;
 
   void itemAboutToBeDestroyed(Scene_item *) Q_DECL_OVERRIDE;
 

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.h
@@ -31,6 +31,7 @@ using namespace CGAL::Three;
   Q_OBJECT
 public:
   typedef CGAL::qglviewer::ManipulatedFrame ManipulatedFrame;
+  static const int number_of_bitset = 4; // also defined in "shader_c3t3.frag" and "shader_c3t3_edges.frag"
 
   Scene_triangulation_3_item(bool display_elements = true);
   Scene_triangulation_3_item(const T3 t3, bool display_elements = true);

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3.frag
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3.frag
@@ -1,4 +1,7 @@
 #version 150
+
+const int number_of_bitset = 4;
+
 in vec4 color;
 in vec4 fP; 
 in vec3 fN; 
@@ -19,8 +22,8 @@ uniform bool writing;
 uniform sampler2D sampler;
 uniform float alpha;
 uniform bool is_surface;
-uniform vec4 is_visible_bitset;
 uniform bool is_filterable;
+uniform int is_visible_bitset[number_of_bitset];
 out  vec4 out_color;
 
 float depth(float z)
@@ -33,11 +36,13 @@ void main(void) {
   {
     uint domain1 = uint(subdomain_out.x);
     uint domain2 = uint(subdomain_out.y);
-    uint i1 = domain1/25u;
-    uint i2 = domain2/25u;
+    uint i1 = domain1/32u;
+    uint j1 = domain1%32u;
+    uint i2 = domain2/32u;
+    uint j2 = domain2%32u;
     uint visible1 = uint(is_visible_bitset[i1]);
     uint visible2 = uint(is_visible_bitset[i2]);
-    if((visible1>>(domain1%25u))%2u == 0u && (visible2>>(domain2%25u))%2u == 0u)
+    if(((visible1>>j1)&1u) == 0u && ((visible2>>j2)&1u) == 0u)
     {
       discard;
     }

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3_edges.frag
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3_edges.frag
@@ -1,9 +1,12 @@
 #version 150
+
+const int number_of_bitset = 4;
+
 in vec4 color;
 flat in vec2 subdomain_out;
 uniform bool is_surface;
-uniform vec4 is_visible_bitset;
 uniform bool is_filterable;
+uniform int is_visible_bitset[number_of_bitset];
 out vec4 out_color;
 void main(void) 
 { 
@@ -12,10 +15,12 @@ void main(void)
     uint domain1 = uint(subdomain_out.x);
     uint domain2 = uint(subdomain_out.y);
     uint i1 = domain1/32u;
+    uint j1 = domain1%32u;
     uint i2 = domain2/32u;
+    uint j2 = domain2%32u;
     uint visible1 = uint(is_visible_bitset[i1]);
     uint visible2 = uint(is_visible_bitset[i2]);
-    if((visible1>>(domain1%32u))%2u == 0u && (visible2>>(domain2%32u))%2u == 0u)
+    if(((visible1>>j1)&1u) == 0u && ((visible2>>j2)&1u) == 0u)
     {
       discard;
     }

--- a/STL_Extension/include/CGAL/Handle.h
+++ b/STL_Extension/include/CGAL/Handle.h
@@ -18,6 +18,7 @@
 #define CGAL_HANDLE_H
 
 #include <cstddef>
+#include <cstdint>
 #include <atomic>
 #include <CGAL/Handle_for.h>
 #include <CGAL/assertions.h>


### PR DESCRIPTION
## Summary of Changes

When a triangulation 3 has many subdomains (more than 24), some will not be shown.

Changes done : 
 - [x] Lowered maximum number of subdomains allowed in filtering
 - [x] Made filtering work with up to 128 subdomains
 - [x] Made this limit more easy to change

Possible amelioration :
 - [ ] Make filtering work with any number of subdomains (using a texture buffer)

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): 
* Feature/Small Feature (if any):
* License and copyright ownership:

