### PR TITLE
Flip it if you can't collapse it

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -871,14 +871,14 @@ namespace internal {
         std::array<halfedge_descriptor, 2> r1 = internal::is_badly_shaped(
             face(he, mesh_),
             mesh_, vpmap_, vcmap_, ecmap_, gt_,
-            cap_threshold, // bound on the angle: above 160 deg => cap
             4, // bound on shortest/longest edge above 4 => needle
+            cap_threshold, // bound on the angle: above 160 deg => cap
             0,// collapse length threshold : not needed here
             0); // flip triangle height threshold
 
         std::array<halfedge_descriptor, 2> r2 = internal::is_badly_shaped(
             face(opposite(he, mesh_), mesh_),
-            mesh_, vpmap_, vcmap_, ecmap_, gt_, cap_threshold, 4, 0, 0);
+            mesh_, vpmap_, vcmap_, ecmap_, gt_, 4, cap_threshold, 0, 0);
 
         const bool badly_shaped = (r1[0] != boost::graph_traits<PolygonMesh>::null_halfedge()//needle
                                 || r1[1] != boost::graph_traits<PolygonMesh>::null_halfedge()//cap

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -757,6 +757,24 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
     int kk=0;
     std::ofstream(std::string("tmp/n-00000.off")) << tmesh;
 #endif
+
+    auto run_cap_check = [&](halfedge_descriptor h, bool consider_for_collapse=true)
+    {
+      halfedge_descriptor cap_h = internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
+                                                        cap_threshold, flip_triangle_height_threshold_squared);
+      if(cap_h != null_h)
+      {
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+        std::cout << "\t\t But the face is a cap" << std::endl;
+#endif
+        edges_to_flip.insert(cap_h);
+      }
+      else
+      {
+        if (consider_for_collapse) next_edges_to_collapse.insert(h);
+      }
+    };
+
     while(!edges_to_collapse.empty())
     {
       // note that on the first iteration, 'h' does not indicate a known needle
@@ -772,15 +790,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
         std::cout << "\t Needle criterion not verified" << std::endl;
 #endif
-        halfedge_descriptor cap_h = internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
-                                                          cap_threshold, flip_triangle_height_threshold_squared);
-        if(cap_h != null_h)
-        {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
-          std::cout << "\t\t But the face is a cap" << std::endl;
-#endif
-          edges_to_flip.insert(cap_h);
-        }
+        run_cap_check(h, false);
         continue;
       }
       else
@@ -809,20 +819,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
             std::cout << "\t Geometrically invalid edge collapse!" << std::endl;
 #endif
-          halfedge_descriptor cap_h = internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
-                                                            cap_threshold, flip_triangle_height_threshold_squared);
-          if(cap_h != null_h)
-          {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
-            std::cout << "\t\t But the face is a cap" << std::endl;
-#endif
-            edges_to_flip.insert(cap_h);
-          }
-          else
-          {
-            next_edges_to_collapse.insert(h);
-          }
-
+          run_cap_check(h);
           continue;
         }
 
@@ -831,20 +828,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
             std::cout << "\t edge collapse prevented by the user functor" << std::endl;
 #endif
-          halfedge_descriptor cap_h = internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
-                                                            cap_threshold, flip_triangle_height_threshold_squared);
-          if(cap_h != null_h)
-          {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
-            std::cout << "\t\t But the face is a cap" << std::endl;
-#endif
-            edges_to_flip.insert(cap_h);
-          }
-          else
-          {
-            next_edges_to_collapse.insert(h);
-          }
-
+          run_cap_check(h);
           continue;
         }
 
@@ -934,20 +918,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
         std::cout << "\t Uncollapsable edge!" << std::endl;
 #endif
-
-        halfedge_descriptor cap_h = internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
-                                                          cap_threshold, flip_triangle_height_threshold_squared);
-        if(cap_h != null_h)
-        {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
-            std::cout << "\t\t But the face is a cap" << std::endl;
-#endif
-          edges_to_flip.insert(cap_h);
-        }
-        else
-        {
-          next_edges_to_collapse.insert(h);
-        }
+        run_cap_check(h);
       }
     }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -755,8 +755,10 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
           std::cout << "\t Needle criteria no longer verified" << std::endl;
 #endif
+          if (nc[1]!=boost::graph_traits<TriangleMesh>::null_halfedge()) edges_to_flip.insert(nc[1]);
           continue;
         }
+
 
         // pick the orientation of edge to keep the vertex minimizing the volume variation
         const halfedge_descriptor best_h = internal::get_best_edge_orientation(e, tmesh, vpm, vcm, gt);
@@ -765,7 +767,10 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
             std::cout << "\t Geometrically invalid edge collapse!" << std::endl;
 #endif
-          next_edges_to_collapse.insert(h);
+          if (nc[1]!=boost::graph_traits<TriangleMesh>::null_halfedge())
+            edges_to_flip.insert(nc[1]);
+          else
+            next_edges_to_collapse.insert(h);
           continue;
         }
 
@@ -774,7 +779,10 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
             std::cout << "\t edge collapse prevented by the user functor" << std::endl;
 #endif
-          next_edges_to_collapse.insert(h);
+          if (nc[1]!=boost::graph_traits<TriangleMesh>::null_halfedge())
+            edges_to_flip.insert(nc[1]);
+          else
+            next_edges_to_collapse.insert(h);
           continue;
         }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -751,7 +751,6 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
       return true;
 
     std::unordered_set<halfedge_descriptor> next_edges_to_collapse;
-    std::unordered_set<halfedge_descriptor> next_edges_to_flip;
 
     // Treat needles ===============================================================================
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
@@ -771,7 +770,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
       if(needle_h == null_h)
       {
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
-        std::cout << "\t Needle criterion no longer verified" << std::endl;
+        std::cout << "\t Needle criterion not verified" << std::endl;
 #endif
         halfedge_descriptor cap_h = internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
                                                           cap_threshold, flip_triangle_height_threshold_squared);
@@ -1010,9 +1009,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 
         for(halfedge_descriptor hh : CGAL::halfedges_around_face(h, tmesh))
         {
-          // Remove from 'next_edges_to_flip' because it might have been re-added from a flip
           edges_to_flip.erase(hh);
-          next_edges_to_flip.erase(hh);
           next_edges_to_collapse.erase(hh);
         }
 
@@ -1033,7 +1030,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
           std::cout << "\t Flipping prevented: not the best diagonal" << std::endl;
 #endif
-          next_edges_to_flip.insert(h);
+          next_edges_to_collapse.insert(h);
           continue;
         }
 
@@ -1042,7 +1039,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
           std::cout << "\t Flipping prevented: rejected by user functor" << std::endl;
 #endif
-          next_edges_to_flip.insert(h);
+          next_edges_to_collapse.insert(h);
           continue;
         }
 
@@ -1068,7 +1065,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
         std::cout << "\t Unflippable edge!" << std::endl;
 #endif
         CGAL_assertion(!is_border(h, tmesh));
-        next_edges_to_flip.insert(h);
+        next_edges_to_collapse.insert(h);
       }
 
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
@@ -1085,7 +1082,6 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
       return false;
 
     std::swap(edges_to_collapse, next_edges_to_collapse);
-    std::swap(edges_to_flip, next_edges_to_flip);
   }
 
   return false;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -1006,11 +1006,12 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
           continue;
         }
 
-        if (!accept_change.flip(h))
+        if(!accept_change.flip(h))
         {
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
           std::cout << "\t Flipping prevented: rejected by user functor" << std::endl;
 #endif
+          next_edges_to_flip.insert(h);
           continue;
         }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -646,6 +646,8 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
   typedef typename boost::graph_traits<TriangleMesh>::edge_descriptor           edge_descriptor;
   typedef typename boost::graph_traits<TriangleMesh>::face_descriptor           face_descriptor;
 
+  const halfedge_descriptor null_h = boost::graph_traits<TriangleMesh>::null_halfedge();
+
   typedef Static_boolean_property_map<vertex_descriptor, false>                 Default_VCM;
   typedef typename internal_np::Lookup_named_param_def<internal_np::vertex_is_constrained_t,
                                                        NamedParameters,
@@ -712,36 +714,27 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
     }
   }
 
-  // Start the process of removing bad elements
-  std::set<halfedge_descriptor> edges_to_collapse;
-  std::set<halfedge_descriptor> edges_to_flip;
+  // @todo maybe using a priority queue handling the more almost degenerate elements first should be used
+  std::unordered_set<halfedge_descriptor> edges_to_collapse;
+  std::unordered_set<halfedge_descriptor> edges_to_flip;
 
-  // @todo could probably do something a bit better by looping edges, consider the incident faces
-  // f1 / f2 and look at f1 if f1<f2, and the edge is smaller than the two other edges...
+  // Needless-ness and cap-ness is verified at pop time, so we might as well just
+  // fill the set fully, it's equivalent to saying "check everything"
   for(face_descriptor f : face_range)
-  {
-    internal::collect_badly_shaped_triangles(f, tmesh, vpm, vcm, ecm, gt,
-                                             cap_threshold, needle_threshold,
-                                             collapse_length_threshold, flip_triangle_height_threshold_squared,
-                                             edges_to_collapse, edges_to_flip);
-  }
+    edges_to_collapse.insert(halfedge(f, tmesh));
 
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
-  std::cout << edges_to_collapse.size() << " to collapse" << std::endl;
-  std::cout << edges_to_flip.size() << " to flip" << std::endl;
-#endif
-
+  // Start the process of removing bad elements
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
   int iter = 0;
 #endif
-
   for(;;)
   {
     bool something_was_done = false;
 
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
-    std::cout << edges_to_collapse.size() << " needles and " << edges_to_flip.size() << " caps" << std::endl;
     std::cout << "Iter: " << iter << std::endl;
+    std::cout << edges_to_collapse.size() << " needles and " << edges_to_flip.size() << " caps" << std::endl;
+
     std::ostringstream oss;
     oss << "degen_cleaning_iter_" << iter++ << ".off";
     CGAL::IO::write_polygon_mesh(oss.str(), tmesh, CGAL::parameters::stream_precision(17));
@@ -750,9 +743,8 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
     if(edges_to_collapse.empty() && edges_to_flip.empty())
       return true;
 
-    // @todo maybe using a priority queue handling the more almost degenerate elements should be used
-    std::set<halfedge_descriptor> next_edges_to_collapse;
-    std::set<halfedge_descriptor> next_edges_to_flip;
+    std::unordered_set<halfedge_descriptor> next_edges_to_collapse;
+    std::unordered_set<halfedge_descriptor> next_edges_to_flip;
 
     // Treat needles ===============================================================================
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
@@ -761,16 +753,40 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 #endif
     while(!edges_to_collapse.empty())
     {
+      // note that on the first iteration, 'h' does not indicate a known needle
       halfedge_descriptor h = *edges_to_collapse.begin();
       edges_to_collapse.erase(edges_to_collapse.begin());
+      CGAL_assertion(is_valid_halfedge_descriptor(h, tmesh));
+
+      // Verify that the element is still badly shaped
+      halfedge_descriptor needle_h = internal::is_it_a_needle(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
+                                                              needle_threshold, collapse_length_threshold);
+      if(needle_h == null_h)
+      {
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+        std::cout << "\t Needle criterion no longer verified" << std::endl;
+#endif
+        halfedge_descriptor cap_h = internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
+                                                          cap_threshold, flip_triangle_height_threshold_squared);
+        if(cap_h != null_h)
+        {
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+          std::cout << "\t\t But the face is a cap" << std::endl;
+#endif
+          edges_to_flip.insert(cap_h);
+        }
+        continue;
+      }
+      else
+      {
+        h = needle_h;
+      }
 
       CGAL_assertion(!is_border(h, tmesh));
 
       const edge_descriptor e = edge(h, tmesh);
       CGAL_assertion(!get(ecm, edge(h, tmesh)));
-
-      if(get(vcm, source(h, tmesh)) && get(vcm, target(h, tmesh)))
-        continue;
+      CGAL_assertion(!get(vcm, source(h, tmesh)) && !get(vcm, target(h, tmesh)));
 
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
       std::cout << "  treat needle: " << e
@@ -780,44 +796,49 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
 
       if(CGAL::Euler::does_satisfy_link_condition(e, tmesh))
       {
-        // Verify that the element is still badly shaped
-        const std::array<halfedge_descriptor, 2> nc =
-          internal::is_badly_shaped(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
-                                    needle_threshold, cap_threshold, collapse_length_threshold, flip_triangle_height_threshold_squared);
-
-        if(nc[0] != h)
-        {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
-          std::cout << "\t Needle criteria no longer verified" << std::endl;
-#endif
-          if (nc[1]!=boost::graph_traits<TriangleMesh>::null_halfedge()) edges_to_flip.insert(nc[1]);
-          continue;
-        }
-
-
         // pick the orientation of edge to keep the vertex minimizing the volume variation
         const halfedge_descriptor best_h = internal::get_best_edge_orientation(e, tmesh, vpm, vcm, gt);
-        if(best_h == boost::graph_traits<TriangleMesh>::null_halfedge())
+        if(best_h == null_h)
         {
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
             std::cout << "\t Geometrically invalid edge collapse!" << std::endl;
 #endif
-          if (nc[1]!=boost::graph_traits<TriangleMesh>::null_halfedge())
-            edges_to_flip.insert(nc[1]);
+          halfedge_descriptor cap_h = internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
+                                                            cap_threshold, flip_triangle_height_threshold_squared);
+          if(cap_h != null_h)
+          {
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+            std::cout << "\t\t But the face is a cap" << std::endl;
+#endif
+            edges_to_flip.insert(cap_h);
+          }
           else
+          {
             next_edges_to_collapse.insert(h);
+          }
+
           continue;
         }
 
-        if (!accept_change.collapse(edge(best_h, tmesh)))
+        if(!accept_change.collapse(edge(best_h, tmesh)))
         {
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
             std::cout << "\t edge collapse prevented by the user functor" << std::endl;
 #endif
-          if (nc[1]!=boost::graph_traits<TriangleMesh>::null_halfedge())
-            edges_to_flip.insert(nc[1]);
+          halfedge_descriptor cap_h = internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
+                                                            cap_threshold, flip_triangle_height_threshold_squared);
+          if(cap_h != null_h)
+          {
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+            std::cout << "\t\t But the face is a cap" << std::endl;
+#endif
+            edges_to_flip.insert(cap_h);
+          }
           else
+          {
             next_edges_to_collapse.insert(h);
+          }
+
           continue;
         }
 
@@ -888,10 +909,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
         {
           if(!is_border(hv, tmesh))
           {
-            internal::collect_badly_shaped_triangles(face(hv, tmesh), tmesh, vpm, vcm, ecm, gt,
-                                                     cap_threshold, needle_threshold,
-                                                     collapse_length_threshold, flip_triangle_height_threshold_squared,
-                                                     edges_to_collapse, edges_to_flip);
+            next_edges_to_collapse.insert(hv); // shape will be tested when popped
           }
         }
 
@@ -911,24 +929,23 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
         std::cout << "\t Uncollapsable edge!" << std::endl;
 #endif
 
-        halfedge_descriptor nc =
-          internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
-                                cap_threshold, flip_triangle_height_threshold_squared);
-
-        if (nc==boost::graph_traits<TriangleMesh>::null_halfedge())
-          next_edges_to_collapse.insert(h);
-        else
+        halfedge_descriptor cap_h = internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
+                                                          cap_threshold, flip_triangle_height_threshold_squared);
+        if(cap_h != null_h)
         {
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
-          std::cout << "\t Uncollapsable edge --> register it as cap!" << std::endl;
+            std::cout << "\t\t But the face is a cap" << std::endl;
 #endif
-          edges_to_flip.insert(nc);
+          edges_to_flip.insert(cap_h);
+        }
+        else
+        {
+          next_edges_to_collapse.insert(h);
         }
       }
     }
 
     // Treat caps ==================================================================================
-    CGAL_assertion(next_edges_to_flip.empty());
 
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
     kk=0;
@@ -938,8 +955,24 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
     {
       halfedge_descriptor h = *edges_to_flip.begin();
       edges_to_flip.erase(edges_to_flip.begin());
-
+      CGAL_assertion(is_valid_halfedge_descriptor(h, tmesh));
       CGAL_assertion(!is_border(h, tmesh));
+
+      // check if the face is still a cap
+      halfedge_descriptor cap_h = internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
+                                                        cap_threshold, flip_triangle_height_threshold_squared);
+
+      if(cap_h == null_h)
+      {
+#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
+        std::cout << "\t Cap criterion no longer verified" << std::endl;
+#endif
+        continue;
+      }
+      else
+      {
+        h = cap_h;
+      }
 
       const edge_descriptor e = edge(h, tmesh);
       CGAL_assertion(!get(ecm, e));
@@ -950,23 +983,11 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
                 << " --- " << target(e, tmesh) << " " << tmesh.point(target(h, tmesh)) << ")" << std::endl;
 #endif
 
-      halfedge_descriptor nc =
-        internal::is_it_a_cap(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
-                              cap_threshold, flip_triangle_height_threshold_squared);
-      // Check the triangle is still a cap
-      if(nc != h)
-      {
-#ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
-        std::cout << "\t Cap criteria no longer verified" << std::endl;
-#endif
-        continue;
-      }
-
       // special case of `edge(h, tmesh)` being a border edge --> remove the face
       if(is_border(opposite(h, tmesh), tmesh))
       {
-        // check a non-manifold vertex won't be created
-        bool removal_is_nm=false;
+        // check that a non-manifold vertex won't be created
+        bool removal_is_nm = false;
         for(halfedge_descriptor hh : CGAL::halfedges_around_target(next(h, tmesh), tmesh))
         {
           if (is_border(hh, tmesh))
@@ -975,11 +996,13 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
             break;
           }
         }
-        if (removal_is_nm) continue;
+
+        if(removal_is_nm)
+          continue;
 
         for(halfedge_descriptor hh : CGAL::halfedges_around_face(h, tmesh))
         {
-          // Remove from even 'next_edges_to_flip' because it might have been re-added from a flip
+          // Remove from 'next_edges_to_flip' because it might have been re-added from a flip
           edges_to_flip.erase(hh);
           next_edges_to_flip.erase(hh);
           next_edges_to_collapse.erase(hh);
@@ -1025,16 +1048,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
         for(int i=0; i<2; ++i)
         {
           CGAL_assertion(!is_border(h, tmesh));
-          std::array<halfedge_descriptor, 2> nc =
-            internal::is_badly_shaped(face(h, tmesh), tmesh, vpm, vcm, ecm, gt,
-                                      needle_threshold, cap_threshold,
-                                      collapse_length_threshold, flip_triangle_height_threshold_squared);
-
-          if(nc[1] != boost::graph_traits<TriangleMesh>::null_halfedge() && nc[1] != h)
-            next_edges_to_flip.insert(nc[1]);
-          else if(nc[0] != boost::graph_traits<TriangleMesh>::null_halfedge())
-            next_edges_to_collapse.insert(nc[0]);
-
+          next_edges_to_collapse.insert(h);
           h = opposite(h, tmesh);
         }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -725,10 +725,21 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
   std::unordered_set<halfedge_descriptor> edges_to_collapse;
   std::unordered_set<halfedge_descriptor> edges_to_flip;
 
-  // Needless-ness and cap-ness is verified at pop time, so we might as well just
-  // fill the set fully, it's equivalent to saying "check everything"
+  // initial needless-ness and cap-ness checks
   for(face_descriptor f : face_range)
-    edges_to_collapse.insert(halfedge(f, tmesh));
+  {
+    halfedge_descriptor needle_h = internal::is_it_a_needle(f, tmesh, vpm, vcm, ecm, gt,
+                                                            needle_threshold, collapse_length_threshold);
+    if(needle_h != null_h)
+      edges_to_collapse.insert(needle_h);
+    else
+    {
+      halfedge_descriptor cap_h = internal::is_it_a_cap(f, tmesh, vpm, vcm, ecm, gt,
+                                                        cap_threshold, flip_triangle_height_threshold_squared);
+      if(cap_h != null_h)
+        edges_to_flip.insert(cap_h);
+    }
+  }
 
   // Start the process of removing bad elements
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -151,33 +151,30 @@ void collect_badly_shaped_triangles(const typename boost::graph_traits<TriangleM
 {
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor       halfedge_descriptor;
 
+  const halfedge_descriptor null_h = boost::graph_traits<TriangleMesh>::null_halfedge();
+
   std::array<halfedge_descriptor, 2> res = is_badly_shaped(f, tmesh, vpm, vcm, ecm, gt,
                                                            needle_threshold, cap_threshold,
                                                            collapse_length_threshold, flip_triangle_height_threshold_squared);
 
-  if(res[0] != boost::graph_traits<TriangleMesh>::null_halfedge())
+  if(res[0] != null_h)
   {
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
-    if (res[1] == boost::graph_traits<TriangleMesh>::null_halfedge())
-      std::cout << "add new needle: " << edge(res[0], tmesh) << std::endl;
-    else
-      std::cout << "add new needle (also a cap): " << edge(res[0], tmesh) << std::endl;
+    std::cout << "add new needle: " << edge(res[0], tmesh) << std::endl;
 #endif
     CGAL_assertion(!is_border(res[0], tmesh));
     CGAL_assertion(!get(ecm, edge(res[0], tmesh)));
     edges_to_collapse.insert(res[0]);
   }
-  else // let's not make it possible to have a face be both a cap and a needle (for now)
+
+  if(res[1] != null_h)
   {
-    if(res[1] != boost::graph_traits<TriangleMesh>::null_halfedge())
-    {
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES_EXTRA
-      std::cout << "add new cap: " << edge(res[1],tmesh) << std::endl;
+    std::cout << "add new cap: " << edge(res[1],tmesh) << std::endl;
 #endif
-      CGAL_assertion(!is_border(res[1], tmesh));
-      CGAL_assertion(!get(ecm, edge(res[1], tmesh)));
-      edges_to_flip.insert(res[1]);
-    }
+    CGAL_assertion(!is_border(res[1], tmesh));
+    CGAL_assertion(!get(ecm, edge(res[1], tmesh)));
+    edges_to_flip.insert(res[1]);
   }
 }
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -62,7 +62,9 @@ is_it_a_needle(const typename boost::graph_traits<TriangleMesh>::face_descriptor
                const double collapse_length_threshold) // max length of edges allowed to be collapsed
 {
   namespace PMP = CGAL::Polygon_mesh_processing;
+
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor       halfedge_descriptor;
+
   const halfedge_descriptor null_h = boost::graph_traits<TriangleMesh>::null_halfedge();
 
   halfedge_descriptor res = PMP::is_needle_triangle_face(f, tmesh, needle_threshold,
@@ -93,7 +95,9 @@ is_it_a_cap(const typename boost::graph_traits<TriangleMesh>::face_descriptor f,
             const double flip_triangle_height_threshold_squared) // max height of triangles allowed to be flipped
 {
   namespace PMP = CGAL::Polygon_mesh_processing;
+
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor       halfedge_descriptor;
+
   const halfedge_descriptor null_h = boost::graph_traits<TriangleMesh>::null_halfedge();
 
   halfedge_descriptor res =
@@ -110,6 +114,7 @@ is_it_a_cap(const typename boost::graph_traits<TriangleMesh>::face_descriptor f,
   return null_h;
 }
 
+// This function tests both needle-ness and cap-ness
 template <typename TriangleMesh, typename VPM, typename VCM, typename ECM, typename Traits>
 std::array<typename boost::graph_traits<TriangleMesh>::halfedge_descriptor, 2>
 is_badly_shaped(const typename boost::graph_traits<TriangleMesh>::face_descriptor f,
@@ -123,8 +128,8 @@ is_badly_shaped(const typename boost::graph_traits<TriangleMesh>::face_descripto
                 const double collapse_length_threshold, // max length of edges allowed to be collapsed
                 const double flip_triangle_height_threshold_squared) // max height of triangles allowed to be flipped
 {
-
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor       halfedge_descriptor;
+
   const halfedge_descriptor null_h = boost::graph_traits<TriangleMesh>::null_halfedge();
   std::array<halfedge_descriptor,2> retval = make_array(null_h, null_h);
 
@@ -134,6 +139,7 @@ is_badly_shaped(const typename boost::graph_traits<TriangleMesh>::face_descripto
   return retval;
 }
 
+// This function tests both needle-ness and cap-ness and fills both ranges
 template <typename TriangleMesh, typename HalfedgeContainer,
           typename VPM, typename VCM, typename ECM, typename Traits>
 void collect_badly_shaped_triangles(const typename boost::graph_traits<TriangleMesh>::face_descriptor f,
@@ -695,6 +701,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
   CGAL_precondition(is_valid_polygon_mesh(tmesh));
   CGAL_precondition(is_triangle_mesh(tmesh));
 
+  // constrain extremities of constrained edges
   for(face_descriptor f : face_range)
   {
     if(f == boost::graph_traits<TriangleMesh>::null_face())
@@ -899,7 +906,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
         else
           v = Euler::collapse_edge(edge(best_h, tmesh), tmesh);
 
-        // moving to the midpoint is not a good idea. On a circle for example you might endpoint with
+        // moving to the midpoint is not a good idea. On a circle for example you might end with
         // a bad geometry because you iteratively move one point
         // auto mp = midpoint(tmesh.point(source(h, tmesh)), tmesh.point(target(h, tmesh)));
         // tmesh.point(v) = mp;
@@ -951,6 +958,7 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
     kk=0;
     std::ofstream(std::string("tmp/c-000.off")) << tmesh;
 #endif
+
     while(!edges_to_flip.empty())
     {
       halfedge_descriptor h = *edges_to_flip.begin();

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_remove_caps_needles.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_remove_caps_needles.cpp
@@ -28,7 +28,7 @@ void general_test(std::string filename)
   std::ifstream input(filename);
 
   Mesh mesh;
-  if (!input || !(input >> mesh) || !CGAL::is_triangle_mesh(mesh)) {
+  if (!CGAL::IO::read_polygon_mesh(filename, mesh) || !CGAL::is_triangle_mesh(mesh)) {
     std::cerr << "Not a valid input file." << std::endl;
     exit(EXIT_FAILURE);
   }
@@ -56,7 +56,8 @@ void test_with_envelope(std::string filename, double eps)
   std::ifstream input(filename);
 
   Mesh mesh, bk;
-  if (!input || !(input >> mesh) || !CGAL::is_triangle_mesh(mesh)) {
+  if (!CGAL::IO::read_polygon_mesh(filename, mesh) || !CGAL::is_triangle_mesh(mesh))
+  {
     std::cerr << "Not a valid input file." << std::endl;
     exit(EXIT_FAILURE);
   }
@@ -131,7 +132,8 @@ void test_parameters_on_pig(std::string filename)
   std::ifstream input(filename);
 
   Mesh mesh, bk;
-  if (!input || !(input >> mesh) || !CGAL::is_triangle_mesh(mesh)) {
+  if (!CGAL::IO::read_polygon_mesh(filename, mesh) || !CGAL::is_triangle_mesh(mesh))
+  {
     std::cerr << "Not a valid input file." << std::endl;
     exit(EXIT_FAILURE);
   }
@@ -164,13 +166,11 @@ void test_parameters_on_pig(std::string filename)
 int main(int argc, char** argv)
 {
   const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/pig.off");
+  double eps = (argc > 2) ? atof(argv[2]) : 0.01;
 
   general_test(filename);
-  if (argc==2)
-    test_with_envelope(filename, 0.01);
-  else
-    if (argc==3)
-      test_with_envelope(filename, atof(argv[2]));
+
+  test_with_envelope(filename, eps);
 
   // only run that test with pig.off
   if (argc==1)


### PR DESCRIPTION
if a needle is also a cap, it will be handled as a needle only. But if we can't collapse the edge, a flip will not be tried. Try the flip too.

Note that this will slow down the method as the status of a triangle is tested twice.

Fix #8605