### PR TITLE
[Lab] Fix transparency

### DIFF
--- a/Polyhedron/demo/Polyhedron/Scene.cpp
+++ b/Polyhedron/demo/Polyhedron/Scene.cpp
@@ -766,8 +766,14 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
       fbos.resize(static_cast<int>(viewer->total_pass()));
       depth_test.resize(static_cast<int>(viewer->total_pass())-1);
 
+      int viewport[4];
+      viewer->glGetIntegerv(GL_VIEWPORT, viewport);
+
+      int w = viewport[2];// viewer->width();
+      int h = viewport[3];// viewer->height();
+
       //first pass
-      fbos[0] = new QOpenGLFramebufferObject(viewer->width(), viewer->height(),QOpenGLFramebufferObject::Depth, GL_TEXTURE_2D, GL_RGBA32F);
+      fbos[0] = new QOpenGLFramebufferObject(w, h, QOpenGLFramebufferObject::Depth, GL_TEXTURE_2D, GL_RGBA32F);
       fbos[0]->bind();
       viewer->glDisable(GL_BLEND);
       viewer->glEnable(GL_DEPTH_TEST);
@@ -781,7 +787,8 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
       renderScene(opaque_items, viewer, picked_item_IDs, false, 0,false, nullptr);
       renderScene(transparent_items, viewer, picked_item_IDs, false, 0,false, nullptr);
       fbos[0]->release();
-      depth_test[0] = new QOpenGLFramebufferObject(viewer->width(), viewer->height(),QOpenGLFramebufferObject::Depth, GL_TEXTURE_2D, GL_RGBA32F);
+
+      depth_test[0] = new QOpenGLFramebufferObject(w, h,QOpenGLFramebufferObject::Depth, GL_TEXTURE_2D, GL_RGBA32F);
       depth_test[0]->bind();
       viewer->glDisable(GL_BLEND);
       viewer->glEnable(GL_DEPTH_TEST);
@@ -799,7 +806,7 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
       //other passes
       for(int i=1; i<viewer->total_pass()-1; ++i)
       {
-        fbos[i] = new QOpenGLFramebufferObject(viewer->width(), viewer->height(),QOpenGLFramebufferObject::Depth, GL_TEXTURE_2D, GL_RGBA32F);
+        fbos[i] = new QOpenGLFramebufferObject(w, h,QOpenGLFramebufferObject::Depth, GL_TEXTURE_2D, GL_RGBA32F);
         fbos[i]->bind();
         viewer->glDisable(GL_BLEND);
         viewer->glEnable(GL_DEPTH_TEST);
@@ -816,7 +823,7 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
         renderScene(transparent_items, viewer, picked_item_IDs, false, i, false, depth_test[i-1]);
         fbos[i]->release();
 
-        depth_test[i] = new QOpenGLFramebufferObject(viewer->width(), viewer->height(),QOpenGLFramebufferObject::Depth, GL_TEXTURE_2D, GL_RGBA32F);
+        depth_test[i] = new QOpenGLFramebufferObject(w, h,QOpenGLFramebufferObject::Depth, GL_TEXTURE_2D, GL_RGBA32F);
         depth_test[i]->bind();
         viewer->glDisable(GL_BLEND);
         viewer->glEnable(GL_DEPTH_TEST);
@@ -832,9 +839,8 @@ Scene::draw_aux(bool with_names, CGAL::Three::Viewer_interface* viewer)
         depth_test[i]->release();
       }
 
-
       //last pass
-      fbos[static_cast<int>(viewer->total_pass())-1] = new QOpenGLFramebufferObject(viewer->width(), viewer->height(),QOpenGLFramebufferObject::Depth, GL_TEXTURE_2D, GL_RGBA32F);
+      fbos[static_cast<int>(viewer->total_pass())-1] = new QOpenGLFramebufferObject(w, h,QOpenGLFramebufferObject::Depth, GL_TEXTURE_2D, GL_RGBA32F);
       fbos[static_cast<int>(viewer->total_pass())-1]->bind();
       viewer->glDisable(GL_BLEND);
       viewer->glEnable(GL_DEPTH_TEST);

--- a/Polyhedron/demo/Polyhedron/Triangle_container.cpp
+++ b/Polyhedron/demo/Polyhedron/Triangle_container.cpp
@@ -185,8 +185,11 @@ void Triangle_container::draw(Viewer_interface* viewer,
       getVao(viewer)->program->setUniformValue("far", static_cast<float>(viewer->camera()->zFar()));
       getVao(viewer)->program->setUniformValue("writing", viewer->isDepthWriting());
       getVao(viewer)->program->setUniformValue("alpha", d->alpha);
-      if( fbo)
+      if(fbo) {
         viewer->glBindTexture(GL_TEXTURE_2D, fbo->texture());
+        getVao(viewer)->program->setUniformValue("width", fbo->width() * 1.0f);
+        getVao(viewer)->program->setUniformValue("height", fbo->height() * 1.0f);
+      }
     }
     if(getVao(viewer)->program->property("drawLinesAdjacency").toBool())
     {
@@ -225,8 +228,11 @@ void Triangle_container::draw(Viewer_interface* viewer,
       getVao(viewer)->program->setUniformValue("far", static_cast<float>(viewer->camera()->zFar()));
       getVao(viewer)->program->setUniformValue("writing", viewer->isDepthWriting());
       getVao(viewer)->program->setUniformValue("alpha", d->alpha);
-      if( fbo)
+      if(fbo) {
         viewer->glBindTexture(GL_TEXTURE_2D, fbo->texture());
+        getVao(viewer)->program->setUniformValue("width", fbo->width() * 1.0f);
+        getVao(viewer)->program->setUniformValue("height", fbo->height() * 1.0f);
+      }
     }
     if(getVao(viewer)->program->property("isInstanced").toBool())
     {


### PR DESCRIPTION
## Summary of Changes

The viewer does not return the dimensions of the framebuffer, thus the viewport information is used to create the framebuffers for depth peeling. Also the correct width and height are communicated to the shader.

## Release Management

* Affected package(s): Lab
