### PR TITLE
[PSP3] Adapting to new LASTools version

### DIFF
--- a/Documentation/doc/Documentation/Third_party.txt
+++ b/Documentation/doc/Documentation/Third_party.txt
@@ -248,9 +248,8 @@ imported target `CGAL::LASLIB_support` provided in
 \laslib information can be obtained from
 <a href="https://lastools.github.io/">https://lastools.github.io/</a> and
 <a href="https://rapidlasso.de/product-overview/">https://rapidlasso.de/product-overview/</a>.
-\laslib is usually distributed along with LAStools: for simplicity, \cgal
-provides <a href="https://github.com/CGAL/LAStools">a fork with a
-CMake based install procedure</a>.
+\laslib is usually distributed along with LAStools. Current versions of \laslib provide CMake support.
+BUILD_SHARED_LIBS needs to be set to true on windows to create a dynamic linked library.
 
 \subsection thirdpartyOpenCV OpenCV
 

--- a/Point_set_processing_3/examples/Point_set_processing_3/read_las_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/read_las_example.cpp
@@ -21,7 +21,7 @@ int main(int argc, char*argv[])
   // Reads a .las point set file with normal vectors and colors
   std::ifstream in(fname, std::ios_base::binary);
   std::vector<PointWithColor> points; // store points
-  if(!CGAL::IO::read_LAS_with_properties(in, std::back_inserter (points),
+  if (!CGAL::IO::read_LAS_with_properties(in, std::back_inserter(points),
                                          CGAL::IO::make_las_point_reader(CGAL::First_of_pair_property_map<PointWithColor>()),
                                          std::make_tuple(CGAL::Second_of_pair_property_map<PointWithColor>(),
                                                          CGAL::Construct_array(),

--- a/Point_set_processing_3/include/CGAL/IO/write_las_points.h
+++ b/Point_set_processing_3/include/CGAL/IO/write_las_points.h
@@ -134,57 +134,51 @@ namespace LAS {
     output_value (point, get(current.first, *it), current.second);
   }
 
-  template<typename Value, typename Tuple, std::size_t I>
-  void output_tuple(LASpoint& point, const Value& v, const Tuple& t, std::index_sequence<I>) {
-    output_value(point, std::get<I>(v), std::get<I>(t));
-  }
-
-  template<typename Value, typename Tuple, std::size_t I, std::size_t... Is>
-  void output_tuple(LASpoint& point, const Value& v, const Tuple& t, std::index_sequence<I, Is...>) {
-    output_value(point, std::get<I>(v), std::get<I>(t));
-    output_tuple(point, v, t, std::index_sequence<Is...>());
+  template<typename Value, typename Tuple, std::size_t... Is>
+  void output_tuple(LASpoint& point, const Value& v, const Tuple& t, std::index_sequence<Is...>) {
+    (output_value(point, std::get<Is>(v), std::get<Is>(t)), ...);
   }
 
   template <typename ForwardIterator,
-    typename PropertyMap,
-    typename ... T>
+            typename PropertyMap,
+            typename ... T>
   void output_properties(LASpoint& point,
-    ForwardIterator it,
-    std::tuple<PropertyMap, T ...>&& current)
+                         ForwardIterator it,
+                         std::tuple<PropertyMap, T ...>&& current)
   {
     output_tuple(point, get(std::get<0>(current), *it), std::tuple<T ...>(), std::index_sequence_for<T ...>{});
   }
 
   template <typename ForwardIterator,
-    typename PropertyMap,
-    typename T,
-    typename NextPropertyHandler,
-    typename ... PropertyHandler>
+            typename PropertyMap,
+            typename T,
+            typename NextPropertyHandler,
+            typename ... PropertyHandler>
   void output_properties(LASpoint& point,
-    ForwardIterator it,
-    std::pair<PropertyMap, T>&& current,
-    NextPropertyHandler&& next,
-    PropertyHandler&& ... properties)
+                         ForwardIterator it,
+                         std::pair<PropertyMap, T>&& current,
+                         NextPropertyHandler&& next,
+                         PropertyHandler&& ... properties)
   {
-    output_value(point, get(current.first, *it), current.second);
-    output_properties(point, it, std::forward<NextPropertyHandler>(next),
-      std::forward<PropertyHandler>(properties)...);
+    output_value (point, get(current.first, *it), current.second);
+    output_properties (point, it, std::forward<NextPropertyHandler>(next),
+                       std::forward<PropertyHandler>(properties)...);
   }
 
   template <typename ForwardIterator,
-    typename PropertyMap,
-    typename ... T,
-    typename NextPropertyHandler,
-    typename ... PropertyHandler>
+            typename PropertyMap,
+            typename ... T,
+            typename NextPropertyHandler,
+            typename ... PropertyHandler>
   void output_properties(LASpoint& point,
-    ForwardIterator it,
-    std::tuple<PropertyMap, T ...>&& current,
-    NextPropertyHandler&& next,
-    PropertyHandler&& ... properties)
+                         ForwardIterator it,
+                         std::tuple<PropertyMap, T ...>&& current,
+                         NextPropertyHandler&& next,
+                         PropertyHandler&& ... properties)
   {
     output_tuple(point, get(std::get<0>(current), *it), std::tuple<T ...>(), std::index_sequence_for<T ...>{});
     output_properties(point, it, std::forward<NextPropertyHandler>(next),
-      std::forward<PropertyHandler>(properties)...);
+                      std::forward<PropertyHandler>(properties)...);
   }
 
 } // namespace LAS


### PR DESCRIPTION
## Summary of Changes

Switching to the official LAStools repository

## Release Management

* Affected package(s): PSP3, Point_set_3, Stream_support
* Issue(s) solved (if any): fix #8111 


-----

Edit, @lrineau, 2024/05/24: depends on https://github.com/LAStools/LAStools/pull/194, that has been merged.