### PR TITLE
Store index/dimension in 8 bits

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -76,6 +76,9 @@ Release date: October 2023
 -   Added three functions `vertices()` to the class `Triangulation_3`.
     Each of them returns an array containing the vertices of the given triangulation simplex.
 
+### [dD Triangulations](https://doc.cgal.org/6.0/Manual/packages.html#PkgTriangulations)
+-   **Breaking change**: `CGAL::TDS_full_cell_mirror_storage_policy` is now unsupported in dimension larger than 127.
+
 [Release 5.6](https://github.com/CGAL/cgal/releases/tag/v5.6)
 -----------
 

--- a/Triangulation/doc/Triangulation/CGAL/Triangulation_ds_full_cell.h
+++ b/Triangulation/doc/Triangulation/CGAL/Triangulation_ds_full_cell.h
@@ -37,7 +37,7 @@ indices are not stored).
 <LI>`CGAL::TDS_full_cell_default_storage_policy`. In that case, the mirror
 indices are not stored.
 <LI>`CGAL::TDS_full_cell_mirror_storage_policy`. In that case, the mirror
-indices are stored.
+indices are stored. This last policy is not supported when the dimension is larger than 127.
 </UL>
 See the user manual for how to choose the second option.
 

--- a/Triangulation/include/CGAL/TDS_full_cell_mirror_storage_policy.h
+++ b/Triangulation/include/CGAL/TDS_full_cell_mirror_storage_policy.h
@@ -14,8 +14,8 @@
 
 #include <CGAL/license/Triangulation.h>
 
-
 #include <CGAL/TDS_full_cell_default_storage_policy.h>
+#include <cstdint>
 
 namespace CGAL {
 
@@ -30,7 +30,7 @@ struct   TFC_data< Vertex_handle, Full_cell_handle, Maximal_dimension, TDS_full_
     typedef TFC_data< Vertex_handle, Full_cell_handle, Maximal_dimension, TDS_full_cell_default_storage_policy > Base;
     typedef typename Base::Vertex_handle_array          Vertex_handle_array;
     typedef typename Base::Full_cell_handle_array         Full_cell_handle_array;
-    typedef typename internal::S_or_D_array< int, typename Base::Dimen_plus >   Int_array;
+    typedef typename internal::S_or_D_array< std::uint_least8_t, typename Base::Dimen_plus >   Int_array;
 
 private:
     Int_array            mirror_vertices_;
@@ -42,7 +42,7 @@ public:
 
     void set_mirror_index(const int i, const int index)
     {
-        mirror_vertices_[i] = index;
+        mirror_vertices_[i] = static_cast<std::uint_least8_t>(index);
     }
     int mirror_index(const int i) const
     {

--- a/Triangulation/include/CGAL/TDS_full_cell_mirror_storage_policy.h
+++ b/Triangulation/include/CGAL/TDS_full_cell_mirror_storage_policy.h
@@ -30,7 +30,7 @@ struct   TFC_data< Vertex_handle, Full_cell_handle, Maximal_dimension, TDS_full_
     typedef TFC_data< Vertex_handle, Full_cell_handle, Maximal_dimension, TDS_full_cell_default_storage_policy > Base;
     typedef typename Base::Vertex_handle_array          Vertex_handle_array;
     typedef typename Base::Full_cell_handle_array         Full_cell_handle_array;
-    typedef typename internal::S_or_D_array< std::uint_least8_t, typename Base::Dimen_plus >   Int_array;
+    typedef typename internal::S_or_D_array< std::int_least8_t, typename Base::Dimen_plus >   Int_array;
 
 private:
     Int_array            mirror_vertices_;
@@ -42,7 +42,7 @@ public:
 
     void set_mirror_index(const int i, const int index)
     {
-        mirror_vertices_[i] = static_cast<std::uint_least8_t>(index);
+        mirror_vertices_[i] = static_cast<std::int_least8_t>(index);
     }
     int mirror_index(const int i) const
     {


### PR DESCRIPTION
## Summary of Changes

What dimensions do we want to support in the Triangulation package? The optional policy to store mirror indexes in the full cells of the TDS currently uses an `int` to store an index. Since indexes are bounded by the dimension (+1), that seems like a waste of memory. Using `uint8_t` is sufficient up to dimension ~250, reduces the memory overhead of this policy significantly, and improves performance a bit. Is it ok to assume that the dimension fits in 8 bits (with a bit of margin), or do I need to use some meta-programming so it uses different types depending on the dimension?

For a dynamic dimension, having a whole vector for the mirror indexes remains a large overhead even if it is a `vector<char>`. Since we only need to store ~ d numbers of log(d) bits, a single 64-bit integer should suffice to handle dimensions up to ~ 15 (i.e. the ones I care about). Or the 3 vectors (vertices, neighbors, mirror indices) could be merged into a single vector. And we could reduce a bit the overhead by using `unique_ptr<T[]>` instead of vector, since the size is fixed at construction. But that's all for later, once I have an idea what dimensions are relevant.

## Release Management

* Affected package(s): Triangulation
* License and copyright ownership: unchanged