### PR TITLE
Triangulation_2:  Make IO save by changing file names

### DIFF
--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_constrained_triangulation_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_constrained_triangulation_2.h
@@ -222,52 +222,52 @@ _test_cls_constrained_triangulation(const Triang &)
   /******** I/O *******/
   std::cout << "output to a file" << std::endl;
 
-  std::ofstream of0_1("T01.triangulation", std::ios::out);
+  std::ofstream of0_1("T01ct.triangulation", std::ios::out);
   CGAL::IO::set_ascii_mode(of0_1);
    of0_1 << T0_1; of0_1.close();
 
-  std::ofstream of0_2("T02.triangulation");
+  std::ofstream of0_2("T02ct.triangulation");
   CGAL::IO::set_ascii_mode(of0_2);
   of0_2 << T0_2; of0_2.close();
 
-  std::ofstream of1_1("T11.triangulation");
+  std::ofstream of1_1("T11ct.triangulation");
   CGAL::IO::set_ascii_mode(of1_1);
   of1_1 << T1_1; of1_1.close();
 
-  std::ofstream of1_2("T12.triangulation");
+  std::ofstream of1_2("T12ct.triangulation");
   CGAL::IO::set_ascii_mode(of1_2);
    of1_2 << T1_2; of1_2.close();
 
-  std::ofstream of2_1("T21.triangulation");
+  std::ofstream of2_1("T21ct.triangulation");
   CGAL::IO::set_ascii_mode(of2_1);
   of2_1 << T2_1; of2_1.close();
 
-  std::ofstream of2_2("T22.triangulation");
+  std::ofstream of2_2("T22ct.triangulation");
   CGAL::IO::set_ascii_mode(of2_2);
   of2_2 << T2_2; of2_2.close();
 
   std::cout << "input from a file" << std::endl;
-  std::ifstream if0_1("T01.triangulation"); CGAL::IO::set_ascii_mode(if0_1);
+  std::ifstream if0_1("T01ct.triangulation"); CGAL::IO::set_ascii_mode(if0_1);
   Triang T0_1_copy;   if0_1 >> T0_1_copy;
 
-  std::ifstream if0_2("T02.triangulation"); CGAL::IO::set_ascii_mode(if0_2);
+  std::ifstream if0_2("T02ct.triangulation"); CGAL::IO::set_ascii_mode(if0_2);
   Triang T0_2_copy;  if0_2 >> T0_2_copy;
 
-  std::ifstream if1_1("T11.triangulation"); CGAL::IO::set_ascii_mode(if1_1);
+  std::ifstream if1_1("T11ct.triangulation"); CGAL::IO::set_ascii_mode(if1_1);
   Triang T1_1_copy; if1_1 >> T1_1_copy;
 
-  std::ifstream if1_2("T12.triangulation"); CGAL::IO::set_ascii_mode(if1_2);
+  std::ifstream if1_2("T12ct.triangulation"); CGAL::IO::set_ascii_mode(if1_2);
    Triang T1_2_copy; if1_2 >> T1_2_copy;
 
-  std::ifstream if2_1("T21.triangulation"); CGAL::IO::set_ascii_mode(if2_1);
+  std::ifstream if2_1("T21ct.triangulation"); CGAL::IO::set_ascii_mode(if2_1);
   Triang T2_1_copy; if2_1 >> T2_1_copy;
 
-  std::ifstream if2_2("T22.triangulation"); CGAL::IO::set_ascii_mode(if2_2);
+  std::ifstream if2_2("T22ct.triangulation"); CGAL::IO::set_ascii_mode(if2_2);
   Triang T2_2_copy; if2_2 >> T2_2_copy;
 
   // test copy of constrained Triangulation
    Triang T2_4(T2_2);
-  std::ofstream of2_2_bis("T22.triangulation");
+  std::ofstream of2_2_bis("T22ct.triangulation");
   CGAL::IO::set_ascii_mode(of2_2_bis);
   of2_2_bis << T2_4; of2_2_bis.close();
   All_faces_iterator fit2 = T2_2.all_faces_begin();

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_regular_triangulation_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_regular_triangulation_2.h
@@ -749,23 +749,23 @@ _test_cls_regular_triangulation_2( const Triangulation & )
    // input output have not yet been overload
    // so they do not input output hidden vertices
   std::cout << "    output to a file" << std::endl;
-  std::ofstream of1_5("T15.triangulation");
+  std::ofstream of1_5("T15rt.triangulation");
   CGAL::IO::set_ascii_mode(of1_5);
   of1_5 << T1_5; of1_5.close();
-  std::ofstream of2_3("T23.triangulation");
+  std::ofstream of2_3("T23rt.triangulation");
   CGAL::IO::set_ascii_mode(of2_3);
   of2_3 << T2_3; of2_3.close();
 
 
 //   std::cout << "    input from a file" << std::endl;
 
-//   std::ifstream if1_5("T15.triangulation"); CGAL::IO::set_ascii_mode(if1_5);
+//   std::ifstream if1_5("T15rt.triangulation"); CGAL::IO::set_ascii_mode(if1_5);
 //   Cls T1_5_copy; if1_5 >> T1_5_copy;
  //  assert( T1_5_copy.is_valid(verbose) &&
 //           T1_5_copy.number_of_vertices() ==
 //           T1_5.number_of_vertices() - T1_5.number_of_hidden_vertices());
 
-//   std::ifstream if2_3("T23.triangulation"); CGAL::IO::set_ascii_mode(if2_3);
+//   std::ifstream if2_3("T23rt.triangulation"); CGAL::IO::set_ascii_mode(if2_3);
 //   Cls T2_3_copy; if2_3 >> T2_3_copy;
   // assert( T2_3_copy.is_valid(verbose) &&
 //           T2_3_copy.number_of_vertices() ==

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_triangulation_short_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_triangulation_short_2.h
@@ -476,22 +476,22 @@ _test_cls_triangulation_short_2( const Triangul &)
   /********************/
   /******** I/O *******/
   std::cout << "    output to a file" << std::endl;
-  std::ofstream of1_5("T15.triangulation");
+  std::ofstream of1_5("T15short.triangulation");
   CGAL::IO::set_ascii_mode(of1_5);
   of1_5 << T1_5; of1_5.close();
-  std::ofstream of2_3("T23.triangulation");
+  std::ofstream of2_3("T23short.triangulation");
   CGAL::IO::set_ascii_mode(of2_3);
   of2_3 << T2_3; of2_3.close();
 
 
   std::cout << "    input from a file" << std::endl;
 
-  std::ifstream if1_5("T15.triangulation"); CGAL::IO::set_ascii_mode(if1_5);
+  std::ifstream if1_5("T15short.triangulation"); CGAL::IO::set_ascii_mode(if1_5);
   Triangul T1_5_copy; if1_5 >> T1_5_copy;
   assert( T1_5_copy.is_valid() &&
           T1_5_copy.number_of_vertices() == T1_5.number_of_vertices() );
 
-  std::ifstream if2_3("T23.triangulation"); CGAL::IO::set_ascii_mode(if2_3);
+  std::ifstream if2_3("T23short.triangulation"); CGAL::IO::set_ascii_mode(if2_3);
   Triangul T2_3_copy; if2_3 >> T2_3_copy;
   assert( T2_3_copy.is_valid() &&
           T2_3_copy.number_of_vertices() == T2_3.number_of_vertices() );

--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_triangulation_short_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_triangulation_short_2.h
@@ -24,7 +24,8 @@
 
 #include <iostream>
 #include <fstream>
-
+#include <sstream>
+#include <string>
 #include <utility>
 #include <list>
 
@@ -475,23 +476,31 @@ _test_cls_triangulation_short_2( const Triangul &)
 
   /********************/
   /******** I/O *******/
+  std::string T15fname, T23fname;
+  std::stringstream ss15;
+  ss15 << "T15" << &T1_5 << ".triangulation";
+  ss15 >> T15fname;
+  std::stringstream ss23;
+  ss23 << "T23" << &T2_3 << ".triangulation";
+  ss23 >> T23fname;
+
   std::cout << "    output to a file" << std::endl;
-  std::ofstream of1_5("T15short.triangulation");
+  std::ofstream of1_5(T15fname.c_str());
   CGAL::IO::set_ascii_mode(of1_5);
   of1_5 << T1_5; of1_5.close();
-  std::ofstream of2_3("T23short.triangulation");
+  std::ofstream of2_3(T23fname.c_str());
   CGAL::IO::set_ascii_mode(of2_3);
   of2_3 << T2_3; of2_3.close();
 
 
   std::cout << "    input from a file" << std::endl;
 
-  std::ifstream if1_5("T15short.triangulation"); CGAL::IO::set_ascii_mode(if1_5);
+  std::ifstream if1_5(T15fname.c_str()); CGAL::IO::set_ascii_mode(if1_5);
   Triangul T1_5_copy; if1_5 >> T1_5_copy;
   assert( T1_5_copy.is_valid() &&
           T1_5_copy.number_of_vertices() == T1_5.number_of_vertices() );
 
-  std::ifstream if2_3("T23short.triangulation"); CGAL::IO::set_ascii_mode(if2_3);
+  std::ifstream if2_3(T23fname.c_str()); CGAL::IO::set_ascii_mode(if2_3);
   Triangul T2_3_copy; if2_3 >> T2_3_copy;
   assert( T2_3_copy.is_valid() &&
           T2_3_copy.number_of_vertices() == T2_3.number_of_vertices() );

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
@@ -295,10 +295,10 @@ _test_cls_delaunay_3(const Triangulation &)
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
       {
-        std::ofstream oFileT1("Test1_triangulation_IO_3",std::ios::out);
+        std::ofstream oFileT1("Test1_dtriangulation_IO_3",std::ios::out);
         oFileT1 << T0 << std::endl;
       }
-      std::ifstream iFileT1("Test1_triangulation_IO_3",std::ios::in);
+      std::ifstream iFileT1("Test1_dtriangulation_IO_3",std::ios::in);
       iFileT1 >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == -1);
@@ -316,10 +316,10 @@ _test_cls_delaunay_3(const Triangulation &)
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
       {
-        std::ofstream oFileT2("Test2_triangulation_IO_3",std::ios::out);
+        std::ofstream oFileT2("Test2_dtriangulation_IO_3",std::ios::out);
         oFileT2 << T0 << std::endl;
       }
-      std::ifstream iFileT2("Test2_triangulation_IO_3",std::ios::in);
+      std::ifstream iFileT2("Test2_dtriangulation_IO_3",std::ios::in);
       iFileT2 >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 0);
@@ -338,10 +338,10 @@ _test_cls_delaunay_3(const Triangulation &)
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
       {
-        std::ofstream oFileT3("Test3_triangulation_IO_3",std::ios::out);
+        std::ofstream oFileT3("Test3_dtriangulation_IO_3",std::ios::out);
         oFileT3 << T0 << std::endl;
       }
-      std::ifstream iFileT3("Test3_triangulation_IO_3",std::ios::in);
+      std::ifstream iFileT3("Test3_dtriangulation_IO_3",std::ios::in);
       iFileT3 >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 1);
@@ -360,10 +360,10 @@ _test_cls_delaunay_3(const Triangulation &)
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
       {
-        std::ofstream oFileT4("Test4_triangulation_IO_3",std::ios::out);
+        std::ofstream oFileT4("Test4_dtriangulation_IO_3",std::ios::out);
         oFileT4 << T0;
       }
-      std::ifstream iFileT4("Test4_triangulation_IO_3",std::ios::in);
+      std::ifstream iFileT4("Test4_dtriangulation_IO_3",std::ios::in);
       iFileT4 >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 2);
@@ -382,10 +382,10 @@ _test_cls_delaunay_3(const Triangulation &)
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
       {
-        std::ofstream oFileT5("Test5_triangulation_IO_3",std::ios::out);
+        std::ofstream oFileT5("Test5_dtriangulation_IO_3",std::ios::out);
         oFileT5 << T0;
       }
-      std::ifstream iFileT5("Test5_triangulation_IO_3",std::ios::in);
+      std::ifstream iFileT5("Test5_dtriangulation_IO_3",std::ios::in);
       iFileT5 >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 3);
@@ -465,10 +465,10 @@ _test_cls_delaunay_3(const Triangulation &)
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
       {
-        std::ofstream oFileT6("Test6_triangulation_IO_3",std::ios::out);
+        std::ofstream oFileT6("Test6_dtriangulation_IO_3",std::ios::out);
         oFileT6 << T1_2;
       }
-      std::ifstream iFileT6("Test6_triangulation_IO_3",std::ios::in);
+      std::ifstream iFileT6("Test6_dtriangulation_IO_3",std::ios::in);
       iFileT6 >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 1);
@@ -512,10 +512,10 @@ _test_cls_delaunay_3(const Triangulation &)
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
       {
-        std::ofstream oFileT7("Test7_triangulation_IO_3",std::ios::out);
+        std::ofstream oFileT7("Test7_dtriangulation_IO_3",std::ios::out);
         oFileT7 << T2_0;
       }
-      std::ifstream iFileT7("Test7_triangulation_IO_3",std::ios::in);
+      std::ifstream iFileT7("Test7_dtriangulation_IO_3",std::ios::in);
       iFileT7 >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 2);
@@ -588,10 +588,10 @@ _test_cls_delaunay_3(const Triangulation &)
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
       {
-        std::ofstream oFileT8("Test8_triangulation_IO_3",std::ios::out);
+        std::ofstream oFileT8("Test8_dtriangulation_IO_3",std::ios::out);
         oFileT8 << T3_1;
       }
-      std::ifstream iFileT8("Test8_triangulation_IO_3",std::ios::in);
+      std::ifstream iFileT8("Test8_dtriangulation_IO_3",std::ios::in);
       iFileT8 >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 3);
@@ -679,10 +679,10 @@ _test_cls_delaunay_3(const Triangulation &)
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
       {
-        std::ofstream oFileT8("Test13_triangulation_IO_3",std::ios::out);
+        std::ofstream oFileT8("Test13_dtriangulation_IO_3",std::ios::out);
         oFileT8 << T3_13;
       }
-      std::ifstream iFileT8("Test13_triangulation_IO_3",std::ios::in);
+      std::ifstream iFileT8("Test13_dtriangulation_IO_3",std::ios::in);
       iFileT8 >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 3);


### PR DESCRIPTION
## Summary of Changes

Change file names to avoid interaction between test cases.

@MaelRL I noticed that the RT test does not read back. 

## Release Management

* Affected package(s): Triangulation_2
* Issue(s) solved (if any): fix [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.0-Ic-141/Triangulation_2/TestReport_gimeno_ArchLinux-clang.gz)
* License and copyright ownership:  unchanged

