### PR TITLE
Mesh_3 - document example Weighted image + triple lines

### DIFF
--- a/Mesh_3/doc/Mesh_3/examples.txt
+++ b/Mesh_3/doc/Mesh_3/examples.txt
@@ -7,6 +7,7 @@
 \example Mesh_3/mesh_3D_image_with_detection_of_features.cpp
 \example Mesh_3/mesh_3D_image_with_input_features.cpp
 \example Mesh_3/mesh_3D_weighted_image.cpp
+\example Mesh_3/mesh_3D_weighted_image_with_detection_of_features.cpp
 \example Mesh_3/random_labeled_image.h
 \example CGAL/Mesh_3/initialize_triangulation_from_gray_image.h
 \example CGAL/Mesh_3/initialize_triangulation_from_labeled_image.h

--- a/Mesh_3/examples/Mesh_3/mesh_3D_weighted_image_with_detection_of_features.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_weighted_image_with_detection_of_features.cpp
@@ -20,18 +20,17 @@ using Mesh_domain = CGAL::Mesh_domain_with_polyline_features_3<Image_domain>;
 /// [Domain definition]
 
 #ifdef CGAL_CONCURRENT_MESH_3
-typedef CGAL::Parallel_tag Concurrency_tag;
+using Concurrency_tag = CGAL::Parallel_tag;
 #else
-typedef CGAL::Sequential_tag Concurrency_tag;
+using Concurrency_tag = CGAL::Sequential_tag;
 #endif
 
 // Triangulation
-typedef CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type Tr;
-
-typedef CGAL::Mesh_complex_3_in_triangulation_3<Tr> C3t3;
+using Tr = CGAL::Mesh_triangulation_3<Mesh_domain,CGAL::Default,Concurrency_tag>::type;
+using C3t3 = CGAL::Mesh_complex_3_in_triangulation_3<Tr>;
 
 // Criteria
-typedef CGAL::Mesh_criteria_3<Tr> Mesh_criteria;
+using Mesh_criteria = CGAL::Mesh_criteria_3<Tr>;
 
 // To avoid verbose function and named parameters call
 using namespace CGAL::parameters;

--- a/Mesh_3/examples/Mesh_3/mesh_3D_weighted_image_with_detection_of_features.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_weighted_image_with_detection_of_features.cpp
@@ -1,6 +1,3 @@
-#define CGAL_MESH_3_WEIGHTED_IMAGES_DEBUG
-#define CGAL_MESH_3_VERBOSE 1
-
 #include <iostream>
 
 #include <CGAL/Mesh_triangulation_3.h>


### PR DESCRIPTION
## Summary of Changes

The example with 3D weighted images + detection of triple lines was not part of the documentation. This PR exposes it.

## Release Management

* Affected package(s): Mesh_3 doc
* Related discussion : #8285 
* License and copyright ownership: unchanged

