### PR TITLE
Document `point()` in all triangulations

### DIFF
--- a/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/CGAL/Hyperbolic_Delaunay_triangulation_2.h
+++ b/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/CGAL/Hyperbolic_Delaunay_triangulation_2.h
@@ -200,7 +200,19 @@ public:
     /*!
       Returns the hyperbolic segment formed by the vertices of edge `e`.
     */
-    Hyperbolic_segment hyperbolic_segment (const Edge& e) const;
+    Hyperbolic_segment hyperbolic_segment(const Edge& e) const;
+
+    /*!
+      Returns the hyperbolic point given by the finite vertex `vh`.
+    */
+    Point point(const Vertex_handle vh) const;
+
+    /*!
+      Returns the point given by vertex `i` of face `fh`.
+      \pre `t.dimension()` \f$ \geq0\f$ and \f$ i \in\{0,1,2\}\f$ in dimension 2, \f$ i \in\{0,1\}\f$ in dimension 1, \f$ i = 0\f$ in dimension 0, and the vertex is finite.
+    */
+    Point point(const Face_handle fh, const int i) const;
+
   ///@}
 
 

--- a/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_2.h
+++ b/Hyperbolic_triangulation_2/include/CGAL/Hyperbolic_Delaunay_triangulation_2.h
@@ -740,6 +740,32 @@ public:
   Hyperbolic_segment segment(const Edge& e) const { return hyperbolic_segment(e); }
   Hyperbolic_segment segment(const Edge_circulator& e) const { return hyperbolic_segment(e); }
 
+  const Point& point(const Vertex_handle vh) const
+  {
+    CGAL_precondition(!is_infinite(vh));
+    return vh->point();
+  }
+
+  const Point& point(const Face_handle fh, const int i) const
+  {
+    CGAL_precondition(!is_infinite(fh->vertex(i)));
+    CGAL_precondition(0 <= i && i <= 2);
+    return fh->vertex(i)->point();
+  }
+
+  Point& point(const Vertex_handle vh)
+  {
+    CGAL_precondition(!is_infinite(vh));
+    return vh->point();
+  }
+
+  Point& point(const Face_handle fh, const int i)
+  {
+    CGAL_precondition(!is_infinite(fh->vertex(i)));
+    CGAL_precondition(0 <= i && i <= 2);
+    return fh->vertex(i)->point();
+  }
+
   size_type number_of_vertices() const { return Base::number_of_vertices(); }
   Vertex_circulator adjacent_vertices(Vertex_handle v) const { return Vertex_circulator(v, *this); }
 
@@ -825,32 +851,6 @@ public:
   }
 
 public:
-  const Point& point(const Vertex_handle vh) const
-  {
-    CGAL_precondition(!is_infinite(vh));
-    return vh->point();
-  }
-
-  const Point& point(const Face_handle fh, const int i) const
-  {
-    CGAL_precondition(!is_infinite(fh->vertex(i)));
-    CGAL_precondition(0 <= i && i <= 2);
-    return fh->vertex(i)->point();
-  }
-
-  Point& point(const Vertex_handle vh)
-  {
-    CGAL_precondition(!is_infinite(vh));
-    return vh->point();
-  }
-
-  Point& point(const Face_handle fh, const int i)
-  {
-    CGAL_precondition(!is_infinite(fh->vertex(i)));
-    CGAL_precondition(0 <= i && i <= 2);
-    return fh->vertex(i)->point();
-  }
-
   bool is_valid()
   {
     if (!Base::is_valid())

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_2.h
@@ -595,6 +595,18 @@ public:
 
   /*!
   Equivalent to
+  the call `t.point(t.periodic_point(fh,i));`
+  */
+  Point point(Face_handle fh, int i) const;
+
+  /*!
+  Equivalent to
+  the call `t.point(t.periodic_point(v));`
+  */
+  Point point(Vertex_handle v) const;
+
+  /*!
+  Equivalent to
   the call `t.segment(t.periodic_segment(f,i));`
   */
   Segment segment(Face_handle f, int i) const;

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/CGAL/Periodic_2_triangulation_2.h
@@ -579,7 +579,7 @@ public:
 
   /*!
   Converts the `Periodic_point` `pp` (point-offset pair) to the
-  corresponding `Point` in \f$ \mathbb R^3\f$.
+  corresponding `Point` in \f$ \mathbb R^2\f$.
   */
   Point point(const Periodic_point & pp ) const;
 

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/CGAL/Periodic_3_triangulation_3.h
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/CGAL/Periodic_3_triangulation_3.h
@@ -552,6 +552,24 @@ size_type number_of_stored_facets() const;
 /// @{
 
 /*!
+Converts the `Periodic_point` `pp` (point-offset pair) to the
+corresponding `Point` in \f$ \mathbb R^3\f$.
+*/
+Point point(const Periodic_point& pp) const;
+
+/*!
+Equivalent to
+the call `t.point(t.periodic_point(v));`
+*/
+Point point(Vertex_handle v) const;
+
+/*!
+Equivalent to
+the call `t.point(t.periodic_point(c,idx));`
+*/
+Point point(Cell_handle c, int idx) const;
+
+/*!
 Returns the periodic point given by vertex `v`. If `t` is
 represented in the 1-sheeted covering space, the offset is always
 zero. Otherwise `v` can correspond to a periodic copy outside

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
@@ -1192,6 +1192,18 @@ Segment
 segment(const Edge_iterator& ei) const;
 
 /*!
+Returns the point given by vertex `i` of face `f`.
+\pre `t.dimension()` \f$ \geq0\f$ and f$ i \in\{0,1,2\}\f$ in dimension 2, \f$ i \in\{0,1\}\f$ in dimension 1, \f$ i = 0\f$ in dimension 0, and the vertex is finite.
+*/
+const Point& point(Face_handle f, int i) const;
+
+/*!
+Same as the previous method for vertex `v`.
+\pre `t.dimension()` \f$ \geq0\f$ and the vertex is finite.
+*/
+const Point& point(Vertex_handle v) const;
+
+/*!
 Compute the circumcenter of the face pointed to by f. This function
 is available only if the corresponding function is provided in the
 geometric traits.

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
@@ -1193,7 +1193,7 @@ segment(const Edge_iterator& ei) const;
 
 /*!
 Returns the point given by vertex `i` of face `f`.
-\pre `t.dimension()` \f$ \geq0\f$ and f$ i \in\{0,1,2\}\f$ in dimension 2, \f$ i \in\{0,1\}\f$ in dimension 1, \f$ i = 0\f$ in dimension 0, and the vertex is finite.
+\pre `t.dimension()` \f$ \geq0\f$ and \f$ i \in\{0,1,2\}\f$ in dimension 2, \f$ i \in\{0,1\}\f$ in dimension 1, \f$ i = 0\f$ in dimension 0, and the vertex is finite.
 */
 const Point& point(Face_handle f, int i) const;
 


### PR DESCRIPTION
## Summary of Changes

`point(Vertex_handle)`  and `point(Simplex, int)` was only documented in few triangulations (T3, ToS2), but exist in (almost, P4HT2 is the exception) all triangulations. 

This PR documents it where the functions exist, as they are useful to create packages that are triangulation-agnostic, such as alpha shapes.

## Release Management

* Affected package(s): `Triangulations`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): TODO
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: no change

