### PR TITLE
Polyline_simplification: Fix Detection of Unremovable Vertices

### DIFF
--- a/Polyline_simplification_2/include/CGAL/Polyline_simplification_2/simplify.h
+++ b/Polyline_simplification_2/include/CGAL/Polyline_simplification_2/simplify.h
@@ -154,8 +154,8 @@ public:
       (*it)->set_removable(false);
       ++it;
       for(; it != ite; ++it){
-        if(boost::next(it) != ite){
-          Vertex_handle vp = *boost::prior(it), vn = *boost::next(it);
+        if(std::next(it) != ite){
+          Vertex_handle vp = *std::prev(it), vn = *std::next(it);
           if(vp == vn){
             (*it)->set_removable(false);
           }

--- a/Polyline_simplification_2/include/CGAL/Polyline_simplification_2/simplify.h
+++ b/Polyline_simplification_2/include/CGAL/Polyline_simplification_2/simplify.h
@@ -143,9 +143,10 @@ public:
   }
 
   // endpoints of constraints are unremovable
-  // vertices which are not endpoint and have != 2 incident constrained edges are unremovable
+  // vertices which have more than 1 constraint passing through are unremovable
   void initialize_unremovable()
   {
+    std::unordered_map<Vertex_handle, int> degrees;
     Constraint_iterator cit = pct.constraints_begin(), e = pct.constraints_end();
     for(; cit!=e; ++cit){
       Constraint_id cid = *cit;
@@ -154,6 +155,8 @@ public:
       (*it)->set_removable(false);
       ++it;
       for(; it != ite; ++it){
+        Vertex_handle vh = *it;
+        ++degrees[vh];
         if((boost::next(it) != ite) && (boost::prior(it)== boost::next(it))){
           (*it)->set_removable(false);
         }
@@ -162,19 +165,8 @@ public:
       (*it)->set_removable(false);
     }
 
-    std::unordered_map<Vertex_handle, int> degrees;
-    for (Constrained_edges_iterator it = pct.constrained_edges_begin(); it != pct.constrained_edges_end(); ++it) {
-      Edge e = *it;
-      Face_handle fh = e.first;
-      int ei = e.second;
-      Vertex_handle vh = fh->vertex(pct.cw(ei));
-      ++degrees[vh];
-      vh = fh->vertex(pct.ccw(ei));
-      ++degrees[vh];
-    }
-
     for(Finite_vertices_iterator it = pct.finite_vertices_begin(); it != pct.finite_vertices_end(); ++it){
-      if( it->is_removable() && (degrees[it] != 2) ){
+      if( it->is_removable() && (degrees[it] > 1) ){
         it->set_removable(false);
       }
     }

--- a/Polyline_simplification_2/include/CGAL/Polyline_simplification_2/simplify.h
+++ b/Polyline_simplification_2/include/CGAL/Polyline_simplification_2/simplify.h
@@ -143,10 +143,9 @@ public:
   }
 
   // endpoints of constraints are unremovable
-  // vertices which have more than 1 constraint passing through are unremovable
+  // vertices which are not endpoint and have != 2 incident constrained edges are unremovable
   void initialize_unremovable()
   {
-    std::unordered_map<Vertex_handle, int> degrees;
     Constraint_iterator cit = pct.constraints_begin(), e = pct.constraints_end();
     for(; cit!=e; ++cit){
       Constraint_id cid = *cit;
@@ -155,18 +154,30 @@ public:
       (*it)->set_removable(false);
       ++it;
       for(; it != ite; ++it){
-        Vertex_handle vh = *it;
-        ++degrees[vh];
-        if((boost::next(it) != ite) && (boost::prior(it)== boost::next(it))){
-          (*it)->set_removable(false);
+        if(boost::next(it) != ite){
+          Vertex_handle vp = *boost::prior(it), vn = *boost::next(it);
+          if(vp == vn){
+            (*it)->set_removable(false);
+          }
         }
       }
       it = boost::prior(it);
       (*it)->set_removable(false);
     }
 
+    std::unordered_map<Vertex_handle, int> degrees;
+    for (Constrained_edges_iterator it = pct.constrained_edges_begin(); it != pct.constrained_edges_end(); ++it) {
+      Edge e = *it;
+      Face_handle fh = e.first;
+      int ei = e.second;
+      Vertex_handle vh = fh->vertex(pct.cw(ei));
+      ++degrees[vh];
+      vh = fh->vertex(pct.ccw(ei));
+      ++degrees[vh];
+    }
+
     for(Finite_vertices_iterator it = pct.finite_vertices_begin(); it != pct.finite_vertices_end(); ++it){
-      if( it->is_removable() && (degrees[it] > 1) ){
+      if( it->is_removable() && (degrees[it] != 2) ){
         it->set_removable(false);
       }
     }

--- a/Polyline_simplification_2/test/Polyline_simplification_2/CMakeLists.txt
+++ b/Polyline_simplification_2/test/Polyline_simplification_2/CMakeLists.txt
@@ -8,5 +8,6 @@ project(Polyline_simplification_2_Tests)
 find_package(CGAL REQUIRED)
 
 create_single_source_cgal_program( "issue-5774.cpp" )
+create_single_source_cgal_program( "issue-8735.cpp" )
 create_single_source_cgal_program( "simplify_polygon_test.cpp" )
 create_single_source_cgal_program( "simplify_polyline_with_duplicate_points.cpp" )

--- a/Polyline_simplification_2/test/Polyline_simplification_2/issue-8735.cpp
+++ b/Polyline_simplification_2/test/Polyline_simplification_2/issue-8735.cpp
@@ -1,0 +1,34 @@
+#include <CGAL/Constrained_Delaunay_triangulation_2.h>
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Polyline_simplification_2/simplify.h>
+#include <vector>
+
+namespace PS = CGAL::Polyline_simplification_2;
+typedef CGAL::Exact_predicates_exact_constructions_kernel K;
+typedef PS::Vertex_base_2<K> Vb;
+typedef CGAL::Constrained_triangulation_face_base_2<K> Fb;
+typedef CGAL::Triangulation_data_structure_2<Vb, Fb> TDS;
+typedef CGAL::Constrained_Delaunay_triangulation_2<K, TDS , CGAL::Exact_predicates_tag> CDT;
+typedef CGAL::Constrained_triangulation_plus_2<CDT>     CT;
+typedef CT::Point                            Point;
+typedef PS::Stop_above_cost_threshold        Stop;
+typedef PS::Squared_distance_cost            Cost;
+
+int main()
+{
+  double tolerance = 100;
+  CT ct;
+  std::vector<CT::Point> pts;
+
+  pts.push_back(CT::Point(0, 0));
+  pts.push_back(CT::Point(2, 0));
+  pts.push_back(CT::Point(1, 0));
+  pts.push_back(CT::Point(3, 0));
+  pts.push_back(CT::Point(4, 1));
+  tolerance = 100;
+  ct.insert_constraint(pts.begin(), pts.end(), false);
+
+  PS::simplify(ct, Cost(), Stop(tolerance * tolerance), false);
+
+  return 0;
+}

--- a/STL_Extension/include/CGAL/Skiplist.h
+++ b/STL_Extension/include/CGAL/Skiplist.h
@@ -75,7 +75,7 @@ public:
       all_iterator
     , typename all_list::iterator
     , T
-    >
+    , std::bidirectional_iterator_tag>
   {
   public:
     all_iterator() {}
@@ -91,7 +91,7 @@ public:
       skip_iterator
     , typename skip_list::iterator
     , T
-    >
+    , std::bidirectional_iterator_tag>
   {
   public:
     skip_iterator() {}

--- a/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
+++ b/Triangulation_2/include/CGAL/Triangulation_2/internal/Polyline_constraint_hierarchy_2.h
@@ -85,7 +85,7 @@ public:
     Vertex_it
     , typename Vertex_list::skip_iterator
     , Vertex_handle
-    , boost::use_default
+    , std::bidirectional_iterator_tag
     , Vertex_handle>
   {
   public:


### PR DESCRIPTION
## Summary of Changes

We missed a variation of overlapping constraints.

## Release Management

* Affected package(s): Polyline_simplification 
* Issue(s) solved (if any): fix #8735
* License and copyright ownership:  unchanged

