### PR TITLE
Invalid HTML generated due to post processing

### DIFF
--- a/Documentation/doc/scripts/html_output_post_processing.py
+++ b/Documentation/doc/scripts/html_output_post_processing.py
@@ -57,7 +57,7 @@ def write_out_html(d, fn):
     f.write('<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n')
     f.write('<html xmlns=\"http://www.w3.org/1999/xhtml\">')
     if d.html() is not None:
-      f.write(d.html(method='html'))
+      f.write(d.html().replace("&#13;",""))
     f.write('\n')
     f.write('</html>\n')
     f.close()
@@ -392,9 +392,6 @@ removes some unneeded files, and performs minor repair on some glitches.''')
       url_f=url_f[0]+"/"+url_f[1]
       canonical_link="<link rel=\"canonical\" href=\"https://doc.cgal.org/latest/"+url_f+"\"/>\n"
       re_replace_first_in_file(r'<head>', r'<head>\n'+canonical_link, f)
-    ## special case for how_to_cite.html
-    canonical_link="<link rel=\"canonical\" href=\"https://doc.cgal.org/latest/Manual/how_to_cite.html\"/>\n"
-    re_replace_first_in_file(r'<body>', r'<head>\n'+canonical_link+"</head>\n<body>", os.path.join("Manual","how_to_cite.html"))
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Due to the CGAL specific postprocessing of the doxygen HTML files ("html_output_post_processing.py") invalid HTML is produced. It is best shown by means of "Manual/how_to_cite.html":
```
<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
<html xmlns="http://www.w3.org/1999/xhtml">
<head>
<link rel="canonical" href="https://doc.cgal.org/latest/Manual/how_to_cite.html"/>

<link rel="icon" type="image/png" href="../Manual/g-196x196-doc.png">
<meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8">
<meta http-equiv="X-UA-Compatible" content="IE=9">
<link href="cgal_stylesheet.css" rel="stylesheet" type="text/css">
<title>CGAL 6.1 - Manual: Acknowledging CGAL</title>
</head>
<head>
<link rel="canonical" href="https://doc.cgal.org/latest/Manual/how_to_cite.html"/>
</head>
<body>
....
```

We see here 2 problems
1. the `link` and `meta` statements are not properly closed (they shoudl end with `/>`)
2. there are 2 `head` sections in the file (this is "Manual/how_to_cite.html" specific).

Solution:
1. the `PyQuery` generates the problem regarding the missing `/` , which can be overcome by removing `method='html'`. At least on Windows the code `&#13;` appears (i.e. `^M`) this is filtered out `
2. code can be removed as it is already handled in the general part (just above)

