### PR TITLE
WIP Kernel_23 Add a functor needed for offsetting 

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -4525,6 +4525,32 @@ namespace CartesianKernelFunctors {
   };
 
 
+template <typename K>
+  class Intersect_offset_planes_3
+  {
+    typedef typename K::FT FT;
+    typedef typename K::Point_3 Point_3;
+    typedef typename K::Plane_3 Plane_3;
+  public:
+    // typedef std::pair<Point_3,FT> result_type;
+    typedef FT result_type;
+
+    result_type operator()(const Plane_3& p0, const FT& t0,
+                           const Plane_3& p1, const FT& t1,
+                           const Plane_3& p2, const FT& t2,
+                           const Plane_3& p3, const FT& t3) const
+    {
+      FT x, y, z, t;
+      intersect_offset_planesC3(p0.a(), p0.b(), p0.c(), p0.d(), t0,
+                                p1.a(), p1.b(), p1.c(), p1.d(), t1,
+                                p2.a(), p2.b(), p2.c(), p2.d(), t2,
+                                p3.a(), p3.b(), p3.c(), p3.d(), t3,
+                                x, y, z, t);
+      // return std::make_pair(Point_3(x, y, z),t);
+      return t;
+    }
+  };
+
 } // namespace CartesianKernelFunctors
 
 } //namespace CGAL

--- a/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
+++ b/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
@@ -951,6 +951,17 @@ power_distance_to_power_sphereC3(const FT &px, const FT &py, const FT &pz, const
   return -ff0/(ff1 - ff0);
 }
 
+
+template < class FT >
+void
+intersect_offset_planesC3(const FT &p1a, const FT &p1b, const FT &p1c, const FT &p1d, const FT &t1,
+                          const FT &p2a, const FT &p2b, const FT &p2c, const FT &p2d, const FT &t2,
+                          const FT &p3a, const FT &p3b, const FT &p3c, const FT &p3d, const FT &t3,
+                          const FT &p4a, const FT &p4b, const FT &p4c, const FT &p4d, const FT &t4 ,
+                          FT&px, FT &py, FT &pz, FT& t)
+{
+}
+
  // I will use this to test if the radial axis of three spheres
   // intersect the triangle formed by the centers.
 //   // resolution of the system (where we note c the center)

--- a/Filtered_kernel/include/CGAL/Lazy_kernel.h
+++ b/Filtered_kernel/include/CGAL/Lazy_kernel.h
@@ -79,7 +79,7 @@ struct Lazy_result_type
 
 class Enum_holder {
 protected:
-  enum { NONE, NT, VARIANT, OBJECT, BBOX, OPTIONAL_ };
+  enum { NONE, NT, VARIANT, OBJECT, BBOX, OPTIONAL_ , PAIR};
 };
 
 } // internal
@@ -213,6 +213,7 @@ private:
   CGAL_WRAPPER_TRAIT(Intersect_2, VARIANT)
   CGAL_WRAPPER_TRAIT(Intersect_3, VARIANT)
   CGAL_WRAPPER_TRAIT(Intersect_point_3_for_polyhedral_envelope, OPTIONAL_)
+  CGAL_WRAPPER_TRAIT(Intersect_offset_planes_3, NT)
   CGAL_WRAPPER_TRAIT(Compute_squared_radius_2, NT)
   CGAL_WRAPPER_TRAIT(Compute_x_3, NT)
   CGAL_WRAPPER_TRAIT(Compute_y_3, NT)

--- a/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
@@ -46,6 +46,36 @@ namespace HomogeneousKernelFunctors {
   using CartesianKernelFunctors::Compute_area_divided_by_pi_3;
   using CartesianKernelFunctors::Compute_squared_length_divided_by_pi_square_3;
 
+
+
+template <typename K>
+  class Intersect_offset_planes_3
+  {
+    typedef typename K::FT FT;
+    typedef typename K::Point_3 Point_3;
+    typedef typename K::Plane_3 Plane_3;
+  public:
+    // typedef std::pair<Point_3,T> result_type;
+    typedef FT result_type;
+
+    result_type operator()(const Plane_3& p0, const FT& t0,
+                           const Plane_3& p1, const FT& t1,
+                           const Plane_3& p2, const FT& t2,
+                           const Plane_3& p3, const FT& t3) const
+    {
+      FT x, y, z, t;
+      /*
+      intersect_offset_planesC3(p0.a(), p0.b(), p0.c(), p0.d(), t0,
+                                p1.a(), p1.b(), p1.c(), p1.d(), t1,
+                                p2.a(), p2.b(), p2.c(), p2.d(), t2,
+                                p3.a(), p3.b(), p3.c(), p3.d(), t3,
+                                x, y, z, t);
+      */
+      // return std::make_pair(Point_3(x, y, z),t);
+      assert(false);
+      return t;
+    }
+  };
   template <typename K>
   class Angle_2
   {

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -37,8 +37,6 @@ namespace CGAL {
 
 namespace CommonKernelFunctors {
 
-
-
   template <typename K>
   class Non_zero_coordinate_index_3
   {

--- a/Kernel_23/include/CGAL/Kernel/global_functions_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_3.h
@@ -711,6 +711,22 @@ has_smaller_signed_distance_to_plane(const Plane_3<K> &h,
 
 template < class K >
 inline
+// std::pair<typename K::Point_3, typename K::FT>
+typename K::FT
+intersect_offset_planes(const Plane_3<K> &p0,
+                        const Plane_3<K> &p1,
+                        const Plane_3<K> &p2,
+                        const Plane_3<K> &p3,
+                        const typename K::FT& t0,
+                        const typename K::FT& t1,
+                        const typename K::FT& t2,
+                        const typename K::FT& t3)
+{
+  return internal::intersect_offset_planes(p0, p1, p2, p3, t0, t1, t2, t3, K());
+}
+
+template < class K >
+inline
 typename K::Boolean
 less_x(const Point_3<K> &p, const Point_3<K> &q)
 {

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
@@ -807,6 +807,24 @@ has_smaller_signed_distance_to_plane(const typename K::Point_3 &hp,
 
 template < class K >
 inline
+// std::pair<typename K::Point_3, typename K::FT>
+typename K::FT
+intersect_offset_planes(const typename K::Plane_3 &p0,
+                        const typename K::Plane_3 &p1,
+                        const typename K::Plane_3 &p2,
+                        const typename K::Plane_3 &p3,
+                        const typename K::FT &t0,
+                        const typename K::FT &t1,
+                        const typename K::FT &t2,
+                        const typename K::FT &t3,
+                        const K &k)
+{
+  return k.intersect_offset_planes_3_object()(p0, t0, p1, t1, p2, t2, p3, t3);
+}
+
+
+template < class K >
+inline
 typename K::Boolean
 less_x(const typename K::Point_3 &p,
        const typename K::Point_3 &q,

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -544,6 +544,8 @@ CGAL_Kernel_cons(Intersect_2,
                  intersect_2_object)
 CGAL_Kernel_cons(Intersect_3,
                  intersect_3_object)
+CGAL_Kernel_cons(Intersect_offset_planes_3,
+                 intersect_offset_planes_3_object)
 CGAL_Kernel_cons(Intersect_point_3_for_polyhedral_envelope,
                  intersect_point_3_for_polyhedral_envelope_object)
 CGAL_Kernel_pred(Is_degenerate_2,

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_plane_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_fct_plane_3.h
@@ -23,6 +23,7 @@ _test_fct_plane_sqrt_3(const R&)
 {
  typedef typename  R::Point_3  Point_3;
  typedef typename  R::Plane_3  Plane_3;
+ typedef typename   R::FT       FT;
 
  // bisector of 2 planes
  Point_3 q0(0, 0, 0, 1);
@@ -42,6 +43,11 @@ _test_fct_plane_sqrt_3(const R&)
  assert( bl3 == ql3 );
  assert( CGAL::bisector(ql4, ql2) == ql3 );
  assert( CGAL::bisector(ql1, ql5) == ql1 );
+
+FT one(1);
+
+// std::pair<Point_3, FT> res =
+FT res = CGAL::intersect_offset_planes(ql1, ql2, ql3, ql4, one, one, one, one);
 
  return true;
 }


### PR DESCRIPTION
## Summary of Changes

Add a functor needed for offsetting
Todo: write a Lazy_rep for a pair of a lazy point and a lazy number.

## Release Management

* Affected package(s): Kernel_23
* License and copyright ownership:

