### PR TITLE
[Shape detection] Removed use of internal namespace from example

### DIFF
--- a/Shape_detection/doc/Shape_detection/Concepts/NeighborQuery.h
+++ b/Shape_detection/doc/Shape_detection/Concepts/NeighborQuery.h
@@ -15,7 +15,7 @@ class NeighborQuery {
 
 public:
 
-  /// The reference type to the elements of the input range, e.g., a const_iterator of the input range.
+  /// The reference type to the elements of the input range, e.g., a const_iterator of the input range. Must be a model of `Hashable`.
   typedef unspecified_type Item;
 
   /*!

--- a/Shape_detection/doc/Shape_detection/Concepts/NeighborQuery.h
+++ b/Shape_detection/doc/Shape_detection/Concepts/NeighborQuery.h
@@ -15,7 +15,7 @@ class NeighborQuery {
 
 public:
 
-  /// The reference type to the elements of the input range, e.g., a const_iterator of the input range. Must be a model of `Hashable`.
+  /// The reference type to the elements of the input range, e.g., a `const_iterator` of the input range. Must be a model of `Hashable`.
   typedef unspecified_type Item;
 
   /*!

--- a/Shape_detection/doc/Shape_detection/Concepts/RegionType.h
+++ b/Shape_detection/doc/Shape_detection/Concepts/RegionType.h
@@ -23,10 +23,10 @@ public:
   /// The parameters of the primitive covering the region.
   typedef unspecified_type Primitive;
 
-  /// The reference type to the elements of the input range, e.g., a const_iterator of the input range.  Must be a model of `Hashable`.
+  /// The reference type to the elements of the input range, e.g., a `const_iterator` of the input range.  Must be a model of `Hashable`.
   typedef unspecified_type Item;
 
-  // The region types is defined by a vector of Items.
+  // The Region type is defined by a `vector` of items.
   typedef std::vector<Item> Region;
 
   /*!
@@ -37,11 +37,11 @@ public:
   typedef unspecified_type Region_index_map;
 
   /*!
-    checks if the item `i` can be added to the region represented by `region`.
+    checks if the `Item` `i` can be added to the `Region` represented by `region`.
 
     `CGAL::Shape_detection::Region_growing` calls this function each time when
-    trying to add a new item to a region. If this function returns `true`, the
-    item with the index `i`, is added to the region, otherwise ignored.
+    trying to add a new item to a `Region`. If this function returns `true`, the
+    item with the index `i`, is added to the `region`, otherwise ignored.
   */
   bool is_part_of_region(
     const Item i,
@@ -52,8 +52,8 @@ public:
     checks if `region` satisfies all necessary conditions.
 
     `CGAL::Shape_detection::Region_growing` calls this function at the end of each
-    propagation phase. If this function returns `true`, the region is accepted,
-    otherwise rejected. If the region is rejected, all its items are released and
+    propagation phase. If this function returns `true`, the `region` is accepted,
+    otherwise rejected. If the `region` is rejected, all its items are released and
     available for region growing again.
   */
   bool is_valid_region(
@@ -68,7 +68,7 @@ public:
   }
 
   /*!
-    enables to update any information about the region represented by the collection of Items `region`.
+    enables to update any information about the region represented by the collection of items `region`.
 
     `CGAL::Shape_detection::Region_growing` calls this function each time when a
     new seed item is selected. This case can be identified by checking the
@@ -76,8 +76,8 @@ public:
     when enlarging the region. This case can be identified by checking the
     condition `region.size() > 1`.
 
-    This function also returns a Boolean at the first call when a new region
-    with one seed item is being created. When it is `true`, the new region is
+    This function also returns a boolean at the first call when a new `region`
+    with one seed item is being created. When it is `true`, the new `region` is
     further propagated, otherwise, it is rejected.
   */
   bool update(

--- a/Shape_detection/doc/Shape_detection/Concepts/RegionType.h
+++ b/Shape_detection/doc/Shape_detection/Concepts/RegionType.h
@@ -23,7 +23,7 @@ public:
   /// The parameters of the primitive covering the region.
   typedef unspecified_type Primitive;
 
-  /// The reference type to the elements of the input range, e.g., a const_iterator of the input range.
+  /// The reference type to the elements of the input range, e.g., a const_iterator of the input range.  Must be a model of `Hashable`.
   typedef unspecified_type Item;
 
   // The region types is defined by a vector of Items.

--- a/Shape_detection/examples/Shape_detection/region_growing_with_custom_classes.cpp
+++ b/Shape_detection/examples/Shape_detection/region_growing_with_custom_classes.cpp
@@ -69,7 +69,14 @@ namespace Custom {
     using Item = std::vector<Object>::const_iterator;
     using Region = std::vector<Item>;
 
-    using Region_unordered_map = std::unordered_map<Item, std::size_t, CGAL::Shape_detection::internal::hash_item<Item> >;
+    struct hash_item {
+      std::size_t operator()(Item i) const {
+        using boost::hash_value;
+        return boost::hash_value(i.operator->());
+      }
+    };
+
+    using Region_unordered_map = std::unordered_map<Item, std::size_t, hash_item >;
     using Region_index_map = boost::associative_property_map<Region_unordered_map>;
 
     Region_index_map region_index_map() {


### PR DESCRIPTION
## Summary of Changes

Documented that RegionType::Item and NeighborQuery::Item need to be hashable.
Removed internal namespace from example.

## Release Management

* Affected package(s): Shape_detection
* Issue(s) solved (if any): #8534 
