### PR TITLE
Add missing functions capacity and upper bound in dart_range for cmap and lcc with index

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map_storages_with_index.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_storages_with_index.h
@@ -148,6 +148,10 @@ namespace CGAL {
       { return mmap.mdarts.is_used(i); }
       bool owns(size_type i) const
       { return mmap.mdarts.owns(i); }
+      size_type capacity() const
+      { return mmap.mdarts.capacity(); }
+      size_type upper_bound() const
+      { return mmap.mdarts.upper_bound(); }
     private:
       Self & mmap;
     };
@@ -444,7 +448,7 @@ namespace CGAL {
         (mattribute_containers).upper_bound();
     }
 
-    protected:
+  protected:
     // Set the handle on the i th attribute
     template<unsigned int i>
     void basic_set_dart_attribute(Dart_descriptor dh,

--- a/Linear_cell_complex/include/CGAL/CMap_linear_cell_complex_storages_with_index.h
+++ b/Linear_cell_complex/include/CGAL/CMap_linear_cell_complex_storages_with_index.h
@@ -99,14 +99,14 @@ namespace CGAL {
     {};
     template<int i>
     struct Attribute_const_descriptor:
-        public Helper::template Attribute_const_descriptor<i>
+      public Helper::template Attribute_const_descriptor<i>
     {};
     template<int i>
     struct Attribute_range: public Helper::template Attribute_range<i>
     {};
     template<int i>
     struct Attribute_const_range:
-        public Helper::template Attribute_const_range<i>
+      public Helper::template Attribute_const_range<i>
     {};
 
     typedef typename Attribute_type<0>::type Vertex_attribute;
@@ -169,6 +169,10 @@ namespace CGAL {
       { return mmap.mdarts.is_used(i); }
       bool owns(size_type i) const
       { return mmap.mdarts.owns(i); }
+      size_type capacity() const
+      { return mmap.mdarts.capacity(); }
+      size_type upper_bound() const
+      { return mmap.mdarts.upper_bound(); }
     private:
       Self & mmap;
     };
@@ -202,7 +206,7 @@ namespace CGAL {
      *  @return true iff the map is empty.
      */
     bool is_empty() const
-    { return  darts().empty(); }
+    { return darts().empty(); }
 
     /// @return the number of darts.
     size_type number_of_darts() const
@@ -288,18 +292,18 @@ namespace CGAL {
     typename Attribute_descriptor<i>::type attribute(Dart_descriptor ADart)
     {
       static_assert(Helper::template Dimension_index<i>::value>=0,
-                        "attribute<i> called but i-attributes are disabled.");
+                     "attribute<i> called but i-attributes are disabled.");
       return std::get<Helper::template Dimension_index<i>::value>
-          (mdarts[ADart].mattribute_descriptors);
+        (mdarts[ADart].mattribute_descriptors);
     }
     template<unsigned int i>
     typename Attribute_const_descriptor<i>::type
     attribute(Dart_const_descriptor ADart) const
     {
       static_assert(Helper::template Dimension_index<i>::value>=0,
-                        "attribute<i> called but i-attributes are disabled.");
+                     "attribute<i> called but i-attributes are disabled.");
       return std::get<Helper::template Dimension_index<i>::value>
-          (mdarts[ADart].mattribute_descriptors);
+        (mdarts[ADart].mattribute_descriptors);
     }
 
     // Copy a given attribute
@@ -360,7 +364,7 @@ namespace CGAL {
     {
       CGAL_assertion( ah!=null_descriptor );
       return std::get<Helper::template Dimension_index<i>::value>
-          (mattribute_containers)[ah];
+        (mattribute_containers)[ah];
     }
     template<unsigned int i>
     const typename Attribute_type<i>::type&
@@ -368,7 +372,7 @@ namespace CGAL {
     {
       CGAL_assertion( ah!=null_descriptor );
       return std::get<Helper::template Dimension_index<i>::value>
-          (mattribute_containers)[ah];
+        (mattribute_containers)[ah];
     }
 
     // Get the dart of the given attribute
@@ -486,14 +490,14 @@ namespace CGAL {
                                   typename Attribute_descriptor<i>::type ah)
     {
       std::get<Helper::template Dimension_index<i>::value>
-          (mdarts[dh].mattribute_descriptors) = ah;
+        (mdarts[dh].mattribute_descriptors) = ah;
     }
 
     /** Link a dart with a given dart for a given dimension.
-       * @param adart the dart to link.
-       * @param adart2 the dart to link with.
-       * @param i the dimension.
-       */
+     * @param adart the dart to link.
+     * @param adart2 the dart to link with.
+     * @param i the dimension.
+     */
     template<unsigned int i>
     void dart_link_beta(Dart_descriptor adart, Dart_descriptor adart2)
     {
@@ -509,9 +513,9 @@ namespace CGAL {
     }
 
     /** Unlink a dart for a given dimension.
-       * @param adart a dart.
-       * @param i the dimension.
-       */
+     * @param adart a dart.
+     * @param i the dimension.
+     */
     template<unsigned int i>
     void dart_unlink_beta(Dart_descriptor adart)
     {


### PR DESCRIPTION

_Please use the following template to help us managing pull requests._

## Summary of Changes

Add 2 missing methods in dart_range in CMap and LCC_cmap with index.
Without these two methods, we cannot use a dart_range like a compact container with index which is a bug.

## Release Management

* Affected package(s): CMap and LCC

