### PR TITLE
FOR 5.6.x ONLY: use ubuntu-22.04 as Github runner

### DIFF
--- a/.github/workflows/Remove_labels.yml
+++ b/.github/workflows/Remove_labels.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 jobs:
   remove_label:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: contains(github.event.pull_request.labels.*.name, 'Tested')
     name: remove label
     steps:

--- a/.github/workflows/build_doc.yml
+++ b/.github/workflows/build_doc.yml
@@ -14,7 +14,7 @@ jobs:
       contents: read # to fetch code (actions/checkout)
       pull-requests: write # to create comment
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/github-script@v6
         id: get_round

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/cmake-all.yml
+++ b/.github/workflows/cmake-all.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   cmake-testsuite:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3
@@ -22,7 +22,7 @@ jobs:
 
   cmake-testsuite-with-qt5:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/delete_doc.yml
+++ b/.github/workflows/delete_doc.yml
@@ -11,7 +11,7 @@ jobs:
 
     permissions:
       contents: write  # for Git to git push
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -7,7 +7,7 @@ permissions:
 
 jobs:
   batch_1:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: install dependencies
@@ -15,7 +15,7 @@ jobs:
     - name: run1
       run: ./.github/test.sh 0 ${{ github.workspace }}
   batch_2:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: install dependencies
@@ -23,7 +23,7 @@ jobs:
     - name: run2
       run: ./.github/test.sh 1 ${{ github.workspace }}
   batch_3:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: install dependencies
@@ -31,7 +31,7 @@ jobs:
     - name: run3
       run: ./.github/test.sh 2 ${{ github.workspace }}
   batch_4:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
     - name: install dependencies

--- a/.github/workflows/filter_testsuite.yml
+++ b/.github/workflows/filter_testsuite.yml
@@ -12,7 +12,7 @@ jobs:
       pull-requests: write # to create comment
 
     if: (github.event.comment.user.login == 'sloriot' || github.event.comment.user.login == 'lrineau') && contains(github.event.comment.body, '/testme')
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/github-script@v6
         id: get_label

--- a/.github/workflows/list_workflow_last_run.yml
+++ b/.github/workflows/list_workflow_last_run.yml
@@ -7,7 +7,7 @@
     GH_TOKEN: ${{ github.token }}
   jobs:
     list_workflow:
-      runs-on: ubuntu-latest
+      runs-on: ubuntu-22.04
       outputs:
         messages: ${{ steps.cat_output.outputs.message }}
       steps:

--- a/.github/workflows/send_email.yml
+++ b/.github/workflows/send_email.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   send_email:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
     - name: install ssh keys
       run: |

--- a/.github/workflows/wiki_notification.yml
+++ b/.github/workflows/wiki_notification.yml
@@ -4,7 +4,7 @@ on: gollum
 
 jobs:
   prepare_email:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       messages: ${{ steps.set-result.outputs.result }}
     steps:

--- a/ccpp.yml
+++ b/ccpp.yml
@@ -5,7 +5,7 @@ on: [push]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     
     steps:
     - name: configure all


### PR DESCRIPTION
`ubuntu-latest` was recently turned from 22.04 to 24.04. And 5.6.x is not ready for that.

See the run
https://github.com/CGAL/cgal/actions/runs/12787411585/job/35648286539?pr=8688#step:3:46

**DO NOT MERGE INTO `6.0.x` or `master`.**

