### PR TITLE
Fixed TODO: find a better name in AABB_tree/include/CGAL/AABB_tree/internal/AABB_node.h 🚀

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1147,3 +1147,4 @@ Polygonal_surface_reconstruction/examples/build*
 Polygonal_surface_reconstruction/test/build*
 Solver_interface/examples/build*
 /Mesh_3/examples/Mesh_3/indicator_0.inr.gz
+.qodo

--- a/AABB_tree/include/CGAL/AABB_tree.h
+++ b/AABB_tree/include/CGAL/AABB_tree.h
@@ -541,7 +541,7 @@ public:
     }
 
     template <class Query, class Traversal_traits>
-    void traversal_with_priority_and_group_traversal(const Query& query, Traversal_traits& traits, const std::size_t group_traversal_bound) const
+    void grouped_priority_traversal(const Query& query, Traversal_traits& traits, const std::size_t group_traversal_bound) const
     {
       switch(size())
       {
@@ -551,7 +551,7 @@ public:
         traits.intersection(query, singleton_data());
         break;
       default: // if(size() >= 2)
-        root_node()->traversal_with_priority_and_group_traversal(m_primitives, query, traits, m_primitives.size(), 0, group_traversal_bound);
+        root_node()->grouped_priority_traversal(m_primitives, query, traits, m_primitives.size(), 0, group_traversal_bound);
       }
     }
 

--- a/AABB_tree/include/CGAL/AABB_tree/internal/AABB_node.h
+++ b/AABB_tree/include/CGAL/AABB_tree/internal/AABB_node.h
@@ -74,7 +74,7 @@ public:
                                const std::size_t nb_primitives) const;
 
   template<class Primitive_vector, class Traversal_traits, class Query>
-  void traversal_with_priority_and_group_traversal(const Primitive_vector& primitives,
+  void grouped_priority_traversal(const Primitive_vector& primitives,
                                                    const Query& query,
                                                    Traversal_traits& traits,
                                                    const std::size_t nb_primitives,
@@ -238,7 +238,7 @@ AABB_node<Tr>::traversal_with_priority(const Query& query,
 template<typename Tr>
 template<class Primitive_vector, class Traversal_traits, class Query>
 void
-AABB_node<Tr>::traversal_with_priority_and_group_traversal(const Primitive_vector& primitives,
+AABB_node<Tr>::grouped_priority_traversal(const Primitive_vector& primitives,
                                                            const Query& query,
                                                            Traversal_traits& traits,
                                                            const std::size_t nb_primitives,
@@ -269,7 +269,7 @@ AABB_node<Tr>::traversal_with_priority_and_group_traversal(const Primitive_vecto
     traits.intersection(query, left_data());
     if( traits.go_further() && traits.do_intersect(query, right_child()) )
     {
-      right_child().traversal_with_priority_and_group_traversal(primitives, query, traits, 2, first_primitive_index+1, group_traversal_bound);
+      right_child().grouped_priority_traversal(primitives, query, traits, 2, first_primitive_index+1, group_traversal_bound);
     }
     break;
   default:
@@ -287,22 +287,22 @@ AABB_node<Tr>::traversal_with_priority_and_group_traversal(const Primitive_vecto
         if(pleft >= pright)
         {
           // Inspect the left child first, has higher priority.
-          left_child().traversal_with_priority_and_group_traversal(primitives, query, traits, nb_primitives/2, first_primitive_index, group_traversal_bound);
+          left_child().grouped_priority_traversal(primitives, query, traits, nb_primitives/2, first_primitive_index, group_traversal_bound);
           if( traits.go_further() )
-            right_child().traversal_with_priority_and_group_traversal(primitives, query, traits, nb_primitives-nb_primitives/2, first_primitive_index+nb_primitives/2, group_traversal_bound);
+            right_child().grouped_priority_traversal(primitives, query, traits, nb_primitives-nb_primitives/2, first_primitive_index+nb_primitives/2, group_traversal_bound);
         }
         else
         {
           // Inspect the right child first, has higher priority.
-          right_child().traversal_with_priority_and_group_traversal(primitives, query, traits, nb_primitives-nb_primitives/2, first_primitive_index+nb_primitives/2, group_traversal_bound);
+          right_child().grouped_priority_traversal(primitives, query, traits, nb_primitives-nb_primitives/2, first_primitive_index+nb_primitives/2, group_traversal_bound);
           if( traits.go_further() )
-            left_child().traversal_with_priority_and_group_traversal(primitives, query, traits, nb_primitives/2, first_primitive_index, group_traversal_bound);
+            left_child().grouped_priority_traversal(primitives, query, traits, nb_primitives/2, first_primitive_index, group_traversal_bound);
         }
       }
       else
       {
         // Only the left child has to be inspected.
-        left_child().traversal_with_priority_and_group_traversal(primitives, query, traits, nb_primitives/2, first_primitive_index, group_traversal_bound);
+        left_child().grouped_priority_traversal(primitives, query, traits, nb_primitives/2, first_primitive_index, group_traversal_bound);
       }
     }
     else
@@ -310,7 +310,7 @@ AABB_node<Tr>::traversal_with_priority_and_group_traversal(const Primitive_vecto
       if(iright)
       {
         // Only the right child has to be inspected.
-        right_child().traversal_with_priority_and_group_traversal(primitives, query, traits, nb_primitives-nb_primitives/2, first_primitive_index+nb_primitives/2, group_traversal_bound);
+        right_child().grouped_priority_traversal(primitives, query, traits, nb_primitives-nb_primitives/2, first_primitive_index+nb_primitives/2, group_traversal_bound);
       }
     }
   }


### PR DESCRIPTION
- Changed current method name from `traversal_with_priority_and_group_traversal` to `grouped_priority_traversal`, which is more concise and meaningful. 

