### PR TITLE
Fix how to set BOOST_ROOT

### DIFF
--- a/Documentation/doc/Documentation/Third_party.txt
+++ b/Documentation/doc/Documentation/Third_party.txt
@@ -70,7 +70,7 @@ from <A HREF="https://sourceforge.net/projects/boost/files/boost-binaries/">`htt
 
 As there is no canonical directory for where to find \boost on Windows,
 we recommend that you define the environment variable
-`BOOST_ROOT` and set it to where you have installed \boost, e.g., `C:/local/boost_1_80_0/lib64-msvc-14.3/cmake/Boost-1.80.0`.
+`Boost_ROOT` (or `BOOST_ROOT`) and set it to where you have installed \boost, e.g., `C:/local`, or set `Boost_DIR` to the path of the directory containing the file `BoostConfig.cmake`, e.g.`C:/local/boost_1_80_0/lib64-msvc-14.3/cmake/Boost-1.80.0` (be careful of the case of `Boost_DIR`).
 
 \subsection thirdpartyMP Multi Precision Number Type Library
 

--- a/Documentation/doc/Documentation/Third_party.txt
+++ b/Documentation/doc/Documentation/Third_party.txt
@@ -70,7 +70,7 @@ from <A HREF="https://sourceforge.net/projects/boost/files/boost-binaries/">`htt
 
 As there is no canonical directory for where to find \boost on Windows,
 we recommend that you define the environment variable
-`BOOST_ROOT` and set it to where you have installed \boost, e.g., `C:\boost\boost_1_70_0`.
+`BOOST_ROOT` and set it to where you have installed \boost, e.g., `C:/local/boost_1_80_0/lib64-msvc-14.3/cmake/Boost-1.80.0`.
 
 \subsection thirdpartyMP Multi Precision Number Type Library
 

--- a/Documentation/doc/Documentation/Third_party.txt
+++ b/Documentation/doc/Documentation/Third_party.txt
@@ -69,8 +69,9 @@ For Visual C++ you can download precompiled libraries
 from <A HREF="https://sourceforge.net/projects/boost/files/boost-binaries/">`https://sourceforge.net/projects/boost/files/boost-binaries/`</A>.
 
 As there is no canonical directory for where to find \boost on Windows,
-we recommend that you define the environment variable
-`Boost_ROOT` (or `BOOST_ROOT`) and set it to where you have installed \boost, e.g., `C:/local`, or set `Boost_DIR` to the path of the directory containing the file `BoostConfig.cmake`, e.g.`C:/local/boost_1_80_0/lib64-msvc-14.3/cmake/Boost-1.80.0` (be careful of the case of `Boost_DIR`).
+we recommend to use the config mode of CMake by defining the environment variable
+`Boost_DIR` (case sensitive) to the path of the directory in your boost installation
+containing the file `BoostConfig.cmake`, e.g.`C:/local/boost_1_80_0/lib64-msvc-14.3/cmake/Boost-1.80.0`.
 
 \subsection thirdpartyMP Multi Precision Number Type Library
 


### PR DESCRIPTION
## Summary of Changes

We require at least 1.74, but we gave an example with 1.70
We did not give the path to the boost cmake config file.   

## Release Management

* Affected package(s): documentation


