### PR TITLE
Spatial_searching: Do not quiet warning in CMakeLists.txt

### DIFF
--- a/Spatial_searching/examples/Spatial_searching/CMakeLists.txt
+++ b/Spatial_searching/examples/Spatial_searching/CMakeLists.txt
@@ -7,11 +7,6 @@ project(Spatial_searching_Examples)
 # CGAL and its components
 find_package(CGAL REQUIRED)
 
-if(MSVC)
-  # Turn off VC++ warning
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /wd4244")
-endif()
-
 create_single_source_cgal_program("circular_query.cpp")
 create_single_source_cgal_program("distance_browsing.cpp")
 create_single_source_cgal_program("iso_rectangle_2_query.cpp")


### PR DESCRIPTION
## Summary of Changes

It is not a good idea to quiet a warning in the `CMakeLists.txt` file. 

_Todo:_  Fix it in the code, or  disable warning in the header file itself.

There is another warning disabled in the test of [`Distance_3`](https://github.com/CGAL/cgal/blob/master/Distance_3/test/Distance_3/CMakeLists.txt#L9).  The question is if we have a test case where we force it into the problem, or if the same warning can show up for any user code.   The warning does not show up outside this testsuite which might be an indication.

## Release Management

* Affected package(s): Spatial_searching
* License and copyright ownership: unchanged

