### PR TITLE
Fix Compare_xy_2 for the generic 3D projection traits

### DIFF
--- a/Kernel_23/include/CGAL/Kernel_23/internal/Projection_traits_base_3.h
+++ b/Kernel_23/include/CGAL/Kernel_23/internal/Projection_traits_base_3.h
@@ -372,6 +372,35 @@ public:
   }
 }; // end class Less_xy_along_axis
 
+template <class Traits>
+class Compare_xy_along_axis
+{
+  // private members
+  typedef typename Traits::Vector_3 Vector_3;
+  typedef typename Traits::Point_2 Point;
+  Vector_3 base1, base2;
+
+public:
+  Compare_xy_along_axis(const Vector_3& base1, const Vector_3& base2) : base1(base1), base2(base2)
+  {
+    CGAL_PROFILER("Construct Compare_xy_along_axis")
+    CGAL_TIME_PROFILER("Construct Compare_xy_along_axis")
+  }
+
+  typedef Comparison_result result_type;
+
+  Comparison_result operator()(const Point& p, const Point& q) const
+  {
+    Compare_along_axis<Traits> cx(base1);
+    Comparison_result crx = cx(p, q);
+    if (crx != EQUAL) {
+      return crx;
+    }
+    Compare_along_axis<Traits> cy(base2);
+    return cy(p, q);
+  }
+}; // end class Compare_xy_along_axis
+
 } // end namespace TriangulationProjectionTraitsCartesianFunctors
 
 
@@ -426,12 +455,13 @@ public:
   typedef typename K::Line_3      Line_2;
 
   typedef typename K::Angle_3                                Angle_2;
-  typedef typename K::Compare_xyz_3                          Compare_xy_2;
 
   typedef TriangulationProjectionTraitsCartesianFunctors::
     Compare_along_axis<Self>                                 Compare_x_2;
   typedef TriangulationProjectionTraitsCartesianFunctors::
     Compare_along_axis<Self>                                 Compare_y_2;
+  typedef TriangulationProjectionTraitsCartesianFunctors::
+    Compare_xy_along_axis<Self>                              Compare_xy_2;
 
   typedef TriangulationProjectionTraitsCartesianFunctors::
     Less_along_axis<Self>                                    Less_x_2;
@@ -498,6 +528,12 @@ public:
     return Compare_y_2(this->base2());
   }
 
+  Compare_xy_2
+  compare_xy_2_object() const
+  {
+    return Compare_xy_2(this->base1(), this->base2());
+  }
+
   Orientation_2
   orientation_2_object() const
   {
@@ -524,9 +560,6 @@ public:
 
   Angle_2  angle_2_object() const
     {return Angle_2();}
-
-  Compare_xy_2  compare_xy_2_object() const
-    {return Compare_xy_2();}
 
   Construct_point_2  construct_point_2_object() const
     {return Construct_point_2();}


### PR DESCRIPTION
## Summary of Changes

The previous implementation defined `Compare_xy_2` as simply `Compare_xyz_3`. This does define an order over the projected points, but it has a strong downside: it ignores the direction of the normal, so its order can be the opposite of the lexicographical order
would give. This new order is in conflict with the existing `Compare_x_2` and `Compare_y_2`, which take the normal's direction into account.

(Also with the `Less_x_2`, `Less_y_2`, and `Less_xy_2` family, which also exist for the projection traits.)

## Release Management

* Affected package(s): `Kernel_23`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): - 
* License and copyright ownership: no change

