### PR TITLE
Mesh_3 - fix concept `MeshFacetCriteria_3`

### DIFF
--- a/Mesh_3/doc/Mesh_3/Concepts/MeshFacetCriteria_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshFacetCriteria_3.h
@@ -62,6 +62,11 @@ a natural model of this concept.
 */
 typedef unspecified_type Is_facet_bad;
 
+/*!
+* Numerical type.
+*/
+typedef unspecified_type FT;
+
 /// @}
 
 /// \name Operations
@@ -72,6 +77,12 @@ Returns the `Is_facet_bad` value of the facet `f`, which lives in the triangulat
 The type `Tr` must be identical to the triangulation type used by the mesh generation function.
 */
 Is_facet_bad operator()(const Tr& tr, Facet f);
+
+/**
+* @returns the squared value of minimal radius bound if set,
+* and `std::nullopt` otherwise
+*/
+std::optional<FT> squared_min_radius_bound() const;
 
 /// @}
 

--- a/Mesh_3/include/CGAL/Mesh_facet_criteria_3.h
+++ b/Mesh_3/include/CGAL/Mesh_facet_criteria_3.h
@@ -179,6 +179,10 @@ public:
     return topology_;
   }
 
+  /**
+  * @returns the squared value of minimal radius bound if it was set,
+  * and `std::nullopt` otherwise
+  */
   std::optional<FT> squared_min_radius_bound() const {
     if(squared_min_radius_bound_)
       return *squared_min_radius_bound_;


### PR DESCRIPTION
## Summary of Changes

The concept and class were missing `squared_min_radius_bound()` since PR #7754

## Release Management

* Affected package(s): Mesh_3

