### PR TITLE
Polyhedron demo : Add clip box plugin support for more items

### DIFF
--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -231,12 +231,12 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   endmacro(add_item)
 
   add_item(scene_triangulation_3_item Scene_triangulation_3_item.cpp)
-  target_link_libraries(scene_triangulation_3_item PUBLIC scene_basic_objects)
+  target_link_libraries(scene_triangulation_3_item PUBLIC scene_basic_objects scene_edit_box_item)
 
   add_item(scene_c3t3_item Scene_c3t3_item.cpp)
   target_link_libraries(
     scene_c3t3_item PUBLIC scene_triangulation_3_item
-    scene_surface_mesh_item scene_polygon_soup_item scene_edit_box_item
+    scene_surface_mesh_item scene_polygon_soup_item
     scene_basic_objects ${TBB_LIBRARIES})
 
   if(TARGET CGAL::TBB_support)

--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -236,7 +236,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
   add_item(scene_c3t3_item Scene_c3t3_item.cpp)
   target_link_libraries(
     scene_c3t3_item PUBLIC scene_triangulation_3_item
-    scene_surface_mesh_item scene_polygon_soup_item
+    scene_surface_mesh_item scene_polygon_soup_item scene_edit_box_item
     scene_basic_objects ${TBB_LIBRARIES})
 
   if(TARGET CGAL::TBB_support)

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
@@ -163,13 +163,13 @@ void Clipping_box_plugin::clip(bool b)
   clipping = b;
   if (b)
   {
-    Q_FOREACH(CGAL::QGLViewer* v, CGAL::QGLViewer::QGLViewerPool())
+    for(CGAL::QGLViewer* v : CGAL::QGLViewer::QGLViewerPool())
     {
       v->installEventFilter(this);
     }
   }
   else {
-    Q_FOREACH(CGAL::QGLViewer* v, CGAL::QGLViewer::QGLViewerPool())
+    for(CGAL::QGLViewer* v : CGAL::QGLViewer::QGLViewerPool())
     {
       v->removeEventFilter(this);
     }

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
@@ -64,10 +64,14 @@ public Q_SLOTS:
   void tab_change();
 private:
   bool eventFilter(QObject *, QEvent *);
+  bool process_event_clip_box(QEvent *);
+  bool process_event_clip_orthographic(QEvent *);
+  void do_clip(bool);
   QAction* actionClipbox;
   ClipWidget* dock_widget;
   Scene_edit_box_item* item;
   bool shift_pressing;
+  bool clipping;
   Selection_visualizer* visualizer;
 }; // end Clipping_box_plugin
 
@@ -96,6 +100,7 @@ void Clipping_box_plugin::init(QMainWindow* mainWindow, CGAL::Three::Scene_inter
           this, SLOT(connectNewViewer(QObject*)));
   visualizer = nullptr;
   shift_pressing = false;
+  clipping = false;
 }
 
 void Clipping_box_plugin::clipbox()
@@ -148,6 +153,25 @@ void Clipping_box_plugin::enableAction() {
 }
 
 void Clipping_box_plugin::clip(bool b)
+{
+  clipping = b;
+  if (b)
+  {
+    Q_FOREACH(CGAL::QGLViewer* v, CGAL::QGLViewer::QGLViewerPool())
+    {
+      v->installEventFilter(this);
+    }
+  }
+  else {
+    Q_FOREACH(CGAL::QGLViewer* v, CGAL::QGLViewer::QGLViewerPool())
+    {
+      v->removeEventFilter(this);
+    }
+  }
+  do_clip(b);
+}
+
+void Clipping_box_plugin::do_clip(bool b)
 {
   typedef CGAL::Epick Kernel;
   typedef CGAL::Polyhedron_3<Kernel> Mesh;
@@ -231,12 +255,20 @@ void Clipping_box_plugin::tab_change()
 
 }
 
-bool Clipping_box_plugin::eventFilter(QObject *, QEvent *event) {
-  static QImage background;
-  if (dock_widget->isHidden() || !(dock_widget->isActiveWindow()) || dock_widget->tabWidget->currentIndex() != 1
-      || (dock_widget->tabWidget->currentIndex() == 1 && !dock_widget->clipButton->isChecked()))
+bool Clipping_box_plugin::process_event_clip_box(QEvent *event)
+{
+  if (event->type() == QEvent::MouseButtonRelease)
+  {
+//    item->itemChanged();
+    do_clip(clipping);
     return false;
+  }
+  return false;
+}
 
+bool Clipping_box_plugin::process_event_clip_orthographic(QEvent *event)
+{
+  static QImage background;
   if(event->type() == QEvent::KeyPress || event->type() == QEvent::KeyRelease)
   {
     QKeyEvent *keyEvent = static_cast<QKeyEvent*>(event);
@@ -358,5 +390,17 @@ bool Clipping_box_plugin::eventFilter(QObject *, QEvent *event) {
     return true;
   }
   return false;
+}
+
+bool Clipping_box_plugin::eventFilter(QObject *, QEvent *event) {
+  if (dock_widget->isHidden() || !dock_widget->isActiveWindow())
+    return false;
+  if (dock_widget->tabWidget->currentIndex() == 0 && dock_widget->pushButton->isChecked())
+    return process_event_clip_box(event);
+  else if (dock_widget->tabWidget->currentIndex() == 1 && dock_widget->clipButton->isChecked())
+    return process_event_clip_orthographic(event);
+  else
+    return false;
+
 }
 #include "Clipping_box_plugin.moc"

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_plugin.cpp
@@ -135,6 +135,12 @@ void Clipping_box_plugin::clipbox()
   });
   connect(dock_widget->tabWidget, &QTabWidget::currentChanged,
           this, &Clipping_box_plugin::tab_change);
+  connect(dock_widget->resetButton, &QPushButton::clicked,
+          this, [this]()
+  {
+    item->reset();
+    do_clip(true);
+  });
   item->setName("Clipping box");
   item->setRenderingMode(FlatPlusEdges);
 

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_widget.ui
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Clipping_box_widget.ui
@@ -66,6 +66,43 @@
          </layout>
         </item>
         <item>
+         <layout class="QHBoxLayout" name="horizontalLayout_6">
+          <item>
+           <spacer name="horizontalSpacer_6">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QPushButton" name="resetButton">
+            <property name="text">
+             <string>Reset</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <spacer name="horizontalSpacer_7">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </item>
+        <item>
          <spacer name="verticalSpacer_2">
           <property name="orientation">
            <enum>Qt::Vertical</enum>

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
@@ -99,7 +99,7 @@ struct Scene_edit_box_item_priv{
     constraint.setRotationConstraintDirection(CGAL::qglviewer::Vec(.0,.0,.1));
     frame->setConstraint(&constraint);
     //create the sphere model
-    float eps = 1.e-3;
+    double eps = 1.e-3;
     pool[0] = bb.xmin()-eps; pool[3] = bb.xmax()+eps;
     pool[1] = bb.ymin()-eps; pool[4] = bb.ymax()+eps;
     pool[2] = bb.zmin()-eps; pool[5] = bb.zmax()+eps;
@@ -255,7 +255,7 @@ struct Scene_edit_box_item_priv{
   void reset_vertices()
   {
     Scene_item::Bbox bb = scene->bbox();
-    float eps = 1.e-3;
+    double eps = 1.e-3;
     pool[0] = bb.xmin()-eps; pool[3] = bb.xmax()+eps;
     pool[1] = bb.ymin()-eps; pool[4] = bb.ymax()+eps;
     pool[2] = bb.zmin()-eps; pool[5] = bb.zmax()+eps;

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
@@ -281,6 +281,7 @@ struct Scene_edit_box_item_priv{
 Scene_edit_box_item::Scene_edit_box_item()
 {
   d = nullptr;
+  contextMenu();
 }
 Scene_edit_box_item::Scene_edit_box_item(const Scene_interface *scene_interface)
 {
@@ -311,10 +312,24 @@ Scene_edit_box_item::Scene_edit_box_item(const Scene_interface *scene_interface)
                             : Vi::PROGRAM_NO_SELECTION,
                             false));
   }
+  contextMenu();
 }
 QString Scene_edit_box_item::toolTip() const {
 
   return QString();
+}
+
+
+QMenu* Scene_edit_box_item::contextMenu()
+{
+  // diasable "Alpha slider" in menu
+  QMenu* resMenu = Scene_item::contextMenu();
+  bool prop = property("menu_changed").toBool();
+  if(!prop)
+  {
+    setProperty("menu_changed", true);
+  }
+  return resMenu;
 }
 
 void Scene_edit_box_item::drawSpheres(Viewer_interface *viewer, const QMatrix4x4 f_matrix ) const

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
@@ -99,9 +99,10 @@ struct Scene_edit_box_item_priv{
     constraint.setRotationConstraintDirection(CGAL::qglviewer::Vec(.0,.0,.1));
     frame->setConstraint(&constraint);
     //create the sphere model
-    pool[0] = bb.xmin(); pool[3] = bb.xmax();
-    pool[1] = bb.ymin(); pool[4] = bb.ymax();
-    pool[2] = bb.zmin(); pool[5] = bb.zmax();
+    float eps = 1.e-3;
+    pool[0] = bb.xmin()-eps; pool[3] = bb.xmax()+eps;
+    pool[1] = bb.ymin()-eps; pool[4] = bb.ymax()+eps;
+    pool[2] = bb.zmin()-eps; pool[5] = bb.zmax()+eps;
 
     vertex_spheres.resize(0);
     normal_spheres.resize(0);
@@ -254,7 +255,7 @@ struct Scene_edit_box_item_priv{
   void reset_vertices()
   {
     Scene_item::Bbox bb = scene->bbox();
-    float eps = 1.e-6;
+    float eps = 1.e-3;
     pool[0] = bb.xmin()-eps; pool[3] = bb.xmax()+eps;
     pool[1] = bb.ymin()-eps; pool[4] = bb.ymax()+eps;
     pool[2] = bb.zmin()-eps; pool[5] = bb.zmax()+eps;

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.cpp
@@ -251,6 +251,22 @@ struct Scene_edit_box_item_priv{
   double applyX(int id, double x, double dirx);
   double applyY(int id, double y, double diry);
   double applyZ(int id, double z, double dirz);
+  void reset_vertices()
+  {
+    Scene_item::Bbox bb = scene->bbox();
+    float eps = 1.e-6;
+    pool[0] = bb.xmin()-eps; pool[3] = bb.xmax()+eps;
+    pool[1] = bb.ymin()-eps; pool[4] = bb.ymax()+eps;
+    pool[2] = bb.zmin()-eps; pool[5] = bb.zmax()+eps;
+    double x=(bb.xmin()+bb.xmax())/2;
+    double y=(bb.ymin()+bb.ymax())/2;
+    double z=(bb.zmin()+bb.zmax())/2;
+    center_ = CGAL::qglviewer::Vec(x,y,z);
+    relative_center_ = CGAL::qglviewer::Vec(0,0,0);
+    const CGAL::qglviewer::Vec offset = static_cast<CGAL::Three::Viewer_interface*>(CGAL::QGLViewer::QGLViewerPool().first())->offset();
+    frame->setPosition(center_+offset);
+    item->invalidateOpenGLBuffers();
+  }
   const Scene_interface* scene;
   Scene_edit_box_item* item;
   QPoint picked_pixel;
@@ -1306,4 +1322,9 @@ void Scene_edit_box_item::connectNewViewer(QObject *o)
   if(!viewer)
     return;
   viewer->setMouseTracking(true);
+}
+
+void Scene_edit_box_item::reset()
+{
+  d->reset_vertices();
 }

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.h
@@ -59,6 +59,7 @@ public Q_SLOTS:
     void highlight(CGAL::Three::Viewer_interface* viewer);
     void clearHL();
     void connectNewViewer(QObject* o);
+    void reset();
 protected:
     friend struct Scene_edit_box_item_priv;
     Scene_edit_box_item_priv* d;

--- a/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/PCA/Scene_edit_box_item.h
@@ -33,6 +33,7 @@ class SCENE_EDIT_BOX_ITEM_EXPORT Scene_edit_box_item:
     }
 
     QString toolTip() const;
+    QMenu* contextMenu();
 
     bool eventFilter(QObject *, QEvent *);
     // Indicate if rendering mode is supported

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
@@ -756,6 +756,7 @@ void Scene_image_item::drawEdges(Viewer_interface *viewer) const
     getEdgeContainer(0)->setWidth(3.0f);
   }
   getEdgeContainer(0)->setColor(QColor(Qt::black));
+  getEdgeContainer(0)->setClipping(false);
   viewer->glDepthRangef(0.00001f, 0.99999f);
   getEdgeContainer(0)->draw(viewer, true);
   viewer->glDepthRangef(0.0f, 1.0f);

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -3,7 +3,6 @@
 #include "Scene_triangulation_3_item.h"
 #include "Scene_surface_mesh_item.h"
 #include "Scene_spheres_item.h"
-#include "Plugins/PCA/Scene_edit_box_item.h"
 
 #include <QVector>
 #include <QColor>

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -3,6 +3,7 @@
 #include "Scene_triangulation_3_item.h"
 #include "Scene_surface_mesh_item.h"
 #include "Scene_spheres_item.h"
+#include "Plugins/PCA/Scene_edit_box_item.h"
 
 #include <QVector>
 #include <QColor>
@@ -456,13 +457,11 @@ struct Scene_triangulation_3_item_priv {
   {
     if (intersection)
       intersection->setVisible(b);
+    cut_plane_enabled = b;
   }
   bool is_intersection_enabled()
   {
-    if (intersection)
-      return intersection->visible();
-    else
-      return false;
+    return cut_plane_enabled;
   }
   bool is_item_clip_box(int id)
   {
@@ -530,6 +529,7 @@ struct Scene_triangulation_3_item_priv {
   boost::dynamic_bitset<> visible_subdomain;
   std::bitset<24> bs[4] = {16777215, 16777215, 16777215, 16777215};
   bool show_tetrahedra;
+  bool cut_plane_enabled;
   bool is_aabb_tree_built;
   bool last_intersection;
   bool cut_edges;

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -1,7 +1,9 @@
+#include "Scene.h"
 #include "config.h"
 #include "Scene_triangulation_3_item.h"
 #include "Scene_surface_mesh_item.h"
 #include "Scene_spheres_item.h"
+#include "Plugins/PCA/Scene_edit_box_item.h"
 
 #include <QVector>
 #include <QColor>
@@ -20,6 +22,7 @@
 #include <unordered_map>
 #include <bitset>
 
+#include <CGAL/Three/Scene_item.h>
 #include <CGAL/Three/Scene_interface.h>
 #include <CGAL/Three/Triangle_container.h>
 #include <CGAL/Three/Edge_container.h>
@@ -179,7 +182,15 @@ public :
     QVector4D cp = cgal_plane_to_vector4d(plane);
     getEdgeContainer(0)->setPlane(cp);
     getEdgeContainer(0)->setColor(QColor(Qt::black));
-    getEdgeContainer(0)->draw(viewer, true);
+    if (!cut_edges) {
+      bool clipping = getEdgeContainer(0)->getClipping();
+      getEdgeContainer(0)->setClipping(false);
+      getEdgeContainer(0)->draw(viewer, true);
+      getEdgeContainer(0)->setClipping(clipping);
+    }
+    else {
+      getEdgeContainer(0)->draw(viewer, true);
+    }
 
   }
 
@@ -278,6 +289,10 @@ public :
     m_alpha = a / 255.0f;
     redraw();
   }
+  void setCutEdges(bool b)
+  {
+    cut_edges = b;
+  }
 private:
 
   //contains the data
@@ -290,6 +305,8 @@ private:
   mutable bool is_fast;
   mutable QSlider* alphaSlider;
   mutable float m_alpha ;
+
+  bool cut_edges;
 }; //end of class Scene_triangle_item
 
 
@@ -436,6 +453,25 @@ struct Scene_triangulation_3_item_priv {
   Scene_spheres_item *spheres;
   std::vector<Tr::Vertex> tr_vertices;
   Scene_intersection_item *intersection;
+  void set_intersection_enabled(bool b)
+  {
+    if (intersection)
+      intersection->setVisible(b);
+  }
+  bool is_intersection_enabled()
+  {
+    if (intersection)
+      return intersection->visible();
+    else
+      return false;
+  }
+  bool is_item_clip_box(int id)
+  {
+    if(dynamic_cast<Scene_edit_box_item*>(CGAL::Three::Three::scene()->item(id)))
+      return true;
+    else
+      return false;
+  }
   bool spheres_are_shown;
   const Scene_item* data_item_;
   QPixmap histogram_;
@@ -497,6 +533,7 @@ struct Scene_triangulation_3_item_priv {
   bool show_tetrahedra;
   bool is_aabb_tree_built;
   bool last_intersection;
+  bool cut_edges;
 
   void push_normal(std::vector<float>& normals, const EPICK::Vector_3& n) const
   {
@@ -550,6 +587,14 @@ void Scene_triangulation_3_item::common_constructor(bool display_elements)
   {
     v->installEventFilter(this);
   }
+  for(int i = 0, end = scene->numberOfEntries();
+       i < end; ++i)
+  {
+    if (d->is_item_clip_box(i))
+      d->set_intersection_enabled(false);
+  }
+  connect(static_cast<Scene*>(CGAL::Three::Three::scene()), SIGNAL(newItem(int)), this, SLOT(check_new_item(int)));
+  connect(static_cast<Scene*>(CGAL::Three::Three::scene()), SIGNAL(indexErased(Scene_interface::Item_id)), this, SLOT(check_deleted_item(Scene_interface::Item_id)));
 }
 Scene_triangulation_3_item::Scene_triangulation_3_item(bool display_elements)
   : Scene_group_item("unnamed")
@@ -600,6 +645,20 @@ void
 Scene_triangulation_3_item::data_item_destroyed()
 {
   set_data_item(NULL);
+}
+
+void
+Scene_triangulation_3_item::check_new_item(int id)
+{
+  if (d->is_item_clip_box(id))
+    d->set_intersection_enabled(false);
+}
+
+void
+Scene_triangulation_3_item::check_deleted_item(Scene_interface::Item_id id)
+{
+  if (d->is_item_clip_box(id))
+    d->set_intersection_enabled(true);
 }
 
 const T3&
@@ -913,6 +972,8 @@ Scene_triangulation_3_item_priv::compute_color_map(const QColor& c)
 
 Geom_traits::Plane_3 Scene_triangulation_3_item::plane(CGAL::qglviewer::Vec offset) const
 {
+  if (!d->is_intersection_enabled())
+    return Geom_traits::Plane_3(1.0, 0.0, 0.0, std::numeric_limits<float>::max());
   const CGAL::qglviewer::Vec& pos = d->frame->position() - offset;
   const CGAL::qglviewer::Vec& n =
     d->frame->inverseTransformOf(CGAL::qglviewer::Vec(0.f, 0.f, 1.f));
@@ -1018,7 +1079,7 @@ void Scene_triangulation_3_item::draw(CGAL::Three::Viewer_interface* viewer) con
       d->spheres->setPlane(this->plane());
     }
   }
-  if(d->is_grid_shown)
+  if(d->is_grid_shown && d->is_intersection_enabled())
   {
 
     getEdgeContainer(Grid_edges)->setColor(QColor(Qt::black));
@@ -1026,7 +1087,11 @@ void Scene_triangulation_3_item::draw(CGAL::Three::Viewer_interface* viewer) con
     for (int i = 0; i<16; i++)
       f_mat.data()[i] = static_cast<float>(d->frame->matrix()[i]);
     getEdgeContainer(Grid_edges)->setFrameMatrix(f_mat);
+    // always draw plane (disable clipping)
+    bool clipping = getEdgeContainer(Grid_edges)->getClipping();
+    getEdgeContainer(Grid_edges)->setClipping(false);
     getEdgeContainer(Grid_edges)->draw(viewer, true);
+    getEdgeContainer(Grid_edges)->setClipping(clipping);
   }
 }
 
@@ -1056,14 +1121,18 @@ void Scene_triangulation_3_item::drawEdges(CGAL::Three::Viewer_interface* viewer
       computeElements();
       initializeBuffers(viewer);
     }
-    if(renderingMode() == Wireframe && d->is_grid_shown)
+    if(renderingMode() == Wireframe && d->is_grid_shown && d->is_intersection_enabled())
     {
      getEdgeContainer(Grid_edges)->setColor(QColor(Qt::black));
       QMatrix4x4 f_mat;
       for (int i = 0; i<16; i++)
         f_mat.data()[i] = static_cast<float>(d->frame->matrix()[i]);
       getEdgeContainer(Grid_edges)->setFrameMatrix(f_mat);
+      // always draw plane (disable clipping)
+      bool clipping = getEdgeContainer(Grid_edges)->getClipping();
+      getEdgeContainer(Grid_edges)->setClipping(false);
       getEdgeContainer(Grid_edges)->draw(viewer, true);
+      getEdgeContainer(Grid_edges)->setClipping(clipping);
     }
 
     QVector4D cp = cgal_plane_to_vector4d(this->plane());
@@ -1079,7 +1148,15 @@ void Scene_triangulation_3_item::drawEdges(CGAL::Three::Viewer_interface* viewer
     getEdgeContainer(T3_edges)->setPlane(cp);
     getEdgeContainer(T3_edges)->setIsSurface(is_surface());
     getEdgeContainer(T3_edges)->setColor(QColor(Qt::black));
-    getEdgeContainer(T3_edges)->draw(viewer, true);
+    if (!d->cut_edges) {
+      bool clipping = getEdgeContainer(T3_edges)->getClipping();
+      getEdgeContainer(T3_edges)->setClipping(false);
+      getEdgeContainer(T3_edges)->draw(viewer, true);
+      getEdgeContainer(T3_edges)->setClipping(clipping);
+    }
+    else {
+      getEdgeContainer(T3_edges)->draw(viewer, true);
+    }
 
     if(d->show_tetrahedra){
       if(!d->frame->isManipulated())
@@ -1216,6 +1293,14 @@ QMenu* Scene_triangulation_3_item::contextMenu()
       connect(actionShowSpheres, SIGNAL(toggled(bool)),
               this, SLOT(show_spheres(bool)));
     }
+
+    QAction* actionToggleCutEdges =
+        menu->addAction(tr("Cut &edges"));
+    actionToggleCutEdges->setCheckable(true);
+    actionToggleCutEdges->setChecked(true);
+    actionToggleCutEdges->setObjectName("actionToggleCutEdges");
+    connect(actionToggleCutEdges, SIGNAL(toggled(bool)),
+            this, SLOT(set_cut_edge(bool)));
 
     menu->setProperty(prop_name, true);
   }
@@ -2079,6 +2164,13 @@ void Scene_triangulation_3_item::computeIntersection()
   {
     d->computeIntersections(static_cast<CGAL::Three::Viewer_interface*>(v));
   }
+}
+
+void Scene_triangulation_3_item::set_cut_edge(bool b)
+{
+  d->cut_edges = b;
+  d->intersection->setCutEdges(b);
+  Q_EMIT redraw();
 }
 
 #include "Scene_triangulation_3_item.moc"

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -576,6 +576,7 @@ void Scene_triangulation_3_item::common_constructor(bool display_elements)
 
   d->is_grid_shown = display_elements;
   d->show_tetrahedra = display_elements;
+  d->cut_plane_enabled = display_elements;
   d->last_intersection = !d->show_tetrahedra;
 
   setTriangleContainer(T3_faces, new Tc(Vi::PROGRAM_C3T3, false));

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.h
@@ -2,7 +2,6 @@
 #define SCENE_TRIANGULATION_3_ITEM_H
 
 #include "Scene_triangulation_3_item_config.h"
-#include "Plugins/PCA/Scene_edit_box_item.h"
 #include "T3_type.h"
 
 #include <QVector>

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.h
@@ -121,6 +121,9 @@ public:
 
   void data_item_destroyed();
 
+  void check_new_item(int id);
+  void check_deleted_item(Scene_interface::Item_id id);
+
   void reset_spheres();
 
   void reset_intersection_item();
@@ -128,6 +131,7 @@ public:
   void show_grid(bool b);
   void show_spheres(bool b);
   void computeIntersection();
+  void set_cut_edge(bool b);
 
   virtual QPixmap graphicalToolTip() const Q_DECL_OVERRIDE;
 

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.h
@@ -2,6 +2,7 @@
 #define SCENE_TRIANGULATION_3_ITEM_H
 
 #include "Scene_triangulation_3_item_config.h"
+#include "Plugins/PCA/Scene_edit_box_item.h"
 #include "T3_type.h"
 
 #include <QVector>

--- a/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.frag
+++ b/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.frag
@@ -7,6 +7,7 @@ in GS_OUT
   flat vec4 color[4];
   vec2 uv;
   flat vec4 prob[4];
+  float dist[6];
 } fs_in;
 
 uniform bool is_two_side;
@@ -15,11 +16,20 @@ uniform vec4 light_diff;
 uniform vec4 light_spec;
 uniform vec4 light_amb;
 uniform float spec_power ;
+uniform bool is_clipbox_on;
 
 out vec4 out_color;
 
 void main(void)
 {
+  if(is_clipbox_on)
+    if(fs_in.dist[0]>0.0 ||
+      fs_in.dist[1]>0.0 ||
+      fs_in.dist[2]>0.0 ||
+      fs_in.dist[3]>0.0 ||
+      fs_in.dist[4]>0.0 ||
+      fs_in.dist[5]>0.0)
+        discard;
   vec4 color;
   //find base color of pixel
   vec4 m1 = mix(fs_in.prob[0], fs_in.prob[1], fs_in.uv.y);

--- a/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.geom
+++ b/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.geom
@@ -8,6 +8,7 @@ in VS_OUT
   vec4 fP;
   vec3 fN;
   vec4 out_color;
+  float dist[6];
 } gs_in[4];
 
 out GS_OUT
@@ -17,6 +18,7 @@ out GS_OUT
   flat vec4 color[4];
   vec2 uv;
   flat vec4 prob[4];
+  float dist[6];
 } gs_out;
 
 void main(void)
@@ -25,19 +27,21 @@ void main(void)
   gs_out.fN = gs_in[0].fN;
   gs_out.fP = gs_in[0].fP;
   gs_out.uv = vec2(0.0, 0.0);
-
+  gs_out.dist = gs_in[0].dist;
   EmitVertex();
 
   gl_Position = gl_in[1].gl_Position;
   gs_out.fN = gs_in[1].fN;
   gs_out.fP = gs_in[1].fP;
   gs_out.uv = vec2(0.0, 1.0);
+  gs_out.dist = gs_in[1].dist;
   EmitVertex();
 
   gl_Position = gl_in[3].gl_Position;
   gs_out.fN = gs_in[3].fN;
   gs_out.fP = gs_in[3].fP;
   gs_out.uv = vec2(1.0, 0.0);
+  gs_out.dist = gs_in[3].dist;
 
   // We're only writing the output color for the last
   // vertex here because they're flat attributes,
@@ -67,18 +71,21 @@ void main(void)
   gs_out.fN = gs_in[1].fN;
   gs_out.fP = gs_in[1].fP;
   gs_out.uv = vec2(0.0, 1.0);
+  gs_out.dist = gs_in[1].dist;
   EmitVertex();
 
   gl_Position = gl_in[2].gl_Position;
   gs_out.fN = gs_in[2].fN;
   gs_out.fP = gs_in[2].fP;
   gs_out.uv = vec2(1.0, 1.0);
+  gs_out.dist = gs_in[2].dist;
   EmitVertex();
 
   gl_Position = gl_in[3].gl_Position;
   gs_out.fN = gs_in[3].fN;
   gs_out.fP = gs_in[3].fP;
   gs_out.uv = vec2(1.0, 0.0);
+  gs_out.dist = gs_in[3].dist;
   // Again, only write the output color for the last vertex
   gs_out.color[0] = gs_in[0].out_color;
   gs_out.color[1] = gs_in[1].out_color;

--- a/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.vert
+++ b/Polyhedron/demo/Polyhedron/resources/no_interpolation_shader.vert
@@ -9,15 +9,39 @@ out VS_OUT
   vec4 fP;
   vec3 fN;
   vec4 out_color;
+  float dist[6];
 }vs_out;
 
 uniform mat4 mvp_matrix;
 uniform mat4 mv_matrix;
 uniform mat4 norm_matrix;
 
+uniform bool is_clipbox_on;
+uniform mat4 clipbox1;
+uniform mat4 clipbox2;
+
+void compute_distances(void)
+{
+  for(int i=0; i<3; ++i)
+  {
+    vs_out.dist[i]=
+    clipbox1[i][0]*vertex.x+
+    clipbox1[i][1]*vertex.y+
+    clipbox1[i][2]*vertex.z +
+    clipbox1[i][3];
+    vs_out.dist[i+3]=
+    clipbox2[i][0]*vertex.x+
+    clipbox2[i][1]*vertex.y+
+    clipbox2[i][2]*vertex.z +
+    clipbox2[i][3];
+  }
+}
+
 void main(void)
 {
    vs_out.out_color=colors;
+   if(is_clipbox_on)
+    compute_distances();
    vs_out.fP = mv_matrix * vertex;
    vs_out.fN = mat3(norm_matrix)* normals;
    gl_Position = mvp_matrix * vertex;

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3.vert
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3.vert
@@ -12,13 +12,37 @@ uniform  float shrink_factor;
 out vec4 fP;
 out vec3 fN;
 out vec4 color;
+out float dist[6];
 flat out vec2 subdomain_out;
+uniform bool is_clipbox_on;
+uniform mat4 clipbox1;
+uniform mat4 clipbox2;
 uniform  float point_size;
+
+void compute_distances(void)
+{
+  for(int i=0; i<3; ++i)
+  {
+    dist[i]=
+    clipbox1[i][0]*vertex.x+
+    clipbox1[i][1]*vertex.y+
+    clipbox1[i][2]*vertex.z +
+    clipbox1[i][3];
+    dist[i+3]=
+    clipbox2[i][0]*vertex.x+
+    clipbox2[i][1]*vertex.y+
+    clipbox2[i][2]*vertex.z +
+    clipbox2[i][3];
+  }
+}
+
 void main(void)
 {
   subdomain_out = subdomain_in;
   gl_PointSize = point_size;
   color = vec4(colors, vertex.x * cutplane.x  + vertex.y * cutplane.y  + vertex.z * cutplane.z  +  cutplane.w);
+  if(is_clipbox_on)
+   compute_distances();
   fP = mv_matrix * vertex;
 
   mat3 norm_matrix_3;

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3_edges.frag
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3_edges.frag
@@ -1,12 +1,22 @@
 #version 150
 in vec4 color;
+in float dist[6];
 flat in vec2 subdomain_out;
+uniform bool is_clipbox_on;
 uniform bool is_surface;
 uniform vec4 is_visible_bitset;
 uniform bool is_filterable;
 out vec4 out_color;
 void main(void) 
 { 
+  if(is_clipbox_on)
+    if(dist[0]>0.0 ||
+      dist[1]>0.0 ||
+      dist[2]>0.0 ||
+      dist[3]>0.0 ||
+      dist[4]>0.0 ||
+      dist[5]>0.0)
+        discard;
   if(is_filterable)
   {
     uint domain1 = uint(subdomain_out.x);

--- a/Polyhedron/demo/Polyhedron/resources/shader_c3t3_edges.vert
+++ b/Polyhedron/demo/Polyhedron/resources/shader_c3t3_edges.vert
@@ -5,12 +5,36 @@ in vec2 subdomain_in;
 uniform  mat4 mvp_matrix;
 uniform  vec4 cutplane;
 out  vec4 color; 
+out float dist[6];
 uniform  float point_size;
 flat out vec2 subdomain_out;
+uniform bool is_clipbox_on;
+uniform mat4 clipbox1;
+uniform mat4 clipbox2;
+
+void compute_distances(void)
+{
+  for(int i=0; i<3; ++i)
+  {
+    dist[i]=
+    clipbox1[i][0]*vertex.x+
+    clipbox1[i][1]*vertex.y+
+    clipbox1[i][2]*vertex.z +
+    clipbox1[i][3];
+    dist[i+3]=
+    clipbox2[i][0]*vertex.x+
+    clipbox2[i][1]*vertex.y+
+    clipbox2[i][2]*vertex.z +
+    clipbox2[i][3];
+  }
+}
+
 void main(void)
 {
   subdomain_out = subdomain_in;
   gl_PointSize = point_size;
   color = vec4(colors, vertex.x * cutplane.x  + vertex.y * cutplane.y  + vertex.z * cutplane.z  +  cutplane.w);
+  if(is_clipbox_on)
+   compute_distances();
   gl_Position = mvp_matrix * vertex;
 }


### PR DESCRIPTION
## Summary of Changes

The clip box plugin only set shader uniforms. We can add these uniforms in shaders where they were not added.

Tasks :
 - [x] Add support for Images (no_interpolation_shader)
 - [x] Add support for Tetrahedral meshes
 - [x] Disable tetrahedral clip plane
 - [x] Add option to always show edges when clipping
 - [x] Make clip button behave like a toggle
 - [x] Add reset button on clipping box

## Release Management

* Affected package(s): Polyhedron demo
* Feature/Small Feature (if any):
* License and copyright ownership:

