### PR TITLE
issue #7765 Problem with Boost 1.54 and a non reachable ticket

### DIFF
--- a/Point_set_processing_3/include/CGAL/mst_orient_normals.h
+++ b/Point_set_processing_3/include/CGAL/mst_orient_normals.h
@@ -553,9 +553,6 @@ create_mst_graph(
    For this reason it should not be called on sorted containers.
    It is based on \cgalCite{cgal:hddms-srup-92}.
 
-   \warning This function may fail when Boost version 1.54 is used,
-   because of the following bug: https://svn.boost.org/trac/boost/ticket/9012
-
    \pre Normals must be unit vectors
    \pre `k >= 2`
 


### PR DESCRIPTION
CGAL as of version 5.6 requires Boost 1.66 or higher so the warning is not valid anymore
