### PR TITLE
Mesh_2: Fixes of write_VTU()

### DIFF
--- a/Mesh_2/doc/Mesh_2/CGAL/IO/write_VTU.h
+++ b/Mesh_2/doc/Mesh_2/CGAL/IO/write_VTU.h
@@ -6,6 +6,8 @@ namespace IO {
 //!
 //! The faces output are those for which `DelaunayMeshFaceBase_2::is_in_domain()` returns `true`,
 //! the edges are those for which `ConstrainedTriangulationFaceBase_2::is_constrained()` returns `true`.
+//!\attention To read a binary file, the flag `std::ios::binary` must be set during the creation of `os`.
+//!
 //! \tparam CDT a `Constrained_Delaunay_triangulation_2` with face type model of `DelaunayMeshFaceBase_2`.
 //!
 //! \param os the stream used for writing.
@@ -23,9 +25,12 @@ void write_VTU(std::ostream& os,
 //! \brief writes the faces of a domain and its constrained edges embedded in
 //! a 2D constrained Delaunay triangulation using the `PolyData` XML
 //! format.
-  //! The faces output are those for which `get(ipm, f)` returns
-  //! `true` where `f` is a  `CDT::Face_handle`,
+//! The faces output are those for which `get(ipm, f)` returns
+//! `true` where `f` is a  `CDT::Face_handle`,
 //! the edges are those for which `ConstrainedTriangulationFaceBase_2::is_constrained()` returns `true`.
+//!
+//!\attention To read a binary file, the flag `std::ios::binary` must be set during the creation of `os`.
+//!
 //! \tparam CDT a `Constrained_Delaunay_triangulation_2` with face
 //! type model of `DelaunayMeshFaceBase_2`.
 //! \tparam InDomainPmap a class model of `ReadWritePropertyMap` with

--- a/Stream_support/include/CGAL/IO/VTK/VTK_writer.h
+++ b/Stream_support/include/CGAL/IO/VTK/VTK_writer.h
@@ -25,6 +25,8 @@ template <class FT>
 void write_vector(std::ostream& os,
                   const std::vector<FT>& vect)
 {
+  if(vect.empty())
+    return;
   const char* buffer = reinterpret_cast<const char*>(&(vect[0]));
   std::size_t size = vect.size()*sizeof(FT);
 


### PR DESCRIPTION
## Summary of Changes

Add warning that the stream must be opened with `std::ios::binary`.
Deal with a potentially empty vector of faces.

## Release Management

* Affected package(s): Mesh_2
* License and copyright ownership:  unchanged

