### PR TITLE
Mesh_3 - avoid a timeout in the testsuite

### DIFF
--- a/Mesh_3/test/Mesh_3/test_meshing_without_features_determinism.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_without_features_determinism.cpp
@@ -24,6 +24,7 @@
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
 
+
 template <typename Concurrency_tag>
 void test()
 {
@@ -31,7 +32,7 @@ void test()
   std::size_t nb_runs   = 2;
   unsigned int nb_lloyd = 2;
   unsigned int nb_odt   = 2;
-  double perturb_bound  = 9.;
+  double perturb_bound  = 7.;
   double exude_bound    = 15.;
 
   // Domain

--- a/Mesh_3/test/Mesh_3/test_meshing_without_features_determinism.cpp
+++ b/Mesh_3/test/Mesh_3/test_meshing_without_features_determinism.cpp
@@ -31,7 +31,7 @@ void test()
   std::size_t nb_runs   = 2;
   unsigned int nb_lloyd = 2;
   unsigned int nb_odt   = 2;
-  double perturb_bound  = 10.;
+  double perturb_bound  = 9.;
   double exude_bound    = 15.;
 
   // Domain


### PR DESCRIPTION
## Summary of Changes

Tests of Mesh_3 in the daily testsuite (too) often end with timeouts, because of the test `test_meshing_without_features_determinism`. This happens on many different platforms.

This PR reduces the target dihedral angle from 10 degrees to 9 degrees for `CGAL::perturb_mesh_3()` to fit in the testsuite timeout.

My experiments showed that the perturber always succeeds to get to 10 degrees, but it may be long and go beyond the timeout, in particular in Debug mode. This test is not about the perturber itself, but about determinism, so it must not be considered as a regression.

## Release Management

* Affected package(s): Mesh_3 tests
* License and copyright ownership: unchanged

