### PR TITLE
Orthtree: Doc and traits bugfixes

### DIFF
--- a/Orthtree/include/CGAL/Octree.h
+++ b/Orthtree/include/CGAL/Octree.h
@@ -25,7 +25,7 @@ namespace CGAL {
   \brief Alias that specializes the `Orthtree` class to a 3D octree storing 3D points.
 
   \tparam GeomTraits a model of `Kernel`
-  \tparam PointRange a model of `Range` whose value type is the key type of `PointMap`
+  \tparam PointRange a model of `Range` whose value type is the key type of `PointMap` and whose iterator type is a model of `RandomAccessIterator`
   \tparam PointMap a model of `ReadablePropertyMap` whose value type is `GeomTraits::Point_3`
   \tparam cubic_nodes Boolean to enforce cubic nodes
  */

--- a/Orthtree/include/CGAL/Orthtree/Split_predicates.h
+++ b/Orthtree/include/CGAL/Orthtree/Split_predicates.h
@@ -85,7 +85,7 @@ public:
   \ingroup PkgOrthtreeSplitPredicates
   \brief A class used to choose when a node should be split depending on the depth and the number of contained elements.
 
-  This predicate makes a note split if it contains more than a
+  This predicate makes a node split if it contains more than a
   certain number of items and if its depth is lower than a certain
   limit.
 

--- a/Orthtree/include/CGAL/Orthtree_traits_base.h
+++ b/Orthtree/include/CGAL/Orthtree_traits_base.h
@@ -91,7 +91,7 @@ struct Orthtree_traits_base {
 
   struct Construct_point_d {
     template <typename ...Args, typename T = std::common_type_t<Args...>>
-    typename Point_d operator()(Args ...args) {
+    Point_d operator()(Args ...args) {
       std::initializer_list<T> args_list{ args... };
       return Point_d{ static_cast<int>(args_list.size()), args_list.begin(), args_list.end() };
     }

--- a/Orthtree/include/CGAL/Orthtree_traits_base.h
+++ b/Orthtree/include/CGAL/Orthtree_traits_base.h
@@ -89,13 +89,16 @@ struct Orthtree_traits_base {
   using Adjacency = int;
   /// @}
 
-  //using Construct_point_d = Point_d(*)(std::initializer_list<FT> args);
+  struct Construct_point_d {
+    template <typename ...Args, typename T = std::common_type_t<Args...>>
+    typename Point_d operator()(Args ...args) {
+      std::initializer_list<T> args_list{ args... };
+      return Point_d{ static_cast<int>(args_list.size()), args_list.begin(), args_list.end() };
+    }
+  };
 
-  auto construct_point_d_object() const {
-    return [](auto... Args) -> Point_d {
-      std::initializer_list<FT> args_list{Args...};
-      return Point_d{static_cast<int>(args_list.size()), args_list.begin(), args_list.end()};
-    };
+  Construct_point_d construct_point_d_object() const {
+    return Construct_point_d();
   }
 };
 

--- a/Orthtree/include/CGAL/Orthtree_traits_base.h
+++ b/Orthtree/include/CGAL/Orthtree_traits_base.h
@@ -89,6 +89,8 @@ struct Orthtree_traits_base {
   using Adjacency = int;
   /// @}
 
+  //using Construct_point_d = Point_d(*)(std::initializer_list<FT> args);
+
   auto construct_point_d_object() const {
     return [](auto... Args) -> Point_d {
       std::initializer_list<FT> args_list{Args...};
@@ -115,7 +117,9 @@ struct Orthtree_traits_base<GeomTraits, 2> {
     UP
   };
 
-  auto construct_point_d_object() const {
+  using Construct_point_d = Point_d(*)(const FT&, const FT&);
+
+  Construct_point_d construct_point_d_object() const {
     return [](const FT& x, const FT& y) -> Point_d {
       return {x, y};
     };
@@ -153,7 +157,9 @@ struct Orthtree_traits_base<GeomTraits, 3> {
     RIGHT_TOP_FRONT
   };
 
-  auto construct_point_d_object() const {
+  using Construct_point_d = Point_d(*)(const FT&, const FT&, const FT&);
+
+  Construct_point_d construct_point_d_object() const {
     return [](const FT& x, const FT& y, const FT& z) -> Point_d {
       return {x, y, z};
     };

--- a/Orthtree/include/CGAL/Orthtree_traits_point.h
+++ b/Orthtree/include/CGAL/Orthtree_traits_point.h
@@ -171,7 +171,7 @@ public:
   struct Distribute_node_contents {
     const PointMap m_point_map;
     Distribute_node_contents(const PointMap& point_map) : m_point_map(point_map) {}
-    typename void operator()(Node_index n, Tree& tree, const typename Self::Point_d& center) {
+    void operator()(Node_index n, Tree& tree, const typename Self::Point_d& center) {
       CGAL_precondition(!tree.is_leaf(n));
       reassign_points(tree, m_point_map, n, center, tree.data(n));
     };

--- a/Orthtree/include/CGAL/Orthtree_traits_point.h
+++ b/Orthtree/include/CGAL/Orthtree_traits_point.h
@@ -96,7 +96,7 @@ public:
   using Node_index = typename Base::Node_index;
   using Node_data_element = typename std::iterator_traits<typename PointRange::iterator>::value_type;
 
-  static_assert(std::is_same<typename std::iterator_traits<typename PointRange::iterator>::iterator_category, std::random_access_iterator_tag>::value);
+  static_assert(std::is_same_v<typename std::iterator_traits<typename PointRange::iterator>::iterator_category, std::random_access_iterator_tag>);
 
   Orthtree_traits_point(
     PointRange& points,

--- a/Orthtree/include/CGAL/Orthtree_traits_point.h
+++ b/Orthtree/include/CGAL/Orthtree_traits_point.h
@@ -96,10 +96,14 @@ public:
   using Node_index = typename Base::Node_index;
   using Node_data_element = typename std::iterator_traits<typename PointRange::iterator>::value_type;
 
+  static_assert(std::is_same<typename std::iterator_traits<typename PointRange::iterator>::iterator_category, std::random_access_iterator_tag>::value);
+
   Orthtree_traits_point(
     PointRange& points,
     PointMap point_map = PointMap()
   ) : m_points(points), m_point_map(point_map) {}
+
+  using Construct_root_node_bbox = typename Self::Bbox_d(*)();
 
   auto construct_root_node_bbox_object() const {
     return [&]() -> typename Self::Bbox_d {
@@ -152,41 +156,65 @@ public:
     };
   }
 
-  auto construct_root_node_contents_object() const {
-    return [&]() -> typename Self::Node_data {
-      return {m_points.begin(), m_points.end()};
-    };
+  struct Construct_root_node_contents {
+    PointRange& m_points;
+    Construct_root_node_contents(PointRange& points) : m_points(points) {}
+    typename Self::Node_data operator()() {
+      return { m_points.begin(), m_points.end() };
+    }
+  };
+
+  Construct_root_node_contents construct_root_node_contents_object() const {
+    return Construct_root_node_contents(m_points);
   }
 
-  auto distribute_node_contents_object() const {
-    return [&](Node_index n, Tree& tree, const typename Self::Point_d& center) {
+  struct Distribute_node_contents {
+    const PointMap m_point_map;
+    Distribute_node_contents(const PointMap& point_map) : m_point_map(point_map) {}
+    typename void operator()(Node_index n, Tree& tree, const typename Self::Point_d& center) {
       CGAL_precondition(!tree.is_leaf(n));
       reassign_points(tree, m_point_map, n, center, tree.data(n));
     };
+  };
+
+  Distribute_node_contents distribute_node_contents_object() const {
+    return Distribute_node_contents(m_point_map);
   }
 
-  auto construct_sphere_d_object() const {
+  using Construct_sphere_d = typename Self::Sphere_d(*)(const typename Self::Point_d&, const typename Self::FT&);
+
+  Construct_sphere_d construct_sphere_d_object() const {
     return [](const typename Self::Point_d& center, const typename Self::FT& squared_radius) -> typename Self::Sphere_d {
       return typename Self::Sphere_d(center, squared_radius);
       };
   }
 
-  auto construct_center_d_object() const {
+  using Construct_center_d = typename Self::Point_d(*)(const typename Self::Sphere_d&);
+
+  Construct_center_d construct_center_d_object() const {
     return [](const typename Self::Sphere_d& sphere) -> typename Self::Point_d {
       return sphere.center();
       };
   }
 
-  auto compute_squared_radius_d_object() const {
+  using Compute_squared_radius_d = typename Self::FT(*)(const typename Self::Sphere_d&);
+
+  Compute_squared_radius_d compute_squared_radius_d_object() const {
     return [](const typename Self::Sphere_d& sphere) -> typename Self::FT {
       return sphere.squared_radius();
       };
   }
 
-  auto squared_distance_of_element_object() const {
-    return [&](const Node_data_element& index, const typename Self::Point_d& point) -> typename Self::FT {
+  struct Squared_distance_of_element {
+    const PointMap m_point_map;
+    Squared_distance_of_element(const PointMap& point_map) : m_point_map(point_map) {}
+    typename Self::FT operator()(const Node_data_element& index, const typename Self::Point_d& point) {
       return CGAL::squared_distance(get(m_point_map, index), point);
-      };
+    };
+  };
+
+  Squared_distance_of_element squared_distance_of_element_object() const {
+    return Squared_distance_of_element(m_point_map);
   }
 
   PointRange& m_points;


### PR DESCRIPTION
## Summary of Changes

Octree doc states requirement of RandomAccessIterator for point range
added missing _object types for functors in traits

## Release Management

* Affected package(s): Orthtree

