### PR TITLE
CGAL_error_msg -> CGAL_NEF_TRACEN to allow convex decomposition on particular input

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/SNC_const_decorator.h
+++ b/Nef_3/include/CGAL/Nef_3/SNC_const_decorator.h
@@ -273,7 +273,7 @@ public:
 
     SFace_handle sf;
     if(!CGAL::assign(sf,o)) {
-      CGAL_error_msg( "it is not possible to decide which one is a visible facet (if any)");
+      CGAL_NEF_TRACEN( "it is not possible to decide which one is a visible facet (if any)");
       return Halffacet_handle();
     }
 


### PR DESCRIPTION
## Summary of Changes

Apologies for the programming by accident here as I don't understand the majority of the code here. However, I propose here changing one particular occurrence of `CGAL_error_msg` to `CGAL_NEF_TRACEN `, which may be warranted giving the surrounding lines. `CGAL_error_msg` gives an assertion error and terminates program (at least on my configuration) however the code seems to be allowed to fall through since a null handle is returned on the next line which is actually handled at the call site.

### Data

[nef.txt](https://github.com/CGAL/cgal/files/14110073/nef.txt)

### Steps to reproduce

```C++
int main(int, char**) {
	std::ifstream ifs("nef.txt");
	CGAL::Nef_polyhedron_3<CGAL::Epeck> nef;
	ifs >> nef;
	CGAL::convex_decomposition_3(nef);
}
```

- Without proposed fix throws assertion violation
- With proposed fix runs (seemlingly) normal

### Output

![afbeelding](https://github.com/CGAL/cgal/assets/1096535/f108eeb5-2664-4a52-8f2d-a45b8a9b67d9)

(the apparent self intersections, I think are rendering artefacts from the z offset of edge rendering in blender).

## Release Management

* Affected package(s): Convex Decomposition of Polyhedra / 3D Boolean Operations on Nef Polyhedra
* Issue(s) solved (if any): - 
* Feature/Small Feature (if any): -
* Link to compiled documentation: -
* License and copyright ownership: -

