### PR TITLE
Tetrahedral remeshing - move sliver peeling to its own header file

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/peel_slivers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/peel_slivers.h
@@ -1,0 +1,117 @@
+// Copyright (c) 2020 GeometryFactory (France) and Telecom Paris (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+//
+//
+// Author(s)     : Jane Tournois, Noura Faraj, Jean-Marc Thiery, Tamy Boubekeur
+
+#ifndef CGAL_INTERNAL_PEEL_SLIVERS_H
+#define CGAL_INTERNAL_PEEL_SLIVERS_H
+
+#include <CGAL/license/Tetrahedral_remeshing.h>
+
+#include <CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h>
+
+namespace CGAL
+{
+namespace Tetrahedral_remeshing
+{
+
+template<typename C3T3, typename CellSelector>
+std::size_t peel_slivers(C3T3& c3t3,
+                         const typename C3T3::Triangulation::Geom_traits::FT& sliver_angle,
+                         const CellSelector& cell_selector)
+{
+  using FT = typename C3T3::Triangulation::Geom_traits::FT;
+  using Cell_handle = typename C3T3::Triangulation::Cell_handle;
+  using Surface_patch_index = typename C3T3::Surface_patch_index;
+
+  auto& tr = c3t3.triangulation();
+
+  std::size_t nb_slivers_peel = 0;
+  std::vector<std::pair<Cell_handle, std::array<bool, 4> > > peelable_cells;
+
+#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
+  FT mindh = FT(180);
+#endif
+  for (Cell_handle cit : c3t3.cells_in_complex())
+  {
+    if(!get(cell_selector, cit))
+      continue;
+
+    std::array<bool, 4> facets_on_surface;
+
+    const FT dh = min_dihedral_angle(tr, cit);
+    if (dh < sliver_angle && is_peelable(c3t3, cit, facets_on_surface))
+      peelable_cells.push_back(std::make_pair(cit, facets_on_surface));
+
+#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
+      mindh = (std::min)(dh, mindh);
+#endif
+  }
+
+#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
+  std::cout << "Min dihedral angle : " << mindh << std::endl;
+  std::cout << "Peelable cells : " << peelable_cells.size() << std::endl;
+#endif
+
+  for (auto c_i : peelable_cells)
+  {
+    Cell_handle c = c_i.first;
+    const std::array<bool, 4>& f_on_surface = c_i.second;
+
+    boost::optional<Surface_patch_index> patch;
+    for (int i = 0; i < 4; ++i)
+    {
+      if (f_on_surface[i])
+      {
+        Surface_patch_index spi = c3t3.surface_patch_index(c, i);
+        if (patch != boost::none && patch != spi)
+        {
+          patch = boost::none;
+          break;
+        }
+        else
+        {
+          patch = spi;
+        }
+      }
+    }
+    if (patch == boost::none)
+      continue;
+
+    for (int i = 0; i < 4; ++i)
+    {
+      if (f_on_surface[i])
+        c3t3.remove_from_complex(c, i);
+      else
+        c3t3.add_to_complex(c, i, patch.get());
+    }
+
+    c3t3.remove_from_complex(c);
+    ++nb_slivers_peel;
+  }
+
+#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
+  mindh = FT(180);
+  for (Cell_handle cit : c3t3.cells_in_complex())
+  {
+    const FT dh = min_dihedral_angle(tr, cit);
+    mindh = (std::min)(dh, mindh);
+  }
+  std::cout << "Peeling done (removed " << nb_slivers_peel << " slivers, "
+    << "min dihedral angle = " << mindh << ")." << std::endl;
+#endif
+
+  return nb_slivers_peel;
+}
+
+} // end namespace Tetrahedral_remeshing
+} // end namespace CGAL
+
+#endif // CGAL_INTERNAL_PEEL_SLIVERS_H

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -26,6 +26,7 @@
 #include <CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h>
 #include <CGAL/Tetrahedral_remeshing/internal/flip_edges.h>
 #include <CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h>
+#include <CGAL/Tetrahedral_remeshing/internal/peel_slivers.h>
 
 #include <CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h>
 #include <CGAL/Tetrahedral_remeshing/internal/compute_c3t3_statistics.h>
@@ -291,67 +292,8 @@ public:
     std::cout.flush();
 #endif
 
-    std::size_t nb_slivers_peel = 0;
-    std::vector<std::pair<Cell_handle, std::array<bool, 4> > > peelable_cells;
-#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
-    double mindh = 180.;
-#endif
-    for (Cell_handle cit : tr().finite_cell_handles())
-    {
-      std::array<bool, 4> facets_on_surface;
-      if (m_c3t3.is_in_complex(cit))
-      {
-        const double dh = min_dihedral_angle(tr(), cit);
-        if(dh < sliver_angle && is_peelable(m_c3t3, cit, facets_on_surface))
-          peelable_cells.push_back(std::make_pair(cit, facets_on_surface));
-
-#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
-        mindh = (std::min)(dh, mindh);
-#endif
-      }
-    }
-
-#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
-    std::cout << "Min dihedral angle : " << mindh << std::endl;
-    std::cout << "Peelable cells : " << peelable_cells.size() << std::endl;
-#endif
-
-    for (auto c_i : peelable_cells)
-    {
-      Cell_handle c = c_i.first;
-      const std::array<bool, 4>& f_on_surface = c_i.second;
-
-      std::optional<Surface_patch_index> patch;
-      for (int i = 0; i < 4; ++i)
-      {
-        if (f_on_surface[i])
-        {
-          Surface_patch_index spi = m_c3t3.surface_patch_index(c, i);
-          if (patch != std::nullopt && patch != spi)
-          {
-            patch = std::nullopt;
-            break;
-          }
-          else
-          {
-            patch = spi;
-          }
-        }
-      }
-      if(patch == std::nullopt)
-        continue;
-
-      for (int i = 0; i < 4; ++i)
-      {
-        if(f_on_surface[i])
-          m_c3t3.remove_from_complex(c, i);
-        else
-          m_c3t3.add_to_complex(c, i, patch.value());
-      }
-
-      m_c3t3.remove_from_complex(c);
-      ++nb_slivers_peel;
-    }
+    const std::size_t nb_peeled
+      = CGAL::Tetrahedral_remeshing::peel_slivers(m_c3t3, sliver_angle, m_cell_selector);
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
     CGAL_assertion(tr().tds().is_valid(true));
@@ -360,21 +302,8 @@ public:
 #ifdef CGAL_DUMP_REMESHING_STEPS
     CGAL::Tetrahedral_remeshing::debug::dump_c3t3(m_c3t3, "99-postprocess");
 #endif
-#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
-    mindh = 180.;
-    for (Cell_handle cit : tr().finite_cell_handles())
-    {
-      if (m_c3t3.is_in_complex(cit))
-      {
-        const double dh = min_dihedral_angle(tr(), cit);
-        mindh = (std::min)(dh, mindh);
-      }
-    }
-    std::cout << "Peeling done (removed " << nb_slivers_peel << " slivers, "
-      << "min dihedral angle = " << mindh << ")." << std::endl;
 
-#endif
-    return nb_slivers_peel;
+    return nb_peeled;
   }
 
   void finalize()


### PR DESCRIPTION
## Summary of Changes

This PR moves the "sliver peeling" function to its own internal header file.

## Release Management

* Affected package(s): Tetrahedral remeshing
* License and copyright ownership: unchanged

