### PR TITLE
[KSR] Fix crash in collect_connected_border()

### DIFF
--- a/Kinetic_surface_reconstruction/include/CGAL/Kinetic_surface_reconstruction_3.h
+++ b/Kinetic_surface_reconstruction/include/CGAL/Kinetic_surface_reconstruction_3.h
@@ -1534,7 +1534,7 @@ private:
     // Start extraction of a border from each dart (each dart is a 1/n-edge)
     // Search starting darts by searching faces
     //borders contains Attribute<0> handles casted to std::size_t
-    std::vector<bool> processed(m_lcc.number_of_darts(), false);
+    std::vector<bool> processed(m_lcc.upper_bound_on_dart_ids(), false);
 
     borders_per_region.resize(region_index.size());
 


### PR DESCRIPTION
## Summary of Changes

using LCC with `GenericMap::upper_bound_on_dart_ids()` instead of `GenericMap::number_of_darts()`.

`number_of_darts()` only provides the number, but not the largest id.

## Release Management

* Affected package(s): KSR