### PR TITLE
edge-collapse: garland-heckbert: no non-zero precondition for cost matrices

### DIFF
--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_probabilistic_plane_policies.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_probabilistic_plane_policies.h
@@ -116,7 +116,10 @@ public:
                                 const Col_4& /*p0*/,
                                 const Col_4& /*p1*/) const
   {
-    // @fixme check this
+    // TODO: an all-zero matrix is just a specific case of a non-invertible matrix;
+    // shouldn't this rather assert that quadric is invertible?
+    CGAL_precondition(!quadric.isZero(0));
+
     return construct_optimal_point_invertible<GeomTraits>(quadric);
   }
 };

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_probabilistic_triangle_policies.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_probabilistic_triangle_policies.h
@@ -106,7 +106,9 @@ public:
 
   Col_4 construct_optimal_point(const Mat_4& quadric, const Col_4& /*p0*/, const Col_4& /*p1*/) const
   {
-    // @fixme check this
+    // TODO: an all-zero matrix is just a specific case of a non-invertible matrix;
+    // shouldn't this rather assert that quadric is invertible?
+    CGAL_precondition(!quadric.isZero(0));
     return construct_optimal_point_invertible<GeomTraits>(quadric);
   }
 };

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/internal/GarlandHeckbert_policy_base.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/internal/GarlandHeckbert_policy_base.h
@@ -208,9 +208,6 @@ public:
     if(!placement)
       return boost::optional<typename Profile::FT>();
 
-    CGAL_precondition(!get(vcm(), profile.v0()).isZero(0));
-    CGAL_precondition(!get(vcm(), profile.v1()).isZero(0));
-
     const Mat_4 combined_matrix = combine_matrices(get(vcm(), profile.v0()),
                                                    get(vcm(), profile.v1()));
     const Col_4 pt = point_to_homogenous_column(*placement);
@@ -224,9 +221,6 @@ public:
   template <typename Profile>
   boost::optional<typename Profile::Point> operator()(const Profile& profile) const
   {
-    CGAL_precondition(!get(vcm(), profile.v0()).isZero(0));
-    CGAL_precondition(!get(vcm(), profile.v1()).isZero(0));
-
     // the combined matrix has already been computed in the evaluation of the cost...
     const Mat_4 combined_matrix = combine_matrices(get(vcm(), profile.v0()),
                                                    get(vcm(), profile.v1()));


### PR DESCRIPTION
Before: The non-probabilistic garland-heckbert strategies (planar and triangular) trigger the precondition for cost matrices to be non-zero after initialization, when the mesh contains vertices surrounded by degenerate triangles.

Now: the non-zero precondition check is applied for probabilistic strategies only (planar-probablistic and triangular-probabilistic). The non-probabilistic strategies behave well-defined for non-invertible cost matrices, including all-zero cost-matrices.

_Please use the following template to help us managing pull requests._

## Summary of Changes

_Describe what your pull request changes to CGAL (this can be skipped if it solves an issue already in the tracker or if it is a Feature or Small Feature submitted to the CGAL Wiki)._

## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

