### PR TITLE
Pass random instance to GeneratorOnObject in Generic_random_point_generator for consistency

### DIFF
--- a/Generator/include/CGAL/Generator/internal/Generic_random_point_generator.h
+++ b/Generator/include/CGAL/Generator/internal/Generic_random_point_generator.h
@@ -105,7 +105,7 @@ void Generic_random_point_generator<Id, ObjectFromIdMap,  GeneratorOnObject, P>:
   );
 
   // generate the points
-  GeneratorOnObject pointCreator(object_from_id_map(ids[target]));
+  GeneratorOnObject pointCreator(object_from_id_map(ids[target]), random);
   this->d_item = *pointCreator;
 }
 


### PR DESCRIPTION
## Summary of Changes

[sample_triangle_mesh](https://doc.cgal.org/latest/Polygon_mesh_processing/group__PMP__distance__grp.html#ga6307a4504382c46dc3b0e578ca1f7a3b) was passed a random seed but did not produce stable results.

Pass random instance to GeneratorOnObject in Generic_random_point_generator for consistency

## Release Management

* Affected package(s): PMP

