### PR TITLE
Polyhedron Demo: Add sampling plugin

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/examples.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/examples.txt
@@ -46,4 +46,6 @@
 \example Polygon_mesh_processing/cc_compatible_orientations.cpp
 \example Polygon_mesh_processing/remesh_planar_patches.cpp
 \example Polygon_mesh_processing/remesh_almost_planar_patches.cpp
+\example Polygon_mesh_processing/sample_example.cpp
+*/
 */

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
@@ -7,6 +7,7 @@ project(Polygon_mesh_processing_Examples)
 # CGAL and its components
 find_package(CGAL REQUIRED)
 
+create_single_source_cgal_program("sample_example.cpp" )
 create_single_source_cgal_program("extrude.cpp" )
 create_single_source_cgal_program("polyhedral_envelope.cpp" )
 create_single_source_cgal_program("polyhedral_envelope_of_triangle_soup.cpp" )

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/sample_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/sample_example.cpp
@@ -1,0 +1,51 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Polygon_mesh_processing/distance.h>
+
+#include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
+#include <CGAL/Point_set_3.h>
+#include <iostream>
+#include <string>
+#include <vector>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel   K;
+typedef K::Point_3                                            Point;
+
+typedef CGAL::Point_set_3<Point>                              Point_set;
+
+typedef CGAL::Surface_mesh<Point>                             Mesh;
+typedef boost::graph_traits<Mesh>::vertex_descriptor          vertex_descriptor;
+typedef boost::graph_traits<Mesh>::face_descriptor            face_descriptor;
+
+namespace PMP = CGAL::Polygon_mesh_processing;
+
+int main(int argc, char* argv[])
+{
+  const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/eight.off");
+
+  Mesh mesh;
+  if(!PMP::IO::read_polygon_mesh(filename, mesh))
+  {
+    std::cerr << "Invalid input." << std::endl;
+    return 1;
+  }
+
+  const double points_per_face = (argc > 2) ? atof(argv[2]) : 10;
+
+  std::vector<Point> points;
+
+  PMP::sample_triangle_mesh(mesh, std::back_inserter(points), CGAL::parameters::number_of_points_per_face(points_per_face));
+
+  std::cout.precision(17);
+  for(const Point& p : points){
+    std::cout << p << std::endl;
+  }
+
+  Point_set point_set;
+  PMP::sample_triangle_mesh(mesh,
+                            point_set.point_back_inserter(),
+                            CGAL::parameters::point_map(point_set.point_push_map()));
+
+  std::cout << point_set.number_of_points() << std::endl;
+  return 0;
+}

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/sample_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/sample_example.cpp
@@ -30,18 +30,13 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  const double points_per_face = (argc > 2) ? atof(argv[2]) : 10;
+  const int points_per_face = (argc > 2) ? std::stoi(argv[2]) : 10;
 
   std::vector<Point> points;
-
   PMP::sample_triangle_mesh(mesh,
                             std::back_inserter(points),
                             CGAL::parameters::number_of_points_per_face(points_per_face));
 
-  std::cout.precision(17);
-  for(const Point& p : points){
-    std::cout << p << std::endl;
-  }
 
   Point_set point_set;
   PMP::sample_triangle_mesh(mesh,

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/sample_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/sample_example.cpp
@@ -34,7 +34,9 @@ int main(int argc, char* argv[])
 
   std::vector<Point> points;
 
-  PMP::sample_triangle_mesh(mesh, std::back_inserter(points), CGAL::parameters::number_of_points_per_face(points_per_face));
+  PMP::sample_triangle_mesh(mesh,
+                            std::back_inserter(points),
+                            CGAL::parameters::number_of_points_per_face(points_per_face));
 
   std::cout.precision(17);
   for(const Point& p : points){
@@ -43,8 +45,7 @@ int main(int argc, char* argv[])
 
   Point_set point_set;
   PMP::sample_triangle_mesh(mesh,
-                            point_set.point_back_inserter(),
-                            CGAL::parameters::point_map(point_set.point_push_map()));
+                            point_set.point_back_inserter());
 
   std::cout << point_set.number_of_points() << std::endl;
   return 0;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -747,7 +747,7 @@ struct Triangle_structure_sampler_for_triangle_soup
  * @tparam TriangleMesh a model of the concepts `EdgeListGraph` and `FaceListGraph`
  * @tparam PointOutputIterator a model of `OutputIterator`
  *  holding objects of the same point type as
- *  the value type of the point type associated to the mesh `tm`, i.e. the value type of the vertex
+ *  the value type of the point type associated to the mesh `tm`, i.e., the value type of the vertex
  *  point map property map, if provided, or the value type of the internal point property map otherwise
  * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
  *
@@ -1570,7 +1570,7 @@ bounded_error_squared_Hausdorff_distance_impl(const TriangleMesh1& tm1,
     candidate_triangles.pop();
 
     // Only process the triangle if it can contribute to the Hausdorff distance,
-    // i.e. if its upper bound is higher than the currently known best lower bound
+    // i.e., if its upper bound is higher than the currently known best lower bound
     // and the difference between the bounds to be obtained is larger than the
     // user-given error.
     const auto& triangle_bounds = triangle_and_bounds.bounds;

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/CMakeLists.txt
@@ -13,6 +13,13 @@ target_link_libraries(
   PUBLIC scene_surface_mesh_item scene_polygon_soup_item
          scene_points_with_normal_item)
 
+polyhedron_demo_plugin(point_set_from_sampling_plugin
+                       Point_set_from_sampling_plugin)
+target_link_libraries(
+  point_set_from_sampling_plugin
+  PUBLIC scene_surface_mesh_item scene_polygon_soup_item
+         scene_points_with_normal_item)
+
 polyhedron_demo_plugin(diff_between_meshes_plugin Diff_between_meshes_plugin)
 target_link_libraries(diff_between_meshes_plugin PUBLIC scene_surface_mesh_item)
 

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Point_set_from_sampling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Point_set_from_sampling_plugin.cpp
@@ -1,0 +1,105 @@
+#include <QApplication>
+#include <QAction>
+#include <QList>
+#include <QMainWindow>
+#include <QMessageBox>
+#include <QtDebug>
+
+#include "Scene_points_with_normal_item.h"
+#include "Scene_surface_mesh_item.h"
+#include "Scene_polygon_soup_item.h"
+
+#include <CGAL/Three/Polyhedron_demo_plugin_interface.h>
+#include "Messages_interface.h"
+
+#include <CGAL/Polygon_mesh_processing/distance.h>
+
+using namespace CGAL::Three;
+class Polyhedron_demo_point_set_from_sampling_plugin :
+  public QObject,
+  public Polyhedron_demo_plugin_interface
+{
+  Q_OBJECT
+  Q_INTERFACES(CGAL::Three::Polyhedron_demo_plugin_interface)
+  Q_PLUGIN_METADATA(IID "com.geometryfactory.PolyhedronDemo.PluginInterface/1.0")
+
+public:
+  void init(QMainWindow* mainWindow,
+            CGAL::Three::Scene_interface* scene_interface, Messages_interface*);
+
+  bool applicable(QAction*) const {
+    const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
+
+    return qobject_cast<Scene_surface_mesh_item*>(scene->item(index))
+      || qobject_cast<Scene_polygon_soup_item*>(scene->item(index));
+  }
+
+  QList<QAction*> actions() const;
+
+public Q_SLOTS:
+  void createPointSet();
+
+private:
+  CGAL::Three::Scene_interface* scene;
+  QAction* actionPointSetFromSampling;
+
+
+}; // end Polyhedron_demo_point_set_from_sampling_plugin
+
+void Polyhedron_demo_point_set_from_sampling_plugin::init(QMainWindow* mainWindow,
+                                                          CGAL::Three::Scene_interface* scene_interface,
+                                                          Messages_interface*)
+{
+  scene = scene_interface;
+  actionPointSetFromSampling = new QAction(tr("&Create Point Set from Sampling"), mainWindow);
+  actionPointSetFromSampling->setObjectName("actionPointSetFromSampling");
+  connect(actionPointSetFromSampling, SIGNAL(triggered()),
+          this, SLOT(createPointSet()));
+}
+
+QList<QAction*> Polyhedron_demo_point_set_from_sampling_plugin::actions() const {
+  return QList<QAction*>() << actionPointSetFromSampling;
+}
+
+
+
+void Polyhedron_demo_point_set_from_sampling_plugin::createPointSet()
+{
+  QApplication::setOverrideCursor(Qt::WaitCursor);
+  const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
+
+  Scene_points_with_normal_item* points = new Scene_points_with_normal_item();
+  std::vector<Kernel::Point_3> pts;
+
+  if (points){
+    points->setColor(Qt::blue);
+  }else{
+    return;
+  }
+  Scene_surface_mesh_item* sm_item =
+    qobject_cast<Scene_surface_mesh_item*>(scene->item(index));
+
+  if (sm_item){
+    points->setName(QString("%1 (sampled)").arg(sm_item->name()));
+    CGAL::Polygon_mesh_processing::sample_triangle_mesh(*sm_item->polyhedron(),
+                                                        std::back_inserter(pts));
+  }
+
+  Scene_polygon_soup_item* soup_item =
+    qobject_cast<Scene_polygon_soup_item*>(scene->item(index));
+
+  if (soup_item){
+    points->setName(QString("%1 (sampled)").arg(soup_item->name()));
+    CGAL::Polygon_mesh_processing::sample_triangle_soup(soup_item->points(),
+                                                        soup_item->polygons(),
+                                                        std::back_inserter(pts));
+  }
+  for (std::size_t i = 0; i < pts.size(); ++i){
+    points->point_set()->insert(pts[i]);
+  }
+    scene->addItem(points);
+  QApplication::restoreOverrideCursor();
+}
+
+
+#include "Point_set_from_sampling_plugin.moc"

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Point_set_from_sampling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Point_set_from_sampling_plugin.cpp
@@ -114,7 +114,7 @@ void Polyhedron_demo_point_set_from_sampling_plugin::createPointSet()
     qobject_cast<Scene_polygon_soup_item*>(scene->item(index));
 
   if (soup_item){
-    int nf = soup_item->polygons().size();
+    int nf = static_cast<int>(soup_item->polygons().size());
 
     for(const auto& f : soup_item->polygons()){
       if(f.size() != 3){

--- a/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Point_set_from_sampling_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Operations_on_polyhedra/Point_set_from_sampling_plugin.cpp
@@ -94,10 +94,11 @@ void Polyhedron_demo_point_set_from_sampling_plugin::createPointSet()
                                                         soup_item->polygons(),
                                                         std::back_inserter(pts));
   }
+  points->point_set()->reserve(pts.size());
   for (std::size_t i = 0; i < pts.size(); ++i){
     points->point_set()->insert(pts[i]);
   }
-    scene->addItem(points);
+  scene->addItem(points);
   QApplication::restoreOverrideCursor();
 }
 


### PR DESCRIPTION
## Summary of Changes

Add a plugin that samples meshes and polygon soups

### Todo

- [x] Add dialog for the various parameters of the sampling function
- [x] Check that the input is triangular.

## Release Management

* Affected package(s): Polyhedron
* License and copyright ownership: unchanged

