### PR TITLE
Spelling correction

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -1852,7 +1852,7 @@ public:
             if (coplanar_patches_of_tm1.test(patch_id))
             {
               // Two "identical" coplanar patches that are entire connected components
-              //we have the correspondance between cpln patches thanks to faces in tm1_coplanar_faces and tm2_coplanar_faces
+              // we have the correspondence between cpln patches thanks to faces in tm1_coplanar_faces and tm2_coplanar_faces
               CGAL_assertion(tm1_coplanar_faces.size()==tm2_coplanar_faces.size());
               if (coplanar_tm1_to_coplanar_tm2.empty()) // fill container only once
               {

--- a/Surface_mesh_skeletonization/benchmark/Surface_mesh_skeletonization/mcf_scale_invariance.cpp
+++ b/Surface_mesh_skeletonization/benchmark/Surface_mesh_skeletonization/mcf_scale_invariance.cpp
@@ -101,7 +101,7 @@ int main(int argc, char* argv[])
   output.close();
 
   // Output skeleton points and the corresponding surface points
-  output.open("correspondance.cgal");
+  output.open("correspondence.cgal");
   for(Skeleton_vertex v : vertices(skeleton))
     for(vertex_descriptor vd : skeleton[v].vertices)
       output << "2 " << skeleton[v].point << "  " << get(CGAL::vertex_point, tmesh, vd)  << "\n";

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_LCC_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_LCC_example.cpp
@@ -63,7 +63,7 @@ int main()
   output.close();
 
   // Output skeleton points and the corresponding surface points
-  output.open("correspondance-lcc.polylines.txt");
+  output.open("correspondence-lcc.polylines.txt");
   for(Skeleton_vertex v : CGAL::make_range(vertices(skeleton)))
     for(vertex_descriptor vd : skeleton[v].vertices)
       output << "2 " << skeleton[v].point << "  " << get(CGAL::vertex_point, lcc, vd)  << "\n";

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_example.cpp
@@ -65,7 +65,7 @@ int main(int argc, char* argv[])
   output.close();
 
   // Output skeleton points and the corresponding surface points
-  output.open("correspondance-poly.polylines.txt");
+  output.open("correspondence-poly.polylines.txt");
   for(Skeleton_vertex v : CGAL::make_range(vertices(skeleton)))
     for(vertex_descriptor vd : skeleton[v].vertices)
       output << "2 " << skeleton[v].point << "  " << get(CGAL::vertex_point, tmesh, vd)  << "\n";

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_om_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_om_example.cpp
@@ -72,7 +72,7 @@ int main(int argc, char* argv[])
   output.close();
 
   // Output skeleton points and the corresponding surface points
-  output.open("correspondance-sm.polylines.txt");
+  output.open("correspondence-sm.polylines.txt");
   for(Skeleton_vertex v : CGAL::make_range(vertices(skeleton)))
     for(vertex_descriptor vd : skeleton[v].vertices)
       output << "2 " << skeleton[v].point << "  " << get(CGAL::vertex_point, tmesh, vd)  << "\n";

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_sm_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_sm_example.cpp
@@ -64,7 +64,7 @@ int main(int argc, char* argv[])
   output.close();
 
   // Output skeleton points and the corresponding surface points
-  output.open("correspondance-sm.polylines.txt");
+  output.open("correspondence-sm.polylines.txt");
   for(Skeleton_vertex v : CGAL::make_range(vertices(skeleton)))
     for(vertex_descriptor vd : skeleton[v].vertices)
       output << "2 " << skeleton[v].point << "  " << get(CGAL::vertex_point, tmesh, vd)  << "\n";

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_LCC_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_LCC_example.cpp
@@ -69,7 +69,7 @@ int main()
   output.close();
 
   // Output skeleton points and the corresponding surface points
-  output.open("correspondance-lcc.polylines.txt");
+  output.open("correspondence-lcc.polylines.txt");
   for(Skeleton_vertex v : CGAL::make_range(vertices(skeleton)))
     for(vertex_descriptor vd : skeleton[v].vertices)
       output << "2 " << skeleton[v].point << " "

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_example.cpp
@@ -69,7 +69,7 @@ int main(int argc, char* argv[])
   output.close();
 
   // Output skeleton points and the corresponding surface points
-  output.open("correspondance-poly.polylines.txt");
+  output.open("correspondence-poly.polylines.txt");
   for(Skeleton_vertex v : CGAL::make_range(vertices(skeleton)))
     for(vertex_descriptor vd : skeleton[v].vertices)
       output << "2 " << skeleton[v].point << " "

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_sm_example.cpp
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_sm_example.cpp
@@ -48,7 +48,7 @@ int main(int argc, char* argv[])
   output.close();
 
   // Output skeleton points and the corresponding surface points
-  output.open("correspondance-sm.polylines.txt");
+  output.open("correspondence-sm.polylines.txt");
   for(Skeleton_vertex v : CGAL::make_range(vertices(skeleton)))
     for(vertex_descriptor vd : skeleton[v].vertices)
       output << "2 " << skeleton[v].point << "  " << get(CGAL::vertex_point, tmesh, vd)  << "\n";


### PR DESCRIPTION
Spelling correction

Note: we also have a similar spelling error in:
```
Surface_mesh_skeletonization/benchmark/Surface_mesh_skeletonization/mcf_scale_invariance.cpp:104:  output.open("correspondance.cgal");
Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_example.cpp:68:  output.open("correspondance-poly.polylines.txt");
Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_LCC_example.cpp:66:  output.open("correspondance-lcc.polylines.txt");
Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_om_example.cpp:75:  output.open("correspondance-sm.polylines.txt");
Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/MCF_Skeleton_sm_example.cpp:67:  output.open("correspondance-sm.polylines.txt");
Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_example.cpp:72:  output.open("correspondance-poly.polylines.txt");
Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_LCC_example.cpp:72:  output.open("correspondance-lcc.polylines.txt");
Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/simple_mcfskel_sm_example.cpp:51:  output.open("correspondance-sm.polylines.txt");
```
but as this in filenames I didn't change it.

