### PR TITLE
Change inclusion order to check dependencies

### DIFF
--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_parallel_union_meshes.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/corefinement_parallel_union_meshes.cpp
@@ -10,6 +10,7 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel Kernel;
 typedef Kernel::Point_3 Point_3;
+typedef Kernel::Aff_transformation_3 Aff_transformation_3;
 typedef CGAL::Surface_mesh<Point_3> Mesh;
 
 namespace PMP = CGAL::Polygon_mesh_processing;
@@ -23,7 +24,7 @@ int main(int argc, char** argv)
   in >> meshes[0];
   for (int i=1; i<nb_copies; ++i)
   {
-    CGAL::Aff_transformation_3<Kernel> trans(CGAL::Translation(),  Kernel::Vector_3(i*0.2, 0, 0));
+    Aff_transformation_3 trans(CGAL::Translation(),  Kernel::Vector_3(i*0.2, 0, 0));
     meshes[i]=meshes[0];
     PMP::transform(trans, meshes[i]);
   }

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/hausdorff_bounded_error_distance_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/hausdorff_bounded_error_distance_example.cpp
@@ -1,5 +1,4 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Aff_transformation_3.h>
 #include <CGAL/IO/OFF.h>
 
 #include <CGAL/Surface_mesh.h>
@@ -8,15 +7,15 @@
 #include <CGAL/Polygon_mesh_processing/distance.h>
 #include <CGAL/Polygon_mesh_processing/transform.h>
 
-using Kernel   = CGAL::Exact_predicates_inexact_constructions_kernel;
-using FT       = typename Kernel::FT;
-using Point_3  = typename Kernel::Point_3;
-using Vector_3 = typename Kernel::Vector_3;
-
+using Kernel                  = CGAL::Exact_predicates_inexact_constructions_kernel;
+using FT                      = typename Kernel::FT;
+using Point_3                 = typename Kernel::Point_3;
+using Vector_3                = typename Kernel::Vector_3;
+using Affine_transformation_3 = typename Kernel::Aff_transformation_3;
 using TAG                     = CGAL::Sequential_tag;
 using Surface_mesh            = CGAL::Surface_mesh<Point_3>;
 using Polyhedron              = CGAL::Polyhedron_3<Kernel>;
-using Affine_transformation_3 = CGAL::Aff_transformation_3<Kernel>;
+
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -1449,6 +1449,8 @@ bounded_error_squared_Hausdorff_distance_impl(const TriangleMesh1& tm1,
   using Point_3 = typename Kernel::Point_3;
   using Triangle_3 = typename Kernel::Triangle_3;
 
+  auto midpoint = Kernel().construct_midpoint_3_object();
+
 #ifdef CGAL_HAUSDORFF_DEBUG
   std::cout << " -- Bounded Hausdorff --" << std::endl;
   std::cout << "error bound: " << error_bound << std::endl;
@@ -1645,9 +1647,9 @@ bounded_error_squared_Hausdorff_distance_impl(const TriangleMesh1& tm1,
     }
 
     // Subdivide the triangle into four smaller triangles.
-    const Point_3 v01 = CGAL::midpoint(v0, v1);
-    const Point_3 v02 = CGAL::midpoint(v0, v2);
-    const Point_3 v12 = CGAL::midpoint(v1, v2);
+    const Point_3 v01 = midpoint(v0, v1);
+    const Point_3 v02 = midpoint(v0, v2);
+    const Point_3 v12 = midpoint(v1, v2);
     const std::array<Triangle_3, 4> sub_triangles = { Triangle_3(v0, v01, v02), Triangle_3(v1 , v01, v12),
                                                       Triangle_3(v2, v02, v12), Triangle_3(v01, v02, v12) };
 
@@ -2372,17 +2374,19 @@ typename Kernel::FT recursive_hausdorff_subdivision(const typename Kernel::Point
   using FT = typename Kernel::FT;
   using Point_3 = typename Kernel::Point_3;
 
+  auto midpoint = Kernel().construct_midpoint_3_object();
+  auto squared_distance = Kernel().compute_squared_distance_3_object();
   // If all edge lengths of the triangle are below the error bound,
   // return the maximum of the distances of the three points to TM2 (via TM2_tree).
-  const FT max_squared_edge_length = (CGAL::max)((CGAL::max)(CGAL::squared_distance(p0, p1),
-                                                             CGAL::squared_distance(p0, p2)),
-                                                             CGAL::squared_distance(p1, p2));
+  const FT max_squared_edge_length = (CGAL::max)((CGAL::max)(squared_distance(p0, p1),
+                                                             squared_distance(p0, p2)),
+                                                             squared_distance(p1, p2));
 
   if(max_squared_edge_length < sq_error_bound)
   {
-    return (CGAL::max)((CGAL::max)(CGAL::squared_distance(p0, tm2_tree.closest_point(p0)),
-                                   CGAL::squared_distance(p1, tm2_tree.closest_point(p1))),
-                                   CGAL::squared_distance(p2, tm2_tree.closest_point(p2)));
+    return (CGAL::max)((CGAL::max)(squared_distance(p0, tm2_tree.closest_point(p0)),
+                                   squared_distance(p1, tm2_tree.closest_point(p1))),
+                                   squared_distance(p2, tm2_tree.closest_point(p2)));
   }
 
   // Else subdivide the triangle and proceed recursively.

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/delaunay_remeshing_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/delaunay_remeshing_test.cpp
@@ -1,10 +1,11 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-
-#include <CGAL/Surface_mesh.h>
-#include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polygon_mesh_processing/detect_features.h>
 #include <CGAL/Polygon_mesh_processing/surface_Delaunay_remeshing.h>
 #include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
+
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Polyhedron_3.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <vector>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/extrude_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/extrude_test.cpp
@@ -1,7 +1,9 @@
+#include <CGAL/Polygon_mesh_processing/extrude.h>
+
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Polygon_mesh_processing/extrude.h>
+
 #include <iostream>
 #include <fstream>
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/fairing_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/fairing_test.cpp
@@ -1,8 +1,9 @@
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/fair.h>
+
 #include <CGAL/Surface_mesh.h>
 
-#include <CGAL/Polygon_mesh_processing/fair.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Timer.h>
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/measures_test.cpp
@@ -1,11 +1,11 @@
 #include <CGAL/Polygon_mesh_processing/measure.h>
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/bbox.h>
 
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Surface_mesh.h>
 
-#include <CGAL/Polygon_mesh_processing/bbox.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <CGAL/Bbox_3.h>
 
@@ -376,4 +376,3 @@ int main(int argc, char* argv[])
   std::cerr << "All done." << std::endl;
   return 0;
 }
-

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/orient_polygon_mesh_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/orient_polygon_mesh_test.cpp
@@ -1,8 +1,10 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/orientation.h>
+
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Surface_mesh.h>
-#include <CGAL/Polygon_mesh_processing/orientation.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <CGAL/Timer.h>
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/orient_polygon_soup_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/orient_polygon_soup_test.cpp
@@ -1,17 +1,19 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/Surface_mesh.h>
-
-#include <CGAL/Cartesian_converter.h>
-#include <CGAL/IO/polygon_mesh_io.h>
-#include <CGAL/IO/polygon_soup_io.h>
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
 #include <CGAL/Polygon_mesh_processing/polygon_mesh_to_polygon_soup.h>
 #include <CGAL/Polygon_mesh_processing/orientation.h>
 #include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
 #include <CGAL/Polygon_mesh_processing/orient_polygon_soup_extension.h>
+
+#include <CGAL/IO/polygon_mesh_io.h>
+#include <CGAL/IO/polygon_soup_io.h>
+
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
+#include <CGAL/Cartesian_converter.h>
 
 #include <algorithm>
 #include <cstdlib>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/pmp_compute_normals_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/pmp_compute_normals_test.cpp
@@ -1,15 +1,16 @@
 // #define CGAL_PMP_COMPUTE_NORMAL_DEBUG_PP
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-//#include <CGAL/Exact_predicates_exact_constructions_kernel_with_sqrt.h>
+#include <CGAL/Polygon_mesh_processing/compute_normal.h>
+#include <CGAL/Polygon_mesh_processing/bbox.h>
+#include <CGAL/Polygon_mesh_processing/shape_predicates.h>
 
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
 
 #include <CGAL/centroid.h>
-#include <CGAL/Polygon_mesh_processing/compute_normal.h>
-#include <CGAL/Polygon_mesh_processing/bbox.h>
-#include <CGAL/Polygon_mesh_processing/shape_predicates.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+//#include <CGAL/Exact_predicates_exact_constructions_kernel_with_sqrt.h>
 
 #include <iostream>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/pmp_do_intersect_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/pmp_do_intersect_test.cpp
@@ -1,16 +1,16 @@
+#include <CGAL/Polygon_mesh_processing/intersection.h>
+
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
+#include <CGAL/Timer.h>
 
 #include <cstdlib>
 #include <iostream>
 #include <fstream>
 #include <sstream>
-
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-#include <CGAL/Polygon_mesh_processing/intersection.h>
-
-#include <CGAL/Surface_mesh.h>
-
-#include <CGAL/Timer.h>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel     Epic;
 typedef CGAL::Exact_predicates_exact_constructions_kernel       Epec;

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/point_inside_polyhedron_boundary_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/point_inside_polyhedron_boundary_test.cpp
@@ -1,7 +1,6 @@
-
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Side_of_triangle_mesh.h>
 #include <CGAL/Polyhedron_3.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include "point_inside_helpers.h"
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/point_inside_surface_mesh_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/point_inside_surface_mesh_test.cpp
@@ -1,11 +1,11 @@
+#include <CGAL/Side_of_triangle_mesh.h>
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
 #include <CGAL/boost/graph/helpers.h>
 
-#include <CGAL/Side_of_triangle_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include "point_inside_helpers.h"
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/polygon_mesh_slicer_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/polygon_mesh_slicer_test.cpp
@@ -1,19 +1,22 @@
 // #define USE_SURFACE_MESH
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_slicer.h>
+
 #ifdef USE_SURFACE_MESH
 #include <CGAL/Surface_mesh.h>
 #else
 #include <CGAL/Polyhedron_3.h>
 #endif
+
 #include <CGAL/AABB_halfedge_graph_segment_primitive.h>
 
-#include <CGAL/Polygon_mesh_slicer.h>
 #include <CGAL/Polygon_mesh_processing/orientation.h>
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_traits.h>
 #include <CGAL/Polygon_2.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <fstream>
 #include <cassert>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_quality_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_quality_test.cpp
@@ -1,8 +1,10 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/remesh.h>
 #include <CGAL/Polygon_mesh_processing/Adaptive_sizing_field.h>
 #include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
+
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <fstream>
 #include <limits>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test.cpp
@@ -7,17 +7,18 @@
 //#define CGAL_PMP_REMESHING_VERY_VERBOSE
 //#define CGAL_PMP_REMESHING_EXPENSIVE_DEBUG
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-
-#include <CGAL/Surface_mesh.h>
-
 #include <CGAL/Polygon_mesh_processing/remesh.h>
 #include <CGAL/Polygon_mesh_processing/border.h>
 #include <CGAL/Polygon_mesh_processing/connected_components.h>
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
 #include <CGAL/Polygon_mesh_processing/detect_features.h>
 
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
 #include <CGAL/Timer.h>
+
 #include <fstream>
 #include <vector>
 #include <cstdlib>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test_P_SM_OM.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_test_P_SM_OM.cpp
@@ -1,14 +1,17 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/remesh.h>
+
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
-#include <fstream>
-#include <map>
 #include <OpenMesh/Core/IO/MeshIO.hh>
 #include <OpenMesh/Core/Mesh/PolyMesh_ArrayKernelT.hh>
 #include <OpenMesh/Core/Mesh/TriMesh_ArrayKernelT.hh>
 #include <CGAL/boost/graph/graph_traits_PolyMesh_ArrayKernelT.h>
 #include <CGAL/boost/graph/graph_traits_TriMesh_ArrayKernelT.h>
-#include <CGAL/Polygon_mesh_processing/remesh.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <fstream>
+#include <map>
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_with_isolated_constraints_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/remeshing_with_isolated_constraints_test.cpp
@@ -1,10 +1,11 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
-
-#include <CGAL/boost/graph/helpers.h>
-#include <CGAL/boost/graph/generators.h>
 #include <CGAL/Polygon_mesh_processing/remesh.h>
 #include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
+
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/boost/graph/helpers.h>
+#include <CGAL/boost/graph/generators.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <fstream>
 #include <iostream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/self_intersection_polyhedron_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/self_intersection_polyhedron_test.cpp
@@ -1,15 +1,15 @@
-#include <cstdlib>
-#include <iostream>
-#include <fstream>
-#include <sstream>
+#include <CGAL/Polygon_mesh_processing/self_intersections.h>
+
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Timer.h>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/Polygon_mesh_processing/self_intersections.h>
-
-#include <CGAL/Timer.h>
+#include <cstdlib>
+#include <iostream>
+#include <fstream>
+#include <sstream>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel     Epic;
 typedef CGAL::Exact_predicates_exact_constructions_kernel       Epec;

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/self_intersection_surface_mesh_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/self_intersection_surface_mesh_test.cpp
@@ -1,11 +1,12 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-
-#include <CGAL/Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
 #include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
+
+#include <CGAL/Surface_mesh.h>
 #include <CGAL/tags.h>
 #include <CGAL/Timer.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <cstdlib>
 #include <iostream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/self_intersection_triangle_soup_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/self_intersection_triangle_soup_test.cpp
@@ -1,11 +1,12 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-
-#include <CGAL/Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
 #include <CGAL/IO/polygon_soup_io.h>
 #include <CGAL/tags.h>
+
 #include <CGAL/Timer.h>
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <cstdlib>
 #include <iostream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/surface_intersection_sm_poly.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/surface_intersection_sm_poly.cpp
@@ -1,14 +1,15 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/intersection.h>
+
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Linear_cell_complex_for_combinatorial_map.h>
 #include <CGAL/boost/graph/graph_traits_Linear_cell_complex_for_combinatorial_map.h>
 #include <CGAL/Linear_cell_complex_for_bgl_combinatorial_map_helper.h>
 #include <CGAL/iterator.h>
-
-#include <CGAL/Polygon_mesh_processing/intersection.h>
 #include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
 #include <CGAL/Timer.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <iostream>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_autorefinement.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_autorefinement.cpp
@@ -1,5 +1,3 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
 
 #include <CGAL/Polygon_mesh_processing/intersection.h>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
@@ -7,6 +5,9 @@
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
 
 #include <CGAL/IO/polygon_soup_io.h>
+
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <fstream>
 #include <sstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_coref_epic_points_identity.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_coref_epic_points_identity.cpp
@@ -1,6 +1,6 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <iostream>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefine.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefine.cpp
@@ -1,7 +1,9 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/corefinement.h>
+
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/Polygon_mesh_processing/corefinement.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <iostream>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_and_constraints.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_and_constraints.cpp
@@ -1,6 +1,6 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <iostream>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_bool_op.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_bool_op.cpp
@@ -2,9 +2,9 @@
 // #define CGAL_COREFINEMENT_DEBUG
 #define  CGAL_USE_DERIVED_SURFACE_MESH
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <iostream>
 #include <vector>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_decimation_of_planar_patches.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_decimation_of_planar_patches.cpp
@@ -1,9 +1,3 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#ifdef USE_POLYHEDRON
-#include <CGAL/Polyhedron_3.h>
-#else
-#include <CGAL/Surface_mesh.h>
-#endif
 #include <CGAL/Polygon_mesh_processing/remesh_planar_patches.h>
 #include <CGAL/Polygon_mesh_processing/region_growing.h>
 #include <CGAL/Polygon_mesh_processing/manifoldness.h>
@@ -11,6 +5,14 @@
 #include <CGAL/Polygon_mesh_processing/detect_features.h>
 #include <CGAL/Polygon_mesh_processing/remesh.h>
 #include <CGAL/subdivision_method_3.h>
+
+#ifdef USE_POLYHEDRON
+#include <CGAL/Polyhedron_3.h>
+#else
+#include <CGAL/Surface_mesh.h>
+#endif
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <iostream>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_degenerate_pmp_clip_split_corefine.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_degenerate_pmp_clip_split_corefine.cpp
@@ -1,8 +1,7 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polygon_mesh_processing/clip.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
-
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 // #define CGAL_DEBUG_PMP_CLIP
 
 // TODO: test coref

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_detect_features.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_detect_features.cpp
@@ -1,7 +1,7 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
-
 #include <CGAL/Polygon_mesh_processing/detect_features.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
 #include <CGAL/Real_timer.h>
 
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_does_bound_a_volume.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_does_bound_a_volume.cpp
@@ -1,6 +1,6 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/orientation.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <iostream>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_hausdorff_bounded_error_distance.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_hausdorff_bounded_error_distance.cpp
@@ -4,21 +4,23 @@
 // Use this def in order to get all DEBUG info related to the bounded-error Hausdorff code!
 #define CGAL_HAUSDORFF_DEBUG
 
-#include <CGAL/Simple_cartesian.h>
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
-#include <CGAL/Polyhedron_3.h>
-
-#include <CGAL/Aff_transformation_3.h>
-#include <CGAL/Bbox_3.h>
-#include <CGAL/IO/PLY.h>
 #include <CGAL/Polygon_mesh_processing/bbox.h>
 #include <CGAL/Polygon_mesh_processing/distance.h>
 #include <CGAL/Polygon_mesh_processing/remesh.h>
 #include <CGAL/Polygon_mesh_processing/random_perturbation.h>
 #include <CGAL/Polygon_mesh_processing/transform.h>
+#include <CGAL/Aff_transformation_3.h>
+#include <CGAL/Bbox_3.h>
+#include <CGAL/IO/PLY.h>
+
 #include <CGAL/Real_timer.h>
+
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Polyhedron_3.h>
+
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 using SCK   = CGAL::Simple_cartesian<double>;
 using EPICK = CGAL::Exact_predicates_inexact_constructions_kernel;

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_interpolated_corrected_curvatures.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_interpolated_corrected_curvatures.cpp
@@ -1,10 +1,11 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polygon_mesh_processing/interpolated_corrected_curvatures.h>
 #include <CGAL/Polygon_mesh_processing/random_perturbation.h>
 #include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/property_map.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <boost/graph/graph_traits.hpp>
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_is_polygon_soup_a_polygon_mesh.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_is_polygon_soup_a_polygon_mesh.cpp
@@ -1,16 +1,17 @@
-#include <CGAL/Simple_cartesian.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/boost/graph/graph_traits_Polyhedron_3.h>
+#include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
+#include <CGAL/Polygon_mesh_processing/polygon_mesh_to_polygon_soup.h>
+#include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
 
 #include <CGAL/boost/graph/helpers.h>
 #include <CGAL/boost/graph/property_maps.h>
 #include <CGAL/Dynamic_property_map.h>
-#include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
-#include <CGAL/Polygon_mesh_processing/polygon_mesh_to_polygon_soup.h>
-#include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
+
 #include <CGAL/IO/OFF.h>
+
+#include <CGAL/Polyhedron_3.h>
+
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <array>
 #include <string>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_isolevel_refinement.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_isolevel_refinement.cpp
@@ -1,8 +1,8 @@
-#include <CGAL/Simple_cartesian.h>
-#include <CGAL/Surface_mesh.h>
-
 #include <CGAL/Polygon_mesh_processing/refine_mesh_at_isolevel.h>
 #include <CGAL/Polygon_mesh_processing/connected_components.h>
+
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Simple_cartesian.h>
 
 #include <fstream>
 #include <iostream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_merging_border_vertices.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_merging_border_vertices.cpp
@@ -1,11 +1,9 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
-
 #include <CGAL/Polygon_mesh_processing/merge_border_vertices.h>
-#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
+
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <fstream>
-
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef CGAL::Surface_mesh<K::Point_3> Surface_mesh;

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_mesh_smoothing.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_mesh_smoothing.cpp
@@ -1,9 +1,10 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/angle_and_area_smoothing.h>
+#include <CGAL/Polygon_mesh_processing/tangential_relaxation.h>
 
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/Polygon_mesh_processing/angle_and_area_smoothing.h>
-#include <CGAL/Polygon_mesh_processing/tangential_relaxation.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/property_map.h>
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_orient_cc.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_orient_cc.cpp
@@ -1,10 +1,12 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
-
-#include <CGAL/boost/graph/named_params_helper.h>
 #include <CGAL/Polygon_mesh_processing/orientation.h>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
+
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/boost/graph/named_params_helper.h>
 #include <CGAL/Timer.h>
+
 #include <iostream>
 #include <fstream>
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_clip.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_clip.cpp
@@ -1,10 +1,11 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polygon_mesh_processing/clip.h>
-#include <CGAL/Surface_mesh.h>
-#include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polygon_mesh_processing/transform.h>
 
-#include <CGAL/boost/graph/Face_filtered_graph.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Polyhedron_3.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
 #include <boost/property_map/property_map.hpp>
 
 #include <iostream>
@@ -879,5 +880,3 @@ int main()
   std::cout << "Done!" << std::endl;
   return EXIT_SUCCESS;
 }
-
-

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_collision_detection.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_collision_detection.cpp
@@ -1,8 +1,9 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Rigid_triangle_mesh_collision_detection.h>
+
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
 
-#include <CGAL/Rigid_triangle_mesh_collision_detection.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <iostream>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_locate.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_locate.cpp
@@ -1,6 +1,4 @@
-﻿#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-#include <CGAL/Simple_cartesian.h>
+﻿#include <CGAL/Polygon_mesh_processing/locate.h>
 
 // Graphs
 #include <CGAL/Polyhedron_3.h>
@@ -9,7 +7,9 @@
 #include <CGAL/boost/graph/graph_traits_Regular_triangulation_2.h>
 #include <CGAL/boost/graph/properties_Regular_triangulation_2.h>
 
-#include <CGAL/Polygon_mesh_processing/locate.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Simple_cartesian.h>
 
 #include <CGAL/AABB_tree.h>
 #include <CGAL/AABB_face_graph_triangle_primitive.h>
@@ -23,12 +23,11 @@
 #include <CGAL/Origin.h>
 #include <CGAL/property_map.h>
 #include <CGAL/Random.h>
-#include <CGAL/Unique_hash_map.h>
 
 #include <boost/graph/graph_traits.hpp>
 #include <boost/graph/properties.hpp>
-#include <optional>
 
+#include <optional>
 #include <fstream>
 #include <iostream>
 #include <limits>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_manifoldness.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_manifoldness.cpp
@@ -1,10 +1,11 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/repair.h>
 
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Surface_mesh.h>
 
 #include <CGAL/boost/graph/named_params_helper.h>
-#include <CGAL/Polygon_mesh_processing/repair.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <cassert>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_non_conforming_snapping.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_non_conforming_snapping.cpp
@@ -1,20 +1,20 @@
 //#define CGAL_PMP_SNAP_DEBUG_PP
 //#define CGAL_PMP_SNAP_DEBUG_OUTPUT
 
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/Polyhedron_items_with_id_3.h>
-#include <CGAL/Surface_mesh.h>
-
 #include <CGAL/Polygon_mesh_processing/border.h>
 #include <CGAL/Polygon_mesh_processing/internal/Snapping/snap.h>
 #include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
 #include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
 
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Polyhedron_items_with_id_3.h>
+#include <CGAL/Surface_mesh.h>
+
 #include <CGAL/property_map.h>
 #include <CGAL/IO/STL.h>
+
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <array>
 #include <iostream>
@@ -169,4 +169,3 @@ int main(int, char**)
 
   return EXIT_SUCCESS;
 }
-

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_np_function.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_np_function.cpp
@@ -1,12 +1,15 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/compute_normal.h>
+#include <CGAL/boost/graph/named_params_helper.h>
+#include <CGAL/Named_function_parameters.h>
+
 #include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
 #include <sstream>
 #include <iostream>
 #include <unordered_map>
 
-#include <CGAL/boost/graph/named_params_helper.h>
-#include <CGAL/Named_function_parameters.h>
-#include <CGAL/Polygon_mesh_processing/compute_normal.h>
 
 namespace CGAL {
 template <class PolygonMesh,

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_polyhedral_envelope.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_polyhedral_envelope.cpp
@@ -1,10 +1,12 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
 #include <CGAL/Polyhedral_envelope.h>
 #include <CGAL/Polygon_mesh_processing/repair_self_intersections.h>
+#include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
+
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Polyhedron_3.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 namespace PMP = CGAL::Polygon_mesh_processing;
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_read_polygon_mesh.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_read_polygon_mesh.cpp
@@ -1,4 +1,4 @@
-#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
 
 #include <CGAL/Surface_mesh.h>
 
@@ -8,7 +8,7 @@
 #include <CGAL/Linear_cell_complex_for_bgl_combinatorial_map_helper.h>
 #include <CGAL/boost/graph/graph_traits_Linear_cell_complex_for_combinatorial_map.h>
 
-#include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
+#include <CGAL/Simple_cartesian.h>
 
 #include <fstream>
 #include <vector>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_remove_border_edge.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_remove_border_edge.cpp
@@ -1,7 +1,9 @@
-#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Polygon_mesh_processing/repair.h>
+
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
-#include <CGAL/Polygon_mesh_processing/repair.h>
+
+#include <CGAL/Simple_cartesian.h>
 
 #include <fstream>
 #include <cassert>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_repair_degeneracies.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_repair_degeneracies.cpp
@@ -1,14 +1,14 @@
 #define CGAL_PMP_DEBUG_SMALL_CC_REMOVAL
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/connected_components.h>
+#include <CGAL/Polygon_mesh_processing/repair.h>
 
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
 
-#include <CGAL/Polygon_mesh_processing/connected_components.h>
-#include <CGAL/Polygon_mesh_processing/repair.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <iostream>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_repair_self_intersections.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_repair_self_intersections.cpp
@@ -3,11 +3,11 @@
 #define CGAL_PMP_REMOVE_SELF_INTERSECTION_DEBUG
 #define CGAL_PMP_REMOVE_SELF_INTERSECTION_OUTPUT
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
-
 #include <CGAL/Polygon_mesh_processing/repair.h>
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
+
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <iostream>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_snapping.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_snapping.cpp
@@ -1,17 +1,17 @@
 // #define CGAL_PMP_SNAP_DEBUG_PP
 
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/border.h>
+#include <CGAL/Polygon_mesh_processing/internal/Snapping/snap.h>
+#include <CGAL/Polygon_mesh_processing/internal/Snapping/helper.h>
 
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
 #include <CGAL/Surface_mesh.h>
 
-#include <CGAL/Polygon_mesh_processing/border.h>
-#include <CGAL/Polygon_mesh_processing/internal/Snapping/helper.h>
-#include <CGAL/Polygon_mesh_processing/internal/Snapping/snap.h>
-
 #include <CGAL/property_map.h>
+
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <iostream>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_transform.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_transform.cpp
@@ -1,11 +1,12 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polygon_mesh_processing/transform.h>
-#include <iostream>
-#include <fstream>
 
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Aff_transformation_3.h>
 
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <iostream>
+#include <fstream>
 
 
 namespace PMP = CGAL::Polygon_mesh_processing;

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_triangle.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_triangle.cpp
@@ -1,7 +1,9 @@
 #include <CGAL/Polygon_mesh_processing/triangle.h>
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/boost/graph/generators.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
 typedef K::Point_3 Point_3;

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_remove_caps_needles.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_remove_caps_needles.cpp
@@ -1,12 +1,13 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
-
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
-#include <fstream>
 #include <CGAL/Polygon_mesh_processing/repair_degeneracies.h>
+
 #include <CGAL/Polyhedral_envelope.h>
 #include <CGAL/Polygon_mesh_processing/measure.h>
 
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <fstream>
 #include <iostream>
 #include <vector>
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_repair_polygon_soup.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_repair_polygon_soup.cpp
@@ -1,10 +1,10 @@
 #define CGAL_PMP_REPAIR_POLYGON_SOUP_VERBOSE_PP
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-
 #include <CGAL/Polygon_mesh_processing/repair_polygon_soup.h>
 
 #include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <algorithm>
 #include <deque>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_shape_predicates.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_shape_predicates.cpp
@@ -1,14 +1,15 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/shape_predicates.h>
+#include <CGAL/Polygon_mesh_processing/repair.h>
 
 #include <CGAL/Surface_mesh.h>
 
-#include <CGAL/Polygon_mesh_processing/repair.h>
-#include <CGAL/Polygon_mesh_processing/shape_predicates.h>
-
 #include <CGAL/number_type_config.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <fstream>
 #include <iostream>
+#include <vector>
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel         K;
 typedef K::FT                                                       FT;

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_shape_smoothing.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_shape_smoothing.cpp
@@ -1,13 +1,13 @@
 #define CGAL_PMP_SMOOTHING_DEBUG
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/smooth_shape.h>
+#include <CGAL/Polygon_mesh_processing/measure.h>
 
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_items_with_id_3.h>
 
-#include <CGAL/Polygon_mesh_processing/measure.h>
-#include <CGAL/Polygon_mesh_processing/smooth_shape.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/utility.h>
 #include <CGAL/use.h>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_simplify_polylines_pmp.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_simplify_polylines_pmp.cpp
@@ -1,5 +1,5 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Polygon_mesh_processing/internal/simplify_polyline.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <vector>
 #include <fstream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_split_volume.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_split_volume.cpp
@@ -1,8 +1,11 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/orientation.h>
 #include <CGAL/boost/graph/Face_filtered_graph.h>
 #include <CGAL/Polygon_mesh_processing/transform.h>
+
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
 #include <boost/core/ref.hpp>
 
 #include <iostream>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_stitching.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_stitching.cpp
@@ -1,15 +1,17 @@
 // #define CGAL_PMP_STITCHING_DEBUG_PP
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/Surface_mesh.h>
+#include <CGAL/Polygon_mesh_processing/stitch_borders.h>
+#include <CGAL/Polygon_mesh_processing/border.h>
 
 #include <CGAL/boost/graph/named_params_helper.h>
 #include <CGAL/boost/graph/copy_face_graph.h>
 #include <CGAL/Dynamic_property_map.h>
-#include <CGAL/Polygon_mesh_processing/border.h>
-#include <CGAL/Polygon_mesh_processing/stitch_borders.h>
+
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <algorithm>
 #include <deque>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_faces_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_faces_test.cpp
@@ -1,6 +1,3 @@
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-#include <CGAL/Surface_mesh.h>
 
 #include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
 
@@ -9,6 +6,11 @@
 #include <CGAL/boost/graph/named_params_helper.h>
 #include <CGAL/centroid.h>
 #include <CGAL/Polygon_mesh_processing/polygon_mesh_to_polygon_soup.h>
+
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <boost/graph/filtered_graph.hpp>
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_Polyhedron_3_no_delaunay_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_Polyhedron_3_no_delaunay_test.cpp
@@ -1,22 +1,21 @@
 //#define POLY
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 #include <CGAL/Polygon_mesh_processing/internal/Hole_filling/do_not_use_DT3.h>
+#include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
+
 #ifdef POLY
 #include <CGAL/Polyhedron_3.h>
 #else
 #include <CGAL/Surface_mesh.h>
 #endif
+
 #include <CGAL/boost/graph/helpers.h>
-
-#include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
-
-#include <CGAL/assertions.h>
-
 #include <CGAL/boost/graph/Euler_operations.h>
 
 #include <CGAL/Weights/uniform_weights.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
 
 #include <cassert>
 #include <vector>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_Polyhedron_3_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_Polyhedron_3_test.cpp
@@ -1,6 +1,8 @@
 //#define POLY
 
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
+
+
 #ifdef POLY
 #include <CGAL/Polyhedron_3.h>
 #else
@@ -10,8 +12,9 @@
 #include <CGAL/boost/graph/helpers.h>
 #include <CGAL/assertions.h>
 #include <CGAL/boost/graph/Euler_operations.h>
-#include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
 #include <CGAL/Weights/uniform_weights.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <cassert>
 #include <vector>

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_polyline_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_polyline_test.cpp
@@ -1,6 +1,4 @@
-
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
 
 #include <cassert>
 #include <vector>
@@ -10,7 +8,9 @@
 #include <CGAL/Polyhedron_incremental_builder_3.h>
 #include <CGAL/Polyhedron_3.h>
 
-#include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel  Epic;
 typedef CGAL::Exact_predicates_exact_constructions_kernel  Epec;

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_with_cdt_2_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/triangulate_hole_with_cdt_2_test.cpp
@@ -1,17 +1,20 @@
+#define CGAL_NO_CDT_2_WARNING
+
+#include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
+#include <CGAL/Polygon_mesh_processing/orientation.h>
+
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Polyhedron_3.h>
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+
 #include <set>
 #include <vector>
 #include <fstream>
 #include <cassert>
 #include <string>
 
-#define CGAL_NO_CDT_2_WARNING
-
-#include <CGAL/Surface_mesh.h>
-#include <CGAL/Polyhedron_3.h>
-#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
-#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-#include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
-#include <CGAL/Polygon_mesh_processing/orientation.h>
 
 template<
 class PolygonMesh,


### PR DESCRIPTION
## Summary of Changes

Issue #8009 revealed that some header files do not `#include` all what they need.  We do not see that in the testsuite, as we "usually" first include a kernel and then only header files of higher level functions.  This PR includes the  high level first and then only a kernel. We start with the _Polygon Mesh Processing_ package, but will extend this to the other packages.

This PR should fix the reported issue, but changes in the testsuite itself should reveal other similar issues. 

## Release Management

* Affected package(s): PMP
* Issue(s) solved (if any):  tbd #8009

* License and copyright ownership: unchanged.

