### PR TITLE
feat: read support for vn and vt added for OBJ file format

### DIFF
--- a/Stream_support/include/CGAL/IO/OBJ.h
+++ b/Stream_support/include/CGAL/IO/OBJ.h
@@ -24,6 +24,8 @@
 #include <boost/range/value_type.hpp>
 #include <CGAL/Named_function_parameters.h>
 
+#include <CGAL/Kernel_traits.h>
+
 #include <algorithm>
 #include <fstream>
 #include <iostream>
@@ -41,14 +43,20 @@ namespace CGAL {
 namespace IO {
 namespace internal {
 
-template <typename PointRange, typename PolygonRange, typename VertexNormalOutputIterator, typename VertexTextureOutputIterator>
+template <typename PointRange,
+          typename PolygonRange,
+          typename VertexNormalOutputIterator,
+          typename VertexTextureOutputIterator,
+          typename VertexNormalIndexOutputIterator,
+          typename VertexTextureIndexOutputIterator>
 bool read_OBJ(std::istream& is,
               PointRange& points,
               PolygonRange& polygons,
-              VertexNormalOutputIterator,
-              VertexTextureOutputIterator,
-              const bool verbose = false)
-{
+              VertexNormalOutputIterator vn_out,
+              VertexTextureOutputIterator vt_out,
+              VertexNormalIndexOutputIterator vn_id_out,
+              VertexTextureIndexOutputIterator vt_id_out,
+              const bool verbose = false) {
   if(!is.good())
   {
     if(verbose)
@@ -57,12 +65,19 @@ bool read_OBJ(std::istream& is,
   }
 
   typedef typename boost::range_value<PointRange>::type                               Point;
+  typedef typename CGAL::Kernel_traits<Point>::Kernel                                 Kernel;
+  typedef typename Kernel::Point_2                                                    Texture;
+  typedef typename Kernel::Vector_3                                                   Normal;
+  typedef typename Kernel::FT                                                         FT;
 
   set_ascii_mode(is); // obj is ASCII only
 
   int mini(1), maxi(-1);
   std::string s;
   Point p;
+
+  int normal_count = 0;
+  int texture_count = 0;
 
   std::string line;
   bool tex_found(false), norm_found(false);
@@ -107,39 +122,61 @@ bool read_OBJ(std::istream& is,
     else if(s == "vt")
     {
       tex_found = true;
+      texture_count++;
+      double u = 0.0, v = 0.0;
+      iss >> u >> v;
+      *vt_out++ = Texture{FT(u), FT(v)};
     }
     else if(s == "vn")
     {
       norm_found = true;
+      normal_count++;
+      double nx = 0.0;
+      double ny = 0.0;
+      double nz = 0.0;
+      iss >> nx >> ny >> nz;
+      *vn_out++ = Normal{FT(nx), FT(ny), FT(nz)};
     }
     else if(s == "f")
     {
-      int i;
+      std::string vertex_token;
       polygons.emplace_back();
-      while(iss >> i)
+      while(iss >> vertex_token)
       {
-        if(i < 1)
-        {
+        std::istringstream token_stream(vertex_token);
+        std::string v_str, vt_str, vn_str;
+
+        std::getline(token_stream, v_str, '/');
+        std::getline(token_stream, vt_str, '/');
+        std::getline(token_stream, vn_str, '/');
+
+        int i = std::stoi(v_str);
+
+        if(i < 1) {
           const std::size_t n = polygons.back().size();
           ::CGAL::internal::resize(polygons.back(), n + 1);
           polygons.back()[n] = static_cast<int>(points.size()) + i; // negative indices are relative references
           if(i < mini)
             mini = i;
-        }
-        else
-        {
+        } else {
           const std::size_t n = polygons.back().size();
           ::CGAL::internal::resize(polygons.back(), n + 1);
           polygons.back()[n] = i - 1;
-          if(i-1 > maxi)
-            maxi = i-1;
+          if(i - 1 > maxi)
+            maxi = i - 1;
         }
 
-        // the format can be "f v1/vt1/vn1 v2/vt2/vn2 v3/vt3/vn3 ..." and we only read vertex ids for now,
-        // so skip to the next vertex, but be tolerant about which whitespace is used
-        if (!std::isspace(iss.peek())) {
-          std::string ignoreme;
-          iss >> ignoreme;
+        // We read vt and vn in the given format and then we move on to next vertex
+        // Texture index
+        if(!vt_str.empty()) {
+          int vti = std::stoi(vt_str);
+          *vt_id_out++ = (vti < 0) ? static_cast<int>(texture_count) + vti : vti - 1;
+        }
+
+        // Normal index
+        if(!vn_str.empty()) {
+          int vni = std::stoi(vn_str);
+          *vn_id_out++ = (vni < 0) ? static_cast<int>(normal_count) + vni : vni - 1;
         }
       }
 
@@ -244,9 +281,8 @@ bool read_OBJ(std::istream& is,
 {
   const bool verbose = parameters::choose_parameter(parameters::get_parameter(np, internal_np::verbose), false);
 
-  return internal::read_OBJ(is, points, polygons,
-                            CGAL::Emptyset_iterator(), CGAL::Emptyset_iterator(),
-                            verbose);
+  return internal::read_OBJ(is, points, polygons, CGAL::Emptyset_iterator(), CGAL::Emptyset_iterator(),
+                            CGAL::Emptyset_iterator(), CGAL::Emptyset_iterator(), verbose);
 }
 
 /// \ingroup PkgStreamSupportIoFuncsOBJ

--- a/Stream_support/test/Stream_support/test_OBJ.cpp
+++ b/Stream_support/test/Stream_support/test_OBJ.cpp
@@ -10,6 +10,8 @@
 typedef CGAL::Simple_cartesian<double>                Kernel;
 typedef Kernel::Point_3                               Point;
 typedef std::vector<std::size_t>                      Face;
+typedef Kernel::Point_2                               Texture;
+typedef Kernel::Vector_3                              Normal;
 
 int main(int argc, char** argv)
 {
@@ -17,6 +19,10 @@ int main(int argc, char** argv)
 
   std::vector<Point> points;
   std::vector<Face> polygons;
+  std::vector<Normal> normals;
+  std::vector<Texture> UVcoords;
+  std::vector<int> normal_indices;
+  std::vector<int> texture_indices;
 
   bool ok = CGAL::IO::read_OBJ(obj_file, points, polygons, CGAL::parameters::verbose(true));
   assert(ok);
@@ -24,6 +30,20 @@ int main(int argc, char** argv)
 
   if(argc == 1)
     assert(points.size() == 434 && polygons.size() == 864);
+
+  points.clear();
+  polygons.clear();
+
+  // Check for internal read_OBJ with normal and texture coordinates reading capapbility
+  std::ifstream input(obj_file);
+  ok = CGAL::IO::internal::read_OBJ(input, points, polygons, std::back_inserter(normals), std::back_inserter(UVcoords),
+                                    std::back_inserter(normal_indices), std::back_inserter(texture_indices), true);
+  assert(ok);
+  std::cout << points.size() << " points " << polygons.size() << " polygons " << normals.size() << " normals "
+            << UVcoords.size() << " texture coords" << std::endl;
+
+  if(argc == 1)
+    assert(points.size() == 434 && polygons.size() == 864 && normals.size() == 242 && UVcoords.size() == 627);
 
   points.clear();
   polygons.clear();


### PR DESCRIPTION
## Summary of Changes

This PR adds the ability to parse normals and texture coordinates from .obj files using the existing face parsing logic. This is currently internal-only, and not exposed in the documented API or parameter sets.

The goal is to fully integrate OBJ normal and texture support in a future PR, once the writer logic is updated, and a broader set of test cases are validated.

- Internal parsing logic implemented
- test added for face parsing with v/vt/vn syntax
- Not exposed to public interface yet

Why not public yet?
- Writer does not yet support output of texture and normal attributes.

Once these conditions are met, the feature will be promoted to the public API.

## Release Management

* Affected package(s): [*Stream Support*](https://github.com/CGAL/cgal/tree/master/Stream_support)
* Issue(s) solved (if any): partially worked on [#8344](https://github.com/CGAL/cgal/issues/8344)
* Feature/Small Feature (if any): added capability of reading normals and texture coordinates in OBJ file format (not yet exposed to public API though, only kept to internal::read_obj() )
* Link to compiled documentation (obligatory for small feature) [**Not yet exposed to the public API to write documentation for**](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: Same as CGAL

