### PR TITLE
Remove extra rounding mode changes for sqrt for interval

### DIFF
--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -618,6 +618,7 @@ inline double IA_sqrt_toward_zero(double d) {
 #ifdef CGAL_ALWAYS_ROUND_TO_NEAREST
   return (d > 0.0) ? nextafter(std::sqrt(d), 0.) : 0.0;
 #else
+  CGAL_assertion(FPU_get_cw()==CGAL_FE_UPWARD);
   FPU_set_cw(CGAL_FE_DOWNWARD);
   double i = (d > 0.0) ? CGAL_IA_FORCE_TO_DOUBLE(CGAL_BUG_SQRT(CGAL_IA_STOP_CPROP(d))) : 0.0;
   FPU_set_cw(CGAL_FE_UPWARD);


### PR DESCRIPTION
The only place where the function is call is in `Interval_nt::sqrt()` and that functions start with the creation of a protector.
Even worse, if we are using interval with no protection, we get an incorrect rounding mode after a call to sqrt.