### PR TITLE
Kernel_d: Use integral_division()

### DIFF
--- a/Kernel_d/include/CGAL/Kernel_d/Linear_algebraHd_impl.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Linear_algebraHd_impl.h
@@ -95,13 +95,13 @@ linear_solver(const Matrix& A, const Vector& b,
 
       for(i = k + 1; i < rows; i++)
         for (j = 0; j <  rows; j++)  //and all columns of |L|
-          L(i,j) = (L(i,j)*C(k,k) - C(i,k)*L(k,j))/denom;
+          L(i,j) = integral_division((L(i,j)*C(k,k) - C(i,k)*L(k,j)), denom);
 
       for(i = k + 1; i < rows; i++) {
         /* the following iteration uses and changes |C(i,k)| */
         RT temp = C(i,k);
         for (j = k; j <= cols; j++)
-          C(i,j) = (C(i,j)*C(k,k) - temp*C(k,j))/denom;
+          C(i,j) = integral_division((C(i,j)*C(k,k) - temp*C(k,j)), denom);
       }
       denom = C(k,k);
       #ifdef CGAL_LA_SELFTEST
@@ -140,7 +140,7 @@ linear_solver(const Matrix& A, const Vector& b,
       for (j = i + 1; j < rank; j++) {
         h -= C(i,j)*x[var[j]];
       }
-      x[var[i]]= h / C(i,i);
+      x[var[i]]= integral_division(h, C(i,i));
     }
     #ifdef CGAL_LA_SELFTEST
       CGAL_assertion( (M*x).is_zero() );
@@ -156,7 +156,7 @@ linear_solver(const Matrix& A, const Vector& b,
           RT_ h = - C(i,rank + l)*D;
           for ( j= i + 1; j<rank; j++)
             h -= C(i,j)*spanning_vectors(var[j],l);
-          spanning_vectors(var[i],l)= h / C(i,i);
+          spanning_vectors(var[i],l)= integral_division(h, C(i,i));
         }
     #ifdef CGAL_LA_SELFTEST
           /* we check whether the $l$ - th spanning vector is a solution
@@ -908,13 +908,13 @@ homogeneous_linear_solver(const Matrix &A,
 
       for(i = k + 1; i < rows; i++)
         for (j = 0; j <  rows; j++)  //and all columns of |L|
-          L(i,j) = (L(i,j)*C(k,k) - C(i,k)*L(k,j))/denom;
+          L(i,j) = integral_division(L(i,j)*C(k,k) - C(i,k)*L(k,j),denom);
 
       for(i = k + 1; i < rows; i++) {
         /* the following iteration uses and changes |C(i,k)| */
         RT temp = C(i,k);
         for (j = k; j <= cols; j++)
-          C(i,j) = (C(i,j)*C(k,k) - temp*C(k,j))/denom;
+          C(i,j) = integral_division(C(i,j)*C(k,k) - temp*C(k,j), denom);
       }
       denom = C(k,k);
       #ifdef CGAL_LA_SELFTEST
@@ -949,7 +949,7 @@ homogeneous_linear_solver(const Matrix &A,
     for (j = i + 1; j < rank; j++) {
       h -= C(i,j)*x[var[j]];
     }
-    x[var[i]]= h / C(i,i);
+    x[var[i]]= integral_division(h, C(i,i));
   }
   #ifdef CGAL_LA_SELFTEST
     CGAL_assertion( (M*x).is_zero() );
@@ -965,7 +965,7 @@ homogeneous_linear_solver(const Matrix &A,
         RT_ h = - C(i,rank + l)*D;
         for ( j= i + 1; j<rank; j++)
           h -= C(i,j)*spanning_vectors(var[j],l);
-        spanning_vectors(var[i],l)= h / C(i,i);
+        spanning_vectors(var[i],l)= integral_division(h , C(i,i));
       }
   #ifdef CGAL_LA_SELFTEST
         /* we check whether the $l$ - th spanning vector is a solution

--- a/Kernel_d/include/CGAL/Kernel_d/Linear_algebraHd_impl.h
+++ b/Kernel_d/include/CGAL/Kernel_d/Linear_algebraHd_impl.h
@@ -241,13 +241,13 @@ determinant(const Matrix& A)
 
       for(i = k + 1; i < rows; i++)
         for (j = 0; j <  rows; j++)  //and all columns of |L|
-          L(i,j) = (L(i,j)*C(k,k) - C(i,k)*L(k,j))/denom;
+          L(i,j) = integral_division(L(i,j)*C(k,k) - C(i,k)*L(k,j), denom);
 
       for(i = k + 1; i < rows; i++) {
         /* the following iteration uses and changes |C(i,k)| */
         RT temp = C(i,k);
         for (j = k; j <= cols; j++)
-          C(i,j) = (C(i,j)*C(k,k) - temp*C(k,j))/denom;
+          C(i,j) = integral_division(C(i,j)*C(k,k) - temp*C(k,j), denom);
       }
       denom = C(k,k);
       #ifdef CGAL_LA_SELFTEST
@@ -355,13 +355,13 @@ determinant(const Matrix& A,
 
       for(i = k + 1; i < rows; i++)
         for (j = 0; j <  rows; j++)  //and all columns of |L|
-          L(i,j) = (L(i,j)*C(k,k) - C(i,k)*L(k,j))/denom;
+          L(i,j) = integral_division(L(i,j)*C(k,k) - C(i,k)*L(k,j), denom);
 
       for(i = k + 1; i < rows; i++) {
         /* the following iteration uses and changes |C(i,k)| */
         RT temp = C(i,k);
         for (j = k; j <= cols; j++)
-          C(i,j) = (C(i,j)*C(k,k) - temp*C(k,j))/denom;
+          C(i,j) = integral_division(C(i,j)*C(k,k) - temp*C(k,j), denom);
       }
       denom = C(k,k);
       #ifdef CGAL_LA_SELFTEST
@@ -551,13 +551,13 @@ independent_columns(const Matrix& A,
 
       for(i = k + 1; i < rows; i++)
         for (j = 0; j <  rows; j++)  //and all columns of |L|
-          L(i,j) = (L(i,j)*C(k,k) - C(i,k)*L(k,j))/denom;
+          L(i,j) = integral_division(L(i,j)*C(k,k) - C(i,k)*L(k,j), denom);
 
       for(i = k + 1; i < rows; i++) {
         /* the following iteration uses and changes |C(i,k)| */
         RT temp = C(i,k);
         for (j = k; j <= cols; j++)
-          C(i,j) = (C(i,j)*C(k,k) - temp*C(k,j))/denom;
+          C(i,j) = integral_division(C(i,j)*C(k,k) - temp*C(k,j), denom);
       }
       denom = C(k,k);
       #ifdef CGAL_LA_SELFTEST
@@ -666,13 +666,13 @@ rank(const Matrix& A)
 
       for(i = k + 1; i < rows; i++)
         for (j = 0; j <  rows; j++)  //and all columns of |L|
-          L(i,j) = (L(i,j)*C(k,k) - C(i,k)*L(k,j))/denom;
+          L(i,j) = integral_division(L(i,j)*C(k,k) - C(i,k)*L(k,j), denom);
 
       for(i = k + 1; i < rows; i++) {
         /* the following iteration uses and changes |C(i,k)| */
         RT temp = C(i,k);
         for (j = k; j <= cols; j++)
-          C(i,j) = (C(i,j)*C(k,k) - temp*C(k,j))/denom;
+          C(i,j) = integral_division(C(i,j)*C(k,k) - temp*C(k,j), denom);
       }
       denom = C(k,k);
       #ifdef CGAL_LA_SELFTEST
@@ -774,13 +774,13 @@ inverse(const Matrix& A, Matrix& inverse,
 
       for(i = k + 1; i < rows; i++)
         for (j = 0; j <  rows; j++)  //and all columns of |L|
-          L(i,j) = (L(i,j)*C(k,k) - C(i,k)*L(k,j))/denom;
+          L(i,j) = integral_division(L(i,j)*C(k,k) - C(i,k)*L(k,j), denom);
 
       for(i = k + 1; i < rows; i++) {
         /* the following iteration uses and changes |C(i,k)| */
         RT temp = C(i,k);
         for (j = k; j <= cols; j++)
-          C(i,j) = (C(i,j)*C(k,k) - temp*C(k,j))/denom;
+          C(i,j) = integral_division(C(i,j)*C(k,k) - temp*C(k,j), denom);
       }
       denom = C(k,k);
       #ifdef CGAL_LA_SELFTEST
@@ -822,7 +822,7 @@ inverse(const Matrix& A, Matrix& inverse,
       h = L (j,i) * D;
       for (int l = j + 1; l<rows; l++)
         h -= C(j,l)*inverse(var[l],i);
-      inverse(var[j],i) = h / C(j,j);
+      inverse(var[j],i) = integral_division(h, C(j,j));
     }
   }
 

--- a/Kernel_d/test/Kernel_d/Linear_algebra-test.cpp
+++ b/Kernel_d/test/Kernel_d/Linear_algebra-test.cpp
@@ -10,22 +10,8 @@
 #include <CGAL/Exact_integer.h>
 #include <CGAL/Exact_rational.h>
 
-#if defined( CGAL_USE_LEDA) || defined ( CGAL_USE_GMP )
-
 typedef CGAL::Exact_integer RT;
 typedef CGAL::Exact_rational FT;
-
-#else
-
-// The following are too slow :
-// #include <CGAL/MP_Float.h>
-// #include <CGAL/Quotient.h>
-// typedef CGAL::MP_Float     RT;
-// typedef CGAL::Quotient<RT> FT;
-typedef double RT;
-typedef double FT;
-
-#endif
 
 int main(int argc, char* argv[])
 {
@@ -72,8 +58,6 @@ int main(int argc, char* argv[])
       Vector v21(v13),v22(v13);
       v21 *= 13;
       CGAL_TEST(v21 == NT(13)*v22){}
-      v21 /= 13;
-      CGAL_TEST(v21 == v22){}
       if (IOTEST) CGAL_IO_TEST(v1,v2,CGAL::IO::ASCII);
     }
 

--- a/Kernel_d/test/Kernel_d/interface-test.cpp
+++ b/Kernel_d/test/Kernel_d/interface-test.cpp
@@ -5,22 +5,12 @@
 #include <CGAL/double.h>
 #include <CGAL/test_macros.h>
 
-#ifdef CGAL_USE_LEDA
-#include <CGAL/leda_integer.h>
-#include <CGAL/leda_rational.h>
-typedef leda_integer  RT_;
-typedef leda_rational FT_;
-#else
-#ifdef CGAL_USE_GMP
-#include <CGAL/Gmpz.h>
-#include <CGAL/Quotient.h>
-typedef CGAL::Gmpz RT_;
-typedef CGAL::Quotient<RT_> FT_;
-#else
-typedef double RT_;
-typedef double FT_;
-#endif
-#endif
+#include <CGAL/Exact_integer.h>
+#include <CGAL/Exact_rational.h>
+
+typedef CGAL::Exact_integer RT_;
+typedef CGAL::Exact_rational FT_;
+
 
 int main()
 { CGAL_KD_SETDTHREAD(2);

--- a/Kernel_d/test/Kernel_d/intersection-test.cpp
+++ b/Kernel_d/test/Kernel_d/intersection-test.cpp
@@ -5,28 +5,11 @@
 #include <CGAL/test_macros.h>
 #include <CGAL/use.h>
 
-#ifdef CGAL_USE_LEDA
+#include <CGAL/Exact_integer.h>
+#include <CGAL/Exact_rational.h>
 
-#include <CGAL/leda_integer.h>
-#include <CGAL/leda_real.h>
-typedef leda_integer RT;
-typedef leda_real    FT;
-
-#elif defined CGAL_USE_GMP
-
-#include <CGAL/Gmpz.h>
-#include <CGAL/Gmpq.h>
-typedef CGAL::Gmpz RT;
-typedef CGAL::Gmpq FT;
-
-#else
-
-#include <CGAL/MP_Float.h>
-#include <CGAL/Quotient.h>
-typedef CGAL::MP_Float     RT;
-typedef CGAL::Quotient<RT> FT;
-
-#endif
+typedef CGAL::Exact_integer RT;
+typedef CGAL::Exact_rational FT;
 
 int main()
 { CGAL::IO::set_pretty_mode ( std::cerr );
@@ -383,4 +366,3 @@ int main()
 }
   CGAL_TEST_END;
 }
-


### PR DESCRIPTION
## Summary of Changes

In case neither GMP or Leda are installed the Kernel_d testsuite shows a bug, namely a division using `/`.
We replace it with `integral_division`. 

There is more to do, as there are some testcases which define double as RT.   This leads to runtime errors
and may gloss over more errors for a number type without divisions.

## Release Management

* Affected package(s):  Kernel_d


