### PR TITLE
Kernel_23: Deal with concurrent executions and IO

### DIFF
--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_io.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_io.h
@@ -17,26 +17,19 @@
 #ifndef CGAL__TEST_IO_H
 #define CGAL__TEST_IO_H
 
-#include <fstream>
+#include <sstream>
 #include <cassert>
-
-#ifndef TEST_FILENAME
-#  define TEST_FILENAME "Test_IO.out"
-#endif
 
 template <class T>
 void
 _test_io_for(const T& t)
 {
-    {
-        std::ofstream oFile(TEST_FILENAME, std::ios::out);
-        oFile << t << std::endl;
-    }
+    std::stringstream ss;
+    ss << t << std::endl;
 
-    std::ifstream iFile(TEST_FILENAME, std::ios::in);
     T u = t;
-    iFile >> u;
-    assert(!iFile.fail());
+    ss >> u;
+    assert(! ss.fail() );
     assert(u == t);
 }
 


### PR DESCRIPTION
## Summary of Changes

Write and read back in a  `std::stringstream` to avoid simultaneous IO on the same file name.
Error seen in this [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.0-Ic-124/Circular_kernel_2/TestReport_gimeno_ArchLinux-clang-CXX17-Release.gz).

## Release Management

* Affected package(s):  Kernel_23, Circular_kernel_2
* License and copyright ownership: unchanged

