### PR TITLE
issue #8334 Incorrect example in "Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt"

### DIFF
--- a/Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt
+++ b/Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt
@@ -33,14 +33,17 @@ This section describes a minimal example of a program that uses \cgal and Qt6 fo
 \skip cmake_minimum_required
 \until project
 
+
 \skip #CGAL_Qt6 is needed for the drawing.
-\until endif()
+\until find_package
+
 
 \skip #create the executable of the application
 \until "draw_surface_mesh.cpp"
 
+
 \skip if(CGAL_Qt6_FOUND)
-\until target_link_libraries(draw_surface_mesh PUBLIC CGAL::CGAL_Qt6)
+\until target_link_libraries(draw_surface_mesh PUBLIC CGAL::CGAL_Basic_viewer)
 \skip endif
 \until #end of the file
 


### PR DESCRIPTION
The problem surfaced between the releases CGAL 5.3.2 and CGAL 5.4.4. The "Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt" had not been adjusted for the changes in "Surface_mesh/examples/Surface_mesh/CMakeLists.txt" i.e. the changes in its structure and also during the change Qt5 -> Qt6 this was not detected.
