### PR TITLE
Tet remeshing - missing typedefs

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/smooth_vertices.h
@@ -213,8 +213,7 @@ private:
     // build AABB tree of facets in complex
     for (const Facet& f : c3t3.facets_in_complex())
     {
-      const Triangle_3 t = c3t3.triangulation().triangle(f);
-      m_aabb_triangles.push_back(t);
+      m_aabb_triangles.push_back(c3t3.triangulation().triangle(f));
     }
     m_triangles_aabb_tree.rebuild(m_aabb_triangles.begin(), m_aabb_triangles.end());
     m_triangles_aabb_tree.accelerate_distance_queries();
@@ -222,8 +221,7 @@ private:
     // build AABB tree of edges in complex
     for (const Edge& e : c3t3.edges_in_complex())
     {
-      const Segment_3 s = c3t3.triangulation().segment(e);
-      m_aabb_segments.push_back(s);
+      m_aabb_segments.push_back(c3t3.triangulation().segment(e));
     }
     m_segments_aabb_tree.rebuild(m_aabb_segments.begin(), m_aabb_segments.end());
     m_segments_aabb_tree.accelerate_distance_queries();

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -1446,6 +1446,7 @@ auto sizing_at_midpoint(const typename C3t3::Edge& e,
                         const Cell_selector& cell_selector)
 {
   using FT = typename C3t3::Triangulation::Geom_traits::FT;
+  using Point_3 = typename C3t3::Triangulation::Geom_traits::Point_3;
 
   auto cp = c3t3.triangulation().geom_traits().construct_point_3_object();
   const Point_3 m = CGAL::midpoint(cp(e.first->vertex(e.second)->point()),


### PR DESCRIPTION
## Summary of Changes

Fix missing typedefs introduced by PR #7830

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged

