### PR TITLE
[LASlib] Prevent usage of LASlib with msvc 2017

### DIFF
--- a/Point_set_processing_3/examples/Point_set_processing_3/CMakeLists.txt
+++ b/Point_set_processing_3/examples/Point_set_processing_3/CMakeLists.txt
@@ -67,17 +67,23 @@ foreach(
   target_link_libraries(${target} PRIVATE ${CGAL_libs})
 endforeach()
 
-find_package(LASLIB)
-include(CGAL_LASLIB_support)
-if(TARGET CGAL::LASLIB_support)
-  create_single_source_cgal_program("read_las_example.cpp")
-  create_single_source_cgal_program("write_las_example.cpp")
-  target_link_libraries(read_las_example PRIVATE ${CGAL_libs} CGAL::LASLIB_support)
-  target_link_libraries(write_las_example PRIVATE ${CGAL_libs} CGAL::LASLIB_support)
+
+#disable if MSVC 2017
+if(NOT MSVC_VERSION OR MSVC_VERSION GREATER_EQUAL 1919 OR MSVC_VERSION LESS 1910)
+  find_package(LASLIB)
+  include(CGAL_LASLIB_support)
+  if (TARGET CGAL::LASLIB_support)
+    create_single_source_cgal_program("read_las_example.cpp")
+    create_single_source_cgal_program("write_las_example.cpp")
+    target_link_libraries(read_las_example PRIVATE ${CGAL_libs} CGAL::LASLIB_support)
+    target_link_libraries(write_las_example PRIVATE ${CGAL_libs} CGAL::LASLIB_support)
+  else()
+    message(
+      STATUS
+        "NOTICE : the LAS reader test requires LASlib and will not be compiled.")
+  endif()
 else()
-  message(
-    STATUS
-      "NOTICE : the LAS reader test requires LASlib and will not be compiled.")
+  message(STATUS "NOTICE : the LAS reader does not work with your version of Visual Studio 2017.")
 endif()
 
 # Use Eigen

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
@@ -1,12 +1,16 @@
 include(polyhedron_demo_macros)
 
-find_package(LASLIB)
-set_package_properties(
-  LASLIB PROPERTIES
-  DESCRIPTION "A library for some I/O."
-  PURPOSE "Requiered for reading or writing LAS files.")
+if (NOT MSVC_VERSION OR MSVC_VERSION GREATER_EQUAL 1919 OR MSVC_VERSION LESS 1910)
+  find_package(LASLIB)
+  set_package_properties(
+    LASLIB PROPERTIES
+    DESCRIPTION "A library for some I/O."
+    PURPOSE "Requiered for reading or writing LAS files.")
+  include(CGAL_LASLIB_support)
+else()
+  message(STATUS "NOTICE : the LAS reader does not work with your version of Visual Studio 2017.")
+endif()
 
-include(CGAL_LASLIB_support)
 
 polyhedron_demo_plugin(gocad_plugin GOCAD_io_plugin KEYWORDS Viewer)
 target_link_libraries(gocad_plugin PUBLIC scene_surface_mesh_item)
@@ -103,6 +107,7 @@ else()
   target_link_libraries(ply_plugin PUBLIC scene_points_with_normal_item scene_polygon_soup_item scene_surface_mesh_item scene_textured_item)
   target_compile_features(ply_plugin PRIVATE ${needed_cxx_features})
 
+  #disable if MSVC 2017
   if (TARGET CGAL::LASLIB_support)
     polyhedron_demo_plugin(las_plugin LAS_io_plugin KEYWORDS Viewer PointSetProcessing Classification)
     target_link_libraries(las_plugin PUBLIC scene_points_with_normal_item CGAL::LASLIB_support)

--- a/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
+++ b/Polyhedron/demo/Polyhedron/Plugins/IO/CMakeLists.txt
@@ -107,7 +107,6 @@ else()
   target_link_libraries(ply_plugin PUBLIC scene_points_with_normal_item scene_polygon_soup_item scene_surface_mesh_item scene_textured_item)
   target_compile_features(ply_plugin PRIVATE ${needed_cxx_features})
 
-  #disable if MSVC 2017
   if (TARGET CGAL::LASLIB_support)
     polyhedron_demo_plugin(las_plugin LAS_io_plugin KEYWORDS Viewer PointSetProcessing Classification)
     target_link_libraries(las_plugin PUBLIC scene_points_with_normal_item CGAL::LASLIB_support)

--- a/Stream_support/test/Stream_support/CMakeLists.txt
+++ b/Stream_support/test/Stream_support/CMakeLists.txt
@@ -41,7 +41,6 @@ foreach(cppfile ${cppfiles})
     endif()
   else()
     if("${cppfile}" STREQUAL "test_LAS.cpp")
-      #disable if MSVC 2017
       if(TARGET CGAL::LASLIB_support)
         create_single_source_cgal_program("test_LAS.cpp")
         target_link_libraries(test_LAS PRIVATE CGAL::LASLIB_support)

--- a/Stream_support/test/Stream_support/CMakeLists.txt
+++ b/Stream_support/test/Stream_support/CMakeLists.txt
@@ -13,8 +13,12 @@ find_library(
   NAMES 3MF
   DOC "Path to the lib3MF library")
 
-find_package(LASLIB QUIET)
-include(CGAL_LASLIB_support)
+if (NOT MSVC_VERSION OR MSVC_VERSION GREATER_EQUAL 1919 OR MSVC_VERSION LESS 1910)
+  find_package(LASLIB QUIET)
+  include(CGAL_LASLIB_support)
+else()
+  message(STATUS "NOTICE : the LAS reader does not work with your version of Visual Studio 2017.")
+endif()
 
 # create a target per cppfile
 file(
@@ -37,6 +41,7 @@ foreach(cppfile ${cppfiles})
     endif()
   else()
     if("${cppfile}" STREQUAL "test_LAS.cpp")
+      #disable if MSVC 2017
       if(TARGET CGAL::LASLIB_support)
         create_single_source_cgal_program("test_LAS.cpp")
         target_link_libraries(test_LAS PRIVATE CGAL::LASLIB_support)


### PR DESCRIPTION
## Summary of Changes

LASlib is not compatible with msvc 2017

## Release Management

* Affected package(s): Point_set_3, Point_set_processing_3, Stream_support, Polyhedron demo

