### PR TITLE
Testsuite: Custom platform names display in test results

### DIFF
--- a/Maintenance/test_handling/create_testresult_page
+++ b/Maintenance/test_handling/create_testresult_page
@@ -155,8 +155,15 @@ sub collect_results_of_platform($)
 # Create an anonymous hash that hashes packages to their result.
     my $platform_results = {};
     my $test_result="results_${platform}.txt";
+    my $display_name = $platform;
     my ($yeahs, $nays, $warnings,$third_party_warnings,$timeout,$reqs) = (0,0,0,0,0,0);
     my $resulttext;
+    if (open(PLATFORM_INFO, "results_${platform}.info")) {
+        my @info = <PLATFORM_INFO>;
+        chomp(@info);
+        $display_name = $info[-1] if ($info[-1] ne "-");
+        close(PLATFORM_INFO);
+    }
     open(TESTRESULT, $test_result) or return $platform_results;
     while (<TESTRESULT>) {
         if (/^\s*(.*?)\s+(\w)\s*$/) {
@@ -192,6 +199,7 @@ sub collect_results_of_platform($)
     $platform_results->{"t"} = $third_party_warnings;
     $platform_results->{"o"} = $timeout;
     $platform_results->{"r"} = $reqs;
+    $platform_results->{"display_name"} = $display_name;
     return $platform_results;
 }
 
@@ -490,6 +498,7 @@ sub print_platform_descriptions()
 EOF
     my ($platform_num)=(0);
     foreach $pf (@platforms_to_do) {
+        my $display_name = $testresults[$platform_num]->{"display_name"} || $pf;
         my $pf_num_plus_one = $platform_num + 1;
         print OUTPUT "<tr>\n<td><a name=\"platform$pf_num_plus_one\">$pf_no</a>\n";
         $pf_no++;
@@ -504,7 +513,7 @@ EOF
             $_ = <PLATFORM_INFO>; # COMPILER
             chomp;
             my $compiler = $_;
-            print OUTPUT " title=\"$compiler\">$pf_short</a>";
+            print OUTPUT " title=\"$compiler\">$display_name</a>";
             $_ = <PLATFORM_INFO>; # OPERATING_SYSTEM
             chomp;
             my $operating_system = $_;

--- a/Maintenance/test_handling/to_zipped_format
+++ b/Maintenance/test_handling/to_zipped_format
@@ -51,7 +51,7 @@ sub reformat_results($)
     $_ = $line;
     open (PLATFORM_INFO,">${platform}.info") or return;
     open (PLATFORM_NEW_RESULTS,">${platform}.new_results") or return;
-    my ($CGAL_VERSION,$LEDA_VERSION,$COMPILER,$OS,$TESTER_NAME,$TESTER_ADDRESS,$GMP,$MPFR,$ZLIB,$OPENGL,$BOOST,$QT,$CMAKE,$TPL) = ("-","-","-","-","-","-","-","-","-","-","-","-","no","TPL:");
+    my ($CGAL_VERSION,$LEDA_VERSION,$COMPILER,$OS,$TESTER_NAME,$TESTER_ADDRESS,$GMP,$MPFR,$ZLIB,$OPENGL,$BOOST,$QT,$CMAKE,$TPL,$PLATFORM_NAME) = ("-","-","-","-","-","-","-","-","-","-","-","-","no","TPL:","-");
     my ($LDFLAGS,$CXXFLAGS) = ("", "");
     while (! /^------/) {
         if(/^\s*$/) {
@@ -138,6 +138,12 @@ sub reformat_results($)
     if (/^-- Third-party library (.+)$/) {
         $TPL = "$TPL $1,";
     }
+    if (/^CGAL_TEST_PLATFORM\s+(.*)$/) {
+        $PLATFORM_NAME = $1 if ($PLATFORM_NAME eq "-");
+    }
+    if (/^CGAL_SUMMARY_NAME\s+(.*)$/) {
+        $PLATFORM_NAME = $1;
+    }
 NEXT:	if(! ($_= <PLATFORM_RESULTS>)) {
             # should never happen!!
             last;
@@ -162,6 +168,7 @@ $LEDA_VERSION
 $CXXFLAGS
 $LDFLAGS
 $TPL
+$PLATFORM_NAME
 EOF
     close(PLATFORM_INFO);
     close(PLATFORM_RESULTS);


### PR DESCRIPTION
## Summary of Changes

Update Perl scripts to support custom platform display names through CGAL_SUMMARY_NAME variable.

