### PR TITLE
Mesh_3 - add `surface_only()` named parameter

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -28,7 +28,7 @@
 -   Added two new meshing parameters that enable mesh initialization customization :
   - `initial_points_generator` : enables the user to specify a functor that generates initial points,
   - `initial_points` : enables the user to specify a `Range` of initial points.
-
+-   Added a new meshing parameter `surface_only`, to improve performances when the user is only interested in surface mesh generation.
 
 ### [2D Triangulations](https://doc.cgal.org/6.1/Manual/packages.html#PkgTriangulation2)
 
@@ -42,6 +42,7 @@
 
 ### Triangulations
 -   All triangulations now offer the functions `point(Vertex_handle)` and `point(Simplex, int)`, which enables users to access the geometric position of a vertex and of the i-th vertex of a simplex of a triangulation.
+
 
 ## [Release 6.0.1](https://github.com/CGAL/cgal/releases/tag/v6.0.1)
 

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_3/parameters.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_3/parameters.h
@@ -246,6 +246,21 @@ unspecified_type no_features();
 /*!
  * \ingroup PkgMesh3Parameters
  *
+ * The function `parameters::surface_only()`
+ * enables the meshing algorithm
+ * to mesh the input surface only and not take the volume into account.
+ *
+ * When this option is enabled, the ouput mesh has no complex cells, only complex facets, edges and vertices.
+ * Full-3D optimization steps such as mesh perturbation and mesh exudation are automatically disabled.
+ *
+ * \sa `CGAL::make_mesh_3()`
+ * \sa `CGAL::refine_mesh_3()`
+ */
+unspecified_type surface_only();
+
+/*!
+ * \ingroup PkgMesh3Parameters
+ *
  * The function `parameters::no_lloyd()` enables the user to tell the mesh generation functions
  * `make_mesh_3()` and `refine_mesh_3()` that no lloyd optimization must be done.
  *

--- a/Mesh_3/doc/Mesh_3/CGAL/Mesh_3/parameters.h
+++ b/Mesh_3/doc/Mesh_3/CGAL/Mesh_3/parameters.h
@@ -250,7 +250,8 @@ unspecified_type no_features();
  * enables the meshing algorithm
  * to mesh the input surface only and not take the volume into account.
  *
- * When this option is enabled, the ouput mesh has no complex cells, only complex facets, edges and vertices.
+ * When this option is enabled, the ouput mesh has no cells in the 3D complex,
+ * only facets, edges and vertices.
  * Full-3D optimization steps such as mesh perturbation and mesh exudation are automatically disabled.
  *
  * \sa `CGAL::make_mesh_3()`

--- a/Mesh_3/doc/Mesh_3/Mesh_3.txt
+++ b/Mesh_3/doc/Mesh_3/Mesh_3.txt
@@ -677,9 +677,10 @@ View of 3D meshes produced from a polyhedral domain with a nested surface.
 \subsubsection Mesh_3RemeshingPolyhedralSurface Remeshing a Polyhedral Surface
 
 The following code creates a polyhedral domain, with only one polyhedron,
-and no "bounding polyhedron". Since the volumetric part of the domain may be empty,
-and should not be meshed,
-it is necessary to use the `CGAL::parameters::surface_only()` parameter to mesh the surface only.
+and no "bounding polyhedron". The volumetric part of the domain may be empty
+and should not be meshed.
+In this case, it is recommended to use the `CGAL::parameters::surface_only()` parameter
+to speedup the meshing of the surface only.
 This enables to remesh a surface, and is equivalent to the function `make_surface_mesh()`.
 
 \cgalExample{Mesh_3/remesh_polyhedral_surface.cpp}

--- a/Mesh_3/doc/Mesh_3/Mesh_3.txt
+++ b/Mesh_3/doc/Mesh_3/Mesh_3.txt
@@ -666,7 +666,6 @@ View of 3D meshes produced from a polyhedral domain. (i) is a view of file out_1
 In the following example we have a "bounding polyhedron" which defines the meshing domain and two surfaces inside this domain.
 The surfaces inside the domain may be closed surfaces as well as surfaces with boundaries. In the case of a closed surface
 the volume delimited by this surface is also considered as inside the domain.
-previous subsection.
 
 
 \cgalExample{Mesh_3/mesh_polyhedral_domain_with_surface_inside.cpp}
@@ -678,7 +677,9 @@ View of 3D meshes produced from a polyhedral domain with a nested surface.
 \subsubsection Mesh_3RemeshingPolyhedralSurface Remeshing a Polyhedral Surface
 
 The following code creates a polyhedral domain, with only one polyhedron,
-and no "bounding polyhedron", so the volumetric part of the domain will be empty.
+and no "bounding polyhedron". Since the volumetric part of the domain may be empty,
+and should not be meshed,
+it is necessary to use the `CGAL::parameters::surface_only()` parameter to mesh the surface only.
 This enables to remesh a surface, and is equivalent to the function `make_surface_mesh()`.
 
 \cgalExample{Mesh_3/remesh_polyhedral_surface.cpp}

--- a/Mesh_3/examples/Mesh_3/remesh_polyhedral_surface.cpp
+++ b/Mesh_3/examples/Mesh_3/remesh_polyhedral_surface.cpp
@@ -36,13 +36,10 @@ int main()
     return EXIT_FAILURE;
   }
 
-  // Create a vector with only one element: the pointer to the polyhedron.
-  std::vector<Polyhedron*> poly_ptrs_vector(1, &poly);
-
   // Create a polyhedral domain, with only one polyhedron,
-  // and no "bounding polyhedron", so the volumetric part of the domain will be
-  // empty.
-  Mesh_domain domain(poly_ptrs_vector.begin(), poly_ptrs_vector.end());
+  // and no "bounding polyhedron".
+  // The volumetric part will be omitted by the use of `params::surface_only()`
+  Mesh_domain domain(poly);
 
   // Get sharp features
   domain.detect_features(); //includes detection of borders

--- a/Mesh_3/examples/Mesh_3/remesh_polyhedral_surface.cpp
+++ b/Mesh_3/examples/Mesh_3/remesh_polyhedral_surface.cpp
@@ -54,7 +54,7 @@ int main()
                                  facet_distance(0.001));
 
   // Mesh generation
-  C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria, params::no_perturb().no_exude());
+  C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria, params::surface_only());
 
   // Output the facets of the c3t3 to an OFF file. The facets will not be
   // oriented.

--- a/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_gray_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_gray_image.h
@@ -28,7 +28,7 @@ namespace CGAL
  *
  * Functor for generating initial points in gray images.
  * This functor is a model of the `InitialPointsGenerator_3` concept,
- * and can be passed as a parameter to `CGAL::make_mesh_3` using the
+ * and can be passed as a parameter to `CGAL::make_mesh_3()` using the
  * `CGAL::parameters::initial_points_generator()` parameter function.
  *
  * On images that contain multiple connected components,

--- a/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_labeled_image.h
@@ -75,7 +75,7 @@ struct Get_point
  *
  * Functor for generating initial points in labeled images.
  * This functor is a model of the `InitialPointsGenerator_3` concept,
- * and can be passed as a parameter to `CGAL::make_mesh_3` using the
+ * and can be passed as a parameter to `CGAL::make_mesh_3()` using the
  * `CGAL::parameters::initial_points_generator()` parameter function.
  *
  * This functor scans the complete image to detect all its connected components,

--- a/Mesh_3/include/CGAL/Polygon_mesh_processing/surface_Delaunay_remeshing.h
+++ b/Mesh_3/include/CGAL/Polygon_mesh_processing/surface_Delaunay_remeshing.h
@@ -293,7 +293,8 @@ surface_Delaunay_remeshing(const TriangleMesh& tmesh,
   // Mesh generation
   C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria,
                                       CGAL::parameters::no_perturb(),
-                                      CGAL::parameters::no_exude());
+                                      CGAL::parameters::no_exude(),
+                                      CGAL::parameters::surface_only());
 
   TriangleMeshOut out;
   CGAL::facets_in_complex_3_to_triangle_mesh(c3t3, out);

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -121,6 +121,10 @@ several other components (closed or not)
 that will be represented in the final mesh.
 This class is a model of the concept `MeshDomain_3`.
 
+\note When the given surface(s) are not closed, the surface only will be meshed.
+It is then recommended to use the parameter `parameters::surface_only()` to speedup
+the meshing process.
+
 \tparam Polyhedron stands for the type of the input polyhedral surface(s),
 model of `FaceListGraph`.
 
@@ -239,11 +243,11 @@ public:
   /// @{
 
   /*!
-    Construction from a polyhedral surface which must and free of intersections.
-    If `polyhedron` is closed, the inside of `bounding_polyhedron` will be meshed,
+    Construction from a polyhedral surface which must be free of intersections.
+    If `polyhedron` is closed, its inside will be meshed,
     otherwise there will be no interior and only the surface will be meshed.
   */
-  Polyhedral_mesh_domain_3(const Polyhedron& bounding_polyhedron
+  Polyhedral_mesh_domain_3(const Polyhedron& polyhedron
 #ifndef DOXYGEN_RUNNING
                            , CGAL::Random* p_rng = nullptr
 #endif
@@ -252,14 +256,14 @@ public:
     , bounding_tree_(&tree_) // the bounding tree is tree_
     , p_rng_(p_rng)
   {
-    this->add_primitives(bounding_polyhedron);
-    if(! is_triangle_mesh(bounding_polyhedron)) {
+    this->add_primitives(polyhedron);
+    if(!is_triangle_mesh(polyhedron)) {
       std::cerr << "Your input polyhedron must be triangulated!\n";
       CGAL_error_msg("Your input polyhedron must be triangulated!");
     }
     this->build();
 
-    if(!is_closed(bounding_polyhedron))
+    if(!is_closed(polyhedron))
       set_surface_only();
   }
 

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_3.h
@@ -112,6 +112,7 @@ The class `Polyhedral_mesh_domain_3` implements
 a domain defined by a simplicial polyhedral surface.
 
 The input polyhedral surface must be free of intersections.
+
 It must include (at least) one closed connected component
 that defines the boundary of the domain to be meshed.
 Inside this bounding component,
@@ -238,8 +239,9 @@ public:
   /// @{
 
   /*!
-    Construction from a bounding polyhedral surface which must be closed, and free of intersections.
-    The inside of `bounding_polyhedron` will be meshed.
+    Construction from a polyhedral surface which must and free of intersections.
+    If `polyhedron` is closed, the inside of `bounding_polyhedron` will be meshed,
+    otherwise there will be no interior and only the surface will be meshed.
   */
   Polyhedral_mesh_domain_3(const Polyhedron& bounding_polyhedron
 #ifndef DOXYGEN_RUNNING
@@ -256,6 +258,9 @@ public:
       CGAL_error_msg("Your input polyhedron must be triangulated!");
     }
     this->build();
+
+    if(!is_closed(bounding_polyhedron))
+      set_surface_only();
   }
 
   /*!

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -72,6 +72,10 @@ It is a model of the concept `MeshDomainWithFeatures_3`. It also provides
 a member function to automatically detect sharp features and boundaries from
 the input polyhedral surface(s).
 
+\note When the given surface(s) are not closed, the surface only will be meshed.
+It is then recommended to use the parameter `parameters::surface_only()` to speedup
+the meshing process.
+
 \tparam IGT stands for a geometric traits class providing the types
 and functors required to implement the intersection tests and intersection computations
 for polyhedral boundary surfaces. This parameter has to be
@@ -162,11 +166,12 @@ public:
 
   /*!
     Constructor from a polyhedral surface.
-    No feature detection is done at this level. Note that a copy of `bounding_polyhedron` will be done.
-    The polyhedron `bounding_polyhedron` has to be closed and free of intersections.
-    The interior of `bounding_polyhedron` will be meshed.
+    No feature detection is done at this level. Note that a copy of `polyhedron` will be done.
+    The polyhedron `polyhedron` must be free of intersections.
+    If `polyhedron` is closed, its inside will be meshed,
+    otherwise there will be no interior and only the surface will be meshed.
   */
-  Polyhedral_mesh_domain_with_features_3(const Polyhedron& bounding_polyhedron
+  Polyhedral_mesh_domain_with_features_3(const Polyhedron& polyhedron
 #ifndef DOXYGEN_RUNNING
                                          , CGAL::Random* p_rng = nullptr
 #endif
@@ -174,10 +179,13 @@ public:
     : Base(p_rng) , borders_detected_(false)
   {
     stored_polyhedra.resize(1);
-    stored_polyhedra[0] = bounding_polyhedron;
+    stored_polyhedra[0] = polyhedron;
     get(face_patch_id_t<Patch_id>(), stored_polyhedra[0]);
     this->add_primitives(stored_polyhedra[0]);
     this->build();
+
+    if(!is_closed(polyhedron))
+      set_surface_only();
   }
 
 #ifndef CGAL_NO_DEPRECATED_CODE

--- a/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_mesh_domain_with_features_3.h
@@ -185,7 +185,7 @@ public:
     this->build();
 
     if(!is_closed(polyhedron))
-      set_surface_only();
+      this->set_surface_only();
   }
 
 #ifndef CGAL_NO_DEPRECATED_CODE

--- a/Mesh_3/include/CGAL/make_mesh_3.h
+++ b/Mesh_3/include/CGAL/make_mesh_3.h
@@ -490,14 +490,15 @@ struct C3t3_initializer < C3T3, MD, MC, true, CGAL::Tag_false>
  *                           </UL>}
  *     \cgalParamDefault{`parameters::features(domain)`}
  *   \cgalParamSectionEnd
- *   \cgalParamSectionBegin{Meshing surface}
+ *   \cgalParamSectionBegin{Meshing surface only}
  *     \cgalParamDescription{If the user wants to mesh only the surface of the domain, the following named parameter
  *                           activates this option:
  *                           <UL>
  *                             <LI>\link parameters::surface_only() `parameters::surface_only()` \endlink
  *                           </UL>
  *                           When this parameter is used, the output `C3T3` has no complex cells,
- *                           only complex facets, edges and vertices.}
+ *                           only complex facets, edges and vertices.
+ *                           Mesh perturbation and mesh exudation are automatically disabled.}
  *     \cgalParamDefault{This option is not activated, the volume is meshed according to `domain`}
  *   \cgalParamSectionEnd
  *   \cgalParamSectionBegin{Topological options (manifoldness)}

--- a/Mesh_3/include/CGAL/make_mesh_3.h
+++ b/Mesh_3/include/CGAL/make_mesh_3.h
@@ -490,6 +490,16 @@ struct C3t3_initializer < C3T3, MD, MC, true, CGAL::Tag_false>
  *                           </UL>}
  *     \cgalParamDefault{`parameters::features(domain)`}
  *   \cgalParamSectionEnd
+ *   \cgalParamSectionBegin{Meshing surface}
+ *     \cgalParamDescription{If the user wants to mesh only the surface of the domain, the following named parameter
+ *                           activates this option:
+ *                           <UL>
+ *                             <LI>\link parameters::surface_only() `parameters::surface_only()` \endlink
+ *                           </UL>
+ *                           When this parameter is used, the output `C3T3` has no complex cells,
+ *                           only complex facets, edges and vertices.}
+ *     \cgalParamDefault{This option is not activated, the volume is meshed according to `domain`}
+ *   \cgalParamSectionEnd
  *   \cgalParamSectionBegin{Topological options (manifoldness)}
  *     \cgalParamDescription{In order to drive the meshing algorithm and ensure that the output mesh follows a desired topological criterion,
  *                           three named parameters control this option:

--- a/Mesh_3/include/CGAL/make_mesh_3.h
+++ b/Mesh_3/include/CGAL/make_mesh_3.h
@@ -494,7 +494,7 @@ struct C3t3_initializer < C3T3, MD, MC, true, CGAL::Tag_false>
  *     \cgalParamDescription{If the user wants to mesh only the surface of the domain, the following named parameter
  *                           activates this option:
  *                           <UL>
- *                             <LI>\link parameters::surface_only() `parameters::surface_only()` \endlink
+ *                             <LI>`parameters::surface_only()`
  *                           </UL>
  *                           When this parameter is used, the output `C3T3` has no complex cells,
  *                           only complex facets, edges and vertices.

--- a/Mesh_3/include/CGAL/make_mesh_3.h
+++ b/Mesh_3/include/CGAL/make_mesh_3.h
@@ -517,7 +517,7 @@ struct C3t3_initializer < C3T3, MD, MC, true, CGAL::Tag_false>
  *                           Two named parameters control this behavior:
  *                           <UL>
  *                             <LI> `parameters::no_lloyd()`
- *                             <LI> `parameters::lloyd_optimize_mesh_3()`
+ *                             <LI> `parameters::lloyd()`
  *                           </UL>}
  *     \cgalParamDefault{`parameters::no_lloyd()`}
  *   \cgalParamSectionEnd

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -193,7 +193,7 @@ private:
  *                           Two named parameters control this behavior:
  *                           <UL>
  *                             <LI> `parameters::no_lloyd()`
- *                             <LI> `parameters::lloyd_optimize_mesh_3()`
+ *                             <LI> `parameters::lloyd()`
  *                           </UL>}
  *     \cgalParamDefault{`parameters::no_lloyd()`}
  *   \cgalParamSectionEnd

--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -355,7 +355,8 @@ void refine_mesh_3_impl(C3T3& c3t3,
                  , mesh_options.pointer_to_stop_atomic_boolean
 #endif
                  );
-  double refine_time = mesher.refine_mesh(mesh_options.dump_after_refine_surface_prefix);
+  double refine_time = mesher.refine_mesh(mesh_options.dump_after_refine_surface_prefix,
+                                          mesh_options.surface_only);
   c3t3.clear_manifold_info();
 
   dump_c3t3(c3t3, mesh_options.dump_after_refine_prefix);
@@ -387,7 +388,7 @@ void refine_mesh_3_impl(C3T3& c3t3,
   }
 
   // Perturbation
-  if ( perturb )
+  if ( perturb && !mesh_options.surface_only )
   {
     double perturb_time_limit = refine_time;
 
@@ -403,7 +404,7 @@ void refine_mesh_3_impl(C3T3& c3t3,
   }
 
   // Exudation
-  if ( exude )
+  if ( exude  && !mesh_options.surface_only )
   {
     double exude_time_limit = refine_time;
 

--- a/Mesh_3/test/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/test/Mesh_3/CMakeLists.txt
@@ -55,6 +55,7 @@ create_single_source_cgal_program( "test_meshing_with_one_step_with_features.cpp
 create_single_source_cgal_program( "test_mesh_cell_base_3.cpp")
 create_single_source_cgal_program( "test_min_edge_length.cpp")
 create_single_source_cgal_program( "test_max_edge_distance.cpp")
+create_single_source_cgal_program( "test_remeshing_polyhedron.cpp" )
 
 foreach(target
     test_boost_has_xxx
@@ -87,6 +88,7 @@ foreach(target
     test_max_edge_distance
     test_min_size_criteria
     test_meshing_polyhedral_complex_with_manifold_and_min_size
+    test_remeshing_polyhedron
     )
   if(TARGET ${target})
     target_link_libraries(${target} PRIVATE CGAL::Eigen3_support)
@@ -113,6 +115,7 @@ if(TARGET CGAL::TBB_support)
       test_min_edge_length
       test_max_edge_distance
       test_min_size_criteria
+      test_remeshing_polyhedron
       )
     if(TARGET ${target})
       target_link_libraries(${target} PRIVATE CGAL::TBB_support)
@@ -131,6 +134,7 @@ if(TARGET CGAL::TBB_support)
       "execution   of  test_mesh_3_issue_1554"
       "execution   of  test_mesh_polyhedral_domain_with_features_deprecated"
       "execution   of  test_mesh_cell_base_3"
+      "execution   of  test_remeshing_polyhedron"
       PROPERTY RUN_SERIAL 1)
     if(TARGET test_meshing_3D_image)
       set_property(TEST

--- a/Mesh_3/test/Mesh_3/CMakeLists.txt
+++ b/Mesh_3/test/Mesh_3/CMakeLists.txt
@@ -115,7 +115,6 @@ if(TARGET CGAL::TBB_support)
       test_min_edge_length
       test_max_edge_distance
       test_min_size_criteria
-      test_remeshing_polyhedron
       )
     if(TARGET ${target})
       target_link_libraries(${target} PRIVATE CGAL::TBB_support)

--- a/Mesh_3/test/Mesh_3/test_remeshing_polyhedron.cpp
+++ b/Mesh_3/test/Mesh_3/test_remeshing_polyhedron.cpp
@@ -1,0 +1,103 @@
+// Copyright (c) 2025 GeometryFactory, France.
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+//
+//
+// Author(s)     : Jane Tournois
+//
+//******************************************************************************
+// File Description :
+//******************************************************************************
+
+#include <CGAL/SMDS_3/io_signature.h>
+#include "test_meshing_utilities.h"
+#include <CGAL/Polyhedral_mesh_domain_3.h>
+#include <CGAL/IO/Polyhedron_iostream.h>
+
+#include <CGAL/SMDS_3/Dump_c3t3.h>
+
+#include <CGAL/disable_warnings.h>
+
+#include <type_traits>
+#include <string>
+
+template <typename K>
+struct Polyhedron_tester : public Tester<K>
+{
+  void polyhedron(const std::string& filename) const
+  {
+    using GT = K;
+    using Polyhedron = CGAL::Polyhedron_3<GT>;
+    using Mesh_domain = CGAL::Polyhedral_mesh_domain_3<Polyhedron, GT>;
+    using Tr = typename CGAL::Mesh_triangulation_3<Mesh_domain, GT>::type;
+    using C3t3 = CGAL::Mesh_complex_3_in_triangulation_3<Tr>;
+    using Mesh_criteria = CGAL::Mesh_criteria_3<Tr>;
+
+    Polyhedron polyhedron;
+    std::ifstream input(filename);
+    input >> polyhedron;
+    input.close();
+
+    auto rng = &CGAL::get_default_random();
+    const auto seed = rng->get_seed();
+
+    std::cout << "\tSeed is\t" << seed << std::endl;
+    Mesh_domain domain(polyhedron, rng);
+
+    // Set mesh criteria - only facet criteria here
+    Mesh_criteria criteria(CGAL::parameters::facet_angle(30)
+                                            .facet_size(0.2)
+                                            .facet_distance(0.02));
+
+    // Mesh generation with surface_only() option
+    C3t3 c3t3_surface_only = CGAL::make_mesh_3<C3t3>(domain, criteria,
+                                                     CGAL::parameters::surface_only());
+
+    assert(c3t3_surface_only.number_of_facets_in_complex() > 0);
+    assert(c3t3_surface_only.number_of_cells_in_complex() == 0);
+
+    CGAL::dump_c3t3(c3t3_surface_only, "c3t3_surface_only.binary.cgal");
+
+    std::cout << "\t With surface_only() option:" << std::endl;
+    std::cout << "\t\t Nb of facets = " << c3t3_surface_only.number_of_facets_in_complex() << std::endl;
+    std::cout << "\t\t Nb of cells = " << c3t3_surface_only.number_of_cells_in_complex() << std::endl;
+
+    // Mesh generation without surface_only() option,
+    // i.e. volume meshing, with no cell criteria
+    C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria,
+                                        CGAL::parameters::no_exude().no_perturb());
+
+    assert(c3t3.number_of_facets_in_complex() > 0);
+    if(is_closed(polyhedron)) {
+      assert(c3t3.number_of_cells_in_complex() > 0);
+    } else {
+      assert(c3t3.number_of_cells_in_complex() == 0);
+    }
+
+    CGAL::dump_c3t3(c3t3, "c3t3_no_surface_only.binary.cgal");
+
+    std::cout << "\t Without surface_only() option:" << std::endl;
+    std::cout << "\t\t Nb of facets = " << c3t3.number_of_facets_in_complex() << std::endl;
+    std::cout << "\t\t Nb of cells = " << c3t3.number_of_cells_in_complex() << std::endl;
+  }
+};
+
+int main()
+{
+  Polyhedron_tester<K_e_i> test_epic;
+
+  std::cerr << "Remeshing from a closed polyhedron (sphere.off):\n";
+  const std::string sphere = CGAL::data_file_path("meshes/sphere.off");
+  test_epic.polyhedron(sphere);
+
+  std::cerr << "Remeshing from a non-closed polyhedron (lion.off):\n";
+  const std::string lion = CGAL::data_file_path("meshes/lion.off");
+  test_epic.polyhedron(lion);
+
+  return EXIT_SUCCESS;
+}

--- a/STL_Extension/include/CGAL/STL_Extension/internal/mesh_option_classes.h
+++ b/STL_Extension/include/CGAL/STL_Extension/internal/mesh_option_classes.h
@@ -142,6 +142,7 @@ struct Mesh_3_options {
     , dump_after_exude_prefix()
     , number_of_initial_points(-1)
     , nonlinear_growth_of_balls(nonlinear)
+    , surface_only(false)
     , maximal_number_of_vertices(0)
     , pointer_to_error_code(0)
 #ifndef CGAL_NO_ATOMIC
@@ -157,6 +158,7 @@ struct Mesh_3_options {
   std::string dump_after_exude_prefix;
   int number_of_initial_points;
   bool nonlinear_growth_of_balls;
+  bool surface_only;
   std::size_t maximal_number_of_vertices;
   Mesh_error_code* pointer_to_error_code;
 #ifndef CGAL_NO_ATOMIC

--- a/STL_Extension/include/CGAL/STL_Extension/internal/mesh_parameters_interface.h
+++ b/STL_Extension/include/CGAL/STL_Extension/internal/mesh_parameters_interface.h
@@ -368,3 +368,16 @@ features(const MeshDomain& /*domain*/)
   typedef Named_function_parameters<::CGAL::parameters::internal::Features_options, ::CGAL::internal_np::features_option_param_t, CGAL_NP_BASE> Param;
   return CGAL_NP_BUILD(Param,Generator()());
 }
+
+// -----------------------------------
+// Surface only (replacing Surface_mesher)
+// -----------------------------------
+inline Named_function_parameters<::CGAL::parameters::internal::Mesh_3_options, ::CGAL::internal_np::mesh_param_t, CGAL_NP_BASE>
+surface_only()
+{
+  typedef Named_function_parameters<::CGAL::parameters::internal::Mesh_3_options, ::CGAL::internal_np::mesh_param_t, CGAL_NP_BASE> Param;
+  ::CGAL::parameters::internal::Mesh_3_options options;
+
+  options.surface_only = true;
+  return CGAL_NP_BUILD(Param, options);
+}


### PR DESCRIPTION
## Summary of Changes

Add the option `surface_only()` to `make_mesh_3()`, to completely skip the "refine_cells" part of Mesh_3, and cancel perturbation and exudation.
@soesau and I noticed that scanning cells, even in the context of "Surface mesher", takes a lot of useless time.


@soesau you can use this branch for your benchmark

@lrineau do you think `surface_only` should be a member of `Mesher_3` or a parameter of `Mesher_3::refine_mesh()` (as done here)?

## Release Management

* Affected package(s): Mesh_3
* [Small Feature](https://cgalwiki.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Mesh_3_surface_only()) Pre-approved by [User:Sloriot](https://cgalwiki.geometryfactory.com/CGAL/Members/wiki/User:Sloriot) -- 2025/03/17
* Link to compiled documentation [make_mesh_3()](https://cgal.github.io/8781/v0/Mesh_3/group__PkgMesh3Functions.html#gac8599a0c967075f740bf8e2e92c4770e) and [parameters::surface_only()](https://cgal.github.io/8781/v0/Mesh_3/group__PkgMesh3Parameters.html#gaa2618c09b6117d7caab12dccca16ee58)
* License and copyright ownership: unchanged

