### PR TITLE
Correcting permanent redirect in Algebraic_kernel_d

### DIFF
--- a/Documentation/doc/biblio/cgal_manual.bib
+++ b/Documentation/doc/biblio/cgal_manual.bib
@@ -2778,7 +2778,7 @@ author = "Pedro M.M. de Castro and Frederic Cazals and Sebastien Loriot and Moni
  editor = "Jacob E. Goodman, J\'anos Pach and Emo Welzl",
  year = {2005},
  pages = {439-458},
- URL = {http://library.slmath.org/books/Book52/files/23liu.pdf},
+ URL = {https://library.slmath.org/books/Book52/files/23liu.pdf},
  publisher = {MSRI Publications}
 }
 


### PR DESCRIPTION
Address is a https address
