### PR TITLE
PMP: Fix links for preconditions

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
@@ -150,7 +150,7 @@ namespace internal{
  * where its sequence of vertices is seen counterclockwise.
  *
  * @pre `CGAL::is_closed``(tm)`
- * @pre '\link CGAL::is_closed `CGAL::is_closed(tm)` \endlink
+ * @pre \link CGAL::is_closed `CGAL::is_closed(tm)` \endlink
  * @pre `CGAL::is_triangle_mesh(tm)`
  * @pre If `tm` contains several connected components, they are oriented consistently.
  *      In other words, the answer to this predicate would be the same for each

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orientation.h
@@ -149,7 +149,8 @@ namespace internal{
  * The normal vector to each face is chosen pointing on the side of the face
  * where its sequence of vertices is seen counterclockwise.
  *
- * @pre `CGAL::is_closed(tm)`
+ * @pre `CGAL::is_closed``(tm)`
+ * @pre '\link CGAL::is_closed `CGAL::is_closed(tm)` \endlink
  * @pre `CGAL::is_triangle_mesh(tm)`
  * @pre If `tm` contains several connected components, they are oriented consistently.
  *      In other words, the answer to this predicate would be the same for each


### PR DESCRIPTION
## Summary of Changes

For preconditions we write function calls of CGAL functions with arguments which are a  `@param`  of the functions we document.
Doxygen then does not succeed to link.

## Release Management

* Affected package(s): PMP (and  probably others)
* Issue(s) solved (if any): fix #7839
* License and copyright ownership:  unchanged

