### PR TITLE
Prevent out-of-bound warnings

### DIFF
--- a/TDS_3/include/CGAL/Triangulation_utils_3.h
+++ b/TDS_3/include/CGAL/Triangulation_utils_3.h
@@ -35,10 +35,10 @@ struct Triangulation_utils_base_3
 
 template < class T >
 const char Triangulation_utils_base_3<T>::tab_next_around_edge[4][4] = {
-      {5, 2, 3, 1},
-      {3, 5, 0, 2},
-      {1, 3, 5, 0},
-      {2, 0, 1, 5} };
+      {-0, 2, 3, 1},
+      {3, -0, 0, 2},
+      {1, 3, -0, 0},
+      {2, 0, 1, -0} };
 
 template < class T >
 const int Triangulation_utils_base_3<T>::tab_vertex_triple_index[4][3] = {

--- a/TDS_3/include/CGAL/Triangulation_utils_3.h
+++ b/TDS_3/include/CGAL/Triangulation_utils_3.h
@@ -35,10 +35,10 @@ struct Triangulation_utils_base_3
 
 template < class T >
 const char Triangulation_utils_base_3<T>::tab_next_around_edge[4][4] = {
-      {-0, 2, 3, 1},
-      {3, -0, 0, 2},
-      {1, 3, -0, 0},
-      {2, 0, 1, -0} };
+      {5, 2, 3, 1},
+      {3, 5, 0, 2},
+      {1, 3, 5, 0},
+      {2, 0, 1, 5} };
 
 template < class T >
 const int Triangulation_utils_base_3<T>::tab_vertex_triple_index[4][3] = {

--- a/TDS_3/include/CGAL/Triangulation_utils_3.h
+++ b/TDS_3/include/CGAL/Triangulation_utils_3.h
@@ -80,6 +80,7 @@ struct Triangulation_utils_3
     CGAL_triangulation_precondition( ( i >= 0 && i < 4 ) &&
                                      ( j >= 0 && j < 4 ) &&
                                      ( i != j ) );
+    CGAL_assume(i!=j);
     return tab_next_around_edge[i][j];
   }
 


### PR DESCRIPTION
Fixes warnings for example [here](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.0-Ic-121/Mesh_3/TestReport_lrineau_Fedora-rawhide-Release.gz)

