### PR TITLE
CGAL::IO::Internal::read_OBJ(): allow arbitrary whitespace in "f" lines

### DIFF
--- a/Stream_support/include/CGAL/IO/OBJ.h
+++ b/Stream_support/include/CGAL/IO/OBJ.h
@@ -136,8 +136,11 @@ bool read_OBJ(std::istream& is,
         }
 
         // the format can be "f v1/vt1/vn1 v2/vt2/vn2 v3/vt3/vn3 ..." and we only read vertex ids for now,
-        // so skip to the next vertex
-        iss.ignore(256, ' ');
+        // so skip to the next vertex, but be tolerant about which whitespace is used
+        if (!std::isspace(iss.peek())) {
+          std::string ignoreme;
+          iss >> ignoreme;
+        }
       }
 
       if(iss.bad())


### PR DESCRIPTION
The "OBJ" file format does not specify which whitespace to use, so be more tolerant about it.
This allows correct reading of OBJ files where only ```\t``` (tabulator) is used as a separator in the ```f``` lines.