### PR TITLE
protect CGAL against macro `free`

### DIFF
--- a/BGL/include/CGAL/boost/graph/METIS/partition_dual_graph.h
+++ b/BGL/include/CGAL/boost/graph/METIS/partition_dual_graph.h
@@ -116,8 +116,8 @@ void partition_dual_graph(const TriangleMesh& tm,
   delete[] eptr;
   delete[] eind;
 
-  std::free(npart);
-  std::free(epart);
+  (std::free)(npart);
+  (std::free)(epart);
 }
 
 template<typename TriangleMesh, typename NamedParameters>

--- a/BGL/include/CGAL/boost/graph/METIS/partition_graph.h
+++ b/BGL/include/CGAL/boost/graph/METIS/partition_graph.h
@@ -151,8 +151,8 @@ void partition_graph(const TriangleMesh& tm,
   delete[] eptr;
   delete[] eind;
 
-  std::free(npart);
-  std::free(epart);
+  (std::free)(npart);
+  (std::free)(epart);
 }
 
 template<typename TriangleMesh, typename NamedParameters>

--- a/CGAL_Core/include/CGAL/CORE/ExprRep.h
+++ b/CGAL_Core/include/CGAL/CORE/ExprRep.h
@@ -595,7 +595,7 @@ public:
   }
 
   void operator delete( void *p, size_t ){
-    MemoryPool<ConstPolyRep>::global_allocator().free(p);
+    (MemoryPool<ConstPolyRep>::global_allocator().free)(p);
   }
 
 private:
@@ -1248,7 +1248,7 @@ void * AddSubRep<O>::operator new( size_t size)
 
 template <typename O>
 void AddSubRep<O>::operator delete( void *p, size_t )
-{ MemoryPool<AddSubRep<O> >::global_allocator().free(p); }
+{ (MemoryPool<AddSubRep<O> >::global_allocator().free)(p); }
 
 
 /// \typedef AddRep

--- a/CGAL_Core/include/CGAL/CORE/Impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Impl.h
@@ -51,7 +51,7 @@
     CGAL_INLINE_FUNCTION void *T::operator new( size_t size)             \
     { return MemoryPool<T>::global_allocator().allocate(size); }         \
     CGAL_INLINE_FUNCTION void T::operator delete( void *p, size_t )      \
-    { MemoryPool<T>::global_allocator().free(p); }
+    { (MemoryPool<T>::global_allocator().free)(p); }
   #define CORE_MEMORY_IMPL_TEMPLATE_WITH_ONE_ARG(C)                       \
   template <typename T>                                                   \
   CGAL_INLINE_FUNCTION void *C<T>::operator new( size_t size)             \

--- a/CGAL_Core/include/CGAL/CORE/Impl.h
+++ b/CGAL_Core/include/CGAL/CORE/Impl.h
@@ -58,7 +58,7 @@
   { return MemoryPool<C<T> >::global_allocator().allocate(size); }        \
   template <typename T>                                                   \
   CGAL_INLINE_FUNCTION void C<T>::operator delete( void *p, size_t )      \
-  { MemoryPool<C<T> >::global_allocator().free(p); }
+  { (MemoryPool<C<T> >::global_allocator().free)(p); }
 #endif
 
 // include some common header files

--- a/CGAL_Core/include/CGAL/CORE/MemoryPool.h
+++ b/CGAL_Core/include/CGAL/CORE/MemoryPool.h
@@ -116,7 +116,7 @@ void* MemoryPool< T, nObjects >::allocate(std::size_t) {
 }
 
 template< class T, int nObjects >
-void MemoryPool< T, nObjects >::free(void* t) {
+void MemoryPool< T, nObjects >::free BOOST_PREVENT_MACRO_SUBSTITUTION (void* t) {
    CGAL_assertion(t != 0);
    if (t == 0) return; // for safety
    if(blocks.empty()){

--- a/CGAL_Core/include/CGAL/CORE/MemoryPool.h
+++ b/CGAL_Core/include/CGAL/CORE/MemoryPool.h
@@ -73,7 +73,7 @@ public:
 
 
    void* allocate(std::size_t size);
-   void free(void* p);
+   void free BOOST_PREVENT_MACRO_SUBSTITUTION (void* p);
 
   // Access the corresponding static global allocator.
   static MemoryPool<T,nObjects>& global_allocator() {

--- a/CGAL_Core/include/CGAL/CORE/RealRep.h
+++ b/CGAL_Core/include/CGAL/CORE/RealRep.h
@@ -154,7 +154,7 @@ void * Realbase_for<T>::operator new( size_t size)
 
 template <class T>
 void Realbase_for<T>::operator delete( void *p, size_t )
-{ MemoryPool<Realbase_for<T> >::global_allocator().free(p); }
+{ (MemoryPool<Realbase_for<T> >::global_allocator().free)(p); }
 
 typedef Realbase_for<long> RealLong;
 typedef Realbase_for<double> RealDouble;

--- a/Classification/include/CGAL/Classification/Feature/Elevation.h
+++ b/Classification/include/CGAL/Classification/Feature/Elevation.h
@@ -130,7 +130,7 @@ public:
           std::nth_element (z.begin(), z.begin() + (z.size() / 10), z.end());
           dtm_x(i,j) = z[z.size() / 10];
         }
-    dem.free();
+    (dem.free)();
 
     if (grid.width() * grid.height() > input.size())
       values.resize (input.size(), compressed_float(0));
@@ -162,7 +162,7 @@ public:
               values[*it] = v;
           }
         }
-    dtm_x.free();
+    (dtm_x.free)();
 
   }
 

--- a/Classification/include/CGAL/Classification/Feature/Height_above.h
+++ b/Classification/include/CGAL/Classification/Feature/Height_above.h
@@ -100,7 +100,7 @@ public:
         std::size_t J = grid.y(i);
         values[i] = float(dtm(I,J) - get (point_map, *(input.begin() + i)).z());
       }
-      dtm.free();
+      (dtm.free)();
     }
 
   }

--- a/Classification/include/CGAL/Classification/Feature/Height_below.h
+++ b/Classification/include/CGAL/Classification/Feature/Height_below.h
@@ -100,7 +100,7 @@ public:
         std::size_t J = grid.y(i);
         values[i] = float(get (point_map, *(input.begin() + i)).z() - dtm(I,J));
       }
-      dtm.free();
+      (dtm.free)();
     }
 
   }

--- a/Classification/include/CGAL/Classification/Feature/Vertical_range.h
+++ b/Classification/include/CGAL/Classification/Feature/Vertical_range.h
@@ -102,7 +102,7 @@ public:
         std::size_t J = grid.y(i);
         values[i] = dtm(I,J);
       }
-      dtm.free();
+      (dtm.free)();
     }
 
   }

--- a/Classification/include/CGAL/Classification/Image.h
+++ b/Classification/include/CGAL/Classification/Image.h
@@ -71,7 +71,7 @@ public:
   {
   }
 
-  void free()
+  void free BOOST_PREVENT_MACRO_SUBSTITUTION ()
   {
     m_raw.reset();
     m_sparse.reset();

--- a/Hash_map/include/CGAL/Hash_map/internal/chained_map.h
+++ b/Hash_map/include/CGAL/Hash_map/internal/chained_map.h
@@ -16,7 +16,6 @@
 #ifndef CGAL_HASH_MAP_INTERNAL_CHAINED_MAP_H
 #define CGAL_HASH_MAP_INTERNAL_CHAINED_MAP_H
 
-#include <CGAL/config.h>
 #include <CGAL/memory.h>
 #include <iostream>
 #include <limits>
@@ -45,7 +44,7 @@ class chained_map
 
    chained_map_elem<T>* table;
    chained_map_elem<T>* table_end;
-   chained_map_elem<T>* free;
+   chained_map_elem<T>* freelist;
    std::size_t table_size;
    std::size_t table_size_1;
 
@@ -144,10 +143,10 @@ void chained_map<T, Allocator>::init_table(std::size_t n)
     std::allocator_traits<allocator_type>::construct(alloc,table + i);
   }
 
-  free = table + t;
+  freelist = table + t;
   table_end = table + t + t/2;
 
-  for (Item p = table; p < free; ++p)
+  for (Item p = table; p < freelist; ++p)
   { p->succ = nullptr;
     p->k = nullkey;
   }
@@ -161,10 +160,10 @@ inline void chained_map<T, Allocator>::insert(std::size_t x, T y)
     q->k = x;
     q->i = y;
   } else {
-    free->k = x;
-    free->i = y;
-    free->succ = q->succ;
-    q->succ = free++;
+    freelist->k = x;
+    freelist->i = y;
+    freelist->succ = q->succ;
+    q->succ = freelist++;
   }
 }
 
@@ -214,7 +213,7 @@ T& chained_map<T, Allocator>::access(Item p, std::size_t x)
 
   // index x not present, insert it
 
-  if (free == table_end)   // table full: rehash
+  if (freelist == table_end)   // table full: rehash
   { rehash();
     p = HASH(x);
   }
@@ -225,7 +224,7 @@ T& chained_map<T, Allocator>::access(Item p, std::size_t x)
     return p->i;
   }
 
-  q = free++;
+  q = freelist++;
   q->k = x;
   init_inf(q->i);    // initializes q->i to xdef
   q->succ = p->succ;
@@ -246,7 +245,7 @@ chained_map<T, Allocator>::chained_map(const chained_map<T, Allocator>& D)
 {
   init_table(D.table_size);
 
-  for(Item p = D.table; p < D.free; ++p)
+  for(Item p = D.table; p < D.freelist; ++p)
   { if (p->k != nullkey || p >= D.table + D.table_size)
     { insert(p->k,p->i);
       //D.copy_inf(p->i);  // see chapter Implementation
@@ -258,7 +257,7 @@ chained_map<T, Allocator>::chained_map(chained_map<T, Allocator>&& D)
   noexcept(std::is_nothrow_move_constructible_v<Allocator> && std::is_nothrow_move_constructible_v<T>)
   : table(std::exchange(D.table, nullptr))
   , table_end(std::exchange(D.table_end, nullptr))
-  , free BOOST_PREVENT_MACRO_SUBSTITUTION (std::exchange(D.free, nullptr))
+  , freelist(std::exchange(D.freelist, nullptr))
   , table_size(std::exchange(D.table_size, 0))
   , table_size_1(std::exchange(D.table_size_1, 0))
   , alloc(std::move(D.alloc))
@@ -273,7 +272,7 @@ chained_map<T, Allocator>& chained_map<T, Allocator>::operator=(const chained_ma
 
   init_table(D.table_size);
 
-  for(Item p = D.table; p < D.free; ++p)
+  for(Item p = D.table; p < D.freelist; ++p)
   { if (p->k != nullkey || p >= D.table + D.table_size)
     { insert(p->k,p->i);
       //copy_inf(p->i);    // see chapter Implementation
@@ -290,7 +289,7 @@ chained_map<T, Allocator>& chained_map<T, Allocator>::operator=(chained_map<T, A
 
   table = std::exchange(D.table, nullptr);
   table_end = std::exchange(D.table_end, nullptr);
-  free = std::exchange(D.free, nullptr);
+  freelist = std::exchange(D.freelist, nullptr);
   table_size = std::exchange(D.table_size, 0);
   table_size_1 = std::exchange(D.table_size_1, 0);
   alloc = std::move(D.alloc);
@@ -339,7 +338,7 @@ void chained_map<T, Allocator>::statistics() const
   std::size_t n = 0;
   for (Item p = table; p < table + table_size; ++p)
      if (p ->k != nullkey) ++n;
-  std::size_t used_in_overflow = free - (table + table_size );
+  std::size_t used_in_overflow = freelist - (table + table_size );
   n += used_in_overflow;
   std::cout << "number of entries: " << n << "\n";
   std::cout << "fraction of entries in first position: " <<

--- a/Hash_map/include/CGAL/Hash_map/internal/chained_map.h
+++ b/Hash_map/include/CGAL/Hash_map/internal/chained_map.h
@@ -16,6 +16,7 @@
 #ifndef CGAL_HASH_MAP_INTERNAL_CHAINED_MAP_H
 #define CGAL_HASH_MAP_INTERNAL_CHAINED_MAP_H
 
+#include <CGAL/config.h>
 #include <CGAL/memory.h>
 #include <iostream>
 #include <limits>
@@ -257,7 +258,7 @@ chained_map<T, Allocator>::chained_map(chained_map<T, Allocator>&& D)
   noexcept(std::is_nothrow_move_constructible_v<Allocator> && std::is_nothrow_move_constructible_v<T>)
   : table(std::exchange(D.table, nullptr))
   , table_end(std::exchange(D.table_end, nullptr))
-  , free(std::exchange(D.free, nullptr))
+  , free BOOST_PREVENT_MACRO_SUBSTITUTION (std::exchange(D.free, nullptr))
   , table_size(std::exchange(D.table_size, 0))
   , table_size_1(std::exchange(D.table_size_1, 0))
   , alloc(std::move(D.alloc))

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -42,7 +42,7 @@
 // Include support for memory leak detection
 // This is only available in debug mode and when _CRTDBG_MAP_ALLOC is defined.
 // It will include <crtdbg.h> which will redefine `malloc` and `free`.
-#  define _CRTDBG_MAP_ALLOC 1
+// #  define _CRTDBG_MAP_ALLOC 1
 #endif
 // Mimic users including this file which defines min max macros
 // and other names leading to name clashes

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -42,7 +42,7 @@
 // Include support for memory leak detection
 // This is only available in debug mode and when _CRTDBG_MAP_ALLOC is defined.
 // It will include <crtdbg.h> which will redefine `malloc` and `free`.
-// #  define _CRTDBG_MAP_ALLOC 1
+#  define _CRTDBG_MAP_ALLOC 1
 #endif
 // Mimic users including this file which defines min max macros
 // and other names leading to name clashes

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -37,6 +37,13 @@
 #endif
 
 #ifdef CGAL_INCLUDE_WINDOWS_DOT_H
+
+#if defined(_MSC_VER) && defined(_DEBUG)
+// Include support for memory leak detection
+// This is only available in debug mode and when _CRTDBG_MAP_ALLOC is defined.
+// It will include <crtdbg.h> which will redefine `malloc` and `free`.
+#  define _CRTDBG_MAP_ALLOC 1
+#endif
 // Mimic users including this file which defines min max macros
 // and other names leading to name clashes
 #include <windows.h>


### PR DESCRIPTION
## Summary of Changes

From vcpkg CI, there is this error:

```
123456789101112131415161718192021222324252627C:\PROGRA~1\MICROS~1\2022\ENTERP~1\VC\Tools\MSVC\1441~1.341\bin\Hostx64\x64\cl.exe   /TP -DBOOST_ATOMIC_DYN_LINK -DBOOST_ATOMIC_NO_LIB -DBOOST_CHRONO_DYN_LINK -DBOOST_CHRONO_NO_LIB -DBOOST_CONTAINER_DYN_LINK -DBOOST_CONTAINER_NO_LIB -DBOOST_DATE_TIME_DYN_LINK -DBOOST_DATE_TIME_NO_LIB -DBOOST_IOSTREAMS_DYN_LINK -DBOOST_IOSTREAMS_NO_LIB -DBOOST_PROGRAM_OPTIONS_DYN_LINK -DBOOST_PROGRAM_OPTIONS_NO_LIB -DBOOST_RANDOM_DYN_LINK -DBOOST_RANDOM_NO_LIB -DBOOST_SERIALIZATION_DYN_LINK -DBOOST_SERIALIZATION_NO_LIB -DBOOST_THREAD_DYN_LINK -DBOOST_THREAD_NO_LIB -DBOOST_THREAD_USE_DLL -DCGAL_USE_GMPXX=1 -DGFLAGS_IS_A_DLL=1 -DGLOG_NO_ABBREVIATED_SEVERITIES -DGLOG_USE_GFLAGS -DGLOG_USE_GLOG_EXPORT -DH5_BUILT_AS_DYNAMIC_LIB -D_LIB -D_USE_BOOST -D_USE_EIGEN -D_USE_FAST_CBRT -D_USE_FAST_FLOAT2INT -D_USE_NONFREE -D_USE_OPENGL -D_USE_SSE -ID:\b\openmvs\x64-windows-dbg\libs\MVS\MVS_autogen\include -ID:\b\openmvs\src\v2.1.0-1e694de437.clean -ID:\b\openmvs\x64-windows-dbg -external:ID:\installed\x64-windows\include -external:ID:\installed\x64-windows\include\eigen3 -external:W0 /nologo /DWIN32 /D_WINDOWS /utf-8 /GR /EHsc /MP   /D _CRT_SECURE_NO_DEPRECATE /D _CRT_NONSTDC_NO_DEPRECATE /D _SCL_SECURE_NO_WARNINGS /Gy /bigobj /Oi /Zm170 /Zc:__cplusplus  /wd4231 /wd4251 /wd4308 /wd4396 /wd4503 /wd4661 /wd4996 /D_DEBUG /MDd /Z7 /Ob0 /Od /RTC1   -std:c++17 -D_SCL_SECURE_NO_DEPRECATE -D_SCL_SECURE_NO_WARNINGS /fp:strict /fp:except- /bigobj /Zc:__cplusplus /YuD:/b/openmvs/x64-windows-dbg/libs/MVS/CMakeFiles/MVS.dir/cmake_pch.hxx /FpD:/b/openmvs/x64-windows-dbg/libs/MVS/CMakeFiles/MVS.dir/./cmake_pch.cxx.pch /FID:/b/openmvs/x64-windows-dbg/libs/MVS/CMakeFiles/MVS.dir/cmake_pch.hxx /showIncludes /Folibs\MVS\CMakeFiles\MVS.dir\SceneReconstruct.cpp.obj /Fdlibs\MVS\CMakeFiles\MVS.dir\MVS.pdb /FS -c D:\b\openmvs\src\v2.1.0-1e694de437.clean\libs\MVS\SceneReconstruct.cpp
D:\installed\x64-windows\include\CGAL/CORE/MemoryPool.h(76): error C2059: syntax error: 'constant'
D:\installed\x64-windows\include\CGAL/CORE/MemoryPool.h(76): note: the template instantiation context (the oldest one first) is
D:\installed\x64-windows\include\CGAL/CORE/MemoryPool.h(39): note: while compiling class template 'CORE::MemoryPool'
D:\installed\x64-windows\include\CGAL/CORE/MemoryPool.h(119): error C2988: unrecognizable template declaration/definition
D:\installed\x64-windows\include\CGAL/CORE/MemoryPool.h(119): error C2059: syntax error: 'constant'
D:\installed\x64-windows\include\CGAL/CORE/Expr_impl.h(1217): error C2660: 'CORE::MemoryPool<CORE::ConstDoubleRep,1024>::_free_dbg': function does not take 2 arguments
D:\installed\x64-windows\include\CGAL/CORE/MemoryPool.h(76): note: see declaration of 'CORE::MemoryPool<CORE::ConstDoubleRep,1024>::_free_dbg'
D:\installed\x64-windows\include\CGAL/CORE/Expr_impl.h(1217): note: while trying to match the argument list '(void *, int)'
```

There is probably a macro named `free` somewhere.

---
**Update:** If the macros `_DEBUG` and `_CRTDBG_MAP_ALLOC` are defined, then [the Windows runtime headers redefine `free` and `malloc`](https://learn.microsoft.com/en-us/cpp/c-runtime-library/debug-versions-of-heap-allocation-functions).

This PR also adds a test for `_CRTDBG_MAP_ALLOC` in the CGAL test suite.

## Release Management

* Affected package(s): BGL, CGAL_Core, Classification, Installation
* Issue(s) solved (if any): relates to vcpkg's PR https://github.com/microsoft/vcpkg/pull/41300
* License and copyright ownership: N/A
