### PR TITLE
fix a typo in Tutorial_hello_world.txt

### DIFF
--- a/Documentation/doc/Documentation/Tutorials/Tutorial_hello_world.txt
+++ b/Documentation/doc/Documentation/Tutorials/Tutorial_hello_world.txt
@@ -73,7 +73,7 @@ seems that the points are collinear, or perform a right turn.
 
 If you must ensure that your numbers get interpreted at their full precision
 you can use a \cgal kernel that performs exact predicates and
-extract constructions.
+exact constructions.
 
 \cgalExample{Kernel_23/exact.cpp}
 


### PR DESCRIPTION
## Summary of Changes

Fix a typo in Tutorial_hello_world.txt:

https://github.com/CGAL/cgal/blob/8718201f3e8d0043d66dd5ba16602c4b8dfb022a/Documentation/doc/Documentation/Tutorials/Tutorial_hello_world.txt#L74-L76

`extract` -> `exact`
