### PR TITLE
Polytope_distance: Use Exact_integer

### DIFF
--- a/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Width_3.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Width_3.h
@@ -25,7 +25,7 @@ width-planes.
 \f$ \mathcal{W(S)}=\mathcal{W}_{d_{opt}}\mathcal{(S)}\f$
 </OL>
 
-\Note There might be several optimal build directions. Hence
+\note There might be several optimal build directions. Hence
 neither the width-planes nor the direction \f$ \mathbf{d}_{opt}\f$ are
 unique - only the width is.   There may also be duplicates reported,
 different vectors having the same or the opposite directions.

--- a/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Width_3.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Width_3.h
@@ -25,9 +25,10 @@ width-planes.
 \f$ \mathcal{W(S)}=\mathcal{W}_{d_{opt}}\mathcal{(S)}\f$
 </OL>
 
-<I>Note:</I> There might be several optimal build directions. Hence
+\Note There might be several optimal build directions. Hence
 neither the width-planes nor the direction \f$ \mathbf{d}_{opt}\f$ are
-unique - only the width is.
+unique - only the width is.   There may also be duplicates reported,
+different vectors having the same or the opposite directions.
 
 \tparam Traits must be a model for `WidthTraits_3`.
 

--- a/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Width_3.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Width_3.h
@@ -54,7 +54,7 @@ Because there is no need for dividing values during the algorithm, the
 numbers can get really huge (all the computations are made using a lot
 of multiplications). Therefore it is strongly recommended to use a
 number type that can handle numbers of arbitrary length (e.g.,
-`leda_integer` in combination with the homogeneous representation
+`Exact_integer` in combination with the homogeneous representation
 of the points). But these large numbers have a disadvantage:
 Operations on them are slower as greater the number gets. Therefore it
 is possible to shorten the numbers by using the compiler flag

--- a/Polytope_distance_d/doc/Polytope_distance_d/Concepts/AllFurthestNeighborsTraits_2.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/Concepts/AllFurthestNeighborsTraits_2.h
@@ -16,14 +16,10 @@ convex polygon using the function `all_furthest_neighbors_2()`.
 
 \sa `CGAL::all_furthest_neighbors_2()`
 
-\cgalHeading{Notes}
-
-<UL>
-<LI>`AllFurthestNeighborsTraits_2::Less_xy_2` and
+\note  `AllFurthestNeighborsTraits_2::Less_xy_2` and
 `AllFurthestNeighborsTraits_2::Orientation_2` are used for (expensive)
 precondition checking only. Therefore, they need not to be
 specified, in case that precondition checking is disabled.
-</UL>
 
 */
 

--- a/Polytope_distance_d/doc/Polytope_distance_d/Concepts/WidthTraits_3.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/Concepts/WidthTraits_3.h
@@ -24,7 +24,7 @@ class WidthTraits_3 {
 public:
 
 /// \name Types
-/// <I>Notes:</I> If you want to compute the width of a <I>polyhedron</I> then you have to make sure that the point type in the traits class and the point type in the polyhedron class are the same! The same holds for `Traits::Plane_3` and `Polyhedron::Plane_3`.
+/// \note If you want to compute the width of a <I>polyhedron</I> then you have to make sure that the point type in the traits class and the point type in the polyhedron class are the same! The same holds for `Traits::Plane_3` and `Polyhedron::Plane_3`.
 /// @{
 
 /*!

--- a/Polytope_distance_d/examples/Polytope_distance_d/width_simplex.cpp
+++ b/Polytope_distance_d/examples/Polytope_distance_d/width_simplex.cpp
@@ -1,20 +1,11 @@
 #include <CGAL/Homogeneous.h>
 #include <CGAL/Width_default_traits_3.h>
 #include <CGAL/Width_3.h>
+#include <CGAL/Exact_integer.h>
 #include <iostream>
 #include <vector>
 
-#if defined(CGAL_USE_GMP)
-#include <CGAL/Gmpz.h>
-typedef CGAL::Gmpz                           RT;
-#elif defined (CGAL_USE_LEDA)
-#include <CGAL/leda_integer.h>
-typedef leda_integer                          RT;
-#else
-#include <CGAL/MP_Float.h>
-typedef CGAL::MP_Float                        RT;
-#endif
-
+typedef CGAL::Exact_integer                   RT;
 typedef CGAL::Homogeneous<RT>                 Kernel;
 typedef Kernel::Point_3                       Point_3;
 typedef Kernel::Plane_3                       Plane_3;


### PR DESCRIPTION
## Summary of Changes

Do not `#ifdef` for GMP or alternatives, but use `Exact_integer`.

Looking at other examples I am wondering if we should not introduce a type `CGAL::Exact_TBD`   to replace
```cpp
#ifdef CGAL_USE_GMP
#include <CGAL/Gmpzf.h>
typedef CGAL::Gmpzf ET;
#else
#include <CGAL/MP_Float.h>
typedef CGAL::MP_Float ET;
#endif
``` 
for examples [here](https://doc.cgal.org/latest/Polytope_distance_d/Polytope_distance_d_2polytope_distance_d_8cpp-example.html)   Any suggestion for a name @mglisse ?  

## Release Management

* Affected package(s): Polytope_distance
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:  unchanged

