### PR TITLE
Typo: labelled is UK English

### DIFF
--- a/Kinetic_surface_reconstruction/include/CGAL/Kinetic_surface_reconstruction_3.h
+++ b/Kinetic_surface_reconstruction/include/CGAL/Kinetic_surface_reconstruction_3.h
@@ -2041,14 +2041,14 @@ private:
     // 4 xmin
     // 5 zmax
     const double force = static_cast<double>(m_total_inliers * 3);
-    // 0 - cost for labelled as outside
+    // 0 - cost for labeled as outside
     cost_matrix[0][0] = 0;
     cost_matrix[0][1] = 0;
     cost_matrix[0][2] = 0;
     cost_matrix[0][3] = 0;
     cost_matrix[0][4] = 0;
     cost_matrix[0][5] = 0;
-    // 1 - cost for labelled as inside
+    // 1 - cost for labeled as inside
     cost_matrix[1][0] = 0;
     cost_matrix[1][1] = 0;
     cost_matrix[1][2] = 0;

--- a/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
@@ -1097,7 +1097,7 @@ public:
     Surface_patch operator()(const Point_3& a, const Point_3& b) const
     {
       // If f(a) != f(b), then [a,b] intersects some surface. Here we consider
-      // [a,b] intersects surface_patch labelled <f(a),f(b)> (or <f(b),f(a)>).
+      // [a,b] intersects surface_patch labeled <f(a),f(b)> (or <f(b),f(a)>).
       // It may be false, further rafinement will improve precision
       const Subdomain_index value_a = r_domain_.function_(a);
       const Subdomain_index value_b = r_domain_.function_(b);

--- a/Orthtree/doc/Orthtree/Orthtree.txt
+++ b/Orthtree/doc/Orthtree/Orthtree.txt
@@ -197,7 +197,7 @@ Figure \cgalFigureRef{Orthtree_traversal_fig} shows in which order
 nodes are visited depending on the traversal method used.
 
 \cgalFigureBegin{Orthtree_traversal_fig, quadtree_traversal.png}
-%Quadtree visualized as a graph. Each node is labelled according to the
+%Quadtree visualized as a graph. Each node is labeled according to the
 order in which it is visited by the traversal. When using leaves and
 level traversals, the quadtree is only partially traversed.
 \cgalFigureEnd

--- a/Surface_mesher/doc/Surface_mesher/Surface_mesher.txt
+++ b/Surface_mesher/doc/Surface_mesher/Surface_mesher.txt
@@ -313,7 +313,7 @@ class is not yet documented because its interface and code have not yet
 been stabilized.
 
 The Surface Mesh Generator demo allows to mesh not only gray level images,
-but also segmented images, when voxels are labelled with a domain
+but also segmented images, when voxels are labeled with a domain
 index. Such images are for example the result of a segmentation of 3D
 medical images.
 


### PR DESCRIPTION
## Summary of Changes

labelled -> labeled

Remains a function  `labellized_trilinear_interpolation()` where I am not sure how public it is.  @janetournois ??

## Release Management

* License and copyright ownership: unchanged

