### PR TITLE
IO: Fix `OutputIteratorValueType` being ignored

### DIFF
--- a/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/read_ply_points.h
@@ -138,8 +138,6 @@ bool read_PLY_with_properties(std::istream& is,
                               PointOutputIterator output,
                               PropertyHandler&& ... properties)
 {
-  typedef typename value_type_traits<PointOutputIterator>::type OutputValueType;
-
   if(!is)
     return false;
 
@@ -168,7 +166,7 @@ bool read_PLY_with_properties(std::istream& is,
 
       if(element.name() == "vertex" || element.name() == "vertices")
       {
-        OutputValueType new_element;
+        OutputIteratorValueType new_element;
         internal::process_properties(element, new_element, std::forward<PropertyHandler>(properties)...);
         *(output ++) = new_element;
       }


### PR DESCRIPTION
The template typename `OutputIteratorValueType` was unused.

This made specifying it (as suggested by the docs) ineffective, and forbade to use PLY functions e.g. with `boost::function_output_iterator`, or any other output iterator whose `value_type` is `void`.

_Please use the following template to help us managing pull requests._

## Summary of Changes

_Describe what your pull request changes to CGAL (this can be skipped if it solves an issue already in the tracker or if it is a Feature or Small Feature submitted to the CGAL Wiki)._

## Release Management

* Affected package(s): `Point_set_processing_3`
* License and copyright ownership: no change

