### PR TITLE
PMP Examples: Unify type names

### DIFF
--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/compute_normals_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/compute_normals_example.cpp
@@ -7,14 +7,14 @@
 #include <iostream>
 #include <string>
 
-typedef CGAL::Exact_predicates_inexact_constructions_kernel       K;
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 
-typedef K::Point_3                                                Point;
-typedef K::Vector_3                                               Vector;
+typedef K::Point_3                                          Point;
+typedef K::Vector_3                                         Vector;
 
-typedef CGAL::Surface_mesh<Point>                                 Surface_mesh;
-typedef boost::graph_traits<Surface_mesh>::vertex_descriptor      vertex_descriptor;
-typedef boost::graph_traits<Surface_mesh>::face_descriptor        face_descriptor;
+typedef CGAL::Surface_mesh<Point>                           Mesh;
+typedef boost::graph_traits<Mesh>::vertex_descriptor        vertex_descriptor;
+typedef boost::graph_traits<Mesh>::face_descriptor          face_descriptor;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -22,7 +22,7 @@ int main(int argc, char* argv[])
 {
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/eight.off");
 
-  Surface_mesh mesh;
+  Mesh mesh;
   if(!PMP::IO::read_polygon_mesh(filename, mesh))
   {
     std::cerr << "Invalid input." << std::endl;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/compute_normals_example_Polyhedron.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/compute_normals_example_Polyhedron.cpp
@@ -16,9 +16,9 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel   K;
 typedef K::Point_3                                            Point;
 typedef K::Vector_3                                           Vector;
 
-typedef CGAL::Polyhedron_3<K>                                 Polyhedron;
-typedef boost::graph_traits<Polyhedron>::vertex_descriptor    vertex_descriptor;
-typedef boost::graph_traits<Polyhedron>::face_descriptor      face_descriptor;
+typedef CGAL::Polyhedron_3<K>                                 Mesh;
+typedef boost::graph_traits<Mesh>::vertex_descriptor          vertex_descriptor;
+typedef boost::graph_traits<Mesh>::face_descriptor            face_descriptor;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -26,7 +26,7 @@ int main(int argc, char* argv[])
 {
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/eight.off");
 
-  Polyhedron mesh;
+  Mesh mesh;
   if(!PMP::IO::read_polygon_mesh(filename, mesh))
   {
     std::cerr << "Invalid input." << std::endl;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_LCC.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_LCC.cpp
@@ -12,7 +12,7 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel   Kernel;
 typedef Kernel::Point_3                                       Point;
 
 typedef CGAL::Linear_cell_complex_traits<3, Kernel>           MyTraits;
-typedef CGAL::Linear_cell_complex_for_bgl_combinatorial_map_helper<2, 3, MyTraits>::type LCC;
+typedef CGAL::Linear_cell_complex_for_bgl_combinatorial_map_helper<2, 3, MyTraits>::type Mesh;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -21,7 +21,7 @@ int main(int argc, char* argv[])
   const std::string filename1 = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/blobby.off");
   const std::string filename2 = (argc > 2) ? argv[2] : CGAL::data_file_path("meshes/eight.off");
 
-  LCC mesh1, mesh2;
+  Mesh mesh1, mesh2;
   if(!PMP::IO::read_polygon_mesh(filename1, mesh1) || !PMP::IO::read_polygon_mesh(filename2, mesh2))
   {
     std::cerr << "Invalid input." << std::endl;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/extrude.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/extrude.cpp
@@ -8,13 +8,13 @@
 #include <fstream>
 #include <string>
 
-typedef CGAL::Exact_predicates_inexact_constructions_kernel  Kernel;
-typedef CGAL::Surface_mesh<Kernel::Point_3> SM;
-typedef boost::graph_traits<SM>::vertex_descriptor           vertex_descriptor;
+typedef CGAL::Exact_predicates_inexact_constructions_kernel    Kernel;
+typedef CGAL::Surface_mesh<Kernel::Point_3>                    Mesh;
+typedef boost::graph_traits<Mesh>::vertex_descriptor           vertex_descriptor;
 
-typedef Kernel::Vector_3                                     Vector;
-typedef boost::property_map<SM, CGAL::vertex_point_t>::type  VPMap;
-typedef SM::template Property_map<vertex_descriptor, Vector> VNMap;
+typedef Kernel::Vector_3                                       Vector;
+typedef boost::property_map<Mesh, CGAL::vertex_point_t>::type  VPMap;
+typedef Mesh::template Property_map<vertex_descriptor, Vector> VNMap;
 
 struct Bottom
 {
@@ -52,7 +52,7 @@ struct Top
 
 int main(int argc, char* argv[])
 {
-  SM in, out;
+  Mesh in, out;
 
   std::string filename = (argc > 1) ? std::string(argv[1]) : CGAL::data_file_path("meshes/cube-ouvert.off");
   double vlen = (argc > 2) ? std::stod(argv[2]) : 0.1;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example.cpp
@@ -12,11 +12,11 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel   Kernel;
 
-typedef CGAL::Polyhedron_3<Kernel>                            Polyhedron;
+typedef CGAL::Polyhedron_3<Kernel>                            Mesh;
 
-typedef Polyhedron::Vertex_handle                             Vertex_handle;
-typedef Polyhedron::Halfedge_handle                           Halfedge_handle;
-typedef Polyhedron::Facet_handle                              Facet_handle;
+typedef Mesh::Vertex_handle                                   Vertex_handle;
+typedef Mesh::Halfedge_handle                                 Halfedge_handle;
+typedef Mesh::Facet_handle                                    Facet_handle;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -24,7 +24,7 @@ int main(int argc, char* argv[])
 {
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/mech-holes-shark.off");
 
-  Polyhedron poly;
+  Mesh poly;
   if(!PMP::IO::read_polygon_mesh(filename, poly))
   {
     std::cerr << "Invalid input." << std::endl;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example_LCC.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/hole_filling_example_LCC.cpp
@@ -14,11 +14,11 @@
 typedef CGAL::Exact_predicates_inexact_constructions_kernel                              Kernel;
 typedef Kernel::Point_3                                                                  Point;
 typedef CGAL::Linear_cell_complex_traits<3, Kernel>                                      MyTraits;
-typedef CGAL::Linear_cell_complex_for_bgl_combinatorial_map_helper<2, 3, MyTraits>::type LCC;
+typedef CGAL::Linear_cell_complex_for_bgl_combinatorial_map_helper<2, 3, MyTraits>::type Mesh;
 
-typedef boost::graph_traits<LCC>::vertex_descriptor                                      vertex_descriptor;
-typedef boost::graph_traits<LCC>::halfedge_descriptor                                    halfedge_descriptor;
-typedef boost::graph_traits<LCC>::face_descriptor                                        face_descriptor;
+typedef boost::graph_traits<Mesh>::vertex_descriptor                                     vertex_descriptor;
+typedef boost::graph_traits<Mesh>::halfedge_descriptor                                   halfedge_descriptor;
+typedef boost::graph_traits<Mesh>::face_descriptor                                       face_descriptor;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -26,7 +26,7 @@ int main(int argc, char* argv[])
 {
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/mech-holes-shark.off");
 
-  LCC mesh;
+  Mesh mesh;
   if(!PMP::IO::read_polygon_mesh(filename, mesh))
   {
     std::cerr << "Invalid input." << std::endl;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/interpolated_corrected_curvatures_PH.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/interpolated_corrected_curvatures_PH.cpp
@@ -7,17 +7,17 @@
 #include <boost/graph/graph_traits.hpp>
 
 #include <iostream>
-#include <unordered_map>
+#include <string>
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Epic_kernel;
-typedef CGAL::Polyhedron_3<Epic_kernel> Polyhedron;
-typedef boost::graph_traits<Polyhedron>::vertex_descriptor vertex_descriptor;
+typedef CGAL::Polyhedron_3<Epic_kernel>                     Mesh;
+typedef boost::graph_traits<Mesh>::vertex_descriptor        vertex_descriptor;
 
 int main(int argc, char* argv[])
 {
-  Polyhedron polyhedron;
+  Mesh polyhedron;
   const std::string filename = (argc > 1) ?
     argv[1] :
     CGAL::data_file_path("meshes/sphere.off");
@@ -29,11 +29,11 @@ int main(int argc, char* argv[])
   }
 
   // define property map to store curvature value and directions
-  boost::property_map<Polyhedron, CGAL::dynamic_vertex_property_t<Epic_kernel::FT>>::type
+  boost::property_map<Mesh, CGAL::dynamic_vertex_property_t<Epic_kernel::FT>>::type
     mean_curvature_map = get(CGAL::dynamic_vertex_property_t<Epic_kernel::FT>(), polyhedron),
     Gaussian_curvature_map = get(CGAL::dynamic_vertex_property_t<Epic_kernel::FT>(), polyhedron);
 
-  boost::property_map<Polyhedron, CGAL::dynamic_vertex_property_t<PMP::Principal_curvatures_and_directions<Epic_kernel>>>::type
+  boost::property_map<Mesh, CGAL::dynamic_vertex_property_t<PMP::Principal_curvatures_and_directions<Epic_kernel>>>::type
     principal_curvatures_and_directions_map =
     get(CGAL::dynamic_vertex_property_t<PMP::Principal_curvatures_and_directions<Epic_kernel>>(), polyhedron);
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/interpolated_corrected_curvatures_SM.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/interpolated_corrected_curvatures_SM.cpp
@@ -11,12 +11,12 @@
 namespace PMP = CGAL::Polygon_mesh_processing;
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Epic_kernel;
-typedef CGAL::Surface_mesh<Epic_kernel::Point_3> Surface_Mesh;
-typedef boost::graph_traits<Surface_Mesh>::vertex_descriptor vertex_descriptor;
+typedef CGAL::Surface_mesh<Epic_kernel::Point_3> Mesh;
+typedef boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
 
 int main(int argc, char* argv[])
 {
-  Surface_Mesh smesh;
+  Mesh smesh;
   const std::string filename = (argc > 1) ?
     argv[1] :
     CGAL::data_file_path("meshes/sphere.off");
@@ -29,7 +29,7 @@ int main(int argc, char* argv[])
 
   // creating and tying surface mesh property maps for curvatures (with defaults = 0)
   bool created = false;
-  Surface_Mesh::Property_map<vertex_descriptor, Epic_kernel::FT>
+  Mesh::Property_map<vertex_descriptor, Epic_kernel::FT>
     mean_curvature_map, Gaussian_curvature_map;
 
   boost::tie(mean_curvature_map, created) =
@@ -41,7 +41,7 @@ int main(int argc, char* argv[])
   assert(created);
 
   // we use a tuple of 2 scalar values and 2 vectors for principal curvatures and directions
-  Surface_Mesh::Property_map<vertex_descriptor, PMP::Principal_curvatures_and_directions<Epic_kernel>>
+  Mesh::Property_map<vertex_descriptor, PMP::Principal_curvatures_and_directions<Epic_kernel>>
     principal_curvatures_and_directions_map;
 
   boost::tie(principal_curvatures_and_directions_map, created) =
@@ -67,4 +67,5 @@ int main(int argc, char* argv[])
       << ", GC = " << Gaussian_curvature_map[v] << "\n"
       << ", PC = [ " << PC.min_curvature << " , " << PC.max_curvature << " ]\n";
   }
+  return 0;
 }

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/interpolated_corrected_curvatures_vertex.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/interpolated_corrected_curvatures_vertex.cpp
@@ -6,17 +6,18 @@
 #include <boost/graph/graph_traits.hpp>
 
 #include <iostream>
+#include <string>
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Epic_kernel;
-typedef CGAL::Surface_mesh<Epic_kernel::Point_3> Surface_Mesh;
-typedef boost::graph_traits<Surface_Mesh>::vertex_descriptor vertex_descriptor;
+typedef CGAL::Surface_mesh<Epic_kernel::Point_3>            Mesh;
+typedef boost::graph_traits<Mesh>::vertex_descriptor        vertex_descriptor;
 
 int main(int argc, char* argv[])
 {
   // instantiating and reading mesh
-  Surface_Mesh smesh;
+  Mesh smesh;
   const std::string filename = (argc > 1) ?
     argv[1] :
     CGAL::data_file_path("meshes/sphere.off");
@@ -47,4 +48,5 @@ int main(int argc, char* argv[])
       << ", GC = " << g << "\n"
       << ", PC = [ " << p.min_curvature << " , " << p.max_curvature << " ]\n";
   }
+  return 0;
 }

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/orient_polygon_soup_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/orient_polygon_soup_example.cpp
@@ -15,7 +15,7 @@
 #include <vector>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel          K;
-typedef CGAL::Polyhedron_3<K, CGAL::Polyhedron_items_with_id_3>      Polyhedron;
+typedef CGAL::Polyhedron_3<K, CGAL::Polyhedron_items_with_id_3>      Mesh;
 
 // Optional visitor for orientating a polygon soup to demonstrate usage for some functions.
 // inherits from the default class as some functions are not overloaded
@@ -59,12 +59,12 @@ int main(int argc, char* argv[])
   Visitor visitor;
   CGAL::Polygon_mesh_processing::orient_polygon_soup(points, polygons, CGAL::parameters::visitor(visitor));
 
-  Polyhedron mesh;
+  Mesh mesh;
   CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh(points, polygons, mesh);
 
   // Number the faces because 'orient_to_bound_a_volume' needs a face <--> index map
   int index = 0;
-  for(Polyhedron::Face_iterator fb=mesh.facets_begin(), fe=mesh.facets_end(); fb!=fe; ++fb)
+  for(Mesh::Face_iterator fb=mesh.facets_begin(), fe=mesh.facets_end(); fb!=fe; ++fb)
     fb->id() = index++;
 
   if(CGAL::is_closed(mesh))

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/point_inside_example.cpp
@@ -12,14 +12,14 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel    K;
 typedef K::Point_3                                             Point;
-typedef CGAL::Polyhedron_3<K>                                  Polyhedron;
+typedef CGAL::Polyhedron_3<K>                                  Mesh;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
-double max_coordinate(const Polyhedron& poly)
+double max_coordinate(const Mesh& poly)
 {
   double max_coord = -std::numeric_limits<double>::infinity();
-  for(Polyhedron::Vertex_handle v : vertices(poly))
+  for(Mesh::Vertex_handle v : vertices(poly))
   {
     Point p = v->point();
     max_coord = (std::max)(max_coord, CGAL::to_double(p.x()));
@@ -33,14 +33,14 @@ int main(int argc, char* argv[])
 {
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/eight.off");
 
-  Polyhedron poly;
+  Mesh poly;
   if(!PMP::IO::read_polygon_mesh(filename, poly) || CGAL::is_empty(poly) || !CGAL::is_triangle_mesh(poly))
   {
     std::cerr << "Invalid input." << std::endl;
     return 1;
   }
 
-  CGAL::Side_of_triangle_mesh<Polyhedron, K> inside(poly);
+  CGAL::Side_of_triangle_mesh<Mesh, K> inside(poly);
 
   double size = max_coordinate(poly);
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/polyhedral_envelope.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/polyhedral_envelope.cpp
@@ -9,13 +9,13 @@ int main(int argc, char* argv[])
 {
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
   typedef Kernel::Point_3 Point_3;
-  typedef CGAL::Surface_mesh<Point_3> Surface_mesh;
-  typedef boost::graph_traits<Surface_mesh>::vertex_descriptor vertex_descriptor;
+  typedef CGAL::Surface_mesh<Point_3> Mesh;
+  typedef boost::graph_traits<Mesh>::vertex_descriptor vertex_descriptor;
 
   typedef CGAL::Polyhedral_envelope<Kernel> Envelope;
 
   std::ifstream in((argc>1) ? argv[1] : CGAL::data_file_path("meshes/blobby.off"));
-  Surface_mesh tmesh;
+  Mesh tmesh;
 
   in >> tmesh;
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/polyhedral_envelope_mesh_containment.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/polyhedral_envelope_mesh_containment.cpp
@@ -13,19 +13,19 @@ int main(int argc, char* argv[])
 {
   typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
   typedef Kernel::Point_3 Point_3;
-  typedef CGAL::Surface_mesh<Point_3> Surface_mesh;
+  typedef CGAL::Surface_mesh<Point_3> Mesh;
 
   typedef CGAL::Polyhedral_envelope<Kernel> Envelope;
 
   std::ifstream in((argc>1) ? argv[1] : CGAL::data_file_path("meshes/blobby.off"));
-  Surface_mesh tmesh;
+  Mesh tmesh;
   in >> tmesh;
 
   // remesh the input using the longest edge size as target edge length
-  Surface_mesh query = tmesh;
-  Surface_mesh::Edge_iterator longest_edge_it =
+  Mesh query = tmesh;
+  Mesh::Edge_iterator longest_edge_it =
     std::max_element(edges(query).begin(), edges(query).end(),
-                     [&query](Surface_mesh::Edge_index e1, Surface_mesh::Edge_index e2)
+                     [&query](Mesh::Edge_index e1, Mesh::Edge_index e2)
                      {
                         return PMP::edge_length(halfedge(e1, query), query) <
                                PMP::edge_length(halfedge(e2, query), query);

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/random_perturbation_SM_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/random_perturbation_SM_example.cpp
@@ -10,9 +10,9 @@
 typedef CGAL::Exact_predicates_inexact_constructions_kernel   K;
 typedef K::Point_3                                            Point;
 
-typedef CGAL::Surface_mesh<Point>                             Surface_mesh;
-typedef boost::graph_traits<Surface_mesh>::vertex_descriptor  vertex_descriptor;
-typedef boost::graph_traits<Surface_mesh>::face_descriptor    face_descriptor;
+typedef CGAL::Surface_mesh<Point>                             Mesh;
+typedef boost::graph_traits<Mesh>::vertex_descriptor          vertex_descriptor;
+typedef boost::graph_traits<Mesh>::face_descriptor            face_descriptor;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -20,7 +20,7 @@ int main(int argc, char* argv[])
 {
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/eight.off");
 
-  Surface_mesh mesh;
+  Mesh mesh;
   if(!PMP::IO::read_polygon_mesh(filename, mesh))
   {
     std::cerr << "Invalid input." << std::endl;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/refine_fair_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/refine_fair_example.cpp
@@ -13,8 +13,8 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 
-typedef CGAL::Polyhedron_3<Kernel>                          Polyhedron;
-typedef Polyhedron::Vertex_handle                           Vertex_handle;
+typedef CGAL::Polyhedron_3<Kernel>                          Mesh;
+typedef Mesh::Vertex_handle                                 Vertex_handle;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -34,7 +34,7 @@ void extract_k_ring(Vertex_handle v,
   {
     v = qv[current_index++];
 
-    Polyhedron::Halfedge_around_vertex_circulator e(v->vertex_begin()), e_end(e);
+    Mesh::Halfedge_around_vertex_circulator e(v->vertex_begin()), e_end(e);
     do {
       Vertex_handle new_v = e->opposite()->vertex();
       if (D.insert(std::make_pair(new_v, dist_v + 1)).second)
@@ -47,14 +47,14 @@ int main(int argc, char* argv[])
 {
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/blobby.off");
 
-  Polyhedron poly;
+  Mesh poly;
   if(!PMP::IO::read_polygon_mesh(filename, poly) || !CGAL::is_triangle_mesh(poly))
   {
     std::cerr << "Invalid input." << std::endl;
     return 1;
   }
 
-  std::vector<Polyhedron::Facet_handle>  new_facets;
+  std::vector<Mesh::Facet_handle>  new_facets;
   std::vector<Vertex_handle> new_vertices;
 
   PMP::refine(poly, faces(poly),
@@ -68,7 +68,7 @@ int main(int argc, char* argv[])
   refined_off.close();
   std::cout << "Refinement added " << new_vertices.size() << " vertices." << std::endl;
 
-  Polyhedron::Vertex_iterator v = poly.vertices_begin();
+  Mesh::Vertex_iterator v = poly.vertices_begin();
   std::advance(v, 82/*e.g.*/);
   std::vector<Vertex_handle> region;
   extract_k_ring(v, 12/*e.g.*/, region);

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/remesh_almost_planar_patches.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/remesh_almost_planar_patches.cpp
@@ -14,13 +14,13 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 typedef Kernel::Point_3 Point_3;
-typedef CGAL::Surface_mesh<Kernel::Point_3> Surface_mesh;
+typedef CGAL::Surface_mesh<Kernel::Point_3> Mesh;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
 int main()
 {
-  Surface_mesh sm;
+  Mesh sm;
   CGAL::IO::read_polygon_mesh(CGAL::data_file_path("meshes/fandisk.off"), sm);
 
   //apply a perturbation to input vertices so that points are no longer coplanar
@@ -51,7 +51,7 @@ int main()
                                                      edge_is_constrained_map(CGAL::make_random_access_property_map(ecm)));
 
   // run the remeshing algorithm using filled properties
-  Surface_mesh out;
+  Mesh out;
   PMP::remesh_almost_planar_patches(sm,
                                     out,
                                     nb_regions, nb_corners,

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/remesh_planar_patches.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/remesh_planar_patches.cpp
@@ -12,12 +12,12 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 typedef Kernel::Point_3 Point_3;
-typedef CGAL::Surface_mesh<Kernel::Point_3> Surface_mesh;
+typedef CGAL::Surface_mesh<Kernel::Point_3> Mesh;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 int main()
 {
-  Surface_mesh sm;
+  Mesh sm;
   CGAL::IO::read_polygon_mesh(CGAL::data_file_path("meshes/cube_quad.off"), sm);
 
   // triangulate faces;
@@ -25,8 +25,8 @@ int main()
   std::cout << "Input mesh has " << faces(sm).size() << " faces" << std::endl;
   assert(faces(sm).size()==12);
 
-  Surface_mesh::Property_map<Surface_mesh::Edge_index, bool> ecm =
-    sm.add_property_map<Surface_mesh::Edge_index, bool>("ecm",false).first;
+  Mesh::Property_map<Mesh::Edge_index, bool> ecm =
+    sm.add_property_map<Mesh::Edge_index, bool>("ecm",false).first;
 
   // detect sharp edges of the cube
   PMP::detect_sharp_edges(sm, 60, ecm);
@@ -37,7 +37,7 @@ int main()
   assert(faces(sm).size()>100);
 
   // decimate the mesh
-  Surface_mesh out;
+  Mesh out;
   PMP::remesh_planar_patches(sm, out);
   CGAL::IO::write_polygon_mesh("cube_decimated.off", out, CGAL::parameters::stream_precision(17));
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/stitch_borders_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/stitch_borders_example.cpp
@@ -9,7 +9,7 @@
 #include <string>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel   K;
-typedef CGAL::Polyhedron_3<K>                                 Polyhedron;
+typedef CGAL::Polyhedron_3<K>                                 Mesh;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -17,7 +17,7 @@ int main(int argc, char* argv[])
 {
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/quads_to_stitch.off");
 
-  Polyhedron mesh;
+  Mesh mesh;
   if(!PMP::IO::read_polygon_mesh(filename, mesh))
   {
     std::cerr << "Invalid input." << std::endl;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/stitch_borders_example_OM.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/stitch_borders_example_OM.cpp
@@ -10,8 +10,8 @@
 #include <string>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
-
 typedef OpenMesh::PolyMesh_ArrayKernelT< > Mesh;
+
 int main(int argc, char* argv[])
 {
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/quads_to_stitch.off");

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_example.cpp
@@ -11,7 +11,7 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 typedef Kernel::Point_3                                     Point;
-typedef CGAL::Surface_mesh<Point>                           Surface_mesh;
+typedef CGAL::Surface_mesh<Point>                           Mesh;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 
@@ -20,7 +20,7 @@ int main(int argc, char* argv[])
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/P.off");
   const char* outfilename = (argc > 2) ? argv[2] : "P_tri.off";
 
-  Surface_mesh mesh;
+  Mesh mesh;
   if(!PMP::IO::read_polygon_mesh(filename, mesh))
   {
     std::cerr << "Error: Invalid input." << std::endl;
@@ -41,7 +41,7 @@ int main(int argc, char* argv[])
   PMP::triangulate_faces(mesh);
 
   // Confirm that all faces are triangles.
-  for(boost::graph_traits<Surface_mesh>::face_descriptor f : faces(mesh))
+  for(boost::graph_traits<Mesh>::face_descriptor f : faces(mesh))
   {
     if(!CGAL::is_triangle(halfedge(f, mesh), mesh))
       std::cerr << "Error: non-triangular face left in mesh." << std::endl;

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_split_visitor_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/triangulate_faces_split_visitor_example.cpp
@@ -6,15 +6,14 @@
 
 #include <iostream>
 #include <fstream>
-#include <map>
 #include <string>
 #include <unordered_map>
 #include <utility>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
-typedef Kernel::Point_3                    Point;
-typedef CGAL::Surface_mesh<Point>          Surface_mesh;
-typedef boost::graph_traits<Surface_mesh>::face_descriptor face_descriptor;
+typedef Kernel::Point_3                                     Point;
+typedef CGAL::Surface_mesh<Point>                           Mesh;
+typedef boost::graph_traits<Mesh>::face_descriptor          face_descriptor;
 
 class Insert_iterator
 {
@@ -41,7 +40,7 @@ public:
 };
 
 
-struct Visitor : public CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor<Surface_mesh>
+struct Visitor : public CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor<Mesh>
 {
    typedef std::unordered_map<face_descriptor,face_descriptor> Container;
 
@@ -78,7 +77,7 @@ int main(int argc, char* argv[])
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/P.off");
   std::ifstream input(filename);
 
-  Surface_mesh mesh;
+  Mesh mesh;
   if (!input || !(input >> mesh) || mesh.is_empty())
   {
     std::cerr << "Not a valid off file." << std::endl;
@@ -87,7 +86,7 @@ int main(int argc, char* argv[])
 
   std::unordered_map<face_descriptor,face_descriptor> t2q;
 
-  Surface_mesh copy;
+  Mesh copy;
 
   CGAL::copy_face_graph(mesh, copy, CGAL::parameters::face_to_face_output_iterator(Insert_iterator(t2q)));
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/volume_connected_components.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/volume_connected_components.cpp
@@ -12,7 +12,7 @@
 #include <string>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel   Kernel;
-typedef CGAL::Surface_mesh<Kernel::Point_3>                   Surface_mesh;
+typedef CGAL::Surface_mesh<Kernel::Point_3>                   Mesh;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 namespace params = CGAL::parameters;
@@ -21,7 +21,7 @@ int main(int argc, char** argv)
 {
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/blobby.off");
 
-  Surface_mesh mesh;
+  Mesh mesh;
   if(!PMP::IO::read_polygon_mesh(filename, mesh))
   {
     std::cerr << "Invalid input." << std::endl;
@@ -29,8 +29,8 @@ int main(int argc, char** argv)
   }
 
   // property map to assign a volume id for each face
-  Surface_mesh::Property_map<Surface_mesh::Face_index, std::size_t> vol_id_map =
-    mesh.add_property_map<Surface_mesh::Face_index, std::size_t>().first;
+  Mesh::Property_map<Mesh::Face_index, std::size_t> vol_id_map =
+    mesh.add_property_map<Mesh::Face_index, std::size_t>().first;
 
   // fill the volume id map
   std::vector<PMP::Volume_error_code> err_codes;
@@ -39,7 +39,7 @@ int main(int argc, char** argv)
   std::cout << "Found " << nb_vol << " volumes\n";
 
   // write each volume in an OFF file
-  typedef CGAL::Face_filtered_graph<Surface_mesh> Filtered_graph;
+  typedef CGAL::Face_filtered_graph<Mesh> Filtered_graph;
   Filtered_graph vol_mesh(mesh, 0, vol_id_map);
   for(std::size_t id = 0; id < nb_vol; ++id)
   {
@@ -49,11 +49,12 @@ int main(int argc, char** argv)
     if(id > 0)
       vol_mesh.set_selected_faces(id, vol_id_map);
 
-    Surface_mesh out;
+    Mesh out;
     CGAL::copy_face_graph(vol_mesh, out);
     std::ostringstream oss;
     oss << "vol_" << id <<".off";
     std::ofstream os(oss.str().data());
     os << out;
   }
+  return 0;
 }


### PR DESCRIPTION
## Summary of Changes

Let's typedef it `Mesh`, whether it is a Surface_mesh, LCC, OpenMesh, Polyhedon_3

## Release Management

* Affected package(s):  PMP

