### PR TITLE
Mark variables declared at global scope in headers as 'inline'.

### DIFF
--- a/STL_Extension/include/CGAL/Named_function_parameters.h
+++ b/STL_Extension/include/CGAL/Named_function_parameters.h
@@ -510,13 +510,13 @@ struct Boost_parameter_compatibility_wrapper<Tag, true, false>
   }
 
 #define CGAL_add_named_parameter_with_compatibility(X, Y, Z)        \
-  const Boost_parameter_compatibility_wrapper<internal_np::X> Z;
+  inline const Boost_parameter_compatibility_wrapper<internal_np::X> Z;
 #define CGAL_add_named_parameter_with_compatibility_cref_only(X, Y, Z)        \
-  const Boost_parameter_compatibility_wrapper<internal_np::X, true, true> Z;
+  inline const Boost_parameter_compatibility_wrapper<internal_np::X, true, true> Z;
 #define CGAL_add_named_parameter_with_compatibility_ref_only(X, Y, Z)        \
-  const Boost_parameter_compatibility_wrapper<internal_np::X, true, false> Z;
+  inline const Boost_parameter_compatibility_wrapper<internal_np::X, true, false> Z;
 #define CGAL_add_extra_named_parameter_with_compatibility(X, Y, Z)        \
-  const Boost_parameter_compatibility_wrapper<internal_np::X> Z;
+  inline const Boost_parameter_compatibility_wrapper<internal_np::X> Z;
 #include <CGAL/STL_Extension/internal/parameters_interface.h>
 #undef CGAL_add_named_parameter
 #undef CGAL_add_extra_named_parameter_with_compatibility


### PR DESCRIPTION
## Summary of Changes

`const` variables declared at global scope have internal linkage, and so if they are declared in a header file, they are replicated in every file that `#include` the header. They also can't be the target of `using` declarations that exports the variable into a C++20 module. This change marks a number of variables with `inline`, which gives these variables external linkage, allows the linker to unify all of these variables between different `.o` files, and also allows for their use in C++20 modules.

There is a separate question whether these variables could or should be `constexpr` instead of just `const`. The difference between `constexpr` and `const` has no effect on linkage, and so in the spirit of taking one step at a time, this patch does not address the `constexpr` vs `const` question.

This patch fixes #8871. Related to https://github.com/dealii/dealii/issues/18071.

## Release Management

* Affected package(s): 5.6.1
* Issue(s) solved (if any): #8871
* License and copyright ownership: Same license as used throughout CGAL.

