### PR TITLE
Convex_hull_3: Add named parameter geom_traits

### DIFF
--- a/Convex_hull_3/doc/Convex_hull_3/CGAL/convex_hull_3.h
+++ b/Convex_hull_3/doc/Convex_hull_3/CGAL/convex_hull_3.h
@@ -11,15 +11,29 @@ if the convex hull is a point or a segment, endpoints will be added in `pm` as i
 
 \tparam InputIterator must be an input iterator with a value type  equivalent to `Traits::Point_3`.
 \tparam PolygonMesh must be a model of `MutableFaceGraph`.
-\tparam Traits must be a model of the concept `ConvexHullTraits_3`.
-For the purposes of checking the postcondition that the convex hull
-is valid, `Traits` must also be a model of the concept
-`IsStronglyConvexTraits_3`.
+\tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
 
-If the kernel `R` of the points determined by the value type of `InputIterator`
-is a kernel with exact predicates but inexact constructions
-(in practice we check `R::Has_filtered_predicates_tag` is `Tag_true` and `R::FT` is a floating point type),
-then the default traits class of `::convex_hull_3()` is `Convex_hull_traits_3<R>`, and `R` otherwise.
+\param first
+\param last
+\param pm the `PolygonMesh` that will contain the convex hull
+\param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
+
+  \cgalNamedParamsBegin
+  \cgalParamNBegin{geom_traits}
+      \cgalParamDescription{an instance of a geometric traits class}
+      \cgalParamType{a class model of the concept `ConvexHullTraits_3`.
+                     For the purposes of checking the postcondition that the convex hull
+                     is valid, `Traits` must also be a model of the concept `IsStronglyConvexTraits_3`.}
+      \cgalParamDefault{a \cgal Kernel deduced from the point type, using `CGAL::Kernel_traits`.
+                        If the kernel `R` of the points determined by the value type of `InputIterator`
+                        is a kernel with exact predicates but inexact constructions
+                        (in practice we check `R::Has_filtered_predicates_tag` is `Tag_true` and `R::FT` is a floating point type),
+                        then the default traits class of `::convex_hull_3()` is `Convex_hull_traits_3<R>`, and `R` otherwise.}
+      \cgalParamExtra{The geometric traits class must be compatible with the vertex point type.}
+    \cgalParamNEnd
+  \cgalNamedParamsEnd
+
+
 
 \attention The user must include the header file of the `PolygonMesh` type.
 
@@ -31,8 +45,8 @@ Barber <I>et al.</I> \cgalCite{bdh-qach-96}.
 
 */
 
-template <class InputIterator, class PolygonMesh, class Traits>
-void convex_hull_3(InputIterator first, InputIterator last, PolygonMesh& pm, const Traits& ch_traits = Default_traits);
+template <class InputIterator, class PolygonMesh, class NamedParameters = CGAL::parameters::Default_named_parameters>
+void convex_hull_3(InputIterator first, InputIterator last, PolygonMesh& pm, const NamedParameters &  np = p = parameters::default_values());
 
 
 /*!

--- a/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_3.h
@@ -261,7 +261,7 @@ namespace CGAL
         // compute the intersection of the half-space using the dual formulation
         Hull_traits_dual_3 dual_traits(*origin);
         Polyhedron_dual_3 dual_convex_hull;
-        CGAL::convex_hull_3(begin, end, dual_convex_hull, dual_traits);
+        CGAL::convex_hull_3(begin, end, dual_convex_hull, parameters::geom_traits(dual_traits));
         Convex_hull_3::internal::build_primal_polyhedron(P, dual_convex_hull, *origin);
 
         // Posterior check if the origin is inside the computed polyhedron

--- a/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_with_constructions_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_with_constructions_3.h
@@ -127,7 +127,7 @@ namespace CGAL
           }
 
           Polyhedron ch;
-          CGAL::convex_hull_3(dual_points.begin(), dual_points.end(), ch, ch_traits);
+          CGAL::convex_hull_3(dual_points.begin(), dual_points.end(), ch, parameters::geom_traits(ch_traits));
 
           Convex_hull_3::internal::build_dual_polyhedron (ch, P, p_origin);
         }

--- a/Convex_hull_3/include/CGAL/Extreme_points_traits_adapter_3.h
+++ b/Convex_hull_3/include/CGAL/Extreme_points_traits_adapter_3.h
@@ -75,7 +75,10 @@ class Extreme_points_traits_adapter_3
   PointPropertyMap vpm_;
 
 public:
-  Extreme_points_traits_adapter_3(const PointPropertyMap& vpmap,
+Extreme_points_traits_adapter_3()
+{}
+
+Extreme_points_traits_adapter_3(const PointPropertyMap& vpmap,
                                   Base_traits base = Base_traits())
     :
       Base_traits(base), vpm_(vpmap)

--- a/Convex_hull_3/include/CGAL/convex_hull_3.h
+++ b/Convex_hull_3/include/CGAL/convex_hull_3.h
@@ -990,11 +990,16 @@ void convex_hull_3(InputIterator first, InputIterator beyond,
    convex_hull_3(first, beyond, ch_object, Traits());
 }
 
-template <class InputIterator, class PolygonMesh, class Traits>
+template <class InputIterator, class PolygonMesh, class CGAL_NP_TEMPLATE_PARAMETERS>
 void convex_hull_3(InputIterator first, InputIterator beyond,
                    PolygonMesh& polyhedron,
-                   const Traits& traits)
+                   const CGAL_NP_CLASS& np = parameters::default_values())
 {
+  using parameters::choose_parameter;
+  using parameters::get_parameter;
+  typedef typename GetGeomTraits<PolygonMesh,CGAL_NP_CLASS>::type         Traits;
+
+  Traits traits = choose_parameter(get_parameter(np, internal_np::geom_traits), Traits());
   typedef typename Traits::Point_3                Point_3;
   typedef std::list<Point_3>                      Point_3_list;
   typedef typename Point_3_list::iterator         P3_iterator;
@@ -1048,33 +1053,36 @@ void convex_hull_3(InputIterator first, InputIterator beyond,
     polyhedron, traits);
 }
 
+/*
 template <class InputIterator, class PolygonMesh>
 void convex_hull_3(InputIterator first, InputIterator beyond,
-                   PolygonMesh& polyhedron,
+                   PolygonMesh& polyhedron
+                //   ,
                    // workaround to avoid ambiguity with next overload.
-                   std::enable_if_t<CGAL::is_iterator<InputIterator>::value>* = 0)
+                //   std::enable_if_t<CGAL::is_iterator<InputIterator>::value>* = 0
+                  )
 {
   typedef typename std::iterator_traits<InputIterator>::value_type Point_3;
   typedef typename Convex_hull_3::internal::Default_traits_for_Chull_3<Point_3, PolygonMesh>::type Traits;
   convex_hull_3(first, beyond, polyhedron, Traits());
 }
-
-template <class VertexListGraph, class PolygonMesh, class NamedParameters = parameters::Default_named_parameters>
+*/
+template <class VertexListGraph, class PolygonMesh, class CGAL_NP_TEMPLATE_PARAMETERS>
 void convex_hull_3(const VertexListGraph& g,
                    PolygonMesh& pm,
-                   const NamedParameters& np = parameters::default_values())
+                   const CGAL_NP_CLASS& np = parameters::default_values())
 {
   using CGAL::parameters::choose_parameter;
   using CGAL::parameters::get_parameter;
 
-  typedef typename GetVertexPointMap<VertexListGraph, NamedParameters>::const_type Vpmap;
+  typedef typename GetVertexPointMap<VertexListGraph, CGAL_NP_CLASS>::const_type Vpmap;
   typedef CGAL::Property_map_to_unary_function<Vpmap> Vpmap_fct;
   Vpmap vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                                get_const_property_map(boost::vertex_point, g));
 
   Vpmap_fct v2p(vpm);
   convex_hull_3(boost::make_transform_iterator(vertices(g).begin(), v2p),
-                boost::make_transform_iterator(vertices(g).end(), v2p), pm);
+                boost::make_transform_iterator(vertices(g).end(), v2p), pm, np);  // AF: Added np but is it the right one?
 }
 
 
@@ -1091,7 +1099,7 @@ void convex_hull_3(InputIterator first, InputIterator beyond,
   typedef typename Kernel_traits<Point_3>::type Traits;
 
   Convex_hull_3::internal::Indexed_triangle_set<PointRange, TriangleRange> its(vertices,faces);
-  convex_hull_3(first, beyond, its, Traits());
+  convex_hull_3(first, beyond, its, parameters::geom_traits(Traits()));
 }
 
 
@@ -1116,7 +1124,7 @@ extreme_points_3(const InputRange& range,
                  const Traits& traits)
 {
   Convex_hull_3::internal::Output_iterator_wrapper<OutputIterator> wrapper(out);
-  convex_hull_3(range.begin(), range.end(), wrapper, traits);
+  convex_hull_3(range.begin(), range.end(), wrapper, CGAL::parameters::geom_traits(traits));
   return out;
 }
 

--- a/Convex_hull_3/test/Convex_hull_3/quickhull_test_3.cpp
+++ b/Convex_hull_3/test/Convex_hull_3/quickhull_test_3.cpp
@@ -97,7 +97,7 @@ void test_small_hull()
   points.push_back(Point_3(1,3,2));
 
   Polyhedron_3 polyhedron1;
-  CGAL::convex_hull_3(points.begin(), points.end(), polyhedron1, Traits());
+  CGAL::convex_hull_3(points.begin(), points.end(), polyhedron1, CGAL::parameters::geom_traits(Traits()));
   assert( polyhedron1.size_of_vertices() == 5 &&
            polyhedron1.size_of_facets() == 6 );
   Polyhedron_3 polyhedron2;
@@ -117,7 +117,7 @@ void test_coplanar_hull()
   points.push_back(Point_3(1.5,0.5,0));
   points.push_back(Point_3(0.5,1.1,0));
   Polyhedron_3 polyhedron;
-  CGAL::convex_hull_3(points.begin(), points.end(), polyhedron, Traits());
+  CGAL::convex_hull_3(points.begin(), points.end(), polyhedron, CGAL::parameters::geom_traits(Traits()));
   assert( polyhedron.is_valid() );
   assert( polyhedron.size_of_facets() == 4 );
   assert( polyhedron.is_pure_triangle() );

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -18,6 +18,10 @@
 ### [BGL](https://doc.cgal.org/6.1/Manual/packages.html#PkgBGL)
 -   Added the function `CGAL::Euler::remove_degree_2_vertex()`, which enables users to remove vertices which have exactly two incident edges.
 
+### [3D Convex Hulls](https://doc.cgal.org/6.1/Manual/packages.html#PkgConvexHull3)
+
+- **Breaking change**: For function `CGAL::convex_hull_3()` the traits class has become a named parameter.
+
 ### [2D Arrangements](https://doc.cgal.org/6.1/Manual/packages.html#PkgArrangementOnSurface2)
 
 -   Introduces two traits decorators, namely `Arr_tracing_traits_2` and `Arr_counting_traits_2`, which can be used to extract debugging and informative metadata about the traits in use while a program is being executed.

--- a/Polytope_distance_d/include/CGAL/Width_3.h
+++ b/Polytope_distance_d/include/CGAL/Width_3.h
@@ -166,7 +166,7 @@ class Width_3 {
     typedef Width_polyhedron_items_3                        Items;
     typedef Polyhedron_3< Traits, Items, HalfedgeDS_list>   LocalPolyhedron;
     LocalPolyhedron P;
-    convex_hull_3( begin, beyond, P, CHT());
+    convex_hull_3( begin, beyond, P, parameters::geom_traits(CHT()));
     width_3_convex(P);
   }
 


### PR DESCRIPTION
## Summary of Changes

Instead of the traits class being a `\tparam`  we make it a named parameter.  This is a breaking change, but we have to fix an ambiguity detected by one compiler, as reported in Issue #8759

### Todo 

- [ ] documentation
- [x] changes
- [ ] do the same for other functions in the package


## Release Management

* Affected package(s):  Convex_hull_3
* Issue(s) solved (if any): fix #8759
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

