### PR TITLE
Point_set_3: property uchar refers to the range 0..255 not the char type

### DIFF
--- a/Point_set_3/test/Point_set_3/CMakeLists.txt
+++ b/Point_set_3/test/Point_set_3/CMakeLists.txt
@@ -10,6 +10,7 @@ find_package(CGAL REQUIRED)
 create_single_source_cgal_program("point_set_test.cpp")
 create_single_source_cgal_program("point_set_test_join.cpp")
 create_single_source_cgal_program("test_deprecated_io_ps.cpp")
+create_single_source_cgal_program("issue7996.cpp")
 
 #Use LAS
 #disable if MSVC 2017

--- a/Point_set_3/test/Point_set_3/issue7996.cpp
+++ b/Point_set_3/test/Point_set_3/issue7996.cpp
@@ -1,0 +1,59 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Point_set_3.h>
+
+#include <fstream>
+#include <iostream>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
+typedef Kernel::Point_3 Point;
+typedef CGAL::Point_set_3<Point> Point_set;
+
+
+int main()
+{
+  Point_set ps;
+  ps.insert(Point(0,0,0));
+  ps.insert(Point(1,1,1));
+
+  Point_set::Property_map<unsigned char>
+    red   = ps.add_property_map<unsigned char>("red"  , 0).first,
+    green = ps.add_property_map<unsigned char>("green", 0).first,
+    blue  = ps.add_property_map<unsigned char>("blue" , 0).first;
+
+
+  int i = 1;
+  for (Point_set::iterator it = ps.begin(); it != ps.end(); ++ it){
+    put(red,   *it, static_cast<unsigned char>(11 * i++));
+    put(green, *it, static_cast<unsigned char>(11 * i++));
+    put(blue,  *it, static_cast<unsigned char>(11 * i++));
+  }
+
+  {
+    std::ofstream out("ascii.ply");
+    out << ps;
+    out.close();
+
+    Point_set ps2;
+    std::ifstream in("ascii.ply");
+    in >> ps2;
+
+    std::cout << ps2 << std::endl;
+  }
+
+  {
+    std::ofstream out("binary.ply", std::ios::binary);
+    CGAL::set_binary_mode(out);
+    out << ps;
+    out.close();
+
+    Point_set ps2;
+    std::ifstream in("binary.ply", std::ios::binary);
+    CGAL::set_binary_mode(in);
+    in >> ps2;
+
+    std::cout << ps2 << std::endl;
+  }
+
+
+  return 0;
+}

--- a/Point_set_3/test/Point_set_3/issue7996.cpp
+++ b/Point_set_3/test/Point_set_3/issue7996.cpp
@@ -42,13 +42,13 @@ int main()
 
   {
     std::ofstream out("binary.ply", std::ios::binary);
-    CGAL::set_binary_mode(out);
+    CGAL::IO::set_binary_mode(out);
     out << ps;
     out.close();
 
     Point_set ps2;
     std::ifstream in("binary.ply", std::ios::binary);
-    CGAL::set_binary_mode(in);
+    CGAL::IO::set_binary_mode(in);
     in >> ps2;
 
     std::cout << ps2 << std::endl;

--- a/Stream_support/include/CGAL/IO/PLY/PLY_writer.h
+++ b/Stream_support/include/CGAL/IO/PLY/PLY_writer.h
@@ -266,7 +266,7 @@ public:
   virtual void print(std::ostream& stream, const Index& index)
   {
     if(get_mode(stream) == CGAL::IO::ASCII)
-      stream << get(m_pmap, index);
+      stream << no_char_character(get(m_pmap, index));
     else
     {
       Type t = Type(get(m_pmap, index));


### PR DESCRIPTION
## Summary of Changes

In the [ply file format](https://paulbourke.net/dataformats/ply/) one specifies in the header the type of properties. For a color one typically writes `property uchar red`, and then later writes a number between 0 and 255. We wrote a single char which is a mistake and was reported in issue #7996.   Note that even the CGAL ply reader cannot read it. And there is a [comment](https://github.com/CGAL/cgal/blob/96f698ca09b61b6ca7587d43b022a0db43519699/Stream_support/include/CGAL/IO/PLY/PLY_reader.h#L157) in the reader which explains that it reads an integer string and not a single char.

## Release Management

* Affected package(s): Point_set_3
* Issue(s) solved (if any): fix #7996
* License and copyright ownership: unchanged.

