### PR TITLE
fixed mandatory code in CGAL_assert

### DIFF
--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_CK_traits_2.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_CK_traits_2.h
@@ -249,15 +249,15 @@ namespace internal {
         std::pair<Circular_arc_point_2, unsigned> pair;
 
         CGAL_assertion_code(bool ok=)
-	  assign(pair,inters[0]);
+        assign(pair,inters[0]);
         CGAL_assertion(ok);
-	CGAL_assertion(pair.second == 1);
+        CGAL_assertion(pair.second == 1);
         if(_gt.less_y_2_object()(p, q))
           return Line_arc_2(bis_pq,a,pair.first);
 
-	CGAL_assertion_code(bool ok=)
-	  assign(pair,inters[1]);
-	CGAL_assertion(ok);
+        CGAL_assertion_code(ok=)
+        assign(pair,inters[1]);
+        CGAL_assertion(ok);
         CGAL_assertion(pair.second == 1);
         return Line_arc_2(bis_pq,a,pair.first);
       }
@@ -274,7 +274,7 @@ namespace internal {
       std::pair<Circular_arc_point_2, unsigned> pair;
 
       CGAL_assertion_code(bool ok=)
-	assign(pair,inters[0]);
+      assign(pair,inters[0]);
       CGAL_assertion(ok);
       CGAL_assertion(pair.second == 1);
 
@@ -289,8 +289,8 @@ namespace internal {
         return Circular_arc_2(*c_pq, pair.first, a);
       }
 
-      CGAL_assertion_code(bool ok=)
-	assign(pair,inters[1]);
+      CGAL_assertion_code(ok=)
+      assign(pair,inters[1]);
       CGAL_assertion(ok);
       if(_gt.orientation_2_object()(approx_c,approx_a,approx_pinf) == POSITIVE)
         return Circular_arc_2(*c_pq, pair.first, a);

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_CK_traits_2.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_CK_traits_2.h
@@ -77,16 +77,18 @@ namespace internal {
           std::vector< Intersection_result > inters;
           intersection(*c_pq, *c_qr, std::back_inserter(inters));
 
-          CGAL_assertion(assign(pair, inters[0]));
-	  assign(pair, inters[0]);
-          if(pair.second == 1)
+          CGAL_assertion_code(bool ok=)
+	    assign(pair, inters[0]);
+	  CGAL_assertion(ok);
+	  if(pair.second == 1)
           {
             if(_gt.has_on_bounded_side_2_object()(l_inf, pair.first))
               return pair.first;
 
-            CGAL_assertion(assign(pair, inters[1]));
-	    assign(pair, inters[1]);
-            return pair.first;
+            CGAL_assertion_code(bool ok=)
+	      assign(pair, inters[1]);
+            CGAL_assertion(ok);
+	    return pair.first;
           }
           return pair.first;
         }
@@ -106,16 +108,18 @@ namespace internal {
       std::vector< Intersection_result > inters;
       intersection(*l, *c, std::back_inserter(inters));
 
-      CGAL_assertion(assign(pair,inters[0]));
-      assign(pair,inters[0]);
+      CGAL_assertion_code(bool ok=)
+	  assign(pair,inters[0]);
+      CGAL_assertion(ok);
       if(pair.second == 1)
       {
         if(_gt.has_on_bounded_side_2_object()(l_inf, pair.first))
           return pair.first;
 
-        CGAL_assertion(assign(pair, inters[1]));
-	assign(pair, inters[1]);
-        return pair.first;
+        CGAL_assertion_code(bool ok=)
+	  assign(pair, inters[1]);
+	CGAL_assertion(ok);
+	return pair.first;
       }
       return pair.first;
     }
@@ -244,14 +248,16 @@ namespace internal {
         intersection(bis_pq, l_inf, std::back_inserter(inters));
         std::pair<Circular_arc_point_2, unsigned> pair;
 
-        CGAL_assertion(assign(pair,inters[0]));
-	assign(pair,inters[0]);
-        CGAL_assertion(pair.second == 1);
+        CGAL_assertion_code(bool ok=)
+	  assign(pair,inters[0]);
+        CGAL_assertion(ok);
+	CGAL_assertion(pair.second == 1);
         if(_gt.less_y_2_object()(p, q))
           return Line_arc_2(bis_pq,a,pair.first);
 
-        CGAL_assertion(assign(pair,inters[1]));
-	assign(pair,inters[1]);
+	CGAL_assertion_code(bool ok=)
+	  assign(pair,inters[1]);
+	CGAL_assertion(ok);
         CGAL_assertion(pair.second == 1);
         return Line_arc_2(bis_pq,a,pair.first);
       }
@@ -267,8 +273,9 @@ namespace internal {
       intersection(*c_pq, l_inf, std::back_inserter(inters));
       std::pair<Circular_arc_point_2, unsigned> pair;
 
-      CGAL_assertion(assign(pair,inters[0]));
-      assign(pair,inters[0]);
+      CGAL_assertion_code(bool ok=)
+	assign(pair,inters[0]);
+      CGAL_assertion(ok);
       CGAL_assertion(pair.second == 1);
 
       Hyperbolic_point_2 approx_pinf(to_double(pair.first.x()), to_double(pair.first.y()));
@@ -282,8 +289,9 @@ namespace internal {
         return Circular_arc_2(*c_pq, pair.first, a);
       }
 
-      CGAL_assertion(assign(pair,inters[1]));
-      assign(pair,inters[1]);
+      CGAL_assertion_code(bool ok=)
+	assign(pair,inters[1]);
+      CGAL_assertion(ok);
       if(_gt.orientation_2_object()(approx_c,approx_a,approx_pinf) == POSITIVE)
         return Circular_arc_2(*c_pq, pair.first, a);
 

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_CK_traits_2.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_CK_traits_2.h
@@ -78,17 +78,17 @@ namespace internal {
           intersection(*c_pq, *c_qr, std::back_inserter(inters));
 
           CGAL_assertion_code(bool ok=)
-	    assign(pair, inters[0]);
-	  CGAL_assertion(ok);
-	  if(pair.second == 1)
+          assign(pair, inters[0]);
+          CGAL_assertion(ok);
+          if(pair.second == 1)
           {
             if(_gt.has_on_bounded_side_2_object()(l_inf, pair.first))
               return pair.first;
 
             CGAL_assertion_code(bool ok=)
-	      assign(pair, inters[1]);
+            assign(pair, inters[1]);
             CGAL_assertion(ok);
-	    return pair.first;
+            return pair.first;
           }
           return pair.first;
         }
@@ -109,7 +109,7 @@ namespace internal {
       intersection(*l, *c, std::back_inserter(inters));
 
       CGAL_assertion_code(bool ok=)
-	  assign(pair,inters[0]);
+      assign(pair,inters[0]);
       CGAL_assertion(ok);
       if(pair.second == 1)
       {
@@ -117,9 +117,9 @@ namespace internal {
           return pair.first;
 
         CGAL_assertion_code(bool ok=)
-	  assign(pair, inters[1]);
-	CGAL_assertion(ok);
-	return pair.first;
+        assign(pair, inters[1]);
+        CGAL_assertion(ok);
+        return pair.first;
       }
       return pair.first;
     }

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_CK_traits_2.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_CK_traits_2.h
@@ -78,12 +78,14 @@ namespace internal {
           intersection(*c_pq, *c_qr, std::back_inserter(inters));
 
           CGAL_assertion(assign(pair, inters[0]));
+	  assign(pair, inters[0]);
           if(pair.second == 1)
           {
             if(_gt.has_on_bounded_side_2_object()(l_inf, pair.first))
               return pair.first;
 
             CGAL_assertion(assign(pair, inters[1]));
+	    assign(pair, inters[1]);
             return pair.first;
           }
           return pair.first;
@@ -105,12 +107,14 @@ namespace internal {
       intersection(*l, *c, std::back_inserter(inters));
 
       CGAL_assertion(assign(pair,inters[0]));
+      assign(pair,inters[0]);
       if(pair.second == 1)
       {
         if(_gt.has_on_bounded_side_2_object()(l_inf, pair.first))
           return pair.first;
 
         CGAL_assertion(assign(pair, inters[1]));
+	assign(pair, inters[1]);
         return pair.first;
       }
       return pair.first;
@@ -241,11 +245,13 @@ namespace internal {
         std::pair<Circular_arc_point_2, unsigned> pair;
 
         CGAL_assertion(assign(pair,inters[0]));
+	assign(pair,inters[0]);
         CGAL_assertion(pair.second == 1);
         if(_gt.less_y_2_object()(p, q))
           return Line_arc_2(bis_pq,a,pair.first);
 
         CGAL_assertion(assign(pair,inters[1]));
+	assign(pair,inters[1]);
         CGAL_assertion(pair.second == 1);
         return Line_arc_2(bis_pq,a,pair.first);
       }
@@ -262,6 +268,7 @@ namespace internal {
       std::pair<Circular_arc_point_2, unsigned> pair;
 
       CGAL_assertion(assign(pair,inters[0]));
+      assign(pair,inters[0]);
       CGAL_assertion(pair.second == 1);
 
       Hyperbolic_point_2 approx_pinf(to_double(pair.first.x()), to_double(pair.first.y()));
@@ -276,6 +283,7 @@ namespace internal {
       }
 
       CGAL_assertion(assign(pair,inters[1]));
+      assign(pair,inters[1]);
       if(_gt.orientation_2_object()(approx_c,approx_a,approx_pinf) == POSITIVE)
         return Circular_arc_2(*c_pq, pair.first, a);
 


### PR DESCRIPTION
## Summary of Changes

Some code was embedded in CGAL_assert so was only working in Debug mode. The mandatory code is now also outside the assert
This is a bug-fix

## Release Management

* Affected package(s): Hyperbolic_triangulation_2
