### PR TITLE
Tet remeshing - remove assertion in Adaptive sizing field

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Adaptive_remeshing_sizing_field.h
+++ b/Tetrahedral_remeshing/include/CGAL/Adaptive_remeshing_sizing_field.h
@@ -497,7 +497,6 @@ average_edge_length_around(const Vertex_handle v, const Tr& tr,
     break;
   }
 
-  CGAL_assertion(!edges.empty());
   if (edges.empty())
     return 0;
 


### PR DESCRIPTION
## Summary of Changes

The assertion is invalid (at least) when the function takes a far vertex, inserted by parallel version of Mesh_3.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

