### PR TITLE
PMP: Make stitch_borders() deterministic

### DIFF
--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS.h
@@ -111,6 +111,10 @@ struct HDS_edge {
                       i.halfedge():i.halfedge()->opposite());
   }
 
+  friend std::ostream& operator<<(std::ostream& os, const HDS_edge& e)
+  {
+    return os;
+  }
 private:
   Halfedge_handle halfedge_;
 };

--- a/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS.h
+++ b/HalfedgeDS/include/CGAL/boost/graph/graph_traits_HalfedgeDS.h
@@ -113,6 +113,7 @@ struct HDS_edge {
 
   friend std::ostream& operator<<(std::ostream& os, const HDS_edge& e)
   {
+    os << e.halfedge_;
     return os;
   }
 private:

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -106,9 +106,9 @@ struct Default_halfedges_keeper
 {
   typedef typename boost::graph_traits<Mesh>::halfedge_descriptor       halfedge_descriptor;
 
-  halfedge_descriptor operator()(const halfedge_descriptor h1, const halfedge_descriptor h2) const
+  halfedge_descriptor operator()(const halfedge_descriptor h1, const halfedge_descriptor) const
   {
-    return (h1 < h2) ? h1 : h2; // Arbitrary preference
+    return h1;
   }
 };
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -1025,9 +1025,9 @@ std::size_t zip_boundary_cycle(typename boost::graph_traits<PolygonMesh>::halfed
     if(!hedges_to_stitch.empty())
     {
 #ifdef CGAL_PMP_STITCHING_DEBUG_PP
-      std::cout << hedges_to_stitch.size() " halfedge pairs to stitch on border containing:\n"
-                << edge(h, pmesh) << "\n\t" << source(h, pmesh) << "\t(" << get(vpm, source(h, pmesh)) << ")"
-                                  << "\n\t" << target(h, pmesh) << "\t(" << get(vpm, target(h, pmesh)) << ")" << std::endl;
+      std::cout << hedges_to_stitch.size() << " halfedge pairs to stitch on border containing:\n"
+                << edge(bh, pmesh) << "\n\t" << source(bh, pmesh) << "\t(" << get(vpm, source(bh, pmesh)) << ")"
+                                  << "\n\t" << target(bh, pmesh) << "\t(" << get(vpm, target(bh, pmesh)) << ")" << std::endl;
 #endif
 
       std::size_t local_stitches = internal::stitch_halfedge_range(hedges_to_stitch, cycle_halfedges,
@@ -1369,12 +1369,12 @@ std::size_t stitch_borders(const BorderHalfedgeRange& boundary_cycle_representat
                                                          std::back_inserter(to_stitch), np);
   res += stitch_halfedge_range(to_stitch, to_consider, pmesh, vpm, cycle_maintainer);
 
+  const auto& new_representatives = cycle_maintainer.cycle_representatives();
+
 #ifdef CGAL_PMP_STITCHING_DEBUG
   std::cout << "------- Stitched " << res << " halfedge pairs after cycles & general" << std::endl;
   std::cout << "------- Stitch cycles (#2)... (" << new_representatives.size() << " cycle(s))" << std::endl;
 #endif
-
-  const auto& new_representatives = cycle_maintainer.cycle_representatives();
 
   // Don't care about keeping track of the sub-cycles as this is the last pass
   internal::Dummy_cycle_rep_maintainer<PolygonMesh> dummy_cycle_maintainer(pmesh);

--- a/STL_Extension/include/CGAL/In_place_list.h
+++ b/STL_Extension/include/CGAL/In_place_list.h
@@ -114,8 +114,7 @@ namespace internal {
 
     friend std::ostream& operator<<(std::ostream& os, const Self& i)
     {
-      os << &*(i);
-      return os;
+      return os << i.operator->();
     }
   };
 }
@@ -180,8 +179,7 @@ namespace internal {
 
     friend std::ostream& operator<<(std::ostream& os, const Self& i)
     {
-      os << &*(i);
-      return os;
+      return os << i.operator->();
     }
   };
 

--- a/STL_Extension/include/CGAL/In_place_list.h
+++ b/STL_Extension/include/CGAL/In_place_list.h
@@ -111,6 +111,11 @@ namespace internal {
       --*this;
       return tmp;
     }
+
+    friend std::ostream& operator<<(std::ostream& os, const Self& i)
+    {
+      return os;
+    }
   };
 }
 
@@ -171,6 +176,11 @@ namespace internal {
     {
       return In_place_list_iterator<T,Alloc>(const_cast<T*>(node));
     }
+
+    friend std::ostream& operator<<(std::ostream& os, const Self& i)
+    {
+      return os;
+    }
   };
 
 
@@ -188,6 +198,7 @@ template <class T, class Alloc>
     const T* ptr = i.operator->();
     return reinterpret_cast<std::size_t>(ptr)/ sizeof(T);
   }
+
 
 }
 

--- a/STL_Extension/include/CGAL/In_place_list.h
+++ b/STL_Extension/include/CGAL/In_place_list.h
@@ -114,6 +114,7 @@ namespace internal {
 
     friend std::ostream& operator<<(std::ostream& os, const Self& i)
     {
+      os << &*(i);
       return os;
     }
   };
@@ -179,6 +180,7 @@ namespace internal {
 
     friend std::ostream& operator<<(std::ostream& os, const Self& i)
     {
+      os << &*(i);
       return os;
     }
   };


### PR DESCRIPTION
## Summary of Changes

This PR makes the function `CGAL::Polygon_mesh_processing::stitch_borders()`  deterministic.
It was already deterministic for `CGAL::Surface_mesh` but not for `CGAL::Polyhedron_3` as it compared pointers.

In case we do not want to change the code, we can also document the existing named parameter `halfedges_keeper`.

## Release Management

* Affected package(s): PMP
* License and copyright ownership: unchanged

