### PR TITLE
Qt6: fix a bug with devicePixelRatio and picking

### DIFF
--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -1047,6 +1047,9 @@ static QString mouseButtonsString(::Qt::MouseButtons b) {
 
 CGAL_INLINE_FUNCTION
 void CGAL::QGLViewer::performClickAction(qglviewer::ClickAction ca, const QMouseEvent *const e) {
+  // the following call is needed to update the pixel ratio
+  camera()->setScreenWidthAndHeight(this->width(), this->height(), this->devicePixelRatio());
+
   // Note: action that need it should call update().
   switch (ca) {
   // # CONNECTION setMouseBinding prevents adding NO_CLICK_ACTION in


### PR DESCRIPTION
## Summary of Changes

The picking was no longer working reliably on my machine (Linux with Wayland). That was due to the handling of pixel ratio (Retina/HiDPI). On my machine I have a screen at 200% and another at 125%.

## Release Management

* Affected package(s): Polyhedron/demo
