### PR TITLE
Polygon_repair:: Use move semantics; Add Polygon_2::reserve()

### DIFF
--- a/Polygon/include/CGAL/Multipolygon_with_holes_2.h
+++ b/Polygon/include/CGAL/Multipolygon_with_holes_2.h
@@ -78,6 +78,8 @@ public:
 
   void add_polygon(const Polygon_2& pgn) { m_polygons.push_back(Polygon_with_holes_2(pgn)); }
 
+  void add_polygon(const Polygon_2&& pgn) { m_polygons.push_back(Polygon_with_holes_2(std::forward(pgn))); }
+
   void add_polygon_with_holes(const Polygon_with_holes_2& pgn) { m_polygons.push_back(pgn); }
 
   void add_polygon_with_holes(Polygon_with_holes_2&& pgn) { m_polygons.emplace_back(std::move(pgn)); }

--- a/Polygon/include/CGAL/Polygon_2.h
+++ b/Polygon/include/CGAL/Polygon_2.h
@@ -34,6 +34,7 @@
 #include <CGAL/enum.h>
 
 #include <CGAL/Aff_transformation_2.h>
+#include <CGAL/Container_helper.h>
 
 #include <CGAL/Polygon_2_algorithms.h>
 #include <CGAL/Polygon_2/Polygon_2_vertex_circulator.h>
@@ -541,6 +542,12 @@ class Polygon_2 {
     void resize(std::size_t s)
     {
      container().resize(s);
+    }
+
+    /// Calls `container().reserve(s)` if this is available for `Container`.
+    void reserve(std::size_t s)
+    {
+      internal::reserve(container(),s);
     }
 
     /// @}

--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_impl.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_impl.h
@@ -88,6 +88,7 @@ operator>>(std::istream &is, Polygon_2<Traits_P,Container_P>& p)
 
   if (is) {
     p.erase(p.vertices_begin(),p.vertices_end());
+    p.reserve(n);
     for (int i=0; i<n; i++) {
       if(is >> point){
         p.push_back(point);
@@ -146,6 +147,7 @@ transform(const Transformation& t, const Polygon_2<Traits_P,Container_P>& p)
 {
   typedef typename Polygon_2<Traits_P,Container_P>::Vertex_const_iterator VI;
   Polygon_2<Traits_P,Container_P> result;
+  result.reserve(p.size());
   for (VI i = p.vertices_begin(); i != p.vertices_end(); ++i)
     result.push_back(t(*i));
   return result;

--- a/Polygon_repair/include/CGAL/Polygon_repair/repair.h
+++ b/Polygon_repair/include/CGAL/Polygon_repair/repair.h
@@ -645,12 +645,14 @@ public:
         reconstruct_ring(ring, face, opposite_vertex);
 
         // Put ring in polygons
-        Polygon_2<Kernel, Container> polygon(ring.begin(), ring.end());
+        Polygon_2<Kernel, Container> polygon;
+        polygon.reserve(ring.size());
+        polygon.insert(polygon.vertices_end(),ring.begin(), ring.end());
         // std::cout << "Reconstructed ring for polygon " << face->label() << " with ccw? " << (polygon.orientation() == CGAL::COUNTERCLOCKWISE) << std::endl;
         if (polygon.orientation() == CGAL::COUNTERCLOCKWISE) {
-          polygons[face->label()-1] = polygon;
+          polygons[face->label()-1] = std::move(polygon);
         } else {
-          holes[face->label()-1].insert(polygon);
+          holes[face->label()-1].insert(std::move(polygon));
         } break;
       }
     }
@@ -658,11 +660,11 @@ public:
     // Create polygons with holes and put in multipolygon
     std::set<Polygon_with_holes_2<Kernel, Container>, Polygon_with_holes_less> ordered_polygons;
     for (std::size_t i = 0; i < polygons.size(); ++i) {
-      ordered_polygons.insert(Polygon_with_holes_2<Kernel, Container>(polygons[i], holes[i].begin(), holes[i].end()));
+      ordered_polygons.insert(Polygon_with_holes_2<Kernel, Container>(std::move(polygons[i]), holes[i].begin(), holes[i].end()));
     }
     for (auto const& polygon: ordered_polygons) {
       // std::cout << "Adding polygon " << polygon << std::endl;
-      mp.add_polygon_with_holes(polygon);
+      mp.add_polygon_with_holes(std::move(polygon));
     }
   }
 
@@ -685,7 +687,7 @@ public:
     return t;
   }
 
-  Multipolygon_with_holes_2<Kernel, Container> multipolygon() {
+  const Multipolygon_with_holes_2<Kernel, Container>& multipolygon() {
     return mp;
   }
 


### PR DESCRIPTION
## Summary of Changes

Avoid copying sequences of points.   Also add  a function to Polygon_2 that calls reserve in case it is offered by the underlying container.


## Release Management

* Affected package(s): Polygon_repair
* License and copyright ownership:  unchanged

