### PR TITLE
T3/T2/PT: Add namespace to classes in concepts

### DIFF
--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2DelaunayTriangulationTraits_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2DelaunayTriangulationTraits_2.h
@@ -6,7 +6,7 @@
 \cgalConcept
 
 The concept `Periodic_2DelaunayTriangulationTraits_2` is the first template parameter of the class
-`Periodic_2_Delaunay_triangulation_2`. It refines the concepts
+`CGAL::Periodic_2_Delaunay_triangulation_2`. It refines the concepts
 `Periodic_2TriangulationTraits_2` and `DelaunayTriangulationTraits_2`.
 It redefines the geometric objects, predicates and constructions to work with
 point-offset pairs. In most cases the offsets will be (0,0) and the
@@ -123,4 +123,3 @@ public:
 /// @}
 
 }; /* end Periodic_2DelaunayTriangulationTraits_2 */
-

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2TriangulationTraits_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2TriangulationTraits_2.h
@@ -6,7 +6,7 @@
 \cgalConcept
 
 The concept `Periodic_2TriangulationTraits_2` is the first template parameter of the classes
-`Periodic_2_triangulation_2<Traits, Tds>`. This concept provides the types of
+`CGAL::Periodic_2_triangulation_2<Traits, Tds>`. This concept provides the types of
 the geometric primitives used in the triangulation and some function
 object types for the required predicates on those primitives.
 
@@ -294,4 +294,3 @@ public:
 /// @}
 
 }; /* end Periodic_2TriangulationTraits_2 */
-

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3RegularTriangulationTraits_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3RegularTriangulationTraits_3.h
@@ -18,7 +18,7 @@ functor the version without offsets.
 \cgalHasModel `CGAL::Periodic_3_regular_triangulation_traits_3`
 
 In addition to the requirements described for the traits class
-RegularTriangulationTraits_3, the geometric traits class of a
+`RegularTriangulationTraits_3`, the geometric traits class of a
 periodic regular triangulation must fulfill the following
 requirements.
 
@@ -248,4 +248,3 @@ Construct_weighted_circumcenter_3 construct_weighted_circumcenter_3_object();
 /// @}
 
 }; /* end Periodic_3RegularTriangulationTraits_3 */
-

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3TriangulationTraits_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/Concepts/Periodic_3TriangulationTraits_3.h
@@ -4,7 +4,7 @@
 \cgalConcept
 
 The concept `Periodic_3TriangulationTraits_3` is the first template parameter of the class
-`Periodic_3_triangulation_3`. It refines the concept
+`CGAL::Periodic_3_triangulation_3`. It refines the concept
 `TriangulationTraits_3` from the \cgal 3D Triangulations.
 It redefines the geometric objects, predicates and constructions to
 work with point-offset pairs. In most cases the offsets will be
@@ -256,4 +256,3 @@ Construct_tetrahedron_3 construct_tetrahedron_3_object();
 /// @}
 
 }; /* end Periodic_3TriangulationTraits_3 */
-

--- a/Triangulation_3/doc/Triangulation_3/Concepts/DelaunayTriangulationTraits_3.h
+++ b/Triangulation_3/doc/Triangulation_3/Concepts/DelaunayTriangulationTraits_3.h
@@ -4,7 +4,7 @@
 \cgalConcept
 
 The concept `DelaunayTriangulationTraits_3` is the first template parameter of the class
-`Delaunay_triangulation_3`. It defines the geometric objects (points,
+`CGAL::Delaunay_triangulation_3`. It defines the geometric objects (points,
 segments...) forming the triangulation together with a few geometric
 predicates and constructions on these objects.
 
@@ -219,4 +219,3 @@ Construct_ray_3 construct_ray_3_object();
 /// @}
 
 }; /* end DelaunayTriangulationTraits_3 */
-

--- a/Triangulation_3/doc/Triangulation_3/Concepts/TriangulationTraits_3.h
+++ b/Triangulation_3/doc/Triangulation_3/Concepts/TriangulationTraits_3.h
@@ -6,7 +6,7 @@
 \cgalRefines{SpatialSortingTraits_3}
 
 The concept `TriangulationTraits_3` is the first template parameter of the class
-`Triangulation_3`. It defines the geometric objects (points, segments,
+`CGAL::Triangulation_3`. It defines the geometric objects (points, segments,
 triangles and tetrahedra) forming the triangulation together with a few
 geometric predicates and constructions on these objects: lexicographical
 comparison, orientation in case of coplanar points and orientation in space.
@@ -186,4 +186,3 @@ Orientation_3 orientation_3_object();
 /// @}
 
 }; /* end TriangulationTraits_3 */
-


### PR DESCRIPTION
## Summary of Changes

In order to have links to classes in concepts we have to prefix with the namespace.

## Release Management

* Affected package(s): T3, T2, PT2
* License and copyright ownership: unchanged

