### PR TITLE
Lab - Fixes for C3t3 IO in `.vtu` format

### DIFF
--- a/Lab/demo/Lab/Plugins/IO/VTK_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/IO/VTK_io_plugin.cpp
@@ -250,7 +250,7 @@ public:
       if(!c3t3_item || extension != "vtu")
         return false;
 
-      std::ofstream os(output_filename.data());
+      std::ofstream os(output_filename.data(), std::ios::binary);
       os << std::setprecision(16);
       const C3t3& c3t3 = c3t3_item->c3t3();
 

--- a/Lab/demo/Lab/Plugins/IO/VTK_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/IO/VTK_io_plugin.cpp
@@ -447,8 +447,8 @@ public:
            cit != c3t3_item->c3t3().triangulation().finite_cells_end();
            ++cit)
       {
-        CGAL_assertion(cit->info() >= 0);
-        c3t3_item->c3t3().add_to_complex(cit, cit->info());
+        if(cit->info() != 0)
+          c3t3_item->c3t3().add_to_complex(cit, cit->info());
         for(int i=0; i < 4; ++i)
         {
           if(cit->surface_patch_index(i)>0)


### PR DESCRIPTION
## Summary of Changes
* Subdomain indices can be 0 or negative, just the cells with subdomain 0 are not added to the complex.
* make binary status of the opened `ofstream` consistent with call to `CGAL::IO::output_to_vtu()`

## Release Management

* Affected package(s): CGAL Lab
* License and copyright ownership: unchanged

