### PR TITLE
Fix exception double free in Convex decomposition

### DIFF
--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/External_structure_builder.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/External_structure_builder.h
@@ -81,10 +81,10 @@ class External_structure_builder : public Modifier_base<typename Nef_::SNC_and_P
     SNC_point_locator* old_pl = pl;
     pl = pl->clone();
     sncpl.pl = pl;
-    delete old_pl;
     SNC_external_structure C(*sncp,pl);
     C.clear_external_structure();
     C.build_external_structure();
+    delete old_pl;
   }
 };
 

--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/External_structure_builder.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/External_structure_builder.h
@@ -77,51 +77,7 @@ class External_structure_builder : public Modifier_base<typename Nef_::SNC_and_P
     SNC_structure* sncp(sncpl.sncp);
     SNC_point_locator* pl(sncpl.pl);
 
-
-
     Unique_hash_map<SHalfedge_handle, SFace_handle> sedge2sface;
-    /*
-    SFace_iterator sfi;
-    CGAL_forall_sfaces(sfi, *sncp) {
-      SFace_cycle_iterator sfc;
-      for(sfc = sfi->sface_cycles_begin(); sfc != sfi->sface_cycles_end(); ++sfc) {
-        if(sfc.is_shalfedge()){
-          SHalfedge_around_sface_circulator eaf(sfc), end(eaf);
-          CGAL_For_all(eaf,end) {
-            SHalfedge_handle se(eaf);
-            sedge2sface[eaf] = sfi;
-          }
-        }
-      }
-    }
-
-    //    CGAL::SNC_io_parser<SNC_structure> O0(std::cerr, *sncp, false);
-    //    O0.print();
-
-    SHalfedge_iterator sei;
-    CGAL_forall_shalfedges(sei, *sncp) {
-      SHalfedge_handle se(sei);
-      if(sedge2sface[se] == SFace_handle()) {
-        SM_decorator SD(&*sei->source()->source());
-        SFace_handle sf_new = SD.new_sface();
-        sf_new->mark() = sei->incident_sface()->mark();
-
-        CGAL_NEF_TRACEN("new entry sedge " << sei->source()->point()
-                        << "->" << sei->twin()->source()->point()
-                        << " at " << sei->source()->source()->point());
-
-        SD.link_as_face_cycle(sei, sf_new);
-
-        SHalfedge_around_sface_circulator eaf(se), end(eaf);
-        CGAL_For_all(eaf,end) {
-          SHalfedge_handle se(eaf);
-          sedge2sface[eaf] = sf_new;
-        }
-
-        // TODO: relink inner sface cycles
-      }
-    }
-    */
     SNC_point_locator* old_pl = pl;
     pl = pl->clone();
     sncpl.pl = pl;
@@ -129,9 +85,6 @@ class External_structure_builder : public Modifier_base<typename Nef_::SNC_and_P
     SNC_external_structure C(*sncp,pl);
     C.clear_external_structure();
     C.build_external_structure();
-
-    //    CGAL::SNC_io_parser<SNC_structure> Ox(std::cerr, *sncp, false);
-    //    Ox.print();
   }
 };
 

--- a/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/External_structure_builder.h
+++ b/Convex_decomposition_3/include/CGAL/Convex_decomposition_3/External_structure_builder.h
@@ -76,8 +76,6 @@ class External_structure_builder : public Modifier_base<typename Nef_::SNC_and_P
 
     SNC_structure* sncp(sncpl.sncp);
     SNC_point_locator* pl(sncpl.pl);
-
-    Unique_hash_map<SHalfedge_handle, SFace_handle> sedge2sface;
     SNC_point_locator* old_pl = pl;
     pl = pl->clone();
     sncpl.pl = pl;


### PR DESCRIPTION
## Summary of Changes

Change the order of delete in External_structure_builder.h to avoid a double free in the exception case

## Release Management

* Affected package(s): Convex_decomposition_3
* Issue(s) solved (if any): fix #422 
* Feature/Small Feature (if any): bugfix
* License and copyright ownership: Returned to CGAL authors

