### PR TITLE
Use the same generator for reproducible runs

### DIFF
--- a/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_of_one_subdomain.cpp
+++ b/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_of_one_subdomain.cpp
@@ -18,7 +18,7 @@ typedef CGAL::Tetrahedral_remeshing::Remeshing_triangulation_3<K> Remeshing_tria
 
 void generate_input_two_subdomains(const std::size_t nbv, Remeshing_triangulation& tr)
 {
-  CGAL::Random rng;
+  CGAL::Random& rng = CGAL::get_default_random();
 
   typedef Remeshing_triangulation::Point Point;
   typedef Remeshing_triangulation::Cell_handle Cell_handle;


### PR DESCRIPTION
Ref:
```
------------------------------------------------------------------
- Tetrahedral_remeshing/ProgramOutput.execution   of  test_tetrahedral_remeshing_of_one_subdomain
------------------------------------------------------------------

CGAL::Random()::get_seed() = 1736397916
CGAL Random seed = 1736397916
valid data structure
valid triangulation
Tetrahedral remeshing (nb_iter = 1, protect = false)
Init tetrahedral remeshing...done.
# Iteration 1 #
Split long edges... done (2449 splits, in 0.0591981 sec).
Collapse short edges... done (0 collapses, in 0.077903 seconds).
Flip edges...
Flip edges... done (83/2946 surface/volume flips done, in 0.336761 seconds).
Smooth vertices... done (0/760/1915 vertices smoothed, average move = 0.083582, in 0.128201 seconds).
# Iteration 1 done : 3449 vertices #
Flip edges...
Flip edges... done (32/2958 surface/volume flips done, in 0.318584 seconds).
Smooth vertices... done (0/415/1307 vertices smoothed, average move = 0.0443012, in 0.153528 seconds).
# Iteration 2 (flip and smooth only) done : 3449 vertices #
Flip edges...
Flip edges... done (19/2333 surface/volume flips done, in 0.297889 seconds).
Smooth vertices...CGAL error: assertion violation!
Expression : 
File       : /Users/geometryfactory/CGAL/testsuite/CGAL-6.1-Ic-59/include/CGAL/Intersections_3/internal/Ray_3_Triangle_3_intersection.h
Line       : 382
Explanation: 
Refer to the bug-reporting instructions at https://www.cgal.org/bug_report.html
libc++abi: terminating due to uncaught exception of type CGAL::Assertion_exception: CGAL ERROR: assertion violation!
File: /Users/geometryfactory/CGAL/testsuite/CGAL-6.1-Ic-59/include/CGAL/Intersections_3/internal/Ray_3_Triangle_3_intersection.h
Line: 382
```

https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.1-Ic-59/Tetrahedral_remeshing/TestReport_monet_macOS-x86_64-core_boost_backend.gz