### PR TITLE
Remove outdated Qt version checks

### DIFF
--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CurveInputMethods.cpp
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CurveInputMethods.cpp
@@ -111,7 +111,7 @@ void CurveInputMethod::beginInput_()
 
 static inline void clearPainterPath(QPainterPath& ppath)
 {
-  ppath = {};
+  ppath.clear();
 }
 
 

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CurveInputMethods.cpp
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CurveInputMethods.cpp
@@ -109,6 +109,12 @@ void CurveInputMethod::beginInput_()
   for (auto& item : items) this->getScene()->addItem(item);
 }
 
+static inline void clearPainterPath(QPainterPath& ppath)
+{
+  ppath = {};
+}
+
+
 void CurveInputMethod::reset()
 {
   this->resetInput();
@@ -184,6 +190,7 @@ PolylineInputMethod::PolylineInputMethod() :
 
 void PolylineInputMethod::beginInput()
 {
+  clearPainterPath(this->painterPath);
   this->polylineGuide.setPath(this->painterPath);
   this->lastLine.setLine(0, 0, 0, 0);
   QPen pen = this->polylineGuide.pen();
@@ -346,6 +353,8 @@ BezierInputMethod::BezierInputMethod() : CurveInputMethod(CurveType::Bezier, -1)
 
 void BezierInputMethod::beginInput()
 {
+  clearPainterPath(this->painterOldPath);
+  clearPainterPath(this->painterPath);
   this->bezierGuide.setPath(this->painterPath);
   this->bezierOldGuide.setPath(this->painterOldPath);
 
@@ -395,6 +404,7 @@ static void updateBezierPainterPath(
   const std::vector<QPointF>& controlPoints, std::vector<QPointF>& cache,
   const QTransform& worldTransform, QPainterPath& painterPath)
 {
+  clearPainterPath(painterPath);
   if (controlPoints.size() < 2) return;
 
   float pixel_len = approx_pixel_length(controlPoints, worldTransform);

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CurveInputMethods.cpp
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CurveInputMethods.cpp
@@ -109,15 +109,6 @@ void CurveInputMethod::beginInput_()
   for (auto& item : items) this->getScene()->addItem(item);
 }
 
-static inline void clearPainterPath(QPainterPath& ppath)
-{
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 13, 0))
-  ppath.clear();
-#else
-  ppath = {};
-#endif
-}
-
 void CurveInputMethod::reset()
 {
   this->resetInput();
@@ -193,7 +184,6 @@ PolylineInputMethod::PolylineInputMethod() :
 
 void PolylineInputMethod::beginInput()
 {
-  clearPainterPath(this->painterPath);
   this->polylineGuide.setPath(this->painterPath);
   this->lastLine.setLine(0, 0, 0, 0);
   QPen pen = this->polylineGuide.pen();
@@ -356,8 +346,6 @@ BezierInputMethod::BezierInputMethod() : CurveInputMethod(CurveType::Bezier, -1)
 
 void BezierInputMethod::beginInput()
 {
-  clearPainterPath(this->painterOldPath);
-  clearPainterPath(this->painterPath);
   this->bezierGuide.setPath(this->painterPath);
   this->bezierOldGuide.setPath(this->painterOldPath);
 
@@ -407,7 +395,6 @@ static void updateBezierPainterPath(
   const std::vector<QPointF>& controlPoints, std::vector<QPointF>& cache,
   const QTransform& worldTransform, QPainterPath& painterPath)
 {
-  clearPainterPath(painterPath);
   if (controlPoints.size() < 2) return;
 
   float pixel_len = approx_pixel_length(controlPoints, worldTransform);

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/GridGraphicsItem.cpp
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/GridGraphicsItem.cpp
@@ -67,11 +67,7 @@ void GridGraphicsItem::setSpacing(int spacing_)
 static inline qreal
 horizontalAdvance(const QFontMetrics& fm, const QString& text)
 {
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 11, 0))
   return fm.horizontalAdvance(text);
-#else
-  return fm.boundingRect(text).width();
-#endif
 }
 
 void GridGraphicsItem::paint(

--- a/GraphicsView/include/CGAL/Qt/qglviewer.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer.h
@@ -478,6 +478,13 @@ public:
   qreal bufferTextureMaxU() const { return bufferTextureMaxU_; }
   /*! Same as bufferTextureMaxU(), but for the v texture coordinate. */
   qreal bufferTextureMaxV() const { return bufferTextureMaxV_; }
+  // These methods are part of the QGLWidget public API.
+  // As of version 2.7.0, the use of QOpenGLWidget instead means that they have
+  // to be provided for backward compatibility.
+  void renderText(int x, int y, const QString &str,
+                  const QFont &font = QFont());
+  void renderText(double x, double y, double z, const QString &str,
+                  const QFont &font = QFont());
 
 public Q_SLOTS:
   void copyBufferToTexture(GLint, GLenum = GL_NONE);

--- a/GraphicsView/include/CGAL/Qt/qglviewer.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer.h
@@ -478,15 +478,6 @@ public:
   qreal bufferTextureMaxU() const { return bufferTextureMaxU_; }
   /*! Same as bufferTextureMaxU(), but for the v texture coordinate. */
   qreal bufferTextureMaxV() const { return bufferTextureMaxV_; }
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
-  // These methods are part of the QGLWidget public API.
-  // As of version 2.7.0, the use of QOpenGLWidget instead means that they have
-  // to be provided for backward compatibility.
-  void renderText(int x, int y, const QString &str,
-                  const QFont &font = QFont());
-  void renderText(double x, double y, double z, const QString &str,
-                  const QFont &font = QFont());
-#endif
 
 public Q_SLOTS:
   void copyBufferToTexture(GLint, GLenum = GL_NONE);

--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -720,6 +720,28 @@ CGAL_INLINE_FUNCTION
 void CGAL::QGLViewer::drawLight(GLenum, qreal ) const {
 }
 
+CGAL_INLINE_FUNCTION
+void CGAL::QGLViewer::renderText(int x, int y, const QString &str,
+                           const QFont &font) {
+  QColor fontColor = QColor(0, 0,
+                            0, 255);
+
+  // Render text
+  QPainter painter(this);
+  painter.setPen(fontColor);
+  painter.setFont(font);
+  painter.drawText(x, y, str);
+  painter.end();
+}
+
+CGAL_INLINE_FUNCTION
+void CGAL::QGLViewer::renderText(double x, double y, double z, const QString &str,
+                           const QFont &font) {
+  using CGAL::qglviewer::Vec;
+  const Vec proj = camera_->projectedCoordinatesOf(Vec(x, y, z));
+  renderText(int(proj.x), int(proj.y), str, font);
+}
+
 /*! Draws \p text at position \p x, \p y (expressed in screen coordinates
 pixels, origin in the upper left corner of the widget).
 

--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -720,30 +720,6 @@ CGAL_INLINE_FUNCTION
 void CGAL::QGLViewer::drawLight(GLenum, qreal ) const {
 }
 
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 4, 0))
-CGAL_INLINE_FUNCTION
-void CGAL::QGLViewer::renderText(int x, int y, const QString &str,
-                           const QFont &font) {
-  QColor fontColor = QColor(0, 0,
-                            0, 255);
-
-  // Render text
-  QPainter painter(this);
-  painter.setPen(fontColor);
-  painter.setFont(font);
-  painter.drawText(x, y, str);
-  painter.end();
-}
-
-CGAL_INLINE_FUNCTION
-void CGAL::QGLViewer::renderText(double x, double y, double z, const QString &str,
-                           const QFont &font) {
-  using CGAL::qglviewer::Vec;
-  const Vec proj = camera_->projectedCoordinatesOf(Vec(x, y, z));
-  renderText(int(proj.x), int(proj.y), str, font);
-}
-#endif
-
 /*! Draws \p text at position \p x, \p y (expressed in screen coordinates
 pixels, origin in the upper left corner of the widget).
 

--- a/Lab/demo/Lab/CGAL_Lab.cpp
+++ b/Lab/demo/Lab/CGAL_Lab.cpp
@@ -27,6 +27,9 @@ int& code_to_call_before_creation_of_QCoreApplication(int& i) {
   fmt.setOption(QSurfaceFormat::DebugContext);
   QSurfaceFormat::setDefaultFormat(fmt);
 
+  // for windows
+  QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
+
   return i;
 }
 

--- a/Lab/demo/Lab/CGAL_Lab.cpp
+++ b/Lab/demo/Lab/CGAL_Lab.cpp
@@ -27,11 +27,6 @@ int& code_to_call_before_creation_of_QCoreApplication(int& i) {
   fmt.setOption(QSurfaceFormat::DebugContext);
   QSurfaceFormat::setDefaultFormat(fmt);
 
-  //for windows
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 3, 0))
-  QCoreApplication::setAttribute(Qt::AA_UseDesktopOpenGL);
-#endif
-
   return i;
 }
 

--- a/Lab/demo/Lab/MainWindow.cpp
+++ b/Lab/demo/Lab/MainWindow.cpp
@@ -2644,17 +2644,10 @@ void MainWindow::resetHeader()
   sceneView->header()->setSectionResizeMode(Scene::RenderingModeColumn, QHeaderView::ResizeToContents);
   sceneView->header()->setSectionResizeMode(Scene::ABColumn, QHeaderView::Fixed);
   sceneView->header()->setSectionResizeMode(Scene::VisibleColumn, QHeaderView::Fixed);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
   sceneView->header()->resizeSection(Scene::ColorColumn, sceneView->header()->fontMetrics().horizontalAdvance("_#_"));
   sceneView->resizeColumnToContents(Scene::RenderingModeColumn);
   sceneView->header()->resizeSection(Scene::ABColumn, sceneView->header()->fontMetrics().horizontalAdvance(QString("_AB_")));
   sceneView->header()->resizeSection(Scene::VisibleColumn, sceneView->header()->fontMetrics().horizontalAdvance(QString("_View_")));
-#else
-  sceneView->header()->resizeSection(Scene::ColorColumn, sceneView->header()->fontMetrics().width("_#_"));
-  sceneView->resizeColumnToContents(Scene::RenderingModeColumn);
-  sceneView->header()->resizeSection(Scene::ABColumn, sceneView->header()->fontMetrics().width(QString("_AB_")));
-  sceneView->header()->resizeSection(Scene::VisibleColumn, sceneView->header()->fontMetrics().width(QString("_View_")));
-#endif
 }
 
 void MainWindow::reset_default_loaders()

--- a/Lab/demo/Lab/MainWindow.cpp
+++ b/Lab/demo/Lab/MainWindow.cpp
@@ -664,11 +664,6 @@ void MainWindow::loadPlugins()
   }
   QString env_path = qgetenv("LAB_DEMO_PLUGINS_PATH");
   QChar separator = QDir::listSeparator();
-  #if defined(_WIN32)
-    QChar separator = ';';
-  #else
-    QChar separator = ':';
-  #endif
   if(!env_path.isEmpty()) {
 #if defined(_WIN32)
     QString path = qgetenv("PATH");

--- a/Lab/demo/Lab/MainWindow.cpp
+++ b/Lab/demo/Lab/MainWindow.cpp
@@ -663,15 +663,6 @@ void MainWindow::loadPlugins()
     }
   }
   QString env_path = qgetenv("LAB_DEMO_PLUGINS_PATH");
-#if (QT_VERSION >= QT_VERSION_CHECK(5, 6, 0))
-  QChar separator = QDir::listSeparator();
-#else
-#if defined(_WIN32)
-  QChar separator = ';';
-#else
-  QChar separator = ':';
-#endif
-#endif
   if(!env_path.isEmpty()) {
 #if defined(_WIN32)
     QString path = qgetenv("PATH");

--- a/Lab/demo/Lab/MainWindow.cpp
+++ b/Lab/demo/Lab/MainWindow.cpp
@@ -663,6 +663,12 @@ void MainWindow::loadPlugins()
     }
   }
   QString env_path = qgetenv("LAB_DEMO_PLUGINS_PATH");
+  QChar separator = QDir::listSeparator();
+  #if defined(_WIN32)
+    QChar separator = ';';
+  #else
+    QChar separator = ':';
+  #endif
   if(!env_path.isEmpty()) {
 #if defined(_WIN32)
     QString path = qgetenv("PATH");

--- a/Lab/demo/Lab/Plugins/Mesh_3/Io_image_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Mesh_3/Io_image_plugin.cpp
@@ -705,11 +705,7 @@ private:
 
       // Find the right width for the label to accommodate at least 9999
       QFontMetrics metric = x_cubeLabel->fontMetrics();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
       x_cubeLabel->setFixedWidth(metric.horizontalAdvance(QString(".9999.")));
-#else
-      x_cubeLabel->setFixedWidth(metric.width(QString(".9999.")));
-#endif
       x_cubeLabel->setText("0");
       x_cubeLabel->setValidator(validator);
 
@@ -735,11 +731,7 @@ private:
 
       // Find the right width for the label to accommodate at least 9999
       QFontMetrics metric = y_cubeLabel->fontMetrics();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
       y_cubeLabel->setFixedWidth(metric.horizontalAdvance(QString(".9999.")));
-#else
-      y_cubeLabel->setFixedWidth(metric.width(QString(".9999.")));
-#endif
       y_cubeLabel->setText("0");
       y_cubeLabel->setValidator(validator);
       y_slider = new QSlider(mw);
@@ -764,11 +756,7 @@ private:
 
       // Find the right width for the label to accommodate at least 9999
       QFontMetrics metric = z_cubeLabel->fontMetrics();
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
       z_cubeLabel->setFixedWidth(metric.horizontalAdvance(QString(".9999.")));
-#else
-      z_cubeLabel->setFixedWidth(metric.width(QString(".9999.")));
-#endif
       z_cubeLabel->setText("0");
       z_cubeLabel->setValidator(validator);
       z_slider = new QSlider(mw);

--- a/Lab/demo/Lab/Plugins/PMP/Engrave_text_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/PMP/Engrave_text_plugin.cpp
@@ -250,11 +250,7 @@ protected:
     }
     case QEvent::Wheel: {
       QWheelEvent* event = static_cast<QWheelEvent*>(ev);
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-      QPoint pos = event->pos();
-#else
       QPointF pos = event->position();
-#endif
       QPointF old_pos = v->mapToScene(pos.x(), pos.y());
       if(event->angleDelta().y() <0)
         v->scale(1.2, 1.2);

--- a/Lab/demo/Lab/Plugins/Surface_mesh/Parameterization_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Surface_mesh/Parameterization_plugin.cpp
@@ -142,11 +142,7 @@ protected:
     }
     case QEvent::Wheel: {
       QWheelEvent* event = static_cast<QWheelEvent*>(ev);
-#if QT_VERSION < QT_VERSION_CHECK(5, 14, 0)
-      QPoint pos = event->pos();
-#else
       QPointF pos = event->position();
-#endif
       QPointF old_pos = v->mapToScene(pos.x(), pos.y());
       if(event->angleDelta().y() <0)
         v->scale(1.2, 1.2);

--- a/Lab/demo/Lab/Viewer.cpp
+++ b/Lab/demo/Lab/Viewer.cpp
@@ -1152,13 +1152,7 @@ void Viewer::drawVisualHints()
     //Prints the displayMessage
     QFont font = QFont();
     QFontMetrics fm(font);
-    TextItem *message_text = new TextItem(float(10 +
-                                            #if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
-                                                   fm.horizontalAdvance(d->message)/2)
-                                            #else
-                                                   fm.width(d->message)/2)
-                                            #endif
-                                          ,
+    TextItem *message_text = new TextItem(float(10 + fm.horizontalAdvance(d->message)/2),
                                           float(height()-20),
                                           0, d->message, false,
                                           QFont(), Qt::gray );

--- a/Three/include/CGAL/Three/TextRenderer.h
+++ b/Three/include/CGAL/Three/TextRenderer.h
@@ -52,12 +52,7 @@ public :
         :x(p_x), y(p_y), z(p_z),_3D(p_3D), _is_always_visible(always_visible), m_text(p_text), m_font(font), m_color(p_color)
     {
        QFontMetrics fm(m_font);
-#if QT_VERSION >= QT_VERSION_CHECK(5, 11, 0)
        _width = float(fm.horizontalAdvance(m_text)+2);
-#else
-       _width = float(fm.width(m_text)+2);
-#endif
-
        _height = float(fm.height());
     }
     //!\brief Accessor for the string

--- a/Three/include/CGAL/Three/Three.h
+++ b/Three/include/CGAL/Three/Three.h
@@ -31,11 +31,7 @@
 #  define THREE_EXPORT Q_DECL_IMPORT
 #endif
 
-#if QT_VERSION < QT_VERSION_CHECK(5, 15, 0)
-#define CGAL_QT_SKIP_EMPTY_PARTS QString::SkipEmptyParts
-#else
 #define CGAL_QT_SKIP_EMPTY_PARTS ::Qt::SkipEmptyParts
-#endif
 
 namespace CGAL{
 namespace Three{


### PR DESCRIPTION
## Summary of Changes

This PR removes outdated conditional blocks that check for specific Qt versions since CGAL now uses Qt6 exclusively.

## Release Management

* Issue(s) solved (if any): #8381 

