### PR TITLE
kd-tree: Deallocate Point pointer vector after build().

### DIFF
--- a/Spatial_searching/include/CGAL/Kd_tree.h
+++ b/Spatial_searching/include/CGAL/Kd_tree.h
@@ -370,6 +370,7 @@ public:
     pts.swap(ptstmp);
 
     data.clear();
+    data.shrink_to_fit();
 
     built_ = true;
   }


### PR DESCRIPTION
This

    vector<const Point_d*> data;

is no longer needed after being `.clear()`ed at the end of `build()`. This can save a good amount of memory, a `Point_d*` on a 64-bit system is 8 bytes; almost as large as a typical 3-float `Point_d`.

There's no point keeping its capacity, since any call to `build()` will efficiently `.reserve()` it anyway.

_Please use the following template to help us managing pull requests._

## Summary of Changes

_Describe what your pull request changes to CGAL (this can be skipped if it solves an issue already in the tracker or if it is a Feature or Small Feature submitted to the CGAL Wiki)._

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

