### PR TITLE
Removing page outline panel

### DIFF
--- a/Documentation/doc/resources/1.10.0/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.10.0/BaseDoxyfile.in
@@ -523,6 +523,16 @@ DISABLE_INDEX          = YES
 
 GENERATE_TREEVIEW      = YES
 
+# When GENERATE_TREEVIEW is set to YES, the PAGE_OUTLINE_PANEL option determines
+# if an additional navigation panel is shown at the right hand side of the
+# screen, displaying an outline of the contents of the main page, similar to
+# e.g. https://developer.android.com/reference If GENERATE_TREEVIEW is set to
+# NO, this option has no effect.
+# The default value is: YES.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+PAGE_OUTLINE_PANEL     = NO
+
 # When both GENERATE_TREEVIEW and DISABLE_INDEX are set to YES, then the
 # FULL_SIDEBAR option determines if the side bar is limited to only the treeview
 # area (value NO) or if it should extend to the full height of the window (value


### PR DESCRIPTION
In the current master version of doxygen  (and thus upcoming version 1.14.0) a page outline panel is introduced, setting: `PAGE_OUTLINE_PANEL`, though it would be better to disable this in CGAL.

**With the setting `PAGE_OUTLINE_PANEL=YES` (the default)**:

![image](https://github.com/user-attachments/assets/44c59fc7-aa4b-4096-9996-678879c06802)


**With the setting `PAGE_OUTLINE_PANEL=NO`**:


![image](https://github.com/user-attachments/assets/cd9aebab-3e3c-4b95-91cb-cfc9b16cc1b2)
