### PR TITLE
added test for formerly unused OutputIteratorValueType

### DIFF
--- a/Stream_support/test/Stream_support/data/simple_ascii.ply
+++ b/Stream_support/test/Stream_support/data/simple_ascii.ply
@@ -1,0 +1,16 @@
+ply
+format ascii 1.0
+comment VCGLIB generated
+element vertex 3
+property float x
+property float y
+property float z
+property float nx
+property float ny
+property float nz
+element face 0
+property list uchar int vertex_indices
+end_header
+1 1 1 2 2 2 
+3 3 3 4 4 4 
+5 5 5 6 6 6 

--- a/Stream_support/test/Stream_support/issue8155.cpp
+++ b/Stream_support/test/Stream_support/issue8155.cpp
@@ -1,0 +1,50 @@
+#include <CGAL/Simple_cartesian.h>
+
+#include <CGAL/config.h>
+#include <CGAL/IO/read_ply_points.h>
+#include <CGAL/property_map.h>
+#include <boost/iterator/function_output_iterator.hpp>
+
+#include <cassert>
+#include <fstream>
+#include <string>
+#include <vector>
+
+typedef CGAL::Simple_cartesian<double> Kernel;
+typedef Kernel::FT FT;
+typedef Kernel::Point_3 Point_3;
+typedef Kernel::Vector_3 Vector_3;
+typedef std::pair<Point_3, Vector_3> PointVectorPair;
+typedef CGAL::First_of_pair_property_map<PointVectorPair> Point_map;
+typedef CGAL::Second_of_pair_property_map<PointVectorPair> Normal_map;
+
+int main()
+{
+  std::vector<PointVectorPair> pv_pairs;
+  const std::function<void(const PointVectorPair& p)> lambda =
+    [&](const PointVectorPair& p) {
+    FT len = p.second.squared_length();
+    if (len > 0 || len != 1.0) {
+      Vector_3 n = p.second * (1.0 / CGAL::sqrt(len));
+      pv_pairs.push_back(std::make_pair(p.first, n));
+    }
+    else pv_pairs.push_back(p);
+    };
+
+  pv_pairs.clear();
+  std::ifstream file("data/simple_ascii.ply");
+  CGAL::IO::read_PLY_with_properties<PointVectorPair>(file, boost::function_output_iterator(lambda),
+    CGAL::make_ply_point_reader(Point_map()),
+    CGAL::make_ply_normal_reader(Normal_map()));
+
+  assert(pv_pairs[0].first == Point_3(1, 1, 1));
+  assert(pv_pairs[1].first == Point_3(3, 3, 3));
+  assert(pv_pairs[2].first == Point_3(5, 5, 5));
+
+  for (std::size_t i = 0; i < pv_pairs.size(); i++) {
+    FT dev = CGAL::abs(1.0 - pv_pairs[i].second.squared_length());
+    assert(dev < 0.01);
+  }
+
+  return 0;
+}


### PR DESCRIPTION
## Summary of Changes

Follow-up of #8155. Added test.

The issue was only merged into master, but it also should have been applied to cgal5.6

## Release Management

* Affected package(s): Point_set_processing_3 IO
* Issue(s) solved (if any): fix #8163

