### PR TITLE
Bug fix in LCC method set_automatic_attributes_management

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map.h
@@ -3707,6 +3707,9 @@ namespace CGAL {
       this->automatic_attributes_management = newval;
     }
 
+    void set_automatic_attributes_management_without_correction(bool newval)
+    { this->automatic_attributes_management = newval; }
+
     /** Create an half-edge.
      * @return a dart of the new half-edge.
      */

--- a/Generalized_map/include/CGAL/Generalized_map.h
+++ b/Generalized_map/include/CGAL/Generalized_map.h
@@ -2946,6 +2946,9 @@ namespace CGAL {
       this->automatic_attributes_management = newval;
     }
 
+    void set_automatic_attributes_management_without_correction(bool newval)
+    { this->automatic_attributes_management = newval; }
+
     /** Create an half-edge.
      * @return a dart of the new half-edge.
      */

--- a/Linear_cell_complex/demo/Linear_cell_complex/MainWindow.cpp
+++ b/Linear_cell_complex/demo/Linear_cell_complex/MainWindow.cpp
@@ -1012,7 +1012,7 @@ void MainWindow::on_actionMerge_coplanar_faces_triggered()
   timer.start();
 #endif
 
-  scene.lcc->set_update_attributes(false);
+  scene.lcc->set_automatic_attributes_management(false);
 
   std::vector<Dart_descriptor> edges;
   LCC::size_type treated  = scene.lcc->get_new_mark();
@@ -1073,7 +1073,7 @@ void MainWindow::on_actionMerge_coplanar_faces_triggered()
   scene.lcc->free_mark(treated);
   scene.lcc->free_mark(treated2);
 
-  scene.lcc->set_update_attributes(true);
+  scene.lcc->set_automatic_attributes_management(true);
 
 #ifdef CGAL_PROFILE_LCC_DEMO
   timer.stop();
@@ -1100,7 +1100,7 @@ void MainWindow::on_actionMerge_all_volumes_triggered()
 
   LCC::Dart_range::iterator prev;
   bool first = true;
-  scene.lcc->set_update_attributes(false);
+  scene.lcc->set_automatic_attributes_management(false);
 
   for (LCC::Dart_range::iterator it(scene.lcc->darts().begin()),
        itend=scene.lcc->darts().end(); it!=itend; )
@@ -1127,7 +1127,7 @@ void MainWindow::on_actionMerge_all_volumes_triggered()
     }
   }
 
-  scene.lcc->set_update_attributes(true);
+  scene.lcc->set_automatic_attributes_management(true);
 
 #ifdef CGAL_PROFILE_LCC_DEMO
   timer.stop();
@@ -1751,7 +1751,7 @@ void MainWindow::onMengerInc()
 
   if (!mengerUpdateAttributes)
   {
-    scene.lcc->set_update_attributes(false);
+    scene.lcc->set_automatic_attributes_management(false);
   }
 
   std::vector<Dart_descriptor> edges;
@@ -1838,7 +1838,7 @@ void MainWindow::onMengerInc()
         update_volume_list_add(scene.lcc->attribute<3>(mengerVolumes[i]));
     }
 
-    scene.lcc->set_update_attributes(true);
+    scene.lcc->set_automatic_attributes_management(true);
   }
 
 #ifdef CGAL_PROFILE_LCC_DEMO

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_base.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_base.h
@@ -836,7 +836,7 @@ namespace CGAL {
 
     /** Set the status of the management of the attributes of the Map
      */
-    void set_update_attributes(bool newval)
+    void set_automatic_attributes_management(bool newval)
     {
       if (this->automatic_attributes_management == false && newval == true)
       {
@@ -847,6 +847,10 @@ namespace CGAL {
 
       this->automatic_attributes_management = newval;
     }
+
+    void set_automatic_attributes_management_without_correction(bool newval)
+    { this->automatic_attributes_management = newval; }
+
   };
 
 } // namespace CGAL


### PR DESCRIPTION

## Summary of Changes

Correct the name in LCC of the method. The previous name is set_update_attributes which is wrong.
The correct name is set_automatic_attributes_management (which is documented).

Add a non-documented internal method allowing to change the update attribute mode without correcting the attributes.

## Release Management

* Affected package(s): CMap/GMap/LCC

