### PR TITLE
Poisson Surface Reconstruction: Enable Structural Filtering

### DIFF
--- a/Poisson_surface_reconstruction_3/include/CGAL/Reconstruction_triangulation_3.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/Reconstruction_triangulation_3.h
@@ -26,6 +26,7 @@
 #include <CGAL/Delaunay_triangulation_3.h>
 #include <CGAL/Delaunay_triangulation_cell_base_3.h>
 #include <CGAL/Triangulation_cell_base_with_info_3.h>
+#include <CGAL/Triangulation_structural_filtering_traits.h>
 
 #include <CGAL/algorithm.h>
 #include <CGAL/bounding_box.h>
@@ -145,6 +146,12 @@ template <class BaseGt>
 struct Reconstruction_triangulation_default_geom_traits_3 : public BaseGt
 {
   typedef Point_with_normal_3<BaseGt> Point_3;
+};
+
+
+template < class BaseGt >
+struct Triangulation_structural_filtering_traits<Reconstruction_triangulation_default_geom_traits_3<BaseGt> > {
+  typedef typename Triangulation_structural_filtering_traits<BaseGt>::Use_structural_filtering_tag  Use_structural_filtering_tag;
 };
 
 

--- a/Triangulation_3/include/CGAL/Robust_weighted_circumcenter_filtered_traits_3.h
+++ b/Triangulation_3/include/CGAL/Robust_weighted_circumcenter_filtered_traits_3.h
@@ -18,6 +18,7 @@
 #include <CGAL/number_utils_classes.h>
 #include <CGAL/Cartesian_converter.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Triangulation_structural_filtering_traits.h>
 #include <CGAL/constructions/kernel_ftC3.h>
 
 namespace CGAL {
@@ -530,6 +531,13 @@ public:
 
   Robust_circumcenter_filtered_traits_3(const Kernel& k = Kernel()) : Kernel(k) { }
 };
+
+
+template < class BaseGt >
+struct Triangulation_structural_filtering_traits<Robust_circumcenter_filtered_traits_3<BaseGt> > {
+    typedef typename Triangulation_structural_filtering_traits<BaseGt>::Use_structural_filtering_tag  Use_structural_filtering_tag;
+};
+
 
 template<class K_>
 class Robust_weighted_circumcenter_filtered_traits_3


### PR DESCRIPTION
## Summary of Changes

The algorithm performed exact locate all the time.  Activating structural filtering makes it faster.

## Release Management

* Affected package(s): Poisson Surface Reconstruction
* License and copyright ownership: unchanged

