### PR TITLE
Incorrect link to "Perturbations for Delaunay and weighted Delaunay 3D Triangulations"

### DIFF
--- a/Documentation/doc/biblio/cgal_manual.bib
+++ b/Documentation/doc/biblio/cgal_manual.bib
@@ -778,7 +778,7 @@ Teillaud"
 , volume      = 44
 , year        = 2011
 , pages       = "160--168"
-, url         = "https://theses.hal.science/inria-00560388/"
+, url         = "https://hal.science/inria-00560388/"
 , doi         = "10.1016/j.comgeo.2010.09.010"
 }
 


### PR DESCRIPTION
The link for the document "Perturbations for Delaunay and weighted Delaunay 3D Triangulations" was in #7811 (based on #7762) changed but it is not available at he address "https://theses.hal.science/inria-00560388/" but at "https://hal.science/inria-00560388/". (The other changes were correct).

Found in Triangulation_3/citelist.html


