### PR TITLE
fix the fatal bug of the convolution calculation part of the Minkowski sum

### DIFF
--- a/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_conv_2.h
+++ b/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_conv_2.h
@@ -533,7 +533,7 @@ private:
     // list for subsequences sharing a common move_on indicator. When we
     // encounter such a subsequence that equals the size of the corresponding
     // polygon, we can safely remove it from the convolution cycle.
-    typename std::list<Labeled_segment_2>::iterator  first, curr;
+    typename std::list<Labeled_segment_2>::iterator  first, curr, newins;
     bool move_on;
     unsigned int count = 1;
     bool reduced_cycle = false;
@@ -611,7 +611,7 @@ private:
         res = f_compare_xy(curr_pt, next_pt);
 
         if (res != EQUAL) {
-          cycle.insert(curr,
+          newins = cycle.insert(curr,
                        Labeled_segment_2(Segment_2(curr_pt, next_pt),
                                          X_curve_label((res == SMALLER),
                                                        cycle_id,
@@ -621,7 +621,13 @@ private:
 
         cycle.erase(curr);
         cycle.erase(next);
-        curr = after_next;
+        if (res != EQUAL) {
+          //continue comparing the new combined line with the next line
+          curr = newins;
+        }
+        else {
+          curr = after_next;
+        }
 
         if (after_next != cycle.end()) {
           next = curr;

--- a/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_conv_2.h
+++ b/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_conv_2.h
@@ -533,7 +533,7 @@ private:
     // list for subsequences sharing a common move_on indicator. When we
     // encounter such a subsequence that equals the size of the corresponding
     // polygon, we can safely remove it from the convolution cycle.
-    typename std::list<Labeled_segment_2>::iterator  first, curr, newins;
+    typename std::list<Labeled_segment_2>::iterator  first, curr;
     bool move_on;
     unsigned int count = 1;
     bool reduced_cycle = false;
@@ -611,7 +611,7 @@ private:
         res = f_compare_xy(curr_pt, next_pt);
 
         if (res != EQUAL) {
-          newins = cycle.insert(curr,
+          after_next = cycle.insert(curr,
                        Labeled_segment_2(Segment_2(curr_pt, next_pt),
                                          X_curve_label((res == SMALLER),
                                                        cycle_id,
@@ -621,13 +621,7 @@ private:
 
         cycle.erase(curr);
         cycle.erase(next);
-        if (res != EQUAL) {
-          //continue comparing the new combined line with the next line
-          curr = newins;
-        }
-        else {
-          curr = after_next;
-        }
+        curr = after_next;
 
         if (after_next != cycle.end()) {
           next = curr;


### PR DESCRIPTION


## Summary of Changes
Modify the convolution calculation part of the Minkowski sum. In the 'elimination of antennas' phase, before I fix it, only the antennas of the first segment were eliminated, skipping the possible subsequent antennas. For more details, please refer to the explanation in the issue. I modified it so that if a new antenna is merged, the newly merged antenna is used as `curr` for the next iteration; otherwise, `after_next` is used as `curr`.


## Release Management
* Affected package(s): Minkowski_sum_2
* Issue(s) solved: fix #8551

