### PR TITLE
Autorefinement: insert points in edge to avoid filter failures

### DIFF
--- a/Intersections_3/include/CGAL/Intersections_3/internal/Triangle_3_Triangle_3_intersection.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Triangle_3_Triangle_3_intersection.h
@@ -39,11 +39,15 @@ struct Point_on_triangle
 {
   // triangle points are not stored in this class but are expected
   // to always be passed in the same order. For a triangle pqr,
-  // edge 0 is pq, edge 1 qr and edge 2 rp. Point 0 is p, 1 is q and 2 is r.
+  // edge 1 is pq, edge 2 qr and edge 3 rp. Point -1 is p, -2 is q and -3 is r.
   //
-  // (id, -1) point on t1
-  // (-1, id) point on t2
-  // (id1, id2) intersection of edges
+  //  (0,-) vertex of t2 inside t1
+  //  (-,-) common point of t1 and t2
+  //  (-,0) vertex of t1 inside t2
+  //  (-,+) vertex of t1 on an edge of t2
+  //  (+,+) edge of t1 intersecting edge of t2
+  //  (+,-) vertex of t2 on an edge of t1
+  //
   std::pair<int, int> t1_t2_ids;
   boost::container::flat_set<int> extra_t1; // store other ids of edges containing the point
   typename Kernel::FT alpha; //
@@ -60,16 +64,16 @@ struct Point_on_triangle
   {
     switch(id)
     {
-      case 0:
+      case -1:
         return p;
-      case 1:
+      case -2:
         return q;
       default:
         return r;
     }
   }
 
-  Point_on_triangle(int i1, int i2=-1, typename Kernel::FT alpha = 0.) // TODO add global zero()?
+  Point_on_triangle(int i1, int i2, typename Kernel::FT alpha = 0.) // TODO add global zero()?
     : t1_t2_ids(i1,i2)
     , alpha(alpha)
   {}
@@ -85,20 +89,20 @@ struct Point_on_triangle
                const typename Kernel::Point_3& r2,
                const Kernel& k) const
   {
-    if (t1_t2_ids.first!=-1)
+    if (t1_t2_ids.first!=0 && t1_t2_ids.second >=0)
     {
-      if (t1_t2_ids.second==-1)
+      if (t1_t2_ids.first<0)
         return (edge_id1==t1_t2_ids.first || (edge_id1+1)%3==t1_t2_ids.first) ? ZERO:POSITIVE; // it is a point on t1
       // this is an intersection point
 
       if (t1_t2_ids.first==edge_id1)
         return ZERO;
-      if (t1_t2_ids.first==(edge_id1+1)%3)
+      if (t1_t2_ids.first-1==(edge_id1)%3)
       {
         if (alpha==0) return ZERO;
         return alpha>=0 ? POSITIVE:NEGATIVE;
       }
-      CGAL_assertion((t1_t2_ids.first+1)%3==edge_id1);
+      CGAL_assertion((t1_t2_ids.first)%3==edge_id1-1);
       if (alpha==1) return ZERO;
       return alpha<=1?POSITIVE:NEGATIVE;
     }
@@ -111,8 +115,12 @@ struct Point_on_triangle
     }
   }
 
+
   int id1() const { return t1_t2_ids.first; }
   int id2() const { return t1_t2_ids.second; }
+
+  void set_id1(int i) { t1_t2_ids.first=i; }
+  void set_id2(int i) { t1_t2_ids.second=i; }
 
   // construct the intersection point from the info stored
   typename Kernel::Point_3
@@ -124,12 +132,13 @@ struct Point_on_triangle
         const typename Kernel::Point_3& r2,
         const Kernel& k) const
   {
-    if (t1_t2_ids.first==-1)
+    if (t1_t2_ids.second<0)
       return point_from_id(p2,q2,r2,t1_t2_ids.second);
-    if (t1_t2_ids.second==-1)
+    if (t1_t2_ids.first<0)
       return point_from_id(p1,q1,r1,t1_t2_ids.first);
 
-    return k.construct_barycenter_3_object()(point_from_id(p1,q1,r1,(t1_t2_ids.first+1)%3), alpha, point_from_id(p1,q1,r1,t1_t2_ids.first)) ;
+    return k.construct_barycenter_3_object()(point_from_id(p1,q1,r1,-(t1_t2_ids.first)%3), alpha,
+                                             point_from_id(p1,q1,r1,-t1_t2_ids.first)) ;
   }
 };
 
@@ -160,153 +169,50 @@ intersection(const Point_on_triangle<Kernel>& p,
   typename Kernel::Compute_alpha_for_coplanar_triangle_intersection_3 compute_alpha
     = k.compute_alpha_for_coplanar_triangle_intersection_3_object();
   typedef Point_on_triangle<Kernel> Pot;
-  switch(p.id1())
+
+  auto common_edge_id = [](int pid, int qid)
   {
-    case -1:
+    if (pid==0 || qid==0) return 0;
+    if (pid<0)
     {
-      switch(q.id1())
+      if (qid<0)
       {
-        case -1: // A: (-1, ip2) - (-1, iq2)
-        {
-          CGAL_assertion((p.id2()+1)%3 == q.id2() || (q.id2()+1)%3 == p.id2());
-//          CGAL_assertion(p.extra_t1.empty() && q.extra_t1.empty());  // TMP to see if it's worth implementing special case
-#ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-          std::cout << " -- case 1\n";
-#endif
-          typename Kernel::FT alpha = compute_alpha(p1, q1,
-                                                    Pot::point_from_id(p2, q2, r2, p.id2()),
-                                                    Pot::point_from_id(p2, q2, r2, q.id2()));
-          int id2 = (p.id2()+1)%3 == q.id2() ? p.id2() : q.id2();
-          return  Point_on_triangle<Kernel>(edge_id_t1, id2, alpha); // intersection with an original edge of t2
-        }
-        default:
-          if (q.id2()!=-1) // B: (-1, ip2) - (iq1, iq2)
-          {
-            if (p.id2() == q.id2() || p.id2() == (q.id2()+1)%3)
-            {
-#ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-              std::cout << " -- case 2\n";
-#endif
-              // points are on the same edge of t2 --> we shorten an already cut edge
-              typename Kernel::FT alpha = compute_alpha(p1, q1,
-                                                        Pot::point_from_id(p2, q2, r2,  q.id2()),
-                                                        Pot::point_from_id(p2, q2, r2, (q.id2()+1)%3));
-
-              return  Point_on_triangle<Kernel>(edge_id_t1, q.id2(), alpha);
-            }
-#ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-            std::cout << " -- case 3\n";
-#endif
-            // point of t1: look for an edge of t1 containing both points
-            CGAL_assertion( p.extra_t1.count(q.id1())!=0 || p.extra_t1.count(3-q.id1()-edge_id_t1)!=0 );
-            int eid1 = p.extra_t1.count(q.id1())!=0 ? q.id1() : 3-q.id1()-edge_id_t1;
-            return  Point_on_triangle<Kernel>((eid1+1)%3==edge_id_t1?edge_id_t1:(edge_id_t1+1)%3, -1); // vertex of t1
-          }
-          // C: (-1, ip2) - (iq1, -1)
-          //vertex of t1, special case t1 edge passed thru a vertex of t2
-          CGAL_assertion(edge_id_t1 == 2);
-#ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-          std::cout << " -- case 4\n";
-#endif
-          CGAL_assertion(q.id1()==1);
-          CGAL_assertion(!p.extra_t1.empty());
-          return  Point_on_triangle<Kernel>(p.extra_t1.count(0)==1?0:2,-1);
+        return (-pid)%3==-qid-1 ? -pid:-qid;
+      }
+      else
+      {
+        return (-pid==qid || (qid)%3==-pid-1) ? qid : 0;
       }
     }
-    default:
+    else
     {
-      switch(p.id2())
+      if (qid<0)
       {
-        case -1:
-        {
-          switch(q.id1())
-          {
-            case -1: // G: (ip1, -1) - (-1, iq2)
-              //vertex of t1, special case t1 edge passed thru a vertex of t2
-#ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-              std::cout << " -- case 5\n";
-#endif
-              CGAL_assertion(edge_id_t1 == 2);
-              CGAL_assertion(p.id1()==1);
-              CGAL_assertion(!q.extra_t1.empty());
-              return  Point_on_triangle<Kernel>(q.extra_t1.count(0)==1?0:2,-1);
-            default:
-            {
-#ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-              std::cout << " -- case 6\n";
-#endif
-              CGAL_assertion(q.id2()!=-1); // I: (ip1, -1) - (iq2, -1)
-              //H: (ip1,-1), (iq1, iq2)
-              CGAL_assertion(edge_id_t1==2);
-              // p and q are on the same edge of t1
-              CGAL_assertion(p.id1()==q.id1() || p.id1()==(q.id1()+1)%3);
-              return  Point_on_triangle<Kernel>((q.id1()+1)%3==edge_id_t1?edge_id_t1:(edge_id_t1+1)%3 , -1);
-            }
-          }
-        }
-        default:
-        {
-          switch(q.id1())
-          {
-            case -1: // D: (ip1, ip2) - (-1, iq2)
-            {
-              if (q.id2() == p.id2() || q.id2() == (p.id2()+1)%3)
-              {
-#ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-                std::cout << " -- case 7\n";
-#endif
-                // points are on the same edge of t2 --> we shorten an already cut edge
-                typename Kernel::FT alpha = compute_alpha(p1, q1,
-                                                          Pot::point_from_id(p2, q2, r2,  p.id2()),
-                                                          Pot::point_from_id(p2, q2, r2, (p.id2()+1)%3));
-
-                return  Point_on_triangle<Kernel>(edge_id_t1, p.id2(), alpha);
-              }
-#ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-              std::cout << " -- case 8\n";
-#endif
-              // point of t1
-              //std::cout << "q.extra_t1: "; for(int qet1 : q.extra_t1) std::cout << " " << qet1; std::cout << "\n";
-              CGAL_assertion( q.extra_t1.count(p.id1())!=0 || q.extra_t1.count(3-p.id1()-edge_id_t1)!=0 );
-              int eid1 = q.extra_t1.count(p.id1())!=0 ? p.id1() : 3-p.id1()-edge_id_t1;
-              return  Point_on_triangle<Kernel>((eid1+1)%3==edge_id_t1?edge_id_t1:(edge_id_t1+1)%3, -1); // vertex of t1
-            }
-            default:
-            {
-              switch(q.id2())
-              {
-                case -1: // F: (ip1, ip2) - (iq1, -1)
-                {
-                  // p and q are on the same edge of t1
-                  CGAL_assertion(q.id1()==p.id1() ||  q.id1()==(p.id1()+1)%3);
-#ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-                  std::cout << " -- case 9\n";
-#endif
-                  return  Point_on_triangle<Kernel>((p.id1()+1)%3==edge_id_t1?edge_id_t1:(edge_id_t1+1)%3 , -1);
-                }
-                default: // E: (ip1, ip2) - (iq1, iq2)
-                {
-                  if (p.id2()==q.id2())
-                  {
-#ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-                    std::cout << " -- case 10\n";
-#endif
-                    typename Kernel::FT alpha = compute_alpha(p1, q1,
-                                                              Pot::point_from_id(p2, q2, r2,  q.id2()),
-                                                              Pot::point_from_id(p2, q2, r2, (q.id2()+1)%3));
-                    return  Point_on_triangle<Kernel>(edge_id_t1, q.id2(), alpha);
-                  }
-                  // we are intersecting an edge of t1
-                  CGAL_assertion(p.id1()==q.id1() || edge_id_t1==2);
-                  int eid1 = p.id1()==q.id1() ? p.id1() : 1;
-                  return  Point_on_triangle<Kernel>((eid1+1)%3==edge_id_t1?edge_id_t1:(edge_id_t1+1)%3, -1); // vertex of t1
-                }
-              }
-            }
-          }
-        }
+        return (-qid==pid || (pid)%3==-qid-1) ? pid : 0;
+      }
+      else
+      {
+        return pid==qid ? pid : 0;
       }
     }
+  };
+
+  int common_eid1 = common_edge_id(p.id1(), q.id1());
+  int common_eid2 = common_edge_id(p.id2(), q.id2());
+
+  if (common_eid1!=0)
+  {
+    CGAL_assertion( (common_eid1)%3==edge_id_t1-1 || (edge_id_t1)%3==common_eid1-1 );
+    int pid1 = (common_eid1)%3==edge_id_t1-1? -edge_id_t1:-common_eid1;
+    return Point_on_triangle<Kernel>(pid1, common_eid2);
+  }
+  else
+  {
+    CGAL_assertion(common_eid2!=0);
+    typename Kernel::FT alpha = compute_alpha(p1, q1,
+                                              Pot::point_from_id(p2, q2, r2, -common_eid2),
+                                              Pot::point_from_id(p2, q2, r2, -(common_eid2)%3-1));
+    return Point_on_triangle<Kernel>(edge_id_t1, common_eid2, alpha);
   }
 }
 
@@ -336,8 +242,17 @@ void intersection_coplanar_triangles_cutoff(const typename Kernel::Point_3& p1,
   for (Point_on_triangle<Kernel>& pot : inter_pts)
   {
     orientations[ &pot ]=pot.orientation(p1,q1,r1,edge_id,p2,q2,r2,k);
-    if (pot.id1()==-1 && orientations[ &pot ]==COLLINEAR)
-      pot.extra_t1.insert(edge_id);
+    if (orientations[ &pot ]==COLLINEAR)
+    {
+      if (pot.id1()==0)
+        pot.set_id1(edge_id);
+      else
+      {
+        CGAL_assertion(pot.id1()>0);
+        CGAL_assertion((edge_id)%3==pot.id1()-1 || (pot.id1())%3==edge_id-1);
+        pot.set_id1( (edge_id)%3==pot.id1()-1 ? -pot.id1(): -edge_id );
+      }
+    }
   }
 
 #ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
@@ -411,30 +326,30 @@ intersection_coplanar_triangles(const typename K::Triangle_3& t1,
                              r2 = t2.vertex(2);
 
   std::list<Point_on_triangle<K>> inter_pts;
-  inter_pts.push_back(Point_on_triangle<K>(-1,0));
-  inter_pts.push_back(Point_on_triangle<K>(-1,1));
-  inter_pts.push_back(Point_on_triangle<K>(-1,2));
+  inter_pts.push_back(Point_on_triangle<K>(0,-1));
+  inter_pts.push_back(Point_on_triangle<K>(0,-2));
+  inter_pts.push_back(Point_on_triangle<K>(0,-3));
 
 #ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
   auto print_points = [&]()
   {
-    for(auto p : inter_pts) std::cout << "  (" << p.id1() << "," << p.id2() << ",[" << p.alpha << "]) "; std::cout <<"\n";
+    for(auto p : inter_pts) {std::cout << "  (" << p.id1() << "," << p.id2() << ",[" << p.alpha << "]) ";} std::cout <<"\n";
   };
   std::cout << "  ipts size: " << inter_pts.size() << "\n";
   print_points();
 #endif
   //intersect t2 with the three half planes which intersection defines t1
-  intersection_coplanar_triangles_cutoff(p1,q1,r1,0,p2,q2,r2,k,inter_pts); //line pq
+  intersection_coplanar_triangles_cutoff(p1,q1,r1,1,p2,q2,r2,k,inter_pts); //line pq
 #ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
   std::cout << "  ipts size: " << inter_pts.size() << "\n";
   print_points();
 #endif
-  intersection_coplanar_triangles_cutoff(q1,r1,p1,1,p2,q2,r2,k,inter_pts); //line qr
+  intersection_coplanar_triangles_cutoff(q1,r1,p1,2,p2,q2,r2,k,inter_pts); //line qr
 #ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
   std::cout << "  ipts size: " << inter_pts.size() << "\n";
   print_points();
 #endif
-  intersection_coplanar_triangles_cutoff(r1,p1,q1,2,p2,q2,r2,k,inter_pts); //line rp
+  intersection_coplanar_triangles_cutoff(r1,p1,q1,3,p2,q2,r2,k,inter_pts); //line rp
 #ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
   std::cout << "  ipts size: " << inter_pts.size() << "\n";
   print_points();

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Triangle_3_Triangle_3_intersection.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Triangle_3_Triangle_3_intersection.h
@@ -137,7 +137,7 @@ struct Point_on_triangle
     if (t1_t2_ids.first<0)
       return point_from_id(p1,q1,r1,t1_t2_ids.first);
 
-    return k.construct_barycenter_3_object()(point_from_id(p1,q1,r1,-(t1_t2_ids.first)%3), alpha,
+    return k.construct_barycenter_3_object()(point_from_id(p1,q1,r1,-(t1_t2_ids.first)%3-1), alpha,
                                              point_from_id(p1,q1,r1,-t1_t2_ids.first)) ;
   }
 };
@@ -164,7 +164,7 @@ intersection(const Point_on_triangle<Kernel>& p,
 #ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
   std::cout << "    calling intersection: ";
   std::cout << " (" << p.id1() << "," << p.id2() << ",[" << p.alpha << "]) -";
-  std::cout << " (" << q.id1() << "," << q.id2() << ",[" << q.alpha << "]) || e" << edge_id_t1;
+  std::cout << " (" << q.id1() << "," << q.id2() << ",[" << q.alpha << "]) || e" << edge_id_t1 << "\n";
 #endif
   typename Kernel::Compute_alpha_for_coplanar_triangle_intersection_3 compute_alpha
     = k.compute_alpha_for_coplanar_triangle_intersection_3_object();
@@ -333,25 +333,22 @@ intersection_coplanar_triangles(const typename K::Triangle_3& t1,
 #ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
   auto print_points = [&]()
   {
+    std::cout << "  ipts size: " << inter_pts.size() << "\n";
     for(auto p : inter_pts) {std::cout << "  (" << p.id1() << "," << p.id2() << ",[" << p.alpha << "]) ";} std::cout <<"\n";
   };
-  std::cout << "  ipts size: " << inter_pts.size() << "\n";
   print_points();
 #endif
   //intersect t2 with the three half planes which intersection defines t1
   intersection_coplanar_triangles_cutoff(p1,q1,r1,1,p2,q2,r2,k,inter_pts); //line pq
 #ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-  std::cout << "  ipts size: " << inter_pts.size() << "\n";
   print_points();
 #endif
   intersection_coplanar_triangles_cutoff(q1,r1,p1,2,p2,q2,r2,k,inter_pts); //line qr
 #ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-  std::cout << "  ipts size: " << inter_pts.size() << "\n";
   print_points();
 #endif
   intersection_coplanar_triangles_cutoff(r1,p1,q1,3,p2,q2,r2,k,inter_pts); //line rp
 #ifdef CGAL_DEBUG_COPLANAR_T3_T3_INTERSECTION
-  std::cout << "  ipts size: " << inter_pts.size() << "\n";
   print_points();
 #endif
 

--- a/Kernel_23/include/CGAL/Kernel_23/internal/Projection_traits_3.h
+++ b/Kernel_23/include/CGAL/Kernel_23/internal/Projection_traits_3.h
@@ -20,6 +20,7 @@
 
 #include <CGAL/Kernel/global_functions_2.h>
 #include <CGAL/Kernel_23/internal/Has_boolean_tags.h>
+#include <CGAL/Triangulation_structural_filtering_traits.h>
 
 namespace CGAL {
 
@@ -1210,6 +1211,14 @@ public:
 };
 
 
-} } //namespace CGAL::internal
+
+} // namespace internal
+
+template <class R, int dim>
+struct Triangulation_structural_filtering_traits<::CGAL::internal::Projection_traits_3<R,dim> > {
+  typedef typename Triangulation_structural_filtering_traits<R>::Use_structural_filtering_tag  Use_structural_filtering_tag;
+};
+
+ } //namespace CGAL
 
 #endif // CGAL_INTERNAL_PROJECTION_TRAITS_3_H

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/autorefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/autorefinement.h
@@ -255,12 +255,12 @@ do_coplanar_segments_intersect(std::size_t pi, std::size_t qi,
 
 // imported from Intersections_3/include/CGAL/Intersections_3/internal/Triangle_3_Triangle_3_intersection.h
 template<class K>
-void coplanar_intersections(const std::vector<typename K::Point_3>& t1,
-                            const std::vector<typename K::Point_3>& t2,
+void coplanar_intersections(const std::array<typename K::Point_3, 3>& t1,
+                            const std::array<typename K::Point_3, 3>& t2,
                             std::vector<std::tuple<typename K::Point_3, int, int>>& inter_pts)
 {
-  const typename K::Point_3& p1 = t1[0], & q1 = t1[1], & r1 = t1[2];
-  const typename K::Point_3& p2 = t2[0], & q2 = t2[1], & r2 = t2[2];
+  const typename K::Point_3& p1 = t1[0], q1 = t1[1], r1 = t1[2];
+  const typename K::Point_3& p2 = t2[0], q2 = t2[1], r2 = t2[2];
 
   std::list<Intersections::internal::Point_on_triangle<K>> l_inter_pts;
   l_inter_pts.push_back(Intersections::internal::Point_on_triangle<K>(0,-1));
@@ -416,8 +416,8 @@ test_edge(const typename K::Point_3& p, const typename K::Point_3& q,
 }
 
 template <class K>
-bool collect_intersections(const std::vector<typename K::Point_3>& t1,
-                           const std::vector<typename K::Point_3>& t2,
+bool collect_intersections(const std::array<typename K::Point_3, 3>& t1,
+                           const std::array<typename K::Point_3, 3>& t2,
                            std::vector<std::tuple<typename K::Point_3, int, int>>& inter_pts)
 {
   // test edges of t1 vs t2
@@ -548,9 +548,10 @@ template <class EK,
 #endif
           class PointVector>
 void generate_subtriangles(std::size_t ti,
-                           std::vector<Triangle_data>& all_triangle_data,
+                           Triangle_data& triangle_data,
                            const std::set<std::pair<std::size_t, std::size_t> >& intersecting_triangles,
                            const std::set<std::pair<std::size_t, std::size_t> >& coplanar_triangles,
+                           const std::vector<std::array<typename EK::Point_3,3>>& triangles,
                            PointVector& new_triangles
                            )
 {
@@ -587,7 +588,6 @@ void generate_subtriangles(std::size_t ti,
 #define CGAL_AUTOREF_COUNTER_INSTRUCTION(X)
 #endif
 
-  Triangle_data& triangle_data=all_triangle_data[ti];
   std::vector<Exact_predicates_exact_constructions_kernel::Point_3>& points=triangle_data.points;
   std::vector<int>& point_locations=triangle_data.point_locations;
   std::vector<std::pair<std::size_t, std::size_t>>& segments=triangle_data.segments;
@@ -680,9 +680,9 @@ void generate_subtriangles(std::size_t ti,
               {
                 CGAL_AUTOREF_COUNTER_INSTRUCTION(counter.timer6.start();)
                 typename EK::Point_3 pt = typename EK::Construct_planes_intersection_point_3()(
-                  all_triangle_data[in_triangle_ids[i]].points[0], all_triangle_data[in_triangle_ids[i]].points[1],all_triangle_data[in_triangle_ids[i]].points[2],
-                  all_triangle_data[in_triangle_ids[j]].points[0], all_triangle_data[in_triangle_ids[j]].points[1],all_triangle_data[in_triangle_ids[j]].points[2],
-                  points[0], points[1],points[2]);
+                  triangles[in_triangle_ids[i]][0], triangles[in_triangle_ids[i]][1],triangles[in_triangle_ids[i]][2],
+                  triangles[in_triangle_ids[j]][0], triangles[in_triangle_ids[j]][1],triangles[in_triangle_ids[j]][2],
+                  triangles[ti][0], triangles[ti][1],triangles[ti][2]);
                 CGAL_AUTOREF_COUNTER_INSTRUCTION(counter.timer6.stop();)
 
                 CGAL_AUTOREF_COUNTER_INSTRUCTION(++counter.c1;)
@@ -831,6 +831,7 @@ void generate_subtriangles(std::size_t ti,
   //typedef CGAL::Constrained_triangulation_plus_2<CDT_2> CDT;
   typedef CDT_2 CDT;
 
+  const std::array<typename EK::Point_3,3>& t = triangles[ti];
   std::vector<typename CDT::Vertex_handle> vhandles(triangle_data.points.size());
 
 #ifdef CGAL_AUTOREF_USE_FIXED_PROJECTION_TRAITS
@@ -838,12 +839,12 @@ void generate_subtriangles(std::size_t ti,
   bool orientation_flipped = false;
   CDT cdt(cdt_traits);
   // TODO: still need to figure out why I can't make the orientation_flipped correctly
-  vhandles[0]=cdt.insert(points[0]);
-  vhandles[1]=cdt.insert(points[1]);
-  vhandles[2]=cdt.insert(points[2]);
+  vhandles[0]=cdt.insert(t[0]);
+  vhandles[1]=cdt.insert(t[1]);
+  vhandles[2]=cdt.insert(t[2]);
 #else
   // positive triangle normal
-  typename EK::Vector_3 n = normal(points[0], points[1], points[2]);
+  typename EK::Vector_3 n = normal(t[0], t[1], t[2]);
   typename EK::Point_3 o(CGAL::ORIGIN);
 
   bool orientation_flipped = false;
@@ -855,14 +856,18 @@ void generate_subtriangles(std::size_t ti,
   P_traits cdt_traits(n);
 
   CDT cdt(cdt_traits);
-  vhandles[0]=cdt.insert_outside_affine_hull(points[0]);
-  vhandles[1]=cdt.insert_outside_affine_hull(points[1]);
+  vhandles[0]=cdt.insert_outside_affine_hull(t[0]);
+  vhandles[1]=cdt.insert_outside_affine_hull(t[1]);
   vhandles[2] = cdt.tds().insert_dim_up(cdt.infinite_vertex(), orientation_flipped);
-  vhandles[2]->set_point(points[2]);
+  vhandles[2]->set_point(t[2]);
 #endif
 
   // insert points and fill vhandles
-  // start by points on edges
+#if 0
+  std::vector<std::size_t> indices(triangle_data.points.size()-3);
+  std::iota(indices.begin(), indices.end(), 3);
+#else
+  //start by points on edges
   std::array<std::vector<std::size_t>, 3> indices_on_edges;
   std::vector<std::size_t> indices;
   for (std::size_t i=3; i<points.size(); ++i)
@@ -928,7 +933,7 @@ void generate_subtriangles(std::size_t ti,
       prev_id=id;
     }
   }
-
+#endif
   // then points in the interior
   typedef typename Pointer_property_map<typename EK::Point_3>::type Pmap;
   typedef Spatial_sort_traits_adapter_2<P_traits,Pmap> Search_traits;
@@ -1102,17 +1107,24 @@ void autorefine_triangle_soup(PointRange& soup_points,
 
   // init the vector of triangles used for the autorefinement of triangles
   typedef CGAL::Exact_predicates_exact_constructions_kernel EK;
+  // even if the info is duplicated with Triangle_data::point, we keep this container
+  // so that we can use it in parallel calls of generate_subtriangles
+  std::vector< std::array<EK::Point_3, 3> > triangles(tiid+1);
   // vector of data for refining triangles
-  std::vector<autorefine_impl::Triangle_data> all_triangle_data(tiid+1);
+  std::vector<autorefine_impl::Triangle_data> all_triangle_data(triangles.size());
   Cartesian_converter<GT, EK> to_exact;
 
   for(Input_TID f : intersected_faces)
   {
     std::size_t tid=tri_inter_ids[f];
+    triangles[tid]= CGAL::make_array(
+      to_exact( get(pm, soup_points[soup_triangles[f][0]]) ),
+      to_exact( get(pm, soup_points[soup_triangles[f][1]]) ),
+      to_exact( get(pm, soup_points[soup_triangles[f][2]]) ) );
     all_triangle_data[tid].points.resize(3);
-    all_triangle_data[tid].points[0]=to_exact( get(pm, soup_points[soup_triangles[f][0]]) );
-    all_triangle_data[tid].points[1]=to_exact( get(pm, soup_points[soup_triangles[f][1]]) );
-    all_triangle_data[tid].points[2]=to_exact( get(pm, soup_points[soup_triangles[f][2]]) );
+    all_triangle_data[tid].points[0]=triangles[tri_inter_ids[f]][0];
+    all_triangle_data[tid].points[1]=triangles[tri_inter_ids[f]][1];
+    all_triangle_data[tid].points[2]=triangles[tri_inter_ids[f]][2];
     all_triangle_data[tid].point_locations.resize(3);
     all_triangle_data[tid].point_locations[0]=-1;
     all_triangle_data[tid].point_locations[1]=-2;
@@ -1134,8 +1146,8 @@ void autorefine_triangle_soup(PointRange& soup_points,
 
     if (i1==-1 || i2==-1) continue; //skip degenerate faces
 
-    const std::vector<EK::Point_3>& t1 = all_triangle_data[i1].points;
-    const std::vector<EK::Point_3>& t2 = all_triangle_data[i2].points;
+    const std::array<EK::Point_3, 3>& t1 = triangles[i1];
+    const std::array<EK::Point_3, 3>& t2 = triangles[i2];
 
     std::vector<std::tuple<EK::Point_3, int, int>> inter_pts;
     bool triangles_are_coplanar = autorefine_impl::collect_intersections<EK>(t1, t2, inter_pts);
@@ -1303,7 +1315,7 @@ void autorefine_triangle_soup(PointRange& soup_points,
 #ifdef CGAL_LINKED_WITH_TBB
   if (parallel_execution)
   {
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, all_triangle_data.size()),
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, triangles.size()),
                       [&](const tbb::blocked_range<size_t>& r) {
                         for (size_t ti = r.begin(); ti != r.end(); ++ti)
                           deduplicate_inserted_segments(ti);
@@ -1312,7 +1324,7 @@ void autorefine_triangle_soup(PointRange& soup_points,
   }
   else
 #endif
-  for (std::size_t ti = 0; ti < all_triangle_data.size(); ++ti) {
+  for (std::size_t ti = 0; ti < triangles.size(); ++ti) {
     deduplicate_inserted_segments(ti);
   }
 
@@ -1333,34 +1345,32 @@ void autorefine_triangle_soup(PointRange& soup_points,
 #endif
 
 #ifdef CGAL_AUTOREF_USE_PROGRESS_DISPLAY
-  boost::timer::progress_display pd(all_triangle_data.size());
+  boost::timer::progress_display pd(triangles.size());
 #endif
 
   auto refine_triangles = [&](std::size_t ti)
   {
     if (all_triangle_data[ti].points.size()==3)
-      new_triangles.push_back({CGAL::make_array(all_triangle_data[ti].points[0],
-                                                all_triangle_data[ti].points[1],
-                                                all_triangle_data[ti].points[2]),
-                               ti});
+      new_triangles.push_back({triangles[ti], ti});
     else
     {
 #ifdef CGAL_AUTOREF_USE_FIXED_PROJECTION_TRAITS
-      typename EK::Vector_3 orth = CGAL::normal(all_triangle_data[ti].points[0], all_triangle_data[ti].points[1], all_triangle_data[ti].points[2]); // TODO::avoid construction?
+      const std::array<typename EK::Point_3, 3>& t = triangles[ti];
+      typename EK::Vector_3 orth = CGAL::normal(t[0], t[1], t[2]); // TODO::avoid construction?
       int c = CGAL::abs(orth[0]) > CGAL::abs(orth[1]) ? 0 : 1;
       c = CGAL::abs(orth[2]) > CGAL::abs(orth[c]) ? 2 : c;
 
       if (c == 0) {
-        autorefine_impl::generate_subtriangles<EK, 0>(ti, all_triangle_data, intersecting_triangles, coplanar_triangles, new_triangles);
+        autorefine_impl::generate_subtriangles<EK, 0>(ti, all_triangle_data[ti], intersecting_triangles, coplanar_triangles, triangles, new_triangles);
       }
       else if (c == 1) {
-        autorefine_impl::generate_subtriangles<EK, 1>(ti, all_triangle_data, intersecting_triangles, coplanar_triangles, new_triangles);
+        autorefine_impl::generate_subtriangles<EK, 1>(ti, all_triangle_data[ti], intersecting_triangles, coplanar_triangles, triangles, new_triangles);
       }
       else if (c == 2) {
-        autorefine_impl::generate_subtriangles<EK, 2>(ti, all_triangle_data, intersecting_triangles, coplanar_triangles, new_triangles);
+        autorefine_impl::generate_subtriangles<EK, 2>(ti, all_triangle_data[ti], intersecting_triangles, coplanar_triangles, triangles, new_triangles);
       }
 #else
-      autorefine_impl::generate_subtriangles<EK>(ti, all_triangle_data, intersecting_triangles, coplanar_triangles, new_triangles);
+      autorefine_impl::generate_subtriangles<EK>(ti, all_triangle_data[ti], intersecting_triangles, coplanar_triangles, triangles, new_triangles);
 #endif
     }
 
@@ -1375,7 +1385,7 @@ void autorefine_triangle_soup(PointRange& soup_points,
 #ifdef CGAL_LINKED_WITH_TBB
   if (parallel_execution)
   {
-    tbb::parallel_for(tbb::blocked_range<size_t>(0, all_triangle_data.size()),
+    tbb::parallel_for(tbb::blocked_range<size_t>(0, triangles.size()),
                       [&](const tbb::blocked_range<size_t>& r) {
                         for (size_t ti = r.begin(); ti != r.end(); ++ti)
                           refine_triangles(ti);
@@ -1384,7 +1394,7 @@ void autorefine_triangle_soup(PointRange& soup_points,
   }
   else
 #endif
-  for (std::size_t ti = 0; ti < all_triangle_data.size(); ++ti) {
+  for (std::size_t ti = 0; ti < triangles.size(); ++ti) {
     refine_triangles(ti);
   }
 
@@ -1441,7 +1451,7 @@ void autorefine_triangle_soup(PointRange& soup_points,
   }
 
   // raw copy of input triangles with no intersection
-  std::vector<std::size_t> tri_inter_ids_inverse(all_triangle_data.size());
+  std::vector<std::size_t> tri_inter_ids_inverse(triangles.size());
   for (Input_TID f=0; f<soup_triangles.size(); ++f)
   {
     if (is_degen[f]) continue; //skip degenerate faces

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/autorefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/autorefinement.h
@@ -486,7 +486,6 @@ bool collect_intersections(const std::array<typename K::Point_3, 3>& t1,
   return false;
 }
 
-//TODO: rename struct
 struct Triangle_data
 {
   using Point_3 = Exact_predicates_exact_constructions_kernel::Point_3;
@@ -950,7 +949,6 @@ void generate_subtriangles(std::size_t ti,
 
   for (const std::pair<std::size_t, std::size_t>& ids : triangle_data.segments)
   {
-    //TODO remove me
     CGAL_assertion(ids.first < vhandles.size());
     CGAL_assertion(ids.second < vhandles.size());
     CGAL_assertion( vhandles[ids.first]!= typename CDT::Vertex_handle() );

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/autorefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/autorefinement.h
@@ -259,8 +259,8 @@ void coplanar_intersections(const std::array<typename K::Point_3, 3>& t1,
                             const std::array<typename K::Point_3, 3>& t2,
                             std::vector<std::tuple<typename K::Point_3, int, int>>& inter_pts)
 {
-  const typename K::Point_3& p1 = t1[0], q1 = t1[1], r1 = t1[2];
-  const typename K::Point_3& p2 = t2[0], q2 = t2[1], r2 = t2[2];
+  const typename K::Point_3& p1 = t1[0], &q1 = t1[1], &r1 = t1[2];
+  const typename K::Point_3& p2 = t2[0], &q2 = t2[1], &r2 = t2[2];
 
   std::list<Intersections::internal::Point_on_triangle<K>> l_inter_pts;
   l_inter_pts.push_back(Intersections::internal::Point_on_triangle<K>(0,-1));

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/autorefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/autorefinement.h
@@ -468,10 +468,10 @@ bool collect_intersections(const std::array<typename K::Point_3, 3>& t1,
     }
   }
 
-  #warning TODO get rid of sort and unique calls
+//  #warning TODO get rid of sort and unique calls
   // because we don't handle intersection type and can have edge-edge edge-vertex duplicates
-  std::sort(inter_pts.begin(), inter_pts.end(), [](auto p, auto q){return get<0>(p)<get<0>(q);});
-  auto last = std::unique(inter_pts.begin(), inter_pts.end(), [](auto p, auto q){return get<0>(p)==get<0>(q);});
+  std::sort(inter_pts.begin(), inter_pts.end(), [](auto p, auto q){return std::get<0>(p)<std::get<0>(q);});
+  auto last = std::unique(inter_pts.begin(), inter_pts.end(), [](auto p, auto q){return std::get<0>(p)==std::get<0>(q);});
   inter_pts.erase(last, inter_pts.end());
 
 #ifdef CGAL_AUTOREF_DEBUG_DEPTH
@@ -493,10 +493,10 @@ struct Triangle_data
   template <int i>
   std::size_t add_point(const std::tuple<Point_3,int, int>& tpl)
   {
-    if (get<i>(tpl) < 0)
-      return -get<i>(tpl)-1;
-    points.push_back(get<0>(tpl));
-    point_locations.push_back(get<i>(tpl));
+    if (std::get<i>(tpl) < 0)
+      return -std::get<i>(tpl)-1;
+    points.push_back(std::get<0>(tpl));
+    point_locations.push_back(std::get<i>(tpl));
     return points.size()-1;
   }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/autorefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/autorefinement.h
@@ -55,7 +55,7 @@
 #endif
 #endif
 
-#ifdef USE_FIXED_PROJECTION_TRAITS
+#ifdef CGAL_AUTOREF_USE_FIXED_PROJECTION_TRAITS
 #include <CGAL/Kernel_23/internal/Projection_traits_3.h>
 #endif
 
@@ -544,7 +544,7 @@ struct Triangle_data
 };
 
 template <class EK,
-#ifdef USE_FIXED_PROJECTION_TRAITS
+#ifdef CGAL_AUTOREF_USE_FIXED_PROJECTION_TRAITS
           int dim,
 #endif
           class PointVector>
@@ -820,7 +820,7 @@ void generate_subtriangles(std::size_t ti,
 
 // init CDT + insert points and constraints
   CGAL_AUTOREF_COUNTER_INSTRUCTION(counter.timer3.start();)
-#ifdef USE_FIXED_PROJECTION_TRAITS
+#ifdef CGAL_AUTOREF_USE_FIXED_PROJECTION_TRAITS
   typedef ::CGAL::internal::Projection_traits_3<EK, dim> P_traits;
 #else
   typedef CGAL::Projection_traits_3<EK> P_traits;
@@ -835,7 +835,7 @@ void generate_subtriangles(std::size_t ti,
   const std::array<typename EK::Point_3,3>& t = triangles[ti];
   std::vector<typename CDT::Vertex_handle> vhandles(triangle_data.points.size());
 
-#ifdef USE_FIXED_PROJECTION_TRAITS
+#ifdef CGAL_AUTOREF_USE_FIXED_PROJECTION_TRAITS
   P_traits cdt_traits;
   bool orientation_flipped = false;
   CDT cdt(cdt_traits);
@@ -1354,7 +1354,7 @@ void autorefine_triangle_soup(PointRange& soup_points,
       new_triangles.push_back({triangles[ti], ti});
     else
     {
-#ifdef USE_FIXED_PROJECTION_TRAITS
+#ifdef CGAL_AUTOREF_USE_FIXED_PROJECTION_TRAITS
       const std::array<typename EK::Point_3, 3>& t = triangles[ti];
       typename EK::Vector_3 orth = CGAL::normal(t[0], t[1], t[2]); // TODO::avoid construction?
       int c = CGAL::abs(orth[0]) > CGAL::abs(orth[1]) ? 0 : 1;

--- a/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_Delaunay_triangulation_2.h
@@ -342,6 +342,25 @@ public:
       return number_of_vertices() - n;
     }
 
+  // function usable only if no constraint has been inserted
+  void restore_Delaunay(Vertex_handle v)
+  {
+    if(this->dimension() <= 1) return;
+
+    Face_handle f=v->face();
+    Face_handle next;
+    int i;
+    Face_handle start(f);
+    do {
+      i = f->index(v);
+      next = f->neighbor(ccw(i));  // turn ccw around v
+      propagating_flip(f,i);
+      f = next;
+    } while(next != start);
+    return;
+  }
+
+
 #ifndef CGAL_TRIANGULATION_2_DONT_INSERT_RANGE_OF_POINTS_WITH_INFO
 private:
   //top stands for tuple-or-pair

--- a/Triangulation_2/include/CGAL/Triangulation_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2.h
@@ -35,6 +35,7 @@
 #include <CGAL/Triangulation_2/internal/Triangulation_line_face_circulator_2.h>
 #include <CGAL/spatial_sort.h>
 #include <CGAL/Spatial_sort_traits_adapter_2.h>
+#include <CGAL/Kernel_23/internal/Projection_traits_3.h>
 
 #include <CGAL/double.h>
 
@@ -433,6 +434,81 @@ protected:
 
   bool has_inexact_negative_orientation(const Point &p, const Point &q,
                                         const Point &r) const;
+
+
+
+template <class T>
+inline
+bool
+projection_traits_has_inexact_negative_orientation(const Point &p, const Point &q, const Point &r,
+                                                   const T& ) const
+{
+  // So that this code works well with Lazy_kernel
+  internal::Static_filters_predicates::Get_approx<Point> get_approx;
+
+  const double px = to_double(get_approx(p).x());
+  const double py = to_double(get_approx(p).y());
+  const double qx = to_double(get_approx(q).x());
+  const double qy = to_double(get_approx(q).y());
+  const double rx = to_double(get_approx(r).x());
+  const double ry = to_double(get_approx(r).y());
+
+  const double pqx = qx - px;
+  const double pqy = qy - py;
+  const double prx = rx - px;
+  const double pry = ry - py;
+
+  return ( determinant(pqx, pqy, prx, pry) < 0);
+}
+
+template <class T>
+inline
+bool
+projection_traits_has_inexact_negative_orientation(const Point &p, const Point &q, const Point &r,
+                                                   const ::CGAL::internal::Projection_traits_3<T,0>& ) const
+{  // So that this code works well with Lazy_kernel
+  internal::Static_filters_predicates::Get_approx<Point> get_approx;
+
+  const double px = to_double(get_approx(p).y());
+  const double py = to_double(get_approx(p).z());
+  const double qx = to_double(get_approx(q).y());
+  const double qy = to_double(get_approx(q).z());
+  const double rx = to_double(get_approx(r).y());
+  const double ry = to_double(get_approx(r).z());
+
+  const double pqx = qx - px;
+  const double pqy = qy - py;
+  const double prx = rx - px;
+  const double pry = ry - py;
+
+  return ( determinant(pqx, pqy, prx, pry) < 0);
+}
+
+
+template <class T>
+inline
+bool
+projection_traits_has_inexact_negative_orientation(const Point &p, const Point &q, const Point &r,
+                                                   const ::CGAL::internal::Projection_traits_3<T,1>& ) const
+{  // So that this code works well with Lazy_kernel
+  internal::Static_filters_predicates::Get_approx<Point> get_approx;
+
+  const double px = to_double(get_approx(p).x());
+  const double py = to_double(get_approx(p).z());
+  const double qx = to_double(get_approx(q).x());
+  const double qy = to_double(get_approx(q).z());
+  const double rx = to_double(get_approx(r).x());
+  const double ry = to_double(get_approx(r).z());
+
+  const double pqx = qx - px;
+  const double pqy = qy - py;
+  const double prx = rx - px;
+  const double pry = ry - py;
+
+  return ( determinant(pqx, pqy, prx, pry) < 0);
+}
+
+
 
 public:
   Face_handle
@@ -3152,6 +3228,7 @@ inexact_locate(const Point & t, Face_handle start, int n_of_turns) const
   return c;
 }
 
+
 template <class Gt, class Tds >
 inline
 bool
@@ -3159,22 +3236,8 @@ Triangulation_2<Gt, Tds>::
 has_inexact_negative_orientation(const Point &p, const Point &q,
                                  const Point &r) const
 {
-  // So that this code works well with Lazy_kernel
-  internal::Static_filters_predicates::Get_approx<Point> get_approx;
-
-  const double px = to_double(get_approx(p).x());
-  const double py = to_double(get_approx(p).y());
-  const double qx = to_double(get_approx(q).x());
-  const double qy = to_double(get_approx(q).y());
-  const double rx = to_double(get_approx(r).x());
-  const double ry = to_double(get_approx(r).y());
-
-  const double pqx = qx - px;
-  const double pqy = qy - py;
-  const double prx = rx - px;
-  const double pry = ry - py;
-
-  return ( determinant(pqx, pqy, prx, pry) < 0);
+  Gt gt;
+  return projection_traits_has_inexact_negative_orientation(p,q,r,gt);
 }
 #endif
 


### PR DESCRIPTION
Collect intersection points on edges and in faces to use CDT dedicated functions.
Also add structural filtering with projection traits and restore "classical" projection traits for testing.