### PR TITLE
fix : iformat/oformat are in CGAL::IO

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Point_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Point_2.h
@@ -736,13 +736,13 @@ public:
     swallow(is, '(');
 
     // read values
-    is >> iformat(rep._m_xy);
+    is >> IO::iformat(rep._m_xy);
     swallow(is, ',');
-    is >> iformat(rep._m_x);
+    is >> IO::iformat(rep._m_x);
     swallow(is, ',');
-    is >> iformat(rep._m_curve);
+    is >> IO::iformat(rep._m_curve);
     swallow(is, ',');
-    is >> iformat(rep._m_arcno);
+    is >> IO::iformat(rep._m_arcno);
     swallow(is, ',');
     is >> rep._m_location;
 

--- a/Mesh_2/include/CGAL/IO/File_poly.h
+++ b/Mesh_2/include/CGAL/IO/File_poly.h
@@ -43,7 +43,7 @@ read_triangle_poly_file(CDT& t, std::istream &f,
     {
       unsigned int j;
       double x, y;
-      f >> j >> iformat(x) >> iformat(y);
+      f >> j >> IO::iformat(x) >> IO::iformat(y);
       Point p(x, y);
       skip_until_EOL(f); skip_comment_OFF(f);
       vertices[--j] = t.insert(p);

--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -198,6 +198,7 @@ if(CGAL_ACTIVATE_CONCURRENT_MESH_3 AND TARGET CGAL::TBB_support)
     target
     mesh_3D_image
     mesh_3D_weighted_image
+    mesh_3D_weighted_image_with_detection_of_features
     mesh_3D_image_variable_size
     mesh_3D_image_with_custom_initialization
     mesh_3D_gray_image_with_custom_initialization

--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -1148,9 +1148,9 @@ number_of_bad_elements_impl()
         const Subdomain mc_subdomain = this->r_oracle_.is_in_domain_object()(this->r_tr_.dual(mc));
 
         std::cerr << "*** Is in complex? c is marked in domain: " << this->r_c3t3_.is_in_complex(c)
-          << " / c is really in subdomain: " << oformat(c_subdomain)
+          << " / c is really in subdomain: " << IO::oformat(c_subdomain)
           << " / mc is marked in domain: " << this->r_c3t3_.is_in_complex(mc)
-          << " / mc is really in subdomain: " << oformat(mc_subdomain)
+          << " / mc is really in subdomain: " << IO::oformat(mc_subdomain)
           << std::endl;
 
 

--- a/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
@@ -134,15 +134,15 @@ bool read_XYZ(std::istream& is,
     {
       iss.clear();
       iss.str(line);
-      if (iss >> iformat(x) >> iformat(y) >> iformat(z))
+      if (iss >> IO::iformat(x) >> IO::iformat(y) >> IO::iformat(z))
       {
         Point point(x,y,z);
         Vector normal = CGAL::NULL_VECTOR;
         // ... + normal...
-        if (iss >> iformat(nx))
+        if (iss >> IO::iformat(nx))
         {
           // In case we could read one number, we expect that there are two more
-          if(iss >> iformat(ny) >> iformat(nz)){
+          if(iss >> IO::iformat(ny) >> IO::iformat(nz)){
             normal = Vector(nx,ny,nz);
           } else {
             std::cerr << "Error line " << lineNumber << " of file (incomplete normal coordinates)" << std::endl;

--- a/Stream_support/include/CGAL/IO/PLY/PLY_reader.h
+++ b/Stream_support/include/CGAL/IO/PLY/PLY_reader.h
@@ -201,7 +201,7 @@ public:
 
   void read_ascii(std::istream& stream, double& t) const
   {
-    if(!(stream >> iformat(t)))
+    if(!(stream >> IO::iformat(t)))
       stream.clear(std::ios::badbit);
   }
 

--- a/Stream_support/include/CGAL/IO/STL/STL_reader.h
+++ b/Stream_support/include/CGAL/IO/STL/STL_reader.h
@@ -75,7 +75,7 @@ bool read_ASCII_facet(std::istream& is,
         return false;
       }
 
-      if(!(is >> iformat(x) >> iformat(y) >> iformat(z)))
+      if(!(is >> IO::iformat(x) >> IO::iformat(y) >> IO::iformat(z)))
       {
         if(verbose)
           std::cerr << "Error while reading point coordinates (premature end of file)" << std::endl;

--- a/Stream_support/include/CGAL/IO/VTK.h
+++ b/Stream_support/include/CGAL/IO/VTK.h
@@ -199,7 +199,7 @@ void write_soup_points_tag(std::ostream& os,
   {
     os << "\">\n";
     for(const Point& p : points)
-      os << oformat(p.x()) << " " << oformat(p.y()) << " " << oformat(p.z()) << " ";
+      os << IO::oformat(p.x()) << " " << IO::oformat(p.y()) << " " << IO::oformat(p.z()) << " ";
     os << "      </DataArray>\n";
   }
   os << "    </Points>\n";

--- a/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_2.h
@@ -623,7 +623,7 @@ public:
   auto display_vertex(Vertex_handle v) const {
     With_point_tag point_tag;
     using CGAL::IO::oformat;
-    return oformat(v, point_tag);
+    return IO::oformat(v, point_tag);
   }
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
 

--- a/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
@@ -865,7 +865,7 @@ insert_constraint(T va, T vb){
   using CGAL::IO::oformat;
   std::cerr << CGAL::internal::cdt_2_indent_level
             << "C_hierachy.insert_constraint( "
-            << oformat(va) << ", " << oformat(vb) << ")\n";
+            << IO::oformat(va) << ", " << IO::oformat(vb) << ")\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   typename Sc_to_c_map::iterator scit = sc_to_c_map.find(he);
   if(scit == sc_to_c_map.end()){
@@ -900,7 +900,7 @@ insert_constraint_old_API(T va, T vb){
   using CGAL::IO::oformat;
   std::cerr << CGAL::internal::cdt_2_indent_level
             << "C_hierachy.insert_constraint_old_API( "
-            << oformat(va) << ", " << oformat(vb) << ")\n";
+            << IO::oformat(va) << ", " << IO::oformat(vb) << ")\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   typename Sc_to_c_map::iterator scit = sc_to_c_map.find(he);
   if(scit == sc_to_c_map.end()){
@@ -933,7 +933,7 @@ append_constraint(Constraint_id cid, T va, T vb){
   using CGAL::IO::oformat;
   std::cerr << CGAL::internal::cdt_2_indent_level
             << "C_hierachy.append_constraint( ..., "
-            << oformat(va) << ", " << oformat(vb) << ")\n";
+            << IO::oformat(va) << ", " << IO::oformat(vb) << ")\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   typename Sc_to_c_map::iterator scit = sc_to_c_map.find(he);
   if(scit == sc_to_c_map.end()){
@@ -1050,7 +1050,7 @@ add_Steiner(T va, T vb, T vc){
   using CGAL::IO::oformat;
   std::cerr << CGAL::internal::cdt_2_indent_level
             << "C_hierachy.add_Steinter( "
-            << oformat(va) << ", " << oformat(vb) << ", " << oformat(vc)
+            << IO::oformat(va) << ", " << IO::oformat(vb) << ", " << IO::oformat(vc)
             << ")\n";
 #endif // CGAL_CDT_2_DEBUG_INTERSECTIONS
   Context_list* hcl=nullptr;


### PR DESCRIPTION
## Summary of Changes

The calls without the `IO::` namespace are deprecated.

Fixes https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.0-I-60/Mesh_3/TestReport_lrineau_Ubuntu-Latest-NO_DEPRECATED_CODE.gz and a lot more.

## Release Management

* Affected package(s): CGAL
* License and copyright ownership: maintenance by GeometryFactory
