### PR TITLE
T2: avoid maybe uninitialized warning

### DIFF
--- a/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
+++ b/Triangulation_2/include/CGAL/Constrained_triangulation_plus_2.h
@@ -739,9 +739,9 @@ public:
     for(auto it = vertices.begin(), succ = it; ++succ != vertices.end(); ++it){
       if(! is_subconstraint(*it, *succ)){ // this checks whether other constraints pass
         Face_handle fh;
-        int i;
-        bool b = Triangulation::is_edge(*it, *succ, fh, i);
-        CGAL_assume(b);
+        int i = -1;
+        Triangulation::is_edge(*it, *succ, fh, i);
+        CGAL_assertion(i != -1);
         Triangulation::remove_constrained_edge(fh,i, out); // this does also flipping if necessary.
       }
     }


### PR DESCRIPTION
## Summary of Changes

We know that the variable `i` will be set by `is_edge()`, we try to indicate it with a `CGAL_assume()` but that does not help the compiler, so let's just initialize it.  We get the warning [here](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.1-I-95/Triangulation_2/TestReport_lrineau_Ubuntu-latest-GCC6-Release.gz).

I am wondering if the `CGAL_assertion()` I have put makes sense. 

## Release Management

* Affected package(s): Triangulation_2
* License and copyright ownership: unchanged

