### PR TITLE
Polyhedron demo - Use subdomain's color only when meshing from labeled images

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -1035,6 +1035,8 @@ treat_result(Scene_item& source_item,
                             float((bbox.ymin() + bbox.ymax())/2.f),
                             float((bbox.zmin() + bbox.zmax())/2.f));
 
+    bool input_is_labeled_img = dynamic_cast<Scene_image_item*>(&source_item) != nullptr;
+    result_item->setUseSubdomainColors(input_is_labeled_img);
     result_item->setColor(source_item.color());
     result_item->setRenderingMode(source_item.renderingMode());
     result_item->set_data_item(&source_item);

--- a/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_image_item.cpp
@@ -89,7 +89,7 @@ Image_accessor<Word_type>::Image_accessor(const Image& im, int dx, int dy, int d
   }
 
   const double nb_Colors = colors_.size()+1;
-  double i=1;
+  double i=0;
   const double starting_hue = default_color.hueF();
   for ( auto it = colors_.begin(),
        end = colors_.end() ; it != end ; ++it, i += 1.)

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -886,7 +886,7 @@ Scene_triangulation_3_item_priv::compute_color_map(const QColor& c)
   typedef Indices::size_type size_type;
 
   const size_type nb_patch_indices = surface_patch_indices_.size();
-  double i = 0;
+  double i = -1;
   double patch_hsv_value = use_subdomain_colors ? fmod(c.valueF() + .5, 1.) : c.valueF();
   for (Indices::iterator it = surface_patch_indices_.begin(),
        end = surface_patch_indices_.end(); it != end; ++it, i += 1.)
@@ -896,18 +896,18 @@ Scene_triangulation_3_item_priv::compute_color_map(const QColor& c)
     colors[*it] = QColor::fromHsvF(hue, c.saturationF(), patch_hsv_value);
   }
 
+  const size_type nb_domains = subdomain_indices_.size();
+  i = -1;
+  for (Indices::iterator it = subdomain_indices_.begin(),
+         end = subdomain_indices_.end(); it != end; ++it, i += 1.)
+  {
+    double hue = c.hueF() + 1. / double(nb_domains) * i;
+    if (hue > 1) { hue -= 1.; }
+    colors_subdomains[*it] = QColor::fromHsvF(hue, c.saturationF(), c.valueF());
+  }
+
   if (use_subdomain_colors)
   {
-    const size_type nb_domains = subdomain_indices_.size();
-    i = 0;
-    for (Indices::iterator it = subdomain_indices_.begin(),
-           end = subdomain_indices_.end(); it != end; ++it, i += 1.)
-    {
-      double hue = c.hueF() + 1. / double(nb_domains) * i;
-      if (hue > 1) { hue -= 1.; }
-      colors_subdomains[*it] = QColor::fromHsvF(hue, c.saturationF(), c.valueF());
-    }
-
     for (std::unordered_map<int, int>::iterator it = visible_surface_patch_to_subdomain.begin(),
          end = visible_surface_patch_to_subdomain.end(); it != end; ++it)
     {

--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.h
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.h
@@ -43,6 +43,7 @@ public:
 
 
   void setColor(QColor c) Q_DECL_OVERRIDE;
+  void setUseSubdomainColors(bool use_subdomain_colors);
 
   void invalidateOpenGLBuffers() Q_DECL_OVERRIDE;
 


### PR DESCRIPTION
## Summary of Changes

Fixes issue #7799 : Surface_patch_index are not colored anymore.
Now, Surface_patch_index are colored by default.
But when meshing from labelled images, the subdomain colors are used.

## Release Management

* Affected package(s): Polyhedral demo
* Issue(s) solved (if any): fix #7799 
* Feature/Small Feature (if any):
* License and copyright ownership:

