### PR TITLE
Improve information on exact nt backend

### DIFF
--- a/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
+++ b/Number_types/include/CGAL/Number_types/internal/Exact_type_selector.h
@@ -317,6 +317,25 @@ template < typename ET >
 struct Exact_type_selector : Exact_field_selector< ET > {};
 #endif
 
+constexpr const char* exact_nt_backend_string()
+{
+  switch(Default_exact_nt_backend)
+  {
+    case GMP_BACKEND:
+      return "GMP_BACKEND";
+    case GMPXX_BACKEND:
+      return "GMPXX_BACKEND";
+    case BOOST_GMP_BACKEND:
+      return "BOOST_GMP_BACKEND";
+    case BOOST_BACKEND:
+      return "BOOST_BACKEND";
+    case LEDA_BACKEND:
+      return "LEDA_BACKEND";
+    case MP_FLOAT_BACKEND:
+      return "MP_FLOAT_BACKEND";
+  }
+}
+
 } } // namespace CGAL::internal
 
 #undef CGAL_EXACT_SELECTORS_SPECS

--- a/Number_types/test/Number_types/CMakeLists.txt
+++ b/Number_types/test/Number_types/CMakeLists.txt
@@ -61,6 +61,7 @@ create_single_source_cgal_program("unsigned.cpp")
 create_single_source_cgal_program("utilities.cpp")
 create_single_source_cgal_program("Exact_rational.cpp")
 create_single_source_cgal_program("Mpzf_new.cpp")
+create_single_source_cgal_program("check_exact_backend.cpp")
 
 if( CGAL_Core_FOUND )
   create_single_source_cgal_program( "CORE_Expr_ticket_4296.cpp" )

--- a/Number_types/test/Number_types/check_exact_backend.cpp
+++ b/Number_types/test/Number_types/check_exact_backend.cpp
@@ -1,0 +1,29 @@
+#include <CGAL/config.h>
+#include <CGAL/Exact_integer.h>
+#include <CGAL/Exact_rational.h>
+
+#include <type_traits>
+
+using namespace CGAL::internal;
+
+int main()
+{
+  static_assert(
+#ifdef CGAL_USE_GMP
+    ( Default_exact_nt_backend!=GMP_BACKEND || (std::is_same_v<CGAL::Exact_integer,CGAL::Gmpz> && std::is_same_v<CGAL::Exact_rational,CGAL::Gmpq>) ) &&
+#endif
+#ifdef CGAL_USE_GMPXX
+    ( Default_exact_nt_backend!=GMPXX_BACKEND || (std::is_same_v<CGAL::Exact_integer,mpz_class> && std::is_same_v<CGAL::Exact_rational,mpq_class>) ) &&
+#endif
+#if defined(CGAL_USE_BOOST_MP) && defined(CGAL_USE_GMP)
+    ( Default_exact_nt_backend!=BOOST_GMP_BACKEND || (std::is_same_v<CGAL::Exact_integer,boost::multiprecision::mpz_int> && std::is_same_v<CGAL::Exact_rational,boost::multiprecision::mpq_rational>) ) &&
+#endif
+#if defined(CGAL_USE_BOOST_MP)
+    ( Default_exact_nt_backend!=BOOST_BACKEND || (std::is_same_v<CGAL::Exact_integer,boost::multiprecision::cpp_int> && std::is_same_v<CGAL::Exact_rational,boost::multiprecision::cpp_rational>) ) &&
+#endif
+#if defined(CGAL_USE_LEDA)
+    ( Default_exact_nt_backend!=LEDA_BACKEND || (std::is_same_v<CGAL::Exact_integer,leda_integer> && std::is_same_v<CGAL::Exact_rational,leda_rational>) ) &&
+#endif
+    ( Default_exact_nt_backend!=MP_FLOAT_BACKEND || (std::is_same_v<CGAL::Exact_integer,CGAL::MP_Float> && std::is_same_v<CGAL::Exact_rational,CGAL::Quotient<CGAL::MP_Float>>) )
+  );
+}

--- a/Number_types/test/Number_types/check_exact_backend.cpp
+++ b/Number_types/test/Number_types/check_exact_backend.cpp
@@ -26,4 +26,6 @@ int main()
 #endif
     ( Default_exact_nt_backend!=MP_FLOAT_BACKEND || (std::is_same_v<CGAL::Exact_integer,CGAL::MP_Float> && std::is_same_v<CGAL::Exact_rational,CGAL::Quotient<CGAL::MP_Float>>) )
   );
+
+  std::cout << "Exact backend is " << exact_nt_backend_string() << "\n";
 }


### PR DESCRIPTION
Add a test checking what we expect is the reality and a function to print the name of the exact backend