### PR TITLE
Mesh 3 fix `min_size` when using external sizing like `Sizing_field_with_aabb_tree`

### DIFF
--- a/Lab/demo/Lab/Plugins/Mesh_3/Mesh_function.h
+++ b/Lab/demo/Lab/Plugins/Mesh_3/Mesh_function.h
@@ -139,28 +139,30 @@ QStringList
 Mesh_parameters::
 log() const
 {
+  auto is_valid = [](const double d)->bool { return d > 0. && d != DBL_MAX; };
+
   QStringList res("Mesh criteria");
 
   // doubles
-  if(edge_sizing > 0)
+  if(is_valid(edge_sizing))
     res << QString("edge max size: %1").arg(edge_sizing);
-  if(edge_min_sizing > 0)
+  if(is_valid(edge_min_sizing))
     res << QString("edge min size: %1").arg(edge_min_sizing);
-  if(edge_distance > 0)
+  if(is_valid(edge_distance))
     res << QString("edge max distance: %1").arg(edge_distance);
-  if(facet_angle > 0)
+  if(is_valid(facet_angle))
     res << QString("facet min angle: %1").arg(facet_angle);
-  if(facet_sizing > 0)
+  if(is_valid(facet_sizing))
     res << QString("facet max size: %1").arg(facet_sizing);
-  if(facet_min_sizing > 0)
+  if(is_valid(facet_min_sizing))
     res << QString("facet min size: %1").arg(facet_min_sizing);
-  if(facet_approx > 0)
+  if(is_valid(facet_approx))
     res << QString("facet approx error: %1").arg(facet_approx);
-  if(tet_shape > 0)
+  if(is_valid(tet_shape))
     res << QString("tet shape (radius-edge): %1").arg(tet_shape);
-  if(tet_sizing > 0)
+  if(is_valid(tet_sizing))
     res << QString("tet max size: %1").arg(tet_sizing);
-  if(tet_min_sizing > 0)
+  if(is_valid(tet_min_sizing))
     res << QString("tet min size: %1").arg(tet_min_sizing);
 
   // booleans

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -455,33 +455,16 @@ private:
     // negative value (marker for special balls).
     if(dim < 0)
       dim = -1 - dim;
-
-    const FT s = field(p, dim, index);
-    if(s < minimal_size_)
-    {
-      std::stringstream msg;
-      msg.precision(17);
-      msg << "Error: the field is smaller than minimal size ("
-        << minimal_size_ << ") at ";
-      if(dim == 0) msg << "corner (";
-      else msg << "point (";
-      msg << p << ")";
-#if CGAL_MESH_3_PROTECTION_DEBUG & 4
-      CGAL_error_msg(([this, str = msg.str()](){
-        dump_c3t3(this->c3t3_, "dump-bug");
-        return str.c_str();
-      }()));
-#else // not CGAL_MESH_3_PROTECTION_DEBUG & 4
-      CGAL_error_msg(msg.str().c_str());
-#endif
-    }
-    return s;
+    else
+      return field(p, dim, index);
   }
 
   /// Query the sizing field and return its value at the point `p`
   FT query_size(const Bare_point& p, int dim, const Index& index) const
   {
     FT s = query_field(p, dim, index, size_);
+    if (use_minimal_size() && s < minimal_size_)
+      return minimal_size_;
     return s;
   }
 

--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -455,8 +455,8 @@ private:
     // negative value (marker for special balls).
     if(dim < 0)
       dim = -1 - dim;
-    else
-      return field(p, dim, index);
+
+    return field(p, dim, index);
   }
 
   /// Query the sizing field and return its value at the point `p`


### PR DESCRIPTION
## Summary of Changes

Using `min_size` with `Sizing_field_with_aabb_tree` (and probably other sizing fields) could lead to `CGAL_error_msg()` though the scenario was "normal".

This PR fixes this issue (and completes PR #8405)

## Release Management

* Affected package(s): Mesh_3
