### PR TITLE
Add missing header

### DIFF
--- a/Intersections_3/include/CGAL/Intersections_3/internal/Plane_3_Triangle_3_intersection.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Plane_3_Triangle_3_intersection.h
@@ -19,6 +19,8 @@
 #include <CGAL/enum.h>
 #include <CGAL/kernel_assertions.h>
 
+#include <boost/next_prior.hpp>
+
 namespace CGAL {
 namespace Intersections {
 namespace internal {


### PR DESCRIPTION
CGAL-5.5.x latest test results are completely broken.

https://cgal.geometryfactory.com/CGAL/testsuite/results-5.5.4-I-166.shtml

That is not due to any code change (there was none since the previous testsuite for 5.5.x). The error are due to Boost 1.84. Probably something change in the includes of Boost. The error is about `boost::prior`.  The header `<boost/next_prior.hpp>` must be included.
