### PR TITLE
Added a precondition for Arrangement_on_surface_2::merge_edge(e1, e2)

### DIFF
--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arrangement_on_surface_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arrangement_on_surface_2.h
@@ -973,6 +973,7 @@ public:
    * u_1\f$ to \f$ u_2\f$.
    * \pre `e1` and `e2` share a common end-vertex, such that the two other
    * end-vertices of the two edges are associated with `c`'s endpoints.
+   * \pre `e1` and `e2` have the same direction.
    */
   Halfedge_handle merge_edge(Halfedge_handle e1,
                              Halfedge_handle e2,


### PR DESCRIPTION
Added a precondition for merge_edge(e1, e2) that requires that two halfedges have the same direction.

## Summary of Changes

The title says it all

## Release Management

* Affected package(s): Arrangement_on_surface_2
* Issue(s) solved (if any): fix #8659
* Feature/Small Feature (if any): 
* Link to compiled documentation:
* License and copyright ownership: TAU

