### PR TITLE
Add missing #include to Surface_sweep_2_impl.h

### DIFF
--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2/Surface_sweep_2_impl.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2/Surface_sweep_2_impl.h
@@ -16,6 +16,8 @@
 
 #include <CGAL/license/Surface_sweep_2.h>
 
+#include <set>
+
 /*! \file
  *
  * Member-function definitions of the Surface_sweep_2 class-template.


### PR DESCRIPTION
This header uses std::set, but doesn't include <set>.  This can break builds depending on how this header is included.
