### PR TITLE
PMP: Initialize to avoid warning

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polyhedral_envelope.h
+++ b/Polygon_mesh_processing/include/CGAL/Polyhedral_envelope.h
@@ -714,7 +714,7 @@ private:
   {
     Vector_3 bmin, bmax;
 
-    Orientation ori;
+    Orientation ori = ON_ORIENTED_BOUNDARY; // to avoid maybe uninitialzed warning
 
     for (unsigned int i = 0; i < prismindex.size(); i++){
       if (prismindex[i] == jump){


### PR DESCRIPTION
## Summary of Changes

An uninitialized variable gets assigned a value inside a `for` loop,
The compiler cannot know that we always enter the loop and [warns]( https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.1-Ic-15/Polygon_mesh_processing_Examples/TestReport_lrineau_Ubuntu-latest-GCC6-Release.gz) when we later use the variable.
We could use `[[assume(x)]]` to indicate that we always will enter the loop but just initializing does the job.

## Release Management

* Affected package(s): PMP 
* License and copyright ownership: unchanged

