### PR TITLE
Polyhedron demo - fix `DoubleEdit`

### DIFF
--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
@@ -9,18 +9,16 @@ public:
     : QDoubleValidator(parent)
   {
     setLocale(QLocale::C);
-    setNotation(QDoubleValidator::StandardNotation);
   }
 
   void fixup ( QString & input ) const
   {
     input.replace(".", locale().decimalPoint());
     input.replace(",", locale().decimalPoint());
-//    QDoubleValidator::fixup(input);
+    QDoubleValidator::fixup(input);
   }
   QValidator::State validate ( QString & input, int & pos ) const
   {
-    fixup(input);
     return QDoubleValidator::validate(input, pos);
   }
 };

--- a/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
+++ b/Polyhedron/demo/Polyhedron/CGAL_double_edit.cpp
@@ -9,13 +9,14 @@ public:
     : QDoubleValidator(parent)
   {
     setLocale(QLocale::C);
+    setNotation(QDoubleValidator::StandardNotation);
   }
 
   void fixup ( QString & input ) const
   {
     input.replace(".", locale().decimalPoint());
     input.replace(",", locale().decimalPoint());
-    QDoubleValidator::fixup(input);
+//    QDoubleValidator::fixup(input);
   }
   QValidator::State validate ( QString & input, int & pos ) const
   {
@@ -59,7 +60,7 @@ public:
 
   void DoubleEdit::setRange(double rmin, double rmax)
   {
-    this->validator->setRange(rmin, rmax, this->validator->decimals());
+    this->validator->setRange(rmin, rmax, -1);
   }
 
   double DoubleEdit::getValue()

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -610,6 +610,8 @@ void Mesh_3_plugin::mesh_3(const Mesh_type mesh_type,
   ui.approx->setRange(diag * 10e-7, // min
                       diag);        // max
   ui.approx->setValue(approx);
+  ui.approx->setToolTip(tr("Approximation error: in [%1; %2]")
+                       .arg(diag * 10e-7).arg(diag));
 
   ui.protect->setEnabled(features_protection_available);
   ui.protect->setChecked(features_protection_available);


### PR DESCRIPTION
## Summary of Changes

With Qt6, scientific notation was used by default. This PR changes it to normal notation for doubles.

~~Note that I had to remove the call to `QDoubleValidator::fixup(input);` to make it work, otherwise I could not add a "." in the number I wanted to enter. I did not find any satisfying explanation for that, but it works...~~

## Release Management

* Affected package(s): Polyhedron demo
* License and copyright ownership: unchanged

