### PR TITLE
Point Set Processing: Remove documentation of deprecated functions

### DIFF
--- a/Point_set_3/include/CGAL/Point_set_3/IO/LAS.h
+++ b/Point_set_3/include/CGAL/Point_set_3/IO/LAS.h
@@ -168,12 +168,6 @@ bool read_LAS(const std::string& fname, CGAL::Point_set_3<Point, Vector>& point_
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 
-/*!
-  \ingroup PkgPointSet3IODeprecated
-
-  \deprecated This function is deprecated since \cgal 5.3,
-              \link PkgPointSet3IO `CGAL::IO::read_LAS()` \endlink should be used instead.
- */
 template <typename Point, typename Vector>
 CGAL_DEPRECATED bool read_las_point_set(std::istream& is, ///< input stream.
                                         CGAL::Point_set_3<Point, Vector>& point_set) ///< point set
@@ -404,12 +398,6 @@ bool write_LAS(const std::string& fname,
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 
-/*!
-  \ingroup PkgPointSet3IODeprecated
-
-  \deprecated This function is deprecated since \cgal 5.3,
-              \link PkgPointSet3IO `CGAL::IO::write_LAS()` \endlink should be used instead.
- */
 template <typename Point, typename Vector>
 CGAL_DEPRECATED bool write_las_point_set(std::ostream& os, ///< output stream.
                                          CGAL::Point_set_3<Point, Vector>& point_set)  ///< point set

--- a/Point_set_3/include/CGAL/Point_set_3/IO/OFF.h
+++ b/Point_set_3/include/CGAL/Point_set_3/IO/OFF.h
@@ -94,12 +94,6 @@ bool read_OFF(const std::string& fname, CGAL::Point_set_3<Point, Vector>& point_
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 
-/*!
-  \ingroup PkgPointSet3IODeprecated
-
-  \deprecated This function is deprecated since \cgal 5.3,
-              \link PkgPointSet3IO `CGAL::IO::read_OFF()` \endlink  should be used instead.
- */
 template <typename Point, typename Vector>
 CGAL_DEPRECATED bool read_off_point_set(std::istream& is,  ///< input stream.
                                         CGAL::Point_set_3<Point, Vector>& point_set)  ///< point set.
@@ -190,12 +184,6 @@ bool write_OFF(const std::string& fname, const CGAL::Point_set_3<Point, Vector>&
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 
-/*!
-  \ingroup PkgPointSet3IODeprecated
-
-  \deprecated This function is deprecated since \cgal 5.3,
-              \link PkgPointSet3IO `CGAL::IO::write_OFF()` \endlink  should be used instead.
- */
 template <typename Point, typename Vector>
 CGAL_DEPRECATED bool write_off_point_set(std::ostream& os, ///< output stream.
                                          const CGAL::Point_set_3<Point, Vector>& point_set) ///< point set

--- a/Point_set_3/include/CGAL/Point_set_3/IO/PLY.h
+++ b/Point_set_3/include/CGAL/Point_set_3/IO/PLY.h
@@ -367,25 +367,6 @@ bool read_PLY(const std::string& fname, CGAL::Point_set_3<Point, Vector>& point_
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 
-/*!
-  \ingroup PkgPointSet3IODeprecated
-
-  \deprecated This function is deprecated since \cgal 5.3,
-              \link PkgPointSet3IO `CGAL::IO::read_PLY()` \endlink  should be used instead.
-
-  \brief reads a point set with properties from an input stream in \ascii or binary PLY format.
-
-  - the operator reads the vertex `point` property;
-  - if three PLY properties `nx`, `ny` and `nz` with type `float`
-     or `double` are found, the normal map is added;
-  - if any other PLY property is found, a "[name]" property map is
-    added, where `[name]` is the name of the PLY property.
-
-  The `comments` parameter can be omitted. If provided, it will be
-  used to store the potential comments found in the PLY
-  header. Each line starting by "comment " in the header is
-  appended to the `comments` string (without the "comment " word).
- */
 template <typename Point, typename Vector>
 CGAL_DEPRECATED bool read_ply_point_set(std::istream& is, ///< input stream.
                                         CGAL::Point_set_3<Point, Vector>& point_set, ///< point set
@@ -744,12 +725,6 @@ bool write_PLY(const std::string& fname, const CGAL::Point_set_3<Point, Vector>&
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 
-/*!
-  \ingroup PkgPointSet3IODeprecated
-
-  \deprecated This function is deprecated since \cgal 5.3,
-              \link PkgPointSet3IO `CGAL::IO::write_PLY()` \endlink  should be used instead.
- */
 template <typename Point, typename Vector>
 CGAL_DEPRECATED bool write_ply_point_set(std::ostream& os,
                                          const CGAL::Point_set_3<Point, Vector>& point_set,

--- a/Point_set_3/include/CGAL/Point_set_3/IO/XYZ.h
+++ b/Point_set_3/include/CGAL/Point_set_3/IO/XYZ.h
@@ -93,12 +93,6 @@ bool read_XYZ(const std::string& fname, CGAL::Point_set_3<Point, Vector>& point_
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 
-/*!
-  \ingroup PkgPointSet3IODeprecated
-
-  \deprecated This function is deprecated since \cgal 5.3,
-              \link PkgPointSet3IO `CGAL::IO::read_XYZ()` \endlink  should be used instead.
- */
 template <typename Point, typename Vector>
 CGAL_DEPRECATED bool read_xyz_point_set(std::istream& is, CGAL::Point_set_3<Point, Vector>& point_set)
 {
@@ -187,12 +181,6 @@ bool write_XYZ(const std::string& fname, const CGAL::Point_set_3<Point, Vector>&
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 
-/*!
-  \ingroup PkgPointSet3IODeprecated
-
-  \deprecated This function is deprecated since \cgal 5.3,
-              \link PkgPointSet3IO `CGAL::IO::write_XYZ()` \endlink  should be used instead.
- */
 template <typename Point, typename Vector>
 CGAL_DEPRECATED bool write_xyz_point_set(std::ostream& os, const CGAL::Point_set_3<Point, Vector>& point_set)
 {

--- a/Point_set_processing_3/doc/Point_set_processing_3/PackageDescription.txt
+++ b/Point_set_processing_3/doc/Point_set_processing_3/PackageDescription.txt
@@ -10,9 +10,6 @@ simplification, etc.).
 \defgroup PkgPointSetProcessing3IO I/O Functions
 \ingroup PkgPointSetProcessing3Ref
 
-\defgroup PkgPointSetProcessing3IODeprecated I/O Functions (Deprecated)
-\ingroup PkgPointSetProcessing3IO
-
 \defgroup PkgPointSetProcessing3IOOff I/O (OFF Formats)
 \ingroup PkgPointSetProcessing3Ref
 

--- a/Point_set_processing_3/doc/Point_set_processing_3/dependencies
+++ b/Point_set_processing_3/doc/Point_set_processing_3/dependencies
@@ -12,4 +12,5 @@ Jet_fitting_3
 Solver_interface
 Shape_detection
 Advancing_front_surface_reconstruction
+Point_set_3
 BGL

--- a/Point_set_processing_3/examples/Point_set_processing_3/read_write_xyz_point_set_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/read_write_xyz_point_set_example.cpp
@@ -22,7 +22,7 @@ int main(int argc, char*argv[])
   const std::string fname = (argc>1) ? argv[1] : CGAL::data_file_path("points_3/oni.pwn");
 
   // Reads a .xyz point set file in points[].
-  // Note: read_points() requires an output iterator
+  // Note: read_XYZ() requires an output iterator
   // over points and as well as property maps to access each
   // point position and normal.
   std::vector<Pwn> points;

--- a/Point_set_processing_3/include/CGAL/IO/read_las_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_las_points.h
@@ -123,7 +123,7 @@ typedef Base<unsigned short, Id::I> I;
 /**
    \ingroup PkgPointSetProcessing3IOLas
 
-   Generates a %LAS property handler to read 3D points. Points are
+   generates a %LAS property handler to read 3D points. Points are
    constructed from the input the using 3 %LAS properties
    `LAS_property::X`, `LAS_property::Y` and `LAS_property::Z`.
 

--- a/Point_set_processing_3/include/CGAL/IO/read_las_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_las_points.h
@@ -574,11 +574,7 @@ bool read_las_points(std::istream& is, ///< input stream.
 
 /// \endcond
 
-/**
- \ingroup PkgPointSetProcessing3IODeprecated
 
- \deprecated This function is deprecated since \cgal 5.3, `CGAL::IO::read_LAS_with_properties()` should be used instead.
-*/
 template <typename OutputIteratorValueType,
           typename OutputIterator,
           typename ... PropertyHandler>
@@ -602,11 +598,6 @@ CGAL_DEPRECATED bool read_las_points_with_properties(std::istream& is,
 
 /// \endcond
 
-/**
- \ingroup PkgPointSetProcessing3IODeprecated
-
- \deprecated This function is deprecated since \cgal 5.3, `CGAL::IO::read_LAS()` should be used instead.
-*/
 template <typename OutputIteratorValueType,
           typename OutputIterator,
           typename CGAL_NP_TEMPLATE_PARAMETERS>

--- a/Point_set_processing_3/include/CGAL/IO/read_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_off_points.h
@@ -410,12 +410,6 @@ bool read_off_points(std::istream& is, ///< input stream.
 
 /// \endcond
 
-/*!
- \ingroup PkgPointSetProcessing3IODeprecated
-
- \deprecated This function is deprecated since \cgal 5.3,
-             \link PkgPointSetProcessing3IOOff `CGAL::IO::read_OFF()` \endlink should be used instead.
-*/
 template <typename OutputIteratorValueType,
           typename OutputIterator,
           typename CGAL_NP_TEMPLATE_PARAMETERS>

--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -434,24 +434,13 @@ bool read_ply_points(std::istream& is, ///< input stream.
 
 /// \endcond
 
-/**
- \ingroup PkgPointSetProcessing3IODeprecated
-
- \deprecated This function is deprecated since \cgal 5.3,
-             \link PkgPointSetProcessing3IOPly `CGAL::IO::read_PLY_with_properties()` \endlink should be used instead.
-  */
 template <typename OutputIteratorValueType, typename OutputIterator, typename ... PropertyHandler>
 CGAL_DEPRECATED bool read_ply_points_with_properties(std::istream& is, OutputIterator output, PropertyHandler&& ... properties)
 {
   return IO::read_PLY_with_properties(is, output, std::forward<PropertyHandler>(properties)...);
 }
 
-/**
-  \ingroup PkgPointSetProcessing3IODeprecated
 
-   \deprecated This function is deprecated since \cgal 5.3,
-               \link PkgPointSetProcessing3IOPly `CGAL::IO::read_PLY()` \endlink should be used instead.
-  */
 template <typename OutputIteratorValueType, typename OutputIterator, typename CGAL_NP_TEMPLATE_PARAMETERS>
 CGAL_DEPRECATED bool read_ply_points(std::istream& is, OutputIterator output, const CGAL_NP_CLASS& np = parameters::default_values())
 {

--- a/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
@@ -394,14 +394,7 @@ bool read_xyz_points(std::istream& is, ///< input stream.
 
 /// \endcond
 
-/**
-   \ingroup PkgPointSetProcessing3IODeprecated
 
-   \deprecated This function is deprecated since \cgal 5.3,
-               \link PkgPointSetProcessing3IOXyz `CGAL::IO::read_XYZ()` \endlink should be used instead.
-
-   \returns `true` if reading was successful, `false` otherwise.
-*/
 template <typename OutputIteratorValueType,
           typename OutputIterator,
           typename CGAL_NP_TEMPLATE_PARAMETERS>

--- a/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_xyz_points.h
@@ -245,9 +245,11 @@ bool read_XYZ(const std::string& fname, OutputIterator output, const CGAL_NP_CLA
   return read_XYZ<typename value_type_traits<OutputIterator>::type>(is, output, np);
 }
 
+/// \endcond
+
 } // namespace IO
 
-/// \endcond
+
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 

--- a/Point_set_processing_3/include/CGAL/IO/write_las_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_las_points.h
@@ -304,7 +304,7 @@ bool write_LAS(std::ostream& os,
 /**
    \ingroup PkgPointSetProcessing3IOLas
 
-   Saves the range of `points` (positions only), using the \ref IOStreamLAS.
+   writes the range of `points` (positions only), using the \ref IOStreamLAS.
 
    \tparam PointRange is a model of `ConstRange`. The value type of
    its iterator is the key type of the named parameter `point_map`.

--- a/Point_set_processing_3/include/CGAL/IO/write_las_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_las_points.h
@@ -378,11 +378,6 @@ bool write_las_points(std::ostream& os, ///< output stream.
 
 /// \endcond
 
-/**
-  \ingroup PkgPointSetProcessing3IODeprecated
-
-  \deprecated This function is deprecated since \cgal 5.3, `CGAL::IO::write_LAS_with_properties()` should be used instead.
-*/
 template <typename PointRange,
           typename PointMap,
           typename ... PropertyHandler>
@@ -397,11 +392,7 @@ CGAL_DEPRECATED bool write_las_points_with_properties(std::ostream& os,
   return IO::write_LAS_with_properties(os, points, point_property, std::forward<PropertyHandler>(properties)...);
 }
 
-/**
-   \ingroup PkgPointSetProcessing3IODeprecated
 
-  \deprecated This function is deprecated since \cgal 5.3, `CGAL::IO::write_LAS()` should be used instead.
-*/
 template <typename PointRange, typename CGAL_NP_TEMPLATE_PARAMETERS>
 bool write_las_points(std::ostream& os, const PointRange& points, const CGAL_NP_CLASS& np = parameters::default_values())
 {

--- a/Point_set_processing_3/include/CGAL/IO/write_off_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_off_points.h
@@ -292,12 +292,6 @@ bool write_off_points(std::ostream& os, ///< output stream.
 
 /// \endcond
 
-/**
-  \ingroup PkgPointSetProcessing3IODeprecated
-
-  \deprecated This function is deprecated since \cgal 5.3,
-              \link PkgPointSetProcessing3IOOff `CGAL::IO::write_OFF()` \endlink should be used instead.
-*/
 template <typename PointRange, typename CGAL_NP_TEMPLATE_PARAMETERS>
 CGAL_DEPRECATED bool write_off_points(std::ostream& os, const PointRange& points, const CGAL_NP_CLASS& np = parameters::default_values())
 {

--- a/Point_set_processing_3/include/CGAL/IO/write_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_ply_points.h
@@ -353,12 +353,7 @@ bool write_ply_points(std::ostream& os, ///< output stream.
 
 /// \endcond
 
-/**
-\ingroup PkgPointSetProcessing3IODeprecated
 
-\deprecated This function is deprecated since \cgal 5.3,
-            \link PkgPointSetProcessing3IOPly `CGAL::IO::write_PLY_with_properties()` \endlink should be used instead.
-*/
 template <typename PointRange,
           typename ... PropertyHandler>
 CGAL_DEPRECATED bool write_ply_points_with_properties(std::ostream& os, ///< output stream.
@@ -368,12 +363,7 @@ CGAL_DEPRECATED bool write_ply_points_with_properties(std::ostream& os, ///< out
   return IO::write_PLY_with_properties(os, points, std::forward<PropertyHandler>(properties)...);
 }
 
-/**
-\ingroup PkgPointSetProcessing3IODeprecated
 
-\deprecated This function is deprecated since \cgal 5.3,
-            \link PkgPointSetProcessing3IOPly `CGAL::IO::write_PLY()` \endlink should be used instead.
-*/
 template <typename PointRange, typename CGAL_NP_TEMPLATE_PARAMETERS>
 CGAL_DEPRECATED bool write_ply_points(std::ostream& os, const PointRange& points, const CGAL_NP_CLASS& np = parameters::default_values())
 {

--- a/Point_set_processing_3/include/CGAL/IO/write_xyz_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_xyz_points.h
@@ -280,12 +280,7 @@ bool write_xyz_points(std::ostream& os, ///< output stream.
 
 /// \endcond
 
-/**
-  \ingroup PkgPointSetProcessing3IODeprecated
 
-  \deprecated This function is deprecated since \cgal 5.3,
-              \link PkgPointSetProcessing3IOXyz `CGAL::write_XYZ()` \endlink should be used instead.
-*/
 template <typename PointRange, typename CGAL_NP_TEMPLATE_PARAMETERS>
 CGAL_DEPRECATED bool write_xyz_points(std::ostream& os, const PointRange& points, const CGAL_NP_CLASS& np = parameters::default_values())
 {


### PR DESCRIPTION
## Summary of Changes

As these functions are deprecated since CGAL 5.3 we remove them from the documentation.

I am also wondering why we have no `CGAL::IO::read_XYZ()` [here](https://doc.cgal.org/latest/Point_set_processing_3/group__PkgPointSetProcessing3IOXyz.html), especially as we have an overload for `Point_set_3` [here](https://doc.cgal.org/latest/Point_set_3/group__PkgPointSet3IOXYZ.html).

## Release Management

* Affected package(s): Point_set_processing_3
* License and copyright ownership:

