### PR TITLE
Mesh_3: add a scope after if(...)

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Refine_facets_3.h
@@ -1677,9 +1677,11 @@ compute_facet_properties(const Facet& facet,
           r_oracle_.surface_patch_index(std::get<1>(intersect)));
       if(surface)
 #endif // CGAL_MESH_3_NO_LONGER_CALLS_DO_INTERSECT_3
-      fp =  Facet_properties(std::make_tuple(*surface,
-                                    std::get<1>(intersect),
-                                    std::get<0>(intersect)));
+      {
+        fp =  Facet_properties(std::make_tuple(*surface,
+                                      std::get<1>(intersect),
+                                      std::get<0>(intersect)));
+      }
     }
   }
   // If the dual is a ray


### PR DESCRIPTION
## Summary of Changes

Trivial, that adds a scope. Before it was:

```c++
      if(surface)
        fp =  Facet_properties(std::make_tuple(*surface,
                                      std::get<1>(intersect),
                                      std::get<0>(intersect)));
```

and now:

```c++
      if(surface)
      {
        fp =  Facet_properties(std::make_tuple(*surface,
                                      std::get<1>(intersect),
                                      std::get<0>(intersect)));
      }
```

## Release Management

* Affected package(s): Mesh_3
