### PR TITLE
Update orient_polygon_soup.h

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orient_polygon_soup.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orient_polygon_soup.h
@@ -388,20 +388,24 @@ struct Polygon_soup_orienter
             vertices_to_duplicate.back().second.push_back(other_p_id);
         }
         while(next!=neighbors[0]);
-
         if (next==v_id){
-          /// turn the otherway round
+          /// turn the other way round
           next = neighbors[0];
+          V_ID last_next = next; // store the initial value
           do{
             P_ID other_p_id;
             std::tie(next, other_p_id) = next_ccw_vertex_around_target(next, v_id, polygons, edges, marked_edges);
             if (next==v_id) break;
+            // If the new 'next' is the same as the previous one, break to avoid an infinite loop.
+            if (next == last_next) break;
+            last_next = next;
             visited_polygons.insert(other_p_id);
             if(nb_link_ccs != 1)
               vertices_to_duplicate.back().second.push_back(other_p_id);
           }
           while(true);
         }
+
         if (nb_link_ccs != 1)
           visitor.link_connected_polygons(v_id, vertices_to_duplicate.back().second);
       }


### PR DESCRIPTION
## Summary of Changes

This pull request fixes an infinite loop in the function `duplicate_singular_vertices()` in the file `Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/orient_polygon_soup.h`. The issue was caused by consecutive duplicate vertices in a cycle (degenerate edge at a T-junction). The fix introduces a check to break out of the loop when a consecutive duplicate is detected, thereby preventing the infinite loop.

## Release Management

* Affected package(s): Polygon_mesh_processing
* Issue(s) solved (if any): fix #8693 
* Feature/Small Feature (if any): Bug fix for handling degenerate edges in polygon soup orientation.
