### PR TITLE
Add a way to collect input coplanar faces after corefinement

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -9,7 +9,8 @@
 ### [Polygon Mesh Processing](https://doc.cgal.org/6.1/Manual/packages.html#PkgPolygonMeshProcessing)
 - Added the function `CGAL::Polygon_mesh_processing::discrete_mean_curvature` and `CGAL::Polygon_mesh_processing::discrete_Guassian_curvature` to evaluate the discrete curvature at a vertex of a mesh.
 - Added the function `CGAL::Polygon_mesh_processing::angle_sum` to compute the sum of the angles around a vertex.
-
+- Added a function in the [visitor of the corefinement based methods](https://doc.cgal.org/6.1/Polygon_mesh_processing/classPMPCorefinementVisitor.html)
+  to know faces in the output meshes that are corresponding to input coplanar faces.
 
 ### [Algebraic Kernel](https://doc.cgal.org/6.1/Manual/packages.html#PkgAlgebraicKernelD)
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
@@ -119,6 +119,9 @@ public:
   /// The point has already been put in the vertex point map.
   void after_vertex_copy(vertex_descriptor v_src, const Triangle_mesh& tm_src,
                          vertex_descriptor v_tgt, const Triangle_mesh& tm_tgt);
+  /// called for each face `f` in the output mesh `tm` that belongs to the intersection of two coplanar faces of the input meshes.
+  void input_coplanar_face(face_descriptor f, TriangleMesh& tm);
+
 /// @}
 
 /// @name Functions used by corefine() for progress tracking

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
@@ -120,7 +120,7 @@ public:
   void after_vertex_copy(vertex_descriptor v_src, const Triangle_mesh& tm_src,
                          vertex_descriptor v_tgt, const Triangle_mesh& tm_tgt);
   /// called for each face `f` present in the output mesh `tm` that corresponds to a face present in both input meshes corefined.
-  void coplanar_face_in_output(face_descriptor f, TriangleMesh& tm);
+  void subface_of_coplanar_faces_intersection(face_descriptor f, TriangleMesh& tm);
 
 /// @}
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPCorefinementVisitor.h
@@ -119,8 +119,8 @@ public:
   /// The point has already been put in the vertex point map.
   void after_vertex_copy(vertex_descriptor v_src, const Triangle_mesh& tm_src,
                          vertex_descriptor v_tgt, const Triangle_mesh& tm_tgt);
-  /// called for each face `f` in the output mesh `tm` that belongs to the intersection of two coplanar faces of the input meshes.
-  void input_coplanar_face(face_descriptor f, TriangleMesh& tm);
+  /// called for each face `f` present in the output mesh `tm` that corresponds to a face present in both input meshes corefined.
+  void coplanar_face_in_output(face_descriptor f, TriangleMesh& tm);
 
 /// @}
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -2141,7 +2141,7 @@ public:
 
         for (face_descriptor f : patches_of_tm1[i].faces)
         {
-          user_visitor.input_coplanar_face(f, tm1);
+          user_visitor.coplanar_face_in_output(f, tm1);
         }
       }
     }
@@ -2154,7 +2154,7 @@ public:
 
         for (face_descriptor f : patches_of_tm2[i].faces)
         {
-          user_visitor.input_coplanar_face(f, tm2);
+          user_visitor.coplanar_face_in_output(f, tm2);
         }
       }
     }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -2141,7 +2141,7 @@ public:
 
         for (face_descriptor f : patches_of_tm1[i].faces)
         {
-          user_visitor.coplanar_face_in_output(f, tm1);
+          user_visitor.subface_of_coplanar_faces_intersection(f, tm1);
         }
       }
     }
@@ -2154,7 +2154,7 @@ public:
 
         for (face_descriptor f : patches_of_tm2[i].faces)
         {
-          user_visitor.coplanar_face_in_output(f, tm2);
+          user_visitor.subface_of_coplanar_faces_intersection(f, tm2);
         }
       }
     }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -2131,6 +2131,34 @@ public:
     Patches1 patches_of_tm1(tm1, tm1_patch_ids, fids1, intersection_edges1, nb_patches_tm1);
     Patches2 patches_of_tm2(tm2, tm2_patch_ids, fids2, intersection_edges2, nb_patches_tm2);
 
+    // report input coplanar faces
+    if (coplanar_patches_of_tm1.any())
+    {
+      for (std::size_t i = coplanar_patches_of_tm1.find_first();
+                 i < coplanar_patches_of_tm1.npos;
+                 i = coplanar_patches_of_tm1.find_next(i))
+      {
+
+        for (face_descriptor f : patches_of_tm1[i].faces)
+        {
+          user_visitor.input_coplanar_face(f, tm1);
+        }
+      }
+    }
+    if (coplanar_patches_of_tm2.any())
+    {
+      for (std::size_t i = coplanar_patches_of_tm2.find_first();
+                 i < coplanar_patches_of_tm2.npos;
+                 i = coplanar_patches_of_tm2.find_next(i))
+      {
+
+        for (face_descriptor f : patches_of_tm2[i].faces)
+        {
+          user_visitor.input_coplanar_face(f, tm2);
+        }
+      }
+    }
+
     // for each boolean operation, define two bitsets of patches contributing
     // to the result
     std::vector< boost::dynamic_bitset<> > patches_of_tm1_used(4);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -428,6 +428,7 @@ struct Default_visitor{
   void before_face_copy(face_descriptor /*f_old*/, const TriangleMesh&, TriangleMesh&){}
   void after_face_copy(face_descriptor /*f_old*/, const TriangleMesh&,
                        face_descriptor /* f_new */, TriangleMesh&){}
+  void input_coplanar_face(face_descriptor /*f*/, TriangleMesh&) {}
 // edge visitor functions
   void before_edge_split(halfedge_descriptor /* h */, TriangleMesh& /* tm */){}
   void edge_split(halfedge_descriptor /* hnew */, TriangleMesh& /* tm */){}

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -428,7 +428,7 @@ struct Default_visitor{
   void before_face_copy(face_descriptor /*f_old*/, const TriangleMesh&, TriangleMesh&){}
   void after_face_copy(face_descriptor /*f_old*/, const TriangleMesh&,
                        face_descriptor /* f_new */, TriangleMesh&){}
-  void input_coplanar_face(face_descriptor /*f*/, TriangleMesh&) {}
+  void coplanar_face_in_output(face_descriptor /*f*/, TriangleMesh&) {}
 // edge visitor functions
   void before_edge_split(halfedge_descriptor /* h */, TriangleMesh& /* tm */){}
   void edge_split(halfedge_descriptor /* hnew */, TriangleMesh& /* tm */){}

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -428,7 +428,7 @@ struct Default_visitor{
   void before_face_copy(face_descriptor /*f_old*/, const TriangleMesh&, TriangleMesh&){}
   void after_face_copy(face_descriptor /*f_old*/, const TriangleMesh&,
                        face_descriptor /* f_new */, TriangleMesh&){}
-  void coplanar_face_in_output(face_descriptor /*f*/, TriangleMesh&) {}
+  void subface_of_coplanar_faces_intersection(face_descriptor /*f*/, TriangleMesh&) {}
 // edge visitor functions
   void before_edge_split(halfedge_descriptor /* h */, TriangleMesh& /* tm */){}
   void edge_split(halfedge_descriptor /* hnew */, TriangleMesh& /* tm */){}


### PR DESCRIPTION
Add a method in the corefinement visitor to collect the list of output faces corresponding to coplanar input faces