### PR TITLE
Set focus to the ok button

### DIFF
--- a/Polyhedron/demo/Polyhedron/File_loader_dialog.h
+++ b/Polyhedron/demo/Polyhedron/File_loader_dialog.h
@@ -19,6 +19,7 @@ class File_loader_dialog : public QDialog, private Ui::FileLoaderDialog
     {
       File_loader_dialog dialog;
       dialog.buttonBox->button(QDialogButtonBox::Ok)->setDefault(true);
+      dialog.buttonBox->button(QDialogButtonBox::Ok)->setFocus();
       dialog.pluginBox->addItems(item_list);
       dialog.label->setText(tr("Available loaders for %1 :").arg(filename));
       QFileInfo fileinfo(filename);


### PR DESCRIPTION
make sure pressing enter always pick the proposed loader by default (the behavior seemed to be platform specific, now it should be uniform).