### PR TITLE
PMP: Write into different files to avoid concurrent writing

### DIFF
--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_Polyhedron_3_no_delaunay_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_Polyhedron_3_no_delaunay_test.cpp
@@ -335,7 +335,7 @@ void test_triangulate_refine_and_fair_hole_compile() {
   std::vector<Vertex_handle> patch_vertices;
 
   // use all param
-  read_poly_with_borders("elephant_quad_hole.off", poly, border_reps);
+  read_poly_with_borders("elephant_quad_hole_no_DT3.off", poly, border_reps);
   CGAL::Polygon_mesh_processing::triangulate_refine_and_fair_hole
   (poly, border_reps[0], back_inserter(patch_facets), back_inserter(patch_vertices),
   CGAL::parameters::
@@ -343,14 +343,14 @@ void test_triangulate_refine_and_fair_hole_compile() {
     sparse_linear_solver(Default_solver()));
 
   // default solver
-  read_poly_with_borders("elephant_quad_hole.off", poly, border_reps);
+  read_poly_with_borders("elephant_quad_hole_no_DT3.off", poly, border_reps);
   CGAL::Polygon_mesh_processing::triangulate_refine_and_fair_hole
     (poly, border_reps[0], back_inserter(patch_facets), back_inserter(patch_vertices),
     CGAL::parameters::
       weight_calculator(CGAL::Weights::Uniform_weight<Polyhedron>()));
 
   // default solver and weight
-  read_poly_with_borders("elephant_quad_hole.off", poly, border_reps);
+  read_poly_with_borders("elephant_quad_hole_no_DT3.off", poly, border_reps);
   CGAL::Polygon_mesh_processing::triangulate_refine_and_fair_hole
     (poly, border_reps[0], back_inserter(patch_facets), back_inserter(patch_vertices));
 }
@@ -369,11 +369,11 @@ void generate_elephant_with_hole()
     {
       Halfedge_handle nh=opposite(halfedge(fd,poly), poly);
       CGAL::Euler::remove_face(halfedge(fd, poly), poly);
-      std::ofstream output("elephant_triangle_hole.off");
+      std::ofstream output("elephant_triangle_hole_no_DT3.off");
       output << poly;
       output.close();
       CGAL::Euler::remove_face(nh, poly);
-      output.open("elephant_quad_hole.off");
+      output.open("elephant_quad_hole_no_DT3.off");
       output << poly;
       return;
     }
@@ -389,8 +389,8 @@ typedef CGAL::Surface_mesh<typename Kernel::Point_3> Polyhedron;
   generate_elephant_with_hole<Polyhedron>();
 
   std::vector<std::string> input_files;
-  input_files.push_back("elephant_triangle_hole.off");
-  input_files.push_back("elephant_quad_hole.off");
+  input_files.push_back("elephant_triangle_hole_no_DT3.off");
+  input_files.push_back("elephant_quad_hole_no_DT3.off");
   input_files.push_back(CGAL::data_file_path("meshes/mech-holes-shark.off"));
   // std::cerr.precision(15);
   for(std::vector<std::string>::iterator it = input_files.begin(); it != input_files.end(); ++it) {


### PR DESCRIPTION
## Summary of Changes

As test programs may be executed in parallel we have to write in files with different names,

## Release Management

* Affected package(s): Polygon_mesh_processing
* License and copyright ownership:  unchanged

