### PR TITLE
Better flip-check criterion for almost degenerate face removal

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -363,6 +363,10 @@ bool is_flip_a_cap_angle_improvement(typename boost::graph_traits<TriangleMesh>:
   // reject if flipping the edge would create a larger cap angle (2 new faces, 3 angles each)
   auto is_worse_cap = [&](const Point_ref p, const Point_ref q, const Point_ref r)
   {
+    // Note that it is useful to test all angles, including the angle(s) at p1:
+    // it checks the (unlikely since p0p1p2 is a cap at p1) case where
+    // the diagonal post-flip is not in the cone p0p1p2 since then one
+    // the angle would be larger than the angle p0p1p2.
     bool res = (angle_cmp(p, q, r, p0, p1, p2) == CGAL::LARGER ||
                 angle_cmp(q, r, p, p0, p1, p2) == CGAL::LARGER ||
                 angle_cmp(r, p, q, p0, p1, p2) == CGAL::LARGER);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -351,9 +351,9 @@ bool is_flip_a_cap_angle_improvement(typename boost::graph_traits<TriangleMesh>:
 
   CGAL_precondition(!is_border(e, tmesh));
 
-  const halfedge_descriptor h = halfedge(e, tmesh);
+  typename Traits::Compare_angle_3 angle_cmp = gt.compare_angle_3_object();
 
-  CGAL_USE(gt);
+  const halfedge_descriptor h = halfedge(e, tmesh);
 
   const Point_ref p0 = get(vpm, target(h, tmesh));
   const Point_ref p1 = get(vpm, target(next(h, tmesh), tmesh));
@@ -363,17 +363,18 @@ bool is_flip_a_cap_angle_improvement(typename boost::graph_traits<TriangleMesh>:
   // reject if flipping the edge would create a larger cap angle (2 new faces, 3 angles each)
   auto is_worse_cap = [&](const Point_ref p, const Point_ref q, const Point_ref r)
   {
-    bool res = (CGAL::compare_angle(p, q, r, p0, p1, p2) == CGAL::LARGER ||
-                CGAL::compare_angle(q, r, p, p0, p1, p2) == CGAL::LARGER ||
-                CGAL::compare_angle(r, p, q, p0, p1, p2) == CGAL::LARGER);
+    bool res = (angle_cmp(p, q, r, p0, p1, p2) == CGAL::LARGER ||
+                angle_cmp(q, r, p, p0, p1, p2) == CGAL::LARGER ||
+                angle_cmp(r, p, q, p0, p1, p2) == CGAL::LARGER);
 
 #ifdef CGAL_PMP_DEBUG_REMOVE_DEGENERACIES
     if (res) {
+      typename Traits::Compute_approximate_angle_3 angle = gt.compute_approximate_angle_3_object();
       std::cout << "flipping would be worse: "
-                << CGAL::approximate_angle(p0, p1, p2) << " --> "
-                << CGAL::approximate_angle(p, q, r)
-                << CGAL::approximate_angle(q, r, p)
-                << CGAL::approximate_angle(r, p, q) << std::endl;
+                << angle(p0, p1, p2) << " --> "
+                << angle(p, q, r)
+                << angle(q, r, p)
+                << angle(r, p, q) << std::endl;
     }
 #endif
     return res;

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -348,7 +348,6 @@ bool should_flip(typename boost::graph_traits<TriangleMesh>::edge_descriptor e,
 {
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor halfedge_descriptor;
 
-  typedef typename Traits:: FT                                            FT;
   typedef typename boost::property_traits<VPM>::reference                 Point_ref;
 
   CGAL_precondition(!is_border(e, tmesh));
@@ -356,6 +355,7 @@ bool should_flip(typename boost::graph_traits<TriangleMesh>::edge_descriptor e,
   const halfedge_descriptor h = halfedge(e, tmesh);
 
 #if 1
+  CGAL_USE(gt);
   const Point_ref p0 = get(vpm, target(h, tmesh));
   const Point_ref p1 = get(vpm, target(next(h, tmesh), tmesh));
   const Point_ref p2 = get(vpm, source(h, tmesh));
@@ -393,6 +393,7 @@ bool should_flip(typename boost::graph_traits<TriangleMesh>::edge_descriptor e,
   return !is_worse_cap(p0, p1, p3) && !is_worse_cap(p3, p1, p2);
 
 #else
+  typedef typename Traits:: FT                                            FT;
   typename Traits::Compute_approximate_angle_3 angle = gt.compute_approximate_angle_3_object();
   const Point_ref p0 = get(vpm, target(h, tmesh));
   const Point_ref p1 = get(vpm, target(next(h, tmesh), tmesh));

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -393,14 +393,15 @@ bool should_flip(typename boost::graph_traits<TriangleMesh>::edge_descriptor e,
 {
   typedef typename boost::graph_traits<TriangleMesh>::halfedge_descriptor halfedge_descriptor;
 
+  typedef typename Traits:: FT                                            FT;
   typedef typename boost::property_traits<VPM>::reference                 Point_ref;
 
   CGAL_precondition(!is_border(e, tmesh));
 
+  typename Traits::Compute_approximate_angle_3 angle = gt.compute_approximate_angle_3_object();
+
   const halfedge_descriptor h = halfedge(e, tmesh);
 
-  typedef typename Traits:: FT                                            FT;
-  typename Traits::Compute_approximate_angle_3 angle = gt.compute_approximate_angle_3_object();
   const Point_ref p0 = get(vpm, target(h, tmesh));
   const Point_ref p1 = get(vpm, target(next(h, tmesh), tmesh));
   const Point_ref p2 = get(vpm, source(h, tmesh));


### PR DESCRIPTION
## Summary of Changes

While trying to remove caps, `PMP::remove_almost_degenerate_faces()` does a Delaunay-like check before allowing the edge flip. Unfortunately, the current criterion (see https://github.com/CGAL/cgal/pull/7125) can prevent some edge flips that would resolve a cap because sometimes this Delaunay-like criterion can prefer a cap if it is balanced by a very small angle on the other side. Then you have alpha + beta < 180 and you're stuck with the cap, but maybe you would have liked to flip still because the largest angles created by a flip would be e.g. 120 and 120, which is not that bad.

However in this function, we are maybe not so interested in having nicely shaped elements as much as we are trying to remove the worst elements. So this PR tries to improve the worst cap angle instead, by checking only (and greedily) if we do not create a worse cap angle when we flip.

This produces better results for the cases that were problematic with alpha + beta < 180

## 1
![image](https://github.com/user-attachments/assets/313b8c1f-8ea4-4153-a41b-406f16d4153c)

## 2
![image](https://github.com/user-attachments/assets/cb74230a-70c1-4ef9-bb73-378331cd1626)

## 3
![image](https://github.com/user-attachments/assets/b31ec7f7-21b0-49c1-bb69-2174f0e5bf86)


## Release Management

* Affected package(s): `PMP`
* Issue(s) solved (if any): 
* Feature/Small Feature (if any): - 
* License and copyright ownership: no change

