### PR TITLE
Polyhedron demo - improve the Mesh_3 log

### DIFF
--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_3_plugin_cgal_code.cpp
@@ -134,6 +134,8 @@ Meshing_thread* cgal_code_mesh_3(QList<const SMesh*> pMeshes,
   param.manifold = manifold;
   param.protect_features = protect_features || protect_borders;
   param.use_sizing_field_with_aabb_tree = polylines.empty() && protect_features;
+  param.image_3_ptr = nullptr;
+  param.weights_ptr = nullptr;
 
   typedef ::Mesh_function<Polyhedral_mesh_domain,
                           Mesh_fnt::Polyhedral_domain_tag> Mesh_function;
@@ -237,6 +239,8 @@ Meshing_thread* cgal_code_mesh_3(const QList<const SMesh*> pMeshes,
   param.manifold = manifold;
   param.protect_features = protect_features || protect_borders;
   param.use_sizing_field_with_aabb_tree = protect_features;
+  param.image_3_ptr = nullptr;
+  param.weights_ptr = nullptr;
 
   typedef ::Mesh_function<Polyhedral_complex_mesh_domain,
                           Mesh_fnt::Polyhedral_domain_tag> Mesh_function;
@@ -292,7 +296,8 @@ Meshing_thread* cgal_code_mesh_3(const Implicit_function_interface* pfunction,
   param.manifold = manifold;
   param.detect_connected_components = false; // to avoid random values
                                              // in the debug displays
-
+  param.image_3_ptr = nullptr;
+  param.weights_ptr = nullptr;
 
   typedef ::Mesh_function<Function_mesh_domain,
                           Mesh_fnt::Implicit_domain_tag> Mesh_function;

--- a/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
+++ b/Polyhedron/demo/Polyhedron/Plugins/Mesh_3/Mesh_function.h
@@ -138,20 +138,40 @@ QStringList
 Mesh_parameters::
 log() const
 {
-  return QStringList()
-  << QString("edge max size: %1").arg(edge_sizing)
-  << QString("edge min size: %1").arg(edge_min_sizing)
-  << QString("facet min angle: %1").arg(facet_angle)
-  << QString("facet max size: %1").arg(facet_sizing)
-  << QString("facet min size: %1").arg(facet_min_sizing)
-  << QString("facet approx error: %1").arg(facet_approx)
-  << QString("tet shape (radius-edge): %1").arg(tet_shape)
-  << QString("tet max size: %1").arg(tet_sizing)
-  << QString("tet min size: %1").arg(tet_min_sizing)
-  << QString("detect connected components: %1")
-    .arg(detect_connected_components)
-  << QString("use weights: %1").arg(weights_ptr != nullptr)
-  << QString("protect features: %1").arg(protect_features);
+  QStringList res("Mesh criteria");
+
+  // doubles
+  if(edge_sizing > 0)
+    res << QString("edge max size: %1").arg(edge_sizing);
+  if(edge_min_sizing > 0)
+    res << QString("edge min size: %1").arg(edge_min_sizing);
+  if(facet_angle > 0)
+    res << QString("facet min angle: %1").arg(facet_angle);
+  if(facet_sizing > 0)
+    res << QString("facet max size: %1").arg(facet_sizing);
+  if(facet_min_sizing > 0)
+    res << QString("facet min size: %1").arg(facet_min_sizing);
+  if(facet_approx > 0)
+    res << QString("facet approx error: %1").arg(facet_approx);
+  if(tet_shape > 0)
+    res << QString("tet shape (radius-edge): %1").arg(tet_shape);
+  if(tet_sizing > 0)
+    res << QString("tet max size: %1").arg(tet_sizing);
+  if(tet_min_sizing > 0)
+    res << QString("tet min size: %1").arg(tet_min_sizing);
+
+  // booleans
+  res << QString("protect features: %1").arg(protect_features);
+  if(image_3_ptr != nullptr)
+  {
+    res << QString("detect connected components: %1")
+             .arg(detect_connected_components);
+    res << QString("use weights: %1").arg(weights_ptr != nullptr);
+  }
+  res << QString("use aabb tree: %1").arg(use_sizing_field_with_aabb_tree);
+  res << QString("manifold: %1").arg(manifold);
+
+  return res;
 }
 
 


### PR DESCRIPTION
## Summary of Changes

This PR changes the log that is displayed in the "Console" box of the demo after Mesh_3.
Now, only the criteria that are used (not the ones set to 0 or unchecked in the dialog) are displayed, to improve readability.

## Release Management

* Affected package(s): Polyhedron demo
* License and copyright ownership: unchanged

