### PR TITLE
CGAL Lab: fix the random appearance of clip plane

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -540,6 +540,7 @@ void Scene_triangulation_3_item::common_constructor(bool display_elements)
 
   d->is_grid_shown = display_elements;
   d->show_tetrahedra = display_elements;
+  d->cut_plane_enabled = display_elements;
   d->last_intersection = !d->show_tetrahedra;
 
   setTriangleContainer(T3_faces, new Tc(Vi::PROGRAM_C3T3, false));


### PR DESCRIPTION
## Summary of Changes

For the `Scene_c3t3_item` (and probably `Scene_triangulation_item` as well) most of the time the clip plane was not shown. This is because of Boolean data member `cut_plane_enabled` that was not initialized.

Fixed easily by one line once found the root cause.

## Release Management

* Affected package(s): Mesh_3, 3D demo (Polyhedron_3 - CGAL Lab)
* License and copyright ownership: n/a
