### PR TITLE
Incorrect rendered formulas

### DIFF
--- a/Documentation/doc/biblio/cgal_manual.bib
+++ b/Documentation/doc/biblio/cgal_manual.bib
@@ -425,7 +425,7 @@ Boissonnat}
 }
 
 @article{cgal:cgm-fobbo-11,
-  title={Fast Oriented Bounding Box Optimization on the Rotation Group $\SO(3, \mathrm{R})$},
+  title={Fast Oriented Bounding Box Optimization on the Rotation Group $SO(3, \mathrm{R})$},
   author={Chang, Chia-Tche and Gorissen, Bastien and Melchior, Samuel},
   journal={ACM Transactions on Graphics (TOG)},
   volume={30},

--- a/Kernel_d/doc/Kernel_d/CGAL/Kernel_d/Aff_transformation_d.h
+++ b/Kernel_d/doc/Kernel_d/CGAL/Kernel_d/Aff_transformation_d.h
@@ -98,7 +98,7 @@ in the plane spanned by the base vectors \f$ b_{e1}\f$ and \f$ b_{e2}\f$ in
 \f$ d\f$-space. Thus the default use delivers a planar rotation in the
 \f$ x\f$-\f$ y\f$ plane.
 
-\pre \f$ sin_num^2 + cos_num^2 = den^2\f$ and \f$ 0 \leq e_1 < e_2 < d\f$.
+\pre \f$ sin\_num^2 + cos\_num^2 = den^2\f$ and \f$ 0 \leq e_1 < e_2 < d\f$.
 \pre `den != 0`.
 
 */


### PR DESCRIPTION
The formula in Documentation/doc/biblio/cgal_manual.bib
```
 @article{cgal:cgm-fobbo-11,
   title={Fast Oriented Bounding Box Optimization on the Rotation Group $\SO(3, \mathrm{R})$},
   author={Chang, Chia-Tche and Gorissen, Bastien and Melchior, Samuel},

```
renders incorrectly (see Optimal_bounding_box/citelist.html) as there is no command `\SO` in LaTeX

The formula in doc/Kernel_d/CGAL/Kernel_d/Aff_transformation_d.h
```
\pre \f$ sin_num^2 + cos_num^2 = den^2\f$ and \f$ 0 \leq e_1 < e_2 < d\f$.
```
renders in an unexpected way (see Kernel_d/classCGAL_1_1Aff__transformation__d.html) as the `_` is seen as subscript operator in LaTeX

