### PR TITLE
WIP: Changes for clang on Windows 

### DIFF
--- a/Number_types/include/CGAL/Mpzf.h
+++ b/Number_types/include/CGAL/Mpzf.h
@@ -66,7 +66,7 @@
 
 #include <boost/cstdint.hpp>
 
-#ifdef _MSC_VER
+#ifdef _MSC_VER && (! defined(__clang__))
 #include <intrin.h>
 #pragma intrinsic(_BitScanForward64)
 #pragma intrinsic(_BitScanReverse64)
@@ -190,7 +190,7 @@ template <class T, class = void> struct no_pool {
 
 // Only used with an argument known not to be 0.
 inline int ctz (std::uint64_t x) {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (! defined(__clang__))
   unsigned long ret;
   _BitScanForward64(&ret, x);
   return (int)ret;
@@ -202,7 +202,7 @@ inline int ctz (std::uint64_t x) {
 #endif
 }
 inline int clz (std::uint64_t x) {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (! defined(__clang__))
   unsigned long ret;
   _BitScanReverse64(&ret, x);
   return 63 - (int)ret;

--- a/Number_types/include/CGAL/cpp_float.h
+++ b/Number_types/include/CGAL/cpp_float.h
@@ -25,7 +25,7 @@ namespace CGAL {
 namespace internal {
   // Only used with an argument known not to be 0.
   inline int low_bit (boost::uint64_t x) {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (! defined(__clang__))
     unsigned long ret;
     _BitScanForward64(&ret, x);
     return (int)ret;
@@ -37,7 +37,7 @@ namespace internal {
 #endif
   }
   inline int high_bit (boost::uint64_t x) {
-#if defined(_MSC_VER)
+#if defined(_MSC_VER) && (! defined(__clang__))
     unsigned long ret;
     _BitScanReverse64(&ret, x);
     return (int)ret;


### PR DESCRIPTION
## Summary of Changes

Currently choosing clang in vscode leads to compilation and link errors.
The first commit of this PR addresses a compilation error.

It works in Visual Studio, so I probably only do something wrong when I configure inside vscode. Let's have a look on Thursday @lrineau 

## Release Management

* Affected package(s): Number_types
* License and copyright ownership:  unchanged

