### PR TITLE
Polyhedron demo : Fix bug in "Show cells not in complex" of a C3t3

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_c3t3_item.cpp
@@ -334,6 +334,8 @@ void Scene_c3t3_item::drawEdges(Viewer_interface *viewer) const
 {
   Scene_triangulation_3_item::drawEdges(viewer);
 //add cnc
+  if(!visible())
+    return;
   if(d->cnc_are_shown)
   {
     getEdgeContainer(CNC)->setColor(QColor(Qt::black));


### PR DESCRIPTION
## Summary of Changes

When "Show cells not in complex" is enabled, turning the c3t3's visibility off will also set the cell not in complex visibility off.

Other upgrades : 
 - [ ] Disable with cut plane
 - [ ] Maybe create a child object (like show protecting spheres) ?

## Release Management

* Affected package(s): Mesh_3 : Polyhedron_demo
* Issue(s) solved (if any): fix #6187 

