### PR TITLE
BGL - add `CGAL::dijkstra_shortest_path(vs, vt, mesh)`

### DIFF
--- a/BGL/doc/BGL/Doxyfile.in
+++ b/BGL/doc/BGL/Doxyfile.in
@@ -20,7 +20,7 @@ INPUT += ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/IO/polygon_mesh_io.h \
          ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/METIS/partition_dual_graph.h \
          ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/alpha_expansion_graphcut.h \
          ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/graph_traits_inheritance_macros.h \
-         ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/shortest_path.h
+         ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/dijkstra_shortest_path.h
 
 
 EXAMPLE_PATH               +=  ${CGAL_Surface_mesh_skeletonization_EXAMPLE_DIR} \

--- a/BGL/doc/BGL/Doxyfile.in
+++ b/BGL/doc/BGL/Doxyfile.in
@@ -19,7 +19,8 @@ INPUT += ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/IO/polygon_mesh_io.h \
          ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/METIS/partition_graph.h \
          ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/METIS/partition_dual_graph.h \
          ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/alpha_expansion_graphcut.h \
-         ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/graph_traits_inheritance_macros.h
+         ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/graph_traits_inheritance_macros.h \
+         ${CGAL_PACKAGE_INCLUDE_DIR}/CGAL/boost/graph/shortest_path.h
 
 
 EXAMPLE_PATH               +=  ${CGAL_Surface_mesh_skeletonization_EXAMPLE_DIR} \

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -467,6 +467,9 @@ the requirement for traversal of all faces in a graph.
 /// \defgroup PkgBGLPartition Partitioning Operations
 /// \ingroup PkgBGLRef
 
+/// \defgroup PkgBGLTraversal Graph Traversal
+/// \ingroup PkgBGLRef
+
 /// \defgroup PkgBGLIOFct I/O Functions
 /// \ingroup PkgBGLRef
 
@@ -760,6 +763,9 @@ user might encounter.
 
 \cgalCRPSection{Conversion Functions}
 - `CGAL::split_graph_into_polylines()`
+
+\cgalCRPSection{Graph Traversal}
+- `CGAL::shortest_path_between_two_vertices()`
 
 \cgalCRPSection{Graph Adaptors}
 - `CGAL::Dual`

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -590,6 +590,12 @@ implementation.
 */
 
 /*!
+\addtogroup PkgBGLTraversal
+
+Methods to traverse a graph, for example to find the shortest path between two vertices.
+*/
+
+/*!
 \addtogroup PkgBGLIOFct
 
 Methods to read and write graphs.

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -771,7 +771,7 @@ user might encounter.
 - `CGAL::split_graph_into_polylines()`
 
 \cgalCRPSection{Graph Traversal}
-- `CGAL::shortest_path_between_two_vertices()`
+- `CGAL::dijkstra_shortest_path()`
 
 \cgalCRPSection{Graph Adaptors}
 - `CGAL::Dual`

--- a/BGL/doc/BGL/examples.txt
+++ b/BGL/doc/BGL/examples.txt
@@ -22,6 +22,7 @@
 \example BGL_surface_mesh/prim.cpp
 \example BGL_surface_mesh/gwdwg.cpp
 \example BGL_surface_mesh/seam_mesh.cpp
+\example BGL_surface_mesh/shortest_path.cpp
 \example BGL_surface_mesh/write_inp.cpp
 \example BGL_surface_mesh/surface_mesh_dual.cpp
 \example BGL_surface_mesh/connected_components.cpp

--- a/BGL/examples/BGL_surface_mesh/CMakeLists.txt
+++ b/BGL/examples/BGL_surface_mesh/CMakeLists.txt
@@ -9,6 +9,7 @@ create_single_source_cgal_program("seam_mesh.cpp")
 create_single_source_cgal_program("write_inp.cpp")
 create_single_source_cgal_program("surface_mesh_dual.cpp")
 create_single_source_cgal_program("connected_components.cpp")
+create_single_source_cgal_program("shortest_path.cpp")
 
 find_package(METIS QUIET)
 include(CGAL_METIS_support)

--- a/BGL/examples/BGL_surface_mesh/shortest_path.cpp
+++ b/BGL/examples/BGL_surface_mesh/shortest_path.cpp
@@ -60,6 +60,9 @@ int main(int argc, char** argv)
   CGAL::dijkstra_shortest_path(vs, vt, sm,
     std::back_inserter(halfedge_sequence));
 
+  assert(source(halfedge_sequence.front(), sm)==vs);
+  assert(target(halfedge_sequence.back(), sm)==vt);
+
   // dump
   std::cout << "Shortest path between vertices " << i0 << " and " << i1
             << " is made of " << halfedge_sequence.size() << " halfedges." << std::endl;
@@ -68,7 +71,7 @@ int main(int argc, char** argv)
   auto vpmap = get(CGAL::vertex_point, sm);
 
   std::ofstream out("shortest_path.polylines.txt");
-  out << halfedge_sequence.size() << " " << get(vpmap, source(halfedge_sequence.front(),sm));
+  out << halfedge_sequence.size()+1 << " " << get(vpmap, source(halfedge_sequence.front(),sm));
   for (const halfedge_descriptor he : halfedge_sequence)
   {
     const vertex_descriptor v = target(he, sm);

--- a/BGL/examples/BGL_surface_mesh/shortest_path.cpp
+++ b/BGL/examples/BGL_surface_mesh/shortest_path.cpp
@@ -57,7 +57,8 @@ int main(int argc, char** argv)
   }
 
   std::vector<halfedge_descriptor> halfedge_sequence;
-  CGAL::shortest_path_between_two_vertices(vs, vt, sm, halfedge_sequence);
+  CGAL::shortest_path_between_two_vertices(vs, vt, sm,
+    std::back_inserter(halfedge_sequence));
 
   // dump
   std::cout << "Shortest path between vertices " << i0 << " and " << i1

--- a/BGL/examples/BGL_surface_mesh/shortest_path.cpp
+++ b/BGL/examples/BGL_surface_mesh/shortest_path.cpp
@@ -1,0 +1,79 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
+
+#include <CGAL/boost/graph/shortest_path.h>
+#include <CGAL/IO/polygon_mesh_io.h>
+
+
+#include <string>
+#include <vector>
+#include <fstream>
+#include <exception>
+#include <algorithm>
+
+using K = CGAL::Exact_predicates_inexact_constructions_kernel;
+using Point = K::Point_3;
+using Mesh = CGAL::Surface_mesh<Point>;
+
+using vertex_descriptor = boost::graph_traits<Mesh>::vertex_descriptor;
+using edge_descriptor = boost::graph_traits<Mesh>::edge_descriptor;
+using halfedge_descriptor = boost::graph_traits<Mesh>::halfedge_descriptor;
+
+namespace PMP = CGAL::Polygon_mesh_processing;
+namespace params = CGAL::parameters;
+
+
+// Example main
+int main(int argc, char** argv)
+{
+  const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/elephant.off");
+
+  // Try building a surface_mesh
+  Mesh sm;
+  bool ok = CGAL::IO::read_polygon_mesh(filename, sm);
+  if (!ok || !sm.is_valid() || sm.is_empty())
+  {
+    std::cerr << "Error: Invalid facegraph" << std::endl;
+    std::cerr << "Filename = " << filename << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  const std::size_t i0 = 0;
+  const std::size_t i1 = num_vertices(sm) / 2;
+
+
+  // Get the vertex descriptors of the source and target vertices
+  const vertex_descriptor vs = *vertices(sm).first;
+  vertex_descriptor vt;
+  std::size_t vid = 0;
+  for (const vertex_descriptor v : vertices(sm))
+  {
+    if (vid++ == i1)
+    {
+      vt = v;
+      break;
+    }
+  }
+
+  std::vector<halfedge_descriptor> halfedge_sequence;
+  CGAL::shortest_path_between_two_vertices(vs, vt, sm, halfedge_sequence);
+
+  // dump
+  std::cout << "Shortest path between vertices " << i0 << " and " << i1
+            << " is made of " << halfedge_sequence.size() << " halfedges." << std::endl;
+
+  // Get the property map of the points of the mesh
+  auto vpmap = get(CGAL::vertex_point, sm);
+
+  std::ofstream out("shortest_path.polylines.txt");
+  for (const halfedge_descriptor he : halfedge_sequence)
+  {
+    const vertex_descriptor v0 = source(he, sm);
+    const vertex_descriptor v1 = target(he, sm);
+    out << "2 " << get(vpmap, v0) << " " << get(vpmap, v1) << std::endl;
+  }
+  out.close();
+
+  return EXIT_SUCCESS;
+}

--- a/BGL/examples/BGL_surface_mesh/shortest_path.cpp
+++ b/BGL/examples/BGL_surface_mesh/shortest_path.cpp
@@ -2,7 +2,7 @@
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/boost/graph/graph_traits_Surface_mesh.h>
 
-#include <CGAL/boost/graph/shortest_path.h>
+#include <CGAL/boost/graph/dijkstra_shortest_path.h>
 #include <CGAL/IO/polygon_mesh_io.h>
 
 
@@ -57,7 +57,7 @@ int main(int argc, char** argv)
   }
 
   std::vector<halfedge_descriptor> halfedge_sequence;
-  CGAL::shortest_path_between_two_vertices(vs, vt, sm,
+  CGAL::dijkstra_shortest_path(vs, vt, sm,
     std::back_inserter(halfedge_sequence));
 
   // dump

--- a/BGL/examples/BGL_surface_mesh/shortest_path.cpp
+++ b/BGL/examples/BGL_surface_mesh/shortest_path.cpp
@@ -56,7 +56,7 @@ int main(int argc, char** argv)
     }
   }
 
-  std::vector<halfedge_descriptor> halfedge_sequence;
+  std::list<halfedge_descriptor> halfedge_sequence;
   CGAL::dijkstra_shortest_path(vs, vt, sm,
     std::back_inserter(halfedge_sequence));
 
@@ -68,12 +68,13 @@ int main(int argc, char** argv)
   auto vpmap = get(CGAL::vertex_point, sm);
 
   std::ofstream out("shortest_path.polylines.txt");
+  out << halfedge_sequence.size() << " " << get(vpmap, source(halfedge_sequence.front(),sm));
   for (const halfedge_descriptor he : halfedge_sequence)
   {
-    const vertex_descriptor v0 = source(he, sm);
-    const vertex_descriptor v1 = target(he, sm);
-    out << "2 " << get(vpmap, v0) << " " << get(vpmap, v1) << std::endl;
+    const vertex_descriptor v = target(he, sm);
+    out << " " << get(vpmap, v);
   }
+  out << std::endl;
   out.close();
 
   return EXIT_SUCCESS;

--- a/BGL/examples/BGL_surface_mesh/shortest_path.cpp
+++ b/BGL/examples/BGL_surface_mesh/shortest_path.cpp
@@ -20,7 +20,6 @@ using vertex_descriptor = boost::graph_traits<Mesh>::vertex_descriptor;
 using edge_descriptor = boost::graph_traits<Mesh>::edge_descriptor;
 using halfedge_descriptor = boost::graph_traits<Mesh>::halfedge_descriptor;
 
-namespace PMP = CGAL::Polygon_mesh_processing;
 namespace params = CGAL::parameters;
 
 

--- a/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
@@ -9,8 +9,8 @@
 // Author(s)     : Jane Tournois, Andreas Fabri
 //
 
-#ifndef CGAL_BOOST_GRAPH_SHORTEST_PATH_H
-#define CGAL_BOOST_GRAPH_SHORTEST_PATH_H
+#ifndef CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATH_H
+#define CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATH_H
 
 #include <boost/graph/dijkstra_shortest_paths.hpp>
 
@@ -92,12 +92,14 @@ namespace internal {
 *    \cgalParamDescription{a property map associating to each edge in the graph its weight or ``length''.
 *                          The weights must all be non-negative.}
 *    \cgalParamType{a class model of `ReadablePropertyMap` with `boost::graph_traits<PolygonMesh>::%edge_descriptor`
-*                   as key type and `FT` as value type.}
+*                   as key type and a value type which as specified in the named parameter `distance_map`of the function
+                    <A href="https://www.boost.org/doc/libs/release/libs/graph/doc/dijkstra_shortest_paths.html">`boost::graph::dijkstra_shortest_paths()`</A>,
+                    with any model of `RingNumberType` fulfilling the requirements. }
 *    \cgalParamDefault{`get(boost::edge_weight, mesh)`}
 *   \cgalParamNEnd
 *
 *   \cgalParamNBegin{vertex_index_map}
-*     \cgalParamDescription{a property map associating to each vertex of `pmesh` a unique index between `0` and `num_vertices(pmesh) - 1`}
+*     \cgalParamDescription{a property map associating to each vertex of `g` a unique index between `0` and `num_vertices(g) - 1`}
 *     \cgalParamType{a class model of `ReadablePropertyMap` with `boost::graph_traits<PolygonMesh>::%vertex_descriptor`
 *                    as key type and `std::size_t` as value type}
 *     \cgalParamDefault{an automatically indexed internal map}
@@ -187,4 +189,4 @@ OutputIterator dijkstra_shortest_path(
 } // namespace CGAL
 
 
-#endif //CGAL_BOOST_GRAPH_SHORTEST_PATH_H
+#endif //CGAL_BOOST_GRAPH_DIJKSTRA_SHORTEST_PATH_H

--- a/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
@@ -70,8 +70,7 @@ namespace internal {
 
 /*!
 * \ingroup PkgBGLTraversal
-* computes the shortest path between two vertices in a graph `g`.
-* The vertices must belong to the same connected component of `g`.
+* computes the shortest path between two vertices in a graph `g`, where the vertices must belong to the same connected component of `g`.
 *
 * @tparam Graph a model of the concept `HalfedgeListGraph`
 * @tparam OutputIterator an output iterator with value type `boost::graph_traits<Graph>::%halfedge_descriptor`

--- a/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
@@ -146,42 +146,14 @@ OutputIterator dijkstra_shortest_path(
   }
   catch (const internal::Dijkstra_end_exception& ){}
 
-  // Walk back from target to source and collect vertices along the way
-  struct vertex_on_path
-  {
-    vertex_descriptor vertex;
-    bool is_constrained;
-  };
-
-  std::vector<vertex_descriptor> constrained_vertices = { vs };
+  std::list<halfedge_descriptor> path;
   vertex_descriptor t = vt;
-  std::vector<vertex_on_path> path;
-  do
-  {
-    const bool is_new_vertex = (constrained_vertices.end()
-      == std::find(constrained_vertices.begin(), constrained_vertices.end(), t));
-
-    vertex_on_path vop;
-    vop.vertex = t;
-    vop.is_constrained = !is_new_vertex;
-    path.push_back(vop);
-
+  do {
+    path.push_front(halfedge(relaxed_edges_map[t],g));
     t = get(pred_pmap, t);
-  }
-  while (t != vs);
-
-  // Add the last vertex
-  vertex_on_path vop;
-  vop.vertex = constrained_vertices.back();
-  vop.is_constrained = true;
-  path.push_back(vop);
-
-  // Display path
-  for (auto path_it = path.begin(); path_it != path.end() - 1; ++path_it)
-  {
-    const auto map_it = vis.relaxed_edges.find(path_it->vertex);
-    if (map_it != vis.relaxed_edges.end())
-      *halfedge_sequence_oit++ = halfedge(map_it->second, g);
+  }while (t != vs);
+  for(auto he : path){
+    *halfedge_sequence_oit++ = he;
   }
   return halfedge_sequence_oit;
 }

--- a/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
@@ -85,7 +85,7 @@ namespace internal {
 *
 *  \cgalNamedParamsBegin
 *   \cgalParamNBegin{edge_weight_map}
-*    \cgalParamDescription{a property map associating to each edge in the graph its weight or ``length''.
+*    \cgalParamDescription{a property map associating to each edge in the graph its weight or "length".
 *                          The weights must all be non-negative.}
 *    \cgalParamType{a class model of `ReadablePropertyMap` with `boost::graph_traits<PolygonMesh>::%edge_descriptor`
 *                   as key type and a value type which as specified in the named parameter `distance_map`of the function

--- a/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
@@ -70,7 +70,7 @@ namespace internal {
 
 /*!
 * \ingroup PkgBGLTraversal
-* Computes the shortest path between two vertices in a graph `g`.
+* computes the shortest path between two vertices in a graph `g`.
 * The vertices must belong to the same connected component of `g`.
 *
 * @tparam Graph a model of the concept `HalfedgeListGraph`

--- a/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
@@ -20,7 +20,7 @@
 #include <boost/property_map/property_map.hpp>
 #include <CGAL/boost/graph/properties.h>
 
-#include <vector>
+#include <list>
 #include <unordered_map>
 
 namespace CGAL {

--- a/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
@@ -40,7 +40,7 @@ namespace internal {
   /// that is when the target has been examined through all its incident edges and
   /// the shortest path is thus known.
   template<typename Graph, typename VertexEdgeMap>
-  class Stop_at_target_Dijkstra_visitor : boost::default_dijkstra_visitor
+  class Stop_at_target_Dijkstra_visitor : public boost::default_dijkstra_visitor
   {
     using vertex_descriptor = typename boost::graph_traits<Graph>::vertex_descriptor;
     using edge_descriptor = typename boost::graph_traits<Graph>::edge_descriptor;
@@ -54,15 +54,12 @@ namespace internal {
       : destination_vd(destination_vd), relaxed_edges(relaxed_edges)
     {}
 
-    void initialize_vertex(const vertex_descriptor& /*s*/, const Graph& /*g*/) const {}
-    void examine_vertex(const vertex_descriptor& /*s*/, const Graph& /*g*/) const {}
-    void examine_edge(const edge_descriptor& /*e*/, const Graph& /*g*/) const {}
+
     void edge_relaxed(const edge_descriptor& e, const Graph& g) const
     {
       relaxed_edges[target(e, g)] = e;
     }
-    void discover_vertex(const vertex_descriptor& /*s*/, const Graph& /*g*/) const {}
-    void edge_not_relaxed(const edge_descriptor& /*e*/, const Graph& /*g*/) const {}
+
     void finish_vertex(const vertex_descriptor& vd, const Graph& /* g*/) const
     {
       if (vd == destination_vd)

--- a/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/dijkstra_shortest_path.h
@@ -107,7 +107,7 @@ namespace internal {
 template<typename Graph,
          typename OutputIterator,
          typename NamedParameters = parameters::Default_named_parameters>
-OutputIterator shortest_path_between_two_vertices(
+OutputIterator dijkstra_shortest_path(
   const typename boost::graph_traits<Graph>::vertex_descriptor vs,//source
   const typename boost::graph_traits<Graph>::vertex_descriptor vt,//target
   const Graph& g,

--- a/BGL/include/CGAL/boost/graph/shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/shortest_path.h
@@ -73,7 +73,8 @@ namespace internal {
 
 /*!
 * \ingroup PkgBGLTraversal
-* Computes the shortest path between two vertices in a graph `g`
+* Computes the shortest path between two vertices in a graph `g`.
+* The vertices must belong to the same connected component of `g`.
 *
 *@tparam Graph a model of the concept `HalfedgeListGraph`
 * @param vs source vertex

--- a/BGL/include/CGAL/boost/graph/shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/shortest_path.h
@@ -70,7 +70,8 @@ namespace internal {
 * @param vs source vertex
 * @param vt target vertex
 * @param g the graph
-* @param halfedge_sequence the sequence of halfedges that form the shortest path on `g`
+* @param halfedge_sequence_oit the output iterator holding the output sequence
+* of halfedges that form the shortest path from `vs` to `vt` on `g`
 * @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
 * ** edge_weight_map : @todo deal with input mesh with no internal pmap.
 *                       default in boost is `get(boost::edge_weight, mesh)`

--- a/BGL/include/CGAL/boost/graph/shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/shortest_path.h
@@ -18,6 +18,8 @@
 #include <CGAL/boost/graph/named_params_helper.h>
 
 #include <boost/property_map/property_map.hpp>
+#include <CGAL/boost/graph/properties.h>
+
 #include <vector>
 #include <unordered_map>
 
@@ -66,6 +68,10 @@ namespace internal {
 * @param vt target vertex
 * @param mesh the mesh
 * @param halfedge_sequence the sequence of halfedges that form the shortest path on `mesh`
+* @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
+* ** edge_weight_map : @todo deal with input mesh with no internal pmap.
+*                       default in boost is `get(boost::edge_weight, mesh)`
+*
 */
 template<typename Mesh,
          typename OutputIterator,
@@ -83,6 +89,12 @@ OutputIterator shortest_path_between_two_vertices(
   using Pred_umap = std::unordered_map<vertex_descriptor, vertex_descriptor>;
   using Pred_pmap = boost::associative_property_map<Pred_umap>;
 
+  using parameters::get_parameter;
+  using parameters::choose_parameter;
+
+  const auto w_map = choose_parameter(get_parameter(np, internal_np::edge_weight),
+                                      get(boost::edge_weight, mesh));
+
   Pred_umap predecessor;
   Pred_pmap pred_pmap(predecessor);
 
@@ -91,7 +103,9 @@ OutputIterator shortest_path_between_two_vertices(
   try
   {
     boost::dijkstra_shortest_paths(mesh, vs,
-      boost::predecessor_map(pred_pmap).visitor(vis));
+      boost::predecessor_map(pred_pmap)
+      .visitor(vis)
+      .weight_map(w_map));
   }
   catch (const std::exception& e){}
 

--- a/BGL/include/CGAL/boost/graph/shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/shortest_path.h
@@ -99,6 +99,7 @@ OutputIterator shortest_path_between_two_vertices(
 {
   using vertex_descriptor = typename boost::graph_traits<Graph>::vertex_descriptor;
   using halfedge_descriptor = typename boost::graph_traits<Graph>::halfedge_descriptor;
+  using edge_descriptor = typename boost::graph_traits<Graph>::edge_descriptor;
 
   using Pred_umap = std::unordered_map<vertex_descriptor, vertex_descriptor>;
   using Pred_pmap = boost::associative_property_map<Pred_umap>;

--- a/BGL/include/CGAL/boost/graph/shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/shortest_path.h
@@ -76,7 +76,10 @@ namespace internal {
 * Computes the shortest path between two vertices in a graph `g`.
 * The vertices must belong to the same connected component of `g`.
 *
-*@tparam Graph a model of the concept `HalfedgeListGraph`
+* @tparam Graph a model of the concept `HalfedgeListGraph`
+* @tparam OutputIterator an output iterator with value type `boost::graph_traits<Graph>::%halfedge_descriptor`
+* @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
+*
 * @param vs source vertex
 * @param vt target vertex
 * @param g the graph

--- a/BGL/include/CGAL/boost/graph/shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/shortest_path.h
@@ -111,7 +111,7 @@ OutputIterator shortest_path_between_two_vertices(
       .visitor(vis)
       .weight_map(w_map));
   }
-  catch (const std::exception& e){}
+  catch (const internal::Dijkstra_end_exception& ){}
 
   // Walk back from target to source and collect vertices along the way
   struct vertex_on_path

--- a/BGL/include/CGAL/boost/graph/shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/shortest_path.h
@@ -39,7 +39,7 @@ namespace internal {
   /// Visitor to stop Dijkstra's algorithm once the given target turns 'BLACK',
   /// that is when the target has been examined through all its incident edges and
   /// the shortest path is thus known.
-  template<typename Graph>
+  template<typename Graph, typename VertexEdgeMap>
   class Stop_at_target_Dijkstra_visitor : boost::default_dijkstra_visitor
   {
     using vertex_descriptor = typename boost::graph_traits<Graph>::vertex_descriptor;
@@ -47,10 +47,10 @@ namespace internal {
 
   public:
     vertex_descriptor destination_vd;
-    std::unordered_map<vertex_descriptor, edge_descriptor>& relaxed_edges;
+    VertexEdgeMap& relaxed_edges;
 
     Stop_at_target_Dijkstra_visitor(vertex_descriptor destination_vd,
-                                    std::unordered_map<vertex_descriptor, edge_descriptor>& relaxed_edges)
+                                    VertexEdgeMap& relaxed_edges)
       : destination_vd(destination_vd), relaxed_edges(relaxed_edges)
     {}
 
@@ -113,8 +113,9 @@ OutputIterator shortest_path_between_two_vertices(
   Pred_umap predecessor;
   Pred_pmap pred_pmap(predecessor);
 
-  std::unordered_map<vertex_descriptor, edge_descriptor> relaxed_edges_map;
-  internal::Stop_at_target_Dijkstra_visitor<Graph> vis(vt, relaxed_edges_map);
+  using VEMap = std::unordered_map<vertex_descriptor, edge_descriptor>;
+  VEMap relaxed_edges_map;
+  internal::Stop_at_target_Dijkstra_visitor<Graph, VEMap> vis(vt, relaxed_edges_map);
   try
   {
     boost::dijkstra_shortest_paths(g, vs,

--- a/BGL/include/CGAL/boost/graph/shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/shortest_path.h
@@ -14,6 +14,9 @@
 
 #include <boost/graph/dijkstra_shortest_paths.hpp>
 
+#include <CGAL/Named_function_parameters.h>
+#include <CGAL/boost/graph/named_params_helper.h>
+
 #include <boost/property_map/property_map.hpp>
 #include <vector>
 #include <unordered_map>
@@ -64,12 +67,15 @@ namespace internal {
 * @param mesh the mesh
 * @param halfedge_sequence the sequence of halfedges that form the shortest path on `mesh`
 */
-template<typename Mesh>
-void shortest_path_between_two_vertices(
+template<typename Mesh,
+         typename OutputIterator,
+         typename NamedParameters = parameters::Default_named_parameters>
+OutputIterator shortest_path_between_two_vertices(
   const typename boost::graph_traits<Mesh>::vertex_descriptor vs,//source
   const typename boost::graph_traits<Mesh>::vertex_descriptor vt,//target
   const Mesh& mesh,
-  std::vector<typename boost::graph_traits<Mesh>::halfedge_descriptor>& halfedge_sequence)
+  OutputIterator halfedge_sequence_oit,
+  const NamedParameters& np = parameters::default_values())
 {
   using vertex_descriptor = typename boost::graph_traits<Mesh>::vertex_descriptor;
   using halfedge_descriptor = typename boost::graph_traits<Mesh>::halfedge_descriptor;
@@ -87,10 +93,7 @@ void shortest_path_between_two_vertices(
     boost::dijkstra_shortest_paths(mesh, vs,
       boost::predecessor_map(pred_pmap).visitor(vis));
   }
-  catch (const std::exception& e)
-  {
-    std::cout << e.what() << std::endl;
-  }
+  catch (const std::exception& e){}
 
   // Walk back from target to source and collect vertices along the way
   struct vertex_on_path
@@ -128,8 +131,9 @@ void shortest_path_between_two_vertices(
     const std::pair<halfedge_descriptor, bool>
       h = halfedge((path_it + 1)->vertex, path_it->vertex, mesh);
     if (h.second)
-      halfedge_sequence.push_back(h.first);
+      *halfedge_sequence_oit++ = h.first;
   }
+  return halfedge_sequence_oit;
 }
 
 } // namespace CGAL

--- a/BGL/include/CGAL/boost/graph/shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/shortest_path.h
@@ -1,0 +1,138 @@
+// Copyright (c) 2025  GeometryFactory (France). All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Jane Tournois, Andreas Fabri
+//
+
+#ifndef CGAL_BOOST_GRAPH_SHORTEST_PATH_H
+#define CGAL_BOOST_GRAPH_SHORTEST_PATH_H
+
+#include <boost/graph/dijkstra_shortest_paths.hpp>
+
+#include <boost/property_map/property_map.hpp>
+#include <vector>
+#include <unordered_map>
+
+namespace CGAL {
+namespace internal {
+
+  /// An exception used while catching a throw that stops Dijkstra's algorithm
+  /// once the shortest path to a target has been found.
+  class Dijkstra_end_exception : public std::exception
+  {
+    const char* what() const throw ()
+    {
+      return "Dijkstra shortest path: reached the target vertex.";
+    }
+  };
+
+  /// Visitor to stop Dijkstra's algorithm once the given target turns 'BLACK',
+  /// that is when the target has been examined through all its incident edges and
+  /// the shortest path is thus known.
+  template<typename Mesh>
+  class Stop_at_target_Dijkstra_visitor : boost::default_dijkstra_visitor
+  {
+    using vertex_descriptor = typename boost::graph_traits<Mesh>::vertex_descriptor;
+    using edge_descriptor = typename boost::graph_traits<Mesh>::edge_descriptor;
+
+  public:
+    vertex_descriptor destination_vd;
+
+    void initialize_vertex(const vertex_descriptor& /*s*/, const Mesh& /*mesh*/) const {}
+    void examine_vertex(const vertex_descriptor& /*s*/, const Mesh& /*mesh*/) const {}
+    void examine_edge(const edge_descriptor& /*e*/, const Mesh& /*mesh*/) const {}
+    void edge_relaxed(const edge_descriptor& /*e*/, const Mesh& /*mesh*/) const {}
+    void discover_vertex(const vertex_descriptor& /*s*/, const Mesh& /*mesh*/) const {}
+    void edge_not_relaxed(const edge_descriptor& /*e*/, const Mesh& /*mesh*/) const {}
+    void finish_vertex(const vertex_descriptor& vd, const Mesh& /* mesh*/) const
+    {
+      if (vd == destination_vd)
+        throw Dijkstra_end_exception();
+    }
+  };
+} // namespace internal
+
+/*!
+*@tparam Mesh a model of the concept `HalfedgeListGraph`
+* @param vs source vertex
+* @param vt target vertex
+* @param mesh the mesh
+* @param halfedge_sequence the sequence of halfedges that form the shortest path on `mesh`
+*/
+template<typename Mesh>
+void shortest_path_between_two_vertices(
+  const typename boost::graph_traits<Mesh>::vertex_descriptor vs,//source
+  const typename boost::graph_traits<Mesh>::vertex_descriptor vt,//target
+  const Mesh& mesh,
+  std::vector<typename boost::graph_traits<Mesh>::halfedge_descriptor>& halfedge_sequence)
+{
+  using vertex_descriptor = typename boost::graph_traits<Mesh>::vertex_descriptor;
+  using halfedge_descriptor = typename boost::graph_traits<Mesh>::halfedge_descriptor;
+
+  using Pred_umap = std::unordered_map<vertex_descriptor, vertex_descriptor>;
+  using Pred_pmap = boost::associative_property_map<Pred_umap>;
+
+  Pred_umap predecessor;
+  Pred_pmap pred_pmap(predecessor);
+
+  internal::Stop_at_target_Dijkstra_visitor<Mesh> vis;
+  vis.destination_vd = vt;
+  try
+  {
+    boost::dijkstra_shortest_paths(mesh, vs,
+      boost::predecessor_map(pred_pmap).visitor(vis));
+  }
+  catch (const std::exception& e)
+  {
+    std::cout << e.what() << std::endl;
+  }
+
+  // Walk back from target to source and collect vertices along the way
+  struct vertex_on_path
+  {
+    vertex_descriptor vertex;
+    bool is_constrained;
+  };
+
+  std::vector<vertex_descriptor> constrained_vertices = { vs };
+  vertex_descriptor t = vt;
+  std::vector<vertex_on_path> path;
+  do
+  {
+    const bool is_new_vertex = (constrained_vertices.end()
+      == std::find(constrained_vertices.begin(), constrained_vertices.end(), t));
+
+    vertex_on_path vop;
+    vop.vertex = t;
+    vop.is_constrained = !is_new_vertex;
+    path.push_back(vop);
+
+    t = get(pred_pmap, t);
+  }
+  while (t != vs);
+
+  // Add the last vertex
+  vertex_on_path vop;
+  vop.vertex = constrained_vertices.back();
+  vop.is_constrained = true;
+  path.push_back(vop);
+
+  // Display path
+  for (auto path_it = path.begin(); path_it != path.end() - 1; ++path_it)
+  {
+    const std::pair<halfedge_descriptor, bool>
+      h = halfedge((path_it + 1)->vertex, path_it->vertex, mesh);
+    if (h.second)
+      halfedge_sequence.push_back(h.first);
+  }
+}
+
+} // namespace CGAL
+
+
+#endif //CGAL_BOOST_GRAPH_SHORTEST_PATH_H

--- a/BGL/include/CGAL/boost/graph/shortest_path.h
+++ b/BGL/include/CGAL/boost/graph/shortest_path.h
@@ -82,10 +82,23 @@ namespace internal {
 * @param halfedge_sequence_oit the output iterator holding the output sequence
 * of halfedges that form the shortest path from `vs` to `vt` on `g`
 * @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
-* ** edge_weight_map : @todo deal with input mesh with no internal pmap.
-*                       default in boost is `get(boost::edge_weight, mesh)`
-* ** vertex_index_map : @todo deal with input mesh with no internal pmap.
 *
+*  \cgalNamedParamsBegin
+*   \cgalParamNBegin{edge_weight_map}
+*    \cgalParamDescription{a property map associating to each edge in the graph its weight or ``length''.
+*                          The weights must all be non-negative.}
+*    \cgalParamType{a class model of `ReadablePropertyMap` with `boost::graph_traits<PolygonMesh>::%edge_descriptor`
+*                   as key type and `FT` as value type.}
+*    \cgalParamDefault{`get(boost::edge_weight, mesh)`}
+*   \cgalParamNEnd
+*
+*   \cgalParamNBegin{vertex_index_map}
+*     \cgalParamDescription{a property map associating to each vertex of `pmesh` a unique index between `0` and `num_vertices(pmesh) - 1`}
+*     \cgalParamType{a class model of `ReadablePropertyMap` with `boost::graph_traits<PolygonMesh>::%vertex_descriptor`
+*                    as key type and `std::size_t` as value type}
+*     \cgalParamDefault{an automatically indexed internal map}
+*   \cgalParamNEnd
+*  \cgalNamedParamsEnd
 */
 template<typename Graph,
          typename OutputIterator,
@@ -109,6 +122,7 @@ OutputIterator shortest_path_between_two_vertices(
 
   const auto w_map = choose_parameter(get_parameter(np, internal_np::edge_weight),
                                       get(boost::edge_weight, g));
+  const auto vim = get_initialized_vertex_index_map(g, np);
 
   Pred_umap predecessor;
   Pred_pmap pred_pmap(predecessor);
@@ -121,7 +135,8 @@ OutputIterator shortest_path_between_two_vertices(
     boost::dijkstra_shortest_paths(g, vs,
       boost::predecessor_map(pred_pmap)
       .visitor(vis)
-      .weight_map(w_map));
+      .weight_map(w_map)
+      .vertex_index_map(vim));
   }
   catch (const internal::Dijkstra_end_exception& ){}
 

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -12,6 +12,11 @@
 -   Introduces two traits decorators, namely `Arr_tracing_traits_2` and `Arr_counting_traits_2`, which can be used to extract debugging and informative metadata about the traits in use while a program is being executed.
 -   Fixed the Landmark point-location strategy so that it can be applied to arrangements on a sphere.
 
+
+### [CGAL and the Boost Graph Library (BGL)](https://doc.cgal.org/6.1/Manual/packages.html#PkgBGL)
+
+-   Added the function `dijkstra_shortest_path()` which computes the geometrically shortest sequence of halfedges between two vertices.
+
 ## [Release 6.0.1](https://github.com/CGAL/cgal/releases/tag/v6.0.1)
 
 ### [Poisson Surface Reconstruction](https://doc.cgal.org/6.0.1/Manual/packages.html#PkgPoissonSurfaceReconstruction3)

--- a/Lab/demo/Lab/Scene_polyhedron_selection_item.cpp
+++ b/Lab/demo/Lab/Scene_polyhedron_selection_item.cpp
@@ -5,7 +5,6 @@
 #include <CGAL/Polygon_mesh_processing/compute_normal.h>
 #include <CGAL/Polygon_mesh_processing/repair.h>
 #include <CGAL/Polygon_mesh_processing/shape_predicates.h>
-#include <boost/graph/dijkstra_shortest_paths.hpp>
 #include <CGAL/boost/graph/helpers.h>
 #include <CGAL/property_map.h>
 #include <CGAL/Handle_hash_function.h>
@@ -31,7 +30,7 @@
 #include "triangulate_primitive.h"
 #include <CGAL/boost/graph/Face_filtered_graph.h>
 #include <CGAL/Polygon_mesh_processing/measure.h>
-#include <CGAL/boost/graph/shortest_path.h>
+#include <CGAL/boost/graph/dijkstra_shortest_path.h>
 #include <CGAL/boost/graph/properties.h>
 
 using namespace CGAL::Three;
@@ -1496,7 +1495,7 @@ void Scene_polyhedron_selection_item_priv::computeAndDisplayPath()
   {
     fg_vertex_descriptor t(*it), s(*(it+1));
 
-    CGAL::shortest_path_between_two_vertices(s, t, mesh,
+    CGAL::dijkstra_shortest_path(s, t, mesh,
       std::back_inserter(path_halfedges));
   }
 

--- a/STL_Extension/include/CGAL/STL_Extension/internal/parameters_interface.h
+++ b/STL_Extension/include/CGAL/STL_Extension/internal/parameters_interface.h
@@ -28,6 +28,7 @@ CGAL_add_named_parameter(use_binary_mode_t, use_binary_mode, use_binary_mode)
 CGAL_add_named_parameter(metis_options_t, METIS_options, METIS_options)
 CGAL_add_named_parameter(vertex_partition_id_t, vertex_partition_id, vertex_partition_id_map)
 CGAL_add_named_parameter(face_partition_id_t, face_partition_id, face_partition_id_map)
+CGAL_add_named_parameter(edge_weight_t, edge_weight, edge_weight_map)
 
 CGAL_add_named_parameter(vertex_output_iterator_t, vertex_output_iterator, vertex_output_iterator)
 CGAL_add_named_parameter(face_output_iterator_t, face_output_iterator, face_output_iterator)


### PR DESCRIPTION
## Summary of Changes

computes the shortest path between two vertices, using Dijkstra algorithm

Todo
- [x] write doc and integrate to 
- [x] add np
- [x] add measure to define what "shortest" means
- [x] add to ref manual top page
- [x] use in demo code

## Release Management

* Affected package(s): BGL
* [Small feature](https://cgalwiki.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Add_CGAL::shortest_path(vs,_vt))
* Link to compiled documentation [CGAL::shortest_path_between_two_vertices()](https://cgal.github.io/8724/v0/BGL/group__PkgBGLTraversal.html#ga5627dee8a6fe4d238cb5c91e123aa763)
* License and copyright ownership: unchanged

