### PR TITLE
SMDS_3 - add `c3t3.set_triangulation()`

### DIFF
--- a/SMDS_3/examples/SMDS_3/tetrahedron_soup_to_c3t3_example.cpp
+++ b/SMDS_3/examples/SMDS_3/tetrahedron_soup_to_c3t3_example.cpp
@@ -70,6 +70,12 @@ int main(int , char* [])
   //build a C3T3
   C3T3 c3t3;
   c3t3.triangulation() = tr;
+  c3t3.rescan_after_load_of_triangulation();
+
+  std::cout << "Number of corners: " << c3t3.number_of_corners() << std::endl;
+  std::cout << "Number of edges: " << c3t3.number_of_edges() << std::endl;
+  std::cout << "Number of facets: " << c3t3.number_of_facets() << std::endl;
+  std::cout << "Number of cells: " << c3t3.number_of_cells() << std::endl;
 
   std::ofstream ofs("c3t3_output.mesh");
   CGAL::IO::write_MEDIT(ofs, c3t3);

--- a/SMDS_3/examples/SMDS_3/tetrahedron_soup_to_c3t3_example.cpp
+++ b/SMDS_3/examples/SMDS_3/tetrahedron_soup_to_c3t3_example.cpp
@@ -69,8 +69,7 @@ int main(int , char* [])
 
   //build a C3T3
   C3T3 c3t3;
-  c3t3.triangulation() = tr;
-  c3t3.rescan_after_load_of_triangulation();
+  c3t3.set_triangulation(tr);
 
   std::cout << "Number of corners: " << c3t3.number_of_corners() << std::endl;
   std::cout << "Number of edges: " << c3t3.number_of_edges() << std::endl;

--- a/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -328,12 +328,18 @@ public:
   const Triangulation& triangulation() const { return tr_; }
 /// @}
 
+#ifndef DOXYGEN_RUNNING
 /// \name Non const access
 /// @{
     /// returns a reference to the triangulation
+    /// \cgalAdvancedBegin
+    /// This function should only be used by advanced users: it merely swaps the triangulation without
+    /// rebuilding critical C3T3 information such as the number of simplexes in complex.
+    /// On the other hand, this is performed by `set_triangulation()`
+    /// \cgalAdvancedEnd
   Triangulation& triangulation() { return tr_; }
 /// @}
-
+#endif
 
 /// \name Modifiers
 /// @{

--- a/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -351,6 +351,14 @@ public:
     far_vertices_.clear();
   }
 
+  /** sets the internal triangulation to \p tr
+  */
+  void set_triangulation(const Triangulation& tr)
+  {
+    tr_ = tr;
+    rescan_after_load_of_triangulation();
+  }
+
   /** adds cell \p cell to the 3D complex, with subdomain index \p index
   */
   void add_to_complex(const Cell_handle& cell, const Subdomain_index& index)

--- a/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
+++ b/SMDS_3/include/CGAL/Mesh_complex_3_in_triangulation_3.h
@@ -358,6 +358,13 @@ public:
     tr_ = tr;
     rescan_after_load_of_triangulation();
   }
+  /** sets the internal triangulation to \p tr
+  */
+  void set_triangulation(Triangulation&& tr)
+  {
+    tr_ = std::move(tr);
+    rescan_after_load_of_triangulation();
+  }
 
   /** adds cell \p cell to the 3D complex, with subdomain index \p index
   */


### PR DESCRIPTION
When loading a .mesh file to a `Triangulation_3`, and then a `C3t3`, as done in [this example](https://doc.cgal.org/latest/SMDS_3/SMDS_3_2tetrahedron_soup_to_c3t3_example_8cpp-example.html) leads to a `C3t3` for which `number_of_facets()` and `number_of_cells()` return 0, because the internal counters have not been updated by `c3t3.triangulation() = tr`.

It is not clear to the user why these numbers are 0, and the function `rescan_after_load_of_triangulation()` (which fixes the counters) is not documented.

## Summary of Changes

~~Add the use of `rescan_after_load_of_triangulation()` in an example.~~

~~The other option would be to use it automatically in the functions that load a triangulation.~~

~~@lrineau @MaelRL do you have an opinion?~~

~~Todo : discuss the API~~

Add and document a function `c3t3.set_triangulation(const Tr& tr)` that internally calls `rescan_after_load_of_triangulation()`, and is easier to use

## Release Management

* Affected package(s): SMDS_3
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: unchanged

