### PR TITLE
Errors in bibliography  and incorrect usage of `\f[` command

### DIFF
--- a/Documentation/doc/biblio/cgal_manual.bib
+++ b/Documentation/doc/biblio/cgal_manual.bib
@@ -1355,7 +1355,7 @@ Teillaud"
 
 @article{cgal:lrt-ccm-22,
   author = {Jacques-Olivier Lachaud and Pascal Romon and Boris Thibert},
-  journal = {Discrete & Computational Geometry},
+  journal = {Discrete \& Computational Geometry},
   title = {Corrected Curvature Measures},
   volume = {68},
   pages = {477-524},

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -996,15 +996,13 @@ to derive new closed-form equations for the corrected curvature measures. These 
 curvature measures are the first step for computing the curvatures. For a triangle \f$ \tau_{ijk} \f$,
 with vertices \a i, \a j, \a k:
 
-\f[
-  \begin{align*}
+\f{align*}{
   \mu^{(0)}(\tau_{ijk}) = &\frac{1}{2} \langle \bar{\mathbf{u}} \mid (\mathbf{x}_j - \mathbf{x}_i) \times (\mathbf{x}_k - \mathbf{x}_i) \rangle, \\
   \mu^{(1)}(\tau_{ijk}) = &\frac{1}{2} \langle \bar{\mathbf{u}} \mid (\mathbf{u}_k - \mathbf{u}_j) \times \mathbf{x}_i + (\mathbf{u}_i - \mathbf{u}_k) \times \mathbf{x}_j + (\mathbf{u}_j - \mathbf{u}_i) \times \mathbf{x}_k \rangle, \\
   \mu^{(2)}(\tau_{ijk}) = &\frac{1}{2} \langle \mathbf{u}_i \mid \mathbf{u}_j \times \mathbf{u}_k \rangle, \\
   \mu^{\mathbf{X},\mathbf{Y}}(\tau_{ijk}) = & \frac{1}{2} \big\langle \bar{\mathbf{u}} \big| \langle \mathbf{Y} | \mathbf{u}_k -\mathbf{u}_i \rangle \mathbf{X} \times (\mathbf{x}_j - \mathbf{x}_i) \big\rangle
     -\frac{1}{2} \big\langle \bar{\mathbf{u}} \big| \langle \mathbf{Y} | \mathbf{u}_j -\mathbf{u}_i \rangle \mathbf{X} \times (\mathbf{x}_k - \mathbf{x}_i) \big\rangle,
-  \end{align*}
-\f]
+\f}
 where \f$ \langle \cdot \mid \cdot \rangle \f$ denotes the usual scalar product,
 \f$ \bar{\mathbf{u}}=\frac{1}{3}( \mathbf{u}_i + \mathbf{u}_j + \mathbf{u}_k )\f$.
 


### PR DESCRIPTION
- The `&` in the bibliography has to be escaped
- the doxygen command `\f[` should not be used to directly change the environment, for this the doxygen command `\f{` exists.

