### PR TITLE
STL_extension: Fix Base_with_time_stamp

### DIFF
--- a/STL_Extension/include/CGAL/Base_with_time_stamp.h
+++ b/STL_Extension/include/CGAL/Base_with_time_stamp.h
@@ -22,11 +22,6 @@ class Base_with_time_stamp : public Base {
 public:
   using Base::Base;
 
-  Base_with_time_stamp(const Base_with_time_stamp& other) :
-    Base(other),
-    time_stamp_(other.time_stamp_)
-  {}
-
   typedef CGAL::Tag_true Has_timestamp;
 
   std::size_t time_stamp() const {


### PR DESCRIPTION
## Summary of Changes

Remove the copy constructor of `Base_with_time_stamp`. 
Otherwise we have 'N' in the [Triangulation_2 testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/results-5.5.4-I-169.shtml#Triangulation_2) for CGAL 5.5.

Note that the copy constructor is not in 5.6 and master. 
Note that this only concerns VC++.

## Release Management

* Affected package(s): STL_extension
* License and copyright ownership:  unchanged

