### PR TITLE
Update an example of Nef_2 to show how to use Exact_rational

### DIFF
--- a/Nef_2/examples/Nef_2/nef_2_construction.cpp
+++ b/Nef_2/examples/Nef_2/nef_2_construction.cpp
@@ -1,10 +1,10 @@
-#include <CGAL/Exact_integer.h>
-#include <CGAL/Filtered_extended_homogeneous.h>
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Extended_cartesian.h>
 #include <CGAL/Nef_polyhedron_2.h>
 #include <cassert>
 
-typedef CGAL::Exact_integer RT;
-typedef CGAL::Filtered_extended_homogeneous<RT> Extended_kernel;
+typedef CGAL::Exact_rational FT;
+typedef CGAL::Extended_cartesian<FT> Extended_kernel;
 typedef CGAL::Nef_polyhedron_2<Extended_kernel> Nef_polyhedron;
 typedef Nef_polyhedron::Point Point;
 typedef Nef_polyhedron::Line  Line;
@@ -13,12 +13,12 @@ int main() {
 
   Nef_polyhedron N1(Nef_polyhedron::COMPLETE);
 
-  Line l(2,4,2); // l : 2x + 4y + 2 = 0
+  Line l(2.1,4.8,2.0); // l : 2.1x + 4.8y + 2 = 0
   Nef_polyhedron N2(l,Nef_polyhedron::INCLUDED);
   Nef_polyhedron N3 = N2.complement();
   assert(N1 == N2.join(N3));
 
-  Point p1(0,0), p2(10,10), p3(-20,15);
+  Point p1(0.1,0.), p2(10.8,10.25), p3(-20.18,15.14);
   Point triangle[3] = { p1, p2, p3 };
   Nef_polyhedron N4(triangle, triangle+3);
   Nef_polyhedron N5 = N2.intersection(N4);


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes

There are 4 examples in Nef_2 package: three use Exact_integer, and one uses a bounded kernel (which is undocumented).

Update one example to show how to use Exact_rational (wich requires to change the kernel).

## Release Management

* Affected package(s): Nef_2

