### PR TITLE
Using std::optional for Property_container::get<T>

### DIFF
--- a/BGL/test/BGL/test_Collapse_edge_with_constraints.cpp
+++ b/BGL/test/BGL/test_Collapse_edge_with_constraints.cpp
@@ -11,9 +11,8 @@ typedef Mesh::Property_map<Mesh::Edge_index, bool> ECM;
 
 bool test_one_side(Mesh::Halfedge_index h, Mesh m)
 {
-  std::pair<ECM, bool> ecm_and_bool = m.property_map<Mesh::Edge_index, bool>("ecm");
   Mesh::Vertex_index vkept=target(h, m);
-  CGAL::Euler::collapse_edge(edge(h, m), m, ecm_and_bool.first);
+  CGAL::Euler::collapse_edge(edge(h, m), m, m.property_map<Mesh::Edge_index, bool>("ecm").value());
   return (!m.is_removed(vkept) && CGAL::is_valid_polygon_mesh(m));
 }
 

--- a/Basic_viewer/examples/Basic_viewer/draw_surface_mesh_small_faces.cpp
+++ b/Basic_viewer/examples/Basic_viewer/draw_surface_mesh_small_faces.cpp
@@ -33,12 +33,12 @@ struct Graphics_scene_options_small_faces:
     if(!m_with_size)
     { return; }
 
-    m_min_size=(*faces_size)[*(sm.faces().begin())];
+    m_min_size=faces_size.value()[*(sm.faces().begin())];
     m_max_size=m_min_size;
     FT cur_size;
     for (typename SM::Face_range::iterator f=sm.faces().begin(); f!=sm.faces().end(); ++f)
     {
-      cur_size=(*faces_size)[*f];
+      cur_size=faces_size.value()[*f];
       if (cur_size<m_min_size) m_min_size=cur_size;
       if (cur_size>m_max_size) m_max_size=cur_size;
     }
@@ -62,11 +62,11 @@ struct Graphics_scene_options_small_faces:
     // Compare the size of the face with the % m_threshold
     bool exist;
     std::optional<typename SM::template Property_map<face_descriptor, FT>> faces_size
-      =sm.template property_map<face_descriptor, FT>("f:size");
+      = sm.template property_map<face_descriptor, FT>("f:size");
     assert(faces_size.has_value());
 
     // If the face is small, color it in red.
-    if (get(*faces_size, fh)<m_min_size+((m_max_size-m_min_size)/(100-m_threshold)))
+    if (get(faces_size.value(), fh)<m_min_size + ((m_max_size - m_min_size) / (100 - m_threshold)))
     { return CGAL::IO::Color(255,20,20); }
 
     return c; // Default color

--- a/Basic_viewer/examples/Basic_viewer/draw_surface_mesh_small_faces.cpp
+++ b/Basic_viewer/examples/Basic_viewer/draw_surface_mesh_small_faces.cpp
@@ -27,17 +27,18 @@ struct Graphics_scene_options_small_faces:
 
   Graphics_scene_options_small_faces(const SM& sm): Base(), m_sm(sm)
   {
-    typename SM::template Property_map<face_descriptor, FT> faces_size;
-    boost::tie(faces_size, m_with_size)=sm.template property_map<face_descriptor, FT>("f:size");
+    std::optional<typename SM::template Property_map<face_descriptor, FT>> faces_size
+      = sm.template property_map<face_descriptor, FT>("f:size");
+    m_with_size = faces_size.has_value();
     if(!m_with_size)
     { return; }
 
-    m_min_size=faces_size[*(sm.faces().begin())];
+    m_min_size=(*faces_size)[*(sm.faces().begin())];
     m_max_size=m_min_size;
     FT cur_size;
     for (typename SM::Face_range::iterator f=sm.faces().begin(); f!=sm.faces().end(); ++f)
     {
-      cur_size=faces_size[*f];
+      cur_size=(*faces_size)[*f];
       if (cur_size<m_min_size) m_min_size=cur_size;
       if (cur_size>m_max_size) m_max_size=cur_size;
     }
@@ -60,12 +61,12 @@ struct Graphics_scene_options_small_faces:
 
     // Compare the size of the face with the % m_threshold
     bool exist;
-    typename SM::template Property_map<face_descriptor, FT> faces_size;
-    boost::tie(faces_size, exist)=sm.template property_map<face_descriptor, FT>("f:size");
-    assert(exist);
+    std::optional<typename SM::template Property_map<face_descriptor, FT>> faces_size
+      =sm.template property_map<face_descriptor, FT>("f:size");
+    assert(faces_size.has_value());
 
     // If the face is small, color it in red.
-    if (get(faces_size, fh)<m_min_size+((m_max_size-m_min_size)/(100-m_threshold)))
+    if (get(*faces_size, fh)<m_min_size+((m_max_size-m_min_size)/(100-m_threshold)))
     { return CGAL::IO::Color(255,20,20); }
 
     return c; // Default color

--- a/Basic_viewer/examples/Basic_viewer/draw_surface_mesh_small_faces.cpp
+++ b/Basic_viewer/examples/Basic_viewer/draw_surface_mesh_small_faces.cpp
@@ -43,7 +43,7 @@ struct Graphics_scene_options_small_faces:
       if (cur_size>m_max_size) m_max_size=cur_size;
     }
 
-    this->face_color=[=](const SM& sm,
+    this->face_color=[this](const SM& sm,
                          typename boost::graph_traits<SM>::face_descriptor fh) -> CGAL::IO::Color
     { return this->get_face_color(sm, fh); };
 
@@ -60,7 +60,6 @@ struct Graphics_scene_options_small_faces:
     if(!m_with_size) { return c; }
 
     // Compare the size of the face with the % m_threshold
-    bool exist;
     std::optional<typename SM::template Property_map<face_descriptor, FT>> faces_size
       = sm.template property_map<face_descriptor, FT>("f:size");
     assert(faces_size.has_value());

--- a/Classification/examples/Classification/example_ethz_random_forest.cpp
+++ b/Classification/examples/Classification/example_ethz_random_forest.cpp
@@ -102,7 +102,7 @@ int main (int argc, char** argv)
   std::cerr << "Classification with graphcut done in " << t.time() << " second(s)" << std::endl;
 
   std::cerr << "Precision, recall, F1 scores and IoU:" << std::endl;
-  Classification::Evaluation evaluation (labels, pts.range(label_map.value(),), label_indices);
+  Classification::Evaluation evaluation (labels, pts.range(label_map.value()), label_indices);
 
   for (Label_handle l : labels)
   {

--- a/Classification/examples/Classification/example_ethz_random_forest.cpp
+++ b/Classification/examples/Classification/example_ethz_random_forest.cpp
@@ -47,10 +47,8 @@ int main (int argc, char** argv)
   std::cerr << "Reading input" << std::endl;
   in >> pts;
 
-  Imap label_map;
-  bool lm_found = false;
-  std::tie (label_map, lm_found) = pts.property_map<int> ("label");
-  if (!lm_found)
+  std::optional<Imap> label_map = pts.property_map<int> ("label");
+  if (!label_map.has_value())
   {
     std::cerr << "Error: \"label\" property not found in input file." << std::endl;
     return EXIT_FAILURE;
@@ -78,7 +76,7 @@ int main (int argc, char** argv)
   Label_handle roof = labels.add ("roof");
 
   // Check if ground truth is valid for this label set
-  if (!labels.is_valid_ground_truth (pts.range(label_map), true))
+  if (!labels.is_valid_ground_truth (pts.range(label_map.value()), true))
     return EXIT_FAILURE;
 
   std::vector<int> label_indices(pts.size(), -1);
@@ -89,7 +87,7 @@ int main (int argc, char** argv)
   std::cerr << "Training" << std::endl;
   t.reset();
   t.start();
-  classifier.train (pts.range(label_map));
+  classifier.train (pts.range(label_map.value()));
   t.stop();
   std::cerr << "Done in " << t.time() << " second(s)" << std::endl;
 
@@ -104,7 +102,7 @@ int main (int argc, char** argv)
   std::cerr << "Classification with graphcut done in " << t.time() << " second(s)" << std::endl;
 
   std::cerr << "Precision, recall, F1 scores and IoU:" << std::endl;
-  Classification::Evaluation evaluation (labels, pts.range(label_map), label_indices);
+  Classification::Evaluation evaluation (labels, pts.range(label_map.value(),), label_indices);
 
   for (Label_handle l : labels)
   {
@@ -126,7 +124,7 @@ int main (int argc, char** argv)
 
   for (std::size_t i = 0; i < label_indices.size(); ++ i)
   {
-    label_map[i] = label_indices[i]; // update label map with computed classification
+    label_map.value()[i] = label_indices[i]; // update label map with computed classification
 
     Label_handle label = labels[label_indices[i]];
     const CGAL::IO::Color& color = label->color();

--- a/Classification/examples/Classification/example_generation_and_training.cpp
+++ b/Classification/examples/Classification/example_generation_and_training.cpp
@@ -44,10 +44,8 @@ int main (int argc, char** argv)
   std::cerr << "Reading input" << std::endl;
   in >> pts;
 
-  Imap label_map;
-  bool lm_found = false;
-  std::tie (label_map, lm_found) = pts.property_map<int> ("label");
-  if (!lm_found)
+  std::optional<Imap> label_map = pts.property_map<int> ("label");
+  if (!label_map.has_value())
   {
     std::cerr << "Error: \"label\" property not found in input file." << std::endl;
     return EXIT_FAILURE;
@@ -82,7 +80,7 @@ int main (int argc, char** argv)
   std::cerr << "Training" << std::endl;
   t.reset();
   t.start();
-  classifier.train<CGAL::Parallel_if_available_tag> (pts.range(label_map), 800);
+  classifier.train<CGAL::Parallel_if_available_tag> (pts.range(label_map.value()), 800);
   t.stop();
   std::cerr << "Done in " << t.time() << " second(s)" << std::endl;
 
@@ -97,7 +95,7 @@ int main (int argc, char** argv)
   std::cerr << "Classification with graphcut done in " << t.time() << " second(s)" << std::endl;
 
   std::cerr << "Precision, recall, F1 scores and IoU:" << std::endl;
-  Classification::Evaluation evaluation (labels, pts.range(label_map), label_indices);
+  Classification::Evaluation evaluation (labels, pts.range(label_map.value()), label_indices);
 
   for (Label_handle l : labels)
   {

--- a/Classification/examples/Classification/example_opencv_random_forest.cpp
+++ b/Classification/examples/Classification/example_opencv_random_forest.cpp
@@ -43,10 +43,8 @@ int main (int argc, char** argv)
   Point_set pts;
   in >> pts;
 
-  Imap label_map;
-  bool lm_found = false;
-  std::tie (label_map, lm_found) = pts.property_map<int> ("label");
-  if (!lm_found)
+  std::optional<Imap> label_map = pts.property_map<int> ("label");
+  if (!label_map.has_value())
   {
     std::cerr << "Error: \"label\" property not found in input file." << std::endl;
     return EXIT_FAILURE;
@@ -81,7 +79,7 @@ int main (int argc, char** argv)
   std::cerr << "Training" << std::endl;
   t.reset();
   t.start();
-  classifier.train (pts.range(label_map));
+  classifier.train (pts.range(label_map.value()));
   t.stop();
   std::cerr << "Done in " << t.time() << " second(s)" << std::endl;
 
@@ -96,7 +94,7 @@ int main (int argc, char** argv)
   std::cerr << "Classification with graphcut done in " << t.time() << " second(s)" << std::endl;
 
   std::cerr << "Precision, recall, F1 scores and IoU:" << std::endl;
-  Classification::Evaluation evaluation (labels, pts.range(label_map), label_indices);
+  Classification::Evaluation evaluation (labels, pts.range(label_map.value()), label_indices);
 
   for (Label_handle l : labels)
   {
@@ -118,7 +116,7 @@ int main (int argc, char** argv)
 
   for (std::size_t i = 0; i < label_indices.size(); ++ i)
   {
-    label_map[i] = label_indices[i]; // update label map with computed classification
+    label_map.value()[i] = label_indices[i]; // update label map with computed classification
 
     Label_handle label = labels[label_indices[i]];
     const CGAL::IO::Color& color = label->color();

--- a/Classification/examples/Classification/gis_tutorial_example.cpp
+++ b/Classification/examples/Classification/gis_tutorial_example.cpp
@@ -691,11 +691,9 @@ int main (int argc, char** argv)
   //! [Classification]
 
   // Get training from input
-  Point_set::Property_map<int> training_map;
-  bool training_found;
-  std::tie (training_map, training_found) = points.property_map<int>("training");
+  std::optional<Point_set::Property_map<int>> training_map = points.property_map<int>("training");
 
-  if (training_found)
+  if (training_map.has_value())
   {
     std::cerr << "Classifying ground/vegetation/building" << std::endl;
 
@@ -718,7 +716,7 @@ int main (int argc, char** argv)
 
     // Train a random forest classifier
     Classification::ETHZ::Random_forest_classifier classifier (labels, features);
-    classifier.train (points.range(training_map));
+    classifier.train (points.range(training_map.value()));
 
     // Classify with graphcut regularization
     Point_set::Property_map<int> label_map = points.add_property_map<int>("labels").first;
@@ -732,7 +730,7 @@ int main (int argc, char** argv)
     // Evaluate
     std::cerr << "Mean IoU on training data = "
               << Classification::Evaluation(labels,
-                                            points.range(training_map),
+                                            points.range(training_map.value()),
                                             points.range(label_map)).mean_intersection_over_union() << std::endl;
 
     // Save the classified point set

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -101,6 +101,12 @@ Release date: June 2024
     `CGAL::Simplicial_mesh_cell_base_3`
     have been modified to enable passing a geometric traits and a custom cell base class.
 
+### [Surface Mesh](https://doc.cgal.org/6.0/Manual/packages.html#PkgSurfaceMesh)
+-   **Breaking change**: The return type of `CGAL::Surface_mesh::property_map()` has been changed to `std::optional`.
+
+### [3D Point Set](https://doc.cgal.org/6.0/Manual/packages.html#PkgPointSet3)
+-   **Breaking change**: The return type of `CGAL::Point_set_3::property_map()` has been changed to `std::optional`.
+
 ### [Surface Mesh Parameterization](https://doc.cgal.org/6.0/Manual/packages.html#PkgSurfaceMeshParameterization)
 - **Breaking change**: LSCM_parameterizer_3 needs Eigen
 

--- a/Lab/demo/Lab/Plugins/Classification/Cluster_classification.cpp
+++ b/Lab/demo/Lab/Plugins/Classification/Cluster_classification.cpp
@@ -31,12 +31,13 @@ Cluster_classification::Cluster_classification(Scene_points_with_normal_item* po
   backup_existing_colors_and_add_new();
 
   bool cluster_found = false;
-  boost::tie (m_cluster_id, cluster_found) = m_points->point_set()->property_map<int>("shape");
-  if (!cluster_found)
+  std::optional<Point_set::Property_map<int>> cluster_id = m_points->point_set()->property_map<int>("shape");
+  if (!cluster_id.has_value())
   {
     std::cerr << "Error! Cluster not found!" << std::endl;
     abort();
   }
+  m_cluster_id = cluster_id.value();
 
   CGAL::Classification::create_clusters_from_indices (*(m_points->point_set()),
                                                       m_points->point_set()->point_map(),
@@ -57,20 +58,20 @@ Cluster_classification::Cluster_classification(Scene_points_with_normal_item* po
 
   if (!classif_found)
   {
-    Point_set::Property_map<unsigned char> las_classif;
-    boost::tie (las_classif, las_found) = m_points->point_set()->property_map<unsigned char>("classification");
+    std::optional<Point_set::Property_map<unsigned char>> las_classif = m_points->point_set()->property_map<unsigned char>("classification");
+    las_found = las_classif.has_value();
     if (las_found)
     {
       m_input_is_las = true;
       for (Point_set::const_iterator it = m_points->point_set()->begin();
            it != m_points->point_set()->first_selected(); ++ it)
       {
-        unsigned char uc = las_classif[*it];
+        unsigned char uc = las_classif.value()[*it];
         m_classif[*it] = int(uc);
         if (!training_found)
           m_training[*it] = int(uc);
       }
-      m_points->point_set()->remove_property_map (las_classif);
+      m_points->point_set()->remove_property_map (las_classif.value());
       classif_found = true;
       training_found = true;
     }
@@ -606,7 +607,7 @@ int Cluster_classification::real_index_color() const
 void Cluster_classification::reset_indices ()
 {
   Point_set::Property_map<Point_set::Index> indices
-    = m_points->point_set()->property_map<Point_set::Index>("index").first;
+    = m_points->point_set()->property_map<Point_set::Index>("index").value();
 
   m_points->point_set()->unselect_all();
   Point_set::Index idx;
@@ -636,11 +637,9 @@ void Cluster_classification::compute_features (std::size_t nb_scales, float voxe
 
   bool colors = (m_color != Point_set::Property_map<CGAL::IO::Color>());
 
-  Point_set::Property_map<std::uint8_t> echo_map;
-  bool echo;
-  boost::tie (echo_map, echo) = m_points->point_set()->template property_map<std::uint8_t>("echo");
-  if (!echo)
-    boost::tie (echo_map, echo) = m_points->point_set()->template property_map<std::uint8_t>("number_of_returns");
+  std::optional<Point_set::Property_map<std::uint8_t>> echo_map = m_points->point_set()->template property_map<std::uint8_t>("echo");
+  if (!echo_map.has_value())
+    echo_map = m_points->point_set()->template property_map<std::uint8_t>("number_of_returns");
 
   Feature_set pointwise_features;
 
@@ -658,8 +657,8 @@ void Cluster_classification::compute_features (std::size_t nb_scales, float voxe
     generator.generate_normal_based_features (pointwise_features, normal_map);
   if (colors)
     generator.generate_color_based_features (pointwise_features, m_color);
-  if (echo)
-    generator.generate_echo_based_features (pointwise_features, echo_map);
+  if (echo_map.has_value())
+    generator.generate_echo_based_features (pointwise_features, echo_map.value());
 
 #ifdef CGAL_LINKED_WITH_TBB
   pointwise_features.end_parallel_additions();

--- a/Lab/demo/Lab/Plugins/Classification/Cluster_classification.cpp
+++ b/Lab/demo/Lab/Plugins/Classification/Cluster_classification.cpp
@@ -30,7 +30,6 @@ Cluster_classification::Cluster_classification(Scene_points_with_normal_item* po
 
   backup_existing_colors_and_add_new();
 
-  bool cluster_found = false;
   std::optional<Point_set::Property_map<int>> cluster_id = m_points->point_set()->property_map<int>("shape");
   if (!cluster_id.has_value())
   {

--- a/Lab/demo/Lab/Plugins/Classification/Cluster_classification.h
+++ b/Lab/demo/Lab/Plugins/Classification/Cluster_classification.h
@@ -124,14 +124,13 @@ class Cluster_classification : public Item_classification_base
   bool try_adding_simple_feature (Feature_set& feature_set, const std::string& name)
   {
     typedef typename Point_set::template Property_map<Type> Pmap;
-    bool okay = false;
-    Pmap pmap;
-    boost::tie (pmap, okay) = m_points->point_set()->template property_map<Type>(name.c_str());
-    if (okay)
-      feature_set.template add<CGAL::Classification::Feature::Simple_feature <Point_set, Pmap> >
-        (*(m_points->point_set()), pmap, name.c_str());
 
-    return okay;
+    std::optional<Pmap> pmap = m_points->point_set()->template property_map<Type>(name.c_str());
+    if (pmap.has_value())
+      feature_set.template add<CGAL::Classification::Feature::Simple_feature <Point_set, Pmap> >
+        (*(m_points->point_set()), pmap.value(), name.c_str());
+
+    return pmap.has_value();
   }
 
   void add_selection_to_training_set (std::size_t label)

--- a/Lab/demo/Lab/Plugins/Classification/Point_set_item_classification.h
+++ b/Lab/demo/Lab/Plugins/Classification/Point_set_item_classification.h
@@ -52,7 +52,7 @@ class Point_set_item_classification : public Item_classification_base
       : point_set (point_set)
       , clusters (&clusters)
     {
-      cluster_id = point_set->property_map<int>("shape").first;
+      cluster_id = point_set->property_map<int>("shape").value();
     }
 
     template <typename OutputIterator>
@@ -148,17 +148,16 @@ class Point_set_item_classification : public Item_classification_base
   {
     typedef typename Point_set::template Property_map<Type> Pmap;
     bool okay = false;
-    Pmap pmap;
-    boost::tie (pmap, okay) = m_points->point_set()->template property_map<Type>(name.c_str());
-    if (okay)
+    std::optional<Pmap> pmap = m_points->point_set()->template property_map<Type>(name.c_str());
+    if (pmap.has_value())
     {
       std::cerr << "Adding property<" << CGAL::demangle(typeid(Type).name()) << ">("
                 << name << ") as feature" << std::endl;
       m_features.template add<CGAL::Classification::Feature::Simple_feature <Point_set, Pmap> >
-        (*(m_points->point_set()), pmap, name.c_str());
+        (*(m_points->point_set()), pmap.value(), name.c_str());
     }
 
-    return okay;
+    return pmap.has_value();
   }
 
   void add_selection_to_training_set (std::size_t label)

--- a/Lab/demo/Lab/Plugins/Classification/Point_set_item_classification.h
+++ b/Lab/demo/Lab/Plugins/Classification/Point_set_item_classification.h
@@ -147,7 +147,6 @@ class Point_set_item_classification : public Item_classification_base
   bool try_adding_simple_feature (const std::string& name)
   {
     typedef typename Point_set::template Property_map<Type> Pmap;
-    bool okay = false;
     std::optional<Pmap> pmap = m_points->point_set()->template property_map<Type>(name.c_str());
     if (pmap.has_value())
     {

--- a/Lab/demo/Lab/Plugins/Classification/Surface_mesh_item_classification.cpp
+++ b/Lab/demo/Lab/Plugins/Classification/Surface_mesh_item_classification.cpp
@@ -56,10 +56,10 @@ Surface_mesh_item_classification::~Surface_mesh_item_classification()
 
 void Surface_mesh_item_classification::backup_existing_colors_and_add_new()
 {
-  bool has_colors = false;
-  boost::tie (m_color, has_colors) = m_mesh->polyhedron()->property_map<face_descriptor, CGAL::IO::Color>("f:color");
-  if (has_colors)
+  std::optional< Mesh::Property_map<face_descriptor, CGAL::IO::Color>> color_map = m_mesh->polyhedron()->property_map<face_descriptor, CGAL::IO::Color>("f:color");
+  if (color_map.has_value())
   {
+    m_color = color_map.value();
     m_real_color
       = m_mesh->polyhedron()->add_property_map<face_descriptor, CGAL::IO::Color>("f:real_color").first;
     for(face_descriptor fd : faces(*(m_mesh->polyhedron())))

--- a/Lab/demo/Lab/Plugins/Display/Display_property_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Display/Display_property_plugin.cpp
@@ -669,11 +669,11 @@ private:
       return;
 
     // Here we only target the property maps added by this plugin, so 'double' is fine
-    SMesh::Property_map<face_descriptor, double> property;
-    bool found;
-    std::tie(property, found) = sm->property_map<face_descriptor, double>(property_name);
-    if(found)
-      sm->remove_property_map(property);
+    std::optional<SMesh::Property_map<face_descriptor, double>> property
+      = sm->property_map<face_descriptor, double>(property_name);
+
+    if(property.has_value())
+      sm->remove_property_map(property.value());
   }
 
   void removeDisplayPluginProperties(Scene_item* item)
@@ -929,8 +929,8 @@ private:
 
     SMesh& smesh = *item->face_graph();
 
-    const auto vnm = smesh.property_map<vertex_descriptor, EPICK::Vector_3>("v:normal_before_perturbation").first;
-    const bool vnm_exists = smesh.property_map<vertex_descriptor, EPICK::Vector_3>("v:normal_before_perturbation").second;
+    const auto vnm = smesh.property_map<vertex_descriptor, EPICK::Vector_3>("v:normal_before_perturbation").value();
+    const bool vnm_exists = smesh.property_map<vertex_descriptor, EPICK::Vector_3>("v:normal_before_perturbation").has_value();
 
     // compute once and store the value per vertex
     bool non_init;
@@ -1512,26 +1512,26 @@ call_on_PS_property(const std::string& name,
                     const Point_set& ps,
                     const Functor& functor) const
 {
-  if(ps.template property_map<std::int8_t>(name).second)
-    return functor(ps.template property_map<std::int8_t>(name).first);
-  else if(ps.template property_map<std::uint8_t>(name).second)
-    return functor(ps.template property_map<std::uint8_t>(name).first);
-  else if(ps.template property_map<std::int16_t>(name).second)
-    return functor(ps.template property_map<std::int16_t>(name).first);
-  else if(ps.template property_map<std::uint16_t>(name).second)
-    return functor(ps.template property_map<std::uint16_t>(name).first);
-  else if(ps.template property_map<std::int32_t>(name).second)
-    return functor(ps.template property_map<std::int32_t>(name).first);
-  else if(ps.template property_map<std::uint32_t>(name).second)
-    return functor(ps.template property_map<std::uint32_t>(name).first);
-  else if(ps.template property_map<std::int64_t>(name).second)
-    return functor(ps.template property_map<std::int64_t>(name).first);
-  else if(ps.template property_map<std::uint64_t>(name).second)
-    return functor(ps.template property_map<std::uint64_t>(name).first);
-  else if(ps.template property_map<float>(name).second)
-    return functor(ps.template property_map<float>(name).first);
-  else if(ps.template property_map<double>(name).second)
-    return functor(ps.template property_map<double>(name).first);
+  if(ps.template property_map<std::int8_t>(name).has_value())
+    return functor(ps.template property_map<std::int8_t>(name).value());
+  else if(ps.template property_map<std::uint8_t>(name).has_value())
+    return functor(ps.template property_map<std::uint8_t>(name).value());
+  else if(ps.template property_map<std::int16_t>(name).has_value())
+    return functor(ps.template property_map<std::int16_t>(name).value());
+  else if(ps.template property_map<std::uint16_t>(name).has_value())
+    return functor(ps.template property_map<std::uint16_t>(name).value());
+  else if(ps.template property_map<std::int32_t>(name).has_value())
+    return functor(ps.template property_map<std::int32_t>(name).value());
+  else if(ps.template property_map<std::uint32_t>(name).has_value())
+    return functor(ps.template property_map<std::uint32_t>(name).value());
+  else if(ps.template property_map<std::int64_t>(name).has_value())
+    return functor(ps.template property_map<std::int64_t>(name).value());
+  else if(ps.template property_map<std::uint64_t>(name).has_value())
+    return functor(ps.template property_map<std::uint64_t>(name).value());
+  else if(ps.template property_map<float>(name).has_value())
+    return functor(ps.template property_map<float>(name).value());
+  else if(ps.template property_map<double>(name).has_value())
+    return functor(ps.template property_map<double>(name).value());
 
   return false;
 }
@@ -1543,26 +1543,26 @@ call_on_SM_property(const std::string& name,
                     const SMesh& mesh,
                     const Functor& functor) const
 {
-  if(mesh.template property_map<Simplex, std::int8_t>(name).second)
-    return functor(mesh.template property_map<Simplex, std::int8_t>(name).first);
-  else if(mesh.template property_map<Simplex, std::uint8_t>(name).second)
-    return functor(mesh.template property_map<Simplex, std::uint8_t>(name).first);
-  else if(mesh.template property_map<Simplex, std::int16_t>(name).second)
-    return functor(mesh.template property_map<Simplex, std::int16_t>(name).first);
-  else if(mesh.template property_map<Simplex, std::uint16_t>(name).second)
-    return functor(mesh.template property_map<Simplex, std::uint16_t>(name).first);
-  else if(mesh.template property_map<Simplex, std::int32_t>(name).second)
-    return functor(mesh.template property_map<Simplex, std::int32_t>(name).first);
-  else if(mesh.template property_map<Simplex, std::uint32_t>(name).second)
-    return functor(mesh.template property_map<Simplex, std::uint32_t>(name).first);
-  else if(mesh.template property_map<Simplex, std::int64_t>(name).second)
-    return functor(mesh.template property_map<Simplex, std::int64_t>(name).first);
-  else if(mesh.template property_map<Simplex, std::uint64_t>(name).second)
-    return functor(mesh.template property_map<Simplex, std::uint64_t>(name).first);
-  else if(mesh.template property_map<Simplex, float>(name).second)
-    return functor(mesh.template property_map<Simplex, float>(name).first);
-  else if(mesh.template property_map<Simplex, double>(name).second)
-    return functor(mesh.template property_map<Simplex, double>(name).first);
+  if(mesh.template property_map<Simplex, std::int8_t>(name).has_value())
+    return functor(mesh.template property_map<Simplex, std::int8_t>(name).value());
+  else if(mesh.template property_map<Simplex, std::uint8_t>(name).has_value())
+    return functor(mesh.template property_map<Simplex, std::uint8_t>(name).value());
+  else if(mesh.template property_map<Simplex, std::int16_t>(name).has_value())
+    return functor(mesh.template property_map<Simplex, std::int16_t>(name).value());
+  else if(mesh.template property_map<Simplex, std::uint16_t>(name).has_value())
+    return functor(mesh.template property_map<Simplex, std::uint16_t>(name).value());
+  else if(mesh.template property_map<Simplex, std::int32_t>(name).has_value())
+    return functor(mesh.template property_map<Simplex, std::int32_t>(name).value());
+  else if(mesh.template property_map<Simplex, std::uint32_t>(name).has_value())
+    return functor(mesh.template property_map<Simplex, std::uint32_t>(name).value());
+  else if(mesh.template property_map<Simplex, std::int64_t>(name).has_value())
+    return functor(mesh.template property_map<Simplex, std::int64_t>(name).value());
+  else if(mesh.template property_map<Simplex, std::uint64_t>(name).has_value())
+    return functor(mesh.template property_map<Simplex, std::uint64_t>(name).value());
+  else if(mesh.template property_map<Simplex, float>(name).has_value())
+    return functor(mesh.template property_map<Simplex, float>(name).value());
+  else if(mesh.template property_map<Simplex, double>(name).has_value())
+    return functor(mesh.template property_map<Simplex, double>(name).value());
 
   return false;
 }

--- a/Lab/demo/Lab/Plugins/Display/Heat_method_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Display/Heat_method_plugin.cpp
@@ -136,12 +136,10 @@ public:
     QApplication::setOverrideCursor(Qt::WaitCursor);
 
     auto vpm = CGAL::get(CGAL::vertex_point, *sm);
-    auto vnormals = sm->property_map<vertex_descriptor, EPICK::Vector_3>("v:normal").first;
+    auto vnormals = sm->property_map<vertex_descriptor, EPICK::Vector_3>("v:normal").value();
 
-    auto [vcolors, vcolors_found] = sm->property_map<vertex_descriptor, CGAL::IO::Color>("v:color");
-    CGAL_assertion(vcolors_found);
-    auto [vdist, vdist_found] = sm->property_map<vertex_descriptor, double>("v:HM_Plugin_heat_intensity");
-    CGAL_assertion(vdist_found);
+    auto vcolors = sm->property_map<vertex_descriptor, CGAL::IO::Color>("v:color").value();
+    auto vdist = sm->property_map<vertex_descriptor, double>("v:HM_Plugin_heat_intensity").value();
 
     verts.clear();
     normals.clear();
@@ -730,11 +728,9 @@ private:
       return;
 
     // Here we only target the property maps added by this plugin, so 'double' is fine
-    SMesh::Property_map<face_descriptor, double> property;
-    bool found;
-    std::tie(property, found) = sm->property_map<face_descriptor, double>(property_name);
-    if(found)
-      sm->remove_property_map(property);
+    std::optional<SMesh::Property_map<face_descriptor, double>> property = sm->property_map<face_descriptor, double>(property_name);
+    if(property.has_value())
+      sm->remove_property_map(property.value());
   }
 
   void removePluginProperties(Scene_item* item)
@@ -801,8 +797,7 @@ private Q_SLOTS:
 
     const SMesh& mesh = *(sm_item->face_graph());
 
-    auto [heat_intensity, found] = mesh.property_map<vertex_descriptor, double>("v:HM_Plugin_heat_intensity");
-    CGAL_assertion(found);
+    auto heat_intensity = mesh.property_map<vertex_descriptor, double>("v:HM_Plugin_heat_intensity").value();
 
     double max = 0;
     vertex_descriptor max_v = boost::graph_traits<SMesh>::null_vertex();

--- a/Lab/demo/Lab/Plugins/IO/3mf_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/IO/3mf_io_plugin.cpp
@@ -212,7 +212,7 @@ class Io_3mf_plugin:
       {
         colors.reserve(triangles.size());
         SMesh::Property_map<face_descriptor, CGAL::IO::Color> fcolors =
-            mesh.property_map<face_descriptor, CGAL::IO::Color >("f:color").first;
+            mesh.property_map<face_descriptor, CGAL::IO::Color >("f:color").value();
         for(auto fd : mesh.faces())
         {
           colors.push_back(get(fcolors, fd));
@@ -222,7 +222,7 @@ class Io_3mf_plugin:
       {
         colors.reserve(triangles.size());
         SMesh::Property_map<face_descriptor, int> fpid =
-            mesh.property_map<face_descriptor, int >("f:patch_id").first;
+            mesh.property_map<face_descriptor, int >("f:patch_id").value();
         for(auto fd : mesh.faces())
         {
           int pid = get(fpid, fd);

--- a/Lab/demo/Lab/Plugins/IO/PLY_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/IO/PLY_io_plugin.cpp
@@ -104,7 +104,7 @@ load(QFileInfo fileinfo, bool& ok, bool add_to_scene) {
     Scene_surface_mesh_item* sm_item = new Scene_surface_mesh_item();
     if (CGAL::IO::read_PLY(in, *sm_item->face_graph(), comments))
     {
-      if(sm_item->face_graph()->property_map<face_descriptor, int >("f:patch_id").second)
+      if(sm_item->face_graph()->property_map<face_descriptor, int >("f:patch_id").has_value())
       {
         sm_item->setItemIsMulticolor(true);
         sm_item->computeItemColorVectorAutomatically(true);

--- a/Lab/demo/Lab/Plugins/Mesh_3/Offset_meshing_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Mesh_3/Offset_meshing_plugin.cpp
@@ -743,7 +743,7 @@ inflate_mesh()
     return;
 
   auto vpm = get(CGAL::vertex_point, *sMesh);
-  auto vnm = sMesh->property_map<vertex_descriptor, EPICK::Vector_3 >("v:normal").first;
+  auto vnm = sMesh->property_map<vertex_descriptor, EPICK::Vector_3 >("v:normal").value();
 
   QApplication::setOverrideCursor(Qt::WaitCursor);
 

--- a/Lab/demo/Lab/Plugins/PMP/Engrave_text_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/PMP/Engrave_text_plugin.cpp
@@ -638,7 +638,7 @@ public Q_SLOTS:
         ("h:v", 0.0f).first;
       SMesh::Halfedge_iterator it;
       SMesh::Property_map<SMesh::Vertex_index, EPICK::Point_2> uv_map =
-          sm->property_map<SMesh::Vertex_index, EPICK::Point_2>("v:uv").first;
+          sm->property_map<SMesh::Vertex_index, EPICK::Point_2>("v:uv").value();
       for(it = sm->halfedges_begin();
           it != sm->halfedges_end();
           ++it)

--- a/Lab/demo/Lab/Plugins/PMP/Orient_soup_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/PMP/Orient_soup_plugin.cpp
@@ -114,7 +114,7 @@ void set_vcolors(SMesh* smesh, std::vector<CGAL::IO::Color> colors)
   typedef SMesh SMesh;
   typedef boost::graph_traits<SMesh>::vertex_descriptor vertex_descriptor;
   SMesh::Property_map<vertex_descriptor, CGAL::IO::Color> vcolors =
-    smesh->property_map<vertex_descriptor, CGAL::IO::Color >("v:color").first;
+    smesh->property_map<vertex_descriptor, CGAL::IO::Color >("v:color").value();
   bool created;
   boost::tie(vcolors, created) = smesh->add_property_map<SMesh::Vertex_index,CGAL::IO::Color>("v:color",CGAL::IO::Color(0,0,0));
   assert(colors.size()==smesh->number_of_vertices());
@@ -128,7 +128,7 @@ void set_fcolors(SMesh* smesh, std::vector<CGAL::IO::Color> colors)
   typedef SMesh SMesh;
   typedef boost::graph_traits<SMesh>::face_descriptor face_descriptor;
   SMesh::Property_map<face_descriptor, CGAL::IO::Color> fcolors =
-    smesh->property_map<face_descriptor, CGAL::IO::Color >("f:color").first;
+    smesh->property_map<face_descriptor, CGAL::IO::Color >("f:color").value();
   bool created;
    boost::tie(fcolors, created) = smesh->add_property_map<SMesh::Face_index,CGAL::IO::Color>("f:color",CGAL::IO::Color(0,0,0));
   assert(colors.size()==smesh->number_of_faces());

--- a/Lab/demo/Lab/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
@@ -408,42 +408,37 @@ void CGAL_Lab_point_set_normal_estimation_plugin::on_actionNormalOrientation_tri
       CGAL::Timer task_timer; task_timer.start();
       std::cerr << "Orient normals with along 2.5D scanlines..." << std::endl;
 
-      Point_set::Property_map<float> scan_angle;
-      Point_set::Property_map<unsigned char> scan_direction_flag;
+      std::optional<Point_set::Property_map<float>> scan_angle = points->property_map<float>("scan_angle");
+      std::optional<Point_set::Property_map<unsigned char>> scan_direction_flag = points->property_map<unsigned char>("scan_direction_flag");
       bool angle_found = false, flag_found = false;
 
-      std::tie (scan_angle, angle_found)
-        = points->property_map<float>("scan_angle");
-      std::tie (scan_direction_flag, flag_found)
-        = points->property_map<unsigned char>("scan_direction_flag");
-
-      if (!angle_found && !flag_found)
+      if (!scan_angle.has_value() && !scan_direction_flag.has_value())
       {
         std::cerr << "  using no additional properties" << std::endl;
         CGAL::scanline_orient_normals(points->all_or_selection_if_not_empty(),
                                       points->parameters());
       }
-      else if (!angle_found && flag_found)
+      else if (!scan_angle.has_value() && scan_direction_flag.has_value())
       {
         std::cerr << "  using scan direction flag" << std::endl;
         CGAL::scanline_orient_normals(points->all_or_selection_if_not_empty(),
                                       points->parameters().
-                                      scanline_id_map (scan_direction_flag));
+                                      scanline_id_map (scan_direction_flag.value()));
       }
-      else if (angle_found && !flag_found)
+      else if (scan_angle.has_value() && !scan_direction_flag.has_value())
       {
         std::cerr << "  using scan angle" << std::endl;
         CGAL::scanline_orient_normals(points->all_or_selection_if_not_empty(),
                                       points->parameters().
-                                      scan_angle_map (scan_angle));
+                                      scan_angle_map (scan_angle.value()));
       }
       else // if (angle_found && flag_found)
       {
         std::cerr << "  using scan angle and direction flag" << std::endl;
         CGAL::scanline_orient_normals(points->all_or_selection_if_not_empty(),
                                       points->parameters().
-                                      scan_angle_map (scan_angle).
-                                      scanline_id_map (scan_direction_flag));
+                                      scan_angle_map (scan_angle.value()).
+                                      scanline_id_map (scan_direction_flag.value()));
       }
       std::size_t memory = CGAL::Memory_sizer().virtual_size();
       std::cerr << "Orient normals: "

--- a/Lab/demo/Lab/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
@@ -410,7 +410,6 @@ void CGAL_Lab_point_set_normal_estimation_plugin::on_actionNormalOrientation_tri
 
       std::optional<Point_set::Property_map<float>> scan_angle = points->property_map<float>("scan_angle");
       std::optional<Point_set::Property_map<unsigned char>> scan_direction_flag = points->property_map<unsigned char>("scan_direction_flag");
-      bool angle_found = false, flag_found = false;
 
       if (!scan_angle.has_value() && !scan_direction_flag.has_value())
       {

--- a/Lab/demo/Lab/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Point_set/Point_set_to_mesh_distance_plugin.cpp
@@ -187,17 +187,16 @@ private Q_SLOTS:
       CGAL::Three::Three::warning("You must select the resulting point set.");
       return;
     }
-    PMap distance_map;
-     boost::tie (distance_map, boost::tuples::ignore) = item->point_set()->property_map<double>("distance");
-   double distance = dock_widget->distance_spinbox->value();
-   for (Point_set::iterator it = item->point_set()->begin();
-        it != item->point_set()->end(); ++ it)
-   {
-     if(distance <= distance_map[*it])
-       item->point_set()->select(*it);
-   }
-   item->invalidateOpenGLBuffers();
-   item->itemChanged();
+    PMap distance_map = item->point_set()->property_map<double>("distance").value();
+    double distance = dock_widget->distance_spinbox->value();
+    for (Point_set::iterator it = item->point_set()->begin();
+         it != item->point_set()->end(); ++ it)
+    {
+      if(distance <= distance_map[*it])
+        item->point_set()->select(*it);
+    }
+    item->invalidateOpenGLBuffers();
+    item->itemChanged();
   }
   void perform()
   {

--- a/Lab/demo/Lab/Plugins/Point_set/Surface_reconstruction_advancing_front_impl.cpp
+++ b/Lab/demo/Lab/Plugins/Point_set/Surface_reconstruction_advancing_front_impl.cpp
@@ -193,7 +193,7 @@ SMesh* advancing_front (const Point_set& points,
   if (structuring) // todo
   {
     Point_set::Property_map<int> shape_map
-      = points.property_map<int>("shape").first;
+      = points.property_map<int>("shape").value();
 
     typedef CGAL::Point_set_with_structure<Kernel> Structuring;
     std::vector<Plane_3> planes;

--- a/Lab/demo/Lab/Plugins/Point_set/Surface_reconstruction_polygonal_impl.cpp
+++ b/Lab/demo/Lab/Plugins/Point_set/Surface_reconstruction_polygonal_impl.cpp
@@ -27,7 +27,7 @@ SMesh* polygonal_reconstruct (const Point_set& points,
   CGAL_USE (solver_name);
 
   Point_set::Property_map<int> shape_map
-    = points.property_map<int>("shape").first;
+    = points.property_map<int>("shape").value();
 
         Polygonal_surface_reconstruction poly
     (points, points.point_map(), points.normal_map(), shape_map);

--- a/Lab/demo/Lab/Plugins/Surface_mesh/Offset_meshing_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Surface_mesh/Offset_meshing_plugin.cpp
@@ -492,7 +492,7 @@ void CGAL_Lab_offset_meshing_plugin::inflate_mesh()
 
   auto vpm = get(CGAL::vertex_point,*sMesh);
   auto vnm =
-      sMesh->property_map<vertex_descriptor, EPICK::Vector_3 >("v:normal").first;
+      sMesh->property_map<vertex_descriptor, EPICK::Vector_3 >("v:normal").value();
 
   for(const auto& v : vertices(*sMesh))
   {

--- a/Lab/demo/Lab/include/Point_set_3.h
+++ b/Lab/demo/Lab/include/Point_set_3.h
@@ -143,8 +143,6 @@ public:
 
   bool check_colors()
   {
-    bool found = false;
-
     std::optional<Byte_map> red_map = this->template property_map<unsigned char>("red");
     if (!red_map.has_value()) {
       red_map = this->template property_map<unsigned char>("r");
@@ -174,8 +172,6 @@ public:
 
   bool get_float_colors()
   {
-    bool found = false;
-
     std::optional<Double_map> red_map = this->template property_map<double>("red");
     if (!red_map.has_value()) {
       red_map = this->template property_map<double>("r");
@@ -205,8 +201,6 @@ public:
 
   bool get_las_colors()
   {
-    bool found = false;
-
     typedef typename Base::template Property_map<unsigned short> Ushort_map;
 
     std::optional<Ushort_map> red_map = this->template property_map<unsigned short>("R");

--- a/Lab/demo/Lab/include/Point_set_3.h
+++ b/Lab/demo/Lab/include/Point_set_3.h
@@ -145,29 +145,29 @@ public:
   {
     bool found = false;
 
-    boost::tie (m_red, found) = this->template property_map<unsigned char>("red");
-    if (!found)
-      {
-        boost::tie (m_red, found) = this->template property_map<unsigned char>("r");
-        if (!found)
-          return get_float_colors();
-      }
+    std::optional<Byte_map> red_map = this->template property_map<unsigned char>("red");
+    if (!red_map.has_value()) {
+      red_map = this->template property_map<unsigned char>("r");
+      if (!red_map.has_value())
+        return get_float_colors();
+    }
+    m_red = red_map.value();
 
-    boost::tie (m_green, found) = this->template property_map<unsigned char>("green");
-    if (!found)
-      {
-        boost::tie (m_green, found) = this->template property_map<unsigned char>("g");
-        if (!found)
-          return false;
-      }
+    std::optional<Byte_map> green_map = this->template property_map<unsigned char>("green");
+    if (!green_map.has_value()) {
+      green_map = this->template property_map<unsigned char>("g");
+      if (!green_map.has_value())
+        return false;
+    }
+    m_green = green_map.value();
 
-    boost::tie (m_blue, found) = this->template property_map<unsigned char>("blue");
-    if (!found)
-      {
-        boost::tie (m_blue, found) = this->template property_map<unsigned char>("b");
-        if (!found)
-          return false;
-      }
+    std::optional<Byte_map> blue_map = this->template property_map<unsigned char>("blue");
+    if (!blue_map.has_value()) {
+      blue_map = this->template property_map<unsigned char>("b");
+      if (!blue_map.has_value())
+        return false;
+    }
+    m_blue = blue_map.value();
 
     return true;
   }
@@ -176,29 +176,30 @@ public:
   {
     bool found = false;
 
-    boost::tie (m_fred, found) = this->template property_map<double>("red");
-    if (!found)
-      {
-        boost::tie (m_fred, found) = this->template property_map<double>("r");
-        if (!found)
-          return get_las_colors();
-      }
+    std::optional<Double_map> red_map = this->template property_map<double>("red");
+    if (!red_map.has_value()) {
+      red_map = this->template property_map<double>("r");
+      if (!red_map.has_value())
+        return get_las_colors();
+    }
+    m_fred = red_map.value();
 
-    boost::tie (m_fgreen, found) = this->template property_map<double>("green");
-    if (!found)
-      {
-        boost::tie (m_fgreen, found) = this->template property_map<double>("g");
-        if (!found)
-          return false;
-      }
+    std::optional<Double_map> green_map = this->template property_map<double>("green");
+    if (!green_map.has_value()) {
+      green_map = this->template property_map<double>("g");
+      if (!green_map.has_value())
+        return false;
+    }
+    m_fgreen = green_map.value();
 
-    boost::tie (m_fblue, found) = this->template property_map<double>("blue");
-    if (!found)
-      {
-        boost::tie (m_fblue, found) = this->template property_map<double>("b");
-        if (!found)
-          return false;
-      }
+    std::optional<Double_map> blue_map = this->template property_map<double>("blue");
+    if (!blue_map.has_value()) {
+      blue_map = this->template property_map<double>("b");
+      if (!blue_map.has_value())
+        return false;
+    }
+    m_fblue = blue_map.value();
+
     return true;
   }
 
@@ -207,25 +208,24 @@ public:
     bool found = false;
 
     typedef typename Base::template Property_map<unsigned short> Ushort_map;
-    Ushort_map red, green, blue;
 
-    boost::tie (red, found) = this->template property_map<unsigned short>("R");
-    if (!found)
+    std::optional<Ushort_map> red_map = this->template property_map<unsigned short>("R");
+    if (!red_map.has_value())
       return false;
 
-    boost::tie (green, found) = this->template property_map<unsigned short>("G");
-    if (!found)
+    std::optional<Ushort_map> green_map = this->template property_map<unsigned short>("G");
+    if (!green_map.has_value())
       return false;
 
-    boost::tie (blue, found) = this->template property_map<unsigned short>("B");
-    if (!found)
+    std::optional<Ushort_map> blue_map = this->template property_map<unsigned short>("B");
+    if (!blue_map.has_value())
       return false;
 
     unsigned int bit_short_to_char = 0;
     for (iterator it = begin(); it != end(); ++ it)
-      if (get(red, *it) > 255
-          || get(green, *it) > 255
-          || get(blue, *it) > 255)
+      if (get(red_map.value(), *it) > 255
+          || get(green_map.value(), *it) > 255
+          || get(blue_map.value(), *it) > 255)
         {
           bit_short_to_char = 8;
           break;
@@ -236,13 +236,13 @@ public:
     m_blue = this->template add_property_map<unsigned char>("b").first;
     for (iterator it = begin(); it != end(); ++ it)
       {
-        put (m_red, *it, (unsigned char)((get(red, *it) >> bit_short_to_char)));
-        put (m_green, *it, (unsigned char)((get(green, *it) >> bit_short_to_char)));
-        put (m_blue, *it, (unsigned char)((get(blue, *it) >> bit_short_to_char)));
+        put (m_red, *it, (unsigned char)((get(red_map.value(), *it) >> bit_short_to_char)));
+        put (m_green, *it, (unsigned char)((get(green_map.value(), *it) >> bit_short_to_char)));
+        put (m_blue, *it, (unsigned char)((get(blue_map.value(), *it) >> bit_short_to_char)));
       }
-    this->remove_property_map(red);
-    this->remove_property_map(green);
-    this->remove_property_map(blue);
+    this->remove_property_map(red_map.value());
+    this->remove_property_map(green_map.value());
+    this->remove_property_map(blue_map.value());
 
     return true;
   }

--- a/Point_set_3/examples/Point_set_3/point_set_property.cpp
+++ b/Point_set_3/examples/Point_set_3/point_set_property.cpp
@@ -17,10 +17,8 @@ typedef Point_set::Property_map<FT> FT_map;
 
 void print_point_set (const Point_set& point_set)
 {
-  Color_map color;
-  boost::tie (color, boost::tuples::ignore) = point_set.property_map<Color>("color");
-  FT_map intensity;
-  boost::tie (intensity, boost::tuples::ignore) =  point_set.property_map<FT>("intensity");
+  Color_map color = *point_set.property_map<Color>("color");
+  FT_map intensity = *point_set.property_map<FT>("intensity");
 
   std::cerr << "Content of point set:" << std::endl;
   for (Point_set::const_iterator it = point_set.begin(); it != point_set.end(); ++ it)

--- a/Point_set_3/examples/Point_set_3/point_set_property.cpp
+++ b/Point_set_3/examples/Point_set_3/point_set_property.cpp
@@ -17,8 +17,8 @@ typedef Point_set::Property_map<FT> FT_map;
 
 void print_point_set (const Point_set& point_set)
 {
-  Color_map color = *point_set.property_map<Color>("color");
-  FT_map intensity = *point_set.property_map<FT>("intensity");
+  Color_map color = point_set.property_map<Color>("color").value();
+  FT_map intensity = point_set.property_map<FT>("intensity").value();
 
   std::cerr << "Content of point set:" << std::endl;
   for (Point_set::const_iterator it = point_set.begin(); it != point_set.end(); ++ it)

--- a/Point_set_3/examples/Point_set_3/point_set_read_ply.cpp
+++ b/Point_set_3/examples/Point_set_3/point_set_read_ply.cpp
@@ -32,15 +32,13 @@ int main (int argc, char** argv)
     std::cerr << " * " << properties[i] << std::endl;
 
   // Recover "label" property of type int
-  Point_set::Property_map<std::int32_t> label_prop;
-  bool found = false;
-  boost::tie(label_prop, found)  = point_set.property_map<std::int32_t> ("label");
+  std::optional<Point_set::Property_map<std::int32_t>> label_prop = point_set.property_map<std::int32_t> ("label");
 
-  if(found)
+  if(label_prop.has_value())
   {
     std::cerr << "Point set has an integer \"label\" property with values:" << std::endl;
     for (Point_set::iterator it = point_set.begin(); it != point_set.end(); ++ it)
-      std::cerr << " * " << label_prop[*it] << std::endl;
+      std::cerr << " * " << (*label_prop)[*it] << std::endl;
   }
 
   if(argc > 2 && strcmp (argv[2], "-b") == 0) // Optional binary output

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -243,9 +243,9 @@ public:
   Point_set_3& operator= (const Point_set_3& ps)
   {
     m_base = ps.m_base;
-    m_indices = this->property_map<Index> ("index").first;
-    m_points = this->property_map<Point> ("point").first;
-    m_normals = this->property_map<Vector> ("normal").first;
+    m_indices = this->property_map<Index> ("index").value();
+    m_points = this->property_map<Point> ("point").value();
+    m_normals = this->property_map<Vector> ("normal").value();
     m_nb_removed = ps.m_nb_removed;
     return *this;
   }
@@ -255,9 +255,9 @@ public:
   Point_set_3 (const Point_set_3& ps)
   {
     m_base = ps.m_base;
-    m_indices = this->property_map<Index> ("index").first;
-    m_points = this->property_map<Point> ("point").first;
-    m_normals = this->property_map<Vector> ("normal").first;
+    m_indices = this->property_map<Index> ("index").value();
+    m_points = this->property_map<Point> ("point").value();
+    m_normals = this->property_map<Vector> ("normal").value();
     m_nb_removed = ps.m_nb_removed;
   }
   /// \endcond
@@ -816,9 +816,7 @@ public:
 
     \param name Name of the property.
 
-    \return Returns a pair containing: the specified property map and a
-    Boolean set to `true` or an empty property map and a Boolean set
-    to `false` (if the property was not found).
+    \return Returns an optional property map (empty if the property was not found).
   */
   template <class T>
   std::optional<Property_map<T>>

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -359,8 +359,8 @@ public:
     other.resize(m_base.size());
     other.transfer(m_base);
     m_base.swap(other);
-    m_indices = *this->property_map<Index>("index");
-    m_points = *this->property_map<Point>("point");
+    m_indices = this->property_map<Index>("index").value();
+    m_points = this->property_map<Point>("point").value();
   }
 
   /*!

--- a/Point_set_3/include/CGAL/Point_set_3.h
+++ b/Point_set_3/include/CGAL/Point_set_3.h
@@ -359,8 +359,8 @@ public:
     other.resize(m_base.size());
     other.transfer(m_base);
     m_base.swap(other);
-    m_indices = this->property_map<Index>("index").first;
-    m_points = this->property_map<Point>("point").first;
+    m_indices = *this->property_map<Index>("index");
+    m_points = *this->property_map<Point>("point");
   }
 
   /*!
@@ -784,9 +784,9 @@ public:
   template <typename T>
   bool has_property_map (const std::string& name) const
   {
-    std::pair<Property_map<T>, bool>
+    std::optional<Property_map<T>>
       pm = m_base.template get<T> (name);
-    return pm.second;
+    return pm.has_value();
   }
 
   /*!
@@ -806,10 +806,7 @@ public:
   std::pair<Property_map<T>, bool>
   add_property_map (const std::string& name, const T t=T())
   {
-    Property_map<T> pm;
-    bool added = false;
-    std::tie (pm, added) = m_base.template add<T> (name, t);
-    return std::make_pair (pm, added);
+    return m_base.template add<T>(name, t);
   }
 
   /*!
@@ -824,13 +821,10 @@ public:
     to `false` (if the property was not found).
   */
   template <class T>
-  std::pair<Property_map<T>,bool>
+  std::optional<Property_map<T>>
   property_map (const std::string& name) const
   {
-    Property_map<T> pm;
-    bool okay = false;
-    std::tie (pm, okay) = m_base.template get<T>(name);
-    return std::make_pair (pm, okay);
+    return m_base.template get<T>(name);
   }
 
   /*!
@@ -857,8 +851,8 @@ public:
   */
   bool has_normal_map() const
   {
-    std::pair<Vector_map, bool> pm = this->property_map<Vector> ("normal");
-    return pm.second;
+    std::optional<Vector_map> pm = this->property_map<Vector> ("normal");
+    return pm.has_value();
   }
   /*!
     \brief Convenience method that adds a normal property.
@@ -936,7 +930,9 @@ public:
   {
     m_base.copy_properties (other.base());
 
-    m_normals = this->property_map<Vector> ("normal").first; // In case normal was added
+    auto normals = this->property_map<Vector>("normal");
+    if (normals.has_value())
+      m_normals = *normals; // In case normal was added
   }
 
 

--- a/Point_set_3/include/CGAL/Point_set_3/IO/LAS.h
+++ b/Point_set_3/include/CGAL/Point_set_3/IO/LAS.h
@@ -302,25 +302,25 @@ bool write_LAS(std::ostream& os,
 
   if(remove_R)
   {
-    Uchar_map charR, charG, charB;
-    bool foundR, foundG, foundB;
-    boost::tie(charR, foundR) = point_set.template property_map<unsigned char>("r");
-    if(!foundR)
-      boost::tie(charR, foundR) = point_set.template property_map<unsigned char>("red");
-    boost::tie(charG, foundG) = point_set.template property_map<unsigned char>("g");
-    if(!foundG)
-      boost::tie(charG, foundG) = point_set.template property_map<unsigned char>("green");
-    boost::tie(charB, foundB) = point_set.template property_map<unsigned char>("b");
-    if(!foundB)
-      boost::tie(charB, foundB) = point_set.template property_map<unsigned char>("blue");
+    std::optional<Uchar_map> charR, charG, charB;
 
-    if(foundR && foundG && foundB)
+    charR = point_set.template property_map<unsigned char>("r");
+    if(!charR.has_value())
+      charR = point_set.template property_map<unsigned char>("red");
+    charG = point_set.template property_map<unsigned char>("g");
+    if(!charG.has_value())
+      charG = point_set.template property_map<unsigned char>("green");
+    charB = point_set.template property_map<unsigned char>("b");
+    if(!charB.has_value())
+      charB = point_set.template property_map<unsigned char>("blue");
+
+    if(charR.has_value() && charG.has_value() && charB.has_value())
     {
       for(typename Point_set::iterator it = point_set.begin(); it != point_set.end(); ++it)
       {
-        put(R, *it, (unsigned short)(get(charR, *it)));
-        put(G, *it, (unsigned short)(get(charG, *it)));
-        put(B, *it, (unsigned short)(get(charB, *it)));
+        put(R, *it, (unsigned short)(get(charR.value(), *it)));
+        put(G, *it, (unsigned short)(get(charG.value(), *it)));
+        put(B, *it, (unsigned short)(get(charB.value(), *it)));
       }
     }
   }

--- a/Point_set_3/include/CGAL/Point_set_3/IO/PLY.h
+++ b/Point_set_3/include/CGAL/Point_set_3/IO/PLY.h
@@ -521,102 +521,92 @@ bool write_PLY(std::ostream& os,
 
     bool okay = false;
     {
-      Int8_map pmap;
-      boost::tie(pmap, okay) = point_set.template property_map<std::int8_t>(prop[i]);
-      if(okay)
+      std::optional<Int8_map> pmap = point_set.template property_map<std::int8_t>(prop[i]);
+      if(pmap.has_value())
       {
         os << "property char " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Int8_map>(pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Int8_map>(*pmap));
         continue;
       }
     }
     {
-      Uint8_map pmap;
-      boost::tie(pmap, okay) = point_set.template property_map<std::uint8_t>(prop[i]);
-      if(okay)
+      std::optional<Uint8_map> pmap = point_set.template property_map<std::uint8_t>(prop[i]);
+      if(pmap.has_value())
       {
         os << "property uchar " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Uint8_map>(pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Uint8_map>(*pmap));
         continue;
       }
     }
     {
-      Int16_map pmap;
-      boost::tie(pmap, okay) = point_set.template property_map<std::int16_t>(prop[i]);
-      if(okay)
+      std::optional<Int16_map> pmap = point_set.template property_map<std::int16_t>(prop[i]);
+      if(pmap.has_value())
       {
         os << "property short " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Int16_map>(pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Int16_map>(*pmap));
         continue;
       }
     }
     {
-      Uint16_map pmap;
-      boost::tie(pmap, okay) = point_set.template property_map<std::uint16_t>(prop[i]);
-      if(okay)
+      std::optional<Uint16_map> pmap = point_set.template property_map<std::uint16_t>(prop[i]);
+      if(pmap.has_value())
       {
         os << "property ushort " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Uint16_map>(pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Uint16_map>(*pmap));
         continue;
       }
     }
     {
-      Int32_map pmap;
-      boost::tie(pmap, okay) = point_set.template property_map<std::int32_t>(prop[i]);
-      if(okay)
+      std::optional<Int32_map> pmap = point_set.template property_map<std::int32_t>(prop[i]);
+      if(pmap.has_value())
       {
         os << "property int " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Int32_map>(pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Int32_map>(*pmap));
         continue;
       }
     }
     {
-      Uint32_map pmap;
-      boost::tie(pmap, okay) = point_set.template property_map<std::uint32_t>(prop[i]);
-      if(okay)
+      std::optional<Uint32_map> pmap = point_set.template property_map<std::uint32_t>(prop[i]);
+      if(pmap.has_value())
       {
         os << "property uint " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Uint32_map>(pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Uint32_map>(*pmap));
         continue;
       }
     }
     {
-      Int64_map pmap;
-      boost::tie(pmap, okay) = point_set.template property_map<std::int64_t>(prop[i]);
-      if(okay)
+      std::optional<Int64_map> pmap = point_set.template property_map<std::int64_t>(prop[i]);
+      if(pmap.has_value())
       {
         os << "property int " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Int64_map,std::int32_t>(pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Int64_map,std::int32_t>(*pmap));
         continue;
       }
     }
     {
-      Uint64_map pmap;
-      boost::tie(pmap, okay) = point_set.template property_map<std::uint64_t>(prop[i]);
-      if(okay)
+      std::optional<Uint64_map> pmap = point_set.template property_map<std::uint64_t>(prop[i]);
+      if(pmap.has_value())
       {
         os << "property uint " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Uint64_map,std::uint32_t>(pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Uint64_map,std::uint32_t>(*pmap));
         continue;
       }
     }
     {
-      Float_map pmap;
-      boost::tie(pmap, okay) = point_set.template property_map<float>(prop[i]);
-      if(okay)
+      std::optional<Float_map> pmap = point_set.template property_map<float>(prop[i]);
+      if(pmap.has_value())
       {
         os << "property float " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Float_map>(pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Float_map>(*pmap));
         continue;
       }
     }
     {
-      Double_map pmap;
-      boost::tie(pmap, okay) = point_set.template property_map<double>(prop[i]);
-      if(okay)
+      std::optional<Double_map> pmap = point_set.template property_map<double>(prop[i]);
+      if(pmap.has_value())
       {
         os << "property double " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Double_map>(pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Double_map>(*pmap));
         continue;
       }
     }

--- a/Point_set_3/include/CGAL/Point_set_3/IO/PLY.h
+++ b/Point_set_3/include/CGAL/Point_set_3/IO/PLY.h
@@ -519,7 +519,6 @@ bool write_PLY(std::ostream& os,
       continue;
     }
 
-    bool okay = false;
     {
       std::optional<Int8_map> pmap = point_set.template property_map<std::int8_t>(prop[i]);
       if(pmap.has_value())

--- a/Point_set_3/include/CGAL/Point_set_3/IO/PLY.h
+++ b/Point_set_3/include/CGAL/Point_set_3/IO/PLY.h
@@ -525,7 +525,7 @@ bool write_PLY(std::ostream& os,
       if(pmap.has_value())
       {
         os << "property char " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Int8_map>(*pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Int8_map>(pmap.value()));
         continue;
       }
     }
@@ -534,7 +534,7 @@ bool write_PLY(std::ostream& os,
       if(pmap.has_value())
       {
         os << "property uchar " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Uint8_map>(*pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Uint8_map>(pmap.value()));
         continue;
       }
     }
@@ -543,7 +543,7 @@ bool write_PLY(std::ostream& os,
       if(pmap.has_value())
       {
         os << "property short " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Int16_map>(*pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Int16_map>(pmap.value()));
         continue;
       }
     }
@@ -552,7 +552,7 @@ bool write_PLY(std::ostream& os,
       if(pmap.has_value())
       {
         os << "property ushort " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Uint16_map>(*pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Uint16_map>(pmap.value()));
         continue;
       }
     }
@@ -561,7 +561,7 @@ bool write_PLY(std::ostream& os,
       if(pmap.has_value())
       {
         os << "property int " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Int32_map>(*pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Int32_map>(pmap.value()));
         continue;
       }
     }
@@ -570,7 +570,7 @@ bool write_PLY(std::ostream& os,
       if(pmap.has_value())
       {
         os << "property uint " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Uint32_map>(*pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Uint32_map>(pmap.value()));
         continue;
       }
     }
@@ -579,7 +579,7 @@ bool write_PLY(std::ostream& os,
       if(pmap.has_value())
       {
         os << "property int " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Int64_map,std::int32_t>(*pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Int64_map,std::int32_t>(pmap.value()));
         continue;
       }
     }
@@ -588,7 +588,7 @@ bool write_PLY(std::ostream& os,
       if(pmap.has_value())
       {
         os << "property uint " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Uint64_map,std::uint32_t>(*pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Uint64_map,std::uint32_t>(pmap.value()));
         continue;
       }
     }
@@ -597,7 +597,7 @@ bool write_PLY(std::ostream& os,
       if(pmap.has_value())
       {
         os << "property float " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Float_map>(*pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Float_map>(pmap.value()));
         continue;
       }
     }
@@ -606,7 +606,7 @@ bool write_PLY(std::ostream& os,
       if(pmap.has_value())
       {
         os << "property double " << prop[i] << std::endl;
-        printers.push_back(new internal::Simple_property_printer<Index,Double_map>(*pmap));
+        printers.push_back(new internal::Simple_property_printer<Index,Double_map>(pmap.value()));
         continue;
       }
     }

--- a/Point_set_3/test/Point_set_3/point_set_test.cpp
+++ b/Point_set_3/test/Point_set_3/point_set_test.cpp
@@ -96,7 +96,7 @@ int main (int, char**)
     }
 
   std::optional<Point_set::Property_map<Color>> color_prop_2 = point_set.property_map<Color>("color");
-  test ((*color_prop_2 == color_prop), "color property not recovered correctly.");
+  test ((color_prop_2.value() == color_prop), "color property not recovered correctly.");
 
   point_set.remove_normal_map ();
   test (!(point_set.has_normal_map()), "point set shouldn't have normals.");

--- a/Point_set_3/test/Point_set_3/point_set_test.cpp
+++ b/Point_set_3/test/Point_set_3/point_set_test.cpp
@@ -95,9 +95,8 @@ int main (int, char**)
       test ((get (color_prop, *it) == c), "recovered color is incorrect.");
     }
 
-  Point_set::Property_map<Color> color_prop_2;
-  boost::tie (color_prop_2, garbage) = point_set.property_map<Color>("color");
-  test ((color_prop_2 == color_prop), "color property not recovered correctly.");
+  std::optional<Point_set::Property_map<Color>> color_prop_2 = point_set.property_map<Color>("color");
+  test ((*color_prop_2 == color_prop), "color property not recovered correctly.");
 
   point_set.remove_normal_map ();
   test (!(point_set.has_normal_map()), "point set shouldn't have normals.");

--- a/Point_set_3/test/Point_set_3/point_set_test_join.cpp
+++ b/Point_set_3/test/Point_set_3/point_set_test_join.cpp
@@ -30,9 +30,8 @@ void test (bool expr, const char* msg)
 void print_point_set (const Point_set& ps, const char* msg)
 
 {
-  Point_set::Property_map<int> intensity;
-  bool has_intensity;
-  boost::tie (intensity, has_intensity) = ps.property_map<int>("intensity");
+  std::optional<Point_set::Property_map<int>> intensity
+    = ps.property_map<int>("intensity");
 
   std::cerr << msg << std::endl;
   for (Point_set::const_iterator it = ps.begin(); it != ps.end(); ++ it)
@@ -40,8 +39,8 @@ void print_point_set (const Point_set& ps, const char* msg)
     std::cerr << *it << ": " << ps.point(*it);
     if (ps.has_normal_map())
       std::cerr << ", normal " << ps.normal(*it);
-    if (has_intensity)
-      std::cerr << ", intensity " << intensity[*it];
+    if (intensity.has_value())
+      std::cerr << ", intensity " << (*intensity)[*it];
     std::cerr << std::endl;
   }
 }

--- a/Point_set_3/test/Point_set_3/point_set_test_join.cpp
+++ b/Point_set_3/test/Point_set_3/point_set_test_join.cpp
@@ -40,7 +40,7 @@ void print_point_set (const Point_set& ps, const char* msg)
     if (ps.has_normal_map())
       std::cerr << ", normal " << ps.normal(*it);
     if (intensity.has_value())
-      std::cerr << ", intensity " << (*intensity)[*it];
+      std::cerr << ", intensity " << intensity.value()[*it];
     std::cerr << std::endl;
   }
 }

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_and_constraints.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_corefinement_and_constraints.cpp
@@ -87,9 +87,9 @@ count_constrained_edges(const Triangle_mesh& tm, const Constrained_edge_map& ecm
 void test_corefine(Triangle_mesh tm1, Triangle_mesh tm2)
 {
   Constrained_edge_map ecm1 =
-    tm1.property_map<Triangle_mesh::Edge_index,bool>("e:cst").first;
+    tm1.property_map<Triangle_mesh::Edge_index,bool>("e:cst").value();
   Constrained_edge_map ecm2 =
-    tm2.property_map<Triangle_mesh::Edge_index,bool>("e:cst").first;
+    tm2.property_map<Triangle_mesh::Edge_index,bool>("e:cst").value();
 
   assert( count_constrained_edges(tm1, ecm1)==307 );
   assert( count_constrained_edges(tm2, ecm2)==307 );
@@ -108,11 +108,11 @@ void test_union_no_copy(
   const char* outname, bool skip_test_1, bool skip_test_2)
 {
   Constrained_edge_map ecm1 =
-    tm1.property_map<Triangle_mesh::Edge_index,bool>("e:cst").first;
+    tm1.property_map<Triangle_mesh::Edge_index,bool>("e:cst").value();
   Constrained_edge_map ecm2 =
-    tm2.property_map<Triangle_mesh::Edge_index,bool>("e:cst").first;
+    tm2.property_map<Triangle_mesh::Edge_index,bool>("e:cst").value();
   Constrained_edge_map ecm_out =
-    tm_out.property_map<Triangle_mesh::Edge_index,bool>(outname).first;
+    tm_out.property_map<Triangle_mesh::Edge_index,bool>(outname).value();
 
   assert( count_constrained_edges(tm1, ecm1)==307 );
   assert( count_constrained_edges(tm2, ecm2)==307 );
@@ -151,15 +151,15 @@ void test_bool_op_no_copy(
   bool reverse)
 {
   Constrained_edge_map ecm1 =
-    tm1.property_map<Triangle_mesh::Edge_index,bool>("e:cst").first;
+    tm1.property_map<Triangle_mesh::Edge_index,bool>("e:cst").value();
   Constrained_edge_map ecm2 =
-    tm2.property_map<Triangle_mesh::Edge_index,bool>("e:cst").first;
+    tm2.property_map<Triangle_mesh::Edge_index,bool>("e:cst").value();
   Constrained_edge_map ecm_out_union = reverse
-    ? tm2.property_map<Triangle_mesh::Edge_index,bool>(outname).first
-    : tm1.property_map<Triangle_mesh::Edge_index,bool>(outname).first;
+    ? tm2.property_map<Triangle_mesh::Edge_index,bool>(outname).value()
+    : tm1.property_map<Triangle_mesh::Edge_index,bool>(outname).value();
   Constrained_edge_map ecm_out_inter = reverse
-    ? tm1.property_map<Triangle_mesh::Edge_index,bool>(outname).first
-    : tm2.property_map<Triangle_mesh::Edge_index,bool>(outname).first;
+    ? tm1.property_map<Triangle_mesh::Edge_index,bool>(outname).value()
+    : tm2.property_map<Triangle_mesh::Edge_index,bool>(outname).value();
 
   assert( count_constrained_edges(tm1, ecm1)==307 );
   assert( count_constrained_edges(tm2, ecm2)==307 );

--- a/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/compute_confidences.h
+++ b/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/compute_confidences.h
@@ -115,7 +115,7 @@ namespace internal {
 
                         // The supporting planar segment of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, Planar_segment*> face_supporting_segments =
-                                mesh.template property_map<Face_descriptor, Planar_segment*>("f:supp_segment").first;
+                                *mesh.template property_map<Face_descriptor, Planar_segment*>("f:supp_segment");
 
                         Planar_segment* segment = face_supporting_segments[face];
                         if (segment == nullptr)
@@ -123,7 +123,7 @@ namespace internal {
 
                         // The supporting plane of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, const Plane*> face_supporting_planes =
-                                mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane").first;
+                                *mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane");
                         // We do everything by projecting the point onto the face's supporting plane
                         const Plane* supporting_plane = face_supporting_planes[face];
                         CGAL_assertion(supporting_plane == segment->supporting_plane());
@@ -186,7 +186,7 @@ namespace internal {
 
                         // The supporting plane of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, const Plane*> face_supporting_planes =
-                                mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane").first;
+                                *mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane");
 
                         FT degenerate_face_area_threshold = CGAL::snap_squared_distance_threshold<FT>() * CGAL::snap_squared_distance_threshold<FT>();
 

--- a/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/compute_confidences.h
+++ b/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/compute_confidences.h
@@ -115,7 +115,7 @@ namespace internal {
 
                         // The supporting planar segment of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, Planar_segment*> face_supporting_segments =
-                                *mesh.template property_map<Face_descriptor, Planar_segment*>("f:supp_segment");
+                                mesh.template property_map<Face_descriptor, Planar_segment*>("f:supp_segment").value();
 
                         Planar_segment* segment = face_supporting_segments[face];
                         if (segment == nullptr)
@@ -123,7 +123,7 @@ namespace internal {
 
                         // The supporting plane of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, const Plane*> face_supporting_planes =
-                                *mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane");
+                                mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane").value();
                         // We do everything by projecting the point onto the face's supporting plane
                         const Plane* supporting_plane = face_supporting_planes[face];
                         CGAL_assertion(supporting_plane == segment->supporting_plane());
@@ -186,7 +186,7 @@ namespace internal {
 
                         // The supporting plane of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, const Plane*> face_supporting_planes =
-                                *mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane");
+                                mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane").value();
 
                         FT degenerate_face_area_threshold = CGAL::snap_squared_distance_threshold<FT>() * CGAL::snap_squared_distance_threshold<FT>();
 

--- a/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/hypothesis.h
+++ b/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/hypothesis.h
@@ -539,9 +539,9 @@ namespace CGAL {
                         // Properties of the bbox_mesh
 
                         typename Polygon_mesh::template Property_map<Edge_descriptor, std::set<const Plane*> > bbox_edge_supporting_planes
-                                = *bbox_mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane");
+                                = bbox_mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane").value();
                         typename Polygon_mesh::template Property_map<Vertex_descriptor, std::set<const Plane*> > bbox_vertex_supporting_planes
-                                = *bbox_mesh.template property_map<Vertex_descriptor, std::set<const Plane*> >("v:supp_plane");
+                                = bbox_mesh.template property_map<Vertex_descriptor, std::set<const Plane*> >("v:supp_plane").value();
 
                         // The properties of the proxy mesh
                         candidate_faces.clear();
@@ -729,11 +729,11 @@ namespace CGAL {
                         Hypothesis<Kernel>::split_edge(Polygon_mesh& mesh, const EdgePos& ep, const Plane* cutting_plane) {
                         // The supporting planes of each edge
                         typename Polygon_mesh::template Property_map<Edge_descriptor, std::set<const Plane*> > edge_supporting_planes =
-                                *mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane");
+                                mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane").value();
 
                         // The supporting planes of each vertex
                         typename Polygon_mesh::template Property_map<Vertex_descriptor, std::set<const Plane*> > vertex_supporting_planes
-                                = *mesh.template property_map<Vertex_descriptor, std::set<const Plane*> >("v:supp_plane");
+                                = mesh.template property_map<Vertex_descriptor, std::set<const Plane*> >("v:supp_plane").value();
 
                         // We cannot use const reference, because it will become invalid after splitting
                         std::set<const Plane*> sfs = edge_supporting_planes[ep.edge];
@@ -771,7 +771,7 @@ namespace CGAL {
 
                         // The supporting plane of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, const Plane*> face_supporting_planes =
-                                *mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane");
+                                mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane").value();
                         const Plane* supporting_plane = face_supporting_planes[face];
 
                         if (supporting_plane == cutting_plane)
@@ -779,11 +779,11 @@ namespace CGAL {
 
                         // The supporting planar segment of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, Planar_segment*> face_supporting_segments =
-                                *mesh.template property_map<Face_descriptor, Planar_segment*>("f:supp_segment");
+                                mesh.template property_map<Face_descriptor, Planar_segment*>("f:supp_segment").value();
 
                         // The supporting planes of each edge
                         typename Polygon_mesh::template Property_map<Edge_descriptor, std::set<const Plane*> > edge_supporting_planes =
-                                *mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane");
+                                mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane").value();
 
                         Planar_segment* supporting_segment = face_supporting_segments[face];
 
@@ -882,13 +882,13 @@ namespace CGAL {
 
                         // The supporting plane of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, const Plane*> face_supporting_planes =
-                                *mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane");
+                                mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane").value();
                         const Plane* supporting_plane = face_supporting_planes[face];
                         if (supporting_plane == cutting_plane)
                                 return;
 
                         typename Polygon_mesh::template Property_map<Edge_descriptor, std::set<const Plane*> > edge_supporting_planes
-                                = *mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane");
+                                = mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane").value();
 
                         const typename Polygon_mesh::template Property_map<Vertex_descriptor, Point>& coords = mesh.points();
 
@@ -997,11 +997,11 @@ namespace CGAL {
                 {
                         // The supporting plane of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, const Plane*> face_supporting_planes =
-                                *mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane");
+                                mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane").value();
 
                         // The supporting planar segment of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, Planar_segment*> face_supporting_segments =
-                                *mesh.template property_map<Face_descriptor, Planar_segment*>("f:supp_segment");
+                                mesh.template property_map<Face_descriptor, Planar_segment*>("f:supp_segment").value();
 
                         std::set<Face_descriptor> intersecting_faces;
                         for(auto f : mesh.faces()) {
@@ -1034,7 +1034,7 @@ namespace CGAL {
 
                         // The supporting plane of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, const Plane*> face_supporting_planes
-                                = *candidate_faces.template property_map<Face_descriptor, const Plane*>("f:supp_plane");
+                                = candidate_faces.template property_map<Face_descriptor, const Plane*>("f:supp_plane").value();
 
                         for (std::size_t i = 0; i < all_faces.size(); ++i) {
                                 Face_descriptor face = all_faces[i];
@@ -1090,7 +1090,7 @@ namespace CGAL {
                 typename Hypothesis<Kernel>::Adjacency Hypothesis<Kernel>::extract_adjacency(const Polygon_mesh& candidate_faces)
                 {
                         typename Polygon_mesh::template Property_map<Vertex_descriptor, std::set<const Plane*> > vertex_supporting_planes
-                                = *candidate_faces.template property_map<Vertex_descriptor, std::set<const Plane*> >("v:supp_plane");
+                                = candidate_faces.template property_map<Vertex_descriptor, std::set<const Plane*> >("v:supp_plane").value();
 
                         // An edge is denoted by its two end points
                         typedef typename std::unordered_map<const Point*, std::set<Halfedge_descriptor> >        Edge_map;

--- a/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/hypothesis.h
+++ b/Polygonal_surface_reconstruction/include/CGAL/Polygonal_surface_reconstruction/internal/hypothesis.h
@@ -539,9 +539,9 @@ namespace CGAL {
                         // Properties of the bbox_mesh
 
                         typename Polygon_mesh::template Property_map<Edge_descriptor, std::set<const Plane*> > bbox_edge_supporting_planes
-                                = bbox_mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane").first;
+                                = *bbox_mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane");
                         typename Polygon_mesh::template Property_map<Vertex_descriptor, std::set<const Plane*> > bbox_vertex_supporting_planes
-                                = bbox_mesh.template property_map<Vertex_descriptor, std::set<const Plane*> >("v:supp_plane").first;
+                                = *bbox_mesh.template property_map<Vertex_descriptor, std::set<const Plane*> >("v:supp_plane");
 
                         // The properties of the proxy mesh
                         candidate_faces.clear();
@@ -729,11 +729,11 @@ namespace CGAL {
                         Hypothesis<Kernel>::split_edge(Polygon_mesh& mesh, const EdgePos& ep, const Plane* cutting_plane) {
                         // The supporting planes of each edge
                         typename Polygon_mesh::template Property_map<Edge_descriptor, std::set<const Plane*> > edge_supporting_planes =
-                                mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane").first;
+                                *mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane");
 
                         // The supporting planes of each vertex
                         typename Polygon_mesh::template Property_map<Vertex_descriptor, std::set<const Plane*> > vertex_supporting_planes
-                                = mesh.template property_map<Vertex_descriptor, std::set<const Plane*> >("v:supp_plane").first;
+                                = *mesh.template property_map<Vertex_descriptor, std::set<const Plane*> >("v:supp_plane");
 
                         // We cannot use const reference, because it will become invalid after splitting
                         std::set<const Plane*> sfs = edge_supporting_planes[ep.edge];
@@ -771,7 +771,7 @@ namespace CGAL {
 
                         // The supporting plane of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, const Plane*> face_supporting_planes =
-                                mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane").first;
+                                *mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane");
                         const Plane* supporting_plane = face_supporting_planes[face];
 
                         if (supporting_plane == cutting_plane)
@@ -779,11 +779,11 @@ namespace CGAL {
 
                         // The supporting planar segment of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, Planar_segment*> face_supporting_segments =
-                                mesh.template property_map<Face_descriptor, Planar_segment*>("f:supp_segment").first;
+                                *mesh.template property_map<Face_descriptor, Planar_segment*>("f:supp_segment");
 
                         // The supporting planes of each edge
                         typename Polygon_mesh::template Property_map<Edge_descriptor, std::set<const Plane*> > edge_supporting_planes =
-                                mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane").first;
+                                *mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane");
 
                         Planar_segment* supporting_segment = face_supporting_segments[face];
 
@@ -882,13 +882,13 @@ namespace CGAL {
 
                         // The supporting plane of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, const Plane*> face_supporting_planes =
-                                mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane").first;
+                                *mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane");
                         const Plane* supporting_plane = face_supporting_planes[face];
                         if (supporting_plane == cutting_plane)
                                 return;
 
                         typename Polygon_mesh::template Property_map<Edge_descriptor, std::set<const Plane*> > edge_supporting_planes
-                                = mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane").first;
+                                = *mesh.template property_map<Edge_descriptor, std::set<const Plane*> >("e:supp_plane");
 
                         const typename Polygon_mesh::template Property_map<Vertex_descriptor, Point>& coords = mesh.points();
 
@@ -997,11 +997,11 @@ namespace CGAL {
                 {
                         // The supporting plane of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, const Plane*> face_supporting_planes =
-                                mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane").first;
+                                *mesh.template property_map<Face_descriptor, const Plane*>("f:supp_plane");
 
                         // The supporting planar segment of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, Planar_segment*> face_supporting_segments =
-                                mesh.template property_map<Face_descriptor, Planar_segment*>("f:supp_segment").first;
+                                *mesh.template property_map<Face_descriptor, Planar_segment*>("f:supp_segment");
 
                         std::set<Face_descriptor> intersecting_faces;
                         for(auto f : mesh.faces()) {
@@ -1034,7 +1034,7 @@ namespace CGAL {
 
                         // The supporting plane of each face
                         typename Polygon_mesh::template Property_map<Face_descriptor, const Plane*> face_supporting_planes
-                                = candidate_faces.template property_map<Face_descriptor, const Plane*>("f:supp_plane").first;
+                                = *candidate_faces.template property_map<Face_descriptor, const Plane*>("f:supp_plane");
 
                         for (std::size_t i = 0; i < all_faces.size(); ++i) {
                                 Face_descriptor face = all_faces[i];
@@ -1090,7 +1090,7 @@ namespace CGAL {
                 typename Hypothesis<Kernel>::Adjacency Hypothesis<Kernel>::extract_adjacency(const Polygon_mesh& candidate_faces)
                 {
                         typename Polygon_mesh::template Property_map<Vertex_descriptor, std::set<const Plane*> > vertex_supporting_planes
-                                = candidate_faces.template property_map<Vertex_descriptor, std::set<const Plane*> >("v:supp_plane").first;
+                                = *candidate_faces.template property_map<Vertex_descriptor, std::set<const Plane*> >("v:supp_plane");
 
                         // An edge is denoted by its two end points
                         typedef typename std::unordered_map<const Point*, std::set<Halfedge_descriptor> >        Edge_map;

--- a/Surface_mesh/examples/Surface_mesh/sm_memory.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_memory.cpp
@@ -32,7 +32,7 @@ int main()
 
   // The status of being used or removed is stored in a property map
   Mesh::Property_map<Mesh::Vertex_index,bool> removed
-    = m.property_map<Mesh::Vertex_index,bool>("v:removed").first;
+    = *m.property_map<Mesh::Vertex_index,bool>("v:removed");
 
 
   std::cout << "\nIterate over vertices and deleted vertices\n"

--- a/Surface_mesh/examples/Surface_mesh/sm_memory.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_memory.cpp
@@ -32,7 +32,7 @@ int main()
 
   // The status of being used or removed is stored in a property map
   Mesh::Property_map<Mesh::Vertex_index,bool> removed
-    = *m.property_map<Mesh::Vertex_index,bool>("v:removed");
+    = m.property_map<Mesh::Vertex_index,bool>("v:removed").value();
 
 
   std::cout << "\nIterate over vertices and deleted vertices\n"

--- a/Surface_mesh/examples/Surface_mesh/sm_properties.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_properties.cpp
@@ -41,7 +41,7 @@ int main()
   }
 
   //  You can't get a property that does not exist
-  Mesh::Property_map<face_descriptor,std::string> gnus = *m.property_map<face_descriptor,std::string>("v:gnus");
+  Mesh::Property_map<face_descriptor,std::string> gnus = m.property_map<face_descriptor,std::string>("v:gnus").value();
 
   // retrieve the point property for which exists a convenience function
   Mesh::Property_map<vertex_descriptor, K::Point_3> location = m.points();

--- a/Surface_mesh/examples/Surface_mesh/sm_properties.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_properties.cpp
@@ -41,7 +41,8 @@ int main()
   }
 
   //  You can't get a property that does not exist
-  Mesh::Property_map<face_descriptor,std::string> gnus = m.property_map<face_descriptor,std::string>("v:gnus").value();
+  std::optional<Mesh::Property_map<face_descriptor,std::string>> opt_gnus = m.property_map<face_descriptor,std::string>("v:gnus");
+  assert(opt_gnus.has_value());
 
   // retrieve the point property for which exists a convenience function
   Mesh::Property_map<vertex_descriptor, K::Point_3> location = m.points();

--- a/Surface_mesh/examples/Surface_mesh/sm_properties.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_properties.cpp
@@ -41,10 +41,7 @@ int main()
   }
 
   //  You can't get a property that does not exist
-  Mesh::Property_map<face_descriptor,std::string> gnus;
-  bool found;
-  boost::tie(gnus, found) = m.property_map<face_descriptor,std::string>("v:gnus");
-  assert(! found);
+  Mesh::Property_map<face_descriptor,std::string> gnus = *m.property_map<face_descriptor,std::string>("v:gnus");
 
   // retrieve the point property for which exists a convenience function
   Mesh::Property_map<vertex_descriptor, K::Point_3> location = m.points();

--- a/Surface_mesh/examples/Surface_mesh/sm_properties.cpp
+++ b/Surface_mesh/examples/Surface_mesh/sm_properties.cpp
@@ -41,8 +41,8 @@ int main()
   }
 
   //  You can't get a property that does not exist
-  std::optional<Mesh::Property_map<face_descriptor,std::string>> opt_gnus = m.property_map<face_descriptor,std::string>("v:gnus");
-  assert(opt_gnus.has_value());
+  std::optional<Mesh::Property_map<face_descriptor,std::string>> gnus = m.property_map<face_descriptor,std::string>("v:gnus");
+  assert(!gnus.has_value());
 
   // retrieve the point property for which exists a convenience function
   Mesh::Property_map<vertex_descriptor, K::Point_3> location = m.points();

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/OFF.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/OFF.h
@@ -384,7 +384,6 @@ bool write_OFF_with_or_without_fcolors(std::ostream& os,
 {
   typedef Surface_mesh<Point>                                            Mesh;
   typedef typename Mesh::Face_index                                      Face_index;
-  typedef CGAL::IO::Color                                                Color;
 
   using parameters::is_default_parameter;
 
@@ -428,7 +427,6 @@ bool write_OFF_with_or_without_vcolors(std::ostream& os,
 {
   typedef Surface_mesh<Point>                                            Mesh;
   typedef typename Mesh::Vertex_index                                    Vertex_index;
-  typedef CGAL::IO::Color                                                Color;
 
   using parameters::is_default_parameter;
 

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/OFF.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/OFF.h
@@ -390,12 +390,10 @@ bool write_OFF_with_or_without_fcolors(std::ostream& os,
 
   const bool has_fcolors = !(is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>::value);
 
-  typename Mesh::template Property_map<Face_index, Color> fcolors;
-  bool has_internal_fcolors;
-  std::tie(fcolors, has_internal_fcolors) = sm.template property_map<Face_index, CGAL::IO::Color>("f:color");
+  auto fcolors  = sm.template property_map<Face_index, CGAL::IO::Color>("f:color");
 
-  if(!has_fcolors && has_internal_fcolors && std::distance(fcolors.begin(), fcolors.end()) > 0)
-    return write_OFF_BGL(os, sm, np.face_color_map(fcolors));
+  if(!has_fcolors && fcolors.has_value() && std::distance(fcolors->begin(), fcolors->end()) > 0)
+    return write_OFF_BGL(os, sm, np.face_color_map(*fcolors));
   else
     return write_OFF_BGL(os, sm, np);
 }
@@ -415,12 +413,10 @@ bool write_OFF_with_or_without_vtextures(std::ostream& os,
 
   const bool has_vtextures = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_texture_map_t>::value);
 
-  typename Mesh::template Property_map<Vertex_index, Texture> vtextures;
-  bool has_internal_vtextures;
-  std::tie(vtextures, has_internal_vtextures) = sm.template property_map<Vertex_index, Texture>("v:texcoord");
+  auto vtextures = sm.template property_map<Vertex_index, Texture>("v:texcoord");
 
-  if(!has_vtextures && has_internal_vtextures && std::distance(vtextures.begin(), vtextures.end()) > 0)
-    return write_OFF_with_or_without_fcolors(os, sm, np.vertex_texture_map(vtextures));
+  if(!has_vtextures && vtextures.has_value() && std::distance(vtextures->begin(), vtextures->end()) > 0)
+    return write_OFF_with_or_without_fcolors(os, sm, np.vertex_texture_map(*vtextures));
   else
     return write_OFF_with_or_without_fcolors(os, sm, np);
 }
@@ -438,12 +434,11 @@ bool write_OFF_with_or_without_vcolors(std::ostream& os,
 
   const bool has_vcolors = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>::value);
 
-  typename Mesh::template Property_map<Vertex_index, Color> vcolors;
-  bool has_internal_vcolors;
-  std::tie(vcolors, has_internal_vcolors) = sm.template property_map<Vertex_index, CGAL::IO::Color>("v:color");
 
-  if(!has_vcolors && has_internal_vcolors && std::distance(vcolors.begin(), vcolors.end()) > 0)
-    return write_OFF_with_or_without_vtextures(os, sm, np.vertex_color_map(vcolors));
+  auto vcolors = sm.template property_map<Vertex_index, CGAL::IO::Color>("v:color");
+
+  if(!has_vcolors && vcolors.has_value() && std::distance(vcolors->begin(), vcolors->end()) > 0)
+    return write_OFF_with_or_without_vtextures(os, sm, np.vertex_color_map(*vcolors));
   else
     return write_OFF_with_or_without_vtextures(os, sm, np);
 }
@@ -463,12 +458,10 @@ bool write_OFF_with_or_without_vnormals(std::ostream& os,
 
   const bool has_vnormals = !(is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_normal_map_t>::value);
 
-  typename Mesh::template Property_map<Vertex_index, Normal> vnormals;
-  bool has_internal_vnormals;
-  std::tie(vnormals, has_internal_vnormals) = sm.template property_map<Vertex_index, Normal>("v:normal");
+  auto vnormals = sm.template property_map<Vertex_index, Normal>("v:normal");
 
-  if(!has_vnormals && has_internal_vnormals && std::distance(vnormals.begin(), vnormals.end()) > 0)
-    return write_OFF_with_or_without_vcolors(os, sm, np.vertex_normal_map(vnormals));
+  if(!has_vnormals && vnormals.has_value() && std::distance(vnormals->begin(), vnormals->end()) > 0)
+    return write_OFF_with_or_without_vcolors(os, sm, np.vertex_normal_map(*vnormals));
   else
     return write_OFF_with_or_without_vcolors(os, sm, np);
 }

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/OFF.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/OFF.h
@@ -392,8 +392,8 @@ bool write_OFF_with_or_without_fcolors(std::ostream& os,
 
   auto fcolors  = sm.template property_map<Face_index, CGAL::IO::Color>("f:color");
 
-  if(!has_fcolors && fcolors.has_value() && std::distance(fcolors->begin(), fcolors->end()) > 0)
-    return write_OFF_BGL(os, sm, np.face_color_map(*fcolors));
+  if(!has_fcolors && fcolors.has_value() && std::distance(fcolors.value().begin(), fcolors.value().end()) > 0)
+    return write_OFF_BGL(os, sm, np.face_color_map(fcolors.value()));
   else
     return write_OFF_BGL(os, sm, np);
 }
@@ -415,8 +415,8 @@ bool write_OFF_with_or_without_vtextures(std::ostream& os,
 
   auto vtextures = sm.template property_map<Vertex_index, Texture>("v:texcoord");
 
-  if(!has_vtextures && vtextures.has_value() && std::distance(vtextures->begin(), vtextures->end()) > 0)
-    return write_OFF_with_or_without_fcolors(os, sm, np.vertex_texture_map(*vtextures));
+  if(!has_vtextures && vtextures.has_value() && std::distance(vtextures.value().begin(), vtextures.value().end()) > 0)
+    return write_OFF_with_or_without_fcolors(os, sm, np.vertex_texture_map(vtextures.value()));
   else
     return write_OFF_with_or_without_fcolors(os, sm, np);
 }
@@ -437,8 +437,8 @@ bool write_OFF_with_or_without_vcolors(std::ostream& os,
 
   auto vcolors = sm.template property_map<Vertex_index, CGAL::IO::Color>("v:color");
 
-  if(!has_vcolors && vcolors.has_value() && std::distance(vcolors->begin(), vcolors->end()) > 0)
-    return write_OFF_with_or_without_vtextures(os, sm, np.vertex_color_map(*vcolors));
+  if(!has_vcolors && vcolors.has_value() && std::distance(vcolors.value().begin(), vcolors.value().end()) > 0)
+    return write_OFF_with_or_without_vtextures(os, sm, np.vertex_color_map(vcolors.value()));
   else
     return write_OFF_with_or_without_vtextures(os, sm, np);
 }
@@ -460,8 +460,8 @@ bool write_OFF_with_or_without_vnormals(std::ostream& os,
 
   auto vnormals = sm.template property_map<Vertex_index, Normal>("v:normal");
 
-  if(!has_vnormals && vnormals.has_value() && std::distance(vnormals->begin(), vnormals->end()) > 0)
-    return write_OFF_with_or_without_vcolors(os, sm, np.vertex_normal_map(*vnormals));
+  if(!has_vnormals && vnormals.has_value() && std::distance(vnormals.value().begin(), vnormals.value().end()) > 0)
+    return write_OFF_with_or_without_vcolors(os, sm, np.vertex_normal_map(vnormals.value()));
   else
     return write_OFF_with_or_without_vcolors(os, sm, np);
 }

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -463,9 +463,8 @@ bool fill_simplex_specific_header(std::ostream& os,
   bool okay = false;
   if(prop == "v:normal")
   {
-    Vector_map pmap;
-    std::tie(pmap, okay) = sm.template property_map<VIndex, Vector>(prop);
-    if(okay)
+    auto pmap = sm.template property_map<VIndex, Vector>(prop);
+    if(pmap.has_value())
     {
       if(std::is_same<FT, float>::value)
       {
@@ -479,23 +478,22 @@ bool fill_simplex_specific_header(std::ostream& os,
            << "property double ny" << std::endl
            << "property double nz" << std::endl;
       }
-      printers.push_back(new Property_printer<VIndex, Vector_map>(pmap));
+      printers.push_back(new Property_printer<VIndex, Vector_map>(*pmap));
       return true;
     }
   }
 
   if(prop == "v:color")
   {
-    Vcolor_map pmap;
-    std::tie(pmap, okay) = sm.template property_map<VIndex, Color>(prop);
-    if(okay)
+    auto pmap = sm.template property_map<VIndex, Color>(prop);
+    if(pmap.has_value())
     {
       os << "property uchar red" << std::endl
          << "property uchar green" << std::endl
          << "property uchar blue" << std::endl
          << "property uchar alpha" << std::endl;
 
-      printers.push_back(new Property_printer<VIndex, Vcolor_map>(pmap));
+      printers.push_back(new Property_printer<VIndex, Vcolor_map>(*pmap));
       return true;
     }
   }
@@ -520,16 +518,15 @@ bool fill_simplex_specific_header(std::ostream& os,
   bool okay = false;
   if(prop == "f:color")
   {
-    Fcolor_map pmap;
-    std::tie(pmap, okay) = sm.template property_map<FIndex, Color>(prop);
-    if(okay)
+    auto pmap = sm.template property_map<FIndex, Color>(prop);
+    if(pmap.has_value())
     {
       os << "property uchar red" << std::endl
          << "property uchar green" << std::endl
          << "property uchar blue" << std::endl
          << "property uchar alpha" << std::endl;
 
-      printers.push_back(new Property_printer<FIndex, Fcolor_map>(pmap));
+      printers.push_back(new Property_printer<FIndex, Fcolor_map>(*pmap));
       return true;
     }
   }
@@ -644,25 +641,23 @@ void fill_header_impl(std::tuple<T,TN...>,
   bool okay = false;
   {
     typedef typename Surface_mesh<Point>::template Property_map<Simplex, T>   Pmap;
-    Pmap pmap;
-    std::tie(pmap, okay) = sm.template property_map<Simplex,T>(pname);
-    if(okay)
+    auto pmap  = sm.template property_map<Simplex,T>(pname);
+    if(pmap.has_value())
     {
       std::string name = get_property_raw_name<Point>(pname, Simplex());
       os << "property " << type_strings[cid] << " " << name << std::endl;
-      printers.push_back(new internal::Simple_property_printer<Simplex,Pmap>(pmap));
+      printers.push_back(new internal::Simple_property_printer<Simplex,Pmap>(*pmap));
       return;
     }
   }
   {
     typedef typename Surface_mesh<Point>::template Property_map<Simplex, std::vector<T>>   Pmap;
-    Pmap pmap;
-    std::tie(pmap, okay) = sm.template property_map<Simplex,std::vector<T>>(pname);
-    if(okay)
+    auto pmap  = sm.template property_map<Simplex,std::vector<T>>(pname);
+    if(pmap.has_value())
     {
       std::string name = get_property_raw_name<Point>(pname, Simplex());
       os << "property list uchar " << type_strings[cid] << " " << name << std::endl;
-      printers.push_back(new internal::Simple_property_vector_printer<Simplex,Pmap>(pmap));
+      printers.push_back(new internal::Simple_property_vector_printer<Simplex,Pmap>(*pmap));
       return;
     }
   }

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -460,7 +460,6 @@ bool fill_simplex_specific_header(std::ostream& os,
     return true;
   }
 
-  bool okay = false;
   if(prop == "v:normal")
   {
     auto pmap = sm.template property_map<VIndex, Vector>(prop);
@@ -515,7 +514,6 @@ bool fill_simplex_specific_header(std::ostream& os,
   if(prop == "f:connectivity" || prop == "f:removed")
     return true;
 
-  bool okay = false;
   if(prop == "f:color")
   {
     auto pmap = sm.template property_map<FIndex, Color>(prop);
@@ -638,7 +636,6 @@ void fill_header_impl(std::tuple<T,TN...>,
                       std::vector<Abstract_property_printer<Simplex>*>& printers)
 {
   constexpr std::size_t cid = s-std::tuple_size<std::tuple<T,TN...>>::value;
-  bool okay = false;
   {
     typedef typename Surface_mesh<Point>::template Property_map<Simplex, T>   Pmap;
     auto pmap  = sm.template property_map<Simplex,T>(pname);

--- a/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
@@ -397,7 +397,7 @@ public:
     {
       std::optional<Get_pmap_type<T>::type> out = get<T>(name);
       if (out.has_value())
-        return *out;
+        return out.value();
       else
         return add<T>(name, t).first;
     }

--- a/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
@@ -395,7 +395,7 @@ public:
     typename Get_pmap_type<T>::type
     get_or_add(const std::string& name, const T t=T())
     {
-      std::optional<Get_pmap_type<T>::type> out = get<T>(name);
+      std::optional<typename Get_pmap_type<T>::type> out = get<T>(name);
       if (out.has_value())
         return out.value();
       else

--- a/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
@@ -20,6 +20,7 @@
 #include <CGAL/property_map.h>
 
 #include <algorithm>
+#include <optional>
 #include <string>
 #include <typeinfo>
 #include <vector>

--- a/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Properties.h
@@ -339,16 +339,16 @@ public:
     };
 
     template <class T>
-    std::pair<typename Get_pmap_type<T>::type, bool>
+    std::optional<typename Get_pmap_type<T>::type>
     get(const std::string& name, std::size_t i) const
     {
       typedef typename Ref_class::template Get_property_map<Key, T>::type Pmap;
       if (parrays_[i]->name() == name)
         {
           if (Property_array<T>* array = dynamic_cast<Property_array<T>*>(parrays_[i]))
-            return std::make_pair (Pmap(array), true);
+            return std::optional(Pmap(array));
         }
-      return std::make_pair(Pmap(), false);
+      return std::nullopt;
     }
 
     // add a property with name \c name and default value \c t
@@ -359,12 +359,9 @@ public:
         typedef typename Ref_class::template Get_property_map<Key, T>::type Pmap;
         for (std::size_t i=0; i<parrays_.size(); ++i)
         {
-            std::pair<Pmap, bool> out = get<T>(name, i);
-            if (out.second)
-              {
-                out.second = false;
-                return out;
-              }
+            std::optional<Pmap> out = get<T>(name, i);
+            if (out.has_value())
+              return std::make_pair(*out, false);
         }
 
         // otherwise add the property
@@ -376,19 +373,19 @@ public:
     }
 
 
-    // get a property by its name. returns invalid property if it does not exist.
+    // get a property by its name. Returns std::nullopt when it doesn't exist
     template <class T>
-    std::pair<typename Get_pmap_type<T>::type, bool>
+    std::optional<typename Get_pmap_type<T>::type>
     get(const std::string& name) const
     {
         typedef typename Ref_class::template Get_property_map<Key, T>::type Pmap;
         for (std::size_t i=0; i<parrays_.size(); ++i)
           {
-            std::pair<Pmap, bool> out = get<T>(name, i);
-            if (out.second)
+            std::optional<Pmap> out = get<T>(name, i);
+            if (out.has_value())
               return out;
           }
-        return std::make_pair(Pmap(), false);
+        return std::nullopt;
     }
 
 
@@ -397,11 +394,11 @@ public:
     typename Get_pmap_type<T>::type
     get_or_add(const std::string& name, const T t=T())
     {
-      typename Ref_class::template Get_property_map<Key, T>::type p;
-      bool b;
-      boost::tie(p,b)= get<T>(name);
-        if (!b) p = add<T>(name, t).first;
-        return p;
+      std::optional<Get_pmap_type<T>::type> out = get<T>(name);
+      if (out.has_value())
+        return *out;
+      else
+        return add<T>(name, t).first;
     }
 
 

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2073,12 +2073,9 @@ private: //--------------------------------------------------- property handling
       return Property_selector<I>(this)().template add<T>(name, t);
     }
 
-    /// returns a property map named `name` with key type `I` and value type `T`,
-    /// and a Boolean that is `true` if the property exists.
-    /// In case it does not exist the Boolean is `false` and the behavior of
-    /// the property map is undefined.
+    /// returns an optional property map named `name` with key type `I` and value type `T`.
     template <class I, class T>
-    std::pair<Property_map<I, T>,bool> property_map(const std::string& name) const
+    std::optional<Property_map<I, T>> property_map(const std::string& name) const
     {
       return Property_selector<I>(const_cast<Surface_mesh*>(this))().template get<T>(name);
     }
@@ -2317,13 +2314,13 @@ operator=(const Surface_mesh<P>& rhs)
         fprops_ = rhs.fprops_;
 
         // property handles contain pointers, have to be reassigned
-        vconn_    = property_map<Vertex_index, Vertex_connectivity>("v:connectivity").first;
-        hconn_    = property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity").first;
-        fconn_    = property_map<Face_index, Face_connectivity>("f:connectivity").first;
-        vremoved_ = property_map<Vertex_index, bool>("v:removed").first;
-        eremoved_ = property_map<Edge_index, bool>("e:removed").first;
-        fremoved_ = property_map<Face_index, bool>("f:removed").first;
-        vpoint_   = property_map<Vertex_index, P>("v:point").first;
+        vconn_    = *property_map<Vertex_index, Vertex_connectivity>("v:connectivity");
+        hconn_    = *property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity");
+        fconn_    = *property_map<Face_index, Face_connectivity>("f:connectivity");
+        vremoved_ = *property_map<Vertex_index, bool>("v:removed");
+        eremoved_ = *property_map<Edge_index, bool>("e:removed");
+        fremoved_ = *property_map<Face_index, bool>("f:removed");
+        vpoint_   = *property_map<Vertex_index, P>("v:point");
 
         // how many elements are removed?
         removed_vertices_  = rhs.removed_vertices_;

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2314,13 +2314,13 @@ operator=(const Surface_mesh<P>& rhs)
         fprops_ = rhs.fprops_;
 
         // property handles contain pointers, have to be reassigned
-        vconn_    = *property_map<Vertex_index, Vertex_connectivity>("v:connectivity");
-        hconn_    = *property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity");
-        fconn_    = *property_map<Face_index, Face_connectivity>("f:connectivity");
-        vremoved_ = *property_map<Vertex_index, bool>("v:removed");
-        eremoved_ = *property_map<Edge_index, bool>("e:removed");
-        fremoved_ = *property_map<Face_index, bool>("f:removed");
-        vpoint_   = *property_map<Vertex_index, P>("v:point");
+        vconn_    = property_map<Vertex_index, Vertex_connectivity>("v:connectivity").value();
+        hconn_    = property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity").value();
+        fconn_    = property_map<Face_index, Face_connectivity>("f:connectivity").value();
+        vremoved_ = property_map<Vertex_index, bool>("v:removed").value();
+        eremoved_ = property_map<Edge_index, bool>("e:removed").value();
+        fremoved_ = property_map<Face_index, bool>("f:removed").value();
+        vpoint_   = property_map<Vertex_index, P>("v:point").value();
 
         // how many elements are removed?
         removed_vertices_  = rhs.removed_vertices_;

--- a/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh.h
@@ -41,9 +41,9 @@ public:
   typedef typename SM::Edge_index                         key_type;
 
   SM_edge_weight_pmap(const CGAL::Surface_mesh<Point>& sm)
-    : pm_(*sm. template property_map<
+    : pm_(sm. template property_map<
             typename SM::Vertex_index,
-            typename SM::Point >("v:point")),
+            typename SM::Point >("v:point").value()),
       sm_(sm)
     {}
 

--- a/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh.h
@@ -41,9 +41,9 @@ public:
   typedef typename SM::Edge_index                         key_type;
 
   SM_edge_weight_pmap(const CGAL::Surface_mesh<Point>& sm)
-    : pm_(sm. template property_map<
+    : pm_(*sm. template property_map<
             typename SM::Vertex_index,
-            typename SM::Point >("v:point").first),
+            typename SM::Point >("v:point")),
       sm_(sm)
     {}
 

--- a/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh_features.h
+++ b/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh_features.h
@@ -100,7 +100,7 @@ typename boost::lazy_disable_if<
 inline get(CGAL::face_patch_id_t<I>, const Surface_mesh<P> & smesh)
 {
  typedef typename boost::graph_traits<Surface_mesh<P> >::face_descriptor face_descriptor;
-  return *smesh. template property_map<face_descriptor,I>("f:patch_id");
+  return smesh. template property_map<face_descriptor,I>("f:patch_id").value();
 }
 
 
@@ -134,7 +134,7 @@ CGAL_PROPERTY_SURFACE_MESH_RETURN_TYPE(CGAL::edge_is_feature_t)
 inline get(CGAL::edge_is_feature_t, const Surface_mesh<P>& smesh)
 {
   typedef typename boost::graph_traits<Surface_mesh<P> >::edge_descriptor edge_descriptor;
-  return *smesh. template property_map<edge_descriptor,bool>("e:is_feature");
+  return smesh. template property_map<edge_descriptor,bool>("e:is_feature").value();
 }
 
 
@@ -151,7 +151,7 @@ CGAL_PROPERTY_SURFACE_MESH_RETURN_TYPE(CGAL::vertex_feature_degree_t)
 inline get(CGAL::vertex_feature_degree_t, const Surface_mesh<P> & smesh)
 {
   typedef typename boost::graph_traits<Surface_mesh<P> >::vertex_descriptor vertex_descriptor;
-  return smesh. template property_map<vertex_descriptor,int>("v:nfe").first;
+  return smesh. template property_map<vertex_descriptor,int>("v:nfe").value();
 }
 
 template <typename P, typename I>
@@ -173,7 +173,7 @@ typename boost::lazy_disable_if<
   inline get(CGAL::vertex_incident_patches_t<I>, const Surface_mesh<P> & smesh)
 {
   typedef typename boost::graph_traits<Surface_mesh<P> >::vertex_descriptor vertex_descriptor;
-  return smesh. template property_map<vertex_descriptor,std::set<I> >("v:ip").first;
+  return smesh. template property_map<vertex_descriptor,std::set<I> >("v:ip").value();
 }
 
 } // namespace CGAL

--- a/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh_features.h
+++ b/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh_features.h
@@ -100,7 +100,7 @@ typename boost::lazy_disable_if<
 inline get(CGAL::face_patch_id_t<I>, const Surface_mesh<P> & smesh)
 {
  typedef typename boost::graph_traits<Surface_mesh<P> >::face_descriptor face_descriptor;
-  return smesh. template property_map<face_descriptor,I>("f:patch_id").first;
+  return *smesh. template property_map<face_descriptor,I>("f:patch_id");
 }
 
 
@@ -134,7 +134,7 @@ CGAL_PROPERTY_SURFACE_MESH_RETURN_TYPE(CGAL::edge_is_feature_t)
 inline get(CGAL::edge_is_feature_t, const Surface_mesh<P>& smesh)
 {
   typedef typename boost::graph_traits<Surface_mesh<P> >::edge_descriptor edge_descriptor;
-  return smesh. template property_map<edge_descriptor,bool>("e:is_feature").first;
+  return *smesh. template property_map<edge_descriptor,bool>("e:is_feature");
 }
 
 

--- a/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh_time_stamp.h
+++ b/Surface_mesh/include/CGAL/boost/graph/properties_Surface_mesh_time_stamp.h
@@ -79,7 +79,7 @@ CGAL_PROPERTY_SURFACE_MESH_RETURN_TYPE(CGAL::vertex_time_stamp_t)
 inline get(CGAL::vertex_time_stamp_t, const Surface_mesh<P> & smesh)
 {
   typedef typename boost::graph_traits<Surface_mesh<P> >::vertex_descriptor vertex_descriptor;
-  return smesh. template property_map<vertex_descriptor,std::size_t>("v:time_stamp").first;
+  return smesh. template property_map<vertex_descriptor,std::size_t>("v:time_stamp").value();
 }
 
 template <typename P>
@@ -95,7 +95,7 @@ CGAL_PROPERTY_SURFACE_MESH_RETURN_TYPE(CGAL::halfedge_time_stamp_t)
 inline get(CGAL::halfedge_time_stamp_t, const Surface_mesh<P> & smesh)
 {
   typedef typename boost::graph_traits<Surface_mesh<P> >::halfedge_descriptor halfedge_descriptor;
-  return smesh. template property_map<halfedge_descriptor,std::size_t>("h:time_stamp").first;
+  return smesh. template property_map<halfedge_descriptor,std::size_t>("h:time_stamp").value();
 }
 
 template <typename P>
@@ -111,7 +111,7 @@ CGAL_PROPERTY_SURFACE_MESH_RETURN_TYPE(CGAL::face_time_stamp_t)
 inline get(CGAL::face_time_stamp_t, const Surface_mesh<P> & smesh)
 {
   typedef typename boost::graph_traits<Surface_mesh<P> >::face_descriptor face_descriptor;
-  return smesh. template property_map<face_descriptor,std::size_t>("v:time_stamp").first;
+  return smesh. template property_map<face_descriptor,std::size_t>("v:time_stamp").value();
 }
 } // namespace CGAL
 

--- a/Surface_mesh/include/CGAL/draw_surface_mesh.h
+++ b/Surface_mesh/include/CGAL/draw_surface_mesh.h
@@ -112,11 +112,11 @@ struct Graphics_scene_options_surface_mesh
 
   Graphics_scene_options_surface_mesh(const SM& amesh)
   {
-    bool found=false;
-    std::tie(vcolors, found)=
+    auto _vcolors =
         amesh.template property_map<vertex_descriptor, CGAL::IO::Color>("v:color");
-    if(found)
+    if(_vcolors.has_value())
     {
+      vcolors = *_vcolors;
       this->colored_vertex=[](const SM &, vertex_descriptor)->bool { return true; };
       this->vertex_color=[this](const SM &, vertex_descriptor v)->CGAL::IO::Color
       { return get(vcolors, v); };
@@ -124,10 +124,11 @@ struct Graphics_scene_options_surface_mesh
     else
     { this->colored_vertex=[](const SM &, vertex_descriptor)->bool { return false; }; }
 
-    std::tie(ecolors, found)=
+    auto _ecolors =
         amesh.template property_map<edge_descriptor, CGAL::IO::Color>("e:color");
-    if(found)
+    if(_ecolors.has_value())
     {
+      ecolors = *_ecolors;
       this->colored_edge=[](const SM &, edge_descriptor)->bool { return true; };
       this->edge_color=[this](const SM &, edge_descriptor e)->CGAL::IO::Color
       { return get(ecolors, e); };
@@ -135,10 +136,11 @@ struct Graphics_scene_options_surface_mesh
     else
     { this->colored_edge=[](const SM &, edge_descriptor)->bool { return false; }; }
 
-    std::tie(fcolors, found)=
+    auto _fcolors =
         amesh.template property_map<face_descriptor, CGAL::IO::Color>("f:color");
-    if(found)
+    if(_fcolors.has_value())
     {
+      fcolors = *_fcolors;
       this->colored_face=[](const SM &, face_descriptor)->bool { return true; };
       this->face_color=[this](const SM &, face_descriptor f)->CGAL::IO::Color
       { return get(fcolors, f); };

--- a/Surface_mesh/include/CGAL/draw_surface_mesh.h
+++ b/Surface_mesh/include/CGAL/draw_surface_mesh.h
@@ -112,8 +112,7 @@ struct Graphics_scene_options_surface_mesh
 
   Graphics_scene_options_surface_mesh(const SM& amesh)
   {
-    std::optional<typename SM::template Property_map<vertex_descriptor, CGAL::IO::Color>> _vcolors =
-        amesh.template property_map<vertex_descriptor, CGAL::IO::Color>("v:color");
+    auto _vcolors = amesh.template property_map<vertex_descriptor, CGAL::IO::Color>("v:color");
     if(_vcolors.has_value())
     {
       vcolors = _vcolors.value();
@@ -124,8 +123,7 @@ struct Graphics_scene_options_surface_mesh
     else
     { this->colored_vertex=[](const SM &, vertex_descriptor)->bool { return false; }; }
 
-    std::optional<typename SM::template Property_map<edge_descriptor, CGAL::IO::Color>> _ecolors
-      = amesh.template property_map<edge_descriptor, CGAL::IO::Color>("e:color");
+    auto _ecolors = amesh.template property_map<edge_descriptor, CGAL::IO::Color>("e:color");
     if(_ecolors.has_value())
     {
       ecolors = _ecolors.value();
@@ -136,8 +134,7 @@ struct Graphics_scene_options_surface_mesh
     else
     { this->colored_edge=[](const SM &, edge_descriptor)->bool { return false; }; }
 
-    auto _fcolors =
-        amesh.template property_map<face_descriptor, CGAL::IO::Color>("f:color");
+    auto _fcolors = amesh.template property_map<face_descriptor, CGAL::IO::Color>("f:color");
     if(_fcolors.has_value())
     {
       fcolors = _fcolors.value();

--- a/Surface_mesh/include/CGAL/draw_surface_mesh.h
+++ b/Surface_mesh/include/CGAL/draw_surface_mesh.h
@@ -112,11 +112,11 @@ struct Graphics_scene_options_surface_mesh
 
   Graphics_scene_options_surface_mesh(const SM& amesh)
   {
-    auto _vcolors =
+    std::optional<typename SM::template Property_map<vertex_descriptor, CGAL::IO::Color>> _vcolors =
         amesh.template property_map<vertex_descriptor, CGAL::IO::Color>("v:color");
     if(_vcolors.has_value())
     {
-      vcolors = *_vcolors;
+      vcolors = _vcolors.value();
       this->colored_vertex=[](const SM &, vertex_descriptor)->bool { return true; };
       this->vertex_color=[this](const SM &, vertex_descriptor v)->CGAL::IO::Color
       { return get(vcolors, v); };
@@ -124,11 +124,11 @@ struct Graphics_scene_options_surface_mesh
     else
     { this->colored_vertex=[](const SM &, vertex_descriptor)->bool { return false; }; }
 
-    auto _ecolors =
-        amesh.template property_map<edge_descriptor, CGAL::IO::Color>("e:color");
+    std::optional<typename SM::template Property_map<edge_descriptor, CGAL::IO::Color>> _ecolors
+      = amesh.template property_map<edge_descriptor, CGAL::IO::Color>("e:color");
     if(_ecolors.has_value())
     {
-      ecolors = *_ecolors;
+      ecolors = _ecolors.value();
       this->colored_edge=[](const SM &, edge_descriptor)->bool { return true; };
       this->edge_color=[this](const SM &, edge_descriptor e)->CGAL::IO::Color
       { return get(ecolors, e); };
@@ -140,7 +140,7 @@ struct Graphics_scene_options_surface_mesh
         amesh.template property_map<face_descriptor, CGAL::IO::Color>("f:color");
     if(_fcolors.has_value())
     {
-      fcolors = *_fcolors;
+      fcolors = _fcolors.value();
       this->colored_face=[](const SM &, face_descriptor)->bool { return true; };
       this->face_color=[this](const SM &, face_descriptor f)->CGAL::IO::Color
       { return get(fcolors, f); };

--- a/Surface_mesh/test/Surface_mesh/sm_open_colored_off.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_open_colored_off.cpp
@@ -34,10 +34,10 @@ void OpenOFF(int i)
 
 
   SMesh::Property_map<face_descriptor, CGAL::IO::Color> fcolors =
-      *surface_mesh.property_map<face_descriptor, CGAL::IO::Color >("f:color");
+      surface_mesh.property_map<face_descriptor, CGAL::IO::Color >("f:color").value();
 
   SMesh::Property_map<vertex_descriptor, CGAL::IO::Color> vcolors =
-    *surface_mesh.property_map<vertex_descriptor, CGAL::IO::Color >("v:color");
+    surface_mesh.property_map<vertex_descriptor, CGAL::IO::Color >("v:color").value();
 
   CGAL::IO::Color c = fcolors[*(surface_mesh.faces().begin())];
   assert(c== CGAL::IO::Color(229,0,0));

--- a/Surface_mesh/test/Surface_mesh/sm_open_colored_off.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_open_colored_off.cpp
@@ -34,10 +34,11 @@ void OpenOFF(int i)
 
 
   SMesh::Property_map<face_descriptor, CGAL::IO::Color> fcolors =
-      surface_mesh.property_map<face_descriptor, CGAL::IO::Color >("f:color").first;
+      *surface_mesh.property_map<face_descriptor, CGAL::IO::Color >("f:color");
 
   SMesh::Property_map<vertex_descriptor, CGAL::IO::Color> vcolors =
-    surface_mesh.property_map<vertex_descriptor, CGAL::IO::Color >("v:color").first;
+    *surface_mesh.property_map<vertex_descriptor, CGAL::IO::Color >("v:color");
+
   CGAL::IO::Color c = fcolors[*(surface_mesh.faces().begin())];
   assert(c== CGAL::IO::Color(229,0,0));
   c = fcolors[*(--surface_mesh.faces().end())];

--- a/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
@@ -91,13 +91,9 @@ int main()
     SMesh mesh_bis;
     CGAL::IO::read_PLY(in, mesh_bis);
 
-    assert((mesh_bis.property_map<SMesh::Vertex_index, float>("v:u").has_value()));
-    assert((mesh_bis.property_map<SMesh::Vertex_index, float>("v:v").has_value()));
-    assert((mesh_bis.property_map<SMesh::Vertex_index, std::vector<float>>("v:uv").has_value()));
-
-    v_uvmap = *mesh_bis.property_map<SMesh::Vertex_index, std::vector<float>>("v:uv");
-    v_umap = *mesh_bis.property_map<SMesh::Vertex_index, float>("v:u");
-    v_vmap = *mesh_bis.property_map<SMesh::Vertex_index, float>("v:v");
+    v_uvmap = mesh_bis.property_map<SMesh::Vertex_index, std::vector<float>>("v:uv").value();
+    v_umap = mesh_bis.property_map<SMesh::Vertex_index, float>("v:u").value();
+    v_vmap = mesh_bis.property_map<SMesh::Vertex_index, float>("v:v").value();
 
     fvalue=1001;
     for (SMesh::Vertex_index v : vertices(mesh_bis))
@@ -110,13 +106,9 @@ int main()
       ++fvalue;
     }
 
-    assert((mesh_bis.property_map<SMesh::Face_index, double>("f:u")));
-    assert((mesh_bis.property_map<SMesh::Face_index, double>("f:v")));
-    assert((mesh_bis.property_map<SMesh::Face_index, std::vector<double>>("f:uv")));
-
-    f_uvmap = *mesh_bis.property_map<SMesh::Face_index, std::vector<double>>("f:uv");
-    f_umap = *mesh_bis.property_map<SMesh::Face_index, double>("f:u");
-    f_vmap = *mesh_bis.property_map<SMesh::Face_index, double>("f:v");
+    f_uvmap = mesh_bis.property_map<SMesh::Face_index, std::vector<double>>("f:uv").value();
+    f_umap = mesh_bis.property_map<SMesh::Face_index, double>("f:u").value();
+    f_vmap = mesh_bis.property_map<SMesh::Face_index, double>("f:v").value();
 
     dvalue=2001;
     for (SMesh::Face_index f : faces(mesh_bis))

--- a/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
@@ -91,13 +91,13 @@ int main()
     SMesh mesh_bis;
     CGAL::IO::read_PLY(in, mesh_bis);
 
-    assert((mesh_bis.property_map<SMesh::Vertex_index, float>("v:u").second));
-    assert((mesh_bis.property_map<SMesh::Vertex_index, float>("v:v").second));
-    assert((mesh_bis.property_map<SMesh::Vertex_index, std::vector<float>>("v:uv").second));
+    assert((mesh_bis.property_map<SMesh::Vertex_index, float>("v:u").has_value()));
+    assert((mesh_bis.property_map<SMesh::Vertex_index, float>("v:v").has_value()));
+    assert((mesh_bis.property_map<SMesh::Vertex_index, std::vector<float>>("v:uv").has_value()));
 
-    v_uvmap = mesh_bis.property_map<SMesh::Vertex_index, std::vector<float>>("v:uv").first;
-    v_umap = mesh_bis.property_map<SMesh::Vertex_index, float>("v:u").first;
-    v_vmap = mesh_bis.property_map<SMesh::Vertex_index, float>("v:v").first;
+    v_uvmap = *mesh_bis.property_map<SMesh::Vertex_index, std::vector<float>>("v:uv");
+    v_umap = *mesh_bis.property_map<SMesh::Vertex_index, float>("v:u");
+    v_vmap = *mesh_bis.property_map<SMesh::Vertex_index, float>("v:v");
 
     fvalue=1001;
     for (SMesh::Vertex_index v : vertices(mesh_bis))
@@ -110,13 +110,13 @@ int main()
       ++fvalue;
     }
 
-    assert((mesh_bis.property_map<SMesh::Face_index, double>("f:u").second));
-    assert((mesh_bis.property_map<SMesh::Face_index, double>("f:v").second));
-    assert((mesh_bis.property_map<SMesh::Face_index, std::vector<double>>("f:uv").second));
+    assert((mesh_bis.property_map<SMesh::Face_index, double>("f:u")));
+    assert((mesh_bis.property_map<SMesh::Face_index, double>("f:v")));
+    assert((mesh_bis.property_map<SMesh::Face_index, std::vector<double>>("f:uv")));
 
-    f_uvmap = mesh_bis.property_map<SMesh::Face_index, std::vector<double>>("f:uv").first;
-    f_umap = mesh_bis.property_map<SMesh::Face_index, double>("f:u").first;
-    f_vmap = mesh_bis.property_map<SMesh::Face_index, double>("f:v").first;
+    f_uvmap = *mesh_bis.property_map<SMesh::Face_index, std::vector<double>>("f:uv");
+    f_umap = *mesh_bis.property_map<SMesh::Face_index, double>("f:u");
+    f_vmap = *mesh_bis.property_map<SMesh::Face_index, double>("f:v");
 
     dvalue=2001;
     for (SMesh::Face_index f : faces(mesh_bis))

--- a/Surface_mesh/test/Surface_mesh/sm_remove.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_remove.cpp
@@ -47,13 +47,14 @@ int main()
 
   // make sure all is OK when clearing the mesh
 
-  auto vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity").first;
-  auto hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity").first;
-  auto fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity").first;
-  auto vpoint = m.property_map<Vertex_index, Point_3>("v:point").first;
-  auto vremoved = m.property_map<Vertex_index, bool>("v:removed").first;
-  auto eremoved = m.property_map<Edge_index, bool>("e:removed").first;
-  auto fremoved = m.property_map<Face_index, bool>("f:removed").first;
+  auto vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity");
+  assert(vconn.has_value());
+  auto hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity");
+  auto fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity");
+  auto vpoint = m.property_map<Vertex_index, Point_3>("v:point");
+  auto vremoved = m.property_map<Vertex_index, bool>("v:removed");
+  auto eremoved = m.property_map<Edge_index, bool>("e:removed");
+  auto fremoved = m.property_map<Face_index, bool>("f:removed");
 
   // first call to squat the first available position
   m.add_property_map<Vertex_index, int>("vprop_dummy");
@@ -74,21 +75,21 @@ int main()
     auto l_fprop = m.add_property_map<Face_index, int>("fprop").first;
     auto l_eprop = m.add_property_map<Edge_index, int>("eprop").first;
 
-    auto l_vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity").first;
-    auto l_hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity").first;
-    auto l_fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity").first;
-    auto l_vpoint = m.property_map<Vertex_index, Point_3>("v:point").first;
-    auto l_vremoved = m.property_map<Vertex_index, bool>("v:removed").first;
-    auto l_eremoved = m.property_map<Edge_index, bool>("e:removed").first;
-    auto l_fremoved = m.property_map<Face_index, bool>("f:removed").first;
+    auto l_vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity");
+    auto l_hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity");
+    auto l_fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity");
+    auto l_vpoint = m.property_map<Vertex_index, Point_3>("v:point");
+    auto l_vremoved = m.property_map<Vertex_index, bool>("v:removed");
+    auto l_eremoved = m.property_map<Edge_index, bool>("e:removed");
+    auto l_fremoved = m.property_map<Face_index, bool>("f:removed");
 
-    assert( &vconn.array() == &l_vconn.array() );
-    assert( &hconn.array() == &l_hconn.array() );
-    assert( &fconn.array() == &l_fconn.array() );
-    assert( &vpoint.array() == &l_vpoint.array() );
-    assert( &vremoved.array() == &l_vremoved.array() );
-    assert( &eremoved.array() == &l_eremoved.array() );
-    assert( &fremoved.array() == &l_fremoved.array() );
+    assert( &vconn->array() == &l_vconn->array() );
+    assert( &hconn->array() == &l_hconn->array() );
+    assert( &fconn->array() == &l_fconn->array() );
+    assert( &vpoint->array() == &l_vpoint->array() );
+    assert( &vremoved->array() == &l_vremoved->array() );
+    assert( &eremoved->array() == &l_eremoved->array() );
+    assert( &fremoved->array() == &l_fremoved->array() );
     assert( &vprop.array() == &l_vprop.array() );
     assert( &hprop.array() == &l_hprop.array() );
     assert( &fprop.array() == &l_fprop.array() );
@@ -98,21 +99,21 @@ int main()
   {
     m.clear();
 
-    auto l_vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity").first;
-    auto l_hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity").first;
-    auto l_fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity").first;
-    auto l_vpoint = m.property_map<Vertex_index, Point_3>("v:point").first;
-    auto l_vremoved = m.property_map<Vertex_index, bool>("v:removed").first;
-    auto l_eremoved = m.property_map<Edge_index, bool>("e:removed").first;
-    auto l_fremoved = m.property_map<Face_index, bool>("f:removed").first;
+    auto l_vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity");
+    auto l_hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity");
+    auto l_fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity");
+    auto l_vpoint = m.property_map<Vertex_index, Point_3>("v:point");
+    auto l_vremoved = m.property_map<Vertex_index, bool>("v:removed");
+    auto l_eremoved = m.property_map<Edge_index, bool>("e:removed");
+    auto l_fremoved = m.property_map<Face_index, bool>("f:removed");
 
-    assert( &vconn.array() == &l_vconn.array() );
-    assert( &hconn.array() == &l_hconn.array() );
-    assert( &fconn.array() == &l_fconn.array() );
-    assert( &vpoint.array() == &l_vpoint.array() );
-    assert( &vremoved.array() == &l_vremoved.array() );
-    assert( &eremoved.array() == &l_eremoved.array() );
-    assert( &fremoved.array() == &l_fremoved.array() );
+    assert( &vconn->array() == &l_vconn->array() );
+    assert( &hconn->array() == &l_hconn->array() );
+    assert( &fconn->array() == &l_fconn->array() );
+    assert( &vpoint->array() == &l_vpoint->array() );
+    assert( &vremoved->array() == &l_vremoved->array() );
+    assert( &eremoved->array() == &l_eremoved->array() );
+    assert( &fremoved->array() == &l_fremoved->array() );
   }
 
   return 0;

--- a/Surface_mesh/test/Surface_mesh/sm_remove.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_remove.cpp
@@ -47,14 +47,13 @@ int main()
 
   // make sure all is OK when clearing the mesh
 
-  auto vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity");
-  assert(vconn.has_value());
-  auto hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity");
-  auto fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity");
-  auto vpoint = m.property_map<Vertex_index, Point_3>("v:point");
-  auto vremoved = m.property_map<Vertex_index, bool>("v:removed");
-  auto eremoved = m.property_map<Edge_index, bool>("e:removed");
-  auto fremoved = m.property_map<Face_index, bool>("f:removed");
+  auto vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity").value();
+  auto hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity").value();
+  auto fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity").value();
+  auto vpoint = m.property_map<Vertex_index, Point_3>("v:point").value();
+  auto vremoved = m.property_map<Vertex_index, bool>("v:removed").value();
+  auto eremoved = m.property_map<Edge_index, bool>("e:removed").value();
+  auto fremoved = m.property_map<Face_index, bool>("f:removed").value();
 
   // first call to squat the first available position
   m.add_property_map<Vertex_index, int>("vprop_dummy");
@@ -75,21 +74,21 @@ int main()
     auto l_fprop = m.add_property_map<Face_index, int>("fprop").first;
     auto l_eprop = m.add_property_map<Edge_index, int>("eprop").first;
 
-    auto l_vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity");
-    auto l_hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity");
-    auto l_fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity");
-    auto l_vpoint = m.property_map<Vertex_index, Point_3>("v:point");
-    auto l_vremoved = m.property_map<Vertex_index, bool>("v:removed");
-    auto l_eremoved = m.property_map<Edge_index, bool>("e:removed");
-    auto l_fremoved = m.property_map<Face_index, bool>("f:removed");
+    auto l_vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity").value();
+    auto l_hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity").value();
+    auto l_fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity").value();
+    auto l_vpoint = m.property_map<Vertex_index, Point_3>("v:point").value();
+    auto l_vremoved = m.property_map<Vertex_index, bool>("v:removed").value();
+    auto l_eremoved = m.property_map<Edge_index, bool>("e:removed").value();
+    auto l_fremoved = m.property_map<Face_index, bool>("f:removed").value();
 
-    assert( &vconn->array() == &l_vconn->array() );
-    assert( &hconn->array() == &l_hconn->array() );
-    assert( &fconn->array() == &l_fconn->array() );
-    assert( &vpoint->array() == &l_vpoint->array() );
-    assert( &vremoved->array() == &l_vremoved->array() );
-    assert( &eremoved->array() == &l_eremoved->array() );
-    assert( &fremoved->array() == &l_fremoved->array() );
+    assert( &vconn.array() == &l_vconn.array() );
+    assert( &hconn.array() == &l_hconn.array() );
+    assert( &fconn.array() == &l_fconn.array() );
+    assert( &vpoint.array() == &l_vpoint.array() );
+    assert( &vremoved.array() == &l_vremoved.array() );
+    assert( &eremoved.array() == &l_eremoved.array() );
+    assert( &fremoved.array() == &l_fremoved.array() );
     assert( &vprop.array() == &l_vprop.array() );
     assert( &hprop.array() == &l_hprop.array() );
     assert( &fprop.array() == &l_fprop.array() );
@@ -99,21 +98,21 @@ int main()
   {
     m.clear();
 
-    auto l_vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity");
-    auto l_hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity");
-    auto l_fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity");
-    auto l_vpoint = m.property_map<Vertex_index, Point_3>("v:point");
-    auto l_vremoved = m.property_map<Vertex_index, bool>("v:removed");
-    auto l_eremoved = m.property_map<Edge_index, bool>("e:removed");
-    auto l_fremoved = m.property_map<Face_index, bool>("f:removed");
+    auto l_vconn = m.property_map<Vertex_index, Vertex_connectivity>("v:connectivity").value();
+    auto l_hconn = m.property_map<Halfedge_index, Halfedge_connectivity>("h:connectivity").value();
+    auto l_fconn = m.property_map<Face_index, Face_connectivity>("f:connectivity").value();
+    auto l_vpoint = m.property_map<Vertex_index, Point_3>("v:point").value();
+    auto l_vremoved = m.property_map<Vertex_index, bool>("v:removed").value();
+    auto l_eremoved = m.property_map<Edge_index, bool>("e:removed").value();
+    auto l_fremoved = m.property_map<Face_index, bool>("f:removed").value();
 
-    assert( &vconn->array() == &l_vconn->array() );
-    assert( &hconn->array() == &l_hconn->array() );
-    assert( &fconn->array() == &l_fconn->array() );
-    assert( &vpoint->array() == &l_vpoint->array() );
-    assert( &vremoved->array() == &l_vremoved->array() );
-    assert( &eremoved->array() == &l_eremoved->array() );
-    assert( &fremoved->array() == &l_fremoved->array() );
+    assert( &vconn.array() == &l_vconn.array() );
+    assert( &hconn.array() == &l_hconn.array() );
+    assert( &fconn.array() == &l_fconn.array() );
+    assert( &vpoint.array() == &l_vpoint.array() );
+    assert( &vremoved.array() == &l_vremoved.array() );
+    assert( &eremoved.array() == &l_eremoved.array() );
+    assert( &fremoved.array() == &l_fremoved.array() );
   }
 
   return 0;


### PR DESCRIPTION
## Summary of Changes
Switching from `std::pair<Property_map<T>, bool>` to `std::optional` in `Property_container::get<T>`

Introducing `Pair_optional_adaptor` for backward compatibility which extends `std::optional<T>` to interface of `std::pair`

using `Pair_optional_adaptor` for `Surface_mesh` and `Point_set_3`

## Release Management

* Affected package(s): Point_set_3, Surface_mesh, STL_Extension

