### PR TITLE
Mesh_3 - bug fixes for `edge_distance` and `edge_min_size`

### DIFF
--- a/Lab/demo/Lab/Plugins/Mesh_3/Mesh_3_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Mesh_3/Mesh_3_plugin.cpp
@@ -750,7 +750,9 @@ void Mesh_3_plugin::mesh_3(const Mesh_type mesh_type,
       }
     }
 
-    if(mesh_type != Mesh_type::SURFACE_ONLY && !material_ids_valid)
+    if(mesh_type != Mesh_type::SURFACE_ONLY
+      && !material_ids_valid
+      && bounding_sm_item != nullptr)
     {
       sm_items.removeAll(make_not_null(bounding_sm_item));
     }

--- a/Lab/demo/Lab/Plugins/Mesh_3/Mesh_function.h
+++ b/Lab/demo/Lab/Plugins/Mesh_3/Mesh_function.h
@@ -171,8 +171,10 @@ log() const
              .arg(detect_connected_components);
     res << QString("use weights: %1").arg(weights_ptr != nullptr);
   }
-  res << QString("use aabb tree: %1").arg(use_sizing_field_with_aabb_tree);
-  res << QString("manifold: %1").arg(manifold);
+  if(use_sizing_field_with_aabb_tree)
+    res << QString("use sizing field with aabb tree: %1").arg(use_sizing_field_with_aabb_tree);
+  if(manifold)
+    res << QString("manifold: %1").arg(manifold);
 
   return res;
 }

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -741,7 +741,7 @@ insert_point(const Bare_point& p, const Weight& w, int dim, const Index& index,
     std::cerr << "SPECIAL ";
   std::cerr << "protecting ball ";
   if(v == Vertex_handle())
-    std::cerr << cwp(p,w*weight_modifier);
+    std::cerr << cwp(p, wwm);
   else
     std::cerr << disp_vert(v);
 

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -867,13 +867,11 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
                       std::back_inserter(cells_in_conflicts),
                       CGAL::Emptyset_iterator());
 
-    for(typename std::vector<Cell_handle>::const_iterator
-          it = cells_in_conflicts.begin(),
-        end = cells_in_conflicts.end(); it != end; ++it)
+    for(Cell_handle cit : cells_in_conflicts)
     {
       for(int i=0, d=tr.dimension(); i<=d; ++i)
       {
-        const Vertex_handle v = (*it)->vertex(i);
+        const Vertex_handle v = cit->vertex(i);
         if(c3t3_.triangulation().is_infinite(v))
           continue;
         if(!vertices_in_conflict_zone_set.insert(v).second)
@@ -1030,21 +1028,20 @@ insert_balls_on_edges()
   domain_.get_curves(std::back_inserter(input_features));
 
   // Iterate on edges
-  for ( typename Input_features::iterator fit = input_features.begin(),
-       end = input_features.end() ; fit != end ; ++fit )
+  for (const Feature_tuple& ft : input_features)
   {
     if(forced_stop()) break;
-    const Curve_index& curve_index = std::get<0>(*fit);
+    const Curve_index& curve_index = std::get<0>(ft);
     if ( ! is_treated(curve_index) )
     {
 #if CGAL_MESH_3_PROTECTION_DEBUG & 1
       std::cerr << "\n** treat curve #" << curve_index << std::endl;
 #endif
-      const Bare_point& p = std::get<1>(*fit).first;
-      const Bare_point& q = std::get<2>(*fit).first;
+      const Bare_point& p = std::get<1>(ft).first;
+      const Bare_point& q = std::get<2>(ft).first;
 
-      const Index& p_index = std::get<1>(*fit).second;
-      const Index& q_index = std::get<2>(*fit).second;
+      const Index& p_index = std::get<1>(ft).second;
+      const Index& q_index = std::get<2>(ft).second;
 
       Vertex_handle vp,vq;
       if ( ! domain_.is_loop(curve_index) )
@@ -1487,14 +1484,11 @@ refine_balls()
     new_sizes.clear();
 
     // Update size of balls
-    for ( typename std::vector<std::pair<Vertex_handle,FT> >::iterator
-          it = new_sizes_copy.begin(),
-          end = new_sizes_copy.end();
-          it != end ; ++it )
+    for (const std::pair<Vertex_handle,FT>& it : new_sizes_copy)
     {
       if(forced_stop()) break;
-      const Vertex_handle v = it->first;
-      const FT new_size = it->second;
+      const Vertex_handle v = it.first;
+      const FT new_size = it.second;
       // Set size of the ball to new value
       if(use_minimal_size() && new_size < minimal_size_) {
         if(!is_special(v)) {

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -720,7 +720,10 @@ insert_point(const Bare_point& p, const Weight& w, int dim, const Index& index,
   typename GT::Construct_weighted_point_3 cwp =
     c3t3_.triangulation().geom_traits().construct_weighted_point_3_object();
 
-  const Weighted_point wp = cwp(p,w*weight_modifier);
+  const FT wwm = use_minimal_size()
+               ? (std::max)(w * weight_modifier, minimal_weight())
+               : w * weight_modifier;
+  const Weighted_point wp = cwp(p, wwm);
 
   typename Tr::Locate_type lt;
   int li, lj;
@@ -1182,7 +1185,7 @@ insert_balls(const Vertex_handle& vp,
   const Weighted_point& vp_wp = c3t3_.triangulation().point(vp);
 
 #if ! defined(CGAL_NO_PRECONDITIONS)
-  if(sp <= minimal_size_) {
+  if(sp < minimal_size_) {
     std::stringstream msg;
     msg.precision(17);
     msg << "Error: the mesh sizing field is smaller than minimal size ";

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -1563,10 +1563,8 @@ approx_is_too_large(const Edge& e, const bool is_edge_in_complex) const
   if ( ! is_edge_in_complex )
     return false;
 
-  const auto& [va, vb] = c3t3_.triangulation().vertices(e);
-
-  const Bare_point& pa = va->point().point();
-  const Bare_point& pb = vb->point().point();
+  const Bare_point& pa = e.first->vertex(e.second)->point().point();
+  const Bare_point& pb = e.first->vertex(e.third)->point().point();
 
   // Construct the geodesic middle point
   const Curve_index curve_index = c3t3_.curve_index(e);

--- a/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
+++ b/Mesh_3/include/CGAL/Mesh_domain_with_polyline_features_3.h
@@ -252,8 +252,8 @@ public:
         : (- negative_distance);
     } else {
       return (pit <= qit)
-        ?     curve_segment_length(p, q, CGAL::POSITIVE)
-        : ( - curve_segment_length(p, q, CGAL::NEGATIVE) );
+        ?     curve_segment_length(p, q, CGAL::POSITIVE, pit, qit)
+        : ( - curve_segment_length(p, q, CGAL::NEGATIVE, pit, qit) );
     }
   }
 

--- a/Mesh_3/include/CGAL/Mesh_edge_criteria_3.h
+++ b/Mesh_3/include/CGAL/Mesh_edge_criteria_3.h
@@ -177,7 +177,13 @@ public:
 
   /// Returns size of tuple (p,dim,index)
   FT sizing_field(const Point_3& p, const int dim, const Index& index) const
-  { return (*p_size_)(p,dim,index); }
+  {
+    const FT s = (*p_size_)(p, dim, index);
+    if (min_length_bound_ == FT(0))
+      return s;
+    else
+      return (std::max)(s, min_length_bound_);
+  }
 
   FT distance_field(const Point_3& p, const int dim, const Index& index) const
   {


### PR DESCRIPTION
## Summary of Changes

While experimenting on self-intersecting polyhedral surfaces, I met two bugs:
* `edge_min_size` was not enough taken into account in `Protect_edges_sizing_field`,
* `edge_distance` was missing the information of which `curve_id` the edge belongs to (available using internal code)
causing crashes.

## Release Management

* Affected package(s): Mesh_3
* License and copyright ownership: unchanged

