### PR TITLE
Tetrahedral remeshing of a C3t3 - fix default cell selector

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -530,7 +530,7 @@ private:
     std::cout << "\t vertices = " << nbv << std::endl;
 
     CGAL::Tetrahedral_remeshing::debug::dump_vertices_by_dimension(
-      m_c3t3.triangulation(), "c3t3_vertices_");
+      m_c3t3.triangulation(), "0-c3t3_vertices_after_init_");
     CGAL::Tetrahedral_remeshing::debug::check_surface_patch_indices(m_c3t3);
 #endif
   }

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -392,7 +392,6 @@ void tetrahedral_isotropic_remeshing(
     = choose_parameter(get_parameter(np, internal_np::smooth_constrained_edges),
       false);
 
-  typedef typename Tr::Cell_handle Cell_handle;
   typedef typename internal_np::Lookup_named_param_def <
               internal_np::cell_selector_t,
               NamedParameters,

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -394,13 +394,13 @@ void tetrahedral_isotropic_remeshing(
 
   typedef typename Tr::Cell_handle Cell_handle;
   typedef typename internal_np::Lookup_named_param_def <
-  internal_np::cell_selector_t,
+              internal_np::cell_selector_t,
               NamedParameters,
-              Constant_property_map<Cell_handle, bool>//default
+              Tetrahedral_remeshing::internal::All_cells_selected<Tr>//default
               > ::type SelectionFunctor;
   SelectionFunctor cell_select
     = choose_parameter(get_parameter(np, internal_np::cell_selector),
-                       Constant_property_map<Cell_handle, bool>(true));
+                       Tetrahedral_remeshing::internal::All_cells_selected<Tr>());
 
   typedef std::pair<typename Tr::Vertex_handle, typename Tr::Vertex_handle> Edge_vv;
   typedef typename internal_np::Lookup_named_param_def <


### PR DESCRIPTION
## Summary of Changes

In the demo, tetrahedral remeshing is called directly on the C3t3. This PR fixes the default `cell_selector` when remeshing is called on a C3t3.

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged

