### PR TITLE
CGAL Lab c3t3 item: fix a segfault

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene_triangulation_3_item.cpp
@@ -2198,7 +2198,7 @@ void Scene_triangulation_3_item::computeIntersection()
 void Scene_triangulation_3_item::set_cut_edge(bool b)
 {
   d->cut_edges = b;
-  d->intersection->setCutEdges(b);
+  if(d->intersection) d->intersection->setCutEdges(b);
   Q_EMIT redraw();
 }
 


### PR DESCRIPTION
## Summary of Changes

With a c3t3 item, or a triangulation item, hide the tetrahedra, and then hide "cut edges". That triggered a segfault. Now fixed.


## Release Management

* Affected package(s): CGAL Lab (`Polyhedron/demo/`)

