### PR TITLE
Tetrahedral_remeshing - fix `operator<()` for `Dihedral_angle_cosine`

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -257,7 +257,7 @@ struct Dihedral_angle_cosine
       CGAL_assertion(l.m_sgn != CGAL::POSITIVE);
       CGAL_assertion(r.m_sgn != CGAL::POSITIVE);
 
-      return (l.m_sq_num * r.m_sq_den >= r.m_sq_num* l.m_sq_den);
+      return (l.m_sq_num * r.m_sq_den > r.m_sq_num* l.m_sq_den);
     }
   }
 


### PR DESCRIPTION
## Summary of Changes

using <= makes possible to have
`dh1 < dh2 && dh2 < dh1 == true`
which is not valid!

This PR fixes [this testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.1-Ic-153/Constrained_triangulation_3_Examples/TestReport_Christo_MSVC2017-Debug-64bits.gz) (running remesh_constrained_Delaunay_triangulation_3)

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged

