### PR TITLE
Fix bad initialisation of the conic traits

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_conic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_conic_traits_2.h
@@ -128,7 +128,11 @@ private:
 public:
   /*! Default constructor.
    */
-  Arr_conic_traits_2() {}
+  Arr_conic_traits_2()
+   : m_rat_kernel(std::make_shared<Rat_kernel>()),
+     m_alg_kernel(std::make_shared<Alg_kernel>()),
+     m_nt_traits(std::make_shared<Nt_traits>())
+  {}
 
   /*! Construct from resources.
    */


### PR DESCRIPTION
Should fix [1](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.1-Ic-123/Arrangement_on_surface_2/TestReport_lrineau_Ubuntu-latest-GCC6-CXX1z.gz), [2](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.1-Ic-123/Arrangement_on_surface_2_Examples/TestReport_lrineau_Ubuntu-latest-GCC6-CXX1z.gz), [4](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.1-Ic-123/Envelope_3/TestReport_lrineau_Ubuntu-latest-GCC6-CXX1z.gz), [5](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.1-Ic-123/Envelope_3_Examples/TestReport_lrineau_Ubuntu-latest-GCC6-CXX1z.gz), [6](cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.1-Ic-123/Minkowski_sum_2/TestReport_lrineau_Ubuntu-latest-GCC6-CXX1z.gz), [7](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.1-Ic-123/Minkowski_sum_2_Examples/TestReport_lrineau_Ubuntu-latest-GCC6-CXX1z.gz), [8](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.1-Ic-123/Surface_sweep_2/TestReport_lrineau_Ubuntu-latest-GCC6-CXX1z.gz)

