### PR TITLE
Internal support for parsing texture and normal indices in OBJ loader and lil typo

### DIFF
--- a/Documentation/doc/Documentation/Developer_manual/Chapter_intro.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_intro.txt
@@ -225,7 +225,7 @@ functionalities for circles, circular arcs living on a 3D sphere
 
 \cgal currently provides several models for the \cgal 2D and 3D kernel
 concept, and one model for the 2D circular and the 3D spherical kernel
-concepts.. Those are again parameterized and differ in their
+concepts. Those are again parameterized and differ in their
 representation of the geometric objects and the exchangeability of
 the types involved.
 In the first four cases the kernels are parameterized by a number type, which
@@ -233,7 +233,7 @@ is used to store coordinates and which determines the basic arithmetic
 of the kernel primitives.
 
 In the last two cases, the circular and spherical kernel are also
-parametrized by Algebraic Kernels, which, along with Algebraic
+parameterized by Algebraic Kernels, which, along with Algebraic
 Foundations, is the third distinct high level of genericity in
 \cgal. The algebraic foundations in \cgal is a collection of concepts
 representing algebraic structures, and are motivated by well-known

--- a/Documentation/doc/Documentation/Usage.txt
+++ b/Documentation/doc/Documentation/Usage.txt
@@ -2,7 +2,7 @@
 \page usage Using %CGAL on Unix (Linux, macOS, ...)
 \cgalAutoToc
 
-Since \cgal version 5.0, \cgal is header-only be default, which means
+Since \cgal version 5.0, \cgal is header-only by default, which means
 that there is <b>no need to build \cgal before it can be used</b>.
 However, some dependencies of \cgal might still need to be installed.
 
@@ -45,7 +45,7 @@ or to build your own project using \cgal, see Section \ref secoptional3rdpartyso
 \section secgettingcgal Downloading CGAL
 
 \cgal can be obtained through different channels. We recommend using a package manager as
-this will ensure that all essential third party dependencies are present, and with the correct versions.
+this will ensure that all essential third-party dependencies are present, and with the correct versions.
 You may also download the sources of \cgal directly, but it is then your responsibility to independently
 acquire these dependencies.
 
@@ -180,7 +180,7 @@ all the required dependencies. This typically happens if you have installed depe
 at non-standard locations.
 Although the command line tool `cmake` accepts CMake variables as arguments of the form
 `-D<VAR>:<TYPE>=<VALUE>`, this is only useful if you already know which variables
-need to be explicitly defined. or this reason, the simplest way to manually set the missing variables
+need to be explicitly defined. For this reason, the simplest way to manually set the missing variables
 is to run the graphical user interface of CMake, `cmake-gui`.
 
     cd CGAL-\cgalReleaseNumber/examples/Triangulation_2

--- a/Stream_support/test/Stream_support/test_OBJ.cpp
+++ b/Stream_support/test/Stream_support/test_OBJ.cpp
@@ -10,6 +10,8 @@
 typedef CGAL::Simple_cartesian<double>                Kernel;
 typedef Kernel::Point_3                               Point;
 typedef std::vector<std::size_t>                      Face;
+typedef Kernel::Point_2 Texture;
+typedef Kernel::Vector_3 Normal;
 
 int main(int argc, char** argv)
 {
@@ -17,6 +19,10 @@ int main(int argc, char** argv)
 
   std::vector<Point> points;
   std::vector<Face> polygons;
+  std::vector<Normal> normals;
+  std::vector<Texture> UVcoords;
+  std::vector<int> normal_indices;
+  std::vector<int> texture_indices;
 
   bool ok = CGAL::IO::read_OBJ(obj_file, points, polygons, CGAL::parameters::verbose(true));
   assert(ok);
@@ -25,6 +31,20 @@ int main(int argc, char** argv)
   if(argc == 1)
     assert(points.size() == 434 && polygons.size() == 864);
 
+  points.clear();
+  polygons.clear();
+
+  // Check for internal read_OBJ with normal and texture coordinates reading capapbility
+  std::ifstream input(obj_file);
+  ok = CGAL::IO::internal::read_OBJ(input, points, polygons, std::back_inserter(normals), std::back_inserter(UVcoords),
+                                    std::back_inserter(normal_indices), std::back_inserter(texture_indices), true);
+  assert(ok);
+  std::cout << points.size() << " points " << polygons.size() << " polygons " << normals.size() << " normals "
+            << UVcoords.size() << " texture coords" << std::endl;
+
+  if(argc == 1)
+    assert(points.size() == 434 && polygons.size() == 864 && normals.size() == 242 && UVcoords.size() == 627);
+  
   points.clear();
   polygons.clear();
   std::string obj_string(obj_file);


### PR DESCRIPTION
## Summary of Changes

This PR adds the ability to parse normals and texture coordinates from .obj files using the existing face parsing logic. This is currently internal-only, and not exposed in the documented API or parameter sets.

The goal is to fully integrate OBJ normal and texture support in a future PR, once the writer logic is updated, and a broader set of test cases are validated.

- Internal parsing logic implemented
- Unit test added for face parsing with v/vt/vn syntax
- Not exposed to public interface yet

Why not public yet?
- Writer does not yet support output of texture and normal attributes.
- Further edge case testing is necessary before public exposure.

Once these conditions are met, the feature will be promoted to the public API.

## Release Management

* Affected package(s): [*Stream Support*](https://github.com/CGAL/cgal/tree/master/Stream_support)
* Issue(s) solved (if any): partially worked on [#8344](https://github.com/CGAL/cgal/issues/8344)
* Feature/Small Feature (if any): added capability of reading normals and texture coordinates in OBJ file format (not yet exposed to public API though, only kept to internal::read_obj() )
* Link to compiled documentation (obligatory for small feature) [**Not yet exposed to the public API to write documentation for**](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: Same as CGAL

