### PR TITLE
Call 3d static filters from NewKernel_d

### DIFF
--- a/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_static_filters.h
+++ b/NewKernel_d/include/CGAL/NewKernel_d/Cartesian_static_filters.h
@@ -16,6 +16,8 @@
 #include <CGAL/Filtered_kernel/internal/Static_filters/tools.h> // bug, should be included by the next one
 #include <CGAL/Filtered_kernel/internal/Static_filters/Orientation_2.h>
 #include <CGAL/Filtered_kernel/internal/Static_filters/Side_of_oriented_circle_2.h>
+#include <CGAL/Filtered_kernel/internal/Static_filters/Orientation_3.h>
+#include <CGAL/Filtered_kernel/internal/Static_filters/Side_of_oriented_sphere_3.h>
 
 namespace CGAL {
 namespace SFA { // static filter adapter
@@ -80,7 +82,72 @@ template <class Base_,class R_> struct Side_of_oriented_sphere_2 : private Store
                 return typename internal::Static_filters_predicates::Side_of_oriented_circle_2<Adapter>()(P(this->kernel(),c,A),P(this->kernel(),c,B),P(this->kernel(),c,C),P(this->kernel(),c,D));
         }
 };
-}
+
+template <class Base_,class R_> struct Adapter_3 {
+        typedef typename Get_type<R_, Point_tag>::type Point;
+        typedef typename Get_functor<R_, Compute_point_cartesian_coordinate_tag>::type CC;
+        typedef typename Get_functor<Base_, Orientation_of_points_tag>::type Orientation_base;
+        typedef typename Get_functor<Base_, Side_of_oriented_sphere_tag>::type Side_of_oriented_sphere_base;
+        struct Point_3 {
+                R_ const&r; CC const&c; Point const& p;
+                Point_3(R_ const&r_, CC const&c_, Point const&p_):r(r_),c(c_),p(p_){}
+                decltype(auto) x()const{return c(p,0);}
+                decltype(auto) y()const{return c(p,1);}
+                decltype(auto) z()const{return c(p,2);}
+        };
+        struct Vector_3 {};
+        struct Sphere_3 {};
+        struct Tetrahedron_3 {};
+        struct Orientation_3 {
+                typedef typename Get_type<R_, Orientation_tag>::type result_type;
+                auto operator()(Point_3 const&A, Point_3 const&B, Point_3 const&C, Point_3 const&D)const{
+                        Point const* t[]={&A.p,&B.p,&C.p,&D.p};
+                        return Orientation_base(A.r)(make_transforming_iterator<Dereference_functor>(t+0),make_transforming_iterator<Dereference_functor>(t+4));
+                }
+        };
+        struct Side_of_oriented_sphere_3 {
+                typedef typename Get_type<R_, Oriented_side_tag>::type result_type;
+                auto operator()(Point_3 const&A, Point_3 const&B, Point_3 const&C, Point_3 const&D, Point_3 const&E)const{
+                        Point const* t[]={&A.p,&B.p,&C.p,&D.p};
+                        return Side_of_oriented_sphere_base(A.r)(make_transforming_iterator<Dereference_functor>(t+0),make_transforming_iterator<Dereference_functor>(t+4),E.p);
+                }
+        };
+};
+template <class Base_,class R_> struct Orientation_of_points_3 : private Store_kernel<R_> {
+        CGAL_FUNCTOR_INIT_STORE(Orientation_of_points_3)
+        typedef typename Get_type<R_, Point_tag>::type Point;
+        typedef typename Get_type<R_, Orientation_tag>::type result_type;
+        typedef typename Get_functor<R_, Compute_point_cartesian_coordinate_tag>::type CC;
+        typedef Adapter_3<Base_, R_> Adapter;
+        template<class Iter> result_type operator()(Iter f, Iter CGAL_assertion_code(e))const{
+                CC c(this->kernel());
+                Point const& A=*f;
+                Point const& B=*++f;
+                Point const& C=*++f;
+                Point const& D=*++f;
+                CGAL_assertion(++f==e);
+                typedef typename Adapter::Point_3 P;
+                return typename internal::Static_filters_predicates::Orientation_3<Adapter>()(P(this->kernel(),c,A),P(this->kernel(),c,B),P(this->kernel(),c,C),P(this->kernel(),c,D));
+        }
+};
+template <class Base_,class R_> struct Side_of_oriented_sphere_3 : private Store_kernel<R_> {
+        CGAL_FUNCTOR_INIT_STORE(Side_of_oriented_sphere_3)
+        typedef typename Get_type<R_, Point_tag>::type Point;
+        typedef typename Get_type<R_, Oriented_side_tag>::type result_type;
+        typedef typename Get_functor<R_, Compute_point_cartesian_coordinate_tag>::type CC;
+        typedef Adapter_3<Base_, R_> Adapter;
+        template<class Iter> result_type operator()(Iter f, Iter CGAL_assertion_code(e), Point const& E)const{
+                CC c(this->kernel());
+                Point const& A=*f;
+                Point const& B=*++f;
+                Point const& C=*++f;
+                Point const& D=*++f;
+                CGAL_assertion(++f==e);
+                typedef typename Adapter::Point_3 P;
+                return typename internal::Static_filters_predicates::Side_of_oriented_sphere_3<Adapter>()(P(this->kernel(),c,A),P(this->kernel(),c,B),P(this->kernel(),c,C),P(this->kernel(),c,D),P(this->kernel(),c,E));
+        }
+};
+} // namespace SFA
 
 template <class Dim_ /* should be implicit */, class R_, class Derived_=Default>
 struct Cartesian_static_filters : public R_ {
@@ -109,6 +176,19 @@ struct Cartesian_static_filters<Dimension_tag<2>, R_, Derived_> : public R_ {
         };
 };
 
-}
-
+template <class R_, class Derived_>
+struct Cartesian_static_filters<Dimension_tag<3>, R_, Derived_> : public R_ {
+  constexpr Cartesian_static_filters(){}
+  constexpr Cartesian_static_filters(int d):R_(d){}
+        typedef Cartesian_static_filters<Dimension_tag<3>, R_, Derived_> Self;
+        typedef typename Default::Get<Derived_,Self>::type Derived;
+        template <class T, class=void> struct Functor : Inherit_functor<R_, T> {};
+        template <class D> struct Functor <Orientation_of_points_tag,D> {
+                typedef SFA::Orientation_of_points_3<R_,Derived> type;
+        };
+        template <class D> struct Functor <Side_of_oriented_sphere_tag,D> {
+                typedef SFA::Side_of_oriented_sphere_3<R_,Derived> type;
+        };
+};
+} // namespace CGAL
 #endif


### PR DESCRIPTION
## Summary of Changes

NewKernel_d already had wrappers so it could call some 2d static filters. I blindly copy-pasted so it could also handle 3d.
IIRC, those static filters were just a proof of concept and could do with more work (I don't think they are used by Epeck_d for instance), but I don't have a lot of time for it, and this simple patch (minimal effort) immediately gave a nice speed-up when building a Delaunay triangulation with `Epick_d<Dimension_tag<3>>` (enough that it isn't worth having a special case for 3d using Delaunay_triangulation_3 in my application). I might add the weighted versions in another PR later...

The main issue with all those filters is that it isn't clear if the testsuite really tests all the layers, but for now it should be ok since Epeck_d does not use static filters.

## Release Management

* Affected package(s): NewKernel_d
* License and copyright ownership: unchanged