### PR TITLE
Warnings in documentation when running xmllint

### DIFF
--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_2.h
@@ -511,6 +511,7 @@ public:
   Converts the current triangulation into the same periodic
   triangulation in the 1-sheeted covering space.
   \pre `is_triangulation_in_1_sheet()`
+
   \cgalAdvancedEnd
   */
   void convert_to_1_sheeted_covering();
@@ -982,6 +983,7 @@ public:
   `f`. Face `f` is modified,
   two new faces are created. If the triangulation contains periodic copies, a point is inserted in all periodic copies.
   \pre The point in vertex `v` lies inside face `f`.
+
   \cgalAdvancedEnd
   */
   Vertex_handle insert_in_face(const Point& p, Face_handle f);
@@ -990,7 +992,9 @@ public:
   \cgalAdvancedFunction
   \cgalAdvancedBegin
   Removes a vertex of degree three. Two of the incident faces are
-  destroyed, the third one is modified. \pre Vertex `v` is a vertex with degree three.
+  destroyed, the third one is modified.
+  \pre Vertex `v` is a vertex with degree three.
+
   \cgalAdvancedEnd
   */
   void remove_degree_3(Vertex_handle v);
@@ -1012,8 +1016,8 @@ public:
   creates a new vertex `v` and use it to star the hole
   whose boundary is described by the sequence of edges
   `[edge_begin, edge_end]`. Returns a handle to the new vertex.
-
   \pre The triangulation is a triangulation of 1 sheet
+
     \cgalAdvancedEnd
   */
   template<class EdgeIt>
@@ -1027,8 +1031,8 @@ public:
   same as above, except that the algorithm
   first recycles faces in the sequence `[face_begin, face_end]`
   and create new ones only when the sequence is exhausted.
-
   \pre The triangulation is a triangulation of 1 sheet
+
   \cgalAdvancedEnd
   */
   template<class EdgeIt, class FaceIt>

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -1188,6 +1188,7 @@ public:
     \return Returns a pair containing: the specified property map and a
     Boolean set to `true` or an empty property map and a Boolean set
     to `false` (if the property was not found).
+
     \cgalAdvancedEnd
   */
   template <class T>
@@ -1213,6 +1214,7 @@ public:
 
     \note The normal property must have been added to the point set
     before calling this method (see `add_normal_map()`).
+
     \cgalAdvancedEnd
   */
   Vector_push_map normal_push_map ()

--- a/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
+++ b/Surface_mesh_skeletonization/include/CGAL/Mean_curvature_flow_skeletonization.h
@@ -528,6 +528,7 @@ public:
   /// after a number of `contract_geometry()`, keeping the specified
   /// vertices fixed in place.
   /// \tparam InputIterator a model of `InputIterator` with `boost::graph_traits<TriangleMesh>::%vertex_descriptor` as value type.
+  ///
   /// \cgalAdvancedEnd
   template<class InputIterator>
   void set_fixed_vertices(InputIterator begin, InputIterator end)

--- a/TDS_3/doc/TDS_3/Concepts/TriangulationDataStructure_3.h
+++ b/TDS_3/doc/TDS_3/Concepts/TriangulationDataStructure_3.h
@@ -130,6 +130,7 @@ data structure that only changes the vertex type. It has to define a type
 `Rebind_vertex<Vb2>::%Other` which is a <I>rebound</I> triangulation data structure, that is, the
 one whose `TriangulationDSVertexBase_3` will be `Vb2`.
 \note It can be implemented using a nested template class.
+
 \cgalAdvancedEnd
 */
 template <typename Vb2>
@@ -143,6 +144,7 @@ data structure that only changes the cell type. It has to define a type
 `Rebind_cell<Cb2>::%Other` which is a <I>rebound</I> triangulation data structure, that is, the
 one whose `TriangulationDSCellBase_3` will be `Cb2`.
 \note It can be implemented using a nested template class.
+
 \cgalAdvancedEnd
 */
 template <typename Cb2>

--- a/Triangulation/doc/Triangulation/CGAL/Triangulation_data_structure.h
+++ b/Triangulation/doc/Triangulation/CGAL/Triangulation_data_structure.h
@@ -81,6 +81,7 @@ data structure that only changes the vertex type. It has to define a type
 `Other` which is a <I>rebound</I> triangulation data structure with `Vb2`
 as vertex type.
 \note It can be implemented using a nested template class.
+
 \cgalAdvancedEnd
 */
 template <typename Vb2>
@@ -94,6 +95,7 @@ data structure that only changes the full cell type. It has to define a type
 `Other` which is a <I>rebound</I> triangulation data structure with `Fcb2`
 as full cell type.
 \note It can be implemented using a nested template class.
+
 \cgalAdvancedEnd
 */
 template <typename Fcb2>
@@ -112,8 +114,9 @@ A set `C` of full cells satisfying the same condition as in method
 method creates new full cells from vertex `v` to the boundary of `C`.
 The boundary is recognized by checking the mark of the full cells.
 This method is used by `Triangulation_data_structure::insert_in_hole()`.
-s
+
 \pre same as `TriangulationDataStructure::insert_in_hole()`
+
 \cgalAdvancedEnd
 
 */

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Constrained_triangulation_plus_2.h
@@ -516,6 +516,7 @@ constraints based on a cost and stop function.
 \pre The vertex referred by vicq is not contained in any other constraint.
 \pre Let `vip` and `vir` be defined as `vip = std::prev(vicq)` and `vir = std::next(vicr)`.
 \pre The line segment between `*vicp->point()` and `*vicr->point()` must not intersect any constraint.
+
 \cgalAdvancedEnd
  */
 void


### PR DESCRIPTION
When running xmllint over the documentation output we get a number of waning's like:

```
save_Periodic_2_triangulation_2/class_c_g_a_l_1_1_periodic__2__triangulation__2.html:1420: parser error : Opening and ending tag mismatch: dd line 1420 and div
"This is an advanced function.">is_triangulation_in_1_sheet()</a></code>  </div>
                                                                               ^
```
they are a consequence of the fact that a a command is not properly ended in this case we have a `\pre` command and its documentation states:
> The `\pre` command ends when a blank line or some other sectioning command is encountered.

and in this case the command is followed by the `\cgalAdvancedEnd` command that does not properly end the `\pre` command. The same is valid in the other cases.