### PR TITLE
Fix range issue in weights

### DIFF
--- a/Straight_skeleton_extrusion_2/include/CGAL/extrude_skeleton.h
+++ b/Straight_skeleton_extrusion_2/include/CGAL/extrude_skeleton.h
@@ -812,7 +812,7 @@ public:
                                           CGAL_SS_i::vertices_begin(hole),
                                           CGAL_SS_i::vertices_end(hole),
                                           std::begin(no_holes), std::end(no_holes),
-                                          std::begin(speeds[hole_id]), std::end(speeds[hole_id]),
+                                          std::begin(speeds[1 + hole_id]), std::end(speeds[1 + hole_id]),
                                           std::begin(no_speeds), std::end(no_speeds),
                                           m_gt);
 


### PR DESCRIPTION
## Summary of Changes

Outward construction does an inward construction for each hole, but the hole weights start at [1] in the weight range, not [0].

## Release Management

* Affected package(s): `Straight_skeleton_extrusion_2`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

