### PR TITLE
Incorrect layout bisector precondition

### DIFF
--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -367,7 +367,7 @@ const CGAL::Line_2<Kernel> &l2);
 /*!
 constructs the bisector plane of the two points `p` and `q`.
 The bisector is oriented in such a way that `p` lies on its
-positive side. \pre `p != q'.
+positive side. \pre `p != q`.
 */
 template <typename Kernel>
 CGAL::Plane_3<Kernel> bisector(const CGAL::Point_3<Kernel> &p,


### PR DESCRIPTION
On the page Kernel_23/group__bisector__grp.html we see for `bisector` with the `Point_3` type arguments in the precondition:
```
‘p != q’
```
instead of
```
p != q
```
due to the fact that there is not a backtick but a single quote as closing part

