### PR TITLE
Fix using the fcolor pmap when there is no face color

### DIFF
--- a/Lab/demo/Lab/Scene_surface_mesh_item.cpp
+++ b/Lab/demo/Lab/Scene_surface_mesh_item.cpp
@@ -626,11 +626,17 @@ void Scene_surface_mesh_item_priv::compute_elements(Scene_item_rendering_helper:
       }
       else if(is_convex)
       {
-        triangulate_convex_facet(fd, &fnormals, &fcolors.value(), nullptr, name, false);
+        if(has_fcolors)
+          triangulate_convex_facet(fd, &fnormals, &fcolors.value(), nullptr, name, false);
+        else
+          triangulate_convex_facet(fd, &fnormals, nullptr, nullptr, name, false);
       }
       else
       {
-        triangulate_facet(fd, &fnormals, &fcolors.value(), nullptr, name, false);
+        if(has_fcolors)
+          triangulate_facet(fd, &fnormals, &fcolors.value(), nullptr, name, false);
+        else
+          triangulate_facet(fd, &fnormals, nullptr, nullptr, name, false);
       }
     }
   }


### PR DESCRIPTION
## Summary of Changes

This is a quick band aid such that the demo can be used. The proper fix would be to not have a Boolean on whether the pmap is defined as item member, while also passing the pmap as parameter of functions...

## Release Management

* Affected package(s): `Lab`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

