### PR TITLE
AW3: Use more iterations in tetrahedral remeshing example

### DIFF
--- a/Alpha_wrap_3/examples/Alpha_wrap_3/volumetric_wrap.cpp
+++ b/Alpha_wrap_3/examples/Alpha_wrap_3/volumetric_wrap.cpp
@@ -159,7 +159,9 @@ int main(int argc, char** argv)
   // edge length of regular tetrahedron with circumradius alpha
   const double l = 1.6329931618554521 * alpha; // sqrt(8/3)
 
-  CGAL::tetrahedral_isotropic_remeshing(tr, l, CGAL::parameters::remesh_boundaries(false));
+  CGAL::tetrahedral_isotropic_remeshing(tr, l,
+                                        CGAL::parameters::remesh_boundaries(false)
+                                                         .number_of_iterations(5));
 
   std::cout << "AFTER: " << tr.number_of_vertices() << " vertices, " << tr.number_of_cells() << " cells" << std::endl;
 


### PR DESCRIPTION
## Summary of Changes

The default iteration number (1) is too few for the remeshing algorithm to produce something nice, given that we start from a rather nasty triangulation at the end of alpha wrap.

![Screenshot From 2025-05-22 10-56-18](https://github.com/user-attachments/assets/d8225798-73a8-4445-815d-3310207b873d)

## Release Management

* Affected package(s): `Alpha_wrap_3`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

