### PR TITLE
PMP: Change the string of the property

### DIFF
--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/compute_normals_example.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/compute_normals_example.cpp
@@ -29,8 +29,8 @@ int main(int argc, char* argv[])
     return 1;
   }
 
-  auto vnormals = mesh.add_property_map<vertex_descriptor, Vector>("v:normals", CGAL::NULL_VECTOR).first;
-  auto fnormals = mesh.add_property_map<face_descriptor, Vector>("f:normals", CGAL::NULL_VECTOR).first;
+  auto vnormals = mesh.add_property_map<vertex_descriptor, Vector>("v:normal", CGAL::NULL_VECTOR).first;
+  auto fnormals = mesh.add_property_map<face_descriptor, Vector>("f:normal", CGAL::NULL_VECTOR).first;
 
   PMP::compute_normals(mesh, vnormals, fnormals);
 

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/extrude.cpp
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/extrude.cpp
@@ -59,7 +59,7 @@ int main(int argc, char* argv[])
 
   CGAL::IO::read_polygon_mesh(filename, in);
 
-  VNMap vnormals = in.template add_property_map<vertex_descriptor, Vector>("v:normals", CGAL::NULL_VECTOR).first;
+  VNMap vnormals = in.template add_property_map<vertex_descriptor, Vector>("v:normal", CGAL::NULL_VECTOR).first;
 
   CGAL::Polygon_mesh_processing::compute_vertex_normals(in, vnormals);
   Bottom bottom(get(CGAL::vertex_point,out), vnormals, vlen);

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/pmp_compute_normals_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/pmp_compute_normals_test.cpp
@@ -142,9 +142,9 @@ void test_SM(const std::string file_name)
   }
 
   typename SM::template Property_map<vertex_descriptor, Vector> vnormals;
-  vnormals = mesh.template add_property_map<vertex_descriptor, Vector>("v:normals", CGAL::NULL_VECTOR).first;
+  vnormals = mesh.template add_property_map<vertex_descriptor, Vector>("v:normal", CGAL::NULL_VECTOR).first;
   typename SM::template Property_map<face_descriptor, Vector> fnormals;
-  fnormals = mesh.template add_property_map<face_descriptor, Vector>("f:normals", CGAL::NULL_VECTOR).first;
+  fnormals = mesh.template add_property_map<face_descriptor, Vector>("f:normal", CGAL::NULL_VECTOR).first;
 
   test<K>(mesh, vnormals, fnormals);
 }


### PR DESCRIPTION
## Summary of Changes

When calling[ `compute_vertex_normals()`](https://doc.cgal.org/latest/Polygon_mesh_processing/group__PMP__normal__grp.html#ga74e6b247d7e28beb677076aad5614d8c) we better change the string associated to the property from `"v:normals"`  to `" v:normal"` as otherwise it will not be written by[ `write_PLY()`](https://doc.cgal.org/latest/Surface_mesh/group__PkgSurfaceMeshIOFuncPLY.html#ga50f0e9f2b293855d2c7f1a62939cbe8d).

Note that is not a change in CGAL code, but just in an example (that not even saves the file).

## Release Management

* Affected package(s): PMP
* License and copyright ownership: unchanged

