### PR TITLE
Add missing closing grouping commands

### DIFF
--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_conic_traits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_conic_traits_2.h
@@ -440,13 +440,14 @@ public:
     Bbox_2 operator()(const X_monotone_curve_2& xcv) const { return bbox(xcv); }
   };
 
-  /*! \name Auxiliary Functor definitions, used gor, e.g., the landmarks
+  /*! \name Auxiliary Functor definitions, used gor, e.g., the landmarks \
    * point-location strategy and the drawing function.
    */
   //@{
   typedef double                                        Approximate_number_type;
   typedef CGAL::Cartesian<Approximate_number_type>      Approximate_kernel;
   typedef Approximate_kernel::Point_2                   Approximate_point_2;
+  //@}
 
   /*! \class Approximate_2
    * A functor that approximates a point and an \f$x\f$-monotone curve.

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_segment_traits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_segment_traits_2.h
@@ -121,6 +121,7 @@ public:
     X_monotone_curve_2(const X_monotone_curve_2& xcv,
                        const Point_2& src, const Point_2& tgt) const;
 
+    //! @}
   } /* end Arr_segment_traits_2::Trim_2 */
 
 }; /* end Arr_segment_traits_2 */

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementBottomSideTraits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementBottomSideTraits_2.h
@@ -29,6 +29,7 @@ public:
 
   /// \name Functor Types
   /// @{
+  /// @}
 
   /// \name Accessing Functor Objects
   /// @{

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementContractedBottomTraits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementContractedBottomTraits_2.h
@@ -33,6 +33,7 @@ public:
 
   /// \name Functor Types
   /// @{
+  /// @}
 
   /// \name Accessing Functor Objects
   /// @{

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementContractedLeftTraits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementContractedLeftTraits_2.h
@@ -33,6 +33,7 @@ public:
 
   /// \name Functor Types
   /// @{
+  /// @}
 
   /// \name Accessing Functor Objects
   /// @{

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementContractedRightTraits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementContractedRightTraits_2.h
@@ -33,6 +33,7 @@ public:
 
   /// \name Functor Types
   /// @{
+  /// @}
 
   /// \name Accessing Functor Objects
   /// @{

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementContractedTopTraits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementContractedTopTraits_2.h
@@ -33,6 +33,7 @@ public:
 
   /// \name Functor Types
   /// @{
+  /// @}
 
   /// \name Accessing Functor Objects
   /// @{

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementLeftSideTraits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementLeftSideTraits_2.h
@@ -29,6 +29,7 @@ public:
 
   /// \name Functor Types
   /// @{
+  /// @}
 
   /// \name Accessing Functor Objects
   /// @{

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementOpenBottomTraits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementOpenBottomTraits_2.h
@@ -33,6 +33,7 @@ public:
 
   /// \name Functor Types
   /// @{
+  /// @}
 
   /// \name Accessing Functor Objects
   /// @{

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementOpenLeftTraits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementOpenLeftTraits_2.h
@@ -33,6 +33,7 @@ public:
 
   /// \name Functor Types
   /// @{
+  /// @}
 
   /// \name Accessing Functor Objects
   /// @{

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementOpenRightTraits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementOpenRightTraits_2.h
@@ -33,6 +33,7 @@ public:
 
   /// \name Functor Types
   /// @{
+  /// @}
 
   /// \name Accessing Functor Objects
   /// @{

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementOpenTopTraits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementOpenTopTraits_2.h
@@ -33,6 +33,7 @@ public:
 
   /// \name Functor Types
   /// @{
+  /// @}
 
   /// \name Accessing Functor Objects
   /// @{

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementRightSideTraits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementRightSideTraits_2.h
@@ -29,6 +29,7 @@ public:
 
   /// \name Functor Types
   /// @{
+  /// @}
 
   /// \name Accessing Functor Objects
   /// @{

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementTopSideTraits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/ArrangementTopSideTraits_2.h
@@ -29,6 +29,7 @@ public:
 
   /// \name Functor Types
   /// @{
+  /// @}
 
   /// \name Accessing Functor Objects
   /// @{

--- a/Arrangement_on_surface_2/include/CGAL/Arr_tracing_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_tracing_traits_2.h
@@ -212,6 +212,7 @@ public:
   using X_monotone_curve_2 = typename Base::X_monotone_curve_2;
   using Curve_2 = typename Base::Curve_2;
   using Multiplicity = typename Base::Multiplicity;
+  //@}
 
   /*! A functor that compares the \f$x\f$-coordinates of two points. */
   class Compare_x_2 {

--- a/CGAL_Core/include/CGAL/CORE/BigFloat.h
+++ b/CGAL_Core/include/CGAL/CORE/BigFloat.h
@@ -600,6 +600,7 @@ inline long longValue(const BigFloat& bf)
 {
   return bf.longValue();
 }
+//@}
 
 } //namespace CORE
 

--- a/Solver_interface/doc/Solver_interface/Concepts/MixedIntegerProgramTraits.h
+++ b/Solver_interface/doc/Solver_interface/Concepts/MixedIntegerProgramTraits.h
@@ -39,6 +39,8 @@ public:
         */
         MixedIntegerProgramVariable(MixedIntegerProgramTraits* solver, Variable_type type, FT lb =, FT ub, const std::string& name, int idx);
 
+        /// @}
+
         /// \name Operations
         /// @{
 
@@ -130,6 +132,8 @@ public:
         the lower bound, upper bound, name, and index.
         */
         MixedIntegerProgramLinearConstraint(MixedIntegerProgramTraits* solver, FT lb, FT ub, const std::string& name, int idx);
+
+        /// @}
 
         /// \name Operations
         /// @{
@@ -237,6 +241,8 @@ public:
         and the objective sense.
         */
         MixedIntegerProgramLinearObjective(MixedIntegerProgramTraits* solver, Sense sense);
+
+        /// @}
 
         /// \name Operations
         /// @{

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/Concepts/EdgeCollapseSimplificationVisitor.h
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/Concepts/EdgeCollapseSimplificationVisitor.h
@@ -21,6 +21,8 @@ The type of the surface mesh to simplify. Must be a model of the `MutableFaceGra
 */
 typedef Edge_profile::Triangle_mesh TriangleMesh;
 
+/// @}
+
 /// \name Operations
 /// @{
 

--- a/Triangulation/doc/Triangulation/Concepts/TriangulationDataStructure.h
+++ b/Triangulation/doc/Triangulation/Concepts/TriangulationDataStructure.h
@@ -870,6 +870,7 @@ a vertex of the `c`.
 */
 int index(Vertex_handle v) const;
 
+/// @}
 
 /// \name Internal
 /// \cgalAdvancedBegin

--- a/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
+++ b/Triangulation_2/doc/Triangulation_2/CGAL/Triangulation_2.h
@@ -785,6 +785,7 @@ is returned.
 */
 Vertex_handle move(Vertex_handle v, const Point & p);
 
+/// @}
 
 /// \name Specialized Modifiers
 /// The following member functions offer more specialized versions of


### PR DESCRIPTION
In a number of cases the command `@{` (or `\{`) is not closed by a corresponding closing command (`@}`). For the `\=name` command this is apparently not necessary but it is better to have corresponding open and close commands.

(also corrected a split in a line that I noticed in Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_conic_traits_2.h)

