### PR TITLE
Do not skip whitespace while reading quotient

### DIFF
--- a/Number_types/include/CGAL/Quotient.h
+++ b/Number_types/include/CGAL/Quotient.h
@@ -421,7 +421,6 @@ operator>>(std::istream& in, Quotient<NT>& r)
   NT num,den=1;
   in >> num;
   if(!in) return in;
-  std::istream::sentry s(in); // skip whitespace
   if(in.peek()!='/'){
           if(!in.good()){
                   in.clear(std::ios_base::eofbit);


### PR DESCRIPTION
Fixes issue mentioned in https://github.com/CGAL/cgal/pull/7927

`sentry` also eats end-of-line and arrangement formatter has a skip-until-eol after reading vertex coordinates

We decide to not allow whitespaces between `num` `/` `dum` 


