### PR TITLE
Use _BitScanForward and _BitScanReverse so x86 builds still compile

### DIFF
--- a/Number_types/include/CGAL/cpp_float.h
+++ b/Number_types/include/CGAL/cpp_float.h
@@ -18,6 +18,7 @@
 #include <CGAL/assertions.h>
 #include <boost/multiprecision/cpp_int.hpp>
 #include <iostream>
+#include <limits>
 
 namespace CGAL {
 
@@ -27,7 +28,13 @@ namespace internal {
   inline int low_bit (boost::uint64_t x) {
 #if defined(_MSC_VER)
     unsigned long ret;
+  #if defined(_M_IX86)
+    CGAL_assertion_msg(x <= static_cast<boost::uint64_t>(std::numeric_limits<unsigned long>::max()),
+      "Using _BitScanForward on input larger than data type");
+    _BitScanForward(&ret, x);
+  #else
     _BitScanForward64(&ret, x);
+  #endif
     return (int)ret;
 #elif defined(__xlC__)
     return __cnttz8 (x);
@@ -39,7 +46,13 @@ namespace internal {
   inline int high_bit (boost::uint64_t x) {
 #if defined(_MSC_VER)
     unsigned long ret;
+  #if defined(_M_IX86)
+    CGAL_assertion_msg(x <= static_cast<boost::uint64_t>(std::numeric_limits<unsigned long>::max()),
+      "Using _BitScanReverse on input larger than data type");
+    _BitScanReverse(&ret, x);
+  #else
     _BitScanReverse64(&ret, x);
+  #endif
     return (int)ret;
 #elif defined(__xlC__)
     // Macro supposedly not defined on z/OS.


### PR DESCRIPTION
## Summary of Changes

Use _BitScanForward and _BitScanReverse so x86 builds still compile

More precisely, avoid using _BitScanForward64 and _BitScanReverse64 since they do not exist in the x86 compiler intrinsics.

https://learn.microsoft.com/en-us/cpp/intrinsics/bitscanforward-bitscanforward64?view=msvc-170

Avoids these compiler errors:
CGAL\include\CGAL/cpp_float.h(30): error C3861: '_BitScanForward64': identifier not found
CGAL\include\CGAL/cpp_float.h(42): error C3861: '_BitScanReverse64': identifier not found

## Release Management

* Affected package(s): Number_types
* Issue(s) solved (if any): compiler errors encountered on Windows x86 builds
* License and copyright ownership: unchanged
