### PR TITLE
Tetrahedral remeshing - fix internal C3t3

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -537,7 +537,7 @@ private:
     std::cout << "\t vertices = " << nbv << std::endl;
 
     CGAL::Tetrahedral_remeshing::debug::dump_vertices_by_dimension(
-      m_c3t3.triangulation(), "c3t3_vertices_");
+      m_c3t3.triangulation(), "0-c3t3_vertices_");
     CGAL::Tetrahedral_remeshing::debug::check_surface_patch_indices(m_c3t3);
 #endif
   }

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -78,6 +78,34 @@ inline int indices(const int& i, const int& j)
     return -1;
 }
 
+template<typename Tr>
+std::array<typename Tr::Vertex_handle, 2>
+vertices(const typename Tr::Edge& e , const Tr&)
+{
+  return std::array<typename Tr::Vertex_handle, 2>{
+               e.first->vertex(e.second),
+               e.first->vertex(e.third)};
+}
+template<typename Tr>
+std::array<typename Tr::Vertex_handle, 3>
+vertices(const typename Tr::Facet& f, const Tr&)
+{
+  return std::array<typename Tr::Vertex_handle, 3>{
+               f.first->vertex(Tr::vertex_triple_index(f.second, 0)),
+               f.first->vertex(Tr::vertex_triple_index(f.second, 1)),
+               f.first->vertex(Tr::vertex_triple_index(f.second, 2))};
+}
+template<typename Tr>
+std::array<typename Tr::Vertex_handle, 4>
+vertices(const typename Tr::Cell_handle c, const Tr&)
+{
+  return std::array<typename Tr::Vertex_handle, 4>{
+               c->vertex(0),
+               c->vertex(1),
+               c->vertex(2),
+               c->vertex(3)};
+}
+
 template<typename Gt, typename Point>
 typename Gt::FT dihedral_angle(const Point& p,
                                const Point& q,

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -529,6 +529,8 @@ void set_index(typename C3t3::Vertex_handle v, const C3t3& c3t3)
     v->set_index(v->cell()->subdomain_index());
     break;
   case 2:
+    CGAL_assertion(surface_patch_index(v, c3t3)
+                  != typename C3t3::Surface_patch_index());
     v->set_index(surface_patch_index(v, c3t3));
     break;
   case 1:


### PR DESCRIPTION
## Summary of Changes

The internal C3T3 vertices may have badly defined `in_dimension` when the input triangulation/c3t3 has inconsistencies.
This may happen when a vertex is inserted by Mesh_3 on a surface, hence is tagged with dimension 2,
but has not incident facet in the restricted Delaunay.

This PR fixes the consistency of dimensions attached to vertices before starting tetrahedral remeshing.

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged
