### PR TITLE
Update wlop_simplify_and_regularize_point_set.h documentation

### DIFF
--- a/Point_set_processing_3/include/CGAL/wlop_simplify_and_regularize_point_set.h
+++ b/Point_set_processing_3/include/CGAL/wlop_simplify_and_regularize_point_set.h
@@ -398,8 +398,7 @@ compute_density_weight_for_sample_point(
        \cgalParamDescription{If `true`, an optional preprocessing is applied, which will give
                              better results if the distribution of the input points is highly non-uniform.}
        \cgalParamType{Boolean}
-       \cgalParamDefault{`35`}
-       \cgalParamExtra{More iterations give a more regular result but increase the runtime}
+       \cgalParamDefault{`false`}
      \cgalParamNEnd
 
      \cgalParamNBegin{callback}


### PR DESCRIPTION
The documentation for the named parameter `require_uniform_sampling` is incorrect. It is a copy of the documentation written for `number_of_iterations`.

## Summary of Changes

This PR fixes the issue described above by updating the default value and removing the irrelevant extra information.

## Release Management

* Affected package(s): Point Set Processing
* License and copyright ownership: I release this contribution to the public domain, for what that's worth.

