### PR TITLE
Move "remove_almost_degenerate_faces()" to the correct repair menu

### DIFF
--- a/Lab/demo/Lab/Plugins/PMP/Repair_polyhedron_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/PMP/Repair_polyhedron_plugin.cpp
@@ -87,6 +87,7 @@ public:
     actionAutorefine->setProperty("subMenuName", "Polygon Mesh Processing/Repair/Experimental");
     actionNewAutorefine->setProperty("subMenuName", "Polygon Mesh Processing/Repair");
     actionAutorefineAndRMSelfIntersections->setProperty("subMenuName", "Polygon Mesh Processing/Repair/Experimental");
+    actionRemoveNeedlesAndCaps->setProperty("subMenuName", "Polygon Mesh Processing/Repair");
     actionSnapBorders->setProperty("subMenuName", "Polygon Mesh Processing/Repair/Experimental");
     actionAddBbox->setProperty("subMenuName", "Polygon Mesh Processing");
 


### PR DESCRIPTION
## Summary of Changes

Fix an action  not being in the correct menu.

![image](https://github.com/user-attachments/assets/3bf28234-3927-4def-9182-a923ce8d10a4)

Not done in https://github.com/CGAL/cgal/pull/8609 because that PR targets 5.6.

## Release Management

* Affected package(s): `Lab`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

