### PR TITLE
Apollonius_graph: Make file names unique

### DIFF
--- a/Apollonius_graph_2/test/Apollonius_graph_2/include/test.h
+++ b/Apollonius_graph_2/test/Apollonius_graph_2/include/test.h
@@ -1,20 +1,16 @@
 #ifndef CGAL_APOLLONIUS_GRAPH_2_TEST_H
 #define CGAL_APOLLONIUS_GRAPH_2_TEST_H
 
+#include <CGAL/Apollonius_graph_2.h>
+#include <CGAL/Apollonius_graph_hierarchy_2.h>
+#include <CGAL/Apollonius_graph_traits_2.h>
+#include <CGAL/Apollonius_graph_filtered_traits_2.h>
+
 #include <cassert>
 #include <CGAL/enum.h>
 #include <CGAL/use.h>
 #include <CGAL/Random.h>
 
-#include <CGAL/Vector_2.h> // this is done in order to avoid error
-// when the  Segment_2_Segment_2_intersection.h file is included from
-// the Triangulation_euclidean_traits_2.h file.
-
-#include <CGAL/Apollonius_graph_2.h>
-#include <CGAL/Apollonius_graph_hierarchy_2.h>
-#include <CGAL/Apollonius_graph_traits_2.h>
-#include <CGAL/Apollonius_graph_filtered_traits_2.h>
-//#include <CGAL/new_traits/Apollonius_graph_new_filtered_traits_2.h>
 
 #include "IO/Null_output_stream.h"
 

--- a/Apollonius_graph_2/test/Apollonius_graph_2/include/test.h
+++ b/Apollonius_graph_2/test/Apollonius_graph_2/include/test.h
@@ -4,6 +4,7 @@
 #include <cassert>
 #include <CGAL/enum.h>
 #include <CGAL/use.h>
+#include <CGAL/Random.h>
 
 #include <CGAL/Vector_2.h> // this is done in order to avoid error
 // when the  Segment_2_Segment_2_intersection.h file is included from
@@ -839,24 +840,29 @@ bool test_algo_generic(InputStream& is)
   // file I/O methods
   //--------------------------------------------------------------------
   {
-    std::ofstream ofs("ag_testsuite.tmp");
+    std::string fname  =  "ag_testsuite_" + std::to_string(CGAL::Random().get_seed())  + ".tmp";
+    std::cout << "writing to " << fname << std::endl;
+
+    std::ofstream ofs(fname);
     assert( ofs );
     ag.file_output(ofs);
     ofs.close();
 
-    std::ifstream ifs("ag_testsuite.tmp");
+    std::ifstream ifs(fname);
     assert( ifs );
     ag.file_input(ifs);
     ifs.close();
     assert( ag.is_valid() );
   }
   {
-    std::ofstream ofs("ag_testsuite.tmp");
+    std::string fname = "ag_testsuite_" + std::to_string(CGAL::Random().get_seed()) + ".tmp";
+    std::cout << "writing to " << fname << std::endl;
+    std::ofstream ofs(fname);
     assert( ofs );
     ofs << ag;
     ofs.close();
 
-    std::ifstream ifs("ag_testsuite.tmp");
+    std::ifstream ifs(fname);
     assert( ifs );
     ifs >> ag;
     ifs.close();


### PR DESCRIPTION
## Summary of Changes

Several test programs write and read back to a file with the same name, which may lead to errors when they are executed simultaneously.  This PR makes the  filenames unique.

## Release Management

* Affected package(s): Apollonius_graph
* License and copyright ownership:  unchanged

