### PR TITLE
Remove double entry from bib file

### DIFF
--- a/Documentation/doc/biblio/cgal_manual.bib
+++ b/Documentation/doc/biblio/cgal_manual.bib
@@ -1545,17 +1545,6 @@ Voronoi diagram"
   ,update       = "97.04 kettner"
 }
 
-@article{cgal:l-lsqp-82,
-  title={Least squares quantization in PCM},
-  author={Lloyd, Stuart},
-  journal={IEEE transactions on information theory},
-  volume={28},
-  number={2},
-  pages={129--137},
-  year={1982},
-  publisher={IEEE}
-}
-
 @InProceedings{ cgal:lprm-lscm-02,
    author    = {Bruno L{\'e}vy and Sylvain Petitjean and Nicolas Ray
                 and J{\'e}rome Maillot},


### PR DESCRIPTION
The entry `cgal:l-lsqp-82` was twice, identical, in the bib file. (Found based on #8320 and proposed pull request https://github.com/doxygen/doxygen/pull/11157).

