### PR TITLE
Scale_space_reconstruction: Doc Fixes

### DIFF
--- a/Scale_space_reconstruction_3/doc/Scale_space_reconstruction_3/dependencies
+++ b/Scale_space_reconstruction_3/doc/Scale_space_reconstruction_3/dependencies
@@ -7,3 +7,5 @@ Spatial_searching
 Solver_interface
 Advancing_front_surface_reconstruction
 Point_set_processing_3
+Polygon_mesh_processing_3
+Algebraic_foundations

--- a/Scale_space_reconstruction_3/doc/Scale_space_reconstruction_3/dependencies
+++ b/Scale_space_reconstruction_3/doc/Scale_space_reconstruction_3/dependencies
@@ -7,5 +7,5 @@ Spatial_searching
 Solver_interface
 Advancing_front_surface_reconstruction
 Point_set_processing_3
-Polygon_mesh_processing_3
+Polygon_mesh_processing
 Algebraic_foundations

--- a/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Jet_smoother.h
+++ b/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Jet_smoother.h
@@ -52,8 +52,8 @@ template <typename Geom_traits,
 class Jet_smoother
 {
 public:
-  typedef typename Geom_traits::FT FT; ///< defines the point type.
-  typedef typename Geom_traits::Point_3 Point; ///< defines the point typ.e
+  typedef typename Geom_traits::FT FT; ///< defines the field number type.
+  typedef typename Geom_traits::Point_3 Point; ///< defines the point type.
 private:
 
   unsigned int m_k;
@@ -65,9 +65,9 @@ public:
   /**
    * Constructs a jet smoother.
    *
-   * \param k number of neighbors used.
+   * \param k number of neighbors used
    * \param degree_fitting fitting degree
-   * \param degree_monge monge degree
+   * \param degree_monge Monge degree
    */
   Jet_smoother (unsigned int k = 12,
                 unsigned int degree_fitting = 2,

--- a/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Weighted_PCA_smoother.h
+++ b/Scale_space_reconstruction_3/include/CGAL/Scale_space_reconstruction_3/Weighted_PCA_smoother.h
@@ -70,8 +70,8 @@ template <typename Geom_traits,
 class Weighted_PCA_smoother
 {
 public:
-  typedef typename Geom_traits::FT FT; ///< defines the point type.
-  typedef typename Geom_traits::Point_3 Point; ///< defines the point typ.e
+  typedef typename Geom_traits::FT FT; ///< defines the field number type.
+  typedef typename Geom_traits::Point_3 Point; ///< defines the point type.
   typedef typename Geom_traits::Vector_3 Vector; ///< defines the vector type.
 private:
 


### PR DESCRIPTION
## Summary of Changes

Doc fixes.

I also noticed that the [concepts](https://doc.cgal.org/latest/Scale_space_reconstruction_3/group__PkgScaleSpaceReconstruction3Concepts.html) are in a namespace. Do we want to change that? What names? 

## Release Management

* Affected package(s): Scale_space_reconstruction
* License and copyright ownership: unchanged

