### PR TITLE
Kernel_23: Exploit Uncertain in collinear_3()

### DIFF
--- a/Cartesian_kernel/include/CGAL/predicates/kernel_ftC3.h
+++ b/Cartesian_kernel/include/CGAL/predicates/kernel_ftC3.h
@@ -102,12 +102,14 @@ collinearC3(const FT &px, const FT &py, const FT &pz,
   FT dqx = qx-rx;
   FT dpy = py-ry;
   FT dqy = qy-ry;
-  if (sign_of_determinant(dpx, dqx, dpy, dqy) != ZERO)
+
+  auto is_zero = sign_of_determinant(dpx, dqx, dpy, dqy) == ZERO;
+  if (certainly_not(is_zero))
       return false;
   FT dpz = pz-rz;
   FT dqz = qz-rz;
-  return CGAL_AND( sign_of_determinant(dpx, dqx, dpz, dqz) == ZERO ,
-                   sign_of_determinant(dpy, dqy, dpz, dqz) == ZERO );
+      return is_zero & CGAL_AND( sign_of_determinant(dpx, dqx, dpz, dqz) == ZERO ,
+                                 sign_of_determinant(dpy, dqy, dpz, dqz) == ZERO );
 }
 
 template < class FT >


### PR DESCRIPTION
## Summary of Changes

Make `collinear_3()` exploit uncertainty to make it faster. See discussion in PR #5207  

## Release Management

* Affected package(s): Kernel_23
* License and copyright ownership:  unchanged

