### PR TITLE
workaround API change in QT 6.9

### DIFF
--- a/Lab/demo/Lab/Plugins/Display/Display_property_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Display/Display_property_plugin.cpp
@@ -382,7 +382,7 @@ private:
                        color);
 
       QRect text_rect(left_margin + cell_width + 10, drawing_height - top_margin - j, 50, text_height);
-      painter.drawText(text_rect, Qt::AlignCenter, QObject::tr("%1").arg(values[i], 0, 'f', 3, QLatin1Char(' ')));
+      painter.drawText(text_rect, Qt::AlignCenter, QObject::tr("%1").arg(static_cast<double>(values[i]), 0, 'f', 3, QLatin1Char(' ')));
     }
 
     if(color_map.size() > size)


### PR DESCRIPTION
Working around `qstring::arg()` API change in Qt 6.9

should fix:
https://cgal.geometryfactory.com/CGAL/testsuite/summary-6.1-I-135.html?package=Lab_Demo