### PR TITLE
CGAL Lab: fix reading of VTK files

### DIFF
--- a/Polyhedron/demo/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/CMakeLists.txt
@@ -179,6 +179,7 @@ if(CGAL_Qt5_FOUND AND Qt5_FOUND)
     Viewer_interface_moc.cpp
     Scene_item_moc.cpp
     Scene_item.cpp
+    Scene_item_with_properties.cpp
     Triangle_container.cpp
     Edge_container.cpp
     Point_container.cpp

--- a/Polyhedron/demo/Polyhedron/Scene_item_with_properties.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_item_with_properties.cpp
@@ -1,0 +1,14 @@
+// Copyright (c) 2023  GeometryFactory Sarl (France)
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Laurent Rineau
+
+#include <CGAL/Three/Scene_item_with_properties.h>
+
+CGAL::Three::Scene_item_with_properties::~Scene_item_with_properties() {}

--- a/Polyhedron/demo/Polyhedron/TextRenderer.cpp
+++ b/Polyhedron/demo/Polyhedron/TextRenderer.cpp
@@ -1,7 +1,6 @@
 #include <CGAL/Three/TextRenderer.h>
 #include <CGAL/Three/Scene_item.h>
 #include <CGAL/Three/Scene_print_item_interface.h>
-#include "Scene_polyhedron_selection_item.h"
 void TextRenderer::draw(CGAL::Three::Viewer_interface *viewer, const QVector3D& scaler)
 {
     QPainter *painter = viewer->getPainter();

--- a/Stream_support/include/CGAL/IO/polygon_soup_io.h
+++ b/Stream_support/include/CGAL/IO/polygon_soup_io.h
@@ -100,7 +100,7 @@ bool read_polygon_soup(const std::string& fname,
   else if(ext == "ts")
     return read_GOCAD(fname, points, polygons, np);
 #ifdef CGAL_USE_VTK
-  else if(ext == "ts")
+  else if(ext == "vtp")
     return read_VTP(fname, points, polygons, np);
 #endif
 

--- a/Three/include/CGAL/Three/Scene_item_with_properties.h
+++ b/Three/include/CGAL/Three/Scene_item_with_properties.h
@@ -13,7 +13,7 @@
 #define SCENE_ITEM_WITH_PROPERTIES_H
 
 #include <CGAL/license/Three.h>
-
+#include <QtGlobal>
 #ifdef demo_framework_EXPORTS
 #  define DEMO_FRAMEWORK_EXPORT Q_DECL_EXPORT
 #else
@@ -30,7 +30,7 @@ namespace Three {
 //! the position of its manipulated frame, ...
 class DEMO_FRAMEWORK_EXPORT Scene_item_with_properties {
 public:
-  virtual ~Scene_item_with_properties(){}
+  virtual ~Scene_item_with_properties();
  //!\brief Copies properties from another Scene_item.
  //!
  //! Override this function to specify what must be copied.


### PR DESCRIPTION
## Summary of Changes

CGAL Lab: fix reading of VTK files

  - fix a memory leak
  - allow to read a polygon soup, in addition to surface meshes
  - fix reading of vtp files

## Release Management

* Affected package(s): CGAL Lab
* License and copyright ownership: unchanged, maintenance by GF
