### PR TITLE
Lab - Fix color from meshes with only one domain

### DIFF
--- a/Lab/demo/Lab/Color_map.h
+++ b/Lab/demo/Lab/Color_map.h
@@ -39,6 +39,30 @@ compute_color_map(QColor base_color,
   return out;
 }
 
+template <typename Output_color_iterator>
+Output_color_iterator
+compute_deterministic_color_map(QColor base_color,
+                                std::size_t nb_of_colors,
+                                Output_color_iterator out)
+{
+  qreal hue = base_color.hueF();
+  qreal saturation = base_color.saturationF();
+  qreal value = base_color.valueF();
+  const qreal hue_step = (hue == -1) ? 0 : (static_cast<qreal>(1)) / nb_of_colors;
+
+  if (hue == -1)
+    hue = 0;
+  for(std::size_t i=0; i<nb_of_colors; ++i)
+  {
+    hue += hue_step;
+    if(hue > 1)
+      hue -= 1;
+    *out++ = QColor::fromHsvF(hue, saturation, value);
+  }
+
+  return out;
+}
+
 inline QColor generate_random_color()
 {
   std::size_t h = static_cast<std::size_t>(std::rand() % 360);

--- a/Lab/demo/Lab/Scene_image_item.cpp
+++ b/Lab/demo/Lab/Scene_image_item.cpp
@@ -11,6 +11,8 @@
 #include <CGAL/use.h>
 #include <QApplication>
 
+#include "Color_map.h"
+
 // -----------------------------------
 // Internal classes
 // -----------------------------------
@@ -88,15 +90,15 @@ Image_accessor<Word_type>::Image_accessor(const Image& im, int dx, int dy, int d
     }
   }
 
-  const double nb_Colors = colors_.size()+1;
-  double i=0;
-  const double starting_hue = default_color.hueF();
-  for ( auto it = colors_.begin(),
-       end = colors_.end() ; it != end ; ++it, i += 1.)
+  // Compute subdomains colors (the background has no color)
+
+  std::vector<QColor> subdomain_colors;
+  compute_deterministic_color_map(default_color, colors_.size(), std::back_inserter(subdomain_colors));
+
+  int i = 0;
+  for (auto& it : colors_)
   {
-    double hue =  starting_hue + 1./nb_Colors * i;
-    if ( hue > 1. ) { hue -= 1.; }
-    it->second = QColor::fromHsvF(hue, default_color.saturationF(), default_color.valueF());
+    it.second = subdomain_colors[i++];
   }
 }
 

--- a/Lab/demo/Lab/Scene_triangulation_3_item.cpp
+++ b/Lab/demo/Lab/Scene_triangulation_3_item.cpp
@@ -941,29 +941,47 @@ Scene_triangulation_3_item::update_histogram()
 }
 
 void
-Scene_triangulation_3_item_priv::compute_color_map(const QColor& c)
+Scene_triangulation_3_item_priv::compute_color_map(const QColor& default_color)
 {
   typedef Indices::size_type size_type;
 
-  const size_type nb_patch_indices = surface_patch_indices_.size();
-  double i = -1;
-  double patch_hsv_value = use_subdomain_colors ? fmod(c.valueF() + .5, 1.) : c.valueF();
-  for (Indices::iterator it = surface_patch_indices_.begin(),
-       end = surface_patch_indices_.end(); it != end; ++it, i += 1.)
+  float default_hue = default_color.hueF();
+  float default_saturation = default_color.saturationF();
+  float default_value = default_color.valueF();
+  if (default_hue < 0)
   {
-    double hue = c.hueF() + 1. / double(nb_patch_indices) * i;
-    if (hue > 1) { hue -= 1.; }
-    colors[*it] = QColor::fromHsvF(hue, c.saturationF(), patch_hsv_value);
+    default_hue = 0;
+  }
+
+  const size_type nb_patch_indices = surface_patch_indices_.size();
+  float i = 0;
+  float patch_hsv_value = use_subdomain_colors ? fmod(default_value + .5, 1.) : default_value;
+  Indices::iterator it = surface_patch_indices_.begin();
+  if (it != surface_patch_indices_.end())
+  {
+    // the first color is probably the background
+    colors[*it] = QColor::fromHsvF(default_hue, default_saturation, patch_hsv_value);
+    for (++it; it != surface_patch_indices_.end(); ++it, i += 1.)
+    {
+      float hue = default_hue + 1. / static_cast<float>(nb_patch_indices) * i;
+      if (hue > 1) { hue -= 1.; }
+      colors[*it] = QColor::fromHsvF(hue, default_saturation, patch_hsv_value);
+    }
   }
 
   const size_type nb_domains = subdomain_indices_.size();
-  i = -1;
-  for (Indices::iterator it = subdomain_indices_.begin(),
-         end = subdomain_indices_.end(); it != end; ++it, i += 1.)
+  i = 0;
+  it = subdomain_indices_.begin();
+  if (it != subdomain_indices_.end())
   {
-    double hue = c.hueF() + 1. / double(nb_domains) * i;
-    if (hue > 1) { hue -= 1.; }
-    colors_subdomains[*it] = QColor::fromHsvF(hue, c.saturationF(), c.valueF());
+    // the first color is probably the background
+    colors_subdomains[*it] = QColor::fromHsvF(default_hue, default_saturation, default_value);
+    for (++it; it != subdomain_indices_.end(); ++it, i += 1.)
+    {
+      float hue = default_hue + 1. / static_cast<float>(nb_domains) * i;
+      if (hue > 1) { hue -= 1.; }
+      colors_subdomains[*it] = QColor::fromHsvF(hue, default_saturation, default_value);
+    }
   }
 
   if (use_subdomain_colors)


### PR DESCRIPTION
## Summary of Changes

Fix the tetrahedrons colors not working on c3t3 with only one subdomain (no outside tetrahedron).
Open the mesh cube.off, create tetrahedral mesh with sharp edge protection, the tetrahedrons colors were black.

## Release Management

* Affected package(s): Lab
* Issue(s) solved (if any): 
* Feature/Small Feature (if any):
* License and copyright ownership:

