### PR TITLE
Rename Polyhedron demo to CGAL Lab everywhere

### DIFF
--- a/AABB_tree/include/CGAL/AABB_triangulation_3_cell_primitive.h
+++ b/AABB_tree/include/CGAL/AABB_triangulation_3_cell_primitive.h
@@ -36,7 +36,7 @@ namespace CGAL
           std::declval<int>())) reference;
       // typedef decltype(
       //   typename GeomTraits::Construct_vertex_3()(
-      //     *std::declval<key_type&>(), 0)) reference; // fails polyhedron demo!
+      //     *std::declval<key_type&>(), 0)) reference; // fails CGAL Lab!
       typedef boost::readable_property_map_tag category;
       typedef Point_from_cell_iterator_proprety_map<GeomTraits, Iterator> Self;
 

--- a/Box_intersection_d/doc/Box_intersection_d/PackageDescription.txt
+++ b/Box_intersection_d/doc/Box_intersection_d/PackageDescription.txt
@@ -36,7 +36,7 @@
 \cgalPkgSince{3.1}
 \cgalPkgBib{cgal:kmz-isiobd}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Convex_decomposition_3/doc/Convex_decomposition_3/PackageDescription.txt
+++ b/Convex_decomposition_3/doc/Convex_decomposition_3/PackageDescription.txt
@@ -13,7 +13,7 @@
 \cgalPkgSince{3.5}
 \cgalPkgBib{cgal:h-emspe}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Convex_hull_3/doc/Convex_hull_3/PackageDescription.txt
+++ b/Convex_hull_3/doc/Convex_hull_3/PackageDescription.txt
@@ -35,7 +35,7 @@ degenerate hull may also be possible.
 \cgalPkgDependsOn{The dynamic algorithms depend on \ref PkgTriangulation3 "3D Triangulations".}
 \cgalPkgBib{cgal:hs-ch3}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Heat_method_3/doc/Heat_method_3/PackageDescription.txt
+++ b/Heat_method_3/doc/Heat_method_3/PackageDescription.txt
@@ -24,7 +24,7 @@ source vertices.}
 \cgalPkgDependsOn{ \ref PkgSolverInterface}
 \cgalPkgBib{cgal:cvf-hm3}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 
 \cgalPkgDescriptionEnd

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -4,7 +4,7 @@ Release History
 [Release 6.0](https://github.com/CGAL/cgal/releases/tag/v6.0)
 -----------
 
-Release date: October 2023
+Release date: June 2024
 
 ### General Changes
 
@@ -17,6 +17,7 @@ Release date: October 2023
 - **Breaking change**: The usage of `boost::variant` has been replaced by `std::variant`. Packages affected are 2D Arrangements, and the Kernel intersection.
 - **Breaking change**: The file CMake file `UseCGAL.cmake` has been removed from CGAL. Usages of the CMake variables `${CGAL_USE_FILE}` and `${CGAL_LIBRARIES}` must be replaced by a link to the imported target `CGAL::CGAL`, for example: `target_link_library(the_target PRIVATE CGAL::CGAL)`.
 - The minimal supported version of Boost is now 1.72.0
+- The CGAL demo formerly known as "Polyhedron demo" has been renamed "CGAL Lab".
 
 ### Installation
 

--- a/Jet_fitting_3/doc/Jet_fitting_3/PackageDescription.txt
+++ b/Jet_fitting_3/doc/Jet_fitting_3/PackageDescription.txt
@@ -16,7 +16,7 @@
 \cgalPkgDependsOn{\ref PkgSolverInterface and \ref thirdpartyEigen}
 \cgalPkgBib{cgal:pc-eldp}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Mesh_3/doc/Mesh_3/PackageDescription.txt
+++ b/Mesh_3/doc/Mesh_3/PackageDescription.txt
@@ -53,7 +53,7 @@
 \cgalPkgDependsOn{\ref PkgTriangulation3 and \ref thirdpartyEigen}
 \cgalPkgBib{cgal:rty-m3}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Minkowski_sum_3/doc/Minkowski_sum_3/PackageDescription.txt
+++ b/Minkowski_sum_3/doc/Minkowski_sum_3/PackageDescription.txt
@@ -15,7 +15,7 @@
 \cgalPkgDependsOn{\ref PkgNef3\, \ref PkgConvexDecomposition3}
 \cgalPkgBib{cgal:h-msp3}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Nef_3/doc/Nef_3/PackageDescription.txt
+++ b/Nef_3/doc/Nef_3/PackageDescription.txt
@@ -24,7 +24,7 @@
 \cgalPkgDependsOn{\ref PkgNef2\, \ref PkgNefS2}
 \cgalPkgBib{cgal:hk-bonp3}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Optimal_bounding_box/doc/Optimal_bounding_box/PackageDescription.txt
+++ b/Optimal_bounding_box/doc/Optimal_bounding_box/PackageDescription.txt
@@ -26,7 +26,7 @@
 \cgalPkgDependsOn{\ref PkgConvexHull3}
 \cgalPkgBib{cgal:obb}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Point_set_3/doc/Point_set_3/PackageDescription.txt
+++ b/Point_set_3/doc/Point_set_3/PackageDescription.txt
@@ -61,7 +61,7 @@
 \cgalPkgSince{4.10}
 \cgalPkgBib{cgal:g-ps}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Point_set_processing_3/doc/Point_set_processing_3/PackageDescription.txt
+++ b/Point_set_processing_3/doc/Point_set_processing_3/PackageDescription.txt
@@ -41,7 +41,7 @@ format.
 \cgalPkgDependsOn{\ref PkgSolverInterface}
 \cgalPkgBib{cgal:ass-psp}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Poisson_surface_reconstruction_3/doc/Poisson_surface_reconstruction_3/PackageDescription.txt
+++ b/Poisson_surface_reconstruction_3/doc/Poisson_surface_reconstruction_3/PackageDescription.txt
@@ -13,7 +13,7 @@
 \cgalPkgDependsOn{\ref PkgSolverInterface}
 \cgalPkgBib{cgal:asg-srps}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
@@ -91,7 +91,7 @@ Boolean operations, remeshing, repairing, collision and intersection detection, 
 \cgalPkgDependsOn{documented for each function; \ref PkgSolverInterface}
 \cgalPkgBib{cgal:lty-pmp}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 
 \cgalPkgDescriptionEnd

--- a/Polyhedron/doc/Polyhedron/PackageDescription.txt
+++ b/Polyhedron/doc/Polyhedron/PackageDescription.txt
@@ -26,7 +26,7 @@
 \cgalPkgDependsOn{\ref PkgHalfedgeDS}
 \cgalPkgBib{cgal:k-ps}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Principal_component_analysis/doc/Principal_component_analysis/PackageDescription.txt
+++ b/Principal_component_analysis/doc/Principal_component_analysis/PackageDescription.txt
@@ -30,7 +30,7 @@
 \cgalPkgDependsOn{\ref PkgSolverInterface}
 \cgalPkgBib{cgal:ap-pcad}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Principal Component Analysis,pca.zip,Operations on Polygons,polygon.zip,Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{Principal Component Analysis,pca.zip,Operations on Polygons,polygon.zip,CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/SMDS_3/doc/SMDS_3/PackageDescription.txt
+++ b/SMDS_3/doc/SMDS_3/PackageDescription.txt
@@ -41,7 +41,7 @@
 \cgalPkgDependsOn{\ref PkgTriangulation3}
 \cgalPkgBib{cgal:ajrtty-mds3}
 \cgalPkgLicense{\ref licensesGPL  "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
+++ b/Scripts/developer_scripts/cgal_demo_copy_all_dlls_cygwin.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#use this script from inside the build directory of the Polyhedron demo
+#use this script from inside the build directory of CGAL Lab
 #Needs the Qt6_DIR env variable set to <Qt6_ROOT>/lib/cmake/Qt6
 
 #No config : in autotest_cgal we use NMake as generator

--- a/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-advanced-draw.cpp
+++ b/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/sdg-advanced-draw.cpp
@@ -494,7 +494,7 @@ int main(int argc, char** argv)
 #endif
 
 #ifdef SDG_DRAW_DUMP_FILES
-  // This file can be visualized with the CGAL 3D Polyhedron Demo
+  // This file can be visualized with CGAL Lab
   std::ofstream out("dual.cgal");
   out.precision(17);
   for(const OK::Segment_2& edge : svd_edges)

--- a/Shape_detection/doc/Shape_detection/PackageDescription.txt
+++ b/Shape_detection/doc/Shape_detection/PackageDescription.txt
@@ -143,7 +143,7 @@ and the Region Growing approach for detecting shapes in a set of arbitrary items
 \cgalPkgDependsOn{\ref thirdpartyEigen}
 \cgalPkgBib{cgal:ovja-pssd}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 
 \cgalPkgDescriptionEnd

--- a/Shape_regularization/doc/Shape_regularization/PackageDescription.txt
+++ b/Shape_regularization/doc/Shape_regularization/PackageDescription.txt
@@ -47,7 +47,7 @@ to the user-specified conditions.}
 \cgalPkgDependsOn{\ref PkgSolverInterface}
 \cgalPkgBib{cgal:asgbl-sr}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 
 \cgalPkgDescriptionEnd

--- a/Subdivision_method_3/doc/Subdivision_method_3/PackageDescription.txt
+++ b/Subdivision_method_3/doc/Subdivision_method_3/PackageDescription.txt
@@ -20,7 +20,7 @@
 \cgalPkgSince{4.11}
 \cgalPkgBib{cgal:s-ssm2}
 \cgalPkgLicense{\ref licensesLGPL "LGPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Surface_mesh_approximation/doc/Surface_mesh_approximation/PackageDescription.txt
+++ b/Surface_mesh_approximation/doc/Surface_mesh_approximation/PackageDescription.txt
@@ -20,7 +20,7 @@ The API is flexible and can be extended to user-defined proxies and error metric
 \cgalPkgBib{cgal:az-tsma}
 \cgalPkgDependsOn{\ref thirdpartyEigen}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Surface_mesh_deformation/doc/Surface_mesh_deformation/PackageDescription.txt
+++ b/Surface_mesh_deformation/doc/Surface_mesh_deformation/PackageDescription.txt
@@ -17,7 +17,7 @@ under positional constraints of some of its vertices, without requiring any addi
 \cgalPkgDependsOn{\ref PkgSolverInterface and \ref thirdpartyEigen}
 \cgalPkgBib{cgal:lsxy-tsmd}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Surface_mesh_deformation/doc/Surface_mesh_deformation/Surface_mesh_deformation.txt
+++ b/Surface_mesh_deformation/doc/Surface_mesh_deformation/Surface_mesh_deformation.txt
@@ -212,7 +212,7 @@ In this example, a survey \cgalCite{Botsch2008OnLinearVariational} model is load
 
 \section SMD_Demo How to Use the Demo
 
-A plugin for the polyhedron demo is available to test the algorithm. The following video tutorials explain how to use it.
+A plugin for CGAL Lab is available to test the algorithm. The following video tutorials explain how to use it.
 When the deformation dock window is open, the picking of control vertices and of the ROI is done by pressing <i>Shift</i>
 and clicking with the left button of the mouse.
 The displacement of the vertices is triggered when the <i>Ctrl</i> button is pressed.

--- a/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/PackageDescription.txt
+++ b/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/PackageDescription.txt
@@ -22,7 +22,7 @@ The code is generic and works with any model of the `FaceGraph` concept.}
 \cgalPkgDependsOn{\ref PkgSolverInterface}
 \cgalPkgBib{cgal:salf-pptsm2}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Surface_mesh_segmentation/doc/Surface_mesh_segmentation/PackageDescription.txt
+++ b/Surface_mesh_segmentation/doc/Surface_mesh_segmentation/PackageDescription.txt
@@ -25,7 +25,7 @@
 \cgalPkgDependsOn{\ref PkgAABBTree}
 \cgalPkgBib{cgal:y-smsimpl}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 
 \cgalPkgDescriptionEnd

--- a/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/PackageDescription.txt
+++ b/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/PackageDescription.txt
@@ -24,7 +24,7 @@
 \cgalPkgSince{4.7}
 \cgalPkgBib{cgal:klcdv-tsmsp}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv)
 
   // For all vertices in the tmesh, compute the points of
   // the shortest path to the source point and write them
-  // into a file readable using the CGAL Polyhedron demo
+  // into a file readable using CGAL Lab
   std::ofstream output("shortest_paths_with_id.polylines.txt");
   vertex_iterator vit, vit_end;
   for ( boost::tie(vit, vit_end) = vertices(tmesh);

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_no_id.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_no_id.cpp
@@ -57,7 +57,7 @@ int main(int argc, char** argv)
 
   // For all vertices in the tmesh, compute the points of
   // the shortest path to the source point and write them
-  // into a file readable using the CGAL Polyhedron demo
+  // into a file readable using CGAL Lab
   std::ofstream output("shortest_paths_no_id.polylines.txt");
   vertex_iterator vit, vit_end;
   for ( boost::tie(vit, vit_end) = vertices(tmesh);

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_with_id.cpp
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/shortest_paths_with_id.cpp
@@ -45,7 +45,7 @@ int main(int argc, char** argv)
 
   // For all vertices in the tmesh, compute the points of
   // the shortest path to the source point and write them
-  // into a file readable using the CGAL Polyhedron demo
+  // into a file readable using CGAL Lab
   std::ofstream output("shortest_paths_with_id.polylines.txt");
   vertex_iterator vit, vit_end;
   for ( boost::tie(vit, vit_end) = vertices(tmesh);

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/PackageDescription.txt
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/PackageDescription.txt
@@ -17,7 +17,7 @@
 \cgalPkgSince{3.3}
 \cgalPkgBib{cgal:c-tsms-12}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Surface_mesh_skeletonization/doc/Surface_mesh_skeletonization/PackageDescription.txt
+++ b/Surface_mesh_skeletonization/doc/Surface_mesh_skeletonization/PackageDescription.txt
@@ -21,7 +21,7 @@
 \cgalPkgDependsOn{ \ref PkgSolverInterface}
 \cgalPkgBib{cgal:glt-tsms}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 \cgalPkgDescriptionEnd
 

--- a/Surface_mesher/doc/Surface_mesher/Surface_mesher.txt
+++ b/Surface_mesher/doc/Surface_mesher/Surface_mesher.txt
@@ -304,7 +304,7 @@ This \cgal component also provides functions to write the reconstructed surface 
 
 \section Surface_mesherUndocumented Undocumented Features Available in Demos
 
-The Polyhedron demo has a feature that allows to remesh a polyhedral
+The CGAL Lab application has a feature that allows to remesh a polyhedral
 surface, using the 3D Surface Mesh Generator. That has been implemented as
 a special model of `SurfaceMeshTraits_3`, for polyhedra. That traits
 class is not yet documented because its interface and code have not yet

--- a/Tetrahedral_remeshing/doc/Tetrahedral_remeshing/PackageDescription.txt
+++ b/Tetrahedral_remeshing/doc/Tetrahedral_remeshing/PackageDescription.txt
@@ -34,7 +34,7 @@ while preserving the input geometric curve and surface features.
 \cgalPkgDependsOn{\ref PkgTriangulation3}
 \cgalPkgBib{cgal:tftb-tr}
 \cgalPkgLicense{\ref licensesGPL "GPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 
 \cgalPkgDescriptionEnd

--- a/Weights/doc/Weights/PackageDescription.txt
+++ b/Weights/doc/Weights/PackageDescription.txt
@@ -489,7 +489,7 @@ weights, and weighting regions. All weights are available both in 2D and 3D.}
 \cgalPkgSince{5.4}
 \cgalPkgBib{cgal:a-wi}
 \cgalPkgLicense{\ref licensesLGPL "LGPL"}
-\cgalPkgDemo{Polyhedron demo,polyhedron_3.zip}
+\cgalPkgDemo{CGAL Lab,cgallab.zip}
 \cgalPkgShortInfoEnd
 
 \cgalPkgDescriptionEnd

--- a/Weights/include/CGAL/Weights/cotangent_weights.h
+++ b/Weights/include/CGAL/Weights/cotangent_weights.h
@@ -305,7 +305,7 @@ public:
 // This class is using a special clamped version of the cotangent weights.
 // This version is currently used in:
 // Polygon_mesh_processing -> fair.h
-// Polyhedron demo -> Hole_filling_plugin.cpp
+// CGAL Lab -> Hole_filling_plugin.cpp
 template<typename PolygonMesh,
          typename VertexPointMap,
          typename GeomTraits>

--- a/Weights/include/CGAL/Weights/uniform_weights.h
+++ b/Weights/include/CGAL/Weights/uniform_weights.h
@@ -93,8 +93,8 @@ typename GeomTraits::FT uniform_weight(const CGAL::Point_3<GeomTraits>& p0,
 // It is currently used in:
 // Polygon_mesh_processing -> triangulate_hole_Polyhedron_3_test.cpp
 // Polygon_mesh_processing -> triangulate_hole_Polyhedron_3_no_delaunay_test.cpp
-// Polyhedron demo -> Fairing_plugin.cpp
-// Polyhedron demo -> Hole_filling_plugin.cpp
+// CGAL Lab -> Fairing_plugin.cpp
+// CGAL Lab -> Hole_filling_plugin.cpp
 template<class PolygonMesh>
 class Uniform_weight
 {


### PR DESCRIPTION
## Summary of Changes

Followup to #8099. Finish to rename occurrences of the name "polyhedron demo" to "CGAL Lab".

## Release Management

* Affected package(s): all CGAL
* License and copyright ownership: maintenance by GF
