### PR TITLE
Correct icon sizes

### DIFF
--- a/Documentation/doc/resources/1.10.0/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.10.0/cgal_stylesheet.css
@@ -52,7 +52,7 @@ h2 {
     font-family: Arial, Helvetica;
     font-weight: bold;
     font-size: 12px;
-    height: 14px;
+    height: 22px;
     width: 16px;
     display: inline-block;
     background-color: #FF0000;
@@ -67,7 +67,7 @@ h2 {
     font-family: Arial, Helvetica;
     font-weight: bold;
     font-size: 12px;
-    height: 14px;
+    height: 22px;
     width: 16px;
     display: inline-block;
     background-color: #0000FF;
@@ -82,7 +82,7 @@ h2 {
     font-family: Arial, Helvetica;
     font-weight: bold;
     font-size: 12px;
-    height: 14px;
+    height: 22px;
     width: 16px;
     display: inline-block;
     background-color: #67489A;

--- a/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
@@ -36,7 +36,7 @@ body, table, div, p, dl {
     font-family: Arial, Helvetica;
     font-weight: bold;
     font-size: 12px;
-    height: 22px;
+    height: 14px;
     width: 16px;
     display: inline-block;
     background-color: #67489A;

--- a/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
@@ -6,7 +6,7 @@ body, table, div, p, dl {
     font-family: Arial, Helvetica;
     font-weight: bold;
     font-size: 12px;
-    height: 14px;
+    height: 22px;
     width: 16px;
     display: inline-block;
     background-color: #FF0000;
@@ -21,7 +21,7 @@ body, table, div, p, dl {
     font-family: Arial, Helvetica;
     font-weight: bold;
     font-size: 12px;
-    height: 14px;
+    height: 22px;
     width: 16px;
     display: inline-block;
     background-color: #0000FF;
@@ -36,7 +36,7 @@ body, table, div, p, dl {
     font-family: Arial, Helvetica;
     font-weight: bold;
     font-size: 12px;
-    height: 14px;
+    height: 22px;
     width: 16px;
     display: inline-block;
     background-color: #67489A;

--- a/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
@@ -21,7 +21,7 @@ body, table, div, p, dl {
     font-family: Arial, Helvetica;
     font-weight: bold;
     font-size: 12px;
-    height: 22px;
+    height: 14px;
     width: 16px;
     display: inline-block;
     background-color: #0000FF;

--- a/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.8.13/cgal_stylesheet.css
@@ -6,7 +6,7 @@ body, table, div, p, dl {
     font-family: Arial, Helvetica;
     font-weight: bold;
     font-size: 12px;
-    height: 22px;
+    height: 14px;
     width: 16px;
     display: inline-block;
     background-color: #FF0000;

--- a/Documentation/doc/resources/1.9.6/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.9.6/cgal_stylesheet.css
@@ -52,7 +52,7 @@ h2 {
     font-family: Arial, Helvetica;
     font-weight: bold;
     font-size: 12px;
-    height: 14px;
+    height: 22px;
     width: 16px;
     display: inline-block;
     background-color: #FF0000;
@@ -67,7 +67,7 @@ h2 {
     font-family: Arial, Helvetica;
     font-weight: bold;
     font-size: 12px;
-    height: 14px;
+    height: 22px;
     width: 16px;
     display: inline-block;
     background-color: #0000FF;
@@ -82,7 +82,7 @@ h2 {
     font-family: Arial, Helvetica;
     font-weight: bold;
     font-size: 12px;
-    height: 14px;
+    height: 22px;
     width: 16px;
     display: inline-block;
     background-color: #67489A;


### PR DESCRIPTION
Correct icon sizes

**Without correction**
![image](https://github.com/user-attachments/assets/e4973cb8-09b8-4c81-8348-edef27859de9)

**With correction**
![image](https://github.com/user-attachments/assets/3513ce79-753d-431c-9dcf-83487448654c)
