### PR TITLE
PMP isotropic_remeshing - add example using `allow_move_functor`

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/examples.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/examples.txt
@@ -48,5 +48,6 @@
 \example Polygon_mesh_processing/remesh_almost_planar_patches.cpp
 \example Polygon_mesh_processing/sample_example.cpp
 \example Polygon_mesh_processing/soup_autorefinement.cpp
+\example Polygon_mesh_processing/isotropic_remeshing_with_allow_move.cpp
 */
 */

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
@@ -54,6 +54,7 @@ create_single_source_cgal_program("cc_compatible_orientations.cpp")
 create_single_source_cgal_program("hausdorff_distance_remeshing_example.cpp")
 create_single_source_cgal_program("hausdorff_bounded_error_distance_example.cpp")
 create_single_source_cgal_program("isotropic_remeshing_with_custom_sizing_example.cpp")
+create_single_source_cgal_program("isotropic_remeshing_with_allow_move.cpp")
 create_single_source_cgal_program("triangle_mesh_autorefinement.cpp")
 create_single_source_cgal_program("soup_autorefinement.cpp")
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_with_allow_move.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_with_allow_move.cpp
@@ -1,0 +1,72 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Polygon_mesh_processing/remesh.h>
+#include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
+#include <CGAL/Polygon_mesh_processing/self_intersections.h>
+#include <CGAL/Side_of_triangle_mesh.h>
+
+#include <iostream>
+#include <string>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel   K;
+typedef CGAL::Surface_mesh<K::Point_3>                        Mesh;
+
+typedef boost::graph_traits<Mesh>::halfedge_descriptor        halfedge_descriptor;
+typedef boost::graph_traits<Mesh>::edge_descriptor            edge_descriptor;
+
+namespace PMP = CGAL::Polygon_mesh_processing;
+
+struct Allow_no_surface_crossing
+{
+  using vertex_descriptor = typename boost::graph_traits<Mesh>::vertex_descriptor;
+  using Point_3 = typename K::Point_3;
+
+  CGAL::Side_of_triangle_mesh<Mesh, K> m_side_of_tmesh;
+
+  Allow_no_surface_crossing(const Mesh& mesh)
+    : m_side_of_tmesh(mesh)
+  {}
+
+  bool operator()(vertex_descriptor v, Point_3 src, Point_3 tgt) const
+  {
+    const CGAL::Bounded_side s_src = m_side_of_tmesh(src);
+    const CGAL::Bounded_side s_tgt = m_side_of_tmesh(tgt);
+    return (s_src == s_tgt);
+  }
+};
+
+int main(int argc, char* argv[])
+{
+  const std::string filename = (argc > 1) ? std::string(argv[1]) : CGAL::data_file_path("meshes/pig.off");
+
+  Mesh mesh;
+  if(!PMP::IO::read_polygon_mesh(filename, mesh) || !CGAL::is_triangle_mesh(mesh))
+  {
+    std::cerr << "Invalid input." << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  double target_edge_length = (argc > 2) ? std::stod(std::string(argv[2])) : 0.05;
+  unsigned int nb_iter = (argc > 3) ? std::stoi(std::string(argv[3])) : 1;
+
+  if (PMP::does_self_intersect(mesh))
+    std::cout << "Input mesh self-intersects" << std::endl;
+  else
+    std::cout << "Input mesh does not self-intersect" << std::endl;
+
+  Allow_no_surface_crossing shall_move(mesh);
+  PMP::isotropic_remeshing(faces(mesh), target_edge_length, mesh,
+    CGAL::parameters::number_of_iterations(nb_iter)
+    .allow_move_functor(shall_move)
+  );
+
+  if (PMP::does_self_intersect(mesh))
+    std::cout << "Output mesh self-intersects" << std::endl;
+  else
+    std::cout << "Output mesh does not self-intersect" << std::endl;
+
+  std::cout << "Remeshing done." << std::endl;
+  CGAL::IO::write_polygon_mesh("out.off", mesh, CGAL::parameters::stream_precision(17));
+
+  return EXIT_SUCCESS;
+}

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_with_allow_move.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_with_allow_move.cpp
@@ -1,4 +1,5 @@
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polygon_mesh_processing/remesh.h>
 #include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
@@ -37,7 +38,7 @@ struct Allow_no_surface_crossing
 
 int main(int argc, char* argv[])
 {
-  const std::string filename = (argc > 1) ? std::string(argv[1]) : CGAL::data_file_path("meshes/pig.off");
+  const std::string filename = (argc > 1) ? std::string(argv[1]) : CGAL::data_file_path("meshes/triceratops.off");
 
   Mesh mesh;
   if(!PMP::IO::read_polygon_mesh(filename, mesh) || !CGAL::is_triangle_mesh(mesh))
@@ -46,8 +47,9 @@ int main(int argc, char* argv[])
     return EXIT_FAILURE;
   }
 
-  double target_edge_length = (argc > 2) ? std::stod(std::string(argv[2])) : 0.05;
+  double target_edge_length = (argc > 2) ? std::stod(std::string(argv[2])) : 0.3;
   unsigned int nb_iter = (argc > 3) ? std::stoi(std::string(argv[3])) : 1;
+  unsigned int nb_smoothing = (argc > 4) ? std::stoi(std::string(argv[4])) : 2;
 
   if (PMP::does_self_intersect(mesh))
     std::cout << "Input mesh self-intersects" << std::endl;
@@ -57,6 +59,7 @@ int main(int argc, char* argv[])
   Allow_no_surface_crossing shall_move(mesh);
   PMP::isotropic_remeshing(faces(mesh), target_edge_length, mesh,
     CGAL::parameters::number_of_iterations(nb_iter)
+    .number_of_relaxation_steps(nb_smoothing)
     .allow_move_functor(shall_move)
   );
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_with_allow_move.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/isotropic_remeshing_with_allow_move.cpp
@@ -28,7 +28,7 @@ struct Allow_no_surface_crossing
     : m_side_of_tmesh(mesh)
   {}
 
-  bool operator()(vertex_descriptor v, Point_3 src, Point_3 tgt) const
+  bool operator()(vertex_descriptor, Point_3 src, Point_3 tgt) const
   {
     const CGAL::Bounded_side s_src = m_side_of_tmesh(src);
     const CGAL::Bounded_side s_tgt = m_side_of_tmesh(tgt);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -174,7 +174,7 @@ namespace Polygon_mesh_processing {
 *   \cgalParamNBegin{allow_move_functor}
 *     \cgalParamDescription{A function object used to determinate if a vertex move should
 *                           be allowed or not during the relaxation step.}
-*     \cgalParamType{Unary functor that provides `bool operator()(vertex_descriptor v, Point_3 src, Point_3 tgt)`
+*     \cgalParamType{Functor that provides `bool operator()(vertex_descriptor v, Point_3 src, Point_3 tgt)`
 *                    returning `true`
 *                    if the vertex `v` can be moved from `src` to `tgt`;
 *                    `%Point_3` being the value type of the vertex point map }


### PR DESCRIPTION
## Summary of Changes

add an example using named parameter introduced in PR #8150

## Release Management

* Affected package(s):
* Issue(s) solved (if any): partially solves #8134
* License and copyright ownership: unchanged

