### PR TITLE
Stream_support: Add read_VTK() 

### DIFF
--- a/Polyhedron/doc/Polyhedron/CGAL/IO/Polyhedron_iostream.h
+++ b/Polyhedron/doc/Polyhedron/CGAL/IO/Polyhedron_iostream.h
@@ -75,7 +75,7 @@ This function overloads the generic function \link PkgBGLIoFuncsOFF `write_OFF(s
 \sa \link PkgPolyhedronIOFunc `operator>>(std::istream& in, Polyhedron_3<Traits>& P)` \endlink
 */
 template <class Traits>
-bool write_OFF( std::ostream& out, Polyhedron_3<Traits>& P);
+bool write_OFF( std::ostream& out, const Polyhedron_3<Traits>& P);
 
 /*!
 \relates Polyhedron_3
@@ -83,7 +83,7 @@ bool write_OFF( std::ostream& out, Polyhedron_3<Traits>& P);
             \link PkgPolyhedronIOFunc `CGAL::IO::write_OFF(std::ostream&, Polyhedron_3<Traits>&)` \endlink should be used instead.
 */
 template <class Traits>
-bool write_off( std::ostream& out, Polyhedron_3<Traits>& P);
+bool write_off( std::ostream& out, const Polyhedron_3<Traits>& P);
 
 /*!
 \relates Polyhedron_3
@@ -91,7 +91,6 @@ bool write_off( std::ostream& out, Polyhedron_3<Traits>& P);
 calls \link write_OFF() `write_OFF(out, P)` \endlink.
 */
 template <class Traits>
-std::ostream& operator<<( std::ostream& out, Polyhedron_3<Traits>& P);
+std::ostream& operator<<( std::ostream& out, const Polyhedron_3<Traits>& P);
 
 } /* namespace CGAL */
-

--- a/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
+++ b/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
@@ -43,7 +43,7 @@ The following table lists some \cgal data structures that have I/O functions com
     <td rowspan="6" width="75">Input</td>
     <td rowspan="3" width="175">Polygon Mesh</td>
     <td width="250">`CGAL::Surface_mesh`</td>
-    <td width="500">\link PkgSurfaceMeshIOFuncOFF CGAL::IO::read_OFF(const char*, CGAL::Surface_mesh&)\endlink</td>
+    <td width="500">\link PkgSurfaceMeshIOFuncOFF CGAL::IO::read_OFF(const std::string&, CGAL::Surface_mesh&)\endlink</td>
   </tr>
   <tr>
     <td>`CGAL::Polyhedron_3`</td>
@@ -71,11 +71,11 @@ The following table lists some \cgal data structures that have I/O functions com
     <td rowspan="6">Output</td>
     <td rowspan="3">Polygon Mesh</td>
     <td>`CGAL::Surface_mesh`</td>
-    <td>\link PkgSurfaceMeshIOFuncOFF CGAL::IO::write_OFF(const char*, CGAL::Surface_mesh&)\endlink</td>
+    <td>\link PkgSurfaceMeshIOFuncOFF CGAL::IO::write_OFF(const std::string, CGAL::Surface_mesh&)\endlink</td>
   </tr>
   <tr>
     <td>`CGAL::Polyhedron_3`</td>
-    <td>\link PkgPolyhedronIOFunc CGAL::IO::write_OFF(const char*, const CGAL::Polyhedron_3&)\endlink</td>
+    <td>\link PkgPolyhedronIOFunc CGAL::IO::write_OFF(const std::string&, const CGAL::Polyhedron_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any model of `FaceGraph`</td>

--- a/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
+++ b/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
@@ -453,23 +453,28 @@ A precise specification of those formats is available at
     <td rowspan="2" width="75">Input</td>
     <td rowspan="1" width="175">Polygon Mesh</td>
     <td width="250">Any model of `MutableFaceGraph`</td>
-    <td width="500">\link PkgBGLIoFuncsVTP CGAL::IO::read_VTP(const char*, Graph&)\endlink</td>
+    <td width="500">\link PkgBGLIoFuncsVTP CGAL::IO::read_VTP(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsVTP CGAL::IO::read_VTP(const char*, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsVTP CGAL::IO::read_VTP(const std::string&, PointRange&, PolygonRange&)\endlink</td>
+  </tr>
+  <tr>
+    <td>Polygon Soup</td>
+    <td>Any point + polygon range</td>
+    <td>\link PkgStreamSupportIoFuncsVTP CGAL::IO::read_VTK(const std::string&, PointRange&, PolygonRange&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Output</td>
     <td rowspan="1">Polygon Mesh</td>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsVTP CGAL::IO::write_VTP(const char*, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsVTP CGAL::IO::write_VTP(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsVTP CGAL::IO::write_VTP(const char*, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsVTP CGAL::IO::write_VTP(const std::string&, const PointRange&, const PolygonRange&)\endlink</td>
   </tr>
 </table>
 

--- a/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
+++ b/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
@@ -47,25 +47,25 @@ The following table lists some \cgal data structures that have I/O functions com
   </tr>
   <tr>
     <td>`CGAL::Polyhedron_3`</td>
-    <td>\link PkgPolyhedronIOFunc CGAL::IO::read_OFF(const char*, CGAL::Polyhedron_3&)\endlink</td>
+    <td>\link PkgPolyhedronIOFunc CGAL::IO::read_OFF(const std::string&, CGAL::Polyhedron_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any model of `MutableFaceGraph`</td>
-    <td>\link PkgBGLIoFuncsOFF CGAL::IO::read_OFF(const char*, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsOFF CGAL::IO::read_OFF(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Point Set</td>
     <td>`CGAL::Point_set_3`</td>
-    <td>\link PkgPointSet3IOOFF CGAL::IO::read_OFF(const char*, CGAL::Point_set_3&)\endlink</td>
+    <td>\link PkgPointSet3IOOFF CGAL::IO::read_OFF(const std::string&, CGAL::Point_set_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any point range</td>
-    <td>\link PkgPointSetProcessing3IOOff CGAL::IO::read_OFF(const char*, PointRange&)\endlink</td>
+    <td>\link PkgPointSetProcessing3IOOff CGAL::IO::read_OFF(const std::string&, PointRange&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsOFF CGAL::IO::read_OFF(const char*, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsOFF CGAL::IO::read_OFF(const std::string&, PointRange&, PolygonRange&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="6">Output</td>
@@ -75,25 +75,25 @@ The following table lists some \cgal data structures that have I/O functions com
   </tr>
   <tr>
     <td>`CGAL::Polyhedron_3`</td>
-    <td>\link PkgPolyhedronIOFunc CGAL::IO::write_OFF(const char*, CGAL::Polyhedron_3&)\endlink</td>
+    <td>\link PkgPolyhedronIOFunc CGAL::IO::write_OFF(const char*, const CGAL::Polyhedron_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsOFF CGAL::IO::write_OFF(const char*, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsOFF CGAL::IO::write_OFF(const std::string&, const Graph&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Point Set</td>
     <td>`CGAL::Point_set_3`</td>
-    <td>\link PkgPointSet3IOOFF CGAL::IO::write_OFF(const char*, CGAL::Point_set_3&)\endlink</td>
+    <td>\link PkgPointSet3IOOFF CGAL::IO::write_OFF(const std::string&, const CGAL::Point_set_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any point range</td>
-    <td>\link PkgPointSetProcessing3IOOff CGAL::IO::write_OFF(const char*, PointRange&)\endlink</td>
+    <td>\link PkgPointSetProcessing3IOOff CGAL::IO::write_OFF(const std::string&, const PointRange&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsOFF CGAL::IO::write_OFF(const char*, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsOFF CGAL::IO::write_OFF(const std::string&, const PointRange&, const PolygonRange&)\endlink</td>
   </tr>
 </table>
 
@@ -128,12 +128,12 @@ A precise specification of the format is available <a href="https://www.martinre
     <td rowspan="2">Output</td>
     <td rowspan="1">Polygon Mesh</td>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsOBJ CGAL::IO::write_OBJ(const std::string&, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsOBJ CGAL::IO::write_OBJ(const std::string&, const Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsOBJ CGAL::IO::write_OBJ(const std::string&, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsOBJ CGAL::IO::write_OBJ(const std::string&, const PointRange&, const PolygonRange&)\endlink</td>
   </tr>
 </table>
 
@@ -169,12 +169,12 @@ A precise specification of those formats is available <a href="https://www.fabbe
     <td rowspan="2">Output</td>
     <td rowspan="1">Polygon Mesh</td>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsSTL CGAL::IO::write_STL(const std::string&, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsSTL CGAL::IO::write_STL(const std::string&, const Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsSTL CGAL::IO::write_STL(const std::string&, PointRange&, TriangleRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsSTL CGAL::IO::write_STL(const std::string&, const PointRange&, const TriangleRange&)\endlink</td>
   </tr>
 </table>
 
@@ -226,25 +226,25 @@ A precise specification of those formats is available <a href="https://paulbourk
     <td rowspan="5">Output</td>
     <td rowspan="2">Polygon Mesh</td>
     <td>`CGAL::Surface_mesh`</td>
-    <td>\link PkgSurfaceMeshIOFuncPLY CGAL::IO::write_PLY(const std::string&, CGAL::Surface_mesh&)\endlink</td>
+    <td>\link PkgSurfaceMeshIOFuncPLY CGAL::IO::write_PLY(const std::string&, const CGAL::Surface_mesh&)\endlink</td>
   </tr>
   <tr>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsPLY CGAL::IO::write_PLY(const std::string&, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsPLY CGAL::IO::write_PLY(const std::string&, const Graph&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Point Set</td>
     <td>`CGAL::Point_set_3`</td>
-    <td>\link PkgPointSet3IOPLY CGAL::IO::write_PLY(const std::string&, CGAL::Point_set_3&)\endlink</td>
+    <td>\link PkgPointSet3IOPLY CGAL::IO::write_PLY(const std::string&, const CGAL::Point_set_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any point range</td>
-    <td>\link PkgPointSetProcessing3IOPly CGAL::IO::write_PLY(const std::string&, PointRange&)\endlink</td>
+    <td>\link PkgPointSetProcessing3IOPly CGAL::IO::write_PLY(const std::string&, const PointRange&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsPLY CGAL::IO::write_PLY(const std::string&, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsPLY CGAL::IO::write_PLY(const std::string&, const PointRange&, PolygonRange&)\endlink</td>
   </tr>
 </table>
 
@@ -280,11 +280,11 @@ A precise specification of those formats is available
     <td rowspan="2">Output</td>
     <td rowspan="2">Point Set</td>
     <td>`CGAL::Point_set_3`</td>
-    <td>\link PkgPointSet3IOLAS CGAL::IO::write_LAS(const std::string&, CGAL::Point_set_3&)\endlink</td>
+    <td>\link PkgPointSet3IOLAS CGAL::IO::write_LAS(const std::string&, const CGAL::Point_set_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any point range</td>
-    <td>\link PkgPointSetProcessing3IOLas CGAL::IO::write_LAS(const std::string&, PointRange&)\endlink</td>
+    <td>\link PkgPointSetProcessing3IOLas CGAL::IO::write_LAS(const std::string&, const PointRange&)\endlink</td>
   </tr>
 </table>
 
@@ -313,11 +313,11 @@ of its coordinates and other properties. Only coordinates and normals are curren
     <td rowspan="2">Output</td>
     <td rowspan="2">Point Set</td>
     <td>`CGAL::Point_set_3`</td>
-    <td>\link PkgPointSet3IOXYZ CGAL::IO::write_XYZ(const std::string&, CGAL::Point_set_3&)\endlink</td>
+    <td>\link PkgPointSet3IOXYZ CGAL::IO::write_XYZ(const std::string&, const CGAL::Point_set_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any point range</td>
-    <td>\link PkgPointSetProcessing3IOXyz CGAL::IO::write_XYZ(const std::string&, PointRange&)\endlink</td>
+    <td>\link PkgPointSetProcessing3IOXyz CGAL::IO::write_XYZ(const std::string&, const PointRange&)\endlink</td>
   </tr>
 </table>
 
@@ -348,12 +348,12 @@ A precise specification of the format is available <a href="https://paulbourke.n
     <td rowspan="2">Output</td>
     <td rowspan="1">Polygon Mesh</td>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsGOCAD CGAL::IO::write_GOCAD(const std::string&, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsGOCAD CGAL::IO::write_GOCAD(const std::string&, const Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsGOCAD CGAL::IO::write_GOCAD(const std::string&, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsGOCAD CGAL::IO::write_GOCAD(const std::string&, const PointRange&, const PolygonRange&)\endlink</td>
   </tr>
 </table>
 
@@ -392,12 +392,12 @@ note that only versions `1.x` are currently supported in \cgal.
     <td rowspan="2">Output</td>
     <td rowspan="1">Polygon Mesh</td>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncs3MF CGAL::IO::write_3MF(const std::string&, GraphRange&)\endlink</td>
+    <td>\link PkgBGLIoFuncs3MF CGAL::IO::write_3MF(const std::string&, const GraphRange&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncs3MF CGAL::IO::write_3MF(const std::string&, PointRanges&, PolygonRanges&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncs3MF CGAL::IO::write_3MF(const std::string&, const PointRanges&, const PolygonRanges&)\endlink</td>
   </tr>
 </table>
 
@@ -422,7 +422,7 @@ A precise specification of the format is available <a href="http://gun.teipir.gr
     <td rowspan="1" width="75">Output</td>
     <td rowspan="1" width="175">Polygon Mesh</td>
     <td width="250">Any model of `FaceGraph`</td>
-    <td width="500">\link PkgBGLIoFuncsWRL CGAL::IO::write_WRL(const std::string&, Graph&)\endlink</td>
+    <td width="500">\link PkgBGLIoFuncsWRL CGAL::IO::write_WRL(const std::string&, const Graph&)\endlink</td>
   </tr>
 </table>
 
@@ -466,7 +466,7 @@ A precise specification of those formats is available at
     <td rowspan="2">Output</td>
     <td rowspan="1">Polygon Mesh</td>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsVTP CGAL::IO::write_VTP(const std::string&, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsVTP CGAL::IO::write_VTP(const std::string&, const Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>

--- a/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
+++ b/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
@@ -426,7 +426,7 @@ A precise specification of the format is available <a href="http://gun.teipir.gr
   </tr>
 </table>
 
-\section IOStreamVTK VTK (VTU / VTP) File Formats
+\section IOStreamVTK VTK (VTU / VTP / legacy) File Formats
 
 \attention \cgal needs to be configured with the VTK Libraries for this function to be available.
 
@@ -440,7 +440,9 @@ The VTK libraries use different file formats to handle data structures, but we o
 
 - The `VTP` format can be used to store collections of points, lines, and triangles.
   In the <a href="https://vtk.org/"> VTK Libraries</a>, it is the format
-  reserved to store `PolyData`, and in \cgal, we use it to store Polygon Meshes.
+  reserved to store `PolyData`, and in \cgal, we use it to store polygon meshes.
+
+We additionally provide a read function for the legacy non-XML file `VTK` file format for polygon meshes.
 
 A precise specification of those formats is available at
 <a href="https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf">vtk.org</a>.

--- a/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
+++ b/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
@@ -60,7 +60,7 @@ The following table lists some \cgal data structures that have I/O functions com
   </tr>
   <tr>
     <td>Any point range</td>
-    <td>\link PkgPointSetProcessing3IOOff CGAL::IO::read_OFF(const std::string&, PointRange&)\endlink</td>
+    <td>\link PkgPointSetProcessing3IOOff CGAL::IO::read_OFF(const std::string&, PointOutputIterator)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>

--- a/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
+++ b/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
@@ -117,23 +117,23 @@ A precise specification of the format is available <a href="https://www.martinre
     <td rowspan="2" width="75">Input</td>
     <td rowspan="1" width="175">Polygon Mesh</td>
     <td width="250">Any model of `MutableFaceGraph`</td>
-    <td width="500">\link PkgBGLIoFuncsOBJ CGAL::IO::read_OBJ(const char*, Graph&)\endlink</td>
+    <td width="500">\link PkgBGLIoFuncsOBJ CGAL::IO::read_OBJ(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsOBJ CGAL::IO::read_OBJ(const char*, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsOBJ CGAL::IO::read_OBJ(const std::string&, PointRange&, PolygonRange&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Output</td>
     <td rowspan="1">Polygon Mesh</td>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsOBJ CGAL::IO::write_OBJ(const char*, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsOBJ CGAL::IO::write_OBJ(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsOBJ CGAL::IO::write_OBJ(const char*, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsOBJ CGAL::IO::write_OBJ(const std::string&, PointRange&, PolygonRange&)\endlink</td>
   </tr>
 </table>
 
@@ -158,23 +158,23 @@ A precise specification of those formats is available <a href="https://www.fabbe
     <td rowspan="2" width="75">Input</td>
     <td rowspan="1" width="175">Polygon Mesh</td>
     <td width="250">Any model of `MutableFaceGraph`</td>
-    <td width="500">\link PkgBGLIoFuncsSTL CGAL::IO::read_STL(const char*, Graph&)\endlink</td>
+    <td width="500">\link PkgBGLIoFuncsSTL CGAL::IO::read_STL(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsSTL CGAL::IO::read_STL(const char*, PointRange&, TriangleRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsSTL CGAL::IO::read_STL(const std::string&, PointRange&, TriangleRange&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Output</td>
     <td rowspan="1">Polygon Mesh</td>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsSTL CGAL::IO::write_STL(const char*, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsSTL CGAL::IO::write_STL(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsSTL CGAL::IO::write_STL(const char*, PointRange&, TriangleRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsSTL CGAL::IO::write_STL(const std::string&, PointRange&, TriangleRange&)\endlink</td>
   </tr>
 </table>
 
@@ -202,49 +202,49 @@ A precise specification of those formats is available <a href="https://paulbourk
     <td rowspan="5" width="75">Input</td>
     <td rowspan="2" width="175">Polygon Mesh</td>
     <td width="250">`CGAL::Surface_mesh`</td>
-    <td width="500">\link PkgSurfaceMeshIOFuncPLY CGAL::IO::read_PLY(const char*, CGAL::Surface_mesh&)\endlink</td>
+    <td width="500">\link PkgSurfaceMeshIOFuncPLY CGAL::IO::read_PLY(const std::string&, CGAL::Surface_mesh&)\endlink</td>
   </tr>
   <tr>
     <td>Any model of `MutableFaceGraph`</td>
-    <td>\link PkgBGLIoFuncsPLY CGAL::IO::read_PLY(const char*, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsPLY CGAL::IO::read_PLY(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Point Set</td>
     <td>`CGAL::Point_set_3`</td>
-    <td>\link PkgPointSet3IOPLY CGAL::IO::read_PLY(const char*, CGAL::Point_set_3&)\endlink</td>
+    <td>\link PkgPointSet3IOPLY CGAL::IO::read_PLY(const std::string&, CGAL::Point_set_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any point range</td>
-    <td>\link PkgPointSetProcessing3IOPly CGAL::IO::read_PLY(const char*, PointRange&)\endlink</td>
+    <td>\link PkgPointSetProcessing3IOPly CGAL::IO::read_PLY(const std::string&, PointRange&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsPLY CGAL::IO::read_PLY(const char*, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsPLY CGAL::IO::read_PLY(const std::string&, PointRange&, PolygonRange&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="5">Output</td>
     <td rowspan="2">Polygon Mesh</td>
     <td>`CGAL::Surface_mesh`</td>
-    <td>\link PkgSurfaceMeshIOFuncPLY CGAL::IO::write_PLY(const char*, CGAL::Surface_mesh&)\endlink</td>
+    <td>\link PkgSurfaceMeshIOFuncPLY CGAL::IO::write_PLY(const std::string&, CGAL::Surface_mesh&)\endlink</td>
   </tr>
   <tr>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsPLY CGAL::IO::write_PLY(const char*, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsPLY CGAL::IO::write_PLY(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Point Set</td>
     <td>`CGAL::Point_set_3`</td>
-    <td>\link PkgPointSet3IOPLY CGAL::IO::write_PLY(const char*, CGAL::Point_set_3&)\endlink</td>
+    <td>\link PkgPointSet3IOPLY CGAL::IO::write_PLY(const std::string&, CGAL::Point_set_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any point range</td>
-    <td>\link PkgPointSetProcessing3IOPly CGAL::IO::write_PLY(const char*, PointRange&)\endlink</td>
+    <td>\link PkgPointSetProcessing3IOPly CGAL::IO::write_PLY(const std::string&, PointRange&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsPLY CGAL::IO::write_PLY(const char*, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsPLY CGAL::IO::write_PLY(const std::string&, PointRange&, PolygonRange&)\endlink</td>
   </tr>
 </table>
 
@@ -270,21 +270,21 @@ A precise specification of those formats is available
     <td rowspan="2" width="75">Input</td>
     <td rowspan="2" width="175">Point Set</td>
     <td width="250">`CGAL::Point_set_3`</td>
-    <td width="500">\link PkgPointSet3IOLAS CGAL::IO::read_LAS(const char*, CGAL::Point_set_3&)\endlink</td>
+    <td width="500">\link PkgPointSet3IOLAS CGAL::IO::read_LAS(const std::string&, CGAL::Point_set_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any point range</td>
-    <td>\link PkgPointSetProcessing3IOLas CGAL::IO::read_LAS(const char*, PointRange&)\endlink</td>
+    <td>\link PkgPointSetProcessing3IOLas CGAL::IO::read_LAS(const std::string&, PointRange&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Output</td>
     <td rowspan="2">Point Set</td>
     <td>`CGAL::Point_set_3`</td>
-    <td>\link PkgPointSet3IOLAS CGAL::IO::write_LAS(const char*, CGAL::Point_set_3&)\endlink</td>
+    <td>\link PkgPointSet3IOLAS CGAL::IO::write_LAS(const std::string&, CGAL::Point_set_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any point range</td>
-    <td>\link PkgPointSetProcessing3IOLas CGAL::IO::write_LAS(const char*, PointRange&)\endlink</td>
+    <td>\link PkgPointSetProcessing3IOLas CGAL::IO::write_LAS(const std::string&, PointRange&)\endlink</td>
   </tr>
 </table>
 
@@ -303,21 +303,21 @@ of its coordinates and other properties. Only coordinates and normals are curren
     <td rowspan="2" width="75">Input</td>
     <td rowspan="2" width="175">Point Set</td>
     <td width="250">`CGAL::Point_set_3`</td>
-    <td width="500">\link PkgPointSet3IOXYZ CGAL::IO::read_XYZ(const char*, CGAL::Point_set_3&)\endlink</td>
+    <td width="500">\link PkgPointSet3IOXYZ CGAL::IO::read_XYZ(const std::string&, CGAL::Point_set_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any point range</td>
-    <td>\link PkgPointSetProcessing3IOXyz CGAL::IO::read_XYZ(const char*, PointRange&)\endlink</td>
+    <td>\link PkgPointSetProcessing3IOXyz CGAL::IO::read_XYZ(const std::string&, PointRange&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Output</td>
     <td rowspan="2">Point Set</td>
     <td>`CGAL::Point_set_3`</td>
-    <td>\link PkgPointSet3IOXYZ CGAL::IO::write_XYZ(const char*, CGAL::Point_set_3&)\endlink</td>
+    <td>\link PkgPointSet3IOXYZ CGAL::IO::write_XYZ(const std::string&, CGAL::Point_set_3&)\endlink</td>
   </tr>
   <tr>
     <td>Any point range</td>
-    <td>\link PkgPointSetProcessing3IOXyz CGAL::IO::write_XYZ(const char*, PointRange&)\endlink</td>
+    <td>\link PkgPointSetProcessing3IOXyz CGAL::IO::write_XYZ(const std::string&, PointRange&)\endlink</td>
   </tr>
 </table>
 
@@ -337,23 +337,23 @@ A precise specification of the format is available <a href="https://paulbourke.n
     <td rowspan="2" width="75">Input</td>
     <td rowspan="1" width="175">Polygon Mesh</td>
     <td width="250">Any model of `MutableFaceGraph`</td>
-    <td width="500">\link PkgBGLIoFuncsGOCAD CGAL::IO::read_GOCAD(const char*, Graph&)\endlink</td>
+    <td width="500">\link PkgBGLIoFuncsGOCAD CGAL::IO::read_GOCAD(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsGOCAD CGAL::IO::read_GOCAD(const char*, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsGOCAD CGAL::IO::read_GOCAD(const std::string&, PointRange&, PolygonRange&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Output</td>
     <td rowspan="1">Polygon Mesh</td>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsGOCAD CGAL::IO::write_GOCAD(const char*, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsGOCAD CGAL::IO::write_GOCAD(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsGOCAD CGAL::IO::write_GOCAD(const char*, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsGOCAD CGAL::IO::write_GOCAD(const std::string&, PointRange&, PolygonRange&)\endlink</td>
   </tr>
 </table>
 
@@ -381,23 +381,23 @@ note that only versions `1.x` are currently supported in \cgal.
     <td rowspan="2" width="75">Input</td>
     <td rowspan="1" width="175">Polygon Mesh</td>
     <td width="250">`CGAL::Surface_mesh`</td>
-    <td width="500">\link PkgSurfaceMeshIOFunc3MF CGAL::IO::read_3MF(const char*, Surface_meshRange&)\endlink</td>
+    <td width="500">\link PkgSurfaceMeshIOFunc3MF CGAL::IO::read_3MF(const std::string&, Surface_meshRange&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncs3MF CGAL::IO::read_3MF(const char*, PointRanges&, PolygonRanges&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncs3MF CGAL::IO::read_3MF(const std::string&, PointRanges&, PolygonRanges&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Output</td>
     <td rowspan="1">Polygon Mesh</td>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncs3MF CGAL::IO::write_3MF(const char*, GraphRange&)\endlink</td>
+    <td>\link PkgBGLIoFuncs3MF CGAL::IO::write_3MF(const std::string&, GraphRange&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncs3MF CGAL::IO::write_3MF(const char*, PointRanges&, PolygonRanges&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncs3MF CGAL::IO::write_3MF(const std::string&, PointRanges&, PolygonRanges&)\endlink</td>
   </tr>
 </table>
 
@@ -416,13 +416,13 @@ A precise specification of the format is available <a href="http://gun.teipir.gr
 
 <table class="iotable">
   <tr>
-    <th colspan="4">3D Manufacturing Format (3MF)</th>
+    <th colspan="4">3D VRML Format (WRL)</th>
   </tr>
   <tr>
     <td rowspan="1" width="75">Output</td>
     <td rowspan="1" width="175">Polygon Mesh</td>
     <td width="250">Any model of `FaceGraph`</td>
-    <td width="500">\link PkgBGLIoFuncsWRL CGAL::IO::write_WRL(const char*, Graph&)\endlink</td>
+    <td width="500">\link PkgBGLIoFuncsWRL CGAL::IO::write_WRL(const std::string&, Graph&)\endlink</td>
   </tr>
 </table>
 
@@ -447,23 +447,18 @@ A precise specification of those formats is available at
 
 <table class="iotable">
   <tr>
-    <th colspan="4">VTK (VTU / VTP) File Formats</th>
+    <th colspan="4">VTK (VTU / VTP / legacy) File Formats</th>
   </tr>
   <tr>
     <td rowspan="2" width="75">Input</td>
     <td rowspan="1" width="175">Polygon Mesh</td>
     <td width="250">Any model of `MutableFaceGraph`</td>
-    <td width="500">\link PkgBGLIoFuncsVTP CGAL::IO::read_VTP(const std::string&, Graph&)\endlink</td>
+    <td width="800">\link PkgBGLIoFuncsVTP CGAL::IO::read_VTP(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsVTP CGAL::IO::read_VTP(const std::string&, PointRange&, PolygonRange&)\endlink</td>
-  </tr>
-  <tr>
-    <td>Polygon Soup</td>
-    <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsVTP CGAL::IO::read_VTK(const std::string&, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsVTP CGAL::IO::read_VTP(const std::string&, PointRange&, PolygonRange&)\endlink, <BR> \link PkgStreamSupportIoFuncsVTP CGAL::IO::read_VTK(const std::string&, PointRange&, PolygonRange&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Output</td>

--- a/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
+++ b/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
@@ -442,7 +442,7 @@ The VTK libraries use different file formats to handle data structures, but we o
   In the <a href="https://vtk.org/"> VTK Libraries</a>, it is the format
   reserved to store `PolyData`, and in \cgal, we use it to store polygon meshes.
 
-We additionally provide a read function for the legacy non-XML file `VTK` file format for polygon meshes.
+We additionally provide a read function for the legacy non-XML `VTK` file format for polygon meshes.
 
 A precise specification of those formats is available at
 <a href="https://vtk.org/wp-content/uploads/2015/04/file-formats.pdf">vtk.org</a>.
@@ -455,23 +455,23 @@ A precise specification of those formats is available at
     <td rowspan="2" width="75">Input</td>
     <td rowspan="1" width="175">Polygon Mesh</td>
     <td width="250">Any model of `MutableFaceGraph`</td>
-    <td width="800">\link PkgBGLIoFuncsVTP CGAL::IO::read_VTP(const std::string&, Graph&)\endlink</td>
+    <td width="800">\link PkgBGLIoFuncsVTK CGAL::IO::read_VTP(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsVTP CGAL::IO::read_VTP(const std::string&, PointRange&, PolygonRange&)\endlink, <BR> \link PkgStreamSupportIoFuncsVTP CGAL::IO::read_VTK(const std::string&, PointRange&, PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsVTK CGAL::IO::read_VTP(const std::string&, PointRange&, PolygonRange&)\endlink, <BR> \link PkgStreamSupportIoFuncsVTK CGAL::IO::read_VTK(const std::string&, PointRange&, PolygonRange&)\endlink</td>
   </tr>
   <tr>
     <td rowspan="2">Output</td>
     <td rowspan="1">Polygon Mesh</td>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsVTP CGAL::IO::write_VTP(const std::string&, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsVTK CGAL::IO::write_VTP(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
     <td>Any point + polygon range</td>
-    <td>\link PkgStreamSupportIoFuncsVTP CGAL::IO::write_VTP(const std::string&, const PointRange&, const PolygonRange&)\endlink</td>
+    <td>\link PkgStreamSupportIoFuncsVTK CGAL::IO::write_VTP(const std::string&, const PointRange&, const PolygonRange&)\endlink</td>
   </tr>
 </table>
 

--- a/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
+++ b/Stream_support/doc/Stream_support/File_formats/Supported_file_formats.txt
@@ -455,7 +455,7 @@ A precise specification of those formats is available at
     <td rowspan="2" width="75">Input</td>
     <td rowspan="1" width="175">Polygon Mesh</td>
     <td width="250">Any model of `MutableFaceGraph`</td>
-    <td width="800">\link PkgBGLIoFuncsVTK CGAL::IO::read_VTP(const std::string&, Graph&)\endlink</td>
+    <td width="800">\link PkgBGLIoFuncsVTP CGAL::IO::read_VTP(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>
@@ -466,7 +466,7 @@ A precise specification of those formats is available at
     <td rowspan="2">Output</td>
     <td rowspan="1">Polygon Mesh</td>
     <td>Any model of `FaceGraph`</td>
-    <td>\link PkgBGLIoFuncsVTK CGAL::IO::write_VTP(const std::string&, Graph&)\endlink</td>
+    <td>\link PkgBGLIoFuncsVTP CGAL::IO::write_VTP(const std::string&, Graph&)\endlink</td>
   </tr>
   <tr>
     <td>Polygon Soup</td>

--- a/Stream_support/doc/Stream_support/IOstream.txt
+++ b/Stream_support/doc/Stream_support/IOstream.txt
@@ -305,18 +305,18 @@ The following table shows which file formats can be read from and written for po
     <tr>
       <td>Input</td>
       <td>`read_points()`</td>
-      <td>\link PkgPointSetProcessing3IOOff `read_OFF()` \endlink</td>
-      <td>\link PkgPointSetProcessing3IOXyz `read_XYZ()` \endlink</td>
-      <td>\link PkgPointSetProcessing3IOPly `read_PLY()` \endlink</td>
-      <td>\link PkgPointSetProcessing3IOLas `read_LAS()` \endlink</td>
+      <td>\link PkgPointSetProcessing3IOOff `CGAL::IO::read_OFF()` \endlink</td>
+      <td>\link PkgPointSetProcessing3IOXyz `GAL::IO::read_XYZ()` \endlink</td>
+      <td>\link PkgPointSetProcessing3IOPly `GAL::IO::read_PLY()` \endlink</td>
+      <td>\link PkgPointSetProcessing3IOLas `GAL::IO::read_LAS()` \endlink</td>
     </tr>
     <tr>
       <td>Output</td>
       <td>`write_points()`</td>
-      <td>\link PkgPointSetProcessing3IOOff `write_OFF()` \endlink</td>
-      <td>\link PkgPointSetProcessing3IOXyz `write_XYZ()` \endlink</td>
-      <td>\link PkgPointSetProcessing3IOPly `write_PLY()` \endlink</td>
-      <td>\link PkgPointSetProcessing3IOLas `write_LAS()` \endlink</td>
+      <td>\link PkgPointSetProcessing3IOOff `GAL::IO::write_OFF()` \endlink</td>
+      <td>\link PkgPointSetProcessing3IOXyz `GAL::IO::write_XYZ()` \endlink</td>
+      <td>\link PkgPointSetProcessing3IOPly `GAL::IO::write_PLY()` \endlink</td>
+      <td>\link PkgPointSetProcessing3IOLas `GAL::IO::write_LAS()` \endlink</td>
     </tr>
 </table>
 
@@ -346,18 +346,18 @@ The file formats supported for `CGAL::Point_set_3` are detailed in the table bel
     <tr>
       <td>Input</td>
       <td>`CGAL::IO::read_point_set()`</td>
-      <td>\link PkgPointSet3IOOFF `read_OFF()` \endlink</td>
-      <td>\link PkgPointSet3IOXYZ `read_XYZ()` \endlink</td>
-      <td>\link PkgPointSet3IOPLY `read_PLY()` \endlink</td>
-      <td>\link PkgPointSet3IOLAS `read_LAS()` \endlink</td>
+      <td>\link PkgPointSet3IOOFF `GAL::IO::read_OFF()` \endlink</td>
+      <td>\link PkgPointSet3IOXYZ `GAL::IO::read_XYZ()` \endlink</td>
+      <td>\link PkgPointSet3IOPLY `GAL::IO::read_PLY()` \endlink</td>
+      <td>\link PkgPointSet3IOLAS `GAL::IO::read_LAS()` \endlink</td>
     </tr>
     <tr>
       <td>Output</td>
       <td>`CGAL::IO::write_point_set()`</td>
-      <td>\link PkgPointSet3IOOFF `write_OFF()` \endlink</td>
-      <td>\link PkgPointSet3IOXYZ `write_XYZ()` \endlink</td>
-      <td>\link PkgPointSet3IOPLY `write_PLY()` \endlink</td>
-      <td>\link PkgPointSet3IOLAS `write_LAS()` \endlink</td>
+      <td>\link PkgPointSet3IOOFF `GAL::IO::write_OFF()` \endlink</td>
+      <td>\link PkgPointSet3IOXYZ `GAL::IO::write_XYZ()` \endlink</td>
+      <td>\link PkgPointSet3IOPLY `GAL::IO::write_PLY()` \endlink</td>
+      <td>\link PkgPointSet3IOLAS `GAL::IO::write_LAS()` \endlink</td>
     </tr>
 </table>
 
@@ -382,26 +382,26 @@ their indices per face (i.e a vector of 3 integers represent a triangle face).
     <tr>
       <td>Input</td>
       <td>`CGAL::IO::read_polygon_soup()`</td>
-      <td>\link PkgStreamSupportIoFuncsOFF `read_OFF()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsOBJ `read_OBJ()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsSTL `read_STL()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsPLY `read_PLY()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsVTK `read_VTP()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsGOCAD `read_GOCAD()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsWKT `read_WKT()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncs3MF `read_3MF()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsOFF `GAL::IO::read_OFF()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsOBJ `GAL::IO::read_OBJ()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsSTL `GAL::IO::read_STL()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsPLY `GAL::IO::read_PLY()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsVTK `GAL::IO::read_VTP()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsGOCAD `GAL::IO::read_GOCAD()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsWKT `GAL::IO::read_WKT()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncs3MF `GAL::IO::read_3MF()` \endlink</td>
     </tr>
     <tr>
       <td>Output</td>
       <td>`CGAL::IO::write_polygon_soup()`</td>
-      <td>\link PkgStreamSupportIoFuncsOFF `write_OFF()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsOBJ `write_OBJ()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsSTL `write_STL()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsPLY `write_PLY()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsVTK `write_VTP()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsGOCAD `write_GOCAD()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsWKT `write_WKT()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncs3MF `write_3MF()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsOFF `GAL::IO::write_OFF()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsOBJ `GAL::IO::write_OBJ()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsSTL `GAL::IO::write_STL()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsPLY `GAL::IO::write_PLY()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsVTK `GAL::IO::write_VTP()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsGOCAD `GAL::IO::write_GOCAD()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsWKT `GAL::IO::write_WKT()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncs3MF `GAL::IO::write_3MF()` \endlink</td>
     </tr>
 </table>
 
@@ -425,21 +425,21 @@ The table above only lists the functions that work with any polygon mesh.
     <tr>
       <td>Input</td>
       <td>`CGAL::IO::read_polygon_mesh()`</td>
-      <td>`read_OFF()`</td>
-      <td>`read_STL()`</td>
-      <td>`read_VTP()`</td>
-      <td>`read_OBJ()`</td>
-      <td>`read_GOCAD()`</td>
+      <td>`CGAL::IO::read_OFF()`</td>
+      <td>`CGAL::IO::read_STL()`</td>
+      <td>`CGAL::IO::read_VTP()`</td>
+      <td>`CGAL::IO::read_OBJ()`</td>
+      <td>`CGAL::IO::read_GOCAD()`</td>
       <td><center> - </center></td>
     </tr>
     <tr>
       <td>Output</td>
       <td>``CGAL::IO::write_polygon_mesh()`</td>
-      <td>`write_OFF()`</td>
-      <td>`write_STL()`</td>
-      <td>`write_VTP()`</td>
-      <td>`write_OBJ()`</td>
-      <td>`write_GOCAD()`</td>
+      <td>`CGAL::IO::write_OFF()`</td>
+      <td>`CGAL::IO::write_STL()`</td>
+      <td>`CGAL::IO::write_VTP()`</td>
+      <td>`CGAL::IO::write_OBJ()`</td>
+      <td>`CGAL::IO::write_GOCAD()`</td>
       <td>`write_WRL()`</td>
     </tr>
 </table>

--- a/Stream_support/doc/Stream_support/IOstream.txt
+++ b/Stream_support/doc/Stream_support/IOstream.txt
@@ -345,7 +345,7 @@ The file formats supported for `CGAL::Point_set_3` are detailed in the table bel
     </tr>
     <tr>
       <td>Input</td>
-      <td>`read_point_set()`</td>
+      <td>`CGAL::IO::read_point_set()`</td>
       <td>\link PkgPointSet3IOOFF `read_OFF()` \endlink</td>
       <td>\link PkgPointSet3IOXYZ `read_XYZ()` \endlink</td>
       <td>\link PkgPointSet3IOPLY `read_PLY()` \endlink</td>
@@ -353,7 +353,7 @@ The file formats supported for `CGAL::Point_set_3` are detailed in the table bel
     </tr>
     <tr>
       <td>Output</td>
-      <td>`write_point_set()`</td>
+      <td>`CGAL::IO::write_point_set()`</td>
       <td>\link PkgPointSet3IOOFF `write_OFF()` \endlink</td>
       <td>\link PkgPointSet3IOXYZ `write_XYZ()` \endlink</td>
       <td>\link PkgPointSet3IOPLY `write_PLY()` \endlink</td>
@@ -381,7 +381,7 @@ their indices per face (i.e a vector of 3 integers represent a triangle face).
     </tr>
     <tr>
       <td>Input</td>
-      <td>`read_polygon_soup()`</td>
+      <td>`CGAL::IO::read_polygon_soup()`</td>
       <td>\link PkgStreamSupportIoFuncsOFF `read_OFF()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncsOBJ `read_OBJ()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncsSTL `read_STL()` \endlink</td>
@@ -393,7 +393,7 @@ their indices per face (i.e a vector of 3 integers represent a triangle face).
     </tr>
     <tr>
       <td>Output</td>
-      <td>`write_polygon_soup()`</td>
+      <td>`CGAL::IO::write_polygon_soup()`</td>
       <td>\link PkgStreamSupportIoFuncsOFF `write_OFF()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncsOBJ `write_OBJ()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncsSTL `write_STL()` \endlink</td>
@@ -424,7 +424,7 @@ The table above only lists the functions that work with any polygon mesh.
     </tr>
     <tr>
       <td>Input</td>
-      <td>`read_polygon_mesh()`</td>
+      <td>`CGAL::IO::read_polygon_mesh()`</td>
       <td>`read_OFF()`</td>
       <td>`read_STL()`</td>
       <td>`read_VTP()`</td>
@@ -434,7 +434,7 @@ The table above only lists the functions that work with any polygon mesh.
     </tr>
     <tr>
       <td>Output</td>
-      <td>`write_polygon_mesh()`</td>
+      <td>``CGAL::IO::write_polygon_mesh()`</td>
       <td>`write_OFF()`</td>
       <td>`write_STL()`</td>
       <td>`write_VTP()`</td>
@@ -478,17 +478,17 @@ from the standard \cgal I/O functions.
 </tr>
 <tr>
 <td>Input</td>
-<td>read_WKT()</td>
-<td>read_multi_point_WKT()</td>
-<td>read_multi_linestring_WKT()</td>
-<td>read_multi_polygon_WKT()</td>
+<td>`CGAL::IO::read_WKT()`</td>
+<td>`CGAL::IO::read_multi_point_WKT()`</td>
+<td>`CGAL::IO::read_multi_linestring_WKT()`</td>
+<td>`CGAL::IO::read_multi_polygon_WKT()`</td>
 </tr>
 <tr>
 <td>Output</td>
 <td><center> - </center></td>
-<td>write_multi_point_WKT()</td>
-<td>write_multi_linestring_WKT()</td>
-<td>write_multi_polygon_WKT()</td>
+<td>`CGAL::IO::write_multi_point_WKT()`</td>
+<td>`CGAL::IO::write_multi_linestring_WKT()`</td>
+<td>`CGAL::IO::write_multi_polygon_WKT()`</td>
 </tr>
 </table>
 

--- a/Stream_support/doc/Stream_support/IOstream.txt
+++ b/Stream_support/doc/Stream_support/IOstream.txt
@@ -440,7 +440,7 @@ The table above only lists the functions that work with any polygon mesh.
       <td>`CGAL::IO::write_VTP()`</td>
       <td>`CGAL::IO::write_OBJ()`</td>
       <td>`CGAL::IO::write_GOCAD()`</td>
-      <td>`write_WRL()`</td>
+      <td>\link CGAL::IO::write_WRL() `write_WRL()`\endlink</td>
     </tr>
 </table>
 

--- a/Stream_support/doc/Stream_support/IOstream.txt
+++ b/Stream_support/doc/Stream_support/IOstream.txt
@@ -440,7 +440,7 @@ The table above only lists the functions that work with any polygon mesh.
       <td>`CGAL::IO::write_VTP()`</td>
       <td>`CGAL::IO::write_OBJ()`</td>
       <td>`CGAL::IO::write_GOCAD()`</td>
-      <td>\link CGAL::IO::write_WRL() `write_WRL()`\endlink</td>
+      <td>`CGAL::IO::write_WRL()`</td>
     </tr>
 </table>
 

--- a/Stream_support/doc/Stream_support/IOstream.txt
+++ b/Stream_support/doc/Stream_support/IOstream.txt
@@ -386,7 +386,7 @@ their indices per face (i.e a vector of 3 integers represent a triangle face).
       <td>\link PkgStreamSupportIoFuncsOBJ `read_OBJ()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncsSTL `read_STL()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncsPLY `read_PLY()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsVTP `read_VTP()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsVTK `read_VTP()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncsGOCAD `read_GOCAD()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncsWKT `read_WKT()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncs3MF `read_3MF()` \endlink</td>
@@ -398,7 +398,7 @@ their indices per face (i.e a vector of 3 integers represent a triangle face).
       <td>\link PkgStreamSupportIoFuncsOBJ `write_OBJ()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncsSTL `write_STL()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncsPLY `write_PLY()` \endlink</td>
-      <td>\link PkgStreamSupportIoFuncsVTP `write_VTP()` \endlink</td>
+      <td>\link PkgStreamSupportIoFuncsVTK `write_VTP()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncsGOCAD `write_GOCAD()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncsWKT `write_WKT()` \endlink</td>
       <td>\link PkgStreamSupportIoFuncs3MF `write_3MF()` \endlink</td>

--- a/Stream_support/doc/Stream_support/PackageDescription.txt
+++ b/Stream_support/doc/Stream_support/PackageDescription.txt
@@ -20,7 +20,7 @@
 /// I/O Functions for the \ref IOStreamOFF
 /// \ingroup IOstreamFunctions
 
-/// \defgroup PkgStreamSupportIoFuncsVTP VTK I/O Functions
+/// \defgroup PkgStreamSupportIoFuncsVTK VTK I/O Functions
 /// I/O Functions for the \ref IOStreamVTK
 /// \ingroup IOstreamFunctions
 
@@ -96,7 +96,7 @@ the printing mode.
 - \link PkgStreamSupportIoFuncsOBJ I/O for OBJ files \endlink
 - \link PkgStreamSupportIoFuncsOFF I/O for OFF files \endlink
 - \link PkgStreamSupportIoFuncsGOCAD I/O for GOCAD files \endlink
-- \link PkgStreamSupportIoFuncsVTP I/O for VTP files \endlink
+- \link PkgStreamSupportIoFuncsVTK I/O for VTK files \endlink
 - \link PkgStreamSupportIoFuncs3MF I/O for 3MF files \endlink
 - \link PkgStreamSupportIoFuncsWKT I/O for WKT files \endlink
 

--- a/Stream_support/doc/Stream_support/PackageDescription.txt
+++ b/Stream_support/doc/Stream_support/PackageDescription.txt
@@ -20,7 +20,7 @@
 /// I/O Functions for the \ref IOStreamOFF
 /// \ingroup IOstreamFunctions
 
-/// \defgroup PkgStreamSupportIoFuncsVTP VTP I/O Functions
+/// \defgroup PkgStreamSupportIoFuncsVTP VTK I/O Functions
 /// I/O Functions for the \ref IOStreamVTK
 /// \ingroup IOstreamFunctions
 
@@ -101,4 +101,3 @@ the printing mode.
 - \link PkgStreamSupportIoFuncsWKT I/O for WKT files \endlink
 
 */
-

--- a/Stream_support/include/CGAL/IO/VTK.h
+++ b/Stream_support/include/CGAL/IO/VTK.h
@@ -26,8 +26,10 @@
 #include <vtkCommand.h>
 #include <vtkCell.h>
 #include <vtkXMLPolyDataReader.h>
+#include <vtkDataSetReader.h>
 #include <vtkPointSet.h>
 #include <vtkPolyData.h>
+#include <vtkUnstructuredGrid.h>
 #endif
 
 #if defined(CGAL_USE_VTK) || defined(DOXYGEN_RUNNING)
@@ -138,6 +140,62 @@ template <typename PointRange, typename PolygonRange>
 bool read_VTP(const std::string& fname, PointRange& points, PolygonRange& polygons)
 {
   return read_VTP(fname, points, polygons, parameters::default_values());
+}
+
+
+template <typename PointRange, typename PolygonRange, typename NamedParameters>
+bool read_VTK(const std::string& fname,
+              PointRange& points,
+              PolygonRange& polygons,
+              const NamedParameters& np)
+{
+  std::ifstream test(fname);
+  if(!test.good())
+  {
+    std::cerr<<"File doesn't exist."<<std::endl;
+    return false;
+  }
+
+  vtkSmartPointer<vtkPointSet> data;
+  vtkSmartPointer<internal::ErrorObserverVtk> obs =
+      vtkSmartPointer<internal::ErrorObserverVtk>::New();
+  vtkSmartPointer<vtkDataSetReader> reader =
+    CGAL::IO::internal::read_vtk_file<vtkDataSetReader>(fname,obs);
+  data = vtkPolyData::SafeDownCast(reader->GetOutput());
+  if (!data)
+    data = vtkUnstructuredGrid::SafeDownCast(reader->GetOutput());
+
+  if (obs->GetError())
+    return false;
+
+  return internal::vtkPointSet_to_polygon_soup(data, points, polygons, np);
+}
+
+/*!
+ * \ingroup PkgStreamSupportIoFuncsVTP
+ *
+ * \brief reads the content of the input file into `points` and `polygons`, using the \ref IOStreamVTK.
+ *
+ * \attention The polygon soup is not cleared, and the data from the file are appended.
+ *
+ * \tparam PointRange a model of the concepts `RandomAccessContainer` and `BackInsertionSequence`
+ *                    whose value type is the point type
+ * \tparam PolygonRange a model of the concepts `SequenceContainer` and `BackInsertionSequence`
+ *                      whose `value_type` is itself a model of the concept `SequenceContainer`
+ *                      and `BackInsertionSequence` whose `value_type` is an unsigned integer type
+ *                      convertible to `std::size_t`
+ *
+ * \param fname the path to the input file
+ * \param points points of the soup of polygons
+ * \param polygons a range of polygons. Each element in it describes a polygon
+ *        using the indices of the points in `points`.
+ *
+ * \returns `true` if the reading was successful, `false` otherwise.
+ */
+template <typename PointRange, typename PolygonRange>
+bool read_VTK(const std::string& fname, PointRange& points, PolygonRange& polygons)
+{
+  return read_VTK(fname, points, polygons, parameters::default_values());
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/Stream_support/include/CGAL/IO/VTK.h
+++ b/Stream_support/include/CGAL/IO/VTK.h
@@ -116,7 +116,7 @@ bool read_VTP(const std::string& fname,
 }
 
 /*!
- * \ingroup PkgStreamSupportIoFuncsVTP
+ * \ingroup PkgStreamSupportIoFuncsVTK
  *
  * \brief reads the content of the input file into `points` and `polygons`, using the \ref IOStreamVTK.
  *
@@ -172,7 +172,7 @@ bool read_VTK(const std::string& fname,
 }
 
 /*!
- * \ingroup PkgStreamSupportIoFuncsVTP
+ * \ingroup PkgStreamSupportIoFuncsVTK
  *
  * \brief reads the content of the input file into `points` and `polygons`, using the legacy file format of the \ref IOStreamVTK.
  *
@@ -398,7 +398,7 @@ void write_soup_polys_points(std::ostream& os,
 } // namespace internal
 
 /*!
- * \ingroup PkgStreamSupportIoFuncsVTP
+ * \ingroup PkgStreamSupportIoFuncsVTK
  *
  * \brief writes the content of `points` and `polygons` in `out`, using the \ref IOStreamVTK.
  *
@@ -486,7 +486,7 @@ bool write_VTP(std::ostream& os,
 }
 
 /*!
- * \ingroup PkgStreamSupportIoFuncsVTP
+ * \ingroup PkgStreamSupportIoFuncsVTK
  *
  * \brief writes the content of `points` and `polygons` in a file named `fname`, using the \ref IOStreamVTK.
  *

--- a/Stream_support/include/CGAL/IO/VTK.h
+++ b/Stream_support/include/CGAL/IO/VTK.h
@@ -174,7 +174,7 @@ bool read_VTK(const std::string& fname,
 /*!
  * \ingroup PkgStreamSupportIoFuncsVTP
  *
- * \brief reads the content of the input file into `points` and `polygons`, using the \ref IOStreamVTK.
+ * \brief reads the content of the input file into `points` and `polygons`, using the legacy file format of the \ref IOStreamVTK.
  *
  * \attention The polygon soup is not cleared, and the data from the file are appended.
  *

--- a/Stream_support/include/CGAL/IO/VTK.h
+++ b/Stream_support/include/CGAL/IO/VTK.h
@@ -123,7 +123,7 @@ bool read_VTP(const std::string& fname,
  * \attention The polygon soup is not cleared, and the data from the file are appended.
  *
  * \tparam PointRange a model of the concepts `RandomAccessContainer` and `BackInsertionSequence`
- *                    whose value type is the point type
+ *                    whose `value_type` is the point type
  * \tparam PolygonRange a model of the concepts `SequenceContainer` and `BackInsertionSequence`
  *                      whose `value_type` is itself a model of the concept `SequenceContainer`
  *                      and `BackInsertionSequence` whose `value_type` is an unsigned integer type
@@ -179,7 +179,7 @@ bool read_VTK(const std::string& fname,
  * \attention The polygon soup is not cleared, and the data from the file are appended.
  *
  * \tparam PointRange a model of the concepts `RandomAccessContainer` and `BackInsertionSequence`
- *                    whose value type is the point type
+ *                    whose `value_type` is the point type
  * \tparam PolygonRange a model of the concepts `SequenceContainer` and `BackInsertionSequence`
  *                      whose `value_type` is itself a model of the concept `SequenceContainer`
  *                      and `BackInsertionSequence` whose `value_type` is an unsigned integer type
@@ -402,7 +402,7 @@ void write_soup_polys_points(std::ostream& os,
  *
  * \brief writes the content of `points` and `polygons` in `out`, using the \ref IOStreamVTK.
  *
- * \tparam PointRange a model of the concept `RandomAccessContainer` whose value type is the point type
+ * \tparam PointRange a model of the concept `RandomAccessContainer` whose `value_type` is the point type
  * \tparam PolygonRange a model of the concept `SequenceContainer`
  *                      whose `value_type` is itself a model of the concept `SequenceContainer`
  *                      whose `value_type` is an unsigned integer type convertible to `std::size_t`
@@ -490,7 +490,7 @@ bool write_VTP(std::ostream& os,
  *
  * \brief writes the content of `points` and `polygons` in a file named `fname`, using the \ref IOStreamVTK.
  *
- * \tparam PointRange a model of the concept `RandomAccessContainer` whose value type is the point type
+ * \tparam PointRange a model of the concept `RandomAccessContainer` whose `valuetype` is the point type
  * \tparam PolygonRange a model of the concept `SequenceContainer`
  *                      whose `value_type` is itself a model of the concept `SequenceContainer`
  *                      whose `value_type` is an unsigned integer type convertible to `std::size_t`


### PR DESCRIPTION
## Summary of Changes

Add `read_VTK()` so that we can also read non-xml   *.vtk files.

- [x] Document it correctly

## Release Management

* Affected package(s): Stream_support 
* Feature/Small Feature (if any):
* Link to compiled documentation:  [overview](https://cgal.github.io/7826/v0/Stream_support/IOStreamSupportedFileFormats.html#IOStreamVTK)   and [function](https://cgal.github.io/7826/v0/Stream_support/group__PkgStreamSupportIoFuncsVTK.html#gaad7f1c5c10e8700a4a6de88294c5a620)

* License and copyright ownership:

