### PR TITLE
Update valid combinations of parameters for intersection() function in documentation

### DIFF
--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -592,6 +592,16 @@ Intersection tests between triangle meshes and/or polylines can be done using
 Additionally, the function `CGAL::Polygon_mesh_processing::intersecting_meshes()`
 records all pairs of intersecting meshes in a range.
 
+\subsubsection PMPIntersectionCombinations Valid Combinations of Parameters for Intersection
+The `CGAL::Polygon_mesh_processing::intersection()` function supports the following combinations of parameters:
+- Point and Circle
+- Point and Sphere
+- Line and Plane
+- Line and Triangle
+- Segment and Triangle
+- Ray and Triangle
+- Triangle and Triangle
+
 \subsubsection PMPSelIntersections Self Intersections
 
 Self intersections within a triangle mesh can be detected by calling the function


### PR DESCRIPTION
This pull request addresses issue #8756 by updating the documentation for the `intersection()` function in the `Polygon_mesh_processing.txt` file. The valid combinations of parameters for the `intersection()` function were missing, and this PR adds the following combinations:

- Point and Circle
- Point and Sphere
- Line and Plane
- Line and Triangle
- Segment and Triangle
- Ray and Triangle
- Triangle and Triangle

These updates ensure that the documentation accurately reflects the supported parameter combinations for the `intersection()` function.

### Changes Made
- Updated the `Polygon_mesh_processing.txt` file to include the missing valid combinations of parameters for the `intersection()` function.

### File Changed
- `cgal/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt`

### Related Issue
- Closes #8756

### Checklist
- [x] Documentation updated
- [x] No new warnings introduced

Please review the changes and let me know if any further modifications are needed.

Additional Notes:
This PR only includes documentation updates and does not affect the functionality of the codebase. The changes are intended to improve the clarity and completeness of the documentation for users of the `CGAL::Polygon_mesh_processing::intersection()` function.