### PR TITLE
update our CMake supported versions to ...3.31

### DIFF
--- a/AABB_tree/benchmark/AABB_tree/CMakeLists.txt
+++ b/AABB_tree/benchmark/AABB_tree/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(AABB_traits_benchmark)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Core)

--- a/AABB_tree/demo/AABB_tree/CMakeLists.txt
+++ b/AABB_tree/demo/AABB_tree/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling the AABB tree demo.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(AABB_tree_Demo)
 
 # Find includes in corresponding build directories

--- a/AABB_tree/examples/AABB_tree/CMakeLists.txt
+++ b/AABB_tree/examples/AABB_tree/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(AABB_tree_Examples)
 
 find_package(CGAL REQUIRED)

--- a/AABB_tree/test/AABB_tree/CMakeLists.txt
+++ b/AABB_tree/test/AABB_tree/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(AABB_tree_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/CMakeLists.txt
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Advancing_front_surface_reconstruction_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Advancing_front_surface_reconstruction/test/Advancing_front_surface_reconstruction/CMakeLists.txt
+++ b/Advancing_front_surface_reconstruction/test/Advancing_front_surface_reconstruction/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Advancing_front_surface_reconstruction_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Algebraic_foundations/examples/Algebraic_foundations/CMakeLists.txt
+++ b/Algebraic_foundations/examples/Algebraic_foundations/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Algebraic_foundations_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Algebraic_foundations/test/Algebraic_foundations/CMakeLists.txt
+++ b/Algebraic_foundations/test/Algebraic_foundations/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Algebraic_foundations_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Algebraic_kernel_d/examples/Algebraic_kernel_d/CMakeLists.txt
+++ b/Algebraic_kernel_d/examples/Algebraic_kernel_d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Algebraic_kernel_d_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Algebraic_kernel_d/test/Algebraic_kernel_d/CMakeLists.txt
+++ b/Algebraic_kernel_d/test/Algebraic_kernel_d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Algebraic_kernel_d_Tests)
 
 # CGAL and its components

--- a/Algebraic_kernel_for_circles/test/Algebraic_kernel_for_circles/CMakeLists.txt
+++ b/Algebraic_kernel_for_circles/test/Algebraic_kernel_for_circles/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Algebraic_kernel_for_circles_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Algebraic_kernel_for_spheres/test/Algebraic_kernel_for_spheres/CMakeLists.txt
+++ b/Algebraic_kernel_for_spheres/test/Algebraic_kernel_for_spheres/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Algebraic_kernel_for_spheres_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Alpha_shapes_2/examples/Alpha_shapes_2/CMakeLists.txt
+++ b/Alpha_shapes_2/examples/Alpha_shapes_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Alpha_shapes_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Alpha_shapes_2/test/Alpha_shapes_2/CMakeLists.txt
+++ b/Alpha_shapes_2/test/Alpha_shapes_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Alpha_shapes_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Alpha_shapes_3/demo/Alpha_shapes_3/CMakeLists.txt
+++ b/Alpha_shapes_3/demo/Alpha_shapes_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Alpha_shapes_3_Demo)
 
 # Find includes in corresponding build directories

--- a/Alpha_shapes_3/examples/Alpha_shapes_3/CMakeLists.txt
+++ b/Alpha_shapes_3/examples/Alpha_shapes_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Alpha_shapes_3_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Alpha_shapes_3/test/Alpha_shapes_3/CMakeLists.txt
+++ b/Alpha_shapes_3/test/Alpha_shapes_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Alpha_shapes_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Alpha_wrap_3/benchmark/Alpha_wrap_3/CMakeLists.txt
+++ b/Alpha_wrap_3/benchmark/Alpha_wrap_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Alpha_wrap_3_Benchmark)
 
 find_package(CGAL REQUIRED)

--- a/Alpha_wrap_3/examples/Alpha_wrap_3/CMakeLists.txt
+++ b/Alpha_wrap_3/examples/Alpha_wrap_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Alpha_wrap_3_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Alpha_wrap_3/test/Alpha_wrap_3/CMakeLists.txt
+++ b/Alpha_wrap_3/test/Alpha_wrap_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Alpha_wrap_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Apollonius_graph_2/examples/Apollonius_graph_2/CMakeLists.txt
+++ b/Apollonius_graph_2/examples/Apollonius_graph_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Apollonius_graph_2_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Apollonius_graph_2/test/Apollonius_graph_2/CMakeLists.txt
+++ b/Apollonius_graph_2/test/Apollonius_graph_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Apollonius_graph_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Arithmetic_kernel/test/Arithmetic_kernel/CMakeLists.txt
+++ b/Arithmetic_kernel/test/Arithmetic_kernel/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Arithmetic_kernel_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CMakeLists.txt
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Arrangement_on_surface_2_Demo)
 
 if(NOT POLICY CMP0070 AND POLICY CMP0053)

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2_earth/CMakeLists.txt
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2_earth/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Arrangement_on_surface_2_earth_Demo)
 
 if(NOT POLICY CMP0070 AND POLICY CMP0053)

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/CMakeLists.txt
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Arrangement_on_surface_2_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS Core OPTIONAL_COMPONENTS Qt6)

--- a/Arrangement_on_surface_2/test/Arrangement_on_surface_2/CMakeLists.txt
+++ b/Arrangement_on_surface_2/test/Arrangement_on_surface_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Arrangement_on_surface_2_Tests)
 
 enable_testing()

--- a/BGL/examples/BGL_LCC/CMakeLists.txt
+++ b/BGL/examples/BGL_LCC/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(BGL_LCC_Examples)
 
 # CGAL and its components

--- a/BGL/examples/BGL_OpenMesh/CMakeLists.txt
+++ b/BGL/examples/BGL_OpenMesh/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(BGL_OpenMesh_Examples)
 
 # CGAL and its components

--- a/BGL/examples/BGL_arrangement_2/CMakeLists.txt
+++ b/BGL/examples/BGL_arrangement_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(BGL_arrangement_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/BGL/examples/BGL_graphcut/CMakeLists.txt
+++ b/BGL/examples/BGL_graphcut/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(BGL_graphcut_Examples)
 

--- a/BGL/examples/BGL_polyhedron_3/CMakeLists.txt
+++ b/BGL/examples/BGL_polyhedron_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(BGL_polyhedron_3_Examples)
 
 # CGAL and its components

--- a/BGL/examples/BGL_surface_mesh/CMakeLists.txt
+++ b/BGL/examples/BGL_surface_mesh/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(BGL_surface_mesh_Examples)
 
 find_package(CGAL REQUIRED)

--- a/BGL/examples/BGL_triangulation_2/CMakeLists.txt
+++ b/BGL/examples/BGL_triangulation_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(BGL_triangulation_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/BGL/test/BGL/CMakeLists.txt
+++ b/BGL/test/BGL/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script_with_options
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(BGL_Tests)
 
 # CGAL and its components

--- a/Barycentric_coordinates_2/benchmark/Barycentric_coordinates_2/CMakeLists.txt
+++ b/Barycentric_coordinates_2/benchmark/Barycentric_coordinates_2/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 project(Barycentric_coordinates_2_Benchmarks)
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Barycentric_coordinates_2/examples/Barycentric_coordinates_2/CMakeLists.txt
+++ b/Barycentric_coordinates_2/examples/Barycentric_coordinates_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script.
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Barycentric_coordinates_2_Examples)
 

--- a/Barycentric_coordinates_2/test/Barycentric_coordinates_2/CMakeLists.txt
+++ b/Barycentric_coordinates_2/test/Barycentric_coordinates_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script.
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Barycentric_coordinates_2_Tests)
 

--- a/Basic_viewer/examples/Basic_viewer/CMakeLists.txt
+++ b/Basic_viewer/examples/Basic_viewer/CMakeLists.txt
@@ -6,7 +6,7 @@
 # Used in /CGAL/Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt.
 # Careful when modifying
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Basic_viewer_Examples)
 
 #CGAL_Qt6 is needed for the drawing.

--- a/Boolean_set_operations_2/examples/Boolean_set_operations_2/CMakeLists.txt
+++ b/Boolean_set_operations_2/examples/Boolean_set_operations_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Boolean_set_operations_2_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS Core OPTIONAL_COMPONENTS Qt6)

--- a/Boolean_set_operations_2/test/Boolean_set_operations_2/CMakeLists.txt
+++ b/Boolean_set_operations_2/test/Boolean_set_operations_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Boolean_set_operations_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Bounding_volumes/examples/Approximate_min_ellipsoid_d/CMakeLists.txt
+++ b/Bounding_volumes/examples/Approximate_min_ellipsoid_d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Approximate_min_ellipsoid_d_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Bounding_volumes/examples/Min_annulus_d/CMakeLists.txt
+++ b/Bounding_volumes/examples/Min_annulus_d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Min_annulus_d_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Bounding_volumes/examples/Min_circle_2/CMakeLists.txt
+++ b/Bounding_volumes/examples/Min_circle_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Min_circle_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Bounding_volumes/examples/Min_ellipse_2/CMakeLists.txt
+++ b/Bounding_volumes/examples/Min_ellipse_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Min_ellipse_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Bounding_volumes/examples/Min_quadrilateral_2/CMakeLists.txt
+++ b/Bounding_volumes/examples/Min_quadrilateral_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Min_quadrilateral_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Bounding_volumes/examples/Min_sphere_d/CMakeLists.txt
+++ b/Bounding_volumes/examples/Min_sphere_d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Min_sphere_d_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Bounding_volumes/examples/Min_sphere_of_spheres_d/CMakeLists.txt
+++ b/Bounding_volumes/examples/Min_sphere_of_spheres_d/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Min_sphere_of_spheres_d_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Bounding_volumes/examples/Rectangular_p_center_2/CMakeLists.txt
+++ b/Bounding_volumes/examples/Rectangular_p_center_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Rectangular_p_center_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Bounding_volumes/test/Bounding_volumes/CMakeLists.txt
+++ b/Bounding_volumes/test/Bounding_volumes/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Bounding_volumes_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Box_intersection_d/examples/Box_intersection_d/CMakeLists.txt
+++ b/Box_intersection_d/examples/Box_intersection_d/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Box_intersection_d_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Box_intersection_d/test/Box_intersection_d/CMakeLists.txt
+++ b/Box_intersection_d/test/Box_intersection_d/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Box_intersection_d_Tests)
 
 find_package(CGAL REQUIRED)

--- a/CGAL_Core/examples/Core/CMakeLists.txt
+++ b/CGAL_Core/examples/Core/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Core_Examples)
 
 # CGAL and its components

--- a/CGAL_ImageIO/examples/CGALimageIO/CMakeLists.txt
+++ b/CGAL_ImageIO/examples/CGALimageIO/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(CGALimageIO_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS ImageIO)

--- a/CGAL_ImageIO/test/CGAL_ImageIO/CMakeLists.txt
+++ b/CGAL_ImageIO/test/CGAL_ImageIO/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(CGAL_ImageIO_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS ImageIO)

--- a/CGAL_ipelets/demo/CGAL_ipelets/CMakeLists.txt
+++ b/CGAL_ipelets/demo/CGAL_ipelets/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(CGAL_ipelets_Demo)
 
 if(NOT POLICY CMP0070 AND POLICY CMP0053)

--- a/CGAL_ipelets/test/CGAL_ipelets/CMakeLists.txt
+++ b/CGAL_ipelets/test/CGAL_ipelets/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(CGAL_ipelets_Tests)
 
 find_package(CGAL REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Top level CMakeLists.txt for CGAL-branchbuild
 
 # Minimal version of CMake:
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 message("== CMake setup ==")
 project(CGAL CXX C)

--- a/Circular_kernel_2/examples/Circular_kernel_2/CMakeLists.txt
+++ b/Circular_kernel_2/examples/Circular_kernel_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Circular_kernel_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Circular_kernel_2/test/Circular_kernel_2/CMakeLists.txt
+++ b/Circular_kernel_2/test/Circular_kernel_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Circular_kernel_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Circular_kernel_3/demo/Circular_kernel_3/CMakeLists.txt
+++ b/Circular_kernel_3/demo/Circular_kernel_3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Circular_kernel_3_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Circular_kernel_3/examples/Circular_kernel_3/CMakeLists.txt
+++ b/Circular_kernel_3/examples/Circular_kernel_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Circular_kernel_3_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Circular_kernel_3/test/Circular_kernel_3/CMakeLists.txt
+++ b/Circular_kernel_3/test/Circular_kernel_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Circular_kernel_3_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Circulator/examples/Circulator/CMakeLists.txt
+++ b/Circulator/examples/Circulator/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Circulator_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Circulator/test/Circulator/CMakeLists.txt
+++ b/Circulator/test/Circulator/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Circulator_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Classification/examples/Classification/CMakeLists.txt
+++ b/Classification/examples/Classification/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Classification_Examples)
 
 # CGAL and its components

--- a/Classification/test/Classification/CMakeLists.txt
+++ b/Classification/test/Classification/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Classification_Tests)
 
 # CGAL and its components

--- a/Combinatorial_map/examples/Combinatorial_map/CMakeLists.txt
+++ b/Combinatorial_map/examples/Combinatorial_map/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Combinatorial_map_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Combinatorial_map/test/Combinatorial_map/CMakeLists.txt
+++ b/Combinatorial_map/test/Combinatorial_map/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Combinatorial_map_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Cone_spanners_2/examples/Cone_spanners_2/CMakeLists.txt
+++ b/Cone_spanners_2/examples/Cone_spanners_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Cone_spanners_2_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Core)

--- a/Cone_spanners_2/test/Cone_spanners_2/CMakeLists.txt
+++ b/Cone_spanners_2/test/Cone_spanners_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Cone_spanners_2_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Convex_decomposition_3/examples/Convex_decomposition_3/CMakeLists.txt
+++ b/Convex_decomposition_3/examples/Convex_decomposition_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Convex_decomposition_3_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Convex_decomposition_3/test/Convex_decomposition_3/CMakeLists.txt
+++ b/Convex_decomposition_3/test/Convex_decomposition_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Convex_decomposition_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Convex_hull_2/examples/Convex_hull_2/CMakeLists.txt
+++ b/Convex_hull_2/examples/Convex_hull_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Convex_hull_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Convex_hull_2/test/Convex_hull_2/CMakeLists.txt
+++ b/Convex_hull_2/test/Convex_hull_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Convex_hull_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
+++ b/Convex_hull_3/examples/Convex_hull_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Convex_hull_3_Examples)
 
 # CGAL and its components

--- a/Convex_hull_3/test/Convex_hull_3/CMakeLists.txt
+++ b/Convex_hull_3/test/Convex_hull_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Convex_hull_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Convex_hull_d/test/Convex_hull_d/CMakeLists.txt
+++ b/Convex_hull_d/test/Convex_hull_d/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Convex_hull_d_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Distance_2/test/Distance_2/CMakeLists.txt
+++ b/Distance_2/test/Distance_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Distance_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Distance_3/test/Distance_3/CMakeLists.txt
+++ b/Distance_3/test/Distance_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Distance_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Documentation/doc/CMakeLists.txt
+++ b/Documentation/doc/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Documentation NONE)
 
 # Check whether this cmake script is the top level one
@@ -24,7 +24,7 @@ else()
   set(CGAL_ROOT "${CMAKE_SOURCE_DIR}")
 endif()
 
-cmake_minimum_required(VERSION 3.18..3.29) # for list(SORT ... COMPARE NATURAL)
+cmake_minimum_required(VERSION 3.18...3.31) # for list(SORT ... COMPARE NATURAL)
 
 find_package(Doxygen REQUIRED)
 find_package(Python3 REQUIRED COMPONENTS Interpreter)

--- a/Envelope_2/examples/Envelope_2/CMakeLists.txt
+++ b/Envelope_2/examples/Envelope_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Envelope_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Envelope_2/test/Envelope_2/CMakeLists.txt
+++ b/Envelope_2/test/Envelope_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Envelope_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Envelope_3/examples/Envelope_3/CMakeLists.txt
+++ b/Envelope_3/examples/Envelope_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Envelope_3_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Envelope_3/test/Envelope_3/CMakeLists.txt
+++ b/Envelope_3/test/Envelope_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Envelope_3_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Filtered_kernel/benchmark/Filtered_kernel/CMakeLists.txt
+++ b/Filtered_kernel/benchmark/Filtered_kernel/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Filtered_kernel_test)
 
 add_executable(bench_simple_comparisons bench_simple_comparisons.cpp)

--- a/Filtered_kernel/examples/Filtered_kernel/CMakeLists.txt
+++ b/Filtered_kernel/examples/Filtered_kernel/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Filtered_kernel_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Filtered_kernel/test/Filtered_kernel/CMakeLists.txt
+++ b/Filtered_kernel/test/Filtered_kernel/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Filtered_kernel_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Generalized_map/examples/Generalized_map/CMakeLists.txt
+++ b/Generalized_map/examples/Generalized_map/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Generalized_map_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Generalized_map/test/Generalized_map/CMakeLists.txt
+++ b/Generalized_map/test/Generalized_map/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Generalized_map_Tests)
 
 # CGAL and its components

--- a/Generator/benchmark/Generator/CMakeLists.txt
+++ b/Generator/benchmark/Generator/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Generator_example)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Generator/examples/Generator/CMakeLists.txt
+++ b/Generator/examples/Generator/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Generator_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Generator/test/Generator/CMakeLists.txt
+++ b/Generator/test/Generator/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Generator_Tests)
 
 find_package(CGAL REQUIRED)

--- a/GraphicsView/demo/Alpha_shapes_2/CMakeLists.txt
+++ b/GraphicsView/demo/Alpha_shapes_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Alpha_shapes_2_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/GraphicsView/demo/Apollonius_graph_2/CMakeLists.txt
+++ b/GraphicsView/demo/Apollonius_graph_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Apollonius_graph_2_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/GraphicsView/demo/Bounding_volumes/CMakeLists.txt
+++ b/GraphicsView/demo/Bounding_volumes/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Bounding_volumes_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/GraphicsView/demo/Circular_kernel_2/CMakeLists.txt
+++ b/GraphicsView/demo/Circular_kernel_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Circular_kernel_2_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/GraphicsView/demo/Generator/CMakeLists.txt
+++ b/GraphicsView/demo/Generator/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Generator_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/GraphicsView/demo/GraphicsView/CMakeLists.txt
+++ b/GraphicsView/demo/GraphicsView/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(GraphicsView_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/GraphicsView/demo/L1_Voronoi_diagram_2/CMakeLists.txt
+++ b/GraphicsView/demo/L1_Voronoi_diagram_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(L1_Voronoi_diagram_2_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/GraphicsView/demo/Largest_empty_rect_2/CMakeLists.txt
+++ b/GraphicsView/demo/Largest_empty_rect_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Largest_empty_rect_2_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/GraphicsView/demo/Periodic_2_triangulation_2/CMakeLists.txt
+++ b/GraphicsView/demo/Periodic_2_triangulation_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_2_triangulation_2_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/GraphicsView/demo/Polygon/CMakeLists.txt
+++ b/GraphicsView/demo/Polygon/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polygon_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6 Core)

--- a/GraphicsView/demo/Segment_Delaunay_graph_2/CMakeLists.txt
+++ b/GraphicsView/demo/Segment_Delaunay_graph_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Segment_Delaunay_graph_2_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6 Core)

--- a/GraphicsView/demo/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
+++ b/GraphicsView/demo/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Segment_Delaunay_graph_Linf_2_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6 Core)

--- a/GraphicsView/demo/Snap_rounding_2/CMakeLists.txt
+++ b/GraphicsView/demo/Snap_rounding_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Snap_rounding_2_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/GraphicsView/demo/Spatial_searching_2/CMakeLists.txt
+++ b/GraphicsView/demo/Spatial_searching_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Spatial_searching_2_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/GraphicsView/demo/Stream_lines_2/CMakeLists.txt
+++ b/GraphicsView/demo/Stream_lines_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Stream_lines_2_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/GraphicsView/demo/Triangulation_2/CMakeLists.txt
+++ b/GraphicsView/demo/Triangulation_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Triangulation_2_Demo)
 
 set(CMAKE_AUTOMOC ON)

--- a/HalfedgeDS/examples/HalfedgeDS/CMakeLists.txt
+++ b/HalfedgeDS/examples/HalfedgeDS/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(HalfedgeDS_Examples)
 
 find_package(CGAL REQUIRED)

--- a/HalfedgeDS/test/HalfedgeDS/CMakeLists.txt
+++ b/HalfedgeDS/test/HalfedgeDS/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(HalfedgeDS_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Hash_map/benchmark/Hash_map/CMakeLists.txt
+++ b/Hash_map/benchmark/Hash_map/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Hash_map)
 
 # CGAL and its components

--- a/Hash_map/test/Hash_map/CMakeLists.txt
+++ b/Hash_map/test/Hash_map/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Hash_map_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Heat_method_3/examples/Heat_method_3/CMakeLists.txt
+++ b/Heat_method_3/examples/Heat_method_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Heat_method_3_Examples)
 
 # CGAL and its components

--- a/Heat_method_3/test/Heat_method_3/CMakeLists.txt
+++ b/Heat_method_3/test/Heat_method_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Heat_method_3_Tests)
 
 # CGAL and its components

--- a/Hyperbolic_triangulation_2/benchmark/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/benchmark/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Hyperbolic_triangulation_2_benchmark)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/demo/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Hyperbolic_triangulation_2_Demo)
 
 # Find includes in corresponding build directories

--- a/Hyperbolic_triangulation_2/examples/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/examples/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Hyperbolic_triangulation_2_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Hyperbolic_triangulation_2/test/Hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Hyperbolic_triangulation_2/test/Hyperbolic_triangulation_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Hyperbolic_triangulation_2_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Inscribed_areas/examples/Inscribed_areas/CMakeLists.txt
+++ b/Inscribed_areas/examples/Inscribed_areas/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Inscribed_areas_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Inscribed_areas/test/Inscribed_areas/CMakeLists.txt
+++ b/Inscribed_areas/test/Inscribed_areas/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Inscribed_areas_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -4,7 +4,7 @@
 # ${CGAL_SOURCE_DIR} and to the root binary directory of the project as
 # ${CGAL_BINARY_DIR} or ${CGAL_BINARY_DIR}.
 if(NOT PROJECT_NAME)
-  cmake_minimum_required(VERSION 3.12...3.29)
+  cmake_minimum_required(VERSION 3.12...3.31)
   project(CGAL CXX C)
 endif()
 

--- a/Installation/cmake/modules/CGAL_Boost_iostreams_support.cmake
+++ b/Installation/cmake/modules/CGAL_Boost_iostreams_support.cmake
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 if(Boost_IOSTREAMS_FOUND AND NOT TARGET CGAL::Boost_iostreams_support)
 
   if( WIN32 )

--- a/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
+++ b/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
@@ -23,7 +23,7 @@
 #    If set, the `LEDA` library will be searched and used to provide
 #    the exact number types used by CGAL kernels.
 #
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 if(CGAL_SetupCGALDependencies_included)
   return()
 endif()

--- a/Installation/cmake/modules/CGAL_SetupLEDA.cmake
+++ b/Installation/cmake/modules/CGAL_SetupLEDA.cmake
@@ -9,7 +9,7 @@
 #    find_package(LEDA)
 #
 # and defines the function :command:`use_CGAL_LEDA_support`.
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 if(CGAL_SetupLEDA_included)
   return()
 endif()

--- a/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
+++ b/Installation/cmake/modules/CGAL_enable_end_of_configuration_hook.cmake
@@ -6,7 +6,7 @@
 # the configuration.
 #
 # See https://stackoverflow.com/a/43300621/1728537 for the starting point.
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 if(CGAL_SKIP_CMAKE_HOOKS)
   return()

--- a/Installation/demo/CMakeLists.txt
+++ b/Installation/demo/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(CGAL_DEMOS)
 
 if(CGAL_BRANCH_BUILD)

--- a/Installation/examples/CMakeLists.txt
+++ b/Installation/examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(CGAL_EXAMPLES)
 
 if(CGAL_BRANCH_BUILD)

--- a/Installation/test/CMakeLists.txt
+++ b/Installation/test/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(CGAL_TESTS)
 
 if(CGAL_BRANCH_BUILD)

--- a/Installation/test/Installation/CMakeLists.txt
+++ b/Installation/test/Installation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project( Installation_Tests )
 

--- a/Installation/test/Installation/test_configuration.cmake.in
+++ b/Installation/test/Installation/test_configuration.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(test_configuration)
 find_package(CGAL)
 add_definitions(-DQT_NO_KEYWORDS)

--- a/Installation/test/Installation/test_configuration_qt.cmake.in
+++ b/Installation/test/Installation/test_configuration_qt.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(test_configuration)
 find_package(CGAL COMPONENTS Qt6)
 add_definitions(-DCGAL_USE_BASIC_VIEWER -DQT_NO_KEYWORDS)

--- a/Installation/test/Installation/test_find_package.cmake.in
+++ b/Installation/test/Installation/test_find_package.cmake.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project( test_find_package_${mode} )
 find_package(CGAL ${VERSION} ${EXACT}REQUIRED
   PATHS ${CGAL_DIR}

--- a/Interpolation/examples/Interpolation/CMakeLists.txt
+++ b/Interpolation/examples/Interpolation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Interpolation_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Interpolation/test/Interpolation/CMakeLists.txt
+++ b/Interpolation/test/Interpolation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Interpolation_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Intersections_2/test/Intersections_2/CMakeLists.txt
+++ b/Intersections_2/test/Intersections_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Intersections_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Intersections_3/test/Intersections_3/CMakeLists.txt
+++ b/Intersections_3/test/Intersections_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Intersections_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Interval_skip_list/examples/Interval_skip_list/CMakeLists.txt
+++ b/Interval_skip_list/examples/Interval_skip_list/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Interval_skip_list_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Interval_skip_list/test/Interval_skip_list/CMakeLists.txt
+++ b/Interval_skip_list/test/Interval_skip_list/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Interval_skip_list_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Interval_support/test/Interval_support/CMakeLists.txt
+++ b/Interval_support/test/Interval_support/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Interval_support_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Jet_fitting_3/examples/Jet_fitting_3/CMakeLists.txt
+++ b/Jet_fitting_3/examples/Jet_fitting_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Jet_fitting_3_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Jet_fitting_3/test/Jet_fitting_3/CMakeLists.txt
+++ b/Jet_fitting_3/test/Jet_fitting_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Jet_fitting_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Kernel_23/benchmark/Kernel_23/CMakeLists.txt
+++ b/Kernel_23/benchmark/Kernel_23/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Kernel_23_benchmark)
 
 find_package(CGAL QUIET OPTIONAL_COMPONENTS Core)

--- a/Kernel_23/examples/Kernel_23/CMakeLists.txt
+++ b/Kernel_23/examples/Kernel_23/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Kernel_23_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Kernel_23/test/Kernel_23/CMakeLists.txt
+++ b/Kernel_23/test/Kernel_23/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Kernel_23_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Kernel_d/test/Kernel_d/CMakeLists.txt
+++ b/Kernel_d/test/Kernel_d/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Kernel_d_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Kinetic_space_partition/examples/Kinetic_space_partition/CMakeLists.txt
+++ b/Kinetic_space_partition/examples/Kinetic_space_partition/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists.
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Kinetic_space_partition_Examples)
 

--- a/Kinetic_space_partition/test/Kinetic_space_partition/CMakeLists.txt
+++ b/Kinetic_space_partition/test/Kinetic_space_partition/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists.
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Kinetic_space_partition_Tests)
 

--- a/Kinetic_surface_reconstruction/examples/Kinetic_surface_reconstruction/CMakeLists.txt
+++ b/Kinetic_surface_reconstruction/examples/Kinetic_surface_reconstruction/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists.
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Kinetic_surface_reconstruction_Examples)
 

--- a/Kinetic_surface_reconstruction/test/Kinetic_surface_reconstruction/CMakeLists.txt
+++ b/Kinetic_surface_reconstruction/test/Kinetic_surface_reconstruction/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists.
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Kinetic_surface_reconstruction_Tests)
 

--- a/Lab/demo/Lab/CMakeLists.txt
+++ b/Lab/demo/Lab/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Lab_Demo)
 include(FeatureSummary)
 

--- a/Lab/demo/Lab/Plugins/Three_examples/CMakeLists.txt
+++ b/Lab/demo/Lab/Plugins/Three_examples/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Three_examples)
 
 if(NOT POLICY CMP0070 AND POLICY CMP0053)

--- a/Lab/demo/Lab/implicit_functions/CMakeLists.txt
+++ b/Lab/demo/Lab/implicit_functions/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling the CGAL Mesh_3 demo implicit functions.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 include(CGALlab_macros)
 

--- a/Linear_cell_complex/benchmark/Linear_cell_complex_2/CMakeLists.txt
+++ b/Linear_cell_complex/benchmark/Linear_cell_complex_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(LCC_performance_2)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake/)

--- a/Linear_cell_complex/benchmark/Linear_cell_complex_3/CMakeLists.txt
+++ b/Linear_cell_complex/benchmark/Linear_cell_complex_3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(LCC_performance_3)
 
 if(NOT POLICY CMP0070 AND POLICY CMP0053)

--- a/Linear_cell_complex/demo/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/demo/Linear_cell_complex/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This is the CMake script for compiling a CGAL application.
 # cmake ../ -DCMAKE_BUILD_TYPE=Debug
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Linear_cell_complex_Demo)
 
 # Find includes in corresponding build directories

--- a/Linear_cell_complex/examples/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/examples/Linear_cell_complex/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Linear_cell_complex_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Linear_cell_complex_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Matrix_search/examples/Matrix_search/CMakeLists.txt
+++ b/Matrix_search/examples/Matrix_search/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Matrix_search_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Matrix_search/test/Matrix_search/CMakeLists.txt
+++ b/Matrix_search/test/Matrix_search/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Matrix_search_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Mesh_2/demo/Mesh_2/CMakeLists.txt
+++ b/Mesh_2/demo/Mesh_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script (and then adapted manually).
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Mesh_2_Demo)
 
 find_package(CGAL REQUIRED)

--- a/Mesh_2/examples/Mesh_2/CMakeLists.txt
+++ b/Mesh_2/examples/Mesh_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Mesh_2_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Mesh_2/test/Mesh_2/CMakeLists.txt
+++ b/Mesh_2/test/Mesh_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Mesh_2_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Mesh_3/benchmark/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/benchmark/Mesh_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Mesh_3_benchmark)
 
 find_package(CGAL REQUIRED COMPONENTS ImageIO)

--- a/Mesh_3/examples/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/examples/Mesh_3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Mesh_3_Examples)
 
 add_compile_definitions(CGAL_MESH_3_NO_DEPRECATED_SURFACE_INDEX

--- a/Mesh_3/test/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/test/Mesh_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project( Mesh_3_Tests )
 
 find_package(CGAL REQUIRED COMPONENTS ImageIO)

--- a/Minkowski_sum_2/examples/Minkowski_sum_2/CMakeLists.txt
+++ b/Minkowski_sum_2/examples/Minkowski_sum_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Minkowski_sum_2_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Minkowski_sum_2/test/Minkowski_sum_2/CMakeLists.txt
+++ b/Minkowski_sum_2/test/Minkowski_sum_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Minkowski_sum_2_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Minkowski_sum_3/examples/Minkowski_sum_3/CMakeLists.txt
+++ b/Minkowski_sum_3/examples/Minkowski_sum_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Minkowski_sum_3_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Minkowski_sum_3/test/Minkowski_sum_3/CMakeLists.txt
+++ b/Minkowski_sum_3/test/Minkowski_sum_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Minkowski_sum_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Modifier/test/Modifier/CMakeLists.txt
+++ b/Modifier/test/Modifier/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Modifier_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Modular_arithmetic/examples/Modular_arithmetic/CMakeLists.txt
+++ b/Modular_arithmetic/examples/Modular_arithmetic/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Modular_arithmetic_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Modular_arithmetic/test/Modular_arithmetic/CMakeLists.txt
+++ b/Modular_arithmetic/test/Modular_arithmetic/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Modular_arithmetic_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Nef_2/examples/Nef_2/CMakeLists.txt
+++ b/Nef_2/examples/Nef_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Nef_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Nef_2/test/Nef_2/CMakeLists.txt
+++ b/Nef_2/test/Nef_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Nef_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Nef_3/examples/Nef_3/CMakeLists.txt
+++ b/Nef_3/examples/Nef_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Nef_3_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Nef_3/test/Nef_3/CMakeLists.txt
+++ b/Nef_3/test/Nef_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Nef_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Nef_S2/examples/Nef_S2/CMakeLists.txt
+++ b/Nef_S2/examples/Nef_S2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Nef_S2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Nef_S2/test/Nef_S2/CMakeLists.txt
+++ b/Nef_S2/test/Nef_S2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Nef_S2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/NewKernel_d/test/NewKernel_d/CMakeLists.txt
+++ b/NewKernel_d/test/NewKernel_d/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This is the CMake script for compiling a CGAL application.
 # Then modified by hand to add Eigen3.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(NewKernel_d_Tests)
 
 if(CMAKE_COMPILER_IS_GNUCCX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)

--- a/Number_types/test/Number_types/CMakeLists.txt
+++ b/Number_types/test/Number_types/CMakeLists.txt
@@ -3,7 +3,7 @@
 # that dependency so as to test all the number types not depending on CORE
 # when it is not installed
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Number_types_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Optimal_bounding_box/benchmark/Optimal_bounding_box/CMakeLists.txt
+++ b/Optimal_bounding_box/benchmark/Optimal_bounding_box/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Optimal_bounding_box_Benchmark)
 
 # CGAL and its components

--- a/Optimal_bounding_box/examples/Optimal_bounding_box/CMakeLists.txt
+++ b/Optimal_bounding_box/examples/Optimal_bounding_box/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Optimal_bounding_box_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Optimal_bounding_box/test/Optimal_bounding_box/CMakeLists.txt
+++ b/Optimal_bounding_box/test/Optimal_bounding_box/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Optimal_bounding_box_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/CMakeLists.txt
+++ b/Optimal_transportation_reconstruction_2/demo/Optimal_transportation_reconstruction_2/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling the Optimal_transportation_reconstruction_2 demo.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Optimal_transportation_reconstruction_2_Demo)
 
 # Find CGAL and CGAL Qt6

--- a/Optimal_transportation_reconstruction_2/examples/Optimal_transportation_reconstruction_2/CMakeLists.txt
+++ b/Optimal_transportation_reconstruction_2/examples/Optimal_transportation_reconstruction_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Optimal_transportation_reconstruction_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Optimal_transportation_reconstruction_2/test/Optimal_transportation_reconstruction_2/CMakeLists.txt
+++ b/Optimal_transportation_reconstruction_2/test/Optimal_transportation_reconstruction_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Optimal_transportation_reconstruction_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Orthtree/benchmark/Orthtree/CMakeLists.txt
+++ b/Orthtree/benchmark/Orthtree/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Orthtree_benchmarks)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Core)

--- a/Orthtree/examples/Orthtree/CMakeLists.txt
+++ b/Orthtree/examples/Orthtree/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Orthtree_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Core)

--- a/Orthtree/test/Orthtree/CMakeLists.txt
+++ b/Orthtree/test/Orthtree/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Orthtree_Tests)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Core)

--- a/Partition_2/examples/Partition_2/CMakeLists.txt
+++ b/Partition_2/examples/Partition_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Partition_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Partition_2/test/Partition_2/CMakeLists.txt
+++ b/Partition_2/test/Partition_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Partition_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/CMakeLists.txt
+++ b/Periodic_2_triangulation_2/examples/Periodic_2_triangulation_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_2_triangulation_2_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/CMakeLists.txt
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_2_triangulation_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Periodic_3_mesh_3/examples/Periodic_3_mesh_3/CMakeLists.txt
+++ b/Periodic_3_mesh_3/examples/Periodic_3_mesh_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_3_mesh_3_Examples)
 
 # CGAL and its components

--- a/Periodic_3_mesh_3/test/Periodic_3_mesh_3/CMakeLists.txt
+++ b/Periodic_3_mesh_3/test/Periodic_3_mesh_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_3_mesh_3_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS ImageIO)

--- a/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/demo/Periodic_3_triangulation_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_3_triangulation_3_Demo)
 
 # Find CGAL

--- a/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/demo/Periodic_Lloyd_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_Lloyd_3_Demo)
 
 # Find includes in corresponding build directories

--- a/Periodic_3_triangulation_3/examples/Periodic_3_triangulation_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/examples/Periodic_3_triangulation_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_3_triangulation_3_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/CMakeLists.txt
+++ b/Periodic_3_triangulation_3/test/Periodic_3_triangulation_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_3_triangulation_3_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Periodic_4_hyperbolic_triangulation_2/benchmark/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/benchmark/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_4_hyperbolic_triangulation_2_Benchmarks)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/demo/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_4_hyperbolic_triangulation_2_Demo)
 
 # Find includes in corresponding build directories

--- a/Periodic_4_hyperbolic_triangulation_2/examples/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/examples/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_4_hyperbolic_triangulation_2_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Core)

--- a/Periodic_4_hyperbolic_triangulation_2/test/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/test/Periodic_4_hyperbolic_triangulation_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Periodic_4_hyperbolic_triangulation_2_Tests)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Core)

--- a/Point_set_2/examples/Point_set_2/CMakeLists.txt
+++ b/Point_set_2/examples/Point_set_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Point_set_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Point_set_2/test/Point_set_2/CMakeLists.txt
+++ b/Point_set_2/test/Point_set_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Point_set_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Point_set_3/examples/Point_set_3/CMakeLists.txt
+++ b/Point_set_3/examples/Point_set_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Point_set_3_Examples)
 
 # CGAL and its components

--- a/Point_set_3/test/Point_set_3/CMakeLists.txt
+++ b/Point_set_3/test/Point_set_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Point_set_3_Tests)
 
 # CGAL and its components

--- a/Point_set_processing_3/examples/Point_set_processing_3/CMakeLists.txt
+++ b/Point_set_processing_3/examples/Point_set_processing_3/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling this folder.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Point_set_processing_3_Examples)
 
 # Find CGAL

--- a/Point_set_processing_3/test/Point_set_processing_3/CMakeLists.txt
+++ b/Point_set_processing_3/test/Point_set_processing_3/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling this folder.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Point_set_processing_3_Tests)
 
 # Find CGAL

--- a/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/CMakeLists.txt
+++ b/Poisson_surface_reconstruction_3/examples/Poisson_surface_reconstruction_3/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling this folder.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Poisson_surface_reconstruction_3_Examples)
 
 # Find CGAL

--- a/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/CMakeLists.txt
+++ b/Poisson_surface_reconstruction_3/test/Poisson_surface_reconstruction_3/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling this folder.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Poisson_surface_reconstruction_3_Tests)
 
 # Find CGAL

--- a/Polygon/examples/Polygon/CMakeLists.txt
+++ b/Polygon/examples/Polygon/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polygon_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Polygon/test/Polygon/CMakeLists.txt
+++ b/Polygon/test/Polygon/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polygon_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polygon_mesh_processing)
 
 # CGAL and its components

--- a/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/examples/Polygon_mesh_processing/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polygon_mesh_processing_Examples)
 
 # CGAL and its components

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polygon_mesh_processing_Tests)
 
 # CGAL and its components

--- a/Polygon_repair/examples/Polygon_repair/CMakeLists.txt
+++ b/Polygon_repair/examples/Polygon_repair/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polygon_repair_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Polygon_repair/test/Polygon_repair/CMakeLists.txt
+++ b/Polygon_repair/test/Polygon_repair/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polygon_repair_Tests)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/CMakeLists.txt
+++ b/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Polygonal_surface_reconstruction_Examples)
 

--- a/Polygonal_surface_reconstruction/test/Polygonal_surface_reconstruction/CMakeLists.txt
+++ b/Polygonal_surface_reconstruction/test/Polygonal_surface_reconstruction/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Polygonal_surface_reconstruction_Tests)
 

--- a/Polyhedron/examples/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/examples/Polyhedron/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polyhedron_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Polyhedron/test/Polyhedron/CMakeLists.txt
+++ b/Polyhedron/test/Polyhedron/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polyhedron_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Polyline_simplification_2/demo/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/demo/Polyline_simplification_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polyline_simplification_2_Demo)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Polyline_simplification_2/examples/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/examples/Polyline_simplification_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polyline_simplification_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Polyline_simplification_2/test/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/test/Polyline_simplification_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polyline_simplification_2_Tests)
 
 # CGAL and its components

--- a/Polynomial/examples/Polynomial/CMakeLists.txt
+++ b/Polynomial/examples/Polynomial/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polynomial_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Polynomial/test/Polynomial/CMakeLists.txt
+++ b/Polynomial/test/Polynomial/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polynomial_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Polytope_distance_d/examples/Polytope_distance_d/CMakeLists.txt
+++ b/Polytope_distance_d/examples/Polytope_distance_d/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polytope_distance_d_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Polytope_distance_d/test/Polytope_distance_d/CMakeLists.txt
+++ b/Polytope_distance_d/test/Polytope_distance_d/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Polytope_distance_d_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Principal_component_analysis/demo/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/demo/Principal_component_analysis/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling the PCA demo.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Principal_component_analysis_Demo)
 
 include_directories(./)

--- a/Principal_component_analysis/examples/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/examples/Principal_component_analysis/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Principal_component_analysis_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Principal_component_analysis/test/Principal_component_analysis/CMakeLists.txt
+++ b/Principal_component_analysis/test/Principal_component_analysis/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Principal_component_analysis_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Profiling_tools/examples/Profiling_tools/CMakeLists.txt
+++ b/Profiling_tools/examples/Profiling_tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Profiling_tools_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Profiling_tools/test/Profiling_tools/CMakeLists.txt
+++ b/Profiling_tools/test/Profiling_tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Profiling_tools_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Property_map/examples/Property_map/CMakeLists.txt
+++ b/Property_map/examples/Property_map/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Property_map_Examples)
 
 # CGAL and its components

--- a/Property_map/test/Property_map/CMakeLists.txt
+++ b/Property_map/test/Property_map/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Property_map_Tests)
 
 # CGAL and its components

--- a/QP_solver/examples/QP_solver/CMakeLists.txt
+++ b/QP_solver/examples/QP_solver/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(QP_solver_Examples)
 
 find_package(CGAL REQUIRED)

--- a/QP_solver/test/QP_solver/CMakeLists.txt
+++ b/QP_solver/test/QP_solver/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(QP_solver_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Random_numbers/test/Random_numbers/CMakeLists.txt
+++ b/Random_numbers/test/Random_numbers/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Random_numbers_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Ridges_3/examples/Ridges_3/CMakeLists.txt
+++ b/Ridges_3/examples/Ridges_3/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is the CMake script for compiling a CGAL application.
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Ridges_3_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Ridges_3/test/Ridges_3/CMakeLists.txt
+++ b/Ridges_3/test/Ridges_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Ridges_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/SMDS_3/examples/SMDS_3/CMakeLists.txt
+++ b/SMDS_3/examples/SMDS_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(SMDS_3_Examples)
 

--- a/SMDS_3/test/SMDS_3/CMakeLists.txt
+++ b/SMDS_3/test/SMDS_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(SMDS_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/STL_Extension/benchmark/compact_container_benchmark/CMakeLists.txt
+++ b/STL_Extension/benchmark/compact_container_benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Compact_container_benchmark)
 
 find_package(CGAL REQUIRED)

--- a/STL_Extension/benchmark/copy_n_benchmark/CMakeLists.txt
+++ b/STL_Extension/benchmark/copy_n_benchmark/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(copy_n_benchmark_example)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/STL_Extension/examples/STL_Extension/CMakeLists.txt
+++ b/STL_Extension/examples/STL_Extension/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(STL_Extension_Examples)
 
 find_package(CGAL REQUIRED)

--- a/STL_Extension/test/STL_Extension/CMakeLists.txt
+++ b/STL_Extension/test/STL_Extension/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(STL_Extension_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Scale_space_reconstruction_3/examples/Scale_space_reconstruction_3/CMakeLists.txt
+++ b/Scale_space_reconstruction_3/examples/Scale_space_reconstruction_3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Scale_space_reconstruction_3_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
+++ b/Scripts/developer_scripts/cgal_create_release_with_cmake.cmake
@@ -10,7 +10,7 @@
 # GPL_PACKAGE_LIST=path to a file containing the list of GPL packages to include in the release. If not provided all of them are.
 # GENERATE_TARBALLS=[ON/OFF] indicates if release tarballs should be created as DESTINATION
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 find_program(BASH NAMES bash sh)
 function(process_package pkg)
   if(VERBOSE)

--- a/Scripts/scripts/cgal_create_CMakeLists
+++ b/Scripts/scripts/cgal_create_CMakeLists
@@ -85,7 +85,7 @@ create_cmake_script_with_options()
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 EOF
   #---------------------------------------------------------------------------

--- a/Scripts/scripts/cgal_create_cmake_script
+++ b/Scripts/scripts/cgal_create_cmake_script
@@ -31,7 +31,7 @@ create_cmake_script()
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project( ${PROJECT}${TYPE} )
 
 find_package(CGAL REQUIRED QUIET OPTIONAL_COMPONENTS Core )

--- a/SearchStructures/examples/RangeSegmentTrees/CMakeLists.txt
+++ b/SearchStructures/examples/RangeSegmentTrees/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(RangeSegmentTrees_Examples)
 
 find_package(CGAL REQUIRED)

--- a/SearchStructures/test/RangeSegmentTrees/CMakeLists.txt
+++ b/SearchStructures/test/RangeSegmentTrees/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(RangeSegmentTrees_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Segment_Delaunay_graph_2/benchmark/Segment_Delaunay_graph_2/CMakeLists.txt
+++ b/Segment_Delaunay_graph_2/benchmark/Segment_Delaunay_graph_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Segment_Delaunay_graph_2_example)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/CMakeLists.txt
+++ b/Segment_Delaunay_graph_2/examples/Segment_Delaunay_graph_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Segment_Delaunay_graph_2_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Core)

--- a/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/CMakeLists.txt
+++ b/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Segment_Delaunay_graph_2_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Segment_Delaunay_graph_Linf_2/benchmark/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
+++ b/Segment_Delaunay_graph_Linf_2/benchmark/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Segment_Delaunay_graph_2_example)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
+++ b/Segment_Delaunay_graph_Linf_2/examples/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Segment_Delaunay_graph_Linf_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Segment_Delaunay_graph_Linf_2_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Set_movable_separability_2/examples/Set_movable_separability_2/CMakeLists.txt
+++ b/Set_movable_separability_2/examples/Set_movable_separability_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Set_movable_separability_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Set_movable_separability_2/test/Set_movable_separability_2/CMakeLists.txt
+++ b/Set_movable_separability_2/test/Set_movable_separability_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Set_movable_separability_2_Tests)
 
 if(RUNNING_CGAL_AUTO_TEST OR CGAL_TEST_SUITE)

--- a/Shape_detection/benchmark/Shape_detection/CMakeLists.txt
+++ b/Shape_detection/benchmark/Shape_detection/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script.
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Shape_detection_Benchmarks)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Shape_detection/examples/Shape_detection/CMakeLists.txt
+++ b/Shape_detection/examples/Shape_detection/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script.
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Shape_detection_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Shape_detection/test/Shape_detection/CMakeLists.txt
+++ b/Shape_detection/test/Shape_detection/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script.
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Shape_detection_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Shape_regularization/benchmark/Shape_regularization/CMakeLists.txt
+++ b/Shape_regularization/benchmark/Shape_regularization/CMakeLists.txt
@@ -3,7 +3,7 @@
 
 project(Shape_regularization_Benchmarks)
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 find_package(CGAL REQUIRED COMPONENTS Core)
 

--- a/Shape_regularization/examples/Shape_regularization/CMakeLists.txt
+++ b/Shape_regularization/examples/Shape_regularization/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists.
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Shape_regularization_Examples)
 

--- a/Shape_regularization/test/Shape_regularization/CMakeLists.txt
+++ b/Shape_regularization/test/Shape_regularization/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists.
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Shape_regularization_Tests)
 

--- a/Skin_surface_3/examples/Skin_surface_3/CMakeLists.txt
+++ b/Skin_surface_3/examples/Skin_surface_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Skin_surface_3_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Skin_surface_3/test/Skin_surface_3/CMakeLists.txt
+++ b/Skin_surface_3/test/Skin_surface_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Skin_surface_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Snap_rounding_2/examples/Snap_rounding_2/CMakeLists.txt
+++ b/Snap_rounding_2/examples/Snap_rounding_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Snap_rounding_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Snap_rounding_2/test/Snap_rounding_2/CMakeLists.txt
+++ b/Snap_rounding_2/test/Snap_rounding_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Snap_rounding_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Solver_interface/examples/Solver_interface/CMakeLists.txt
+++ b/Solver_interface/examples/Solver_interface/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Solver_interface_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Spatial_searching/benchmark/Spatial_searching/CMakeLists.txt
+++ b/Spatial_searching/benchmark/Spatial_searching/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Spatial_searching_)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Spatial_searching/benchmark/Spatial_searching/tools/CMakeLists.txt
+++ b/Spatial_searching/benchmark/Spatial_searching/tools/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(tools_)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Spatial_searching/examples/Spatial_searching/CMakeLists.txt
+++ b/Spatial_searching/examples/Spatial_searching/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Spatial_searching_Examples)
 
 # CGAL and its components

--- a/Spatial_searching/test/Spatial_searching/CMakeLists.txt
+++ b/Spatial_searching/test/Spatial_searching/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Spatial_searching_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Spatial_sorting/benchmark/Spatial_sorting/CMakeLists.txt
+++ b/Spatial_sorting/benchmark/Spatial_sorting/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Spatial_sorting_)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Spatial_sorting/examples/Spatial_sorting/CMakeLists.txt
+++ b/Spatial_sorting/examples/Spatial_sorting/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Spatial_sorting_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Spatial_sorting/test/Spatial_sorting/CMakeLists.txt
+++ b/Spatial_sorting/test/Spatial_sorting/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Spatial_sorting_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Straight_skeleton_2/examples/Straight_skeleton_2/CMakeLists.txt
+++ b/Straight_skeleton_2/examples/Straight_skeleton_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project( Straight_skeleton_2_Examples )
 
 find_package(CGAL REQUIRED COMPONENTS Qt6 Core)

--- a/Straight_skeleton_2/test/Straight_skeleton_2/CMakeLists.txt
+++ b/Straight_skeleton_2/test/Straight_skeleton_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Straight_skeleton_2_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Qt6 Core)

--- a/Straight_skeleton_extrusion_2/test/Straight_skeleton_extrusion_2/CMakeLists.txt
+++ b/Straight_skeleton_extrusion_2/test/Straight_skeleton_extrusion_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Straight_skeleton_extrusion_2_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Qt6 Core)

--- a/Stream_lines_2/examples/Stream_lines_2/CMakeLists.txt
+++ b/Stream_lines_2/examples/Stream_lines_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Stream_lines_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Stream_lines_2/test/Stream_lines_2/CMakeLists.txt
+++ b/Stream_lines_2/test/Stream_lines_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Stream_lines_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Stream_support/benchmark/Stream_support/CMakeLists.txt
+++ b/Stream_support/benchmark/Stream_support/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Stream_support)
 
 # CGAL and its components

--- a/Stream_support/examples/Stream_support/CMakeLists.txt
+++ b/Stream_support/examples/Stream_support/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Stream_support_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Stream_support/test/Stream_support/CMakeLists.txt
+++ b/Stream_support/test/Stream_support/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Stream_support_Tests)
 find_package(CGAL REQUIRED)
 find_path(

--- a/Subdivision_method_3/examples/Subdivision_method_3/CMakeLists.txt
+++ b/Subdivision_method_3/examples/Subdivision_method_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Subdivision_method_3_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Subdivision_method_3/test/Subdivision_method_3/CMakeLists.txt
+++ b/Subdivision_method_3/test/Subdivision_method_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Subdivision_method_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Surface_mesh/benchmark/CMakeLists.txt
+++ b/Surface_mesh/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_performance)
 
 find_package(CGAL REQUIRED)

--- a/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
+++ b/Surface_mesh/examples/Surface_mesh/CMakeLists.txt
@@ -6,7 +6,7 @@
 # Used in /CGAL/Documentation/doc/Documentation/Developer_manual/create_and_use_a_cmakelist.txt.
 # Careful when modifying
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_Examples)
 
 #CGAL_Qt6 is needed for the drawing.

--- a/Surface_mesh/test/Surface_mesh/CMakeLists.txt
+++ b/Surface_mesh/test/Surface_mesh/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Surface_mesh_approximation/benchmark/Surface_mesh_approximation/CMakeLists.txt
+++ b/Surface_mesh_approximation/benchmark/Surface_mesh_approximation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_approximation_Benchmarks)
 
 # CGAL and its components

--- a/Surface_mesh_approximation/examples/Surface_mesh_approximation/CMakeLists.txt
+++ b/Surface_mesh_approximation/examples/Surface_mesh_approximation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_approximation_Examples)
 
 # CGAL and its components

--- a/Surface_mesh_approximation/test/Surface_mesh_approximation/CMakeLists.txt
+++ b/Surface_mesh_approximation/test/Surface_mesh_approximation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_approximation_Tests)
 
 # CGAL and its components

--- a/Surface_mesh_deformation/benchmark/Surface_mesh_deformation/optimal_rotation/CMakeLists.txt
+++ b/Surface_mesh_deformation/benchmark/Surface_mesh_deformation/optimal_rotation/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(benchmark_for_closest_rotation)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Surface_mesh_deformation/demo/Surface_mesh_deformation/CMakeLists.txt
+++ b/Surface_mesh_deformation/demo/Surface_mesh_deformation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_deformation_Demo)
 
 set_property(DIRECTORY PROPERTY CGAL_NO_TESTING TRUE)

--- a/Surface_mesh_deformation/examples/Surface_mesh_deformation/CMakeLists.txt
+++ b/Surface_mesh_deformation/examples/Surface_mesh_deformation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_deformation_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Surface_mesh_deformation/test/Surface_mesh_deformation/CMakeLists.txt
+++ b/Surface_mesh_deformation/test/Surface_mesh_deformation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_deformation_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/CMakeLists.txt
+++ b/Surface_mesh_parameterization/examples/Surface_mesh_parameterization/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling this folder.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_parameterization_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Surface_mesh_parameterization/test/Surface_mesh_parameterization/CMakeLists.txt
+++ b/Surface_mesh_parameterization/test/Surface_mesh_parameterization/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling this folder.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_parameterization_Tests)
 
 # Find CGAL

--- a/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/CMakeLists.txt
+++ b/Surface_mesh_segmentation/examples/Surface_mesh_segmentation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script_with_options
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_segmentation_Examples)
 
 # CGAL and its components

--- a/Surface_mesh_segmentation/test/Surface_mesh_segmentation/CMakeLists.txt
+++ b/Surface_mesh_segmentation/test/Surface_mesh_segmentation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_segmentation_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/CMakeLists.txt
+++ b/Surface_mesh_shortest_path/examples/Surface_mesh_shortest_path/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_shortest_path_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/CMakeLists.txt
+++ b/Surface_mesh_shortest_path/test/Surface_mesh_shortest_path/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_shortest_path_Tests)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Core)

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/CMakeLists.txt
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script_with_options
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_simplification_Examples)
 
 # CGAL and its components

--- a/Surface_mesh_simplification/test/Surface_mesh_simplification/CMakeLists.txt
+++ b/Surface_mesh_simplification/test/Surface_mesh_simplification/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_simplification_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Surface_mesh_skeletonization/benchmark/Surface_mesh_skeletonization/CMakeLists.txt
+++ b/Surface_mesh_skeletonization/benchmark/Surface_mesh_skeletonization/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script_with_options
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Mean_curvature_skeleton)
 
 # CGAL and its components

--- a/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/CMakeLists.txt
+++ b/Surface_mesh_skeletonization/examples/Surface_mesh_skeletonization/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_skeletonization_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Surface_mesh_skeletonization/test/Surface_mesh_skeletonization/CMakeLists.txt
+++ b/Surface_mesh_skeletonization/test/Surface_mesh_skeletonization/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_skeletonization_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Surface_mesh_topology/benchmark/Surface_mesh_topology/CMakeLists.txt
+++ b/Surface_mesh_topology/benchmark/Surface_mesh_topology/CMakeLists.txt
@@ -1,6 +1,6 @@
 project(Surface_mesh_topology_Benchmarks)
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 find_package(CGAL REQUIRED)
 

--- a/Surface_mesh_topology/examples/Surface_mesh_topology/CMakeLists.txt
+++ b/Surface_mesh_topology/examples/Surface_mesh_topology/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_topology_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Surface_mesh_topology/test/Surface_mesh_topology/CMakeLists.txt
+++ b/Surface_mesh_topology/test/Surface_mesh_topology/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesh_topology_Tests)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Surface_mesher/examples/Surface_mesher/CMakeLists.txt
+++ b/Surface_mesher/examples/Surface_mesher/CMakeLists.txt
@@ -1,6 +1,6 @@
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesher_Examples)
 
 find_package(CGAL REQUIRED COMPONENTS ImageIO)

--- a/Surface_mesher/test/Surface_mesher/CMakeLists.txt
+++ b/Surface_mesher/test/Surface_mesher/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_mesher_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Surface_sweep_2/examples/Surface_sweep_2/CMakeLists.txt
+++ b/Surface_sweep_2/examples/Surface_sweep_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_sweep_2_Examples)
 
 # CGAL and its components

--- a/Surface_sweep_2/test/Surface_sweep_2/CMakeLists.txt
+++ b/Surface_sweep_2/test/Surface_sweep_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Surface_sweep_2_Tests)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/TDS_2/test/TDS_2/CMakeLists.txt
+++ b/TDS_2/test/TDS_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(TDS_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/TDS_3/examples/TDS_3/CMakeLists.txt
+++ b/TDS_3/examples/TDS_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(TDS_3_Examples)
 
 find_package(CGAL REQUIRED)

--- a/TDS_3/test/TDS_3/CMakeLists.txt
+++ b/TDS_3/test/TDS_3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(TDS_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/CMakeLists.txt
+++ b/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Tetrahedral_remeshing_Examples)
 

--- a/Tetrahedral_remeshing/test/Tetrahedral_remeshing/CMakeLists.txt
+++ b/Tetrahedral_remeshing/test/Tetrahedral_remeshing/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Tetrahedral_remeshing_Tests)
 

--- a/Three/doc/Three/Three.txt
+++ b/Three/doc/Three/Three.txt
@@ -328,7 +328,7 @@ Configure CMake as you desire and fetch the right Qt6 packages :
     set(CMAKE_INCLUDE_CURRENT_DIR ON)
     # Instruct CMake to run moc automatically when needed.
     set(CMAKE_AUTOMOC ON)
-    cmake_minimum_required(VERSION 3.12...3.29)
+    cmake_minimum_required(VERSION 3.12...3.31)
 
     #Find CGAL
     find_package(CGAL COMPONENTS Qt6)
@@ -366,7 +366,7 @@ Notice that an external plugin will not be automatically loaded in the Lab. It m
     set(CMAKE_INCLUDE_CURRENT_DIR ON)
     # Instruct CMake to run moc automatically when needed.
     set(CMAKE_AUTOMOC ON)
-    cmake_minimum_required(VERSION 3.12...3.29)
+    cmake_minimum_required(VERSION 3.12...3.31)
 
     #Find CGAL
     find_package(CGAL COMPONENTS Qt6)

--- a/Triangulation/applications/Triangulation/CMakeLists.txt
+++ b/Triangulation/applications/Triangulation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script_with_options
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Triangulation_apps)
 
 # CGAL and its components

--- a/Triangulation/benchmark/Triangulation/CMakeLists.txt
+++ b/Triangulation/benchmark/Triangulation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Triangulation_benchmark)
 
 find_package(CGAL REQUIRED COMPONENTS Core)

--- a/Triangulation/examples/Triangulation/CMakeLists.txt
+++ b/Triangulation/examples/Triangulation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Triangulation_Examples)
 
 if(CMAKE_COMPILER_IS_GNUCCX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)

--- a/Triangulation/test/Triangulation/CMakeLists.txt
+++ b/Triangulation/test/Triangulation/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Triangulation_Tests)
 
 if(CMAKE_COMPILER_IS_GNUCCX AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 4.4)

--- a/Triangulation_2/examples/Triangulation_2/CMakeLists.txt
+++ b/Triangulation_2/examples/Triangulation_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Triangulation_2_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Triangulation_2/test/Triangulation_2/CMakeLists.txt
+++ b/Triangulation_2/test/Triangulation_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Triangulation_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Triangulation_3/benchmark/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/benchmark/Triangulation_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_CMakeLists
 # This is the CMake script for compiling a set of CGAL applications.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Triangulation_3)
 

--- a/Triangulation_3/demo/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/demo/Triangulation_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Triangulation_3_Demo)
 
 # Find includes in corresponding build directories

--- a/Triangulation_3/examples/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/examples/Triangulation_3/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Triangulation_3_Examples)
 
 find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)

--- a/Triangulation_3/test/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/test/Triangulation_3/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Triangulation_3_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Triangulation_on_sphere_2/benchmark/Triangulation_on_sphere_2/CMakeLists.txt
+++ b/Triangulation_on_sphere_2/benchmark/Triangulation_on_sphere_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project( Triangulation_on_sphere_2_Benchmarks )
 

--- a/Triangulation_on_sphere_2/demo/Triangulation_on_sphere_2/CMakeLists.txt
+++ b/Triangulation_on_sphere_2/demo/Triangulation_on_sphere_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project (Triangulation_on_sphere_2_Demo)
 

--- a/Triangulation_on_sphere_2/examples/Triangulation_on_sphere_2/CMakeLists.txt
+++ b/Triangulation_on_sphere_2/examples/Triangulation_on_sphere_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project( Triangulation_on_sphere_2_Examples )
 

--- a/Triangulation_on_sphere_2/test/Triangulation_on_sphere_2/CMakeLists.txt
+++ b/Triangulation_on_sphere_2/test/Triangulation_on_sphere_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project( Triangulation_on_sphere_2_Tests )
 

--- a/Union_find/test/Union_find/CMakeLists.txt
+++ b/Union_find/test/Union_find/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Union_find_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Visibility_2/examples/Visibility_2/CMakeLists.txt
+++ b/Visibility_2/examples/Visibility_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Visibility_2_Examples)
 
 find_package(CGAL REQUIRED)

--- a/Visibility_2/test/Visibility_2/CMakeLists.txt
+++ b/Visibility_2/test/Visibility_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Visibility_2_Tests)
 
 find_package(CGAL REQUIRED)

--- a/Voronoi_diagram_2/examples/Voronoi_diagram_2/CMakeLists.txt
+++ b/Voronoi_diagram_2/examples/Voronoi_diagram_2/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Created by the script cgal_create_cmake_script
 # This is the CMake script for compiling a CGAL application.
 
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 project(Voronoi_diagram_2_Examples)
 
 find_package(CGAL REQUIRED QUIET OPTIONAL_COMPONENTS Qt6)

--- a/Voronoi_diagram_2/test/Voronoi_diagram_2/CMakeLists.txt
+++ b/Voronoi_diagram_2/test/Voronoi_diagram_2/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Voronoi_diagram_2_Tests)
 

--- a/Weights/examples/Weights/CMakeLists.txt
+++ b/Weights/examples/Weights/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Weights_Examples)
 

--- a/Weights/test/Weights/CMakeLists.txt
+++ b/Weights/test/Weights/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.12...3.29)
+cmake_minimum_required(VERSION 3.12...3.31)
 
 project(Weights_Tests)
 


### PR DESCRIPTION
## Summary of Changes

Update our CMake supported versions to ...3.31. That will suppress the warnings about `CMP0167` (from CMake 3.30):

```
CMake Warning (dev) at cmake/modules/display-third-party-libs-versions.cmake:37 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning.
```

## Release Management

* Affected package(s): all cmake scripts
* License and copyright ownership: maintenance by GF
