### PR TITLE
Surface_mesh:  Add exact_num_faces(const SM&)

### DIFF
--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -26,6 +26,7 @@
 #include <CGAL/boost/graph/Euler_operations.h>
 #include <CGAL/boost/graph/iterator.h>
 #include <CGAL/boost/graph/named_params_helper.h>
+#include <CGAL/boost/graph/internal/helpers.h>
 #include <CGAL/Named_function_parameters.h>
 #include <CGAL/circulator.h>
 #include <CGAL/Handle_hash_function.h>
@@ -2802,6 +2803,16 @@ namespace internal{
   }
 }
 
+namespace internal {
+
+template <typename P>
+std::size_t
+exact_num_faces(const CGAL::Surface_mesh<P>& sm)
+{
+ return sm.number_of_faces();
+}
+
+} // namespace internal
 } // namespace CGAL
 
 #ifndef DOXYGEN_RUNNING

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -2812,6 +2812,27 @@ exact_num_faces(const CGAL::Surface_mesh<P>& sm)
  return sm.number_of_faces();
 }
 
+template <typename P>
+std::size_t
+exact_num_edges(const CGAL::Surface_mesh<P>& sm)
+{
+ return sm.number_of_edges();
+}
+
+template <typename P>
+std::size_t
+exact_num_halfedges(const CGAL::Surface_mesh<P>& sm)
+{
+ return sm.number_of_halfedges();
+}
+
+template <typename P>
+std::size_t
+exact_num_vertices(const CGAL::Surface_mesh<P>& sm)
+{
+ return sm.number_of_vertices();
+}
+
 } // namespace internal
 } // namespace CGAL
 


### PR DESCRIPTION
## Summary of Changes

Add a partial specialization for `CGAL::internal::exact_num_faces(const Surface_mesh&)`  to have an `O(1)` time.  This was pointed out as important for the `Face_count_stop_predicate`  in Issue #8158 

## Release Management

* Affected package(s): Surface_mesh
* Issue(s) solved (if any): fix #5720
* License and copyright ownership: unchanged

