### PR TITLE
IO OpenMesh - fix boundary halfedges

### DIFF
--- a/BGL/include/CGAL/boost/graph/IO/OM.h
+++ b/BGL/include/CGAL/boost/graph/IO/OM.h
@@ -110,6 +110,11 @@ bool write_OM(std::string fname, const Graph& g, VPM vpm, VFeaturePM vfpm, EFeat
     omesh.status(omv).set_feature(isfeature);
   }
 
+  for (auto v : vertices(omesh))
+  {
+    adjust_border_halfedge(v, omesh);
+  }
+
   return OpenMesh::IO::write_mesh(omesh, fname, OpenMesh::IO::Options::Status, precision);
 }
 } // end of internal namespace


### PR DESCRIPTION
## Summary of Changes

In OpenMesh, the outgoing halfedge of a boundary vertex must be the boundary halfedge.
This PR fixes this orientation issue before writing the file, inside `write_OM()`

This PR completes #8427 and #8612 

## Release Management

* Affected package(s): BGL
* License and copyright ownership: unchanged

