### PR TITLE
Shape_detection: Removing leftover from deprecated Shape_detection_traits

### DIFF
--- a/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Octree.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Efficient_RANSAC/Octree.h
@@ -31,20 +31,12 @@
 namespace CGAL {
 namespace Shape_detection {
 
-// Forward declaration needed for automatic traits detection without
-// including the deprecated header itself…
-template <typename Gt, typename IR, typename IPM, typename INM>
-struct Shape_detection_traits;
-
 namespace internal {
 
 template <typename Traits>
 struct Traits_base { typedef Traits type; };
 template <typename Gt, typename IR, typename IPM, typename INM>
 struct Traits_base<CGAL::Shape_detection::Efficient_RANSAC_traits<Gt,IR,IPM,INM> >
-{ typedef Gt type; };
-template <typename Gt, typename IR, typename IPM, typename INM>
-struct Traits_base<CGAL::Shape_detection::Shape_detection_traits<Gt,IR,IPM,INM> >
 { typedef Gt type; };
 
 template<class Traits>


### PR DESCRIPTION
## Summary of Changes

Removing leftover code referring to the deprecated Shape_detection_traits. 

## Release Management

* Affected package(s): Shape_detection
* Issue(s) solved (if any): fix #8290, fix #7872

