### PR TITLE
Treeview missing due to missing setting in `header_package.html`

### DIFF
--- a/Documentation/doc/resources/1.10.0/header_package.html
+++ b/Documentation/doc/resources/1.10.0/header_package.html
@@ -26,6 +26,7 @@
 <!-- $.treeview -->
 <!-- $.search -->
 <link href="navtree.css" rel="stylesheet" type="text/css"/>
+<script src="$relpath^../Manual/cookie.js" type="text/javascript"></script>
 <script type="text/javascript" src="$relpath^../Manual/resize.js"></script>
 <script type="text/javascript" src="navtreedata.js"></script>
 <script type="text/javascript" src="navtree.js"></script>


### PR DESCRIPTION
The PR #7946 was withdraw because the `$cookie` was not necessary anymore in the `header...`  files as it was part of the of the `$treeview`. In `header_package.html` the `$treeview` has been disables and as such the `cookie.js` is not added/ Adding the `cookie.js` explicitly.

The effect was that there was a divider between the treeview and the textual documentation but it was on the far left (and thus invisible), it could be moved but after a refresh it was "gone" again.



