### PR TITLE
Mesh 3 - Triangulation IO and Save and load C3t3 features

### DIFF
--- a/Installation/include/CGAL/Mesh_3/Triangulation_3_fwd.h
+++ b/Installation/include/CGAL/Mesh_3/Triangulation_3_fwd.h
@@ -1,0 +1,29 @@
+// Copyright (c) 1999-2003  INRIA Sophia-Antipolis (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Monique Teillaud <Monique.Teillaud@sophia.inria.fr>
+//                 Sylvain Pion
+//                 Clement Jamin
+
+#ifndef CGAL_MESH_3_TRIANGULATION_3_FWD_H
+#define CGAL_MESH_3_TRIANGULATION_3_FWD_H
+
+#include <CGAL/license/Triangulation_3.h>
+
+#include <CGAL/Default.h>
+
+namespace CGAL {
+
+template < class GT, class Tds = Default,
+         class Lock_data_structure = Default >
+class Triangulation_3;
+
+} // end namespace CGAL
+
+#endif // CGAL_MESH_3_TRIANGULATION_3_FWD_H

--- a/Installation/include/CGAL/Mesh_3/Triangulation_3_fwd.h
+++ b/Installation/include/CGAL/Mesh_3/Triangulation_3_fwd.h
@@ -1,15 +1,11 @@
-// Copyright (c) 1999-2003  INRIA Sophia-Antipolis (France).
-// All rights reserved.
+// Copyright (C) 2023  GeometryFactory Sarl
 //
-// This file is part of CGAL (www.cgal.org).
+// This file is part of CGAL (www.cgal.org)
 //
 // $URL$
 // $Id$
-// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
 //
-// Author(s)     : Monique Teillaud <Monique.Teillaud@sophia.inria.fr>
-//                 Sylvain Pion
-//                 Clement Jamin
 
 #ifndef CGAL_MESH_3_TRIANGULATION_3_FWD_H
 #define CGAL_MESH_3_TRIANGULATION_3_FWD_H

--- a/Lab/demo/Lab/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -418,6 +418,9 @@ try_load_a_cdt_3(std::istream& is, C3t3& c3t3)
   }
   std::getline(is, s);
   if(s != "") {
+    if(s[s.size()-1] == '\r') { // deal with Windows EOL
+      s.resize(s.size() - 1);
+    }
     if(s != std::string(" ") + CGAL::Get_io_signature<Fake_CDT_3>()()) {
       std::cerr << "load_binary_file:"
                 << "\n  expected format: " << CGAL::Get_io_signature<Fake_CDT_3>()()
@@ -501,6 +504,9 @@ try_load_other_binary_format(std::istream& is, C3t3& c3t3)
   }
   std::getline(is, s);
   if(s != "") {
+    if(s[s.size()-1] == '\r') { // deal with Windows EOL
+      s.resize(s.size() - 1);
+    }
     if(s != std::string(" ") + CGAL::Get_io_signature<Fake_c3t3>()()) {
       std::cerr << "CGAL_Lab_c3t3_binary_io_plugin::try_load_other_binary_format:"
                 << "\n  expected format: " << CGAL::Get_io_signature<Fake_c3t3>()()

--- a/Lab/demo/Lab/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -418,6 +418,12 @@ try_load_a_cdt_3(std::istream& is, C3t3& c3t3)
   }
   std::getline(is, s);
   if(s != "") {
+    if(s.back() == '\r') { // Windows EOL if the file was written without the ios_base::binary flag.
+      is.setstate(std::ios_base::failbit);
+      std::cerr << "load_binary_file:"
+                << "\n  Unexpected char : '\\r'. The file's content was probably written without the ios_base::binary flag." << std::endl;
+      return false;
+    }
     if(s != std::string(" ") + CGAL::Get_io_signature<Fake_CDT_3>()()) {
       std::cerr << "load_binary_file:"
                 << "\n  expected format: " << CGAL::Get_io_signature<Fake_CDT_3>()()
@@ -501,6 +507,12 @@ try_load_other_binary_format(std::istream& is, C3t3& c3t3)
   }
   std::getline(is, s);
   if(s != "") {
+    if(s.back() == '\r') { // Windows EOL if the file was written without the ios_base::binary flag.
+      is.setstate(std::ios_base::failbit);
+      std::cerr << "Polyhedron_demo_c3t3_binary_io_plugin::try_load_other_binary_format:"
+                << "\n  Unexpected char : '\\r'. The file's content was probably written without the ios_base::binary flag." << std::endl;
+      return false;
+    }
     if(s != std::string(" ") + CGAL::Get_io_signature<Fake_c3t3>()()) {
       std::cerr << "CGAL_Lab_c3t3_binary_io_plugin::try_load_other_binary_format:"
                 << "\n  expected format: " << CGAL::Get_io_signature<Fake_c3t3>()()

--- a/Lab/demo/Lab/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -418,9 +418,6 @@ try_load_a_cdt_3(std::istream& is, C3t3& c3t3)
   }
   std::getline(is, s);
   if(s != "") {
-    if(s[s.size()-1] == '\r') { // deal with Windows EOL
-      s.resize(s.size() - 1);
-    }
     if(s != std::string(" ") + CGAL::Get_io_signature<Fake_CDT_3>()()) {
       std::cerr << "load_binary_file:"
                 << "\n  expected format: " << CGAL::Get_io_signature<Fake_CDT_3>()()
@@ -504,9 +501,6 @@ try_load_other_binary_format(std::istream& is, C3t3& c3t3)
   }
   std::getline(is, s);
   if(s != "") {
-    if(s[s.size()-1] == '\r') { // deal with Windows EOL
-      s.resize(s.size() - 1);
-    }
     if(s != std::string(" ") + CGAL::Get_io_signature<Fake_c3t3>()()) {
       std::cerr << "CGAL_Lab_c3t3_binary_io_plugin::try_load_other_binary_format:"
                 << "\n  expected format: " << CGAL::Get_io_signature<Fake_c3t3>()()

--- a/Lab/demo/Lab/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -429,7 +429,7 @@ try_load_a_cdt_3(std::istream& is, C3t3& c3t3)
     }
   }
   if(binary) CGAL::IO::set_binary_mode(is);
-  if(c3t3.triangulation().file_input<
+  if(c3t3.file_input<
        Fake_CDT_3,
        Update_vertex_from_CDT_3<Fake_CDT_3, C3t3::Triangulation>,
        Update_cell_from_CDT_3>(is))
@@ -516,7 +516,7 @@ try_load_other_binary_format(std::istream& is, C3t3& c3t3)
   }
   if(binary) CGAL::IO::set_binary_mode(is);
   else CGAL::IO::set_ascii_mode(is);
-  std::istream& f_is = c3t3.triangulation().file_input<
+  std::istream& f_is = c3t3.file_input<
                          Fake_c3t3::Triangulation,
                          Update_vertex<Fake_c3t3::Triangulation, C3t3::Triangulation>,
                          Update_cell>(is);

--- a/Mesh_3/examples/Mesh_3/mesh_3D_image_with_input_features.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_image_with_input_features.cpp
@@ -13,8 +13,6 @@
 #include <CGAL/Mesh_domain_with_polyline_features_3.h>
 #include <CGAL/Labeled_mesh_domain_3.h>
 
-#include <CGAL/IO/File_binary_mesh_3.h>
-
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Labeled_mesh_domain_3<K> Image_domain;
 typedef CGAL::Mesh_domain_with_polyline_features_3<Image_domain> Mesh_domain;
@@ -64,84 +62,21 @@ int main(int argc, char* argv[])
   /// [Domain creation]
 
   /// Note that `edge_size` is needed with 1D-features [Mesh criteria]
-  Mesh_criteria criteria(params::edge_size = 6//,
-//    params::facet_angle = 30,
-//    params::facet_size = 6,
-//    params::facet_distance = 4,
-//    params::cell_radius_edge_ratio = 3,
-//    params::cell_size = 8
-    );
+  Mesh_criteria criteria(params::edge_size = 6,
+    params::facet_angle = 30,
+    params::facet_size = 6,
+    params::facet_distance = 4,
+    params::cell_radius_edge_ratio = 3,
+    params::cell_size = 8);
   /// [Mesh criteria]
 
   // Meshing
   C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria);
 
   // Output
-//  std::ofstream medit_file("out.mesh");
-//  CGAL::IO::write_MEDIT(medit_file, c3t3);
-//  medit_file.close();
-//  CGAL::dump_c3t3(c3t3, "out");
-
-  std::cout << "Saving" << std::endl;
-  std::ofstream output_file("out.mesh");
-  CGAL::IO::save_binary_file(output_file, c3t3, /*binary=*/false);
-//  output_file << c3t3;
-  output_file.close();
-  std::cout << "Saved" << std::endl;
-
-  std::cout << "Saving binary" << std::endl;
-  std::ofstream output_bin_file("out_bin.mesh", std::ios_base::binary);
-  CGAL::IO::save_binary_file(output_bin_file, c3t3, /*binary=*/true);
-  output_bin_file.close();
-  std::cout << "Saved" << std::endl;
-
-  std::cout << "Reading" << std::endl;
-  C3t3 readC3t3;
-  std::ifstream read_file("out.mesh", std::ios_base::binary);
-  CGAL::IO::load_binary_file(read_file, readC3t3);
-//  read_file >> readC3t3;
-  read_file.close();
-  std::cout << "Read" << std::endl;
-
-  std::cout << "Saveing the read" << std::endl;
-  std::ofstream output_read_file("out_read.mesh");
-  CGAL::IO::save_binary_file(output_read_file, readC3t3, /*binary=*/false);
-//  output_read_file << readC3t3;
-  output_read_file.close();
-  std::cout << "Saved the read" << std::endl;
-
-  std::cout << "Compare original and read" << std::endl;
-  std::ifstream read_file_wr("out.mesh");
-  std::ifstream read_file_re("out_read.mesh");
-  int line = 0;
-  int col = 0;
-  while (read_file_wr && read_file_re)
-  {
-    char c1;
-    char c2;
-    read_file_wr >> c1;
-    read_file_re >> c2;
-    if (c1 != c2)
-    {
-      std::cout << "Different (" << line << ", " << col << " ): "
-        << c1 << " (" << (int)c1 << ") != "
-        << c2 << " (" << (int)c2 << ")" << std::endl;
-      return EXIT_FAILURE;
-    }
-    if (c1 == '\n') {
-      line++;
-      col = 0;
-    }
-    else {
-      col++;
-    }
-  }
-  if (read_file_wr || read_file_re)
-  {
-    std::cout << "Different : not same length" << std::endl;
-    return EXIT_FAILURE;
-  }
-  std::cout << "All good" << std::endl;
+  std::ofstream medit_file("out.mesh");
+  CGAL::IO::write_MEDIT(medit_file, c3t3);
+  medit_file.close();
 
   return EXIT_SUCCESS;
 }

--- a/Mesh_3/examples/Mesh_3/mesh_3D_image_with_input_features.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_image_with_input_features.cpp
@@ -13,6 +13,8 @@
 #include <CGAL/Mesh_domain_with_polyline_features_3.h>
 #include <CGAL/Labeled_mesh_domain_3.h>
 
+#include <CGAL/IO/File_binary_mesh_3.h>
+
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Labeled_mesh_domain_3<K> Image_domain;
 typedef CGAL::Mesh_domain_with_polyline_features_3<Image_domain> Mesh_domain;
@@ -62,21 +64,84 @@ int main(int argc, char* argv[])
   /// [Domain creation]
 
   /// Note that `edge_size` is needed with 1D-features [Mesh criteria]
-  Mesh_criteria criteria(params::edge_size = 6,
-    params::facet_angle = 30,
-    params::facet_size = 6,
-    params::facet_distance = 4,
-    params::cell_radius_edge_ratio = 3,
-    params::cell_size = 8);
+  Mesh_criteria criteria(params::edge_size = 6//,
+//    params::facet_angle = 30,
+//    params::facet_size = 6,
+//    params::facet_distance = 4,
+//    params::cell_radius_edge_ratio = 3,
+//    params::cell_size = 8
+    );
   /// [Mesh criteria]
 
   // Meshing
   C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria);
 
   // Output
-  std::ofstream medit_file("out.mesh");
-  CGAL::IO::write_MEDIT(medit_file, c3t3);
-  medit_file.close();
+//  std::ofstream medit_file("out.mesh");
+//  CGAL::IO::write_MEDIT(medit_file, c3t3);
+//  medit_file.close();
+//  CGAL::dump_c3t3(c3t3, "out");
+
+  std::cout << "Saving" << std::endl;
+  std::ofstream output_file("out.mesh");
+  CGAL::IO::save_binary_file(output_file, c3t3, /*binary=*/false);
+//  output_file << c3t3;
+  output_file.close();
+  std::cout << "Saved" << std::endl;
+
+  std::cout << "Saving binary" << std::endl;
+  std::ofstream output_bin_file("out_bin.mesh", std::ios_base::binary);
+  CGAL::IO::save_binary_file(output_bin_file, c3t3, /*binary=*/true);
+  output_bin_file.close();
+  std::cout << "Saved" << std::endl;
+
+  std::cout << "Reading" << std::endl;
+  C3t3 readC3t3;
+  std::ifstream read_file("out.mesh", std::ios_base::binary);
+  CGAL::IO::load_binary_file(read_file, readC3t3);
+//  read_file >> readC3t3;
+  read_file.close();
+  std::cout << "Read" << std::endl;
+
+  std::cout << "Saveing the read" << std::endl;
+  std::ofstream output_read_file("out_read.mesh");
+  CGAL::IO::save_binary_file(output_read_file, readC3t3, /*binary=*/false);
+//  output_read_file << readC3t3;
+  output_read_file.close();
+  std::cout << "Saved the read" << std::endl;
+
+  std::cout << "Compare original and read" << std::endl;
+  std::ifstream read_file_wr("out.mesh");
+  std::ifstream read_file_re("out_read.mesh");
+  int line = 0;
+  int col = 0;
+  while (read_file_wr && read_file_re)
+  {
+    char c1;
+    char c2;
+    read_file_wr >> c1;
+    read_file_re >> c2;
+    if (c1 != c2)
+    {
+      std::cout << "Different (" << line << ", " << col << " ): "
+        << c1 << " (" << (int)c1 << ") != "
+        << c2 << " (" << (int)c2 << ")" << std::endl;
+      return EXIT_FAILURE;
+    }
+    if (c1 == '\n') {
+      line++;
+      col = 0;
+    }
+    else {
+      col++;
+    }
+  }
+  if (read_file_wr || read_file_re)
+  {
+    std::cout << "Different : not same length" << std::endl;
+    return EXIT_FAILURE;
+  }
+  std::cout << "All good" << std::endl;
 
   return EXIT_SUCCESS;
 }

--- a/SMDS_3/include/CGAL/IO/File_binary_mesh_3.h
+++ b/SMDS_3/include/CGAL/IO/File_binary_mesh_3.h
@@ -86,8 +86,11 @@ bool load_binary_file(std::istream& is, C3T3& c3t3)
   }
   std::getline(is, s);
   if(!s.empty()) {
-    if(s[s.size()-1] == '\r') { // deal with Windows EOL
-      s.resize(s.size() - 1);
+    if(s.back() == '\r') { // Windows EOL if the file was written without the ios_base::binary flag.
+      is.setstate(std::ios_base::failbit);
+      std::cerr << "load_binary_file:"
+                << "\n  Unexpected char : '\\r'. The file's content was probably written without the ios_base::binary flag." << std::endl;
+      return false;
     }
     if(s != std::string(" ") + CGAL::Get_io_signature<C3T3>()()) {
       std::cerr << "load_binary_file:"

--- a/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -1222,6 +1222,12 @@ public:
   std::istream& operator>>(std::istream& is,
     Mesh_complex_3_in_triangulation_3<Tr2, CoI, CuI>& c3t3);
 
+  template <typename Tr2, typename CoI, typename CuI>
+  friend
+  std::ostream & operator<<(std::ostream& os,
+    const Mesh_complex_3_in_triangulation_3<Tr2, CoI, CuI> &c3t3);
+
+
   static std::string io_signature()
   {
     return Get_io_signature<Tr>()();
@@ -2095,8 +2101,69 @@ std::ostream &
 operator<< (std::ostream& os,
             const Mesh_complex_3_in_triangulation_3<Tr,CI_,CSI_> &c3t3)
 {
-  // TODO: implement edge saving
-  return os << c3t3.triangulation();
+  /* Writes:
+   * [Triangulation]
+   *   [Header]
+   *     - the dimension
+   *   [Vertices]
+   *     - the number of finite vertices
+   *     - the non combinatorial information on vertices (point, etc)
+   *   [Cells]
+   *     - the number of cells
+   *     - the cells by the indices of their vertices in the preceding list
+   *       of vertices, plus the non combinatorial information on each cell
+   *   [Cells combinatorial information]
+   *     - the neighbors of each cell by their index in the preceding list of cells
+   *   [Cells other info]
+   *     - when dimension < 3 : the same with faces of maximal dimension
+   * [1D features]
+   *   - the number of edges
+   *   - the edges by the indices of their vertices and their curve_index
+   */
+  using C3t3          = Mesh_complex_3_in_triangulation_3<Tr,CI_,CSI_>;
+  using Vertex_handle = typename C3t3::Vertex_handle;
+  using Curve_index   = typename C3t3::Curve_index;
+
+  // Writes triangulation
+  Unique_hash_map<Vertex_handle, std::size_t> vertices_map;
+  if (!CGAL::IO::export_triangulation_3(os, c3t3.triangulation(), vertices_map))
+  {
+    os.setstate(std::ios_base::failbit);
+    return os;
+  }
+
+  // Writes 1D features
+  std::size_t nEdges = c3t3.edges_.size();
+  if(IO::is_ascii(os))
+  {
+    os << nEdges << '\n';
+  }
+  else
+  {
+    write(os, nEdges);
+  }
+
+  if (!os)
+    return os;
+
+  for ( typename C3t3::Edge_map::const_iterator it = c3t3.edges_.begin(),
+       end = c3t3.edges_.end() ; it != end ; ++it )
+  {
+    const Vertex_handle& v1  = it->left;
+    const Vertex_handle& v2  = it->right;
+    const std::size_t& iv1   = vertices_map[v1];
+    const std::size_t& iv2   = vertices_map[v2];
+    const Curve_index& index = it->info;
+    if (IO::is_ascii(os))
+      os << iv1 << ' ' << iv2 << ' ' << index << '\n';
+    else {
+      write(os, iv1);
+      write(os, iv2);
+      write(os, index);
+    }
+  }
+
+  return os;
 }
 
 
@@ -2105,13 +2172,70 @@ std::istream &
 operator>> (std::istream& is,
             Mesh_complex_3_in_triangulation_3<Tr,CI_,CSI_> &c3t3)
 {
-  // TODO: implement edge loading
-  c3t3.clear();
-  is >> c3t3.triangulation();
+  /* Reads:
+   * [Triangulation]
+   *   [Header]
+   *     - the dimension
+   *   [Vertices]
+   *     - the number of finite vertices
+   *     - the non combinatorial information on vertices (point, etc)
+   *   [Cells]
+   *     - the number of cells
+   *     - the cells by the indices of their vertices in the preceding list
+   *       of vertices, plus the non combinatorial information on each cell
+   *   [Cells combinatorial information]
+   *     - the neighbors of each cell by their index in the preceding list of cells
+   *   [Cells other info]
+   *     - when dimension < 3 : the same with faces of maximal dimension
+   * [1D features]
+   *   - the number of edges
+   *   - the edges by the indices of their vertices and their curve_index
+   */
+  using C3t3          = Mesh_complex_3_in_triangulation_3<Tr,CI_,CSI_>;
+  using Vertex_handle = typename C3t3::Vertex_handle;
+  using Curve_index   = typename C3t3::Curve_index;
+  using Internal_edge = typename C3t3::Internal_edge;
 
-  if (!is) {
+  c3t3.clear();
+
+  // Reads triangulation
+  std::vector< Vertex_handle > vertices_handles;
+  if (!CGAL::IO::import_triangulation_3(is, c3t3.triangulation(), vertices_handles))
+  {
     c3t3.clear();
+    is.setstate(std::ios_base::failbit);
     return is;
+  }
+
+  // Reads 1D features
+  std::size_t nEdges;
+  if(IO::is_ascii(is))
+  {
+    is >> nEdges;
+  }
+  else
+  {
+    read(is, nEdges);
+  }
+  // If the file did not have edges
+  if (!is) {
+    return is;
+  }
+
+  for (std::size_t i = 0; i < nEdges; i++)
+  {
+    std::size_t iv1;
+    std::size_t iv2;
+    Curve_index index;
+    if (IO::is_ascii(is))
+      is >> iv1 >> iv2 >> index;
+    else {
+      read(is, iv1);
+      read(is, iv2);
+      read(is, index);
+    }
+    Internal_edge edge(vertices_handles[iv1], vertices_handles[iv2]);
+    c3t3.add_to_complex(edge, index);
   }
 
   c3t3.rescan_after_load_of_triangulation();

--- a/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -2293,7 +2293,6 @@ operator>> (std::istream& is,
   {
     is.clear();
     c3t3.edges_.clear();
-    return is;
   }
 
   c3t3.rescan_after_load_of_triangulation();

--- a/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -1233,6 +1233,79 @@ public:
     return Get_io_signature<Tr>()();
   }
 
+  std::istream& read_edges(std::istream& is, const std::vector< Vertex_handle >& vertices_handles)
+  {
+    // Reads 1D features
+    std::size_t nEdges;
+    if(IO::is_ascii(is))
+    {
+      is >> nEdges;
+    }
+    else
+    {
+      read(is, nEdges);
+    }
+    // If the file did not have edges
+    if (!is) {
+      return is;
+    }
+
+    for (std::size_t i = 0; i < nEdges; i++)
+    {
+      std::size_t iv1;
+      std::size_t iv2;
+      Curve_index index;
+      if (IO::is_ascii(is))
+        is >> iv1 >> iv2 >> index;
+      else {
+        read(is, iv1);
+        read(is, iv2);
+        read(is, index);
+      }
+      Internal_edge edge(vertices_handles[iv1], vertices_handles[iv2]);
+      add_to_complex(edge, index);
+    }
+    return is;
+  }
+
+  template <typename Tr_src,
+            typename ConvertVertex,
+            typename ConvertCell>
+  std::istream& file_input(std::istream& is,
+                           ConvertVertex convert_vertex = ConvertVertex(),
+                           ConvertCell convert_cell = ConvertCell())
+  {
+    // Reads:
+    // - the dimension
+    // - the number of finite vertices
+    // - the non combinatorial information on vertices (point, etc)
+    // - the number of cells
+    // - the cells by the indices of their vertices in the preceding list
+    //   of vertices, plus the non combinatorial information on each cell
+    // - the neighbors of each cell by their index in the preceding list of cells
+    // - when dimension < 3 : the same with faces of maximal dimension
+    // - the number of edges
+    // - the edges by the indices of their vertices and their curve_index
+
+    // If this is used for a TDS, the vertices are processed from 0 to n.
+    // Else, we make V[0] the infinite vertex and work from 1 to n+1.
+
+    // Reads triangulation
+    std::vector< Vertex_handle > vertices_handles;
+    if (!tr_.template file_input<Tr_src, ConvertVertex, ConvertCell>
+                                (is, vertices_handles, convert_vertex, convert_cell))
+    {
+      clear();
+      is.setstate(std::ios_base::failbit);
+      return is;
+    }
+
+    // Reads 1D Features
+    read_edges(is, vertices_handles);
+
+    return is;
+  }
+
   /**
    * @cond SKIP_IN_MANUAL
    * creates an `Internal_edge` object (i.e a pair of ordered `Vertex_handle`)
@@ -2207,36 +2280,9 @@ operator>> (std::istream& is,
     return is;
   }
 
-  // Reads 1D features
-  std::size_t nEdges;
-  if(IO::is_ascii(is))
-  {
-    is >> nEdges;
-  }
-  else
-  {
-    read(is, nEdges);
-  }
-  // If the file did not have edges
-  if (!is) {
+  c3t3.read_edges(is, vertices_handles);
+  if (!is)
     return is;
-  }
-
-  for (std::size_t i = 0; i < nEdges; i++)
-  {
-    std::size_t iv1;
-    std::size_t iv2;
-    Curve_index index;
-    if (IO::is_ascii(is))
-      is >> iv1 >> iv2 >> index;
-    else {
-      read(is, iv1);
-      read(is, iv2);
-      read(is, index);
-    }
-    Internal_edge edge(vertices_handles[iv1], vertices_handles[iv2]);
-    c3t3.add_to_complex(edge, index);
-  }
 
   c3t3.rescan_after_load_of_triangulation();
   return is;

--- a/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -1302,6 +1302,14 @@ public:
 
     // Reads 1D Features
     read_edges(is, vertices_handles);
+    // To keep compatibility with previous files,
+    // the istream errors should be cleared and the progress reversed
+    if (!is)
+    {
+      is.clear();
+      edges_.clear();
+      return is;
+    }
 
     return is;
   }
@@ -2266,8 +2274,6 @@ operator>> (std::istream& is,
    */
   using C3t3          = Mesh_complex_3_in_triangulation_3<Tr,CI_,CSI_>;
   using Vertex_handle = typename C3t3::Vertex_handle;
-  using Curve_index   = typename C3t3::Curve_index;
-  using Internal_edge = typename C3t3::Internal_edge;
 
   c3t3.clear();
 
@@ -2281,8 +2287,14 @@ operator>> (std::istream& is,
   }
 
   c3t3.read_edges(is, vertices_handles);
+  // To keep compatibility with previous files,
+  // the istream errors should be cleared and the progress reversed
   if (!is)
+  {
+    is.clear();
+    c3t3.edges_.clear();
     return is;
+  }
 
   c3t3.rescan_after_load_of_triangulation();
   return is;

--- a/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
+++ b/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
@@ -10,7 +10,6 @@
 // Author(s)     : Monique Teillaud <Monique.Teillaud@sophia.inria.fr>
 //                 Sylvain Pion
 //                 Clement Jamin
-//                 Ange Clement
 
 
 #ifndef CGAL_IO_TRIANGULATION_RAW_IOSTREAM_3_H
@@ -31,12 +30,13 @@ namespace IO {
 
 namespace internal {
 
-template < class GT, class Tds, class Lds >
-bool construct_vertices_map(const Triangulation_3<GT, Tds, Lds>& tr, Unique_hash_map<typename Tds::Vertex_handle, std::size_t>& vertices_map)
+template < class GT, class Tds_, class Lds_ >
+bool construct_vertices_map(const Triangulation_3<GT, Tds_, Lds_>& tr,
+                            Unique_hash_map<typename Triangulation_3<GT, Tds_>::Vertex_handle, std::size_t>& vertices_map)
 {
-  typedef Triangulation_3<GT, Tds>                 Triangulation;
-  typedef typename Triangulation::size_type        size_type;
-  typedef typename Triangulation::Vertex_iterator  Vertex_iterator;
+  typedef Triangulation_3<GT, Tds_>               Triangulation;
+  typedef typename Triangulation::size_type       size_type;
+  typedef typename Triangulation::Vertex_iterator Vertex_iterator;
 
   size_type i = 0;
   vertices_map[tr.infinite_vertex()] = 0;
@@ -50,8 +50,8 @@ bool construct_vertices_map(const Triangulation_3<GT, Tds, Lds>& tr, Unique_hash
   return true;
 }
 
-template < class GT, class Tds, class Lds >
-bool write_header(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr)
+template < class GT, class Tds_, class Lds_ >
+bool write_header(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr)
 {
   // Writes:
   // - the dimension
@@ -66,8 +66,8 @@ bool write_header(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr)
   return (bool)os;
 }
 
-template < class GT, class Tds, class Lds >
-bool read_header(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr)
+template < class GT, class Tds_, class Lds_ >
+bool read_header(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr)
 {
   // Reads:
   // - the dimension
@@ -86,19 +86,17 @@ bool read_header(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr)
   return (bool)is;
 }
 
-template < class GT, class Tds, class Lds >
-bool write_vertices(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr)
+template < class GT, class Tds_, class Lds_ >
+bool write_vertices(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr)
 {
   // Writes:
   // - the number of finite vertices
   // - the non combinatorial information on vertices (point, etc)
-  typedef Triangulation_3<GT, Tds>                 Triangulation;
-  typedef typename Triangulation::size_type        size_type;
-  typedef typename Triangulation::Vertex_iterator  Vertex_iterator;
+  typedef Triangulation_3<GT, Tds_>               Triangulation;
+  typedef typename Triangulation::size_type       size_type;
+  typedef typename Triangulation::Vertex_iterator Vertex_iterator;
 
   size_type n = tr.number_of_vertices();
-  if (n == 0)
-    return false;
 
   if(IO::is_ascii(os))
   {
@@ -108,6 +106,9 @@ bool write_vertices(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr)
   {
     write(os, n);
   }
+
+  if (n == 0)
+    return false;
 
   for(Vertex_iterator it = ++tr.vertices_begin(), end = tr.vertices_end(); it != end; ++it)
   {
@@ -119,19 +120,20 @@ bool write_vertices(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr)
   return (bool)os;
 }
 
-template < class GT, class Tds, class Lds,
-           typename Tr_src = Triangulation_3<GT, Tds, Lds>,
+template < class GT, class Tds_, class Lds_,
+           typename Tr_src = Triangulation_3<GT, Tds_, Lds_>,
            typename ConvertVertex = Nullptr_t >
 struct read_vertices_functor
 {
-  bool operator()(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, std::vector< typename Tds::Vertex_handle >& vertices_handles,
-                  typename Triangulation_3<GT, Tds>::size_type n,
+  bool operator()(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
+                  std::vector< typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
+                  typename Triangulation_3<GT, Tds_>::size_type n,
                   ConvertVertex convert_vertex = ConvertVertex())
   {
     // Reads:
     // - the non combinatorial information on vertices (point, etc)
     // The vertices are read with the type Tr_src::Vertex
-    // and converted to type Triangulation_3<GT, Tds, Lds>::Vertex
+    // and converted to type Triangulation_3<GT, Tds_, Lds_>::Vertex
     // using the ConvertVertex convertor.
     typedef typename Tr_src::Vertex Vertex1;
 
@@ -148,11 +150,12 @@ struct read_vertices_functor
   }
 };
 
-template < class GT, class Tds, class Lds, class Tr_src >
-struct read_vertices_functor < GT, Tds, Lds, Tr_src, Nullptr_t >
+template < class GT, class Tds_, class Lds_, class Tr_src >
+struct read_vertices_functor < GT, Tds_, Lds_, Tr_src, Nullptr_t >
 {
-  bool operator()(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, std::vector< typename Tds::Vertex_handle >& vertices_handles,
-                  typename Triangulation_3<GT, Tds>::size_type n,
+  bool operator()(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
+                  std::vector< typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
+                  typename Triangulation_3<GT, Tds_>::size_type n,
                   Nullptr_t _ = Nullptr_t())
   {
     // Reads:
@@ -168,17 +171,18 @@ struct read_vertices_functor < GT, Tds, Lds, Tr_src, Nullptr_t >
 };
 
 
-template < class GT, class Tds, class Lds,
-           typename Tr_src = Triangulation_3<GT, Tds, Lds>,
+template < class GT, class Tds_, class Lds_,
+           typename Tr_src = Triangulation_3<GT, Tds_, Lds_>,
            typename ConvertVertex = Nullptr_t >
-bool read_vertices(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, std::vector< typename Tds::Vertex_handle >& vertices_handles,
+bool read_vertices(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
+                   std::vector< typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
                    ConvertVertex convert_vertex = ConvertVertex())
 {
   // Reads:
   // - the number of finite vertices
   // - the non combinatorial information on vertices (point, etc)
-  typedef Triangulation_3<GT, Tds>                 Triangulation;
-  typedef typename Triangulation::size_type        size_type;
+  typedef Triangulation_3<GT, Tds_>         Triangulation;
+  typedef typename Triangulation::size_type size_type;
 
   size_type n;
   if(IO::is_ascii(is))
@@ -195,7 +199,7 @@ bool read_vertices(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, std::vec
   vertices_handles.resize(n+1);
   vertices_handles[0] = tr.infinite_vertex(); // the infinite vertex is numbered 0
 
-  if (!read_vertices_functor<GT, Tds, Lds, Tr_src, ConvertVertex>()(is, tr, vertices_handles, n, convert_vertex))
+  if (!read_vertices_functor<GT, Tds_, Lds_, Tr_src, ConvertVertex>()(is, tr, vertices_handles, n, convert_vertex))
     return false;
 
   return (bool)is;
@@ -234,11 +238,12 @@ bool write_cell_info(std::ostream& os, Iterator start, const Iterator& end)
   return (bool)os;
 }
 
-template < class GT, class Tds, class Lds >
-bool write_cells(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr, const Unique_hash_map<typename Tds::Vertex_handle, std::size_t>& vertices_map)
+template < class GT, class Tds_, class Lds_ >
+bool write_cells(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr,
+                 const Unique_hash_map<typename Triangulation_3<GT, Tds_>::Vertex_handle, std::size_t>& vertices_map)
 {
   // Writes:
-  // [Call to Tds::print_cells]
+  // [Call to Tds_::print_cells]
   // - the number of cells
   // - the cells by the indices of their vertices in the preceding list
   //   of vertices, plus the non combinatorial information on each cell
@@ -246,10 +251,10 @@ bool write_cells(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr, cons
   // [Cells other info]
   // - when dimension < 3 : the same with faces of maximal dimension
 
-  typedef Triangulation_3<GT, Tds>                 Triangulation;
-  typedef typename Triangulation::Cell_iterator    Cell_iterator;
-  typedef typename Triangulation::Edge_iterator    Edge_iterator;
-  typedef typename Triangulation::Facet_iterator   Facet_iterator;
+  typedef Triangulation_3<GT, Tds_>              Triangulation;
+  typedef typename Triangulation::Cell_iterator  Cell_iterator;
+  typedef typename Triangulation::Edge_iterator  Edge_iterator;
+  typedef typename Triangulation::Facet_iterator Facet_iterator;
 
   tr.tds().print_cells(os, vertices_map);
   if (!os)
@@ -281,20 +286,21 @@ bool write_cells(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr, cons
 }
 
 
-template < class GT, class Tds, class Lds,
-           typename Tr_src = Triangulation_3<GT, Tds, Lds>,
+template < class GT, class Tds_, class Lds_,
+           typename Tr_src = Triangulation_3<GT, Tds_, Lds_>,
            typename ConvertCell = Nullptr_t >
 struct read_cells_functor
 {
-  bool operator()(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, const std::vector< typename Tds::Vertex_handle >& vertices_handles,
-                  typename Triangulation_3<GT, Tds>::size_type m, std::vector< typename Triangulation_3<GT, Tds>::Cell_handle >& C,
+  bool operator()(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
+                  const std::vector< typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
+                  typename Triangulation_3<GT, Tds_>::size_type m, std::vector< typename Triangulation_3<GT, Tds_>::Cell_handle >& C,
                   ConvertCell convert_cell = ConvertCell())
   {
     // Reads:
     // [Cells other info]
     // - when dimension < 3 : the same with faces of maximal dimension
     // The cell are read with the type Tr_src::Cell
-    // and converted to type Triangulation_3<GT, Tds, Lds>::Cell
+    // and converted to type Triangulation_3<GT, Tds_, Lds_>::Cell
     // using the ConvertCell convertor.
 
     typedef typename Tr_src::Cell Cell1;
@@ -311,11 +317,12 @@ struct read_cells_functor
   }
 };
 
-template < class GT, class Tds, class Lds, class Tr_src >
-struct read_cells_functor < GT, Tds, Lds, Tr_src, Nullptr_t >
+template < class GT, class Tds_, class Lds_, class Tr_src >
+struct read_cells_functor < GT, Tds_, Lds_, Tr_src, Nullptr_t >
 {
-  bool operator()(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, const std::vector< typename Tds::Vertex_handle >& vertices_handles,
-                  typename Triangulation_3<GT, Tds>::size_type m, std::vector< typename Triangulation_3<GT, Tds>::Cell_handle >& C,
+  bool operator()(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
+                  const std::vector< typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
+                  typename Triangulation_3<GT, Tds_>::size_type m, std::vector< typename Triangulation_3<GT, Tds_>::Cell_handle >& C,
                   Nullptr_t _ = Nullptr_t())
   {
     // Reads:
@@ -330,14 +337,15 @@ struct read_cells_functor < GT, Tds, Lds, Tr_src, Nullptr_t >
   }
 };
 
-template < class GT, class Tds, class Lds,
-           typename Tr_src = Triangulation_3<GT, Tds, Lds>,
+template < class GT, class Tds_, class Lds_,
+           typename Tr_src = Triangulation_3<GT, Tds_, Lds_>,
            typename ConvertCell = Nullptr_t >
-bool read_cells(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, const std::vector< typename Tds::Vertex_handle >& vertices_handles,
+bool read_cells(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
+                const std::vector< typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
                 ConvertCell convert_cell = ConvertCell())
 {
   // Reads:
-  // [Call to Tds::read_cells]
+  // [Call to Tds_::read_cells]
   // - the number of cells
   // - the cells by the indices of their vertices in the preceding list
   //   of vertices, plus the non combinatorial information on each cell
@@ -345,7 +353,7 @@ bool read_cells(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, const std::
   // [Cells other info]
   // - when dimension < 3 : the same with faces of maximal dimension
 
-  typedef Triangulation_3<GT, Tds>                 Triangulation;
+  typedef Triangulation_3<GT, Tds_>                 Triangulation;
   typedef typename Triangulation::Cell_handle      Cell_handle;
 
   std::vector< Cell_handle > C;
@@ -355,7 +363,7 @@ bool read_cells(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, const std::
   if(!is)
     return false;
 
-  if (!read_cells_functor<GT, Tds, Lds, Tr_src, ConvertCell>()(is, tr, vertices_handles, m, C, convert_cell))
+  if (!read_cells_functor<GT, Tds_, Lds_, Tr_src, ConvertCell>()(is, tr, vertices_handles, m, C, convert_cell))
     return false;
 
   return (bool)is;
@@ -364,8 +372,9 @@ bool read_cells(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, const std::
 } // end namespace internal
 
 
-template < class GT, class Tds, class Lds >
-bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr, Unique_hash_map<typename Tds::Vertex_handle, std::size_t>& vertices_map)
+template < class GT, class Tds_, class Lds_ >
+bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr,
+                            Unique_hash_map<typename Triangulation_3<GT, Tds_>::Vertex_handle, std::size_t>& vertices_map)
 {
   // Writes:
   // [Header]
@@ -388,19 +397,20 @@ bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds, Lds
       && internal::write_cells(os, tr, vertices_map);
 }
 
-template < class GT, class Tds, class Lds >
-bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr)
+template < class GT, class Tds_, class Lds_ >
+bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr)
 {
-  Unique_hash_map<typename Tds::Vertex_handle, std::size_t> vertices_map;
+  Unique_hash_map<typename Triangulation_3<GT, Tds_>::Vertex_handle, std::size_t> vertices_map;
   return export_triangulation_3(os, tr, vertices_map);
 }
 
 
-template < class GT, class Tds, class Lds,
-           typename Tr_src = Triangulation_3<GT, Tds, Lds>,
+template < class GT, class Tds_, class Lds_,
+           typename Tr_src = Triangulation_3<GT, Tds_, Lds_>,
            typename ConvertVertex = Nullptr_t,
            typename ConvertCell = Nullptr_t >
-bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, std::vector<typename Tds::Vertex_handle >& vertices_handles,
+bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
+                            std::vector<typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
                             ConvertVertex convert_vertex = ConvertVertex(),
                             ConvertCell convert_cell = ConvertCell())
 {
@@ -423,25 +433,25 @@ bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr,
   tr.set_infinite_vertex(tr.tds().create_vertex());
 
   bool result = internal::read_header(is, tr)
-             && internal::read_vertices<GT, Tds, Lds, Tr_src, ConvertVertex>
+             && internal::read_vertices<GT, Tds_, Lds_, Tr_src, ConvertVertex>
                                        (is, tr, vertices_handles, convert_vertex)
-             && internal::read_cells<GT, Tds, Lds, Tr_src, ConvertCell>
+             && internal::read_cells<GT, Tds_, Lds_, Tr_src, ConvertCell>
                                     (is, tr, vertices_handles, convert_cell);
 
   CGAL_assertion(result && tr.is_valid(true));
   return result;
 }
 
-template < class GT, class Tds, class Lds,
-           typename Tr_src = Triangulation_3<GT, Tds, Lds>,
+template < class GT, class Tds_, class Lds_,
+           typename Tr_src = Triangulation_3<GT, Tds_, Lds_>,
            typename ConvertVertex = Nullptr_t,
            typename ConvertCell = Nullptr_t >
-bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr,
+bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
                             ConvertVertex convert_vertex = ConvertVertex(),
                             ConvertCell convert_cell = ConvertCell())
 {
-  std::vector<typename Tds::Vertex_handle > vertices_handles;
-  return import_triangulation_3<GT, Tds, Lds, Tr_src, ConvertVertex, ConvertCell>
+  std::vector<typename Triangulation_3<GT, Tds_>::Vertex_handle > vertices_handles;
+  return import_triangulation_3<GT, Tds_, Lds_, Tr_src, ConvertVertex, ConvertCell>
                                (is, tr, vertices_handles, convert_vertex, convert_cell);
 }
 

--- a/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
+++ b/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
@@ -1,0 +1,332 @@
+#ifndef CGAL_TRIANGULATION_RAW_IOSTREAM_3_H
+#define CGAL_TRIANGULATION_RAW_IOSTREAM_3_H
+
+#include <iostream>
+#include <vector>
+
+#include <CGAL/Unique_hash_map.h>
+#include <CGAL/Default.h>
+#include <CGAL/IO/io.h>
+
+namespace CGAL {
+
+template < class GT, class Tds = Default,
+         class Lock_data_structure = Default >
+class Triangulation_3;
+
+namespace IO {
+
+namespace internal {
+
+template < class GT, class Tds, class Lds >
+bool construct_vertices_map(const Triangulation_3<GT, Tds, Lds>& tr, Unique_hash_map<typename Tds::Vertex_handle, std::size_t>& vertices_map)
+{
+  typedef Triangulation_3<GT, Tds>                 Triangulation;
+  typedef typename Triangulation::size_type        size_type;
+  typedef typename Triangulation::Vertex_iterator  Vertex_iterator;
+
+  size_type i = 0;
+  vertices_map[tr.infinite_vertex()] = 0;
+  for(Vertex_iterator it = tr.vertices_begin(), end = tr.vertices_end(); it != end; ++it)
+  {
+    vertices_map[it] = i++;
+  }
+
+  CGAL_assertion(i == tr.number_of_vertices()+1);
+
+  return true;
+}
+
+template < class GT, class Tds, class Lds >
+bool write_header(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr)
+{
+  // Writes:
+  // - the dimension
+  if(IO::is_ascii(os))
+  {
+    os << tr.dimension() << "\n";
+  }
+  else
+  {
+    write(os, tr.dimension());
+  }
+  return (bool)os;
+}
+
+template < class GT, class Tds, class Lds >
+bool read_header(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr)
+{
+  // Reads:
+  // - the dimension
+  int dimension;
+  if(IO::is_ascii(is))
+  {
+    is >> dimension;
+  }
+  else
+  {
+    read(is, dimension);
+  }
+  if(dimension > 3 || dimension < -2)
+    return false;
+  tr.tds().set_dimension(dimension);
+  return (bool)is;
+}
+
+template < class GT, class Tds, class Lds >
+bool write_vertices(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr)
+{
+  // Writes:
+  // - the number of finite vertices
+  // - the non combinatorial information on vertices (point, etc)
+  typedef Triangulation_3<GT, Tds>                 Triangulation;
+  typedef typename Triangulation::size_type        size_type;
+  typedef typename Triangulation::Vertex_iterator  Vertex_iterator;
+
+  size_type n = tr.number_of_vertices();
+  if (n == 0)
+    return false;
+
+  if(IO::is_ascii(os))
+  {
+    os << n << '\n';
+  }
+  else
+  {
+    write(os, n);
+  }
+
+  for(Vertex_iterator it = ++tr.vertices_begin(), end = tr.vertices_end(); it != end; ++it)
+  {
+    os << *it;
+    if(IO::is_ascii(os))
+      os << '\n';
+  }
+
+  return (bool)os;
+}
+
+template < class GT, class Tds, class Lds >
+bool read_vertices(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, std::vector< typename Tds::Vertex_handle >& vertices_handles)
+{
+  // Reads:
+  // - the number of finite vertices
+  // - the non combinatorial information on vertices (point, etc)
+  typedef Triangulation_3<GT, Tds>                 Triangulation;
+  typedef typename Triangulation::size_type        size_type;
+
+  size_type n;
+  if(IO::is_ascii(is))
+  {
+    is >> n;
+  }
+  else
+  {
+    read(is, n);
+  }
+  if((n+1) > vertices_handles.max_size())
+    return false;
+
+  vertices_handles.resize(n+1);
+  vertices_handles[0] = tr.infinite_vertex(); // the infinite vertex is numbered 0
+
+  std::cout << tr.dimension() << " " << n << std::endl;
+  for(std::size_t i=1; i <= n; i++)
+  {
+    vertices_handles[i] = tr.tds().create_vertex();
+    if(!(is >> *vertices_handles[i]))
+      return false;
+    std::cout << i << " : " << vertices_handles[i]->in_dimension() << " " << vertices_handles[i]->point().x() << std::endl;
+  }
+  std::cout << tr.dimension() << " " << n << std::endl;
+
+  return (bool)is;
+}
+
+struct Cell_accessor
+{
+  template <class Iterator>
+  auto operator()(const Iterator& it) { return it; }
+};
+
+struct Cell_accessor_first
+{
+  template <class Iterator>
+  auto operator()(const Iterator& it) { return it->first; }
+};
+
+template <class Iterator, class Cell_accessor>
+bool write_cell_info(std::ostream& os, Iterator start, const Iterator& end)
+{
+  Cell_accessor accessor;
+  if(IO::is_ascii(os))
+  {
+    for(; start != end; ++start)
+    {
+      os << *(accessor(start)) << '\n';
+    }
+  }
+  else
+  {
+    for(; start != end; ++start)
+    {
+      os << *(accessor(start));
+    }
+  }
+  return (bool)os;
+}
+
+template < class GT, class Tds, class Lds >
+bool write_cells(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr, const Unique_hash_map<typename Tds::Vertex_handle, std::size_t>& vertices_map)
+{
+  // Writes:
+  // [Call to Tds::print_cells]
+  // - the number of cells
+  // - the cells by the indices of their vertices in the preceding list
+  //   of vertices, plus the non combinatorial information on each cell
+  // - the neighbors of each cell by their index in the preceding list of cells
+  // [Cells other info]
+  // - when dimension < 3 : the same with faces of maximal dimension
+
+  typedef Triangulation_3<GT, Tds>                 Triangulation;
+  typedef typename Triangulation::Cell_iterator    Cell_iterator;
+  typedef typename Triangulation::Edge_iterator    Edge_iterator;
+  typedef typename Triangulation::Facet_iterator   Facet_iterator;
+
+  tr.tds().print_cells(os, vertices_map);
+  if (!os)
+    return false;
+
+  // Write the non combinatorial information on the cells
+  // using the << operator of Cell.
+  // Works because the iterator of the tds traverses the cells in the
+  // same order as the iterator of the triangulation
+  switch(tr.dimension())
+  {
+    case 3:
+    {
+      return write_cell_info<Cell_iterator, Cell_accessor>(os, tr.cells_begin(), tr.cells_end());
+      break;
+    }
+    case 2:
+    {
+      return write_cell_info<Facet_iterator, Cell_accessor_first>(os, tr.facets_begin(), tr.facets_end());
+      break;
+    }
+    case 1:
+    {
+      return write_cell_info<Edge_iterator, Cell_accessor_first>(os, tr.edges_begin(), tr.edges_end());
+      break;
+    }
+  }
+  return false;
+}
+
+
+template < class GT, class Tds, class Lds >
+bool read_cells(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, const std::vector< typename Tds::Vertex_handle >& vertices_handles)
+{
+  // Writes:
+  // [Call to Tds::print_cells]
+  // - the number of cells
+  // - the cells by the indices of their vertices in the preceding list
+  //   of vertices, plus the non combinatorial information on each cell
+  // - the neighbors of each cell by their index in the preceding list of cells
+  // [Cells other info]
+  // - when dimension < 3 : the same with faces of maximal dimension
+
+  typedef Triangulation_3<GT, Tds>                 Triangulation;
+  typedef typename Triangulation::Cell_handle      Cell_handle;
+
+  std::vector< Cell_handle > C;
+
+  std::size_t m;
+  tr.tds().read_cells(is, vertices_handles, m, C);
+  if(!is)
+    return false;
+
+  for(std::size_t i=0 ; i < m; i++)
+    if(!(is >> *(C[i])))
+      return false;
+
+  return (bool)is;
+}
+
+} // end namespace internal
+
+
+template < class GT, class Tds, class Lds >
+bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr)
+{
+  Unique_hash_map<typename Tds::Vertex_handle, std::size_t> vertices_map;
+  return export_triangulation_3(os, tr, vertices_map);
+}
+
+template < class GT, class Tds, class Lds >
+bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr, Unique_hash_map<typename Tds::Vertex_handle, std::size_t>& vertices_map)
+{
+  // Writes:
+  // [Header]
+  //   - the dimension
+  // [Vertices]
+  //   - the number of finite vertices
+  //   - the non combinatorial information on vertices (point, etc)
+  // [Cells]
+  //     - the number of cells
+  //     - the cells by the indices of their vertices in the preceding list
+  //       of vertices, plus the non combinatorial information on each cell
+  //   [Cells combinatorial information]
+  //     - the neighbors of each cell by their index in the preceding list of cells
+  //   [Cells other info]
+  //     - when dimension < 3 : the same with faces of maximal dimension
+
+  return internal::write_header(os, tr)
+      && internal::write_vertices(os, tr)
+      && internal::construct_vertices_map(tr, vertices_map)
+      && internal::write_cells(os, tr, vertices_map);
+}
+
+
+template < class GT, class Tds, class Lds >
+bool import_triangulation_3(std::istream& is, const Triangulation_3<GT, Tds, Lds>& tr)
+{
+  std::vector<typename Tds::Vertex_handle > vertices_handles;
+  return import_triangulation_3(is, tr, vertices_handles);
+}
+
+template < class GT, class Tds, class Lds >
+bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, std::vector<typename Tds::Vertex_handle >& vertices_handles)
+{
+  // Reads:
+  // [Header]
+  //   - the dimension
+  // [Vertices]
+  //   - the number of finite vertices
+  //   - the non combinatorial information on vertices (point, etc)
+  // [Cells]
+  //     - the number of cells
+  //     - the cells by the indices of their vertices in the preceding list
+  //       of vertices, plus the non combinatorial information on each cell
+  //   [Cells combinatorial information]
+  //     - the neighbors of each cell by their index in the preceding list of cells
+  //   [Cells other info]
+  //     - when dimension < 3 : the same with faces of maximal dimension
+
+  tr.tds().clear(); // infinite vertex deleted
+  tr.set_infinite_vertex(tr.tds().create_vertex());
+
+  bool result = internal::read_header(is, tr)
+             && internal::read_vertices(is, tr, vertices_handles)
+             && internal::read_cells(is, tr, vertices_handles);
+
+  CGAL_assertion(tr.is_valid(true));
+  return result;
+}
+
+
+
+} // end namespace IO
+
+} // end namespace CGAL
+
+#endif // CGAL_TRIANGULATION_RAW_IOSTREAM_3_H

--- a/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
+++ b/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
@@ -1,17 +1,20 @@
-// Copyright (c) 20XX,20XX GeometryFactory
+// Copyright (c) 1999-2003  INRIA Sophia-Antipolis (France).
 // All rights reserved.
 //
-// This file is part of CGAL (www.cgal.org)
+// This file is part of CGAL (www.cgal.org).
 //
 // $URL$
 // $Id$
-// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
 //
-// Author(s)     : Ange Clément
+// Author(s)     : Monique Teillaud <Monique.Teillaud@sophia.inria.fr>
+//                 Sylvain Pion
+//                 Clement Jamin
+//                 Ange Clement
 
 
-#ifndef CGAL_TRIANGULATION_RAW_IOSTREAM_3_H
-#define CGAL_TRIANGULATION_RAW_IOSTREAM_3_H
+#ifndef CGAL_IO_TRIANGULATION_RAW_IOSTREAM_3_H
+#define CGAL_IO_TRIANGULATION_RAW_IOSTREAM_3_H
 
 #include <CGAL/license/Triangulation_3.h>
 
@@ -19,14 +22,10 @@
 #include <vector>
 
 #include <CGAL/Unique_hash_map.h>
-#include <CGAL/Default.h>
 #include <CGAL/IO/io.h>
+#include <CGAL/Mesh_3/Triangulation_3_fwd.h>
 
 namespace CGAL {
-
-template < class GT, class Tds = Default,
-         class Lock_data_structure = Default >
-class Triangulation_3;
 
 namespace IO {
 
@@ -393,4 +392,4 @@ bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr,
 
 } // end namespace CGAL
 
-#endif // CGAL_TRIANGULATION_RAW_IOSTREAM_3_H
+#endif // CGAL_IO_TRIANGULATION_RAW_IOSTREAM_3_H

--- a/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
+++ b/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
@@ -11,7 +11,6 @@
 //                 Sylvain Pion
 //                 Clement Jamin
 
-
 #ifndef CGAL_IO_TRIANGULATION_RAW_IOSTREAM_3_H
 #define CGAL_IO_TRIANGULATION_RAW_IOSTREAM_3_H
 
@@ -438,7 +437,7 @@ bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& t
              && internal::read_cells<GT, Tds_, Lds_, Tr_src, ConvertCell>
                                     (is, tr, vertices_handles, convert_cell);
 
-  CGAL_assertion(result && tr.is_valid(true));
+  CGAL_assertion(result && tr.is_valid(false));
   return result;
 }
 

--- a/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
+++ b/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
@@ -1,5 +1,19 @@
+// Copyright (c) 20XX,20XX GeometryFactory
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Ange Clément
+
+
 #ifndef CGAL_TRIANGULATION_RAW_IOSTREAM_3_H
 #define CGAL_TRIANGULATION_RAW_IOSTREAM_3_H
+
+#include <CGAL/license/Triangulation_3.h>
 
 #include <iostream>
 #include <vector>

--- a/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
+++ b/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
@@ -332,12 +332,10 @@ template < class GT, class Tds, class Lds,
            typename Tr_src = Triangulation_3<GT, Tds, Lds>,
            typename ConvertVertex = internal::IdentityConvertVertex,
            typename ConvertCell = internal::IdentityConvertCell >
-bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr,
-                            ConvertVertex convert_vertex = ConvertVertex(),
-                            ConvertCell convert_cell = ConvertCell())
+bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr)
 {
   Unique_hash_map<typename Tds::Vertex_handle, std::size_t> vertices_map;
-  return export_triangulation_3(os, tr, vertices_map, convert_vertex, convert_cell);
+  return export_triangulation_3(os, tr, vertices_map);
 }
 
 
@@ -368,8 +366,10 @@ bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr,
   tr.set_infinite_vertex(tr.tds().create_vertex());
 
   bool result = internal::read_header(is, tr)
-             && internal::read_vertices(is, tr, vertices_handles)
-             && internal::read_cells(is, tr, vertices_handles);
+             && internal::read_vertices<GT, Tds, Lds, Tr_src, ConvertVertex>
+                                       (is, tr, vertices_handles, convert_vertex)
+             && internal::read_cells<GT, Tds, Lds, Tr_src, ConvertCell>
+                                    (is, tr, vertices_handles, convert_cell);
 
   CGAL_assertion(result && tr.is_valid(true));
   return result;
@@ -384,7 +384,8 @@ bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr,
                             ConvertCell convert_cell = ConvertCell())
 {
   std::vector<typename Tds::Vertex_handle > vertices_handles;
-  return import_triangulation_3(is, tr, vertices_handles, convert_vertex, convert_cell);
+  return import_triangulation_3<GT, Tds, Lds, Tr_src, ConvertVertex, ConvertCell>
+                               (is, tr, vertices_handles, convert_vertex, convert_cell);
 }
 
 

--- a/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
+++ b/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
@@ -233,7 +233,6 @@ bool write_cells(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr, cons
   return false;
 }
 
-
 template < class GT, class Tds, class Lds >
 bool read_cells(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, const std::vector< typename Tds::Vertex_handle >& vertices_handles)
 {
@@ -267,13 +266,6 @@ bool read_cells(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, const std::
 
 
 template < class GT, class Tds, class Lds >
-bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr)
-{
-  Unique_hash_map<typename Tds::Vertex_handle, std::size_t> vertices_map;
-  return export_triangulation_3(os, tr, vertices_map);
-}
-
-template < class GT, class Tds, class Lds >
 bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr, Unique_hash_map<typename Tds::Vertex_handle, std::size_t>& vertices_map)
 {
   // Writes:
@@ -297,13 +289,13 @@ bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds, Lds
       && internal::write_cells(os, tr, vertices_map);
 }
 
-
 template < class GT, class Tds, class Lds >
-bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr)
+bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds, Lds>& tr)
 {
-  std::vector<typename Tds::Vertex_handle > vertices_handles;
-  return import_triangulation_3(is, tr, vertices_handles);
+  Unique_hash_map<typename Tds::Vertex_handle, std::size_t> vertices_map;
+  return export_triangulation_3(os, tr, vertices_map);
 }
+
 
 template < class GT, class Tds, class Lds >
 bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, std::vector<typename Tds::Vertex_handle >& vertices_handles)
@@ -334,6 +326,12 @@ bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr,
   return result;
 }
 
+template < class GT, class Tds, class Lds >
+bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr)
+{
+  std::vector<typename Tds::Vertex_handle > vertices_handles;
+  return import_triangulation_3(is, tr, vertices_handles);
+}
 
 
 } // end namespace IO

--- a/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
+++ b/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
@@ -130,15 +130,12 @@ bool read_vertices(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr, std::vec
   vertices_handles.resize(n+1);
   vertices_handles[0] = tr.infinite_vertex(); // the infinite vertex is numbered 0
 
-  std::cout << tr.dimension() << " " << n << std::endl;
   for(std::size_t i=1; i <= n; i++)
   {
     vertices_handles[i] = tr.tds().create_vertex();
     if(!(is >> *vertices_handles[i]))
       return false;
-    std::cout << i << " : " << vertices_handles[i]->in_dimension() << " " << vertices_handles[i]->point().x() << std::endl;
   }
-  std::cout << tr.dimension() << " " << n << std::endl;
 
   return (bool)is;
 }
@@ -288,7 +285,7 @@ bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds, Lds
 
 
 template < class GT, class Tds, class Lds >
-bool import_triangulation_3(std::istream& is, const Triangulation_3<GT, Tds, Lds>& tr)
+bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr)
 {
   std::vector<typename Tds::Vertex_handle > vertices_handles;
   return import_triangulation_3(is, tr, vertices_handles);
@@ -319,7 +316,7 @@ bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds, Lds>& tr,
              && internal::read_vertices(is, tr, vertices_handles)
              && internal::read_cells(is, tr, vertices_handles);
 
-  CGAL_assertion(tr.is_valid(true));
+  CGAL_assertion(tr.is_valid(false));
   return result;
 }
 

--- a/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
+++ b/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
@@ -122,7 +122,7 @@ bool write_vertices(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr)
 template < class GT, class Tds_, class Lds_,
            typename Tr_src,
            typename ConvertVertex >
-bool read_vertices_with_convertion(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
+bool read_vertices_with_conversion(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
                                    std::vector< typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
                                    typename Triangulation_3<GT, Tds_>::size_type n,
                                    ConvertVertex convert_vertex = ConvertVertex())
@@ -147,7 +147,7 @@ bool read_vertices_with_convertion(std::istream& is, Triangulation_3<GT, Tds_, L
 }
 
 template < class GT, class Tds_, class Lds_>
-bool read_vertices_without_convertion(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
+bool read_vertices_without_conversion(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
                    std::vector< typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
                    typename Triangulation_3<GT, Tds_>::size_type n)
 {
@@ -193,12 +193,12 @@ bool read_vertices(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
 
   if constexpr (std::is_same<ConvertVertex, Nullptr_t>::value)
   {
-    if (!read_vertices_without_convertion<GT, Tds_, Lds_>(is, tr, vertices_handles, n))
+    if (!read_vertices_without_conversion<GT, Tds_, Lds_>(is, tr, vertices_handles, n))
       return false;
   }
   else
   {
-    if (!read_vertices_with_convertion<GT, Tds_, Lds_, Tr_src, ConvertVertex>(is, tr, vertices_handles, n, convert_vertex))
+    if (!read_vertices_with_conversion<GT, Tds_, Lds_, Tr_src, ConvertVertex>(is, tr, vertices_handles, n, convert_vertex))
       return false;
   }
 
@@ -289,7 +289,7 @@ bool write_cells(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr,
 template < class GT, class Tds_, class Lds_,
            typename Tr_src,
            typename ConvertCell >
-bool read_cells_with_convertion(std::istream& is, typename Triangulation_3<GT, Tds_>::size_type m,
+bool read_cells_with_conversion(std::istream& is, typename Triangulation_3<GT, Tds_>::size_type m,
                                 std::vector< typename Triangulation_3<GT, Tds_>::Cell_handle >& C,
                                 ConvertCell convert_cell = ConvertCell())
 {
@@ -314,7 +314,7 @@ bool read_cells_with_convertion(std::istream& is, typename Triangulation_3<GT, T
 }
 
 template < class GT, class Tds_, class Lds_ >
-bool read_cells_without_convertion(std::istream& is, typename Triangulation_3<GT, Tds_>::size_type m,
+bool read_cells_without_conversion(std::istream& is, typename Triangulation_3<GT, Tds_>::size_type m,
                                    std::vector< typename Triangulation_3<GT, Tds_>::Cell_handle >& C)
 {
   // Reads:
@@ -356,12 +356,12 @@ bool read_cells(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
 
   if constexpr (std::is_same<ConvertCell, Nullptr_t>::value)
   {
-    if (!read_cells_without_convertion<GT, Tds_, Lds_>(is, m, C))
+    if (!read_cells_without_conversion<GT, Tds_, Lds_>(is, m, C))
       return false;
   }
   else
   {
-    if (!read_cells_with_convertion<GT, Tds_, Lds_, Tr_src, ConvertCell>(is, m, C, convert_cell))
+    if (!read_cells_with_conversion<GT, Tds_, Lds_, Tr_src, ConvertCell>(is, m, C, convert_cell))
       return false;
   }
 

--- a/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
+++ b/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
@@ -29,11 +29,11 @@ namespace IO {
 
 namespace internal {
 
-template < class GT, class Tds_, class Lds_ >
-bool construct_vertices_map(const Triangulation_3<GT, Tds_, Lds_>& tr,
-                            Unique_hash_map<typename Triangulation_3<GT, Tds_>::Vertex_handle, std::size_t>& vertices_map)
+template < class Tr_ >
+bool construct_vertices_map(const Tr_& tr,
+                            Unique_hash_map<typename Tr_::Vertex_handle, std::size_t>& vertices_map)
 {
-  typedef Triangulation_3<GT, Tds_>               Triangulation;
+  typedef Tr_                                     Triangulation;
   typedef typename Triangulation::size_type       size_type;
   typedef typename Triangulation::Vertex_iterator Vertex_iterator;
 
@@ -49,8 +49,8 @@ bool construct_vertices_map(const Triangulation_3<GT, Tds_, Lds_>& tr,
   return true;
 }
 
-template < class GT, class Tds_, class Lds_ >
-bool write_header(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr)
+template < class Tr_ >
+bool write_header(std::ostream& os, const Tr_& tr)
 {
   // Writes:
   // - the dimension
@@ -65,8 +65,8 @@ bool write_header(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr)
   return (bool)os;
 }
 
-template < class GT, class Tds_, class Lds_ >
-bool read_header(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr)
+template < class Tr_ >
+bool read_header(std::istream& is, Tr_& tr)
 {
   // Reads:
   // - the dimension
@@ -85,13 +85,13 @@ bool read_header(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr)
   return (bool)is;
 }
 
-template < class GT, class Tds_, class Lds_ >
-bool write_vertices(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr)
+template < class Tr_ >
+bool write_vertices(std::ostream& os, const Tr_& tr)
 {
   // Writes:
   // - the number of finite vertices
   // - the non combinatorial information on vertices (point, etc)
-  typedef Triangulation_3<GT, Tds_>               Triangulation;
+  typedef Tr_                                     Triangulation;
   typedef typename Triangulation::size_type       size_type;
   typedef typename Triangulation::Vertex_iterator Vertex_iterator;
 
@@ -238,9 +238,9 @@ bool write_cell_info(std::ostream& os, Iterator start, const Iterator& end)
   return (bool)os;
 }
 
-template < class GT, class Tds_, class Lds_ >
-bool write_cells(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr,
-                 const Unique_hash_map<typename Triangulation_3<GT, Tds_>::Vertex_handle, std::size_t>& vertices_map)
+template < class Tr_ >
+bool write_cells(std::ostream& os, const Tr_& tr,
+                 const Unique_hash_map<typename Tr_::Vertex_handle, std::size_t>& vertices_map)
 {
   // Writes:
   // [Call to Tds_::print_cells]
@@ -251,7 +251,7 @@ bool write_cells(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr,
   // [Cells other info]
   // - when dimension < 3 : the same with faces of maximal dimension
 
-  typedef Triangulation_3<GT, Tds_>              Triangulation;
+  typedef Tr_                                    Triangulation;
   typedef typename Triangulation::Cell_iterator  Cell_iterator;
   typedef typename Triangulation::Edge_iterator  Edge_iterator;
   typedef typename Triangulation::Facet_iterator Facet_iterator;
@@ -371,9 +371,9 @@ bool read_cells(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
 } // end namespace internal
 
 
-template < class GT, class Tds_, class Lds_ >
-bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr,
-                            Unique_hash_map<typename Triangulation_3<GT, Tds_>::Vertex_handle, std::size_t>& vertices_map)
+template < class Tr_ >
+bool export_triangulation_3(std::ostream& os, const Tr_& tr,
+                            Unique_hash_map<typename Tr_::Vertex_handle, std::size_t>& vertices_map)
 {
   // Writes:
   // [Header]
@@ -396,10 +396,10 @@ bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds_, Ld
       && internal::write_cells(os, tr, vertices_map);
 }
 
-template < class GT, class Tds_, class Lds_ >
-bool export_triangulation_3(std::ostream& os, const Triangulation_3<GT, Tds_, Lds_>& tr)
+template < class Tr_ >
+bool export_triangulation_3(std::ostream& os, const Tr_& tr)
 {
-  Unique_hash_map<typename Triangulation_3<GT, Tds_>::Vertex_handle, std::size_t> vertices_map;
+  Unique_hash_map<typename Tr_::Vertex_handle, std::size_t> vertices_map;
   return export_triangulation_3(os, tr, vertices_map);
 }
 

--- a/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
+++ b/Triangulation_3/include/CGAL/IO/Triangulation_raw_iostream_3.h
@@ -119,18 +119,18 @@ bool write_vertices(std::ostream& os, const Tr_& tr)
   return (bool)os;
 }
 
-template < class GT, class Tds_, class Lds_,
+template < class Tr_,
            typename Tr_src,
            typename ConvertVertex >
-bool read_vertices_with_conversion(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
-                                   std::vector< typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
-                                   typename Triangulation_3<GT, Tds_>::size_type n,
+bool read_vertices_with_conversion(std::istream& is, Tr_& tr,
+                                   std::vector<typename Tr_::Vertex_handle >& vertices_handles,
+                                   typename Tr_::size_type n,
                                    ConvertVertex convert_vertex = ConvertVertex())
 {
   // Reads:
   // - the non combinatorial information on vertices (point, etc)
   // The vertices are read with the type Tr_src::Vertex
-  // and converted to type Triangulation_3<GT, Tds_, Lds_>::Vertex
+  // and converted to type Tr_::Vertex
   // using the ConvertVertex convertor.
   typedef typename Tr_src::Vertex Vertex1;
 
@@ -146,10 +146,11 @@ bool read_vertices_with_conversion(std::istream& is, Triangulation_3<GT, Tds_, L
   return (bool)is;
 }
 
-template < class GT, class Tds_, class Lds_>
-bool read_vertices_without_conversion(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
-                   std::vector< typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
-                   typename Triangulation_3<GT, Tds_>::size_type n)
+template < class Tr_>
+bool read_vertices_without_conversion(std::istream& is,
+                   Tr_& tr,
+                   std::vector<typename Tr_::Vertex_handle >& vertices_handles,
+                   typename Tr_::size_type n)
 {
   // Reads:
   // - the non combinatorial information on vertices (point, etc)
@@ -163,17 +164,17 @@ bool read_vertices_without_conversion(std::istream& is, Triangulation_3<GT, Tds_
 }
 
 
-template < class GT, class Tds_, class Lds_,
-           typename Tr_src = Triangulation_3<GT, Tds_, Lds_>,
+template < class Tr_, typename Tr_src = Tr_,
            typename ConvertVertex = Nullptr_t >
-bool read_vertices(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
-                   std::vector< typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
+bool read_vertices(std::istream& is,
+                   Tr_& tr,
+                   std::vector< typename Tr_::Vertex_handle >& vertices_handles,
                    ConvertVertex convert_vertex = ConvertVertex())
 {
   // Reads:
   // - the number of finite vertices
   // - the non combinatorial information on vertices (point, etc)
-  typedef Triangulation_3<GT, Tds_>         Triangulation;
+  typedef Tr_                               Triangulation;
   typedef typename Triangulation::size_type size_type;
 
   size_type n;
@@ -193,12 +194,12 @@ bool read_vertices(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
 
   if constexpr (std::is_same<ConvertVertex, Nullptr_t>::value)
   {
-    if (!read_vertices_without_conversion<GT, Tds_, Lds_>(is, tr, vertices_handles, n))
+    if (!read_vertices_without_conversion<Tr_>(is, tr, vertices_handles, n))
       return false;
   }
   else
   {
-    if (!read_vertices_with_conversion<GT, Tds_, Lds_, Tr_src, ConvertVertex>(is, tr, vertices_handles, n, convert_vertex))
+    if (!read_vertices_with_conversion<Tr_, Tr_src, ConvertVertex>(is, tr, vertices_handles, n, convert_vertex))
       return false;
   }
 
@@ -286,18 +287,18 @@ bool write_cells(std::ostream& os, const Tr_& tr,
 }
 
 
-template < class GT, class Tds_, class Lds_,
+template < class Tr_,
            typename Tr_src,
            typename ConvertCell >
-bool read_cells_with_conversion(std::istream& is, typename Triangulation_3<GT, Tds_>::size_type m,
-                                std::vector< typename Triangulation_3<GT, Tds_>::Cell_handle >& C,
+bool read_cells_with_conversion(std::istream& is, typename Tr_::size_type m,
+                                std::vector<typename Tr_::Cell_handle>& cells,
                                 ConvertCell convert_cell = ConvertCell())
 {
   // Reads:
   // [Cells other info]
   // - when dimension < 3 : the same with faces of maximal dimension
   // The cell are read with the type Tr_src::Cell
-  // and converted to type Triangulation_3<GT, Tds_, Lds_>::Cell
+  // and converted to type Tr_::Cell
   // using the ConvertCell convertor.
 
   typedef typename Tr_src::Cell Cell1;
@@ -307,32 +308,32 @@ bool read_cells_with_conversion(std::istream& is, typename Triangulation_3<GT, T
     Cell1 c;
     if(!(is >> c))
       return false;
-    convert_cell(c, *C[i]);
+    convert_cell(c, *cells[i]);
   }
 
   return (bool)is;
 }
 
-template < class GT, class Tds_, class Lds_ >
-bool read_cells_without_conversion(std::istream& is, typename Triangulation_3<GT, Tds_>::size_type m,
-                                   std::vector< typename Triangulation_3<GT, Tds_>::Cell_handle >& C)
+template < class Tr_ >
+bool read_cells_without_conversion(std::istream& is, typename Tr_::size_type m,
+                                   std::vector< typename Tr_::Cell_handle >& cells)
 {
   // Reads:
   // - the non combinatorial information on vertices (point, etc)
   for(std::size_t i=0 ; i < m; i++)
   {
-    if(!(is >> *C[i]))
+    if(!(is >> *cells[i]))
       return false;
   }
 
   return (bool)is;
 }
 
-template < class GT, class Tds_, class Lds_,
-           typename Tr_src = Triangulation_3<GT, Tds_, Lds_>,
+template < class Tr_,
+           typename Tr_src = Tr_,
            typename ConvertCell = Nullptr_t >
-bool read_cells(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
-                const std::vector< typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
+bool read_cells(std::istream& is, Tr_& tr,
+                const std::vector< typename Tr_::Vertex_handle >& vertices_handles,
                 ConvertCell convert_cell = ConvertCell())
 {
   // Reads:
@@ -344,7 +345,7 @@ bool read_cells(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
   // [Cells other info]
   // - when dimension < 3 : the same with faces of maximal dimension
 
-  typedef Triangulation_3<GT, Tds_>                 Triangulation;
+  typedef Tr_                 Triangulation;
   typedef typename Triangulation::Cell_handle      Cell_handle;
 
   std::vector< Cell_handle > C;
@@ -356,12 +357,12 @@ bool read_cells(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
 
   if constexpr (std::is_same<ConvertCell, Nullptr_t>::value)
   {
-    if (!read_cells_without_conversion<GT, Tds_, Lds_>(is, m, C))
+    if (!read_cells_without_conversion<Tr_>(is, m, C))
       return false;
   }
   else
   {
-    if (!read_cells_with_conversion<GT, Tds_, Lds_, Tr_src, ConvertCell>(is, m, C, convert_cell))
+    if (!read_cells_with_conversion<Tr_, Tr_src, ConvertCell>(is, m, C, convert_cell))
       return false;
   }
 
@@ -404,12 +405,13 @@ bool export_triangulation_3(std::ostream& os, const Tr_& tr)
 }
 
 
-template < class GT, class Tds_, class Lds_,
-           typename Tr_src = Triangulation_3<GT, Tds_, Lds_>,
+template < class Tr_,
+           typename Tr_src = Tr_,
            typename ConvertVertex = Nullptr_t,
            typename ConvertCell = Nullptr_t >
-bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
-                            std::vector<typename Triangulation_3<GT, Tds_>::Vertex_handle >& vertices_handles,
+bool import_triangulation_3(std::istream& is,
+                            Tr_& tr,
+                            std::vector<typename Tr_::Vertex_handle>& vertices_handles,
                             ConvertVertex convert_vertex = ConvertVertex(),
                             ConvertCell convert_cell = ConvertCell())
 {
@@ -432,25 +434,26 @@ bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& t
   tr.set_infinite_vertex(tr.tds().create_vertex());
 
   bool result = internal::read_header(is, tr)
-             && internal::read_vertices<GT, Tds_, Lds_, Tr_src, ConvertVertex>
+             && internal::read_vertices<Tr_, Tr_src, ConvertVertex>
                                        (is, tr, vertices_handles, convert_vertex)
-             && internal::read_cells<GT, Tds_, Lds_, Tr_src, ConvertCell>
+             && internal::read_cells<Tr_, Tr_src, ConvertCell>
                                     (is, tr, vertices_handles, convert_cell);
 
   CGAL_assertion(result && tr.is_valid(false));
   return result;
 }
 
-template < class GT, class Tds_, class Lds_,
-           typename Tr_src = Triangulation_3<GT, Tds_, Lds_>,
+template < class Tr_,
+           typename Tr_src = Tr_,
            typename ConvertVertex = Nullptr_t,
            typename ConvertCell = Nullptr_t >
-bool import_triangulation_3(std::istream& is, Triangulation_3<GT, Tds_, Lds_>& tr,
+bool import_triangulation_3(std::istream& is,
+                            Tr_& tr,
                             ConvertVertex convert_vertex = ConvertVertex(),
                             ConvertCell convert_cell = ConvertCell())
 {
-  std::vector<typename Triangulation_3<GT, Tds_>::Vertex_handle > vertices_handles;
-  return import_triangulation_3<GT, Tds_, Lds_, Tr_src, ConvertVertex, ConvertCell>
+  std::vector<typename Tr_::Vertex_handle> vertices_handles;
+  return import_triangulation_3<Tr_, Tr_src, ConvertVertex, ConvertCell>
                                (is, tr, vertices_handles, convert_vertex, convert_cell);
 }
 

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -2337,7 +2337,7 @@ public:
   template <typename Tr_src,
             typename ConvertVertex,
             typename ConvertCell>
-  std::istream& file_input(std::istream& is,
+  std::istream& file_input(std::istream& is, std::vector< Vertex_handle >& vertices_handles,
                            ConvertVertex convert_vertex = ConvertVertex(),
                            ConvertCell convert_cell = ConvertCell())
   {
@@ -2356,8 +2356,21 @@ public:
 
     if (!CGAL::IO::import_triangulation_3<GT, Tds_, Lock_data_structure_,
                                           Tr_src, ConvertVertex, ConvertCell>
-                                         (is, *this, convert_vertex, convert_cell))
+                                         (is, *this, vertices_handles, convert_vertex, convert_cell))
       is.setstate(std::ios_base::failbit);
+    return is;
+  }
+
+  //IO
+  template <typename Tr_src,
+            typename ConvertVertex,
+            typename ConvertCell>
+  std::istream& file_input(std::istream& is,
+                           ConvertVertex convert_vertex = ConvertVertex(),
+                           ConvertCell convert_cell = ConvertCell())
+  {
+    std::vector< Vertex_handle > vertices_handles;
+    file_input<Tr_src, ConvertVertex, ConvertCell>(is, vertices_handles, convert_vertex, convert_cell);
     return is;
   }
 };

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -26,6 +26,7 @@
 
 #include <CGAL/Unique_hash_map.h>
 #include <CGAL/assertions.h>
+#include <CGAL/Mesh_3/Triangulation_3_fwd.h>
 #include <CGAL/Compact_container.h>
 #include <CGAL/Triangulation_utils_3.h>
 
@@ -83,12 +84,6 @@
 #define CGAL_TRIANGULATION_3_USE_THE_4_POINTS_CONSTRUCTOR
 
 namespace CGAL {
-
-#ifndef CGAL_TRIANGULATION_RAW_IOSTREAM_3_H
-template < class GT, class Tds = Default,
-           class Lock_data_structure = Default >
-class Triangulation_3;
-#endif
 
 template < class GT, class Tds, class Lds > std::istream& operator>>
 (std::istream& is, Triangulation_3<GT,Tds,Lds>& tr);

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -46,6 +46,8 @@
 #include <CGAL/Bbox_3.h>
 #include <CGAL/Spatial_lock_grid_3.h>
 
+#include <CGAL/IO/Triangulation_raw_iostream_3.h>
+
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/uniform_smallint.hpp>
 #include <boost/random/variate_generator.hpp>
@@ -82,9 +84,11 @@
 
 namespace CGAL {
 
+#ifndef CGAL_TRIANGULATION_RAW_IOSTREAM_3_H
 template < class GT, class Tds = Default,
            class Lock_data_structure = Default >
 class Triangulation_3;
+#endif
 
 template < class GT, class Tds, class Lds > std::istream& operator>>
 (std::istream& is, Triangulation_3<GT,Tds,Lds>& tr);
@@ -2414,54 +2418,8 @@ std::istream& operator>> (std::istream& is, Triangulation_3<GT, Tds, Lds>& tr)
   //   of vertices, plus the non combinatorial information on each cell
   // - the neighbors of each cell by their index in the preceding list of cells
   // - when dimension < 3 : the same with faces of maximal dimension
-
-  typedef Triangulation_3<GT, Tds>               Triangulation;
-  typedef typename Triangulation::Vertex_handle  Vertex_handle;
-  typedef typename Triangulation::Cell_handle    Cell_handle;
-
-  tr._tds.clear(); // infinite vertex deleted
-  tr.infinite = tr._tds.create_vertex();
-
-  std::size_t n;
-  int d;
-  if(IO::is_ascii(is))
-  {
-    is >> d >> n;
-  }
-  else
-  {
-    read(is, d);
-    read(is, n);
-  }
-  if(!is)
-    return is;
-
-  std::vector< Vertex_handle > V;
-  if(d > 3 || d < -2 || (n+1) > V.max_size()) {
+  if (!CGAL::IO::import_triangulation_3(is, tr))
     is.setstate(std::ios_base::failbit);
-    return is;
-  }
-  tr._tds.set_dimension(d);
-  V.resize(n+1);
-  V[0] = tr.infinite_vertex(); // the infinite vertex is numbered 0
-
-  for(std::size_t i=1; i <= n; i++)
-  {
-    V[i] = tr._tds.create_vertex();
-    if(!(is >> *V[i]))
-      return is;
-  }
-
-  std::vector< Cell_handle > C;
-
-  std::size_t m;
-  tr._tds.read_cells(is, V, m, C);
-
-  for(std::size_t j=0 ; j < m; j++)
-    if(!(is >> *(C[j])))
-      return is;
-
-  CGAL_assertion(tr.is_valid(false));
   return is;
 }
 
@@ -2477,91 +2435,9 @@ std::ostream& operator<< (std::ostream& os, const Triangulation_3<GT, Tds, Lds>&
   //   of vertices, plus the non combinatorial information on each cell
   // - the neighbors of each cell by their index in the preceding list of cells
   // - when dimension < 3 : the same with faces of maximal dimension
-
-  typedef Triangulation_3<GT, Tds>                 Triangulation;
-  typedef typename Triangulation::size_type        size_type;
-  typedef typename Triangulation::Vertex_handle    Vertex_handle;
-  typedef typename Triangulation::Vertex_iterator  Vertex_iterator;
-  typedef typename Triangulation::Cell_iterator    Cell_iterator;
-  typedef typename Triangulation::Edge_iterator    Edge_iterator;
-  typedef typename Triangulation::Facet_iterator   Facet_iterator;
-
-  // outputs dimension and number of vertices
-  size_type n = tr.number_of_vertices();
-  if(IO::is_ascii(os))
-  {
-    os << tr.dimension() << std::endl << n << std::endl;
-  }
-  else
-  {
-    write(os, tr.dimension());
-    write(os, n);
-  }
-
-  if(n == 0)
-    return os;
-
-  std::vector<Vertex_handle> TV(n+1);
-  size_type i = 0;
-
-  // write the vertices
-  for(Vertex_iterator it = tr.vertices_begin(), end = tr.vertices_end(); it != end; ++it)
-    TV[i++] = it;
-
-  CGAL_assertion(i == n+1);
-  CGAL_assertion(tr.is_infinite(TV[0]));
-
-  Unique_hash_map<Vertex_handle, std::size_t > V;
-  V[tr.infinite_vertex()] = 0;
-  for(i=1; i <= n; i++)
-  {
-    os << *TV[i];
-    V[TV[i]] = i;
-    if(IO::is_ascii(os))
-      os << std::endl;
-  }
-
-  // Asks the tds for the combinatorial information
-  tr.tds().print_cells(os, V);
-
-  // Write the non combinatorial information on the cells
-  // using the << operator of Cell.
-  // Works because the iterator of the tds traverses the cells in the
-  // same order as the iterator of the triangulation
-  switch(tr.dimension())
-  {
-    case 3:
-    {
-      for(Cell_iterator it = tr.cells_begin(), end = tr.cells_end(); it != end; ++it)
-      {
-        os << *it; // other information
-        if(IO::is_ascii(os))
-          os << std::endl;
-      }
-      break;
-    }
-    case 2:
-    {
-      for(Facet_iterator it = tr.facets_begin(), end = tr.facets_end(); it != end; ++it)
-      {
-        os << *((*it).first); // other information
-        if(IO::is_ascii(os))
-          os << std::endl;
-      }
-      break;
-    }
-    case 1:
-    {
-      for(Edge_iterator it = tr.edges_begin(), end = tr.edges_end(); it != end; ++it)
-      {
-        os << *((*it).first); // other information
-        if(IO::is_ascii(os))
-          os << std::endl;
-      }
-      break;
-    }
-  }
-  return os ;
+  if (!CGAL::IO::export_triangulation_3(os, tr))
+    os.setstate(std::ios_base::failbit);
+  return os;
 }
 
 template < class GT, class Tds, class Lds >

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -2341,66 +2341,23 @@ public:
                            ConvertVertex convert_vertex = ConvertVertex(),
                            ConvertCell convert_cell = ConvertCell())
   {
-    // reads
-    // the dimension
-    // the number of finite vertices
-    // the non combinatorial information on vertices (point, etc)
-    // the number of cells
-    // the cells by the indices of their vertices in the preceding list
-    // of vertices, plus the non combinatorial information on each cell
-    // the neighbors of each cell by their index in the preceding list of cells
-    // when dimension < 3 : the same with faces of maximal dimension
+    // Reads:
+    // - the dimension
+    // - the number of finite vertices
+    // - the non combinatorial information on vertices (point, etc)
+    // - the number of cells
+    // - the cells by the indices of their vertices in the preceding list
+    //   of vertices, plus the non combinatorial information on each cell
+    // - the neighbors of each cell by their index in the preceding list of cells
+    // - when dimension < 3 : the same with faces of maximal dimension
 
     // If this is used for a TDS, the vertices are processed from 0 to n.
     // Else, we make V[0] the infinite vertex and work from 1 to n+1.
 
-    typedef Self Triangulation;
-    typedef typename Triangulation::Vertex_handle  Vertex_handle;
-    typedef typename Triangulation::Cell_handle    Cell_handle;
-
-    typedef typename Tr_src::Vertex Vertex1;
-    typedef typename Tr_src::Cell Cell1;
-
-    clear();
-    tds().cells().clear();
-
-    std::size_t n;
-    int d;
-    if(IO::is_ascii(is))
-      is >> d >> n;
-    else {
-      read(is, d);
-      read(is, n);
-    }
-    if(!is) return is;
-    tds().set_dimension(d);
-
-    std::size_t V_size = n+1;
-    std::vector< Vertex_handle > V(V_size);
-
-    // the infinite vertex is numbered 0
-    V[0] = infinite_vertex();
-
-    for (std::size_t i = 1; i < V_size; ++i) {
-      Vertex1 v;
-      if(!(is >> v)) return is;
-      Vertex_handle vh=tds().create_vertex( convert_vertex(v) );
-      V[i] = vh;
-      convert_vertex(v, *V[i]);
-    }
-
-    std::vector< Cell_handle > C;
-
-    std::size_t m;
-    tds().read_cells(is, V, m, C);
-
-    for (std::size_t j=0 ; j < m; j++) {
-      Cell1 c;
-      if(!(is >> c)) return is;
-      convert_cell(c, *C[j]);
-    }
-
-    CGAL_assertion( is_valid(false) );
+    if (!CGAL::IO::import_triangulation_3<GT, Tds_, Lock_data_structure_,
+                                          Tr_src, ConvertVertex, ConvertCell>
+                                         (is, *this, convert_vertex, convert_cell))
+      is.setstate(std::ios_base::failbit);
     return is;
   }
 };

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -2332,7 +2332,7 @@ public:
   template <typename Tr_src,
             typename ConvertVertex,
             typename ConvertCell>
-  std::istream& file_input(std::istream& is, std::vector< Vertex_handle >& vertices_handles,
+  std::istream& file_input(std::istream& is, std::vector< Vertex_handle >& vertices,
                            ConvertVertex convert_vertex = ConvertVertex(),
                            ConvertCell convert_cell = ConvertCell())
   {
@@ -2349,9 +2349,9 @@ public:
     // If this is used for a TDS, the vertices are processed from 0 to n.
     // Else, we make V[0] the infinite vertex and work from 1 to n+1.
 
-    if (!CGAL::IO::import_triangulation_3<GT, Tds_, Lock_data_structure_,
+    if (!CGAL::IO::import_triangulation_3<Triangulation_3,
                                           Tr_src, ConvertVertex, ConvertCell>
-                                         (is, *this, vertices_handles, convert_vertex, convert_cell))
+                                         (is, *this, vertices, convert_vertex, convert_cell))
       is.setstate(std::ios_base::failbit);
     return is;
   }
@@ -2364,8 +2364,8 @@ public:
                            ConvertVertex convert_vertex = ConvertVertex(),
                            ConvertCell convert_cell = ConvertCell())
   {
-    std::vector< Vertex_handle > vertices_handles;
-    file_input<Tr_src, ConvertVertex, ConvertCell>(is, vertices_handles, convert_vertex, convert_cell);
+    std::vector< Vertex_handle > vertices;
+    file_input<Tr_src, ConvertVertex, ConvertCell>(is, vertices, convert_vertex, convert_cell);
     return is;
   }
 };


### PR DESCRIPTION
## Summary of Changes

Enable writing and reading of 1D features (edges) of `Mesh_complex_3_in_triangulation_3`.
The `Triangulation_3` writing and loading have been moved to `CGAL::IO::export_triangulation_3` and `CGAL::IO::import_triangulation_3`

Tasks:
 - [x] Move `Triangulation_3 ` writing and loading (`operator<</>>`)
 - [x] Make `Triangulation_3::file_input` use the writing and loading (remove duplicated code)
 - [x] Add 1D features to polyhedron demo

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #7780 , related to #2359 , similar to #5151 
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

