### PR TITLE
Correct documentation mistakes in double.h and long_double.h

### DIFF
--- a/Number_types/doc/Number_types/CGAL/double.h
+++ b/Number_types/doc/Number_types/CGAL/double.h
@@ -4,10 +4,10 @@
 
 This header provides all necessary functions so the fundamental
 type `double` is a model of the concepts `RealEmbeddable` and
-`FieldWithSqrt`. Due to rounding errors and overflow `double` is considered as
+`FieldWithKthRoot`. Due to rounding errors and overflow `double` is considered as
 not exact.
 
-\cgalModels{FieldWithSqrt,RealEmbeddable}
+\cgalModels{FieldWithKthRoot,RealEmbeddable}
 */
 
 

--- a/Number_types/doc/Number_types/CGAL/double.h
+++ b/Number_types/doc/Number_types/CGAL/double.h
@@ -4,7 +4,7 @@
 
 This header provides all necessary functions so the fundamental
 type `double` is a model of the concepts `RealEmbeddable` and
-`Field`. Due to rounding errors and overflow `double` is considered as
+`FieldWithSqrt`. Due to rounding errors and overflow `double` is considered as
 not exact.
 
 \cgalModels{FieldWithSqrt,RealEmbeddable}

--- a/Number_types/doc/Number_types/CGAL/float.h
+++ b/Number_types/doc/Number_types/CGAL/float.h
@@ -6,10 +6,10 @@
 
 This header provides all necessary functions so the fundamental type
 `float` is a model of the concepts `RealEmbeddable` and
-`FieldWithSqrt`. Due to rounding errors and overflow `float` is
+`FieldWithKthRoot`. Due to rounding errors and overflow `float` is
 considered as not exact.
 
-\cgalModels{FieldWithSqrt,RealEmbeddable}
+\cgalModels{FieldWithKthRoot,RealEmbeddable}
 
 */
 

--- a/Number_types/doc/Number_types/CGAL/int.h
+++ b/Number_types/doc/Number_types/CGAL/int.h
@@ -11,4 +11,5 @@ This header provides all necessary functions so the fundamental types
 
 Due to overflow neither of those types is considered as exact.
 
+\cgalModels{RealEmbeddable, EuclideanRing}
 */

--- a/Number_types/doc/Number_types/CGAL/int.h
+++ b/Number_types/doc/Number_types/CGAL/int.h
@@ -3,11 +3,8 @@
 \ingroup nt_builtin
 
 This header provides all necessary functions so the fundamental types
-`int`, `long int`, and `short int` become models of their respective algebraic concepts.
-
-- `int` is a model of `RealEmbeddable` and `EuclideanRing`,
-- `long int` is a model of `RealEmbeddable` and `EuclideanRing`
-- `short int` is a model of `RealEmbeddable` and `EuclideanRing`
+`int`, `long int`, and `short int` are models of the concepts `RealEmbeddable` and
+`EuclideanRing`.
 
 Due to overflow neither of those types is considered as exact.
 

--- a/Number_types/doc/Number_types/CGAL/long_double.h
+++ b/Number_types/doc/Number_types/CGAL/long_double.h
@@ -5,10 +5,10 @@
 
 This header provides all necessary functions so the fundamental type
 `long double` is a model of the concepts `RealEmbeddable` and
-`FieldWithSqrt`. Due to rounding errors and overflow `long double` is
+`FieldWithKthRoot`. Due to rounding errors and overflow `long double` is
 considered as not exact.
 
-\cgalModels{FieldWithSqrt,RealEmbeddable}
+\cgalModels{FieldWithKthRoot,RealEmbeddable}
 */
 
 namespace CGAL {

--- a/Number_types/doc/Number_types/CGAL/long_double.h
+++ b/Number_types/doc/Number_types/CGAL/long_double.h
@@ -7,6 +7,8 @@ This header provides all necessary functions so the fundamental type
 `long double` is a model of the concepts `RealEmbeddable` and
 `FieldWithSqrt`. Due to rounding errors and overflow `long double` is
 considered as not exact.
+
+\cgalModels{FieldWithSqrt,RealEmbeddable}
 */
 
 namespace CGAL {

--- a/Number_types/doc/Number_types/CGAL/long_long.h
+++ b/Number_types/doc/Number_types/CGAL/long_long.h
@@ -6,5 +6,5 @@ This header provides all necessary functions so the fundamental
 type `long long int` is a model of the concepts `RealEmbeddable` and `EuclideanRing`. Due
 to overflow `long long int` is considered as not exact.
 
-\cgalModels{EuclideanRing,RealEmbeddable}
+\cgalModels{RealEmbeddable, EuclideanRing}
 */

--- a/Number_types/doc/Number_types/CGAL/long_long.h
+++ b/Number_types/doc/Number_types/CGAL/long_long.h
@@ -1,8 +1,10 @@
-/// \file long_long.h
-/// \ingroup nt_builtin
-///
-/// This header provides all necessary functions so the fundamental
-/// type `long long int` is an `RealEmbeddable` `EuclideanRing`. Due
-/// to overflow `long long int` is considered as not exact.
-///
-/// \cgalModels{EuclideanRing,RealEmbeddable}
+/*!
+\file long_long.h
+\ingroup nt_builtin
+
+This header provides all necessary functions so the fundamental
+type `long long int` is a model of the concepts `RealEmbeddable` and `EuclideanRing`. Due
+to overflow `long long int` is considered as not exact.
+
+\cgalModels{EuclideanRing,RealEmbeddable}
+*/


### PR DESCRIPTION
## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #7781 #7782 
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

