### PR TITLE
 Issue #8488

### DIFF
--- a/Three/include/CGAL/Three/Triangle_container.h
+++ b/Three/include/CGAL/Three/Triangle_container.h
@@ -49,7 +49,7 @@ struct DEMO_FRAMEWORK_EXPORT Triangle_container :public Primitive_container
     VColors,            //!< Designates the buffer that contains the colors of the smooth vertices.
     FColors,            //!< Designates the buffer that contains the colors of the flat vertices.
     Texture_map,        //!< Designates the buffer that contains the UV map for the texture.
-    Distances,
+    Distances,          //!< Designates the buffer that contains the distance values for vertices or facets
     Subdomain_indices,  //!< Designates the buffer that contains the subdomains of both cells defining a c3t3 facet.
     NbOfVbos            //!< Designates the size of the VBOs vector for `Triangle_container`s
   };


### PR DESCRIPTION
Summary of Changes
This pull request adds an entry for Distances in the vbosName enum. The new entry designates the buffer that contains the distance values for vertices or facets. This change ensures that distances can be managed consistently with other vertex data, such as coordinates, normals, and colors.

Release Management
Affected package(s): GraphicsView (or any package dealing with vertex buffer objects, depending on where this enum is used)
Issue(s) solved (if any):

I, Rachit Mehta, confirm that I have the right to submit this contribution under CGAL's open-source license and that this contribution abides by CGAL's policies.
