### PR TITLE
Triangulation_3 - add `vertices()` helper functions

### DIFF
--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -1304,6 +1304,26 @@ Finite_vertex_handles finite_vertex_handles() const;
 Points points() const;
 
 /*!
+* returns an array of `Vertex_handle`s containing `v`
+*/
+std::array<Vertex_handle, 1> vertices(const Vertex_handle v) const;
+
+/*!
+* returns an array of `Vertex_handle`s containing the end-vertices of `e`
+*/
+std::array<Vertex_handle, 2> vertices(const Edge& e) const;
+
+/*!
+* returns an array of `Vertex_handle`s containing the vertices of `f`
+*/
+std::array<Vertex_handle, 3> vertices(const Facet& f) const;
+
+/*!
+* returns an array of `Vertex_handle`s containing the vertices of `c`
+*/
+std::array<Vertex_handle, 4> vertices(const Cell_handle c) const;
+
+/*!
   returns a range of iterators over the cells intersected by a line segment
 */
 Segment_traverser_cell_handles segment_traverser_cell_handles() const;

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -76,6 +76,7 @@
 #include <unordered_map>
 #include <utility>
 #include <stack>
+#include <array>
 
 #define CGAL_TRIANGULATION_3_USE_THE_4_POINTS_CONSTRUCTOR
 
@@ -1917,6 +1918,33 @@ public:
   Points points() const
   {
     return Points(points_begin(),points_end());
+  }
+
+  /// Vertex ranges defining a simplex
+  std::array<Vertex_handle, 1> vertices(const Vertex_handle v) const
+  {
+    return std::array<Vertex_handle, 1>{v};
+  }
+  std::array<Vertex_handle, 2> vertices(const Edge& e) const
+  {
+    return std::array<Vertex_handle, 2>{
+             e.first->vertex(e.second),
+             e.first->vertex(e.third)};
+  }
+  std::array<Vertex_handle, 3> vertices(const Facet& f) const
+  {
+    return std::array<Vertex_handle, 3>{
+             f.first->vertex(vertex_triple_index(f.second, 0)),
+             f.first->vertex(vertex_triple_index(f.second, 1)),
+             f.first->vertex(vertex_triple_index(f.second, 2))};
+  }
+  std::array<Vertex_handle, 4> vertices(const Cell_handle c) const
+  {
+    return std::array<Vertex_handle, 4>{
+             c->vertex(0),
+             c->vertex(1),
+             c->vertex(2),
+             c->vertex(3)};
   }
 
   // cells around an edge

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_iterator.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_iterator.h
@@ -268,4 +268,39 @@ _test_triangulation_iterator( const Triangulation &T )
   return(n-m+f-t);
 }
 
+template < class Triangulation >
+void
+_test_vertices_array(const Triangulation& tr)
+{
+  typedef typename Triangulation::Facet           Facet;
+  typedef typename Triangulation::Edge            Edge;
+  typedef typename Triangulation::Vertex_handle   Vertex_handle;
+  typedef typename Triangulation::Cell_handle     Cell_handle;
+
+  for (const Vertex_handle vh : tr.all_vertex_handles())
+  {
+    std::array<Vertex_handle, 1> vv = tr.vertices(vh);
+    assert(vv[0] == vh);
+  }
+  for (const Edge& e : tr.all_edges())
+  {
+    std::array<Vertex_handle, 2> vv = tr.vertices(e);
+    assert(vv[0] != vv[1]);
+  }
+  for (const Facet& f : tr.all_facets())
+  {
+    std::array<Vertex_handle, 3> vv = tr.vertices(f);
+    assert(vv[0] != vv[1]);
+    assert(vv[0] != vv[2]);
+    assert(vv[1] != vv[2]);
+  }
+  for (const Cell_handle c : tr.all_cell_handles())
+  {
+    std::array<Vertex_handle, 4> vv = tr.vertices(c);
+    assert(vv[0] != vv[1] && vv[0] != vv[2] && vv[0] != vv[3]);
+    assert(vv[1] != vv[2] && vv[1] != vv[3]);
+    assert(vv[2] != vv[3]);
+  }
+}
+
 #endif // CGAL_TEST_CLS_ITERATOR_C

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_triangulation_3.h
@@ -1031,23 +1031,31 @@ _test_cls_triangulation_3(const Triangulation &)
   Point p28(1,3,5);
   v0=T0_1.insert(p28);
 
-  std::cout << "    Testing Iterator   "<< std::endl;
+  std::cout << "    Testing Iterators and Ranges   "<< std::endl;
   _test_vertex_iterator(T0_1);
   _test_triangulation_iterator(T0_1);
+  _test_vertices_array(T0_1);
   _test_vertex_iterator(T0);
   _test_triangulation_iterator(T0);
+  _test_vertices_array(T0);
   _test_vertex_iterator(T2_0);
   _test_triangulation_iterator(T2_0);
+  _test_vertices_array(T2_0);
   _test_vertex_iterator(T1_0);
   _test_triangulation_iterator(T1_0);
+  _test_vertices_array(T1_0);
   _test_vertex_iterator(T3_1);
   _test_triangulation_iterator(T3_1);
+  _test_vertices_array(T3_1);
   _test_vertex_iterator(T3_0);
   _test_triangulation_iterator(T3_0);
+  _test_vertices_array(T3_0);
   _test_vertex_iterator(T3_2);
   _test_triangulation_iterator(T3_2);
+  _test_vertices_array(T3_2);
   _test_vertex_iterator(T3_3);
   _test_triangulation_iterator(T3_3);
+  _test_vertices_array(T3_3);
 
   std::cout << "    Testing Circulator  "<< std::endl;
   _test_circulator(T0);


### PR DESCRIPTION
## Summary of Changes

This PR introduces new helper functions in `Triangulation_3`, that returns a `std::array<Vertex_handle, dim_of_the_simplex>` for each type of simplex (vertex, edge, facet, cell).

Iterating over the vertices of a simplex is implemented quite a few times in `Tetrahedral_remeshing` for example, and these helper functions would help the readability of the code (and also avoid mistakes).

## Release Management

* Affected package(s): Triangulation_3
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: unchanged

