### PR TITLE
Triangulation 2/3:  fstream -> sstream

### DIFF
--- a/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_constrained_triangulation_2.h
+++ b/Triangulation_2/test/Triangulation_2/include/CGAL/_test_cls_constrained_triangulation_2.h
@@ -21,7 +21,7 @@
 //
 // coordinator   : INRIA Sophia-Antipolis Mariette.Yvinec@sophia.inria.fr
 // ============================================================================
-
+#include <sstream>
 #include <list>
 #include <type_traits>
 #include <CGAL/_test_cls_triangulation_short_2.h>
@@ -222,54 +222,42 @@ _test_cls_constrained_triangulation(const Triang &)
   /******** I/O *******/
   std::cout << "output to a file" << std::endl;
 
-  std::ofstream of0_1("T01ct.triangulation", std::ios::out);
-  CGAL::IO::set_ascii_mode(of0_1);
-   of0_1 << T0_1; of0_1.close();
+  std::stringstream ss0_1;
+  ss0_1 << T0_1;
 
-  std::ofstream of0_2("T02ct.triangulation");
-  CGAL::IO::set_ascii_mode(of0_2);
-  of0_2 << T0_2; of0_2.close();
+  std::stringstream ss0_2;
+  ss0_2 << T0_2;
 
-  std::ofstream of1_1("T11ct.triangulation");
-  CGAL::IO::set_ascii_mode(of1_1);
-  of1_1 << T1_1; of1_1.close();
+  std::stringstream ss1_1;
+  ss1_1 << T1_1;
 
-  std::ofstream of1_2("T12ct.triangulation");
-  CGAL::IO::set_ascii_mode(of1_2);
-   of1_2 << T1_2; of1_2.close();
+  std::stringstream ss1_2;
+  ss1_2 << T1_2;
 
-  std::ofstream of2_1("T21ct.triangulation");
-  CGAL::IO::set_ascii_mode(of2_1);
-  of2_1 << T2_1; of2_1.close();
+  std::stringstream ss2_1;
+  ss2_1 << T2_1;
 
-  std::ofstream of2_2("T22ct.triangulation");
-  CGAL::IO::set_ascii_mode(of2_2);
-  of2_2 << T2_2; of2_2.close();
+  std::stringstream ss2_2;
+  ss2_2 << T2_2;
 
   std::cout << "input from a file" << std::endl;
-  std::ifstream if0_1("T01ct.triangulation"); CGAL::IO::set_ascii_mode(if0_1);
-  Triang T0_1_copy;   if0_1 >> T0_1_copy;
 
-  std::ifstream if0_2("T02ct.triangulation"); CGAL::IO::set_ascii_mode(if0_2);
-  Triang T0_2_copy;  if0_2 >> T0_2_copy;
+  Triang T0_1_copy;   ss0_1 >> T0_1_copy;
 
-  std::ifstream if1_1("T11ct.triangulation"); CGAL::IO::set_ascii_mode(if1_1);
-  Triang T1_1_copy; if1_1 >> T1_1_copy;
+  Triang T0_2_copy;  ss0_2 >> T0_2_copy;
 
-  std::ifstream if1_2("T12ct.triangulation"); CGAL::IO::set_ascii_mode(if1_2);
-   Triang T1_2_copy; if1_2 >> T1_2_copy;
+  Triang T1_1_copy; ss1_1 >> T1_1_copy;
 
-  std::ifstream if2_1("T21ct.triangulation"); CGAL::IO::set_ascii_mode(if2_1);
-  Triang T2_1_copy; if2_1 >> T2_1_copy;
+   Triang T1_2_copy; ss1_2 >> T1_2_copy;
 
-  std::ifstream if2_2("T22ct.triangulation"); CGAL::IO::set_ascii_mode(if2_2);
-  Triang T2_2_copy; if2_2 >> T2_2_copy;
+  Triang T2_1_copy; ss2_1 >> T2_1_copy;
+
+  Triang T2_2_copy; ss2_2 >> T2_2_copy;
 
   // test copy of constrained Triangulation
-   Triang T2_4(T2_2);
-  std::ofstream of2_2_bis("T22ct.triangulation");
-  CGAL::IO::set_ascii_mode(of2_2_bis);
-  of2_2_bis << T2_4; of2_2_bis.close();
+  Triang T2_4(T2_2);
+  std::stringstream of2_2_bis;
+  of2_2_bis << T2_4;
   All_faces_iterator fit2 = T2_2.all_faces_begin();
   All_faces_iterator fit2_bis = T2_4.all_faces_begin();
   for( ; fit2 != T2_2.all_faces_end(); ++fit2, ++fit2_bis) {

--- a/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
+++ b/Triangulation_3/test/Triangulation_3/include/CGAL/_test_cls_delaunay_3.h
@@ -28,7 +28,7 @@
 
 #include <cassert>
 #include <iostream>
-#include <fstream>
+#include <sstream>
 #include <list>
 #include <vector>
 #include <type_traits>
@@ -293,12 +293,9 @@ _test_cls_delaunay_3(const Triangulation &)
   {
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
-      {
-        std::ofstream oFileT1("Test1_dtriangulation_IO_3",std::ios::out);
-        oFileT1 << T0 << std::endl;
-      }
-      std::ifstream iFileT1("Test1_dtriangulation_IO_3",std::ios::in);
-      iFileT1 >> Tfromfile;
+      std::stringstream ss;
+      ss << T0;
+      ss >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == -1);
       assert(Tfromfile.number_of_vertices() == 0);
@@ -314,12 +311,9 @@ _test_cls_delaunay_3(const Triangulation &)
   {
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
-      {
-        std::ofstream oFileT2("Test2_dtriangulation_IO_3",std::ios::out);
-        oFileT2 << T0 << std::endl;
-      }
-      std::ifstream iFileT2("Test2_dtriangulation_IO_3",std::ios::in);
-      iFileT2 >> Tfromfile;
+      std::stringstream ss;
+      ss << T0;
+      ss >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 0);
       assert(Tfromfile.number_of_vertices() == 1);
@@ -336,12 +330,9 @@ _test_cls_delaunay_3(const Triangulation &)
   {
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
-      {
-        std::ofstream oFileT3("Test3_dtriangulation_IO_3",std::ios::out);
-        oFileT3 << T0 << std::endl;
-      }
-      std::ifstream iFileT3("Test3_dtriangulation_IO_3",std::ios::in);
-      iFileT3 >> Tfromfile;
+      std::stringstream ss;
+      ss << T0;
+      ss >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 1);
       assert(Tfromfile.number_of_vertices() == 2);
@@ -358,12 +349,9 @@ _test_cls_delaunay_3(const Triangulation &)
   {
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
-      {
-        std::ofstream oFileT4("Test4_dtriangulation_IO_3",std::ios::out);
-        oFileT4 << T0;
-      }
-      std::ifstream iFileT4("Test4_dtriangulation_IO_3",std::ios::in);
-      iFileT4 >> Tfromfile;
+      std::stringstream ss;
+      ss << T0;
+      ss >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 2);
       assert(Tfromfile.number_of_vertices() == 3);
@@ -380,12 +368,9 @@ _test_cls_delaunay_3(const Triangulation &)
   {
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
-      {
-        std::ofstream oFileT5("Test5_dtriangulation_IO_3",std::ios::out);
-        oFileT5 << T0;
-      }
-      std::ifstream iFileT5("Test5_dtriangulation_IO_3",std::ios::in);
-      iFileT5 >> Tfromfile;
+      std::stringstream ss;
+      ss << T0;
+      ss >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 3);
       assert(Tfromfile.number_of_vertices() == 4);
@@ -463,12 +448,9 @@ _test_cls_delaunay_3(const Triangulation &)
   {
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
-      {
-        std::ofstream oFileT6("Test6_dtriangulation_IO_3",std::ios::out);
-        oFileT6 << T1_2;
-      }
-      std::ifstream iFileT6("Test6_dtriangulation_IO_3",std::ios::in);
-      iFileT6 >> Tfromfile;
+      std::stringstream ss;
+      ss << T1_2;
+      ss >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 1);
       assert(Tfromfile.number_of_vertices() == n);
@@ -510,12 +492,10 @@ _test_cls_delaunay_3(const Triangulation &)
   {
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
-      {
-        std::ofstream oFileT7("Test7_dtriangulation_IO_3",std::ios::out);
-        oFileT7 << T2_0;
-      }
-      std::ifstream iFileT7("Test7_dtriangulation_IO_3",std::ios::in);
-      iFileT7 >> Tfromfile;
+
+      std::stringstream ss;
+      ss << T2_0;
+      ss >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 2);
       assert(Tfromfile.number_of_vertices() == 8);
@@ -586,12 +566,9 @@ _test_cls_delaunay_3(const Triangulation &)
   {
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
-      {
-        std::ofstream oFileT8("Test8_dtriangulation_IO_3",std::ios::out);
-        oFileT8 << T3_1;
-      }
-      std::ifstream iFileT8("Test8_dtriangulation_IO_3",std::ios::in);
-      iFileT8 >> Tfromfile;
+      std::stringstream ss;
+      ss << T3_1;
+      ss >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 3);
       assert(Tfromfile.number_of_vertices() == 22);
@@ -677,12 +654,9 @@ _test_cls_delaunay_3(const Triangulation &)
   {
       Cls Tfromfile;
       std::cout << "    I/O" << std::endl;
-      {
-        std::ofstream oFileT8("Test13_dtriangulation_IO_3",std::ios::out);
-        oFileT8 << T3_13;
-      }
-      std::ifstream iFileT8("Test13_dtriangulation_IO_3",std::ios::in);
-      iFileT8 >> Tfromfile;
+      std::stringstream ss;
+      ss << T3_13;
+      ss >> Tfromfile;
       assert(Tfromfile.is_valid());
       assert(Tfromfile.dimension() == 3);
       assert(Tfromfile.number_of_vertices() == 22);


### PR DESCRIPTION
## Summary of Changes

Several . cpp use the same .h which write in a stream with the same name, which leads to errors when executed in parallel by ctest.

See these testsuites of [Triangulation_3](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-6.0-Ic-173/Triangulation_3/TestReport_lrineau_ArchLinux-CXX14.gz) and  [Triangulation_2](https://cgal.geometryfactory.com/CGAL/Members/testsuite/CGAL-6.0-Ic-173/Triangulation_2/TestReport_gimeno_ArchLinux-clang-CXX17-Release.gz)

## Release Management

* Affected package(s): Triangulation_2, Triangulation_3
* License and copyright ownership: unchanged

