### PR TITLE
CGAL: Do not include basic.h in examples

### DIFF
--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/algebraic_curves.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/algebraic_curves.cpp
@@ -14,7 +14,6 @@ int main ()
 
 #else
 
-#include <CGAL/basic.h>
 #include <CGAL/Arrangement_2.h>
 #include <CGAL/Arr_algebraic_segment_traits_2.h>
 

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/algebraic_segments.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/algebraic_segments.cpp
@@ -14,7 +14,6 @@ int main ()
 }
 #else
 
-#include <CGAL/basic.h>
 #include <CGAL/Arrangement_2.h>
 #include <CGAL/Arr_algebraic_segment_traits_2.h>
 

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/batched_point_location.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/batched_point_location.cpp
@@ -4,7 +4,6 @@
 #include <list>
 #include <vector>
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_batched_point_location.h>
 
 #include "arr_inexact_construction_segments.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/bounded_vertical_decomposition.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/bounded_vertical_decomposition.cpp
@@ -3,7 +3,6 @@
 
 #include <list>
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_vertical_decomposition_2.h>
 
 #include "arr_exact_construction_segments.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/conic_multiplicities.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/conic_multiplicities.cpp
@@ -5,7 +5,6 @@
 
 #ifdef CGAL_USE_CORE
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_naive_point_location.h>
 
 #include "arr_conics.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/consolidated_curve_data.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/consolidated_curve_data.cpp
@@ -2,7 +2,6 @@
 // Associating a color attribute with segments using the consolidated
 // curve-data traits.
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_consolidated_curve_data_traits_2.h>
 
 #include "arr_exact_construction_segments.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/curve_history.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/curve_history.cpp
@@ -1,7 +1,6 @@
 //! \file examples/Arrangement_on_surface_2/curve_history.cpp
 // Constructing an arrangement with curve history.
 
-#include <CGAL/basic.h>
 #include <CGAL/Arrangement_with_history_2.h>
 #include <CGAL/Arr_trapezoid_ric_point_location.h>
 

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/dcel_extension.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/dcel_extension.cpp
@@ -1,7 +1,6 @@
 //! \file examples/Arrangement_on_surface_2/dcel_extension.cpp
 // Extending all DCEL records (vertices, edges and faces).
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_extended_dcel.h>
 
 #include "arr_exact_construction_segments.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/dcel_extension_io.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/dcel_extension_io.cpp
@@ -3,7 +3,6 @@
 
 #include <fstream>
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_extended_dcel.h>
 #include <CGAL/IO/Arr_iostream.h>
 #include <CGAL/IO/Arr_text_formatter.h>

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/dual_with_data.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/dual_with_data.cpp
@@ -4,7 +4,6 @@
 
 #include <algorithm>
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_curve_data_traits_2.h>
 
 #include "arr_linear.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/edge_manipulation_curve_history.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/edge_manipulation_curve_history.cpp
@@ -1,7 +1,6 @@
 //! \file examples/Arrangement_on_surface_2/edge_manipulation_curve_history.cpp
 // Removing curves and manipulating edges in an arrangement with history.
 
-#include <CGAL/basic.h>
 #include <CGAL/Arrangement_with_history_2.h>
 #include <CGAL/Arr_walk_along_line_point_location.h>
 

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/ellipses.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/ellipses.cpp
@@ -5,7 +5,6 @@
 
 #ifdef CGAL_USE_CORE
 
-#include <CGAL/basic.h>
 #include <CGAL/draw_arrangement_2.h>
 
 #include "arr_conics.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/face_extension.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/face_extension.cpp
@@ -1,7 +1,6 @@
 //! \file examples/Arrangement_on_surface_2/face_extension.cpp
 // Extending the arrangement-face records.
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_extended_dcel.h>
 #include <CGAL/Arr_observer.h>
 

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/face_extension_overlay.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/face_extension_overlay.cpp
@@ -3,7 +3,6 @@
 
 #include <cassert>
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_overlay_2.h>
 #include <CGAL/Arr_default_overlay_traits.h>
 

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/generic_curve_data.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/generic_curve_data.cpp
@@ -2,7 +2,6 @@
 // Associating a name attribute with segments using the generic curve-data
 // traits.
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_curve_data_traits_2.h>
 
 #include "arr_polylines.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/hyperbolas.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/hyperbolas.cpp
@@ -5,7 +5,6 @@
 
 #ifdef CGAL_USE_CORE
 
-#include <CGAL/basic.h>
 #include <CGAL/draw_arrangement_2.h>
 
 #include "arr_conics.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/incremental_insertion.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/incremental_insertion.cpp
@@ -1,7 +1,6 @@
 //! \file examples/Arrangement_on_surface_2/incremental_insertion.cpp
 // Using the global incremental insertion functions.
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_naive_point_location.h>
 
 #include "arr_exact_construction_segments.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/io.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/io.cpp
@@ -3,7 +3,6 @@
 
 #include <fstream>
 
-#include <CGAL/basic.h>
 #include <CGAL/IO/Arr_iostream.h>
 
 #include "arr_inexact_construction_segments.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/io_curve_history.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/io_curve_history.cpp
@@ -3,7 +3,6 @@
 
 #include <fstream>
 
-#include <CGAL/basic.h>
 #include <CGAL/Arrangement_with_history_2.h>
 #include <CGAL/IO/Arr_with_history_iostream.h>
 

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/io_unbounded.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/io_unbounded.cpp
@@ -4,7 +4,6 @@
 #include <list>
 #include <fstream>
 
-#include <CGAL/basic.h>
 #include <CGAL/IO/Arr_iostream.h>
 
 #include "arr_linear.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/linear_conics.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/linear_conics.cpp
@@ -5,7 +5,6 @@
 
 #ifdef CGAL_USE_CORE
 
-#include <CGAL/basic.h>
 #include <CGAL/draw_arrangement_2.h>
 
 #include "arr_conics.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/observer.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/observer.cpp
@@ -1,7 +1,6 @@
 //! \file examples/Arrangement_on_surface_2/observer.cpp
 // Using a simple arrangement observer.
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_observer.h>
 
 #include "arr_exact_construction_segments.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/overlay.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/overlay.cpp
@@ -1,7 +1,6 @@
 //! \file examples/Arrangement_on_surface_2/overlay.cpp
 // A simple overlay of two arrangements.
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_overlay_2.h>
 
 #include "arr_exact_construction_segments.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/overlay_color.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/overlay_color.cpp
@@ -3,7 +3,6 @@
 
 #include <cassert>
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_extended_dcel.h>
 #include <CGAL/Arr_overlay_2.h>
 #include <CGAL/Arr_default_overlay_traits.h>

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/overlay_unbounded.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/overlay_unbounded.cpp
@@ -3,7 +3,6 @@
 
 #include <string>
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_extended_dcel.h>
 #include <CGAL/Arr_overlay_2.h>
 #include <CGAL/Arr_default_overlay_traits.h>

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/parabolas.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/parabolas.cpp
@@ -5,7 +5,6 @@
 
 #ifdef CGAL_USE_CORE
 
-#include <CGAL/basic.h>
 #include <CGAL/draw_arrangement_2.h>
 
 #include "arr_conics.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/point_location.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/point_location.cpp
@@ -1,7 +1,6 @@
 //! \file examples/Arrangement_on_surface_2/point_location.cpp
 // Answering point-location queries.
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_naive_point_location.h>
 #include <CGAL/Arr_landmarks_point_location.h>
 

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/polycurve_bezier.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/polycurve_bezier.cpp
@@ -13,7 +13,6 @@ int main() {
 
 #else
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_polycurve_traits_2.h>
 
 #include "arr_Bezier.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/polycurve_circular_arc.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/polycurve_circular_arc.cpp
@@ -15,7 +15,6 @@ int main() {
 
 #include <vector>
 
-#include <CGAL/basic.h>
 #include <CGAL/CORE_algebraic_number_traits.h>
 #include <CGAL/Arr_polycurve_traits_2.h>
 

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/polycurve_conic.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/polycurve_conic.cpp
@@ -15,7 +15,6 @@ int main() {
 
 #include <vector>
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_polycurve_traits_2.h>
 
 #include "arr_conics.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/predefined_kernel.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/predefined_kernel.cpp
@@ -5,8 +5,6 @@
 #include <list>
 #include <chrono>
 
-#include <CGAL/basic.h>
-
 #include "arr_exact_construction_segments.h"
 #include "arr_print.h"
 #include "read_objects.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/spherical_overlay.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/spherical_overlay.cpp
@@ -1,7 +1,6 @@
 //! \file examples/Arrangement_on_surface_2/spherical_overlay.cpp
 // Overlay of two arrangements embedded on the sphere.
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_overlay_2.h>
 #include <CGAL/Arr_default_overlay_traits.h>
 

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/tracing_counting.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/tracing_counting.cpp
@@ -3,7 +3,6 @@
 
 #include <list>
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_tracing_traits_2.h>
 #include <CGAL/Arr_counting_traits_2.h>
 

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/unb_planar_vertical_decomposition.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/unb_planar_vertical_decomposition.cpp
@@ -3,7 +3,6 @@
 
 #include <list>
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_vertical_decomposition_2.h>
 
 #include "arr_linear.h"

--- a/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/vertical_ray_shooting.cpp
+++ b/Arrangement_on_surface_2/examples/Arrangement_on_surface_2/vertical_ray_shooting.cpp
@@ -1,7 +1,6 @@
 //! \file examples/Arrangement_on_surface_2/ex_vertical_ray_shooting.cpp
 // Answering vertical ray-shooting queries.
 
-#include <CGAL/basic.h>
 #include <CGAL/Arr_walk_along_line_point_location.h>
 #include <CGAL/Arr_trapezoid_ric_point_location.h>
 

--- a/Kernel_23/examples/Kernel_23/MyKernel.cpp
+++ b/Kernel_23/examples/Kernel_23/MyKernel.cpp
@@ -1,4 +1,3 @@
-#include <CGAL/basic.h>
 #include <CGAL/Filtered_kernel.h>
 #include <CGAL/Delaunay_triangulation_2.h>
 #include <CGAL/squared_distance_2.h>

--- a/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/test_sdg_traits_2.cpp
+++ b/Segment_Delaunay_graph_2/test/Segment_Delaunay_graph_2/test_sdg_traits_2.cpp
@@ -1,13 +1,10 @@
-#include <iostream>
-#include <fstream>
-#include <cassert>
-#include <vector>
 
-#include <CGAL/basic.h>
-#include <CGAL/Interval_arithmetic.h>
-#include <CGAL/Simple_cartesian.h>
+
 #include <CGAL/Segment_Delaunay_graph_traits_2.h>
 #include <CGAL/Segment_Delaunay_graph_filtered_traits_2.h>
+
+#include <CGAL/Interval_arithmetic.h>
+#include <CGAL/Simple_cartesian.h>
 
 #if defined(CGAL_USE_CORE) || defined(CGAL_USE_LEDA)
 #include <CGAL/Exact_algebraic.h>
@@ -16,6 +13,10 @@
 #include <CGAL/Exact_rational.h>
 #include <CGAL/Exact_integer.h>
 
+#include <iostream>
+#include <fstream>
+#include <cassert>
+#include <vector>
 
 typedef CGAL::Simple_cartesian<double>      Double_Kernel;
 typedef CGAL::Simple_cartesian<CGAL::Interval_nt<true> >   IT_Kernel;

--- a/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_traits_2.cpp
+++ b/Segment_Delaunay_graph_Linf_2/test/Segment_Delaunay_graph_Linf_2/test_sdg_linf_traits_2.cpp
@@ -5,20 +5,20 @@
 #define CGAL_SDG_DEBUG(a) { a }
 #endif
 
+#include <CGAL/Segment_Delaunay_graph_Linf_traits_2.h>
+#include <CGAL/Segment_Delaunay_graph_Linf_filtered_traits_2.h>
+
 #include <iostream>
 #include <fstream>
 #include <cassert>
 #include <vector>
 
-#include <CGAL/basic.h>
 #include <CGAL/Interval_nt.h>
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Exact_integer.h>
 #include <CGAL/Exact_rational.h>
 #include <CGAL/Exact_algebraic.h>
 
-#include <CGAL/Segment_Delaunay_graph_Linf_traits_2.h>
-#include <CGAL/Segment_Delaunay_graph_Linf_filtered_traits_2.h>
 
 
 


### PR DESCRIPTION
## Summary of Changes

Examples are not supposed to ` #include <CGAL/basic.h>`.

## Release Management

* Affected package(s): Arrangements
* License and copyright ownership:  unchanged

