### PR TITLE
Use 'if' rather than %

### DIFF
--- a/Triangulation/include/CGAL/Triangulation.h
+++ b/Triangulation/include/CGAL/Triangulation.h
@@ -993,7 +993,7 @@ Triangulation<TT, TDS>
             // Otherwise, let's find the right infinite cell
             else
             {
-                inf_v_cell = inf_v_cell->neighbor((inf_v_index + 1) % 2);
+                inf_v_cell = inf_v_cell->neighbor((inf_v_index + 1) & 1);
                 inf_v_index = inf_v_cell->index(infinite_vertex());
                 // Is "inf_v_cell" the right infinite cell?
                 // Then inf_v_index should be 1
@@ -1096,9 +1096,14 @@ Triangulation<TT, TDS>
         // For the remembering stochastic walk, we need to start trying
         // with a random index:
         int j, i = rng_.get_int(0, cur_dim);
-        // we check |p| against all the full_cell's hyperplanes in turn
 
-        for(j = 0; j <= cur_dim; ++j, i = (i + 1) % (cur_dim + 1) )
+        // i = (i + 1) % m where 0 <= i < m
+        auto incr_mod = [] (int&i, int m) {
+          if( ++i >= m ) i = 0; // >= or ==
+        };
+
+        // we check |p| against all the full_cell's hyperplanes in turn
+        for(j = 0; j <= cur_dim; ++j, incr_mod(i, cur_dim + 1))
         {
             Full_cell_handle next = s->neighbor(i);
             if( previous == next )
@@ -1127,6 +1132,9 @@ Triangulation<TT, TDS>
             // full_cell because orientation_[i] == NEGATIVE
             previous = s;
             s = next;
+            // We only need to test is_infinite(next->vertex(next->index(previous)))
+            // or equivalently is_infinite(next->vertex(previous->mirror_index(i)))
+            // but it does not seem to help, even when storing mirror indices.
             if( is_infinite(next) )
             {   // we have arrived OUTSIDE the convex hull of the triangulation,
                 // so we stop the search


### PR DESCRIPTION
## Summary of Changes

On my system (x86_64, gcc), to compute `(i+1)%m`, the version with `if` is consistently faster than the version with a division (`%`). For instance, with `benchmark/Triangulation/delaunay.cpp`
master
> Delaunay triangulation of 25000000 points in dim 2:
>  Done in 29.5709 seconds.

PR
>   Done in 28.6321 seconds.

ISTR reading a comparison of all the variants that were tried in Triangulation_23, for the same purpose of cycling through the neighbors of a cell, but I cannot find it anymore. Whether the dimension is a constant known at compile-time may play a role here.

The other 2 changes are less important but don't really deserve their own PR.
* the compiler needs to know that i is nonnegative to replace `i%2` with `i&1`, so help it
* `is_infinite(Face)` appears quite high when profiling my application. It checks if any of the vertices is infinite, but in most cases that's redundant since we walk from a neighboring finite cell. However, identifying the index of the new vertex is even more costly with the default policy, and even with the policy of storing mirror indexes I didn't manage to gain anything significant (maybe most of the cost is reading memory, and those reads happen later anyway?). So I just added a comment.

## Release Management

* Affected package(s): Triangulation
* License and copyright ownership: unchanged