### PR TITLE
Lab - Fixed loading of OpenMesh files without selection

### DIFF
--- a/Lab/demo/Lab/Plugins/IO/OM_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/IO/OM_io_plugin.cpp
@@ -124,6 +124,8 @@ load(QFileInfo fileinfo, bool& ok, bool add_to_scene){
       res << item;
       if(!selection_item->isEmpty())
         res << selection_item;
+      else
+        delete selection_item;
       return res;
     }
   }


### PR DESCRIPTION
## Summary of Changes

A `Scene_polyhedron_selection_item`  is created when loading an OpenMesh file. When there was no selection inside the file, this selection item was neither added to the scene nor deleted. Thus, it still received Qt signals and caused crashes when the actual mesh was removed.

## Release Management

* Affected package(s): CGALlab

