### PR TITLE
Treeview missing due to missing setting in `header.html`

### DIFF
--- a/Documentation/doc/resources/1.10.0/header.html
+++ b/Documentation/doc/resources/1.10.0/header.html
@@ -21,6 +21,7 @@
 <script type="text/javascript" src="$relpath^clipboard.js"></script>
 <!--END COPY_CLIPBOARD-->
 <script src="$relpath$../Manual/hacks.js" type="text/javascript"></script>
+$cookie
 $treeview
 $search
 $mathjax

--- a/Documentation/doc/resources/1.10.0/header_package.html
+++ b/Documentation/doc/resources/1.10.0/header_package.html
@@ -23,6 +23,7 @@
 <script src="$relpath^../Manual/hacks.js" type="text/javascript"></script>
 <!-- Manually include treeview and search to avoid bloat and to fix
      paths to the directory Manual . -->
+<script type="text/javascript" src="$relpath^../Manual/cookie.js"></script>
 <!-- $.treeview -->
 <!-- $.search -->
 <link href="navtree.css" rel="stylesheet" type="text/css"/>


### PR DESCRIPTION
Due to a small change in the doxygen master version: https://github.com/doxygen/doxygen/commit/8a2ad17d6af450eb1208467cb3f14abff0b8292e the treeview is not displayed anymore and the `$cookie` has to be added to the `header.html` file



