### PR TITLE
Mesh 3 : improved meshing with selected polylines

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -368,9 +368,9 @@ std::optional<QString> Mesh_3_plugin::get_items_or_return_error_string() const
   {
     auto poly_items_ptr = std::get_if<Polyhedral_mesh_items>(&items.value());
     auto image_items_ptr = std::get_if<Image_mesh_items>(&items.value());
-    if(poly_items_ptr && poly_items_ptr == nullptr)
+    if(poly_items_ptr != nullptr)
       poly_items_ptr->polylines_item = polylines_item;
-    else if(image_items_ptr && image_items_ptr == nullptr)
+    else if(image_items_ptr != nullptr )
       image_items_ptr->polylines_item = polylines_item;
   }
 
@@ -663,6 +663,8 @@ void Mesh_3_plugin::mesh_3(const Mesh_type mesh_type,
         ui.protectEdges->addItem(boundary_only.first, v(boundary_only.second));
       } else
         ui.protectEdges->addItem(sharp_edges.first, v(sharp_edges.second));
+      if (polylines_item != nullptr)
+        ui.protectEdges->addItem(input_polylines.first, v(input_polylines.second));
     } else if (items->index() == IMAGE_MESH_ITEMS) {
       if (polylines_item != nullptr) {
         ui.protectEdges->addItem(input_polylines.first, QVariant::fromValue(input_polylines.second));
@@ -729,6 +731,7 @@ void Mesh_3_plugin::mesh_3(const Mesh_type mesh_type,
   const auto pe_flags = ui.protectEdges->currentData().value<Protection_flags>();
   protect_borders = ui.protect->isChecked() && pe_flags.testFlag(BORDERS);
   protect_features = ui.protect->isChecked() && pe_flags.testFlag(FEATURES);
+  const bool protect_polylines = ui.protect->isChecked() && polylines_item != nullptr;
 
   const bool detect_connected_components = ui.detectComponents->isChecked();
   const int manifold = (ui.manifoldCheckBox->isChecked() ? 1 : 0) +
@@ -811,7 +814,7 @@ void Mesh_3_plugin::mesh_3(const Mesh_type mesh_type,
     {
       thread = cgal_code_mesh_3(
         polyhedrons,
-        (polylines_item == nullptr) ? plc : polylines_item->polylines,
+        protect_polylines ? polylines_item->polylines : plc,
         bounding_polyhedron,
         item_name,
         angle,


### PR DESCRIPTION
## Summary of Changes

Added a drop-down item "Input polyline only" in "Protect sharp edges" when a polyline item is selected.
Fixed polyline item not working depending on the order of selection.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): 
* Feature/Small Feature (if any):
* License and copyright ownership:

