### PR TITLE
IO of OpenMesh files - use `double`s instead of `float`s

### DIFF
--- a/BGL/include/CGAL/boost/graph/IO/OM.h
+++ b/BGL/include/CGAL/boost/graph/IO/OM.h
@@ -74,7 +74,8 @@ bool read_OM(const std::string& fname, Graph& g, VPM vpm, VFeaturePM vfpm, EFeat
 }
 
 template <typename Graph, typename VPM, typename VFeaturePM, typename EFeaturePM>
-bool write_OM(std::string fname, const Graph& g, VPM vpm, VFeaturePM vfpm, EFeaturePM efpm)
+bool write_OM(std::string fname, const Graph& g, VPM vpm, VFeaturePM vfpm, EFeaturePM efpm,
+              const std::streamsize precision)
 {
   typedef OpenMesh::PolyMesh_ArrayKernelT<OpenMesh::DefaultTraitsDouble> OMesh;
   typedef typename boost::graph_traits<OMesh>::vertex_descriptor om_vertex_descriptor;
@@ -109,7 +110,7 @@ bool write_OM(std::string fname, const Graph& g, VPM vpm, VFeaturePM vfpm, EFeat
     omesh.status(omv).set_feature(isfeature);
   }
 
-  return OpenMesh::IO::write_mesh(omesh, fname, OpenMesh::IO::Options::Status, 18);
+  return OpenMesh::IO::write_mesh(omesh, fname, OpenMesh::IO::Options::Status, precision);
 }
 } // end of internal namespace
 
@@ -209,6 +210,11 @@ bool read_OM(const std::string& fname,
       \cgalParamType{a class model of `ReadablePropertyMap` with `boost::graph_traits<Graph>::%vertex_descriptor`
                      as key type and `bool` as value type.}
     \cgalParamNEnd
+    \cgalParamNBegin{stream_precision}
+      \cgalParamDescription{a parameter used to set the precision (i.e. how many digits are generated) of the output stream}
+      \cgalParamType{int}
+      \cgalParamDefault{the precision of the stream `os`}
+    \cgalParamNEnd
   \cgalNamedParamsEnd
 
   \returns `true` if writing was successful, `false` otherwise.
@@ -229,7 +235,9 @@ bool write_OM(const std::string& fname,
                                CGAL::Constant_property_map<edge_descriptor, bool>(false));
   auto vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                               get_const_property_map(vertex_point, g));
-  return internal::write_OM(fname, g, vpm, vfpm, efpm);
+  std::streamsize precision = choose_parameter(get_parameter(np, internal_np::stream_precision),
+                                               18);
+  return internal::write_OM(fname, g, vpm, vfpm, efpm, precision);
 }
 
 

--- a/BGL/include/CGAL/boost/graph/IO/OM.h
+++ b/BGL/include/CGAL/boost/graph/IO/OM.h
@@ -15,6 +15,7 @@
 
 #include <OpenMesh/Core/IO/MeshIO.hh>
 #include <OpenMesh/Core/Mesh/TriMesh_ArrayKernelT.hh>
+#include <OpenMesh/Core/Mesh/Traits.hh>
 
 #include <CGAL/boost/graph/copy_face_graph.h>
 #include <CGAL/boost/graph/graph_traits_PolyMesh_ArrayKernelT.h>
@@ -34,7 +35,7 @@ namespace internal {
 template <typename Graph, typename VPM, typename VFeaturePM, typename EFeaturePM>
 bool read_OM(const std::string& fname, Graph& g, VPM vpm, VFeaturePM vfpm, EFeaturePM efpm)
 {
-  typedef OpenMesh::PolyMesh_ArrayKernelT<> OMesh;
+  typedef OpenMesh::PolyMesh_ArrayKernelT<OpenMesh::DefaultTraitsDouble> OMesh;
   typedef typename boost::graph_traits<OMesh>::vertex_descriptor om_vertex_descriptor;
   typedef typename boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor;
   typedef typename boost::graph_traits<OMesh>::halfedge_descriptor om_halfedge_descriptor;
@@ -75,7 +76,7 @@ bool read_OM(const std::string& fname, Graph& g, VPM vpm, VFeaturePM vfpm, EFeat
 template <typename Graph, typename VPM, typename VFeaturePM, typename EFeaturePM>
 bool write_OM(std::string fname, const Graph& g, VPM vpm, VFeaturePM vfpm, EFeaturePM efpm)
 {
-  typedef OpenMesh::PolyMesh_ArrayKernelT<> OMesh;
+  typedef OpenMesh::PolyMesh_ArrayKernelT<OpenMesh::DefaultTraitsDouble> OMesh;
   typedef typename boost::graph_traits<OMesh>::vertex_descriptor om_vertex_descriptor;
   typedef typename boost::graph_traits<Graph>::vertex_descriptor vertex_descriptor;
   typedef typename boost::graph_traits<OMesh>::halfedge_descriptor om_halfedge_descriptor;
@@ -108,7 +109,7 @@ bool write_OM(std::string fname, const Graph& g, VPM vpm, VFeaturePM vfpm, EFeat
     omesh.status(omv).set_feature(isfeature);
   }
 
-  return OpenMesh::IO::write_mesh(omesh, fname, OpenMesh::IO::Options::Status);
+  return OpenMesh::IO::write_mesh(omesh, fname, OpenMesh::IO::Options::Status, 18);
 }
 } // end of internal namespace
 

--- a/Lab/demo/Lab/Plugins/IO/OM_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/IO/OM_io_plugin.cpp
@@ -180,12 +180,14 @@ save(QFileInfo fileinfo, QList<CGAL::Three::Scene_item*>& items)
     res = CGAL::IO::write_OM((const char*)fileinfo.filePath().toUtf8()
               , *sm_item->face_graph()
               , CGAL::parameters::vertex_is_constrained_map(selection_item->constrained_vertices_pmap())
-              .edge_is_constrained_map(selection_item->constrained_edges_pmap()));
+              .edge_is_constrained_map(selection_item->constrained_edges_pmap())
+              .stream_precision(18));
   }
   else
   {
     res = CGAL::IO::write_OM((const char*)fileinfo.filePath().toUtf8()
-              , *sm_item->face_graph());
+              , *sm_item->face_graph()
+              , CGAL::parameters::stream_precision(18));
   }
 
   if (res)

--- a/Lab/demo/Lab/Plugins/IO/OM_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/IO/OM_io_plugin.cpp
@@ -181,13 +181,13 @@ save(QFileInfo fileinfo, QList<CGAL::Three::Scene_item*>& items)
               , *sm_item->face_graph()
               , CGAL::parameters::vertex_is_constrained_map(selection_item->constrained_vertices_pmap())
               .edge_is_constrained_map(selection_item->constrained_edges_pmap())
-              .stream_precision(18));
+              .stream_precision(17));
   }
   else
   {
     res = CGAL::IO::write_OM((const char*)fileinfo.filePath().toUtf8()
               , *sm_item->face_graph()
-              , CGAL::parameters::stream_precision(18));
+              , CGAL::parameters::stream_precision(17));
   }
 
   if (res)


### PR DESCRIPTION
## Summary of Changes

The default OpenMesh point type is made of `float`s. This PR changes the traits we use in CGAL to you `double`s and ensure that reading an off/writing an om/reading om gives the same result back.
This PR completes #8427

## Release Management

* Affected package(s): BGL, Demo
* License and copyright ownership: unchanged

