### PR TITLE
Shape Regularization: Documented missing dependency to OSQP when default solver is used

### DIFF
--- a/Shape_regularization/include/CGAL/Shape_regularization/regularize_segments.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/regularize_segments.h
@@ -70,6 +70,9 @@ namespace Segments {
     that should be addressed. The function is based on the class `QP_regularization`.
     Please refer to that class and these concepts for more information.
 
+    This class requires a `QPSolver` model which defaults to the \ref thirdpartyOSQP "OSQP"
+    library, which must be available on the system.
+
     \tparam InputRange
     a model of `ConstRange` whose iterator type is `RandomAccessIterator`
 


### PR DESCRIPTION
## Summary of Changes

Documented dependency to OSQP when default solver is used for regularize_segments.

## Release Management

* Affected package(s): Shape Regularization
* Issue(s) solved (if any): fix #7894
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

