### PR TITLE
CMake - Add one CMakeLists per package

### DIFF
--- a/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/CMakeLists.txt
@@ -1,0 +1,16 @@
+# This is the CMake script for compiling this folder.
+
+cmake_minimum_required(VERSION 3.1...3.23)
+project(Mesh_3)
+
+if(CGAL_ENABLE_TESTING)
+  enable_testing()
+endif()
+
+option(CGAL_MESH_3_BENCHMARK "Add benchmark to project" OFF)
+if(CGAL_MESH_3_BENCHMARK)
+  add_subdirectory("benchmark/Mesh_3")
+endif()
+
+add_subdirectory("examples/Mesh_3")
+add_subdirectory("test/Mesh_3")

--- a/Poisson_surface_reconstruction_3/CMakeLists.txt
+++ b/Poisson_surface_reconstruction_3/CMakeLists.txt
@@ -1,0 +1,11 @@
+# This is the CMake script for compiling this folder.
+
+cmake_minimum_required(VERSION 3.1...3.23)
+project(Poisson_surface_reconstruction_3)
+
+if(CGAL_ENABLE_TESTING)
+  enable_testing()
+endif()
+
+add_subdirectory("examples/Poisson_surface_reconstruction_3")
+add_subdirectory("test/Poisson_surface_reconstruction_3")


### PR DESCRIPTION
## Summary of Changes

To be able to test a full package (tests, examples, and if they exist benchmark and demo) at once, for example using `ctest` (or simply compiling in visual studio), I suggest to add one CMakeLists per package, at the root of the package.

This PR introduces two such CMakeLists, which I think are very handy.

