### PR TITLE
Fixed order of Qt6 components in find_package(Qt6 ....)

### DIFF
--- a/Installation/cmake/modules/CGAL_SetupCGAL_Qt6Dependencies.cmake
+++ b/Installation/cmake/modules/CGAL_SetupCGAL_Qt6Dependencies.cmake
@@ -25,7 +25,7 @@ set(CGAL_SetupCGAL_Qt6Dependencies_included TRUE)
 # ^^^^^^^^^^^^
 #   - :module:`Qt6Config`
 
-find_package(Qt6 QUIET COMPONENTS Widgets OpenGL OpenGLWidgets OPTIONAL_COMPONENTS Svg)
+find_package(Qt6 QUIET COMPONENTS OpenGL OpenGLWidgets Widgets OPTIONAL_COMPONENTS Svg)
 
 set(CGAL_Qt6_MISSING_DEPS "")
 if(NOT Qt6OpenGLWidgets_FOUND)


### PR DESCRIPTION
## Summary of Changes

Fixed the order of Qt6 components in the find_package(Qt6 COMPONENTS ....) 

## Release Management

* Affected package(s): Installation
* Issue(s) solved (if any): fix #8058
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

