### PR TITLE
Spelling correction.

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/refine_with_plane.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/refine_with_plane.h
@@ -219,7 +219,7 @@ void refine_with_plane(PolygonMesh& pm,
  /*
   *    \cgalParamNBegin{visitor}
   *      \cgalParamDescription{TODO add concept}
-  *      \cgalParamType{reference wrapper recommeded if it has state TODO}
+  *      \cgalParamType{reference wrapper recommended if it has state TODO}
   *      \cgalParamDefault{None}
   *    \cgalParamNEnd
  */


### PR DESCRIPTION
Spelling correction.
(Entire documentation here looks a bit incomplete seen the words `TODO`)

