### PR TITLE
Tetrahedral_remeshing - add `vertex_is_constrained_map` to set input corners

### DIFF
--- a/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/mesh_and_remesh_c3t3.cpp
+++ b/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/mesh_and_remesh_c3t3.cpp
@@ -39,6 +39,8 @@ using Vertex_pair = std::pair<Vertex_handle, Vertex_handle>;
 using Constraints_set = std::unordered_set<Vertex_pair, boost::hash<Vertex_pair>>;
 using Constraints_pmap = CGAL::Boolean_property_map<Constraints_set>;
 
+using Corners_set = std::unordered_set<Vertex_handle, boost::hash<Vertex_handle>>;
+using Corners_pmap = CGAL::Boolean_property_map<Corners_set>;
 
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;
@@ -73,8 +75,12 @@ int main(int argc, char* argv[])
   Constraints_set constraints;
   Constraints_pmap constraints_pmap(constraints);
 
+  Corners_set corners;
+  Corners_pmap corners_pmap(corners);
+
   Triangulation_3 tr = CGAL::convert_to_triangulation_3(std::move(c3t3),
-    CGAL::parameters::edge_is_constrained_map(constraints_pmap));
+    CGAL::parameters::edge_is_constrained_map(constraints_pmap).
+                      vertex_is_constrained_map(corners_pmap));
 
   //note we use the move semantic, with std::move(c3t3),
   //  to avoid a copy of the triangulation by the function

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -76,6 +76,7 @@ struct All_cells_selected
 
 template<typename Triangulation
          , typename SizingFunction
+         , typename VertexIsConstrainedMap
          , typename EdgeIsConstrainedMap
          , typename FacetIsConstrainedMap
          , typename CellSelector
@@ -115,6 +116,7 @@ public:
   Adaptive_remesher(Triangulation& tr
                     , const SizingFunction& sizing
                     , const bool protect_boundaries
+                    , VertexIsConstrainedMap vcmap
                     , EdgeIsConstrainedMap ecmap
                     , FacetIsConstrainedMap fcmap
                     , bool smooth_constrained_edges
@@ -131,7 +133,7 @@ public:
   {
     m_c3t3.triangulation().swap(tr);
 
-    init_c3t3(ecmap, fcmap);
+    init_c3t3(vcmap, ecmap, fcmap);
     m_vertex_smoother.init(m_c3t3, m_cell_selector, smooth_constrained_edges);
 
 #ifdef CGAL_DUMP_REMESHING_STEPS
@@ -144,6 +146,7 @@ public:
   Adaptive_remesher(C3t3& c3t3
                     , const SizingFunction& sizing
                     , const bool protect_boundaries
+                    , VertexIsConstrainedMap vcmap
                     , EdgeIsConstrainedMap ecmap
                     , FacetIsConstrainedMap fcmap
                     , bool smooth_constrained_edges
@@ -160,7 +163,7 @@ public:
   {
     m_c3t3.swap(c3t3);
 
-    init_c3t3(ecmap, fcmap);
+    init_c3t3(vcmap, ecmap, fcmap);
     m_vertex_smoother.init(m_c3t3, m_cell_selector, smooth_constrained_edges);
 
 #ifdef CGAL_DUMP_REMESHING_STEPS
@@ -315,7 +318,8 @@ public:
   }
 
 private:
-  void init_c3t3(const EdgeIsConstrainedMap& ecmap,
+  void init_c3t3(const VertexIsConstrainedMap& vcmap,
+                 const EdgeIsConstrainedMap& ecmap,
                  const FacetIsConstrainedMap& fcmap)
   {
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
@@ -431,6 +435,7 @@ private:
     for (Vertex_handle vit : tr().finite_vertex_handles())
     {
       if ( vit->in_dimension() == 0
+           || get(vcmap, vit)
            || nb_incident_complex_edges(vit, m_c3t3) > 2)
       {
         if (!m_c3t3.is_in_complex(vit))

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -487,6 +487,7 @@ void tetrahedral_isotropic_remeshing(
     = choose_parameter(get_parameter(np, internal_np::cell_selector),
                        Tetrahedral_remeshing::internal::All_cells_selected<Tr>());
 
+  typedef typename Tr::Vertex_handle Vertex_handle;
   typedef typename internal_np::Lookup_named_param_def <
               internal_np::vertex_is_constrained_t,
               NamedParameters,


### PR DESCRIPTION
## Summary of Changes

Following PR #7909, this PR introduces a new named parameter for tetrahedral remeshing : `vertex_is_constrained_map`.
This parameter allows to set input corners, that will not be modified throughout remeshing.

Corners can be collected from a C3t3 using its counterpart in `convert_to_triangulation_3()`.

## Release Management

* Affected package : Tetrahedral remeshing
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: unchanged

