### PR TITLE
SMDS_3 - avoid output files for testing

### DIFF
--- a/SMDS_3/test/SMDS_3/test_c3t3_io.cpp
+++ b/SMDS_3/test/SMDS_3/test_c3t3_io.cpp
@@ -389,8 +389,8 @@ struct Test_c3t3_io {
       filename += "_new";
       if(binary) filename += ".binary";
       filename += ".cgal";
-      std::ofstream output(filename.c_str(),
-                           binary ? (std::ios_base::out | std::ios_base::binary)
+      std::ostringstream output(binary
+                           ? (std::ios_base::out | std::ios_base::binary)
                            : std::ios_base::out);
       CGAL::IO::save_binary_file(output, c3t3_bis, binary);
     }


### PR DESCRIPTION
## Summary of Changes

Some test platforms are read-only, and SMDS_3 tests were writing output files on the test platforms. This PR avoids writing output files.

## Release Management

* Affected package(s): SMDS_3
* License and copyright ownership: unchanged

