### PR TITLE
CORE: Accelerate writing to a stream if precision <= 17

### DIFF
--- a/CGAL_Core/include/CGAL/CORE/Expr.h
+++ b/CGAL_Core/include/CGAL/CORE/Expr.h
@@ -346,7 +346,11 @@ public:
 
 /// I/O Stream operator<<
 inline std::ostream& operator<<(std::ostream& o, const Expr& e) {
-  o << *(const_cast<ExprRep*>(&e.getRep()));
+  if (o.precision() > 17) {
+    o << *(const_cast<ExprRep*>(&e.getRep()));
+  } else {
+    o << e.doubleValue();
+  }
   return o;
 }
 /// I/O Stream operator>>

--- a/Straight_skeleton_2/test/Straight_skeleton_2/test_sls_offset.cpp
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/test_sls_offset.cpp
@@ -20,6 +20,7 @@
 #include <CGAL/Straight_skeleton_builder_2.h>
 #include <CGAL/Polygon_offset_builder_2.h>
 #include <CGAL/Straight_skeleton_2/IO/print.h>
+#include <CGAL/Timer.h>
 
 #include <memory>
 
@@ -32,6 +33,7 @@ typedef CGAL::Exact_predicates_inexact_constructions_kernel          EPICK;
 typedef CGAL::Exact_predicates_exact_constructions_kernel            EPECK;
 typedef CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt  EPECK_w_sqrt;
 
+typedef CGAL::Timer Timer;
 template <typename K>
 void test_API()
 {
@@ -936,9 +938,12 @@ void test_offset(const char* filename,
   int i = 0;
   for(const FT& ot : offset_times)
   {
+    Timer t;
+    t.start();
     std::cout << "Offset #" << i++ << " = " << ot << std::endl;
     Polygon_with_holes_2_ptr_container offset_poly_with_holes =
       CGAL::create_interior_skeleton_and_offset_polygons_with_holes_2(ot, p, K());
+    std::cout << t.time() << " sec." << std::endl;
 
     std::cout << offset_poly_with_holes.size() << " polygons with holes" << std::endl;
     for(const auto& offp : offset_poly_with_holes)
@@ -1159,10 +1164,14 @@ void test_kernel()
 
 int main(int, char**)
 {
+#if 1
   test_kernel<EPICK>();
   test_kernel<EPECK>();
   test_kernel<EPECK_w_sqrt>();
-
+#else
+  test_offset<EPECK_w_sqrt>("data/near_degenerate_0.poly");
+  test_offset<EPECK_w_sqrt>("data/degenerate20.poly");
+#endif
   std::cout << "Done!" << std::endl;
 
   return EXIT_SUCCESS;

--- a/Straight_skeleton_2/test/Straight_skeleton_2/test_sls_offset.cpp
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/test_sls_offset.cpp
@@ -1164,14 +1164,14 @@ void test_kernel()
 
 int main(int, char**)
 {
-#if 1
   test_kernel<EPICK>();
   test_kernel<EPECK>();
   test_kernel<EPECK_w_sqrt>();
-#else
-  test_offset<EPECK_w_sqrt>("data/near_degenerate_0.poly");
-  test_offset<EPECK_w_sqrt>("data/degenerate20.poly");
-#endif
+
+  // those two are really slow
+  // test_offset<EPECK_w_sqrt>("data/near_degenerate_0.poly");
+  // test_offset<EPECK_w_sqrt>("data/degenerate20.poly");
+
   std::cout << "Done!" << std::endl;
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary of Changes

Writing an `Expr`to as stream is slow. We make it faster by writing `Expr::doubleValue()` if the precision is smaller or equal to 17.

## Release Management

* Affected package(s): CORE
* License and copyright ownership:  unchanged

