### PR TITLE
[[no_unique_address]] to compact Triangulation_ds_full_cell

### DIFF
--- a/.github/workflows/reuse.yml
+++ b/.github/workflows/reuse.yml
@@ -24,7 +24,7 @@ jobs:
       with:
         args: spdx
     - name: install dependencies
-      run: sudo apt-get install -y cmake
+      run: sudo apt-get update && sudo apt-get install -y cmake
     - name: Create CGAL internal release
       run: |
         mkdir -p ./release

--- a/Triangulation/include/CGAL/Triangulation_ds_full_cell.h
+++ b/Triangulation/include/CGAL/Triangulation_ds_full_cell.h
@@ -249,7 +249,9 @@ private:
     const Vertex_handle_array & vertices() const {return combinatorics_.vertices_; }
 
     // DATA MEMBERS
-    Combinatorics       combinatorics_;
+    // With the Itanium ABI, [[no_unique_address]] allows tda_data_ to reuse the
+    // padding bytes at the end of combinatorics_ when using the mirror policy.
+    CGAL_NO_UNIQUE_ADDRESS Combinatorics combinatorics_;
     mutable TDS_data    tds_data_;
 };
 


### PR DESCRIPTION
## Summary of Changes

When using the mirror policy, `combinatorics_` ends with an array of dim+1 `int8_t`, and Triangulation_ds_full_cell wants to store an `unsigned char` after that. It seems natural for it to end up right after the array, however that's not what the Itanium ABI (used everywhere but windows) does, it leaves the padding at the end of `combinatorics_` alone and puts the extra member after that. If `Combinatorics` was a base class, reusing those padding bytes would work. With this ABI, `[[no_unique_address]]` precisely means to pretend that it is a base class, for the purpose of layout. I admit this is not the most common use for this attribute...

With this change, it becomes tempting to make the mirror-index policy the default for static dimensions. Unless the user adds cell data that would perfectly fit the padding after `tds_data` but would not fit anymore with the mirror indexes (not that far-fetched, I didn't check but that should be the case if the user data is `int` and the dimension is 3), the mirror indexes come for free (storage-wise) up to dimension 6, and at the cost of one extra (size of) pointer per full cell for dimensions 7 to 14. Maybe in a later PR...

## Release Management

* Affected package(s): Triangulation