### PR TITLE
Correcting stylesheet name

### DIFF
--- a/Documentation/doc/scripts/generate_how_to_cite.py
+++ b/Documentation/doc/scripts/generate_how_to_cite.py
@@ -85,7 +85,7 @@ pre_html=r"""<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "htt
 <link rel="icon" type="image/png" href="../Manual/g-196x196-doc.png"/>
 <meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
 <meta http-equiv="X-UA-Compatible" content="IE=9"/>
-<link href="stylesheet.css" rel="stylesheet" type="text/css" />
+<link href="cgal_stylesheet.css" rel="stylesheet" type="text/css" />
 <title>CGAL ${CGAL_CREATED_VERSION_NUM} - Manual: Acknowledging CGAL</title>
 </head>
 <body>

--- a/Documentation/doc/scripts/html_output_post_processing.py
+++ b/Documentation/doc/scripts/html_output_post_processing.py
@@ -70,7 +70,7 @@ def clean_doc():
     duplicate_files=list(package_glob('./*/jquery.js'))
     duplicate_files.extend(package_glob('./*/dynsections.js'))
     duplicate_files.extend(package_glob('./*/resize.js'))
-    duplicate_files.extend(package_glob('./*/stylesheet.css'))
+    duplicate_files.extend(package_glob('./*/cgal_stylesheet.css'))
     # kill _all_, including the one in CGAL tabs.css files
     duplicate_files.extend(glob.glob('./*/tabs.css'))
     # left-over by doxygen?


### PR DESCRIPTION
The name `stylesheet.css` is replaced by a better name `cgal_stylesheet.css` a while ago, but apparently these 2 files were not updated.
