### PR TITLE
Aos_2, AABB_tree: Address warnings

### DIFF
--- a/AABB_tree/include/CGAL/AABB_tree/internal/AABB_traversal_traits.h
+++ b/AABB_tree/include/CGAL/AABB_tree/internal/AABB_traversal_traits.h
@@ -73,7 +73,7 @@ public:
   Result;
 public:
   First_intersection_traits(const AABBTraits& traits)
-    : m_result(), m_traits(traits)
+    : m_result(std::nullopt), m_traits(traits)
   {}
 
   bool go_further() const {
@@ -202,7 +202,7 @@ class First_primitive_traits
 public:
   First_primitive_traits(const AABBTraits& traits)
     : m_is_found(false)
-    , m_result()
+    , m_result(std::nullopt)
     , m_traits(traits) {}
 
   bool go_further() const { return !m_is_found; }

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/Utils/IntersectCurves.cpp
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/Utils/IntersectCurves.cpp
@@ -11,7 +11,7 @@
 
 #include "IntersectCurves.h"
 #include "ArrangementTypes.h"
-#include <boost/function_output_iterator.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 
 template <typename Traits_>

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_internals.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_internals.h
@@ -90,8 +90,11 @@ struct Pixel_2_
 
     Integer sub_x, sub_y; // subpixel coordinates relative to pixel's boundary
                           // (always 0 for pixels)
+    Pixel_2_() = default;
 
-    Pixel_2_& operator =(const Pixel_2_& pix) = default;
+    Pixel_2_(const Pixel_2_&) = default;
+
+    Pixel_2_& operator =(const Pixel_2_&) = default;
 
     bool operator ==(const Pixel_2_& pix) const {
         return (

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_internals.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/gfx/Curve_renderer_internals.h
@@ -90,11 +90,6 @@ struct Pixel_2_
 
     Integer sub_x, sub_y; // subpixel coordinates relative to pixel's boundary
                           // (always 0 for pixels)
-    Pixel_2_() = default;
-
-    Pixel_2_(const Pixel_2_&) = default;
-
-    Pixel_2_& operator =(const Pixel_2_&) = default;
 
     bool operator ==(const Pixel_2_& pix) const {
         return (


### PR DESCRIPTION
## Summary of Changes

Add a default and copy constructor to fix [this warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.0-Ic-169/Arrangement_on_surface_2_Demo/TestReport_Taylor_macOS-Apple_M2-boost_backend-arm64.gz)

Initialize with `std::nullopt` to try to fix [this warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.0-Ic-169/Tetrahedral_remeshing/TestReport_lrineau_Debian-stable-Release.gz)

Also include a on-deprecated boost header.

## Release Management

* Affected package(s): AABB_tree, Arrangement_on_surface_2
* License and copyright ownership: unchanged

