### PR TITLE
Add a Bbox class with dimension as parameter

### DIFF
--- a/Kernel_23/include/CGAL/Bbox.h
+++ b/Kernel_23/include/CGAL/Bbox.h
@@ -20,6 +20,7 @@
 #include <iterator>
 #include <CGAL/assertions.h>
 #include <CGAL/Dimension.h>
+#include <CGAL/use.h>
 
 namespace CGAL {
 namespace Impl {
@@ -112,6 +113,7 @@ protected:
 
     template <typename I>
     void init(int d, I b, I e) {
+        CGAL_USE(e);
         CGAL_assertion(d == std::distance(b,e));
         for(int i=0; i<d; ++i,++b)
         {


### PR DESCRIPTION
## Summary of Changes

For the upcoming Frechet Distance package we need a dD bounding box.  We do not have that in `Kernel_d`, and there is such a class in ign's Distributed Delaunay Triangulation package to come ([link](https://github.com/mbredif/ddt_cgal/blob/master/DDT/include/CGAL/DDT/kernel/Bbox.h)).   This PR copies it to the Kernel package (with the ok of @mbredif), but in the `CGAL` namespace.  

This draft pull request is to get a discussion started.

- In the initial version even the number type is a template parameter. Do we want to keep that?   
- Do we want to make `Bbox_2/3`  a `typedef` of this new class?
- We have to go through the API and probably enrich it with what `Bbox_2` offers additionally.
- Do we have to add functions in `Kernel_d`?

### TODO
- [ ] create a small feature and get it approved

## Release Management

* Affected package(s): Kernel_23
* Feature/Small Feature (if any): tbd
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:  LGPL , owned by IGN

