### PR TITLE
Update .clang-tidy

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,5 +1,4 @@
 ---
-Checks:          '-clang-diagnostic*,-clang-analyzer*,modernize-use-nullptr,google-readability-casting'
-HeaderFilterRegex: 'CGAL/*'
+Checks: '-*,modernize-use-nullptr,google-readability-casting'
+HeaderFilterRegex: '.*CGAL/.*'
 ...
-


### PR DESCRIPTION
Checks: The Checks field now includes -*,modernize-use-nullptr,google-readability-casting. This updates the checks to disable all checks by default (-*) and then explicitly enable the modernize-use-nullptr and google-readability-casting checks. You can adjust the list of checks based on your project's requirements.

HeaderFilterRegex: The HeaderFilterRegex field uses the regular expression .*CGAL/.*, which matches any header file path containing "CGAL/" anywhere in its name.

_Please use the following template to help us managing pull requests._

## Summary of Changes

_Describe what your pull request changes to CGAL (this can be skipped if it solves an issue already in the tracker or if it is a Feature or Small Feature submitted to the CGAL Wiki)._

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

