### PR TITLE
Handle triangulated faces of the convex hull

### DIFF
--- a/Convex_hull_3/include/CGAL/convex_hull_3.h
+++ b/Convex_hull_3/include/CGAL/convex_hull_3.h
@@ -518,6 +518,7 @@ find_visible_set(TDS_2& tds,
         // if haven't already seen this facet
         if (f->info() == 0) {
           f->info() = VISITED;
+          // SL: here we can detect faces that are coplanar with point
           Is_on_positive_side_of_plane_3<Traits> is_on_positive_side(
             traits,f->vertex(0)->point(),f->vertex(2)->point(),f->vertex(1)->point());
           int ind = f->index(*vis_it);

--- a/Convex_hull_3/test/Convex_hull_3/issue_4882.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/issue_4882.cpp
@@ -1,0 +1,56 @@
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Convex_hull_3/dual/halfspace_intersection_3.h>
+#include <CGAL/Convex_hull_3/dual/halfspace_intersection_with_constructions_3.h>
+#include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
+#include <CGAL/Polygon_mesh_processing/self_intersections.h>
+
+#include <cmath>
+#include <set>
+
+using Point = std::tuple <signed long, signed long, signed long>;
+using K = CGAL::Exact_predicates_exact_constructions_kernel;
+
+constexpr signed char L = 24;
+constexpr signed long R = 1000000000000l;
+
+namespace PMP=CGAL::Polygon_mesh_processing;
+
+int main() {
+	double memo[4*L];
+	for (signed char i = 0; i < L; i++)
+		memo[i] = cos(2*M_PI*i/L);
+	for (signed char i = 1; i < 4; i++)
+		for (signed char j = 0; j < L; j++)
+			memo[i*L + j] = memo[j];
+	const double* const cm = memo + 2*L;
+
+	std::set <Point> set;
+	for (signed char a = 0; a < L; a++)
+		for (signed char b = 0; b < L; b++)
+			for (signed char c = 0; c < L; c++)
+				for (signed char d = 0; d < L; d++) {
+					const double x = 2*(cm[a + b] + cm[b + c] + cm[c + d] + cm[d + c - a] + cm[c - a + d - b] + cm[d - b - a]);
+					const double y = 2*(cm[a    ] +             cm[c    ] +                 cm[c - a        ]                );
+					const double z = 2*(            cm[b    ] +             cm[d        ] +                     cm[d - b    ]);
+
+					set.insert(Point(round(R*x), round(R*y), round(R*z)));
+				}
+
+	std::vector <CGAL::Plane_3 <K> > in;
+	for (const auto& p:  set)
+		in.push_back(K::Plane_3(-get <0> (p), -get <1> (p), -get <2> (p), -R));
+
+  {
+	CGAL::Polyhedron_3 <K> hull;
+	CGAL::halfspace_intersection_3(in.begin(), in.end(), hull, CGAL::ORIGIN);
+  assert(PMP::triangulate_faces(hull));
+  assert(!PMP::does_self_intersect(hull));
+  }
+  {
+  //CGAL::Polyhedron_3 <K> hull;
+  //CGAL::halfspace_intersection_with_constructions_3(in.begin(), in.end(), hull, CGAL::ORIGIN);
+  //assert(PMP::triangulate_faces(hull));
+  //assert(!PMP::does_self_intersect(hull));
+  }
+}


### PR DESCRIPTION
## Problem Description

Halfspace intersection (with or without constructions) does not handle the fact that CGAL's convex hull implementation always returns a triangulated hull. In case the dual has a face made of 4 or more coplanar points, this face is triangulated and this results in duplicated vertices in the primal.

## Current Status
For now, I did a simple hack in the version without constructions to make sure that my diagnostic was correct. With the hack the test added passes.

IMO, the right fix should be to add a new named parameter in CH3 to fill an edge property map indicating if an edge is between two planar faces of the convex hull. We can do it greedily or modify the current code to detect that during the intersection test in `find_visible_set()` (basically where I added the comment). This would need to update the CH3 convex to add `Orientation_3()(p1,p2,p3,p4)`.  One interesting thing to note is that in the current implementation, a non-triangle face of the convex hull is stared with the last point added in the face (and in particular TDS::Face_handle are all "new" each time a point is found, so that cannot be put in a map for example).

## Release Management

* Issue(s) solved (if any): fix #4882
