### PR TITLE
Shape_detection: using proper triangulated polygonal faces for linear_least_squares

### DIFF
--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Polygon_mesh/Least_squares_plane_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Polygon_mesh/Least_squares_plane_fit_region.h
@@ -178,9 +178,14 @@ namespace Polygon_mesh {
 
         Polygon_mesh_processing::triangulate_hole_polyline(pts, std::back_inserter(output), parameters::use_2d_constrained_delaunay_triangulation(true));
 
+        // Create entry in map. In case of degenerate polygonal faces, the list stays empty.
         std::vector<Triangle_3>& tris = m_face_triangulations[i];
+
+        // If the output is empty, the polygon is degenerate.
+        if (output.empty())
+          continue;
+
         tris.reserve(output.size());
-        assert(!output.empty());
         for (const auto& t : output)
           tris.push_back(Triangle_3(pts[t.first], pts[t.second], pts[t.third]));
       }
@@ -343,7 +348,7 @@ namespace Polygon_mesh {
       // https://github.com/CGAL/cgal/pull/4563
       const Plane_3 unoriented_plane_of_best_fit =
         internal::create_plane_from_triangulated_faces(
-          m_face_graph, region, m_face_triangulations, m_traits).first;
+          region, m_face_triangulations, m_traits).first;
       const Vector_3 unoriented_normal_of_best_fit =
         unoriented_plane_of_best_fit.orthogonal_vector();
 

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/internal/utils.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/internal/utils.h
@@ -399,12 +399,10 @@ namespace internal {
 
   template<
     typename Traits,
-    typename FaceGraph,
     typename Region,
     typename FaceToTrianglesMap>
   std::pair<typename Traits::Plane_3, typename Traits::FT>
     create_plane_from_triangulated_faces(
-      const FaceGraph& face_graph,
       const Region& region,
       const FaceToTrianglesMap &face_to_triangles_map, const Traits&) {
 
@@ -427,12 +425,15 @@ namespace internal {
 
     for (const typename Region::value_type face : region) {
       const std::vector<Triangle_3>& tris = face_to_triangles_map.at(face);
-      CGAL_precondition(tris.size() > 0);
 
-      for (const auto tri : tris)
+      // Degenerate polygons are omitted.
+      if (tris.empty())
+        continue;
+
+      for (const auto &tri : tris)
         triangles.push_back(iconverter(tri));
     }
-    CGAL_precondition(triangles.size() >= region.size());
+    CGAL_precondition(!triangles.empty());
     IPlane_3 fitted_plane;
     IPoint_3 fitted_centroid;
     const IFT score = CGAL::linear_least_squares_fitting_3(

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/internal/utils.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/internal/utils.h
@@ -48,6 +48,8 @@
 #include <CGAL/Iterator_range.h>
 #ifdef CGAL_SD_RG_USE_PMP
 #include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
+#else
+#include <CGAL/centroid.h>
 #endif
 
 namespace CGAL {

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/internal/utils.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/internal/utils.h
@@ -350,7 +350,7 @@ namespace internal {
 #else
     //use a triangulation using the centroid
     std::size_t nb_edges = points.size();
-    Point_3 c = CGAL::centroid(points.begin(), points.end());
+    typename Traits::Point_3 c = CGAL::centroid(points.begin(), points.end());
     triangles.reserve(nb_edges);
     for (std::size_t i=0; i<nb_edges-1; ++i)
       triangles.emplace_back(points[i], points[i+1], c);

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/internal/utils.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/internal/utils.h
@@ -442,7 +442,7 @@ namespace internal {
     const IConverter iconverter = IConverter();
 
     for (const typename Region::value_type face : region) {
-      const std::vector<Triangle_3>& tris = face_to_triangles_map.at(face);
+      const std::vector<Triangle_3>& tris = get(face_to_triangles_map, face);
 
       // Degenerate polygons are omitted.
       if (tris.empty())


### PR DESCRIPTION
## Summary of Changes

Polygonal faces are now triangulated and face normals are calculated using PMP::compute_face_normal.

The calculated face normals and triangulations are buffered in Least_squares_plane_fit_region. However, Least_squares_plane_fit_sorting is independent and does not benefit from that buffered data.

## Release Management

* Affected package(s): Shape_detection
* Issue(s) solved (if any): fix #7992

