### PR TITLE
Incorrect documentation for enums in Three package

### DIFF
--- a/Three/include/CGAL/Three/Scene_item.h
+++ b/Three/include/CGAL/Three/Scene_item.h
@@ -64,25 +64,25 @@ public:
    */
   enum OpenGL_program_IDs
   {
-    ROGRAM_WITH_LIGHT = 0,      //! Used to render a surface or an edge affected by the light. It uses a per fragment lighting model, and renders the selected item brighter.
-    PROGRAM_WITHOUT_LIGHT,       //! Used to render a polyhedron edge or points. It renders in a uniform color and is not affected by light. \attention It renders the selected item in black.
-    PROGRAM_NO_SELECTION,        //! Used to render a polyline or a surface that is not affected by light, like a cutting plane. It renders in a uniform color that does not change with selection.
-    PROGRAM_WITH_TEXTURE,        //! Used to render a textured polyhedron. Affected by light.
-    PROGRAM_PLANE_TWO_FACES,     //! Used to render a two-faced plane. The two faces have a different color. Not affected by light.
-    PROGRAM_WITH_TEXTURED_EDGES, //! Used to render the edges of a textured polyhedron. Not affected by light.
-    PROGRAM_INSTANCED,           //! Used to display instanced rendered spheres.Affected by light.
-    PROGRAM_INSTANCED_WIRE,      //! Used to display instanced rendered wired spheres. Not affected by light.
-    PROGRAM_C3T3,                //! Used to render a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Affected by light.
-    PROGRAM_C3T3_EDGES,          //! Used to render the edges of a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Not affected by light.
-    PROGRAM_CUTPLANE_SPHERES,    //! Used to render the spheres of an item with a cut plane.
-    PROGRAM_SPHERES,             //! Used to render one or several spheres.
-    PROGRAM_DARK_SPHERES,        //! Used to render one or several spheres without light (for picking for example).
-    PROGRAM_FLAT,                /** Used to render flat shading without pre computing normals*/
-    PROGRAM_OLD_FLAT,            /** Used to render flat shading without pre computing normals without geometry shader*/
-    PROGRAM_SOLID_WIREFRAME,     //! Used to render edges with width superior to 1.
-    PROGRAM_NO_INTERPOLATION,   //! Used to render faces without interpolating their color.
-    PROGRAM_HEAT_INTENSITY,      //! Used to render special item in Heat_method_plugin
-    NB_OF_PROGRAMS               //! Holds the number of different programs in this enum.
+    ROGRAM_WITH_LIGHT = 0,       //!< Used to render a surface or an edge affected by the light. It uses a per fragment lighting model, and renders the selected item brighter.
+    PROGRAM_WITHOUT_LIGHT,       //!< Used to render a polyhedron edge or points. It renders in a uniform color and is not affected by light. \attention It renders the selected item in black.
+    PROGRAM_NO_SELECTION,        //!< Used to render a polyline or a surface that is not affected by light, like a cutting plane. It renders in a uniform color that does not change with selection.
+    PROGRAM_WITH_TEXTURE,        //!< Used to render a textured polyhedron. Affected by light.
+    PROGRAM_PLANE_TWO_FACES,     //!< Used to render a two-faced plane. The two faces have a different color. Not affected by light.
+    PROGRAM_WITH_TEXTURED_EDGES, //!< Used to render the edges of a textured polyhedron. Not affected by light.
+    PROGRAM_INSTANCED,           //!< Used to display instanced rendered spheres.Affected by light.
+    PROGRAM_INSTANCED_WIRE,      //!< Used to display instanced rendered wired spheres. Not affected by light.
+    PROGRAM_C3T3,                //!< Used to render a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Affected by light.
+    PROGRAM_C3T3_EDGES,          //!< Used to render the edges of a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Not affected by light.
+    PROGRAM_CUTPLANE_SPHERES,    //!< Used to render the spheres of an item with a cut plane.
+    PROGRAM_SPHERES,             //!< Used to render one or several spheres.
+    PROGRAM_DARK_SPHERES,        //!< Used to render one or several spheres without light (for picking for example).
+    PROGRAM_FLAT,                //!< Used to render flat shading without pre computing normals
+    PROGRAM_OLD_FLAT,            //!< Used to render flat shading without pre computing normals without geometry shader
+    PROGRAM_SOLID_WIREFRAME,     //!< Used to render edges with width superior to 1.
+    PROGRAM_NO_INTERPOLATION,    //!< Used to render faces without interpolating their color.
+    PROGRAM_HEAT_INTENSITY,      //!< Used to render special item in Heat_method_plugin
+    NB_OF_PROGRAMS               //!< Holds the number of different programs in this enum.
   };
   typedef CGAL::Bbox_3 Bbox;
   typedef CGAL::qglviewer::ManipulatedFrame ManipulatedFrame;

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -53,26 +53,26 @@ public:
     */
   enum OpenGL_program_IDs
   {
-   PROGRAM_WITH_LIGHT = 0,      //! Used to render a surface or an edge affected by the light. It uses a per fragment lighting model, and renders the selected item brighter.
-   PROGRAM_WITHOUT_LIGHT,       //! Used to render a polyhedron edge or points. It renders in a uniform color and is not affected by light. \attention It renders the selected item in black.
-   PROGRAM_NO_SELECTION,        //! Used to render a polyline or a surface that is not affected by light, like a cutting plane. It renders in a uniform color that does not change with selection.
-   PROGRAM_WITH_TEXTURE,        //! Used to render a textured polyhedron. Affected by light.
-   PROGRAM_PLANE_TWO_FACES,     //! Used to render a two-faced plane. The two faces have a different color. Not affected by light.
-   PROGRAM_WITH_TEXTURED_EDGES, //! Used to render the edges of a textured polyhedron. Not affected by light.
-   PROGRAM_INSTANCED,           //! Used to display instanced rendered spheres.Affected by light.
-   PROGRAM_INSTANCED_WIRE,      //! Used to display instanced rendered wired spheres. Not affected by light.
-   PROGRAM_C3T3,                //! Used to render a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Affected by light.
-   PROGRAM_C3T3_EDGES,          //! Used to render the edges of a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Not affected by light.
-   PROGRAM_CUTPLANE_SPHERES,    //! Used to render the spheres of an item with a cut plane.
-   PROGRAM_SPHERES,             //! Used to render one or several spheres.
-   PROGRAM_DARK_SPHERES,        //! Used to render one or several spheres without light (for picking for example).
-   PROGRAM_FLAT,                /** Used to render flat shading without pre computing normals*/
-   PROGRAM_OLD_FLAT,            /** Used to render flat shading without pre computing normals without geometry shader*/
-   PROGRAM_SOLID_WIREFRAME,     //! Used to render edges with width superior to 1.
-   PROGRAM_NO_INTERPOLATION,   //! Used to render faces without interpolating their color.
-   PROGRAM_HEAT_INTENSITY,      //! Used to render special item in Heat_method_plugin
-   PROGRAM_TETRA_FILTERING,     //! Used in Scene_tetrahedra_item with Tetrahedra_filtering_plugin
-   NB_OF_PROGRAMS               //! Holds the number of different programs in this enum.
+   PROGRAM_WITH_LIGHT = 0,      //!< Used to render a surface or an edge affected by the light. It uses a per fragment lighting model, and renders the selected item brighter.
+   PROGRAM_WITHOUT_LIGHT,       //!< Used to render a polyhedron edge or points. It renders in a uniform color and is not affected by light. \attention It renders the selected item in black.
+   PROGRAM_NO_SELECTION,        //!< Used to render a polyline or a surface that is not affected by light, like a cutting plane. It renders in a uniform color that does not change with selection.
+   PROGRAM_WITH_TEXTURE,        //!< Used to render a textured polyhedron. Affected by light.
+   PROGRAM_PLANE_TWO_FACES,     //!< Used to render a two-faced plane. The two faces have a different color. Not affected by light.
+   PROGRAM_WITH_TEXTURED_EDGES, //!< Used to render the edges of a textured polyhedron. Not affected by light.
+   PROGRAM_INSTANCED,           //!< Used to display instanced rendered spheres.Affected by light.
+   PROGRAM_INSTANCED_WIRE,      //!< Used to display instanced rendered wired spheres. Not affected by light.
+   PROGRAM_C3T3,                //!< Used to render a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Affected by light.
+   PROGRAM_C3T3_EDGES,          //!< Used to render the edges of a c3t3_item. It discards any fragment on a side of a plane, meaning that nothing is displayed on this side of the plane. Not affected by light.
+   PROGRAM_CUTPLANE_SPHERES,    //!< Used to render the spheres of an item with a cut plane.
+   PROGRAM_SPHERES,             //!< Used to render one or several spheres.
+   PROGRAM_DARK_SPHERES,        //!< Used to render one or several spheres without light (for picking for example).
+   PROGRAM_FLAT,                //!< Used to render flat shading without pre computing normals
+   PROGRAM_OLD_FLAT,            //!< Used to render flat shading without pre computing normals without geometry shader
+   PROGRAM_SOLID_WIREFRAME,     //!< Used to render edges with width superior to 1.
+   PROGRAM_NO_INTERPOLATION,    //!< Used to render faces without interpolating their color.
+   PROGRAM_HEAT_INTENSITY,      //!< Used to render special item in Heat_method_plugin
+   PROGRAM_TETRA_FILTERING,     //!< Used in Scene_tetrahedra_item with Tetrahedra_filtering_plugin
+   NB_OF_PROGRAMS               //!< Holds the number of different programs in this enum.
   };
 
  //! \brief The viewer's QPainter


### PR DESCRIPTION
Documentation of enums in Three package is incorrect due to usage of wrong doxygen comment signs
