### PR TITLE
Add specialization of Evaluate<> for Lazy_exact_nt

### DIFF
--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -111,14 +111,24 @@ template<class T>inline std::enable_if_t<std::is_empty<T>::value, T> approx(T){r
 template<class T>inline std::enable_if_t<std::is_empty<T>::value, int> depth(T){return -1;}
 
 namespace internal{
-template <typename AT, typename ET, typename E2A>
-struct Evaluate<Lazy<AT,ET,E2A>>
-{
-  void operator()(const Lazy<AT,ET,E2A>& l)
+
+  template <typename AT, typename ET, typename E2A>
+  struct Evaluate<Lazy<AT, ET, E2A>>
   {
-    exact(l);
-  }
+      void operator()(const Lazy<AT, ET, E2A>& l)
+      {
+          exact(l);
+      }
 };
+
+  template <typename ET>
+  struct Evaluate<Lazy_exact_nt<ET>>
+  {
+      void operator()(const Lazy_exact_nt<ET>& l)
+      {
+          exact(l);
+      }
+  };
 } // internal namespace
 
 // For an iterator, exact/approx applies to the objects it points to

--- a/Polygon/test/Polygon/issue7934.cpp
+++ b/Polygon/test/Polygon/issue7934.cpp
@@ -1,0 +1,22 @@
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Polygon_2.h>
+#include <CGAL/Polygon_2_algorithms.h>
+#include <iostream>
+
+using Kernel = CGAL::Exact_predicates_exact_constructions_kernel;
+using Point_2 = Kernel::Point_2;
+using Polygon_2 = CGAL::Polygon_2<Kernel>;
+
+int main()
+{
+  Polygon_2 polygon;
+  for (int i = 0; i < 200000; ++i) {
+      polygon.push_back(Point_2(i* 1.04663, 0));
+  }
+  polygon.push_back(Point_2( 3.1415, 3.1415));
+
+  auto ar = CGAL::polygon_area_2(polygon.vertices_begin(), polygon.vertices_end(), Kernel());
+  
+  std::cout << "done" << std::endl;
+  return 0;
+}

--- a/Polygon/test/Polygon/issue7934.cpp
+++ b/Polygon/test/Polygon/issue7934.cpp
@@ -16,7 +16,7 @@ int main()
   polygon.push_back(Point_2( 3.1415, 3.1415));
 
   auto ar = CGAL::polygon_area_2(polygon.vertices_begin(), polygon.vertices_end(), Kernel());
-  
+
   std::cout << "done" << std::endl;
   return 0;
 }


### PR DESCRIPTION
## Summary of Changes

PR  #8052 did not solve the problem reported in Issue #7934
This PR adds a partial specialization of `Evaluate<>` for `Lazy_exact_nt`, which derives from `Lazy`,
but the partial specialization for `Lazy` is not  taken.

Todo: Generate a testcase that reproduces the reported issue, so that we check before/after.

## Release Management

* Affected package(s): Polygon_2
* Issue(s) solved (if any): fix #7934
* License and copyright ownership:  unchanged

