### PR TITLE
Internal support for parsing texture and normal indices in OBJ loader

### DIFF
--- a/Stream_support/test/Stream_support/test_OBJ.cpp
+++ b/Stream_support/test/Stream_support/test_OBJ.cpp
@@ -10,6 +10,8 @@
 typedef CGAL::Simple_cartesian<double>                Kernel;
 typedef Kernel::Point_3                               Point;
 typedef std::vector<std::size_t>                      Face;
+typedef Kernel::Point_2                               Texture;
+typedef Kernel::Vector_3                              Normal;
 
 int main(int argc, char** argv)
 {
@@ -17,6 +19,10 @@ int main(int argc, char** argv)
 
   std::vector<Point> points;
   std::vector<Face> polygons;
+  std::vector<Normal> normals;
+  std::vector<Texture> UVcoords;
+  std::vector<int> normal_indices;
+  std::vector<int> texture_indices;
 
   bool ok = CGAL::IO::read_OBJ(obj_file, points, polygons, CGAL::parameters::verbose(true));
   assert(ok);
@@ -24,6 +30,20 @@ int main(int argc, char** argv)
 
   if(argc == 1)
     assert(points.size() == 434 && polygons.size() == 864);
+
+  points.clear();
+  polygons.clear();
+
+  // Check for internal read_OBJ with normal and texture coordinates reading capapbility
+  std::ifstream input(obj_file);
+  ok = CGAL::IO::internal::read_OBJ(input, points, polygons, std::back_inserter(normals), std::back_inserter(UVcoords),
+                                    std::back_inserter(normal_indices), std::back_inserter(texture_indices), true);
+  assert(ok);
+  std::cout << points.size() << " points " << polygons.size() << " polygons " << normals.size() << " normals "
+            << UVcoords.size() << " texture coords" << std::endl;
+
+  if(argc == 1)
+    assert(points.size() == 434 && polygons.size() == 864 && normals.size() == 242 && UVcoords.size() == 627);
 
   points.clear();
   polygons.clear();


### PR DESCRIPTION
## Summary of Changes

This PR adds the ability to parse normals and texture coordinates from .obj files using the existing face parsing logic. This is currently internal-only, and not exposed in the documented API or parameter sets.

The goal is to fully integrate OBJ normal and texture support in a future PR, once the writer logic is updated, and a broader set of test cases are validated.

- Internal parsing logic implemented
- Unit test added for face parsing with v/vt/vn syntax
- Not exposed to public interface yet

Why not public yet?
- Writer does not yet support output of texture and normal attributes, so won't provide a complete interface to interact with.

Once these conditions are met, the feature will be promoted to the public API.

## Release Management

* Affected package(s): [*Stream Support*](https://github.com/CGAL/cgal/tree/master/Stream_support)
* Issue(s) solved (if any): partially worked on [#8344](https://github.com/CGAL/cgal/issues/8344)
* Feature/Small Feature (if any): added capability of reading normals and texture coordinates in OBJ file format (not yet exposed to public API though, only kept to internal::read_obj() )
* Link to compiled documentation (obligatory for small feature) [**Not yet exposed to the public API to write documentation for**](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: Same as CGAL

