### PR TITLE
Began adding 'Publish to Winget' Github workflow

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,8 +1,10 @@
+# docs: https://github.com/microsoft/winget-create
+# examples:
+# https://github.com/microsoft/devhome/blob/main/.github/workflows/winget-submission.yml
+# https://github.com/microsoft/terminal/blob/main/.github/workflows/winget.yml
 name: Publish to Winget
 
-on:
-  pull_request:
-    types: [synchronize]
+on: [release]
 
 jobs:
   publish:

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,19 @@
+name: Publish to Winget
+
+on:
+  pull_request:
+    types: [synchronize]
+
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - name: Publish to Winget
+        run: |
+          $id = "CGAL.CGAL"
+          $assets = '${{ toJSON(github.event.release.assets) }}' | ConvertFrom-Json
+          $wingetRelevantAsset = $assets | Where-Object { $_.name -like '*.msixbundle' } | Select-Object -First 1
+          $version = $wingetRelevantAsset.tag_name.Trim("CGAL-")
+
+          & curl.exe -JLO https://aka.ms/wingetcreate/latest
+          & .\wingetcreate.exe update $id -s -v $version -u $wingetRelevantAsset.browser_download_url -t "${{ secrets.WINGET_TOKEN }}"


### PR DESCRIPTION
## Summary of Changes

Added a `.github/workflows/winget.yml` so that CGAL can be published to Winget on release.

## Release Management

This will require a `WINGET_TOKEN` GitHub secret to be created and populated appropriately.
From now on, release assets will also need to include a `.msixbundle`. The workflow assumes that it will be named according to the existing convention, e.g. `CGAL-5.6.1.msixbundle`.

### How to create `WINGET_TOKEN`

See: https://github.com/microsoft/winget-create?tab=readme-ov-file#github-personal-access-token-classic-permissions

1. Create a new GitHub personal access token (PAT)
2. Go to the `cgal` repository settings > Secrets and variables > Actions
3. Copy the PAT to a new secret called `WINGET_TOKEN`

* License and copyright ownership: The Unlicence - you may do as you wish with my contribution