### PR TITLE
CGAL Lab: Add a target CGALlab_compile_all_plugins

### DIFF
--- a/Lab/demo/Lab/CGALlab_compile_all_plugins.cpp
+++ b/Lab/demo/Lab/CGALlab_compile_all_plugins.cpp
@@ -1,0 +1,6 @@
+#include <iostream>
+int main()
+{
+std::cout << "This executable is not intended to be run.\nPlease run the CGALlab executable instead.\n";
+  return 0;
+}

--- a/Lab/demo/Lab/CGALlab_macros.cmake
+++ b/Lab/demo/Lab/CGALlab_macros.cmake
@@ -1,5 +1,11 @@
+include_guard()
+
 include(AddFileDependencies)
 include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
+
+add_custom_target(CGALlab_all_plugins)
+add_executable(CGALlab_compile_all_plugins CGALlab_compile_all_plugins.cpp)
+add_dependencies(CGALlab_compile_all_plugins CGALlab_all_plugins)
 
   macro(cgal_lab_plugin plugin_name plugin_implementation_base_name)
     cmake_parse_arguments(ARG "" "" "KEYWORDS" ${ARGN})
@@ -48,6 +54,7 @@ include(${CGAL_MODULES_DIR}/CGAL_add_test.cmake)
       add_dependencies( ${plugin_name} CGALlab )
     endif()
     if(NOT TARGET CGALlab_all_plugins)
+      message(AUTHOR_WARNING "CGALlab_all_plugins target not found, creating it")
       add_custom_target(CGALlab_all_plugins)
     endif()
     add_dependencies(CGALlab_all_plugins ${plugin_name})

--- a/Lab/demo/Lab/CMakeLists.txt
+++ b/Lab/demo/Lab/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1...3.23)
+cmake_minimum_required(VERSION 3.11...3.23)
 project(Lab_Demo)
 include(FeatureSummary)
 


### PR DESCRIPTION
## Summary of Changes

Fix a usability issue with Visual Studio Code. There is now a new target `CGALlab_compile_all_plugins` that compiles the executable `CGALlab` and all the plugins.

That target, as seen in the vscode Make Project Outline, is placed just below the `CGALlab` target.

![Screenshot_20240524_165017](https://github.com/CGAL/cgal/assets/5746675/9b7ebd26-19f6-46c4-97b1-677c5aecdb48)

If the executable `CGALlab_compile_all_plugins` is launched, it just displays:

```
This executable is not intended to be run.
Please run the CGALlab executable instead.
```

## Release Management

* Affected package(s): Lab

