### PR TITLE
Fix SFINAE usage in insert and do_intersect functions on Ubuntu 24.04

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_on_surface_2_global.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_on_surface_2_global.h
@@ -139,11 +139,11 @@ void insert(Arrangement_on_surface_2<GeometryTraits_2, TopologyTraits>& arr,
 //
 //
 template <typename GeometryTraits_2, typename TopologyTraits,
-          typename PointLocation, typename ZoneVisitor>
+          typename PointLocation, typename ZoneVisitor,
+          typename = std::enable_if_t<std::is_same<PointLocation, int>::value>>
 void insert(Arrangement_on_surface_2<GeometryTraits_2, TopologyTraits>& arr,
             const typename GeometryTraits_2::X_monotone_curve_2& c,
-            const PointLocation& pl, ZoneVisitor &visitor,
-            std::is_same<int, int>::type)
+            const PointLocation& pl, ZoneVisitor &visitor)
 {
   typedef GeometryTraits_2                              Gt2;
   typedef TopologyTraits                                Tt;
@@ -466,10 +466,10 @@ void insert(Arrangement_on_surface_2<GeometryTraits_2, TopologyTraits>& arr,
 // std::bool_constant< true>)'
 //
 template <typename GeometryTraits_2, typename TopologyTraits,
-          typename InputIterator>
+          typename InputIterator,
+          typename = std::enable_if_t<std::is_same<InputIterator, int>::value>>
 void insert(Arrangement_on_surface_2<GeometryTraits_2, TopologyTraits>& arr,
-            InputIterator begin, InputIterator end,
-            std::is_same<int, int>::type)
+            InputIterator begin, InputIterator end)
 {
   typedef GeometryTraits_2                              Gt2;
   typedef TopologyTraits                                Tt;
@@ -1527,11 +1527,12 @@ zone(Arrangement_on_surface_2<GeometryTraits_2, TopologyTraits>& arr,
 // const Arr_segment_2&, const Arr_walk_along_line_point_location<>&, std::bool_constant< true>)'
 //
 template <typename GeometryTraits_2, typename TopologyTraits,
-          typename PointLocation>
+          typename PointLocation,
+          typename = std::enable_if_t<std::is_same<PointLocation, int>::value>>
 bool
 do_intersect(Arrangement_on_surface_2<GeometryTraits_2, TopologyTraits>& arr,
              const typename GeometryTraits_2::X_monotone_curve_2& c,
-             const PointLocation& pl, std::is_same<int, int>::type)
+             const PointLocation& pl)
 {
   typedef GeometryTraits_2                              Gt2;
   typedef TopologyTraits                                Tt;


### PR DESCRIPTION
## Summary of Changes

I fixed an error in the code related to the incorrect use of std::is_same. In the source code, there was an attempt to use std::is_some<int, int>::type as a function parameter, which caused a compilation error. I removed this unnecessary parameter and added type checking using SFINAE (std::enable_if).
I have Ubuntu 24.04:

```bash
loveit0@loveit0-Nitro-AN515-58:~$ uname -a
Linux loveit0-Nitro-AN515-58 6.11.0-17-generic #17~24.04.2-Ubuntu SMP PREEMPT_DYNAMIC Mon Jan 20 22:48:29 UTC 2 x86_64 x86_64 x86_64 GNU/Linux
```

I used the CGAL in my project for intersections with AABB and when I compiling my code, I faced with these kind of errors:

```
/usr/local/include/CGAL/Arrangement_2/Arrangement_on_surface_2_global.h:145:27: error: ‘std::is_same<__remove_cv(int), int>::type’ is not a type
  145 |             const PointLocation& pl, ZoneVisitor &visitor,
      |                           ^~~
/usr/local/include/CGAL/Arrangement_2/Arrangement_on_surface_2_global.h:471:27: error: ‘std::is_same<__remove_cv(int), int>::type’ is not a type
  471 |             InputIterator begin, InputIterator end,
      |                           ^~~
/usr/local/include/CGAL/Arrangement_2/Arrangement_on_surface_2_global.h:1534:5: error: ‘std::is_same<__remove_cv(int), int>::type’ is not a type
 1534 |              const PointLocation& pl, std::is_same<int, int>::type)
      |     ^  
```

## Release Management

- Affected package(s): Arrangement_on_surface_2
- Issue(s) solved (if any): -
- Feature/Small Feature (if any): N/A
- License and copyright ownership: This contribution is licensed under the terms used by CGAL, and the authorship remains with the contributors.

