### PR TITLE
Doxygen incompatibility in respect to `FULL_SIDEBAR` setting

### DIFF
--- a/Documentation/doc/resources/1.10.0/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.10.0/BaseDoxyfile.in
@@ -541,6 +541,18 @@ DISABLE_INDEX          = YES
 
 GENERATE_TREEVIEW      = YES
 
+# When both GENERATE_TREEVIEW and DISABLE_INDEX are set to YES, then the
+# FULL_SIDEBAR option determines if the side bar is limited to only the treeview
+# area (value NO) or if it should extend to the full height of the window (value
+# YES). Setting this to YES gives a layout similar to
+# https://docs.readthedocs.io with more room for contents, but less room for the
+# project logo, title, and description. If either GENERATE_TREEVIEW or
+# DISABLE_INDEX is set to NO, this option has no effect.
+# The default value is: NO.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+FULL_SIDEBAR           = NO
+
 # If the HTML_FORMULA_FORMAT option is set to svg, doxygen will use the pdf2svg
 # tool (see https://github.com/dawbarton/pdf2svg) or inkscape (see
 # https://inkscape.org) to generate formulas as SVG images instead of PNGs for


### PR DESCRIPTION
Due to an incompatibility change in doxygen (see https://github.com/doxygen/doxygen/commit/2a62c197550990a6346d826cf0644a52d5e03e9b#commitcomment-150534822) it is necessary to add the setting for `FULL_SIDEBAR` to the setup of the CGAL documentation.

