### PR TITLE
Interpolated Curvature remaining TODOs

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -1027,7 +1027,7 @@ These computations are performed using (on all vertices of the mesh) `CGAL::Poly
 where function named parameters are used to select the curvatures (and possibly directions) to be computed. An overload function with the same name
 but taking a given vertex is also available in case the computation should be done only for that vertex.
 
-\subsection ICCResults Results & Performance
+\subsection ICCResults Results
 
 First, \cgalFigureRef{icc_measures} illustrates various curvature measures on a triangular mesh.
 
@@ -1069,6 +1069,131 @@ Mean curvature, Gaussian curvature, minimal principal curvature direction and ma
 </center>
 \cgalFigureCaptionBegin{icc_various_ball_radii}
 When changing the integration ball radius, we obtain a scale space of curvature measure that can be used to tackle possible noise in the input as illustrated in the second row (mean curvature only with fixed colormap ranges and ball radii in {0.02,0.03,0.04,0.05}).
+\cgalFigureCaptionEnd
+
+
+\subsection ICCPerformance Performance
+
+The implemented algorithms exhibit a linear complexity in the number of faces of the mesh. It is worth noting that
+we pre-computed the vertex normals and passed them as a named parameter to the function to better estimate the
+performance of the curvature computation. For the data reported in the following table, we used a machine with an
+Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compiled with Visual Studio 2019.
+
+\cgalFigureAnchor{icc_performance_table}
+<table class="tg" style="undefined;table-layout: fixed; width: 952px">
+<colgroup>
+<col style="width: 161px">
+<col style="width: 300px">
+<col style="width: 91px">
+<col style="width: 113px">
+<col style="width: 145px">
+<col style="width: 142px">
+</colgroup>
+<thead>
+  <tr>
+    <th class="tg-0pky">Ball <br>Radius</th>
+    <th class="tg-0pky">Computation</th>
+    <th class="tg-0pky">Spot<br>(<span style="font-weight:bold">6k </span>faces)</th>
+    <th class="tg-0pky">Bunny<br>(<span style="font-weight:bold">144K </span>faces)</th>
+    <th class="tg-0pky">Stanford Dragon<br>(<span style="font-weight:bold">871K </span>faces)</th>
+    <th class="tg-0pky">Old Age or Winter<br>(<span style="font-weight:bold">6M </span>faces)</th>
+  </tr>
+</thead>
+<tbody>
+  <tr>
+    <td class="tg-0pky" rowspan="4">vertex<br>1-ring faces <br>(default)</td>
+    <td class="tg-za14">Mean&nbsp;&nbsp;&nbsp;Curvature</td>
+    <td class="tg-dvpl">  &lt; 0.001 s</td>
+    <td class="tg-jkyp">0.019 s</td>
+    <td class="tg-jkyp">0.11 s</td>
+    <td class="tg-jkyp">2.68 s</td>
+  </tr>
+  <tr>
+    <td class="tg-za14">Gaussian Curvature</td>
+    <td class="tg-dvpl"> &lt; 0.001 s</td>
+    <td class="tg-jkyp">0.017 s</td>
+    <td class="tg-jkyp">0.10 s</td>
+    <td class="tg-jkyp">2.77 s</td>
+  </tr>
+  <tr>
+    <td class="tg-za14">Principal Curvature &amp; Directions</td>
+    <td class="tg-jkyp">0.002 s</td>
+    <td class="tg-jkyp">0.044 s</td>
+    <td class="tg-jkyp">0.25 s</td>
+    <td class="tg-jkyp">3.98 s</td>
+  </tr>
+  <tr>
+    <td class="tg-za14">All (optimized for shared computations)</td>
+    <td class="tg-jkyp">0.003 s</td>
+    <td class="tg-jkyp">0.049 s</td>
+    <td class="tg-jkyp">0.28 s</td>
+    <td class="tg-jkyp">4.52 s</td>
+  </tr>
+  <tr>
+    <td class="tg-0pky" rowspan="4">r = 0.1<br>* avg_edge_length</td>
+    <td class="tg-0pky">Mean   Curvature</td>
+    <td class="tg-jkyp">0.017 s</td>
+    <td class="tg-jkyp">0.401 s</td>
+    <td class="tg-jkyp">2.66 s</td>
+    <td class="tg-jkyp">22.29 s</td>
+  </tr>
+  <tr>
+    <td class="tg-0pky">Gaussian Curvature</td>
+    <td class="tg-jkyp">0.018 s</td>
+    <td class="tg-jkyp">0.406 s</td>
+    <td class="tg-jkyp">2.63 s</td>
+    <td class="tg-jkyp">21.61 s</td>
+  </tr>
+  <tr>
+    <td class="tg-0pky">Principal Curvature &amp; Directions</td>
+    <td class="tg-jkyp">0.019 s</td>
+    <td class="tg-jkyp">0.430 s</td>
+    <td class="tg-jkyp">2.85 s</td>
+    <td class="tg-jkyp">23.55 s</td>
+  </tr>
+  <tr>
+    <td class="tg-0pky">All (optimized for shared computations)</td>
+    <td class="tg-jkyp">0.017 s</td>
+    <td class="tg-jkyp">0.428 s</td>
+    <td class="tg-jkyp">2.89 s</td>
+    <td class="tg-jkyp">24.16 s</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax" rowspan="4">r = 0.5<br>* avg_edge_length</td>
+    <td class="tg-0lax">Mean   Curvature</td>
+    <td class="tg-2b7s">0.024 s</td>
+    <td class="tg-2b7s">0.388 s</td>
+    <td class="tg-2b7s">3.18 s</td>
+    <td class="tg-2b7s">22.79 s</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Gaussian Curvature</td>
+    <td class="tg-2b7s">0.024 s</td>
+    <td class="tg-2b7s">0.392 s</td>
+    <td class="tg-2b7s">3.21 s</td>
+    <td class="tg-2b7s">23.58 s</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">Principal Curvature &amp; Directions</td>
+    <td class="tg-2b7s">0.027 s</td>
+    <td class="tg-2b7s">0.428 s</td>
+    <td class="tg-2b7s">3.41 s</td>
+    <td class="tg-2b7s">24.44 s</td>
+  </tr>
+  <tr>
+    <td class="tg-0lax">All (optimized for shared computations)</td>
+    <td class="tg-2b7s">0.025 s</td>
+    <td class="tg-2b7s">0.417 s</td>
+    <td class="tg-2b7s">3.44 s</td>
+    <td class="tg-2b7s">23.93 s</td>
+  </tr>
+</tbody>
+</table>
+\cgalFigureCaptionBegin{icc_performance_table}
+Performance of the curvature computation on various meshes (in seconds). The first row shows the performance of the default value for the ball radius,
+which is using the 1-ring of neighboring faces around each vertex, instead of actually approximating the inclusion ratio of the faces in the ball.
+The other rows show a ball radius of 0.1 (and 0.5) scaled by the average edge length of the mesh. It is clear that using the 1-ring of faces
+is much faster, but it might not be as effective when used on a noisy input mesh.
 \cgalFigureCaptionEnd
 
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -998,7 +998,7 @@ solver.
 
 The interpolated curvature measures are then computed for each vertex \f$ v \f$ as the sum of
 the curvature measures of the faces in a ball around \f$ v \f$ weighted by the inclusion ratio of the
-triangle in the ball. If the ball radius is not specified, the sum is instead computed over the incident faces
+triangle in the ball. If the ball radius is not specified (or negative), the sum is instead computed over the incident faces
 of \f$ v \f$.
 
 To get the final curvature value for a vertex \f$ v \f$, the respective interpolated curvature measure

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -1085,10 +1085,10 @@ Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compi
   <tr>
     <th>Ball <br>Radius</th>
     <th>Computation</th>
-    <th>Spot<br>(<span style="font-weight:bold">6k </span>faces)</th>
-    <th>Bunny<br>(<span style="font-weight:bold">144K </span>faces)</th>
-    <th>Stanford Dragon<br>(<span style="font-weight:bold">871K </span>faces)</th>
-    <th>Old Age or Winter<br>(<span style="font-weight:bold">6M </span>faces)</th>
+    <th>Spot<br>(<span>6k </span>faces)</th>
+    <th>Bunny<br>(<span>144K </span>faces)</th>
+    <th>Stanford Dragon<br>(<span>871K </span>faces)</th>
+    <th>Old Age or Winter<br>(<span>6M </span>faces)</th>
   </tr>
   <tr>
     <td rowspan="4">vertex<br>1-ring faces <br>(default)</td>
@@ -1172,16 +1172,16 @@ Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compi
   </tr>
   <tr>
     <td>All (optimized for shared computations)</td>
-    <td0.025 s</td>
-    <td0.417 s</td>
-    <td3.44 s</td>
-    <td23.93 s</td>
+    <td>0.025 s</td>
+    <td>0.417 s</td>
+    <td>3.44 s</td>
+    <td>23.93 s</td>
   </tr>
 </table>
 </center>
 \cgalFigureCaptionBegin{icc_performance_table}
-Performance of the curvature computation on various meshes (in seconds). The first row shows the performance of the default value for the ball radius,
-which is using the 1-ring of neighboring faces around each vertex, instead of actually approximating the inclusion ratio of the faces in the ball.
+Performance of the curvature computation on various meshes (in seconds). The first 4 rows show the performance of the default value for the ball radius,
+which is using the 1-ring of neighboring faces around each vertex, instead of actually approximating the inclusion ratio of the faces in a ball of certain radius.
 The other rows show a ball radius of 0.1 (and 0.5) scaled by the average edge length of the mesh. It is clear that using the 1-ring of faces
 is much faster, but it might not be as effective when used on a noisy input mesh.
 \cgalFigureCaptionEnd

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -1092,7 +1092,7 @@ Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compi
   </tr>
   <tr>
     <td rowspan="4">vertex<br>1-ring faces <br>(default)</td>
-    <td>Mean&nbsp;&nbsp;&nbsp;Curvature</td>
+    <td>Mean Curvature</td>
     <td>  &lt; 0.001 s</td>
     <td>0.019 s</td>
     <td>0.11 s</td>
@@ -1106,7 +1106,7 @@ Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compi
     <td>2.77 s</td>
   </tr>
   <tr>
-    <td>Principal Curvature &amp; Directions</td>
+    <td>Principal Curvatures &amp; Directions</td>
     <td>0.002 s</td>
     <td>0.044 s</td>
     <td>0.25 s</td>
@@ -1121,7 +1121,7 @@ Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compi
   </tr>
   <tr>
     <td rowspan="4">r = 0.1<br>* avg_edge_length</td>
-    <td>Mean   Curvature</td>
+    <td>Mean Curvature</td>
     <td>0.017 s</td>
     <td>0.401 s</td>
     <td>2.66 s</td>
@@ -1135,7 +1135,7 @@ Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compi
     <td>21.61 s</td>
   </tr>
   <tr>
-    <td>Principal Curvature &amp; Directions</td>
+    <td>Principal Curvatures &amp; Directions</td>
     <td>0.019 s</td>
     <td>0.430 s</td>
     <td>2.85 s</td>
@@ -1150,7 +1150,7 @@ Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compi
   </tr>
   <tr>
     <td rowspan="4">r = 0.5<br>* avg_edge_length</td>
-    <td>Mean   Curvature</td>
+    <td>Mean Curvature</td>
     <td>0.024 s</td>
     <td>0.388 s</td>
     <td>3.18 s</td>
@@ -1164,7 +1164,7 @@ Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compi
     <td>23.58 s</td>
   </tr>
   <tr>
-    <td>Principal Curvature &amp; Directions</td>
+    <td>Principal Curvatures &amp; Directions</td>
     <td>0.027 s</td>
     <td>0.428 s</td>
     <td>3.41 s</td>

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -998,8 +998,13 @@ solver.
 
 The interpolated curvature measures are then computed for each vertex \f$ v \f$ as the sum of
 the curvature measures of the faces in a ball around \f$ v \f$ weighted by the inclusion ratio of the
-triangle in the ball. If the ball radius is not specified (or negative), the sum is instead computed over the incident faces
-of \f$ v \f$.
+triangle in the ball. This ball radius is an optional (named) parameter of the function. There are 3
+cases for the ball radius passed value:
+- A positive value is passed: it is naturally used as the radius of the ball.
+- 0 is passed, a small epsilon (`average_edge_length * 1e-6`) is used
+(to account for the convergence of curvatures at infinitely small balls).
+- It is not specified (or negative), the sum is instead computed over the incident faces
+of the vertex \f$ v \f$.
 
 To get the final curvature value for a vertex \f$ v \f$, the respective interpolated curvature measure
 is divided by the interpolated area measure.

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -1080,16 +1080,8 @@ performance of the curvature computation. For the data reported in the following
 Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compiled with Visual Studio 2019.
 
 \cgalFigureAnchor{icc_performance_table}
+<center>
 <table class="tg" style="undefined;table-layout: fixed; width: 952px">
-<colgroup>
-<col style="width: 161px">
-<col style="width: 300px">
-<col style="width: 91px">
-<col style="width: 113px">
-<col style="width: 145px">
-<col style="width: 142px">
-</colgroup>
-<thead>
   <tr>
     <th class="tg-0pky">Ball <br>Radius</th>
     <th class="tg-0pky">Computation</th>
@@ -1098,8 +1090,6 @@ Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compi
     <th class="tg-0pky">Stanford Dragon<br>(<span style="font-weight:bold">871K </span>faces)</th>
     <th class="tg-0pky">Old Age or Winter<br>(<span style="font-weight:bold">6M </span>faces)</th>
   </tr>
-</thead>
-<tbody>
   <tr>
     <td class="tg-0pky" rowspan="4">vertex<br>1-ring faces <br>(default)</td>
     <td class="tg-za14">Mean&nbsp;&nbsp;&nbsp;Curvature</td>
@@ -1187,8 +1177,9 @@ Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compi
     <td class="tg-2b7s">3.44 s</td>
     <td class="tg-2b7s">23.93 s</td>
   </tr>
-</tbody>
 </table>
+</center>
+
 \cgalFigureCaptionBegin{icc_performance_table}
 Performance of the curvature computation on various meshes (in seconds). The first row shows the performance of the default value for the ball radius,
 which is using the 1-ring of neighboring faces around each vertex, instead of actually approximating the inclusion ratio of the faces in the ball.

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -974,7 +974,7 @@ introduce a new way to compute curvatures on polygonal meshes. The main idea in 
 based on decoupling the normal information from the position information, which is useful for dealing with
 digital surfaces, or meshes with noise on vertex positions. \cgalCite{cgal:lrtc-iccmps-20} introduces some
 extensions to this framework, as it uses linear interpolation on the corrected normal vector field
-to derive new closed form equations for the corrected curvature measures. These <b>interpolated</b>
+to derive new closed-form equations for the corrected curvature measures. These <b>interpolated</b>
 curvature measures are the first step for computing the curvatures. For a triangle \f$ \tau_{ijk} \f$,
 with vertices \a i, \a j, \a k:
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -960,6 +960,11 @@ quad meshes, and meshes with n-gon faces (for n-gons, the centroid must be insid
 The algorithms used prove to work well in general. Also, on meshes with noise on vertex positions,
 they give accurate results, under the condition that the correct vertex normals are provided.
 
+It is worth noting that the Principal Curvatures and Directions can also be estimated using the
+\ref PkgJetFitting3 package, which estimates the local differential quantities of a surface at a point
+using a local polynomial fitting (fitting a d-jet). Unlike the Interpolated Corrected Curvatures,
+the Jet Fitting method discards topological information and thus can be used on point clouds as well.
+
 \subsection ICCBackground Brief Background
 
 Surface curvatures are quantities that describe the local geometry of a surface. They are important in many
@@ -1301,7 +1306,7 @@ available on 7th of October 2020.  It only uses the high level algorithm of chec
 is covered by a set of prisms, where each prism is an offset for an input triangle.
 That is, the implementation in \cgal does not use indirect predicates.
 
-The interpolated corrected curvatures were implemented during GSoC 2022. This was implemented by Hossam Saeed and under
+The interpolated corrected curvatures were implemented during GSoC 2022. This was implemented by Hossam Saeed and under the
 supervision of David Coeurjolly, Jaques-Olivier Lachaud, and Sébastien Loriot. The implementation is based on \cgalCite{cgal:lrtc-iccmps-20}.
 <a href="https://dgtal-team.github.io/doc-nightly/moduleCurvatureMeasures.html">DGtal's implementation</a> was also
 used as a reference during the project.

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -1081,105 +1081,104 @@ Intel Core i7-8750H CPU @ 2.20GHz, 16GB of RAM, on Windows 11, 64 bits and compi
 
 \cgalFigureAnchor{icc_performance_table}
 <center>
-<table class="tg" style="undefined;table-layout: fixed; width: 952px">
+<table>
   <tr>
-    <th class="tg-0pky">Ball <br>Radius</th>
-    <th class="tg-0pky">Computation</th>
-    <th class="tg-0pky">Spot<br>(<span style="font-weight:bold">6k </span>faces)</th>
-    <th class="tg-0pky">Bunny<br>(<span style="font-weight:bold">144K </span>faces)</th>
-    <th class="tg-0pky">Stanford Dragon<br>(<span style="font-weight:bold">871K </span>faces)</th>
-    <th class="tg-0pky">Old Age or Winter<br>(<span style="font-weight:bold">6M </span>faces)</th>
+    <th>Ball <br>Radius</th>
+    <th>Computation</th>
+    <th>Spot<br>(<span style="font-weight:bold">6k </span>faces)</th>
+    <th>Bunny<br>(<span style="font-weight:bold">144K </span>faces)</th>
+    <th>Stanford Dragon<br>(<span style="font-weight:bold">871K </span>faces)</th>
+    <th>Old Age or Winter<br>(<span style="font-weight:bold">6M </span>faces)</th>
   </tr>
   <tr>
-    <td class="tg-0pky" rowspan="4">vertex<br>1-ring faces <br>(default)</td>
-    <td class="tg-za14">Mean&nbsp;&nbsp;&nbsp;Curvature</td>
-    <td class="tg-dvpl">  &lt; 0.001 s</td>
-    <td class="tg-jkyp">0.019 s</td>
-    <td class="tg-jkyp">0.11 s</td>
-    <td class="tg-jkyp">2.68 s</td>
+    <td rowspan="4">vertex<br>1-ring faces <br>(default)</td>
+    <td>Mean&nbsp;&nbsp;&nbsp;Curvature</td>
+    <td>  &lt; 0.001 s</td>
+    <td>0.019 s</td>
+    <td>0.11 s</td>
+    <td>2.68 s</td>
   </tr>
   <tr>
-    <td class="tg-za14">Gaussian Curvature</td>
-    <td class="tg-dvpl"> &lt; 0.001 s</td>
-    <td class="tg-jkyp">0.017 s</td>
-    <td class="tg-jkyp">0.10 s</td>
-    <td class="tg-jkyp">2.77 s</td>
+    <td>Gaussian Curvature</td>
+    <td> &lt; 0.001 s</td>
+    <td>0.017 s</td>
+    <td>0.10 s</td>
+    <td>2.77 s</td>
   </tr>
   <tr>
-    <td class="tg-za14">Principal Curvature &amp; Directions</td>
-    <td class="tg-jkyp">0.002 s</td>
-    <td class="tg-jkyp">0.044 s</td>
-    <td class="tg-jkyp">0.25 s</td>
-    <td class="tg-jkyp">3.98 s</td>
+    <td>Principal Curvature &amp; Directions</td>
+    <td>0.002 s</td>
+    <td>0.044 s</td>
+    <td>0.25 s</td>
+    <td>3.98 s</td>
   </tr>
   <tr>
-    <td class="tg-za14">All (optimized for shared computations)</td>
-    <td class="tg-jkyp">0.003 s</td>
-    <td class="tg-jkyp">0.049 s</td>
-    <td class="tg-jkyp">0.28 s</td>
-    <td class="tg-jkyp">4.52 s</td>
+    <td>All (optimized for shared computations)</td>
+    <td>0.003 s</td>
+    <td>0.049 s</td>
+    <td>0.28 s</td>
+    <td>4.52 s</td>
   </tr>
   <tr>
-    <td class="tg-0pky" rowspan="4">r = 0.1<br>* avg_edge_length</td>
-    <td class="tg-0pky">Mean   Curvature</td>
-    <td class="tg-jkyp">0.017 s</td>
-    <td class="tg-jkyp">0.401 s</td>
-    <td class="tg-jkyp">2.66 s</td>
-    <td class="tg-jkyp">22.29 s</td>
+    <td rowspan="4">r = 0.1<br>* avg_edge_length</td>
+    <td>Mean   Curvature</td>
+    <td>0.017 s</td>
+    <td>0.401 s</td>
+    <td>2.66 s</td>
+    <td>22.29 s</td>
   </tr>
   <tr>
-    <td class="tg-0pky">Gaussian Curvature</td>
-    <td class="tg-jkyp">0.018 s</td>
-    <td class="tg-jkyp">0.406 s</td>
-    <td class="tg-jkyp">2.63 s</td>
-    <td class="tg-jkyp">21.61 s</td>
+    <td>Gaussian Curvature</td>
+    <td>0.018 s</td>
+    <td>0.406 s</td>
+    <td>2.63 s</td>
+    <td>21.61 s</td>
   </tr>
   <tr>
-    <td class="tg-0pky">Principal Curvature &amp; Directions</td>
-    <td class="tg-jkyp">0.019 s</td>
-    <td class="tg-jkyp">0.430 s</td>
-    <td class="tg-jkyp">2.85 s</td>
-    <td class="tg-jkyp">23.55 s</td>
+    <td>Principal Curvature &amp; Directions</td>
+    <td>0.019 s</td>
+    <td>0.430 s</td>
+    <td>2.85 s</td>
+    <td>23.55 s</td>
   </tr>
   <tr>
-    <td class="tg-0pky">All (optimized for shared computations)</td>
-    <td class="tg-jkyp">0.017 s</td>
-    <td class="tg-jkyp">0.428 s</td>
-    <td class="tg-jkyp">2.89 s</td>
-    <td class="tg-jkyp">24.16 s</td>
+    <td>All (optimized for shared computations)</td>
+    <td>0.017 s</td>
+    <td>0.428 s</td>
+    <td>2.89 s</td>
+    <td>24.16 s</td>
   </tr>
   <tr>
-    <td class="tg-0lax" rowspan="4">r = 0.5<br>* avg_edge_length</td>
-    <td class="tg-0lax">Mean   Curvature</td>
-    <td class="tg-2b7s">0.024 s</td>
-    <td class="tg-2b7s">0.388 s</td>
-    <td class="tg-2b7s">3.18 s</td>
-    <td class="tg-2b7s">22.79 s</td>
+    <td rowspan="4">r = 0.5<br>* avg_edge_length</td>
+    <td>Mean   Curvature</td>
+    <td>0.024 s</td>
+    <td>0.388 s</td>
+    <td>3.18 s</td>
+    <td>22.79 s</td>
   </tr>
   <tr>
-    <td class="tg-0lax">Gaussian Curvature</td>
-    <td class="tg-2b7s">0.024 s</td>
-    <td class="tg-2b7s">0.392 s</td>
-    <td class="tg-2b7s">3.21 s</td>
-    <td class="tg-2b7s">23.58 s</td>
+    <td>Gaussian Curvature</td>
+    <td>0.024 s</td>
+    <td>0.392 s</td>
+    <td>3.21 s</td>
+    <td>23.58 s</td>
   </tr>
   <tr>
-    <td class="tg-0lax">Principal Curvature &amp; Directions</td>
-    <td class="tg-2b7s">0.027 s</td>
-    <td class="tg-2b7s">0.428 s</td>
-    <td class="tg-2b7s">3.41 s</td>
-    <td class="tg-2b7s">24.44 s</td>
+    <td>Principal Curvature &amp; Directions</td>
+    <td>0.027 s</td>
+    <td>0.428 s</td>
+    <td>3.41 s</td>
+    <td>24.44 s</td>
   </tr>
   <tr>
-    <td class="tg-0lax">All (optimized for shared computations)</td>
-    <td class="tg-2b7s">0.025 s</td>
-    <td class="tg-2b7s">0.417 s</td>
-    <td class="tg-2b7s">3.44 s</td>
-    <td class="tg-2b7s">23.93 s</td>
+    <td>All (optimized for shared computations)</td>
+    <td0.025 s</td>
+    <td0.417 s</td>
+    <td3.44 s</td>
+    <td23.93 s</td>
   </tr>
 </table>
 </center>
-
 \cgalFigureCaptionBegin{icc_performance_table}
 Performance of the curvature computation on various meshes (in seconds). The first row shows the performance of the default value for the ball radius,
 which is using the 1-ring of neighboring faces around each vertex, instead of actually approximating the inclusion ratio of the faces in the ball.

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/interpolated_corrected_curvatures.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/interpolated_corrected_curvatures.h
@@ -76,20 +76,6 @@ struct Principal_curvatures_and_directions {
 
 namespace internal {
 
-template<typename PolygonMesh, typename GT>
-typename GT::FT average_edge_length(const PolygonMesh& pmesh) {
-  const std::size_t n = edges(pmesh).size();
-  if (n == 0)
-    return 0;
-
-  typename GT::FT avg_edge_length = 0;
-  for (auto e : edges(pmesh))
-    avg_edge_length += edge_length(e, pmesh);
-
-  avg_edge_length /= static_cast<typename GT::FT>(n);
-  return avg_edge_length;
-}
-
 template<typename GT>
 struct Vertex_measures {
   typename GT::FT area_measure = 0;
@@ -650,7 +636,7 @@ void interpolated_corrected_curvatures_one_vertex(
   typename GT::FT radius = choose_parameter(get_parameter(np, internal_np::ball_radius), -1);
 
   // calculate avg_edge_length as it is used in case radius is 0, and in the principal curvature computation later
-  typename GT::FT avg_edge_length = average_edge_length<PolygonMesh, GT>(pmesh);
+  typename GT::FT avg_edge_length = average_edge_length<PolygonMesh>(pmesh);
 
   // if the radius is 0, we use a small epsilon to expand the ball (scaled with the average edge length)
   if (is_zero(radius))
@@ -799,7 +785,7 @@ private:
 
     // if no radius is given, we pass -1 which will make the expansion be only on the incident faces instead of a ball
     const FT radius = choose_parameter(get_parameter(np, internal_np::ball_radius), -1);
-    avg_edge_length = average_edge_length<PolygonMesh, GT>(pmesh);
+    avg_edge_length = average_edge_length<PolygonMesh>(pmesh);
     set_ball_radius(radius);
 
     // check which curvature maps are provided by the user (determines which curvatures are computed)

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/measure.h
@@ -217,6 +217,25 @@ squared_edge_length(typename boost::graph_traits<PolygonMesh>::edge_descriptor e
   return squared_edge_length(halfedge(e, pmesh), pmesh, np);
 }
 
+template<typename PolygonMesh,
+         typename NamedParameters = parameters::Default_named_parameters>
+typename GetGeomTraits<PolygonMesh, NamedParameters>::type::FT
+average_edge_length(const PolygonMesh& pmesh,
+                    const NamedParameters& np = parameters::default_values())
+{
+  typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type GT;
+
+  const std::size_t n = edges(pmesh).size();
+  CGAL_assertion(n > 0);
+
+  typename GT::FT avg_edge_length = 0;
+  for (auto e : edges(pmesh))
+    avg_edge_length += edge_length(e, pmesh, np);
+
+  avg_edge_length /= static_cast<typename GT::FT>(n);
+  return avg_edge_length;
+}
+
 /**
   * \ingroup PMP_measure_grp
   *

--- a/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
+++ b/Polyhedron/demo/Polyhedron/Plugins/Display/Display_property_plugin.cpp
@@ -90,6 +90,7 @@ private:
   double bI = 0.;
 
   double expand_radius = 0.;
+  double expand_radius_updated = false;
   double maxEdgeLength = -1.;
 
   Color_ramp color_ramp;
@@ -912,6 +913,8 @@ private Q_SLOTS:
 
     expand_radius = (pow(base, val) - 1) * outMax / (pow(base, sliderMax) - 1);
     dock_widget->expandingRadiusLabel->setText(tr("Expanding Radius: %1").arg(expand_radius));
+    CGAL_assertion(expand_radius >= 0);
+    expand_radius_updated = true;
   }
 
 private:
@@ -933,7 +936,7 @@ private:
     bool non_init;
     SMesh::Property_map<vertex_descriptor, double> mu_i_map;
     std::tie(mu_i_map, non_init) = smesh.add_property_map<vertex_descriptor, double>(tied_string, 0);
-    if(non_init)
+    if(non_init || expand_radius_updated)
     {
       if(vnm_exists)
       {
@@ -967,6 +970,8 @@ private:
                                                                   .ball_radius(expand_radius));
         }
       }
+
+      expand_radius_updated = false;
     }
 
     displaySMProperty<vertex_descriptor>(tied_string, smesh);


### PR DESCRIPTION
## Summary of Changes
Remaining issue #7859 to be handled before 6.0 in order not to block the integration of the small feature branch on which two other PRs depend on.

Todos (taken from the issue)
* [x]  Update Results & Performance section
* [x]  Add a comment in the user manual about the relationship to the package [Estimation of Local Differential Properties of Point-Sampled Surfaces](https://doc.cgal.org/latest/Manual/packages.html#PkgJetFitting3)
* [x]  Move `average_edge_length()` and maybe other helper function in `measure.h` or other files.
* [x]  Check that the display plugin works as expected
* [x]  plugin for principal curvature directions? 
* [x]  plugin for principal curvature directions -> make sure the directions make sense in the concave (both negative) surface areas
* [x]  <s>remove Surface_mesh properties created in the plugin</s> not specific to this method and not a big deal.
* [ ]  restrict named parameters (for @sloriot it is easy to make a mistake with and without the_map suffix)
* [x]  Why is ball radius default -1 and not 0

