### PR TITLE
Arrangements:  Unify mix of pre and post condition macros

### DIFF
--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_analysis_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_analysis_2.h
@@ -520,7 +520,7 @@ private:
     void set_event_lines(InputIterator1 event_begin,
                          InputIterator1 event_end,
                          InputIterator2 intermediate_begin,
-                         InputIterator2 CGAL_precondition_code(intermediate_end)) const {
+                         InputIterator2 CGAL_assertion_code(intermediate_end)) const {
 
         if(! this->ptr()->event_coordinates) {
 

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_pair_analysis_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Curve_pair_analysis_2.h
@@ -875,7 +875,7 @@ private:
      * Checks intersection with symbolic methods
      */
     bool check_candidate_symbolically(Status_line_CA_1& e1,size_type ,
-                                      Status_line_CA_1& CGAL_precondition_code(e2),size_type ,
+                                      Status_line_CA_1& CGAL_assertion_code(e2),size_type ,
                                       size_type k) const {
         Polynomial_1 p = -coprincipal_subresultants(k-1);
         Polynomial_1 q = principal_subresultants(k)*Coefficient(k);

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Real_roots.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Real_roots.h
@@ -65,7 +65,7 @@ template < class PolynomialIterator,
 int gen_agebraic_reals_with_mults( PolynomialIterator           fac,
                                    PolynomialIterator           fac_end,
                                    IntIterator                  mul,
-                                   IntIterator                  CGAL_precondition_code(mul_end),
+                                   IntIterator                  CGAL_assertion_code(mul_end),
                                    AlgebraicRealOutputIterator  oi_root,
                                    IntOutputIterator            oi_mult){
 

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Status_line_CPA_1.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Status_line_CPA_1.h
@@ -331,7 +331,7 @@ public:
                              const typename Curve_pair_analysis_2
                                  ::Curve_analysis_2& c1,
                              const typename Curve_pair_analysis_2
-                                 ::Curve_analysis_2& CGAL_precondition_code(c2)) const
+                                 ::Curve_analysis_2& CGAL_assertion_code(c2)) const
     {
 
         CGAL_precondition(0 <= j && j < number_of_events());

--- a/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_on_surface_2_impl.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_on_surface_2_impl.h
@@ -1551,7 +1551,7 @@ split_edge(Halfedge_handle e,
   //    o---------e-------->o
   if (_are_equal(source, cv1, ARR_MIN_END)) {
     const Point_2& p = m_geom_traits->construct_max_vertex_2_object()(cv1);
-    CGAL_postcondition_code
+    CGAL_precondition_code
       (const Point_2& q = m_geom_traits->construct_min_vertex_2_object()(cv2));
     CGAL_precondition(m_geom_traits->equal_2_object()(p, q));
     CGAL_precondition(_are_equal(he1->vertex(), cv2, ARR_MAX_END));
@@ -1562,7 +1562,7 @@ split_edge(Halfedge_handle e,
   //    o<--------e---------o
   if (_are_equal(source, cv1, ARR_MAX_END)) {
     const Point_2& p = m_geom_traits->construct_min_vertex_2_object()(cv1);
-    CGAL_postcondition_code
+    CGAL_precondition_code
       (const Point_2& q = m_geom_traits->construct_max_vertex_2_object()(cv2));
     CGAL_precondition(m_geom_traits->equal_2_object()(p, q));
     CGAL_precondition(_are_equal(he1->vertex(), cv2, ARR_MIN_END));
@@ -1573,7 +1573,7 @@ split_edge(Halfedge_handle e,
   //    o---------e-------->o
   if (_are_equal(source, cv2, ARR_MIN_END)) {
     const Point_2& p = m_geom_traits->construct_max_vertex_2_object()(cv2);
-    CGAL_postcondition_code
+    CGAL_precondition_code
       (const Point_2& q = m_geom_traits->construct_min_vertex_2_object()(cv1));
     CGAL_precondition(m_geom_traits->equal_2_object()(p, q));
     CGAL_precondition(_are_equal(he1->vertex(), cv1, ARR_MAX_END));
@@ -1584,7 +1584,7 @@ split_edge(Halfedge_handle e,
   //    o<--------e---------o
   CGAL_precondition(_are_equal(source, cv2, ARR_MAX_END));
   const Point_2& p = m_geom_traits->construct_min_vertex_2_object()(cv2);
-  CGAL_postcondition_code
+  CGAL_precondition_code
     (const Point_2& q = m_geom_traits->construct_max_vertex_2_object()(cv1));
   CGAL_precondition(m_geom_traits->equal_2_object()(p, q));
   CGAL_precondition(_are_equal(he1->vertex(), cv1, ARR_MIN_END));

--- a/Polytope_distance_d/doc/Polytope_distance_d/Concepts/WidthTraits_3.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/Concepts/WidthTraits_3.h
@@ -4,7 +4,7 @@
 \cgalConcept
 
 This concept defines the requirements for traits classes of
-`Width_3<Traits>`.
+`CGAL::Width_3<Traits>`.
 
 \cgalHeading{Operations}
 

--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -19,6 +19,9 @@
 #ifndef CGAL_ASSERTIONS_H
 #define CGAL_ASSERTIONS_H
 
+// this define is only for one run of the testsuite
+#define CGAL_NO_POSTCONDITIONS
+
 #include <CGAL/export/CGAL.h>
 
 // #include <CGAL/assertions_behaviour.h> // for backward compatibility

--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -19,8 +19,6 @@
 #ifndef CGAL_ASSERTIONS_H
 #define CGAL_ASSERTIONS_H
 
-// this define is only for one run of the testsuite
-#define CGAL_NO_POSTCONDITIONS
 
 #include <CGAL/export/CGAL.h>
 

--- a/STL_Extension/include/CGAL/assertions.h
+++ b/STL_Extension/include/CGAL/assertions.h
@@ -19,7 +19,6 @@
 #ifndef CGAL_ASSERTIONS_H
 #define CGAL_ASSERTIONS_H
 
-
 #include <CGAL/export/CGAL.h>
 
 // #include <CGAL/assertions_behaviour.h> // for backward compatibility


### PR DESCRIPTION
## Summary of Changes

We had `postcondition_code()`  followed by `precondition()` .  I saw it when I only switched off postconditions with a macro.
We might do that for an entire testsuite. 

## Release Management

* Affected package(s): Arrangement on Surface

* License and copyright ownership:  unchanged

