### PR TITLE
Update build scripts to use the number of available processors for parallel compilation

### DIFF
--- a/.github/test.sh
+++ b/.github/test.sh
@@ -9,4 +9,5 @@ PLUGINS_ARRAY=(${LIST_OF_PLUGINS});
 NB_OF_PLUGINS=${#PLUGINS_ARRAY[@]}
 DEL=$(($NB_OF_PLUGINS / 4))
 cd build
-make -j2 ${PLUGINS_ARRAY[@]:$(($FACTOR * $DEL)):$((($FACTOR + 1) * $DEL))}
+NUM_PROCS=$(nproc)
+make -j${NUM_PROCS} ${PLUGINS_ARRAY[@]:$(($FACTOR * $DEL)):$((($FACTOR + 1) * $DEL))}

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -104,8 +104,8 @@ jobs:
               echo "DoxygenError=No package affected." >> $GITHUB_OUTPUT
               exit 1
             fi
-            cd build_doc && make -j2 doc
-            make -j2 doc_with_postprocessing 2>tmp.log
+            cd build_doc && make -j$(nproc) doc
+            make -j$(nproc) doc_with_postprocessing 2>tmp.log
             if [ -s tmp.log ]; then
               content=`cat ./tmp.log`
               delimiter="$(openssl rand -hex 8)"


### PR DESCRIPTION
## Summary of Changes

Optimized GitHub Actions builds by replacing `-j2` with `-j$(nproc)`

## Release Management

* Issue(s) solved (if any): fix #7988

