### PR TITLE
`PMP::isotropic_remeshing()` -  fix relaxation of constrained vertices

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1025,18 +1025,7 @@ namespace internal {
       // property map of constrained vertices for relaxation
       auto vertex_constraint = [&](const vertex_descriptor v)
       {
-        if (is_constrained(v))
-          return true;
-
-        for (halfedge_descriptor h : halfedges_around_target(v, mesh_))
-        {
-          Halfedge_status s = status(h);
-          if ( s == PATCH
-            || s == PATCH_BORDER
-            || status(opposite(h, mesh_)) == PATCH_BORDER)
-            return false;
-        }
-        return true;
+        return is_move_allowed(v, relax_constraints);
       };
       auto constrained_vertices_pmap
         = boost::make_function_property_map<vertex_descriptor>(vertex_constraint);
@@ -1364,6 +1353,24 @@ private:
       if ( is_on_patch_border(next(h, mesh_))
         && is_on_patch_border(prev(opposite(h, mesh_), mesh_)))
         return false;
+      return true;
+    }
+
+    bool is_move_allowed(const vertex_descriptor v, const bool relax_constraints) const
+    {
+      if (is_constrained(v))
+        return false;
+
+      std::vector<halfedge_descriptor> border_halfedges;
+      for (halfedge_descriptor h : halfedges_around_target(v, mesh_))
+      {
+        if (is_on_patch(h))
+          continue;
+        else if (is_on_patch_border(h) && relax_constraints)
+          continue;
+        else
+          return false;
+      }
       return true;
     }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1361,7 +1361,6 @@ private:
       if (is_constrained(v))
         return false;
 
-      std::vector<halfedge_descriptor> border_halfedges;
       for (halfedge_descriptor h : halfedges_around_target(v, mesh_))
       {
         if (is_on_patch(h))

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1025,6 +1025,9 @@ namespace internal {
       // property map of constrained vertices for relaxation
       auto vertex_constraint = [&](const vertex_descriptor v)
       {
+        if (is_constrained(v))
+          return true;
+
         for (halfedge_descriptor h : halfedges_around_target(v, mesh_))
         {
           Halfedge_status s = status(h);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1025,7 +1025,7 @@ namespace internal {
       // property map of constrained vertices for relaxation
       auto vertex_constraint = [&](const vertex_descriptor v)
       {
-        return is_move_allowed(v, relax_constraints);
+        return !is_move_allowed(v, relax_constraints);
       };
       auto constrained_vertices_pmap
         = boost::make_function_property_map<vertex_descriptor>(vertex_constraint);


### PR DESCRIPTION
## Summary of Changes

Constrained vertices, and constrained edges were not properly protected during the smoothing step.

## Release Management

* Affected package(s): PMP
* Issue(s) solved (if any): fix #8388
* License and copyright ownership: unchanged

