### PR TITLE
LaTeX compliance for formulas and errors in bibliography

### DIFF
--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
@@ -1491,7 +1491,7 @@ educational purposes, and thus we do not elaborate on this strategy.
 The data structure needed by the landmark and the trapezoidal map RIC
 strategies can be constructed in \cgalBigO{N \log N} time, where \f$N\f$
 is the overall number of edges in the arrangement, but the constant
-hidden in the \cgalBigO{&nbsp;} notation for the trapezoidal map RIC strategy
+hidden in the \cgalBigO{~} notation for the trapezoidal map RIC strategy
 is much larger. Thus, construction needed by the landmark algorithm is
 in practice significantly faster than the construction needed by the
 trapezoidal map RIC strategy. In addition, although both resulting
@@ -2038,8 +2038,8 @@ so it must be construct from scratch.
 
 In the first case, we sweep over the input curves, compute their
 intersection points, and construct the \dcel that represents their
-arrangement. This process is performed in \cgalBigO{left((n + k)\log
-n\right} time, where \f$k\f$ is the total number of intersection
+arrangement. This process is performed in \cgalBigO{(n + k)\log
+n} time, where \f$k\f$ is the total number of intersection
 points. The running time is asymptotically better than the time needed
 for incremental insertion if the arrangement is relatively sparse
 (when \f$k\f$ is \cgalBigO{\frac{n^2}{\log n}}), but it is recommended

--- a/Documentation/doc/Documentation/Developer_manual/Chapter_intro.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_intro.txt
@@ -169,7 +169,7 @@ complexity are known. Also, the theoretic interest in efficiency for
 realistic inputs, as opposed to worst-case situations, is
 growing \cgalCite{v-ffrim-97}.
 For practical purposes, insight into the constant factors hidden in the
-\cgalBigO{&nbsp;}-notation is necessary, especially if there are several competing
+\cgalBigO{~}-notation is necessary, especially if there are several competing
 algorithms.
 
 Therefore, different implementations should be supplied if there is

--- a/Documentation/doc/resources/1.10.0/CGAL_mathjax.js
+++ b/Documentation/doc/resources/1.10.0/CGAL_mathjax.js
@@ -32,4 +32,14 @@ MathJax.Hub.Config(
   }
 }
 );
+MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
+  var PARSE = MathJax.InputJax.TeX.Parse,
+      TEXT = PARSE.prototype.InternalText;
+  PARSE.Augment({
+    InternalText: function (text,def) {
+      text = text.replace(/\\/g,"");
+      return TEXT.call(this,text,def);
+    }
+  });
+});
 //]]>

--- a/Documentation/doc/resources/1.8.13/CGAL_mathjax.js
+++ b/Documentation/doc/resources/1.8.13/CGAL_mathjax.js
@@ -31,4 +31,14 @@ MathJax.Hub.Config(
   }
 }
 );
+MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
+  var PARSE = MathJax.InputJax.TeX.Parse,
+      TEXT = PARSE.prototype.InternalText;
+  PARSE.Augment({
+    InternalText: function (text,def) {
+      text = text.replace(/\\/g,"");
+      return TEXT.call(this,text,def);
+    }
+  });
+});
 //]]>

--- a/Documentation/doc/resources/1.9.6/CGAL_mathjax.js
+++ b/Documentation/doc/resources/1.9.6/CGAL_mathjax.js
@@ -32,4 +32,14 @@ MathJax.Hub.Config(
   }
 }
 );
+MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
+  var PARSE = MathJax.InputJax.TeX.Parse,
+      TEXT = PARSE.prototype.InternalText;
+  PARSE.Augment({
+    InternalText: function (text,def) {
+      text = text.replace(/\\/g,"");
+      return TEXT.call(this,text,def);
+    }
+  });
+});
 //]]>

--- a/Kinetic_surface_reconstruction/doc/Kinetic_surface_reconstruction/Kinetic_surface_reconstruction.txt
+++ b/Kinetic_surface_reconstruction/doc/Kinetic_surface_reconstruction/Kinetic_surface_reconstruction.txt
@@ -20,7 +20,7 @@ The reconstruction is posed as an energy minimization labeling the convex volume
 <center>
 <table class="center-table" border="0">
 <tr><td>
-\f$\DeclareMathOperator*{\argmin}{arg\,min} \argmin\limits_{l \in {\{0, 1\}}^n} E(l) = (1 - \lambda) D(l) + \lambda U(l)\f$
+\f$\operatorname*{arg\,min}\limits_{l \in {\{0, 1\}}^n} E(l) = (1 - \lambda) D(l) + \lambda U(l)\f$
 
 \f$D(l) = \sum\limits_{i \in C}\sum\limits_{p \in I_i}d_i(p, l_i)\f$
 

--- a/Weights/include/CGAL/Weights/authalic_weights.h
+++ b/Weights/include/CGAL/Weights/authalic_weights.h
@@ -59,7 +59,7 @@ FT weight(const FT cot_gamma, const FT cot_beta, const FT r2)
 
   This function computes the half of the authalic weight using the precomputed
   cotangent and squared distance values. The returned value is
-  \f$\frac{2\textbf{cot}}{\textbf{sq_d}}\f$.
+  \f$\frac{2\textbf{cot}}{\textbf{sq\_d}}\f$.
 
   \tparam FT a model of `FieldNumberType`
 


### PR DESCRIPTION
Correction of incorrect usage of LaTeX  in formulas and bibliography altough MatHJax and bibtex.pl doesn't always signal it.
- Incorrect biblio entry (missing `,` and `}`)
  - Documentation/doc/biblio/geom.bib
- `&nbsp` is not correct LaTeX has to be `~`
  - Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
  - Documentation/doc/Documentation/Developer_manual/Chapter_intro.txt
- Incorrect formula regarding usage of `\left` and `\right` (also signaled by MathJax
  - Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
- `DeclareMathOperator` is a command that should be in the preamble, alternatively the command `\operatorname` can be used explicitly (as done here as it is only used once)
  - Kinetic_surface_reconstruction/doc/Kinetic_surface_reconstruction/Kinetic_surface_reconstruction.txt
- Latex has problems with `_` in a `text...` command so it should be escaped though this gives problems with MathJax hence the extra hook. MathJax reference: https://groups.google.com/g/mathjax-users/c/wSh6-hSIUpQ/m/KmzZhQQGslgJ
  - Documentation/doc/resources/1.10.0/CGAL_mathjax.js
  - Documentation/doc/resources/1.8.13/CGAL_mathjax.js
  - Documentation/doc/resources/1.9.6/CGAL_mathjax.js
  - Weights/include/CGAL/Weights/authalic_weights.h



