### PR TITLE
Incorrect link to book at msri

### DIFF
--- a/Documentation/doc/biblio/cgal_manual.bib
+++ b/Documentation/doc/biblio/cgal_manual.bib
@@ -2778,7 +2778,7 @@ author = "Pedro M.M. de Castro and Frederic Cazals and Sebastien Loriot and Moni
  editor = "Jacob E. Goodman, J\'anos Pach and Emo Welzl",
  year = {2005},
  pages = {439-458},
- URL = {http://library.msri.org/books/Book52/files/23liu.pdf},
+ URL = {http://library.slmath.org/books/Book52/files/23liu.pdf},
  publisher = {MSRI Publications}
 }
 


### PR DESCRIPTION
The msri institute has been renamed to Simons Laufer Mathematical Sciences Institute (SLMath) and hence also the place of the library.

See also :
- https://www.slmath.org/history
- https://en.wikipedia.org/wiki/Simons_Laufer_Mathematical_Sciences_Institute
