### PR TITLE
Aos 2 dcel extension efif

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_dcel_base.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_dcel_base.h
@@ -40,24 +40,24 @@ namespace CGAL {
 
 inline void* _clean_pointer(const void* p)
 {
-  static_assert(sizeof(void*) == sizeof(size_t));
-  const size_t  mask = ~1;
-  const size_t  val = (reinterpret_cast<size_t>(p) & mask);
+  static_assert(sizeof(void*) == sizeof(std::size_t));
+  const std::size_t mask = ~1;
+  const std::size_t val = (reinterpret_cast<std::size_t>(p) & mask);
 
   return (reinterpret_cast<void*>(val));
 }
 
 inline void* _set_lsb(const void* p)
 {
-  const size_t  mask = 1;
-  const size_t  val = (reinterpret_cast<size_t>(p) | mask);
+  const std::size_t  mask = 1;
+  const std::size_t  val = (reinterpret_cast<std::size_t>(p) | mask);
   return (reinterpret_cast<void*>( val));
 }
 
 inline bool _is_lsb_set(const void* p)
 {
-  const size_t  mask = 1;
-  const size_t  val = reinterpret_cast<size_t>(p);
+  const std::size_t  mask = 1;
+  const std::size_t  val = reinterpret_cast<std::size_t>(p);
   return ((val & mask) != 0);
 }
 
@@ -565,7 +565,7 @@ public:
                                                     Outer_ccb_const_iterator;
 
   /*! obtains the number of outer CCBs the face has. */
-  size_t number_of_outer_ccbs() const { return (this->outer_ccbs.size()); }
+  std::size_t number_of_outer_ccbs() const { return (this->outer_ccbs.size()); }
 
   /*! obtains an iterator for the first outer CCB of the face. */
   Outer_ccb_iterator outer_ccbs_begin() { return (this->outer_ccbs.begin()); }
@@ -601,7 +601,7 @@ public:
   typedef Inner_ccb_const_iterator                  Hole_const_iterator;
 
   /*! obtains the number of inner CCBs the face has. */
-  size_t number_of_inner_ccbs() const { return (this->inner_ccbs.size()); }
+  std::size_t number_of_inner_ccbs() const { return (this->inner_ccbs.size()); }
 
   /*! obtains an iterator for the first inner CCB of the face. */
   Inner_ccb_iterator inner_ccbs_begin() { return (this->inner_ccbs.begin()); }
@@ -646,7 +646,7 @@ public:
   }
 
   // Backward compatibility:
-  size_t number_of_holes() const { return number_of_inner_ccbs(); }
+  std::size_t number_of_holes() const { return number_of_inner_ccbs(); }
   Hole_iterator holes_begin() { return inner_ccbs_begin(); }
   Hole_iterator holes_end() { return inner_ccbs_end(); }
   Hole_const_iterator holes_begin() const { return inner_ccbs_begin(); }
@@ -669,7 +669,7 @@ public:
                                               Isolated_vertex_const_iterator;
 
   /*! obtains the number of isloated vertices inside the face. */
-  size_t number_of_isolated_vertices() const
+  std::size_t number_of_isolated_vertices() const
   { return (this->iso_verts.size()); }
 
   /*! obtains an iterator for the first isloated vertex inside the face. */
@@ -986,13 +986,13 @@ protected:
   typedef In_place_list<Inner_ccb, false>        Inner_ccb_list;
   typedef In_place_list<Isolated_vertex, false>  Iso_vert_list;
 
-    typedef std::allocator_traits<Allocator> Allocator_traits;
-    typedef typename Allocator_traits::template rebind_alloc<Vertex>          Vertex_allocator;
-    typedef typename Allocator_traits::template rebind_alloc<Halfedge>        Halfedge_allocator;
-    typedef typename Allocator_traits::template rebind_alloc<Face>            Face_allocator;
-    typedef typename Allocator_traits::template rebind_alloc<Outer_ccb>       Outer_ccb_allocator;
-    typedef typename Allocator_traits::template rebind_alloc<Inner_ccb>       Inner_ccb_allocator;
-    typedef typename Allocator_traits::template rebind_alloc<Isolated_vertex> Iso_vert_allocator;
+  typedef std::allocator_traits<Allocator> Allocator_traits;
+  typedef typename Allocator_traits::template rebind_alloc<Vertex>          Vertex_allocator;
+  typedef typename Allocator_traits::template rebind_alloc<Halfedge>        Halfedge_allocator;
+  typedef typename Allocator_traits::template rebind_alloc<Face>            Face_allocator;
+  typedef typename Allocator_traits::template rebind_alloc<Outer_ccb>       Outer_ccb_allocator;
+  typedef typename Allocator_traits::template rebind_alloc<Inner_ccb>       Inner_ccb_allocator;
+  typedef typename Allocator_traits::template rebind_alloc<Isolated_vertex> Iso_vert_allocator;
 
 public:
   typedef typename Halfedge_list::size_type              Size;
@@ -1002,7 +1002,6 @@ public:
   typedef std::bidirectional_iterator_tag                iterator_category;
 
 protected:
-
   Vertex_list         vertices;             // The vertices container.
   Halfedge_list       halfedges;            // The halfedges container.
   Face_list           faces;                // The faces container.

--- a/Arrangement_on_surface_2/include/CGAL/Arr_extended_dcel.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_extended_dcel.h
@@ -61,8 +61,10 @@ public:
 
   template <typename Point_>
   struct rebind {
-    using Point_2 = Point_;
-    using other = typename Vertex_base::template rebind<Point_2>;
+    using Pnt = Point_;
+    using Rebind_vertex_base = typename Vertex_base::template rebind<Pnt>;
+    using Other_vertex_base = typename Rebind_vertex_base::other;
+    using other = Arr_extended_vertex<Other_vertex_base, Vertex_data>;
   };
 };
 
@@ -101,8 +103,10 @@ public:
 
   template <typename XMonotoneCurve>
   struct rebind {
-    using X_monotonote_curve_2 = XMonotoneCurve;
-    using other = typename Halfedge_base::template rebind<X_monotonote_curve_2>;
+    using Xcv = XMonotoneCurve;
+    using Rebind_halfedge_base = typename Halfedge_base::template rebind<Xcv>;
+    using Other_halfedge_base = typename Rebind_halfedge_base::other;
+    using other = Arr_extended_halfedge<Other_halfedge_base, Halfedge_data>;
   };
 };
 

--- a/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_basic_insertion_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_basic_insertion_traits_2.h
@@ -251,7 +251,7 @@ public:
       // vertex to the extended point.
       if (! vh->is_at_open_boundary() && m_base_equal(base_p, vh->point()))
         return (Point_2(base_p, vh));
-      else return (Point_2(base_p));
+      return (Point_2(base_p));
     }
   };
 
@@ -308,7 +308,7 @@ public:
       // vertex to the extended point.
       if (! vh->is_at_open_boundary() && m_base_equal(base_p, vh->point()))
         return (Point_2(base_p, vh));
-      else return (Point_2(base_p));
+      return (Point_2(base_p));
     }
   };
 

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -11,6 +11,7 @@
 
 -   Introduces two traits decorators, namely `Arr_tracing_traits_2` and `Arr_counting_traits_2`, which can be used to extract debugging and informative metadata about the traits in use while a program is being executed.
 -   Fixed the Landmark point-location strategy so that it can be applied to arrangements on a sphere.
+-   Fixed a bug in the extensions of vertex and halfedge types of the DCEL when used to instantiate Arrangement_with_history_2 or similar arrangement classes that derive from Arrangement_2.
 
 ## [Release 6.0.1](https://github.com/CGAL/cgal/releases/tag/v6.0.1)
 


### PR DESCRIPTION
## Summary of Changes

The changes fix a bug in the extensions of vertex and halfedge types of the DCEL when used to instantiate Arrangement_with_history_2 or similar arrangement classes that derive from Arrangement_2.
Typically, only the face type is extended or all the 3 types (vertex, halfedge, and face) are extended, and for such extensions we have dedicated class templates. The bug shows up when trying to extend any other subset of the 3 types, and apparently, this hasn't been used much with Arrangement_with_history_2.

## Release Management

* Affected package(s): Arrangement_on_surface_2
* Issue(s) solved (if any): NA
* Feature/Small Feature (if any): NA
* Link to compiled documentation: NA
* License and copyright ownership: TAU

