### PR TITLE
Segment_delaunay_graph_2:  Fix Issue 7972

### DIFF
--- a/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
+++ b/Segment_Delaunay_graph_2/include/CGAL/Segment_Delaunay_graph_2.h
@@ -632,11 +632,11 @@ public:
   }
 
   template <class Segment_2>
-  static const Point_2& get_source(const Segment_2& segment){
+  static Point_2 get_source(const Segment_2& segment){
     return segment.source();
   }
   template <class Segment_2>
-  static const Point_2& get_target(const Segment_2& segment){
+  static Point_2 get_target(const Segment_2& segment){
     return segment.target();
   }
 

--- a/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/issue7972.cpp
+++ b/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/issue7972.cpp
@@ -1,0 +1,21 @@
+
+#include <CGAL/Segment_Delaunay_graph_2.h>
+#include <CGAL/Segment_Delaunay_graph_traits_2.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel K;
+typedef CGAL::Segment_Delaunay_graph_traits_2<K>          Gt;
+typedef CGAL::Segment_Delaunay_graph_2<Gt>                SDG2;
+
+int main() {
+    auto segments = std::vector({
+        CGAL::Segment_2<K>(
+            CGAL::Point_2<K>(0.0, 0.0),
+            CGAL::Point_2<K>(1.0, 0.0))
+    });
+
+    SDG2 delaunay;
+    delaunay.insert_segments(segments.begin(), segments.end());
+
+    return 0;
+}


### PR DESCRIPTION
## Summary of Changes

Using the exact construction kernel reveals a bug. A function returns a reference to a local variable. 

## Release Management

* Affected package(s): Segment_delaunay_graph_2
* Issue(s) solved (if any): fix #7972

