### PR TITLE
Don't set the point again when reinserting the same point

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -76,6 +76,12 @@ Release date: October 2023
 -   Added three functions `vertices()` to the class `Triangulation_3`.
     Each of them returns an array containing the vertices of the given triangulation simplex.
 
+### [dD Triangulations](https://doc.cgal.org/6.0/Manual/packages.html#PkgTriangulations)
+-   **Breaking change**: Inserting multiple unweighted points in the same
+    position now keeps the first one, instead of switching to the latest. This
+    only affects custom point types where not all points in the same position
+    are equivalent.
+
 [Release 5.6](https://github.com/CGAL/cgal/releases/tag/v5.6)
 -----------
 

--- a/Triangulation/doc/Triangulation/CGAL/Delaunay_triangulation.h
+++ b/Triangulation/doc/Triangulation/CGAL/Delaunay_triangulation.h
@@ -125,8 +125,8 @@ value of `lt`:
 <DT><B>`OUTSIDE_AFFINE_HULL`</B><DD> Point
 `p` is inserted so as to increase the current dimension of the Delaunay
 triangulation.
-<DT><B>`ON_VERTEX`</B><DD> The position of the vertex `v` described by `f`
-is set to `p`. `v` is returned. <DT><B>Anything else</B><DD> The point `p`
+<DT><B>`ON_VERTEX`</B><DD> The triangulation remains unchanged.
+<DT><B>Anything else</B><DD> The point `p`
 is inserted. the full cell `c` <I>is assumed</I> to be in conflict
 with `p`.
 </DL>

--- a/Triangulation/doc/Triangulation/CGAL/Triangulation.h
+++ b/Triangulation/doc/Triangulation/CGAL/Triangulation.h
@@ -556,8 +556,7 @@ Inserts point `p` into the triangulation and returns a handle to the
 `Vertex` at that position. The action taken depends on the value of
 `loc_type`:
 
-<DL> <DT><B>`ON_VERTEX`</B><DD> The point of the
-p`Vertex` described by `f` is set to `p`.
+<DL> <DT><B>`ON_VERTEX`</B><DD> The triangulation remains unchanged.
 <DT><B>`IN_FACE`</B><DD> The point `p` is inserted in the `Face f`.
 <DT><B>`IN_FACET`</B><DD> The point `p` is inserted in the `Facet ft`.
 <DT><B>Anything else</B><DD> The point `p` is inserted in the triangulation according to the value

--- a/Triangulation/include/CGAL/Delaunay_triangulation.h
+++ b/Triangulation/include/CGAL/Delaunay_triangulation.h
@@ -673,7 +673,6 @@ Delaunay_triangulation<DCTraits, TDS>
         case Base::ON_VERTEX:
         {
             Vertex_handle v = s->vertex(f.index(0));
-            v->set_point(p);
             return v;
             break;
         }
@@ -762,7 +761,7 @@ Delaunay_triangulation<DCTraits, TDS>
 
 Inserts the point `p` in the Delaunay triangulation. Returns a handle to the
 (possibly newly created) vertex at that position.
-\pre The point `p` must be in conflict with the full cell `c`.
+\pre The point `p` must be in conflict with the full cell `s`.
 */
 template< typename DCTraits, typename TDS >
 typename Delaunay_triangulation<DCTraits, TDS>::Vertex_handle

--- a/Triangulation/include/CGAL/Triangulation.h
+++ b/Triangulation/include/CGAL/Triangulation.h
@@ -843,7 +843,6 @@ Triangulation<TT, TDS>
             return insert_in_face(p, f);
             break;
         case ON_VERTEX:
-            s->vertex(f.index(0))->set_point(p);
             return s->vertex(f.index(0));
             break;
     }


### PR DESCRIPTION
## Summary of Changes

In Triangulation and Delaunay_triangulation (but not Regular_triangulation with equal weights), if we insert a point and locate notices that there is already a vertex for this point, we call `set_point` to set this point again. I don't understand why we do that. In most cases it should be useless but harmless. To notice a difference, we would need a `Point_d` type for which 2 objects may represent the same position but differ in some way (probably include extra data like a color). But even in that case, it isn't obvious to me that using the color of the last copy of this point that gets inserted is better than the color of the first copy. If someone was using this mechanism to store the index of points, having a vertex that changes what point it represents in the middle of the construction could break some uses.

It would be nice if someone else could check the logic, not just trust me.

(I don't have any particular use for this, I only noticed it while copy-pasting `insert` so I could customize it)

## Release Management

* Affected package(s): Triangulation
* License and copyright ownership: unchanged