### PR TITLE
Remove unused variable

### DIFF
--- a/Kernel_23/test/Kernel_23/test_approximate_dihedral_angle_3.cpp
+++ b/Kernel_23/test/Kernel_23/test_approximate_dihedral_angle_3.cpp
@@ -53,7 +53,6 @@ int main() {
 
   Point_3 a = {0, 0, 0};
   Point_3 b = {0, -1, 0}; // ab is oriented so that it sees the plan xz positively.
-  // c can be any point in the half-plane xy, with x>0
 
   const query queries[] = {
     { {  1, 0,  0},    0.},
@@ -68,6 +67,7 @@ int main() {
 
   auto cnt = 0u;
   for(double yc = -10; yc < 10; yc += 0.1) {
+    // c can be any point in the half-plane xy, with x>0
     Point_3 c{1, yc, 0};
     // std::cout << "c = " << c << '\n';
     for(const auto& query : queries) {

--- a/Kernel_23/test/Kernel_23/test_approximate_dihedral_angle_3.cpp
+++ b/Kernel_23/test/Kernel_23/test_approximate_dihedral_angle_3.cpp
@@ -53,7 +53,6 @@ int main() {
 
   Point_3 a = {0, 0, 0};
   Point_3 b = {0, -1, 0}; // ab is oriented so that it sees the plan xz positively.
-  [[maybe_unused]] Point_3 c = {1, 0, 0};
   // c can be any point in the half-plane xy, with x>0
 
   const query queries[] = {


### PR DESCRIPTION
The variable is not used as shadowed by the loop variable and the `maybe-unused` requires c++17