### PR TITLE
Image_IO: sprintf -> snprintf

### DIFF
--- a/CGAL_ImageIO/include/CGAL/ImageIO/analyze_impl.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO/analyze_impl.h
@@ -463,60 +463,79 @@ int _readAnalyzeHeader( _image* im, const char* name,
       for ( i=0; i<im->nuser; i++ ) im->user[i] = nullptr;
       i = 0 ;
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("Data lost in the Analyze -> ImageIO conversion:") + 1));
-      sprintf( im->user[i++], "Data lost in the Analyze -> ImageIO conversion:" );
+      size_t buffer_size;
+      buffer_size = strlen("Data lost in the Analyze -> ImageIO conversion:") + 1;
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "Data lost in the Analyze -> ImageIO conversion:" );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  descrip: ") + 1 + strlen(analyzeHeader->hist.descrip) ));
-      sprintf( im->user[i++], "  descrip: %s", analyzeHeader->hist.descrip );
+      buffer_size = strlen("  descrip: ") + 1 + strlen(analyzeHeader->hist.descrip);
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  descrip: %s", analyzeHeader->hist.descrip );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  aux_file: ") + 1 + strlen(analyzeHeader->hist.descrip) ));
-      sprintf( im->user[i++], "  aux_file: %s", analyzeHeader->hist.descrip );
+      buffer_size = strlen("  aux_file: ") + 1 + strlen(analyzeHeader->hist.descrip);
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  aux_file: %s", analyzeHeader->hist.descrip );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  orient: ") + 1+ 2));
-      sprintf( im->user[i++], "  orient: %d", analyzeHeader->hist.orient );
+      buffer_size = strlen("  orient: ") + 1+ 2;
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  orient: %d", analyzeHeader->hist.orient );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  originator: ") + 1 + strlen(analyzeHeader->hist.originator) ));
-      sprintf( im->user[i++], "  originator: %s", analyzeHeader->hist.originator );
+      buffer_size = strlen("  originator: ") + 1 + strlen(analyzeHeader->hist.originator);
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  originator: %s", analyzeHeader->hist.originator );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  generated: ") + 1 + strlen(analyzeHeader->hist.generated) ));
-      sprintf( im->user[i++], "  generated: %s", analyzeHeader->hist.generated );
+      buffer_size = strlen("  generated: ") + 1 + strlen(analyzeHeader->hist.generated);
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  generated: %s", analyzeHeader->hist.generated );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  scannum: ") + 1 + strlen(analyzeHeader->hist.scannum) ));
-      sprintf( im->user[i++], "  scannum: %s", analyzeHeader->hist.scannum );
+      buffer_size = strlen("  scannum: ") + 1 + strlen(analyzeHeader->hist.scannum);
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  scannum: %s", analyzeHeader->hist.scannum );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  patient_id: ") + 1 + strlen(analyzeHeader->hist.patient_id) ));
-      sprintf( im->user[i++], "  patient_id: %s", analyzeHeader->hist.patient_id );
+      buffer_size = strlen("  patient_id: ") + 1 + strlen(analyzeHeader->hist.patient_id);
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  patient_id: %s", analyzeHeader->hist.patient_id );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  exp_date: ") + 1 + strlen(analyzeHeader->hist.exp_date) ));
-      sprintf( im->user[i++], "  exp_date: %s", analyzeHeader->hist.exp_date );
+      buffer_size = strlen("  exp_date: ") + 1 + strlen(analyzeHeader->hist.exp_date);
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  exp_date: %s", analyzeHeader->hist.exp_date );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  exp_time: ") + 1 + strlen(analyzeHeader->hist.exp_time) ));
-      sprintf( im->user[i++], "  exp_time: %s", analyzeHeader->hist.exp_time );
+      buffer_size = strlen("  exp_time: ") + 1 + strlen(analyzeHeader->hist.exp_time);
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  exp_time: %s", analyzeHeader->hist.exp_time );
 
+      buffer_size = strlen("  views: ") + 11 + 1;
       /* A 32 bit int doesn't print on more than 11 chars */
-      im->user[i] = (char *) ImageIO_alloc((strlen("  views: ") + 11 + 1));
-      sprintf( im->user[i++], "  views: %d", analyzeHeader->hist.views );
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  views: %d", analyzeHeader->hist.views );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  vols_added: ") + 11 + 1));
-      sprintf( im->user[i++], "  vols_added: %d", analyzeHeader->hist.vols_added );
+      buffer_size = strlen("  vols_added: ") + 11 + 1;
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  vols_added: %d", analyzeHeader->hist.vols_added );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  start_field: ") + 11 + 1));
-      sprintf( im->user[i++], "  start_field: %d", analyzeHeader->hist.start_field );
+      buffer_size = strlen("  start_field: ") + 11 + 1;
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  start_field: %d", analyzeHeader->hist.start_field );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  field_skip: ") + 11 + 1));
-      sprintf( im->user[i++], "  field_skip: %d", analyzeHeader->hist.field_skip );
+      buffer_size = strlen("  field_skip: ") + 11 + 1;
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  field_skip: %d", analyzeHeader->hist.field_skip );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  omax: ") + 11 + 1));
-      sprintf( im->user[i++], "  omax: %d", analyzeHeader->hist.omax );
+      buffer_size = strlen("  omax: ") + 11 + 1;
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  omax: %d", analyzeHeader->hist.omax );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  omin: ") + 11 + 1));
-      sprintf( im->user[i++], "  omin: %d", analyzeHeader->hist.omin );
+      buffer_size = strlen("  omin: ") + 11 + 1;
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  omin: %d", analyzeHeader->hist.omin );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  smax: ") + 11 + 1));
-      sprintf( im->user[i++], "  smax: %d", analyzeHeader->hist.smax );
+      buffer_size = strlen("  smax: ") + 11 + 1;
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  smax: %d", analyzeHeader->hist.smax );
 
-      im->user[i] = (char *) ImageIO_alloc((strlen("  smin: ") + 11 + 1));
-      sprintf( im->user[i++], "  smin: %d", analyzeHeader->hist.smin );
+      buffer_size = strlen("  smin: ") + 11 + 1;
+      im->user[i] = (char *) ImageIO_alloc(buffer_size);
+      snprintf( im->user[i++], buffer_size, "  smin: %d", analyzeHeader->hist.smin );
 
 
       /* header is read. close header file and open data file. */

--- a/CGAL_ImageIO/include/CGAL/ImageIO/analyze_impl.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO/analyze_impl.h
@@ -468,72 +468,72 @@ int _readAnalyzeHeader( _image* im, const char* name,
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "Data lost in the Analyze -> ImageIO conversion:" );
 
-      buffer_size = strlen("  descrip: ") + 1 + strlen(analyzeHeader->hist.descrip);
+      buffer_size = snprintf(nullptr, 0, "  descrip: %s", analyzeHeader->hist.descrip) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  descrip: %s", analyzeHeader->hist.descrip );
 
-      buffer_size = strlen("  aux_file: ") + 1 + strlen(analyzeHeader->hist.descrip);
+      buffer_size = snprintf(nullptr, 0, "  aux_file: %s", analyzeHeader->hist.descrip ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  aux_file: %s", analyzeHeader->hist.descrip );
 
-      buffer_size = strlen("  orient: ") + 1+ 2;
+      buffer_size = snprintf(nullptr, 0, "  orient: %d", analyzeHeader->hist.orient ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  orient: %d", analyzeHeader->hist.orient );
 
-      buffer_size = strlen("  originator: ") + 1 + strlen(analyzeHeader->hist.originator);
+      buffer_size = snprintf(nullptr, 0, "  originator: %s", analyzeHeader->hist.originator ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  originator: %s", analyzeHeader->hist.originator );
 
-      buffer_size = strlen("  generated: ") + 1 + strlen(analyzeHeader->hist.generated);
+      buffer_size = snprintf(nullptr, 0, "  generated: %s", analyzeHeader->hist.generated ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  generated: %s", analyzeHeader->hist.generated );
 
-      buffer_size = strlen("  scannum: ") + 1 + strlen(analyzeHeader->hist.scannum);
+      buffer_size = snprintf(nullptr, 0, "  scannum: %s", analyzeHeader->hist.scannum ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  scannum: %s", analyzeHeader->hist.scannum );
 
-      buffer_size = strlen("  patient_id: ") + 1 + strlen(analyzeHeader->hist.patient_id);
+      buffer_size = snprintf(nullptr, 0, "  patient_id: %s", analyzeHeader->hist.patient_id ) +1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  patient_id: %s", analyzeHeader->hist.patient_id );
 
-      buffer_size = strlen("  exp_date: ") + 1 + strlen(analyzeHeader->hist.exp_date);
+      buffer_size = snprintf(nullptr, 0,  "  exp_date: %s", analyzeHeader->hist.exp_date ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  exp_date: %s", analyzeHeader->hist.exp_date );
 
-      buffer_size = strlen("  exp_time: ") + 1 + strlen(analyzeHeader->hist.exp_time);
+      buffer_size = snprintf(nullptr, 0,  "  exp_time: %s", analyzeHeader->hist.exp_time ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  exp_time: %s", analyzeHeader->hist.exp_time );
 
-      buffer_size = strlen("  views: ") + 11 + 1;
+      buffer_size = snprintf(nullptr, 0, "  views: %d", analyzeHeader->hist.views ) + 1;
       /* A 32 bit int doesn't print on more than 11 chars */
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  views: %d", analyzeHeader->hist.views );
 
-      buffer_size = strlen("  vols_added: ") + 11 + 1;
+      buffer_size = snprintf(nullptr, 0, "  vols_added: %d", analyzeHeader->hist.vols_added ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  vols_added: %d", analyzeHeader->hist.vols_added );
 
-      buffer_size = strlen("  start_field: ") + 11 + 1;
+      buffer_size = snprintf(nullptr, 0,  "  start_field: %d", analyzeHeader->hist.start_field ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  start_field: %d", analyzeHeader->hist.start_field );
 
-      buffer_size = strlen("  field_skip: ") + 11 + 1;
+      buffer_size = snprintf(nullptr, 0, "  field_skip: %d", analyzeHeader->hist.field_skip ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  field_skip: %d", analyzeHeader->hist.field_skip );
 
-      buffer_size = strlen("  omax: ") + 11 + 1;
+      buffer_size = snprintf(nullptr, 0, "  omax: %d", analyzeHeader->hist.omax ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  omax: %d", analyzeHeader->hist.omax );
 
-      buffer_size = strlen("  omin: ") + 11 + 1;
+      buffer_size = snprintf(nullptr, 0,  "  omin: %d", analyzeHeader->hist.omin ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  omin: %d", analyzeHeader->hist.omin );
 
-      buffer_size = strlen("  smax: ") + 11 + 1;
+      buffer_size = snprintf(nullptr, 0, "  smax: %d", analyzeHeader->hist.smax ) + 1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  smax: %d", analyzeHeader->hist.smax );
 
-      buffer_size = strlen("  smin: ") + 11 + 1;
+      buffer_size = snprintf(nullptr, 0, "  smin: %d", analyzeHeader->hist.smin ) +1;
       im->user[i] = (char *) ImageIO_alloc(buffer_size);
       snprintf( im->user[i++], buffer_size, "  smin: %d", analyzeHeader->hist.smin );
 

--- a/CGAL_ImageIO/include/CGAL/ImageIO/gis_impl.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO/gis_impl.h
@@ -130,10 +130,10 @@ int writeGis( char *name, _image* im) {
             do {
               memset( str, 0, _LGTH_STRING_ );
               for ( j=0; j<n && i<size; j++, i++ ) {
-                sprintf( str+strlen(str), "%d", theBuf[i] );
-                if ( j<n && i<size ) sprintf( str+strlen(str), " " );
+                snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), "%d", theBuf[i] );
+                if ( j<n && i<size ) snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), " " );
               }
-              sprintf( str+strlen(str), "\n" );
+              snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), "\n" );
               done = ImageIO_write( im, str, strlen( str )  );
               res = (done == strlen( str )) ? int(done) : -1;
               if ( res  <= 0 ) {
@@ -150,10 +150,10 @@ int writeGis( char *name, _image* im) {
             do {
               memset( str, 0, _LGTH_STRING_ );
               for ( j=0; j<n && i<size; j++, i++ ) {
-                sprintf( str+strlen(str), "%d", theBuf[i] );
-                if ( j<n && i<size ) sprintf( str+strlen(str), " " );
+                snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), "%d", theBuf[i] );
+                if ( j<n && i<size ) snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), " " );
               }
-              sprintf( str+strlen(str), "\n" );
+              snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), "\n" );
               done = ImageIO_write( im, str, strlen( str )  );
               res = (done == strlen( str )) ? int(done) : -1;
               if ( res  <= 0 ) {
@@ -178,10 +178,10 @@ int writeGis( char *name, _image* im) {
             do {
               memset( str, 0, _LGTH_STRING_ );
               for ( j=0; j<n && i<size; j++, i++ ) {
-                sprintf( str+strlen(str), "%d", theBuf[i] );
-                if ( j<n && i<size ) sprintf( str+strlen(str), " " );
+                snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), "%d", theBuf[i] );
+                if ( j<n && i<size ) snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), " " );
               }
-              sprintf( str+strlen(str), "\n" );
+              snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), "\n" );
               done = ImageIO_write( im, str, strlen( str )  );
               res = (done == strlen( str )) ? int(done) : -1;
               if ( res  <= 0 ) {
@@ -198,10 +198,10 @@ int writeGis( char *name, _image* im) {
             do {
               memset( str, 0, _LGTH_STRING_ );
               for ( j=0; j<n && i<size; j++, i++ ) {
-                sprintf( str+strlen(str), "%d", theBuf[i] );
-                if ( j<n && i<size ) sprintf( str+strlen(str), " " );
+                snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), "%d", theBuf[i] );
+                if ( j<n && i<size ) snprintf( str+strlen(str),_LGTH_STRING_ - strlen(str), " " );
               }
-              sprintf( str+strlen(str), "\n" );
+              snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), "\n" );
               done = ImageIO_write( im, str, strlen( str )  );
               res = (done == strlen( str )) ? int(done) : -1;
               if ( res  <= 0 ) {

--- a/CGAL_ImageIO/include/CGAL/ImageIO/inr_impl.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO/inr_impl.h
@@ -77,22 +77,22 @@ int _writeInrimageHeader(const _image *im, ENDIANNESS end) {
     switch(im->wordKind) {
 
     case WK_FLOAT:
-      sprintf(type, "float");
+      snprintf(type, 30, "float");
       scale[0] = '\0';
       break;
 
     case WK_FIXED:
       switch(im->sign) {
       case SGN_SIGNED:
-        sprintf(type, "signed fixed");
+        snprintf(type, 30, "signed fixed");
         break;
       case SGN_UNSIGNED:
-        sprintf(type, "unsigned fixed");
+        snprintf(type, 30, "unsigned fixed");
         break;
       default:
         return -1;
       }
-      sprintf(scale, "SCALE=2**0\n");
+      snprintf(scale, 20, "SCALE=2**0\n");
       break;
 
     default:
@@ -101,17 +101,17 @@ int _writeInrimageHeader(const _image *im, ENDIANNESS end) {
 
     switch(end) {
     case END_LITTLE:
-      sprintf(endianness, "decm");
+      snprintf(endianness, 5, "decm");
       break;
     case END_BIG:
-      sprintf(endianness, "sun");
+      snprintf(endianness, 5, "sun");
       break;
     default:
       /* fix architecture endianness */
       if( _getEndianness() == END_LITTLE)
-        sprintf(endianness, "decm");
+        snprintf(endianness, 5, "decm");
       else
-        sprintf(endianness, "sun");
+        snprintf(endianness, 5, "sun");
       break;
     }
 

--- a/CGAL_ImageIO/include/CGAL/ImageIO/mincio_impl.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO/mincio_impl.h
@@ -357,7 +357,7 @@ int writeMincFile( const _image* im, const char *filename,
         strcat(newname, filename + i + 1);
       }
       else
-        sprintf(newname, "#TMP#%s", filename);
+        snprintf(newname,strlen(filename) + 10, "#TMP#%s", filename);
     }
   }
 

--- a/CGAL_ImageIO/include/CGAL/ImageIO/pnm_impl.h
+++ b/CGAL_ImageIO/include/CGAL/ImageIO/pnm_impl.h
@@ -524,14 +524,14 @@ int writePgmImage(char *name,_image *im  )
   }
 
   if ( im->dataMode == DM_ASCII )
-    sprintf( string, "%s\n", PGM_ASCII_MAGIC );
+    snprintf( string, 256, "%s\n", PGM_ASCII_MAGIC );
   else
-    sprintf( string, "%s\n", PGM_MAGIC );
+    snprintf( string, 256, "%s\n", PGM_MAGIC );
 
   ImageIO_write( im, string, strlen( string ) );
-  sprintf( string, "# CREATOR: pnm.c $Revision$ $Date$\n" );
+  snprintf( string, 256, "# CREATOR: pnm.c $Revision$ $Date$\n" );
   ImageIO_write( im, string, strlen( string ) );
-  sprintf( string, "%zu %zu\n", im->xdim, im->ydim );
+  snprintf( string, 256, "%zu %zu\n", im->xdim, im->ydim );
   ImageIO_write( im, string, strlen( string ) );
   max = 0;
   switch ( im->wdim ) {
@@ -552,7 +552,7 @@ int writePgmImage(char *name,_image *im  )
   }
   /* max == 0 causes problems for xv */
   if ( max == 0 ) max = 1;
-  sprintf( string, "%d\n", max );
+  snprintf( string, 256, "%d\n", max );
   ImageIO_write( im, string, strlen( string ) );
 
   if ( im->dataMode == DM_ASCII ) {
@@ -574,10 +574,10 @@ int writePgmImage(char *name,_image *im  )
         do {
           memset( str, 0, _LGTH_STRING_ );
           for ( j=0; j<n && i<size; j++, i++ ) {
-            sprintf( str+strlen(str), "%d", theBuf[i] );
-            if ( j<n && i<size ) sprintf( str+strlen(str), " " );
+            snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), "%d", theBuf[i] );
+            if ( j<n && i<size ) snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), " " );
           }
-          sprintf( str+strlen(str), "\n" );
+          snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), "\n" );
           if ( ImageIO_write( im, str, strlen( str ) ) <= 0 ) {
             fprintf(stderr, "writePgmImage: error when writing data in \'%s\'\n", name );
             return( -3 );
@@ -591,10 +591,10 @@ int writePgmImage(char *name,_image *im  )
         do {
           memset( str, 0, _LGTH_STRING_ );
           for ( j=0; j<n && i<size; j++, i++ ) {
-            sprintf( str+strlen(str), "%d", theBuf[i] );
-            if ( j<n && i<size ) sprintf( str+strlen(str), " " );
+            snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), "%d", theBuf[i] );
+            if ( j<n && i<size ) snprintf( str+strlen(str), 2, " " );
           }
-          sprintf( str+strlen(str), "\n" );
+          snprintf( str+strlen(str), _LGTH_STRING_ - strlen(str), "\n" );
           if ( ImageIO_write( im, str, strlen( str ) ) <= 0 ) {
             fprintf(stderr, "writePgmImage: error when writing data in \'%s\'\n", name );
             return( -3 );
@@ -629,6 +629,3 @@ int writePgmImage(char *name,_image *im  )
   im->openMode = OM_CLOSE;
   return 1;
 }
-
-
-


### PR DESCRIPTION
## Summary of Changes

`sprintf()` is deprecated so we replace it with `snprintf()`.

## Release Management

* Affected package(s): CGAL_Image_IO
* Issue(s) solved (if any): fix warnings in the testsuite for example for [Tetrahedral Remeshing](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.0-Ic-143/Tetrahedral_remeshing/TestReport_Taylor_macOS-Apple_M2-boost_backend-arm64.gz)


