### PR TITLE
PMP::isotropic_remeshing() - add NP `allow move functor`

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1014,10 +1014,11 @@ namespace internal {
     // "applies an iterative smoothing filter to the mesh.
     // The vertex movement has to be constrained to the vertex tangent plane [...]
     // smoothing algorithm with uniform Laplacian weights"
-    template <class SizingFunction>
+    template <class SizingFunction, typename AllowMoveFunctor>
     void tangential_relaxation_impl(const bool relax_constraints/*1d smoothing*/
                                   , const unsigned int nb_iterations
-                                  , const SizingFunction& sizing)
+                                  , const SizingFunction& sizing
+                                  , const AllowMoveFunctor& shall_move)
     {
 #ifdef CGAL_PMP_REMESHING_VERBOSE
       std::cout << "Tangential relaxation (" << nb_iterations << " iter.)...";
@@ -1063,6 +1064,7 @@ namespace internal {
             .edge_is_constrained_map(constrained_edges_pmap)
             .vertex_is_constrained_map(constrained_vertices_pmap)
             .relax_constraints(relax_constraints)
+            .allow_move_functor(shall_move)
         );
       }
       else
@@ -1081,6 +1083,7 @@ namespace internal {
             .vertex_is_constrained_map(constrained_vertices_pmap)
             .relax_constraints(relax_constraints)
             .sizing_function(sizing)
+            .allow_move_functor(shall_move)
         );
       }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -171,6 +171,16 @@ namespace Polygon_mesh_processing {
 *     \cgalParamDefault{`false`}
 *   \cgalParamNEnd
 *
+*   \cgalParamNBegin{allow_move_functor}
+*     \cgalParamDescription{A function object used to determinate if a vertex move should
+*                           be allowed or not during the relaxation step.}
+*     \cgalParamType{Unary functor that provides `bool operator()(vertex_descriptor v, Point_3 src, Point_3 tgt)`
+*                    returning `true`
+*                    if the vertex `v` can be moved from `src` to `tgt`;
+*                    `%Point_3` being the value type of the vertex point map }
+*     \cgalParamDefault{If not provided, all moves are allowed.}
+*   \cgalParamNEnd
+*
 *   \cgalParamNBegin{do_project}
 *     \cgalParamDescription{whether vertices should be reprojected on the input surface after creation or displacement}
 *     \cgalParamType{Boolean}

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -19,6 +19,7 @@
 
 #include <CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h>
 #include <CGAL/Polygon_mesh_processing/Uniform_sizing_field.h>
+#include <CGAL/Polygon_mesh_processing/tangential_relaxation.h>
 
 #include <CGAL/Named_function_parameters.h>
 #include <CGAL/boost/graph/named_params_helper.h>
@@ -267,6 +268,9 @@ void isotropic_remeshing(const FaceRange& faces
 #endif
     ) ) );
 
+  auto shall_move = choose_parameter(get_parameter(np, internal_np::allow_move_functor),
+                                     internal::Allow_all_moves());
+
 #if !defined(CGAL_NO_PRECONDITIONS)
   if(protect)
   {
@@ -322,7 +326,7 @@ void isotropic_remeshing(const FaceRange& faces
      remesher.collapse_short_edges(sizing, collapse_constraints);
     if(do_flip)
       remesher.flip_edges_for_valence_and_shape();
-    remesher.tangential_relaxation_impl(smoothing_1d, nb_laplacian, sizing);
+    remesher.tangential_relaxation_impl(smoothing_1d, nb_laplacian, sizing, shall_move);
     if ( choose_parameter(get_parameter(np, internal_np::do_project), true) )
       remesher.project_to_surface(get_parameter(np, internal_np::projection_functor));
 #ifdef CGAL_PMP_REMESHING_VERBOSE


### PR DESCRIPTION
## Summary of Changes

The function `tangential_relaxation()` has a named parameter called `allow_move_functor` that enables the user to prevent and cancel some vertex moves.

With this PR, it is now possible to use the same parameter for the relaxation steps of `CGAL::Polygon_mesh_processing::isotropic_remeshing()`

## Release Management

* Affected package(s): PMP
* Issue(s) solved (if any): partially solves issue #8134
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: unchanged

