### PR TITLE
Rename home page of reference manuals to "Reference Manual"

### DIFF
--- a/AABB_tree/doc/AABB_tree/PackageDescription.txt
+++ b/AABB_tree/doc/AABB_tree/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgAABBTreeRef AABB Tree Reference
+/// \defgroup PkgAABBTreeRef Reference Manual
 
 /// \defgroup PkgAABBTreeConcepts Concepts
 /// \ingroup PkgAABBTreeRef

--- a/Advancing_front_surface_reconstruction/doc/Advancing_front_surface_reconstruction/PackageDescription.txt
+++ b/Advancing_front_surface_reconstruction/doc/Advancing_front_surface_reconstruction/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgAdvancingFrontSurfaceReconstructionRef Advancing Front Surface Reconstruction Reference
+/// \defgroup PkgAdvancingFrontSurfaceReconstructionRef Reference Manual
 
 /// \defgroup PkgAdvancingFrontSurfaceReconstructionRefConcepts Concepts
 /// \ingroup PkgAdvancingFrontSurfaceReconstructionRef

--- a/Algebraic_foundations/doc/Algebraic_foundations/Algebraic_foundations.txt
+++ b/Algebraic_foundations/doc/Algebraic_foundations/Algebraic_foundations.txt
@@ -80,7 +80,7 @@ using overloaded functions. However, for ease of use and backward
 compatibility all functionality is also
 accessible through global functions defined within namespace `CGAL`,
 e.g., \link sqrt `CGAL::sqrt(x)` \endlink. This is realized via function templates using
-the according functor of the traits class. For an overview see
+the according functor of the traits class. For an overview see the section "Global Functions" in the
 \ref PkgAlgebraicFoundationsRef.
 
 \subsection Algebraic_foundationsTagsinAlgebraicStructure Tags in Algebraic Structure Traits

--- a/Algebraic_foundations/doc/Algebraic_foundations/Algebraic_foundations.txt
+++ b/Algebraic_foundations/doc/Algebraic_foundations/Algebraic_foundations.txt
@@ -81,7 +81,7 @@ compatibility all functionality is also
 accessible through global functions defined within namespace `CGAL`,
 e.g., \link sqrt `CGAL::sqrt(x)` \endlink. This is realized via function templates using
 the according functor of the traits class. For an overview see
-Section \ref PkgAlgebraicFoundationsRef in the reference manual.
+\ref PkgAlgebraicFoundationsRef.
 
 \subsection Algebraic_foundationsTagsinAlgebraicStructure Tags in Algebraic Structure Traits
 

--- a/Algebraic_foundations/doc/Algebraic_foundations/PackageDescription.txt
+++ b/Algebraic_foundations/doc/Algebraic_foundations/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgAlgebraicFoundationsRef Algebraic Foundations Reference
+/// \defgroup PkgAlgebraicFoundationsRef Reference Manual
 
 /// \defgroup PkgAlgebraicFoundationsAlgebraicStructuresConcepts Concepts
 /// \ingroup PkgAlgebraicFoundationsRef

--- a/Algebraic_kernel_d/doc/Algebraic_kernel_d/PackageDescription.txt
+++ b/Algebraic_kernel_d/doc/Algebraic_kernel_d/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgAlgebraicKernelDRef Algebraic Kernel Reference
+/// \defgroup PkgAlgebraicKernelDRef Reference Manual
 
 /// \defgroup PkgAlgebraicKernelDConcepts Concepts
 /// \ingroup PkgAlgebraicKernelDRef

--- a/Alpha_shapes_2/doc/Alpha_shapes_2/PackageDescription.txt
+++ b/Alpha_shapes_2/doc/Alpha_shapes_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgAlphaShapes2Ref 2D Alpha Shapes Reference
+/// \defgroup PkgAlphaShapes2Ref Reference Manual
 /// \defgroup PkgAlphaShapes2Concepts Concepts
 /// \ingroup PkgAlphaShapes2Ref
 

--- a/Alpha_shapes_3/doc/Alpha_shapes_3/PackageDescription.txt
+++ b/Alpha_shapes_3/doc/Alpha_shapes_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgAlphaShapes3Ref 3D Alpha Shapes Reference
+/// \defgroup PkgAlphaShapes3Ref Reference Manual
 /// \defgroup PkgAlphaShapes3Concepts Concepts
 /// \ingroup PkgAlphaShapes3Ref
 /*!

--- a/Alpha_wrap_3/doc/Alpha_wrap_3/PackageDescription.txt
+++ b/Alpha_wrap_3/doc/Alpha_wrap_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgAlphaWrap3Ref 3D Alpha Wrapping
+/// \defgroup PkgAlphaWrap3Ref Reference Manual
 
 /// \defgroup AW3_free_functions_grp Free Functions
 /// Functions to create a wrap from point clouds, triangle soups, and triangle meshes.

--- a/Apollonius_graph_2/doc/Apollonius_graph_2/PackageDescription.txt
+++ b/Apollonius_graph_2/doc/Apollonius_graph_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgApolloniusGraph2Ref 2D Apollonius Graphs (Delaunay Graphs of Disks) Reference
+/// \defgroup PkgApolloniusGraph2Ref Reference Manual
 /// \defgroup PkgApolloniusGraph2Concepts Concepts
 /// \ingroup PkgApolloniusGraph2Ref
 /*!

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
@@ -4196,7 +4196,7 @@ are both parameterized by a geometric kernel and model the concepts
 `AosTraits_2` and `AosLandmarkTraits_2`.
 \cgalFootnote{They also model the refined concept
 \cgalFootnoteCode{AosDirectionalXMonotoneTraits_2}, which enables Boolean set
-operations; see Package \ref PkgBooleanSetOperations2Ref.} The class
+operations; see Package \ref PkgBooleanSetOperations2.} The class
 template `Arr_non_caching_segment_traits_2<Kernel>` derives from the
 instance `Arr_non_caching_segment_basic_traits_2<Kernel>`, which
 models the `AosLandmarkTraits_2` traits concept but not the
@@ -4937,7 +4937,7 @@ template models the concepts `AosTraits_2` and
 `AosOpenBoundaryTraits_2`, but it does not model the
 `AosLandmarkTraits_2` concept. It also models the refined
 concept `AosDirectionalXMonotoneTraits_2`, which enables
-Boolean set operations; see Package \ref PkgBooleanSetOperations2Ref.
+Boolean set operations; see Package \ref PkgBooleanSetOperations2.
 Note that it is not a model of `AosLandmarkTraits_2` concept,
 so it is impossible to use the landmark point-location strategy with
 this traits class.
@@ -5167,7 +5167,7 @@ Every instance of the `Arr_Bezier_curve_traits_2` class templates
 models the concept `AosTraits_2` (but it does not model the
 `AosLandmarkTraits_2` concept). It also models the refined
 concept `AosDirectionalXMonotoneTraits_2`, which enables
-Boolean set operations; see Package \ref PkgBooleanSetOperations2Ref.
+Boolean set operations; see Package \ref PkgBooleanSetOperations2.
 
 <!-- ----------------------------------------------------------------------- -->
 \cgalFigureBegin{aos_fig-bezier_curves,bezier_curves.png}

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/PackageDescription.txt
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgArrangementOnSurface2Ref 2D Arrangement Reference
+/// \defgroup PkgArrangementOnSurface2Ref Reference Manual
 
 /// \defgroup PkgArrangementOnSurface2Concepts Concepts
 /// \ingroup PkgArrangementOnSurface2Ref

--- a/BGL/doc/BGL/BGL.txt
+++ b/BGL/doc/BGL/BGL.txt
@@ -698,7 +698,7 @@ using one of the following tags:
 - `CGAL::Alpha_expansion_boost_adjacency_list_tag` (default)
 - `CGAL::Alpha_expansion_boost_compressed_sparse_raw_tag`
 - `CGAL::Alpha_expansion_MaxFlow_tag`, released under GPL
-  license and provided by the \ref PkgSurfaceMeshSegmentationRef
+  license and provided by the \ref PkgSurfaceMeshSegmentation
   package
 
 All these implementations produce the exact same result but behave

--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgBGLRef CGAL and the Boost Graph Library Reference
+/// \defgroup PkgBGLRef Reference Manual
 
 /*! \defgroup PkgBGLConcepts Concepts
  \ingroup PkgBGLRef

--- a/BGL/include/CGAL/boost/graph/alpha_expansion_graphcut.h
+++ b/BGL/include/CGAL/boost/graph/alpha_expansion_graphcut.h
@@ -509,7 +509,7 @@ class Alpha_expansion_MaxFlow_impl;
      \cgalParamNEnd
    \cgalNamedParamsEnd
 
-   \note The `MaxFlow` implementation is provided by the \ref PkgSurfaceMeshSegmentationRef
+   \note The `MaxFlow` implementation is provided by the \ref PkgSurfaceMeshSegmentation
    under GPL license. The header `<CGAL/boost/graph/Alpha_expansion_MaxFlow_tag.h>`
    must be included if users want to use this implementation.
 */

--- a/BGL/include/CGAL/boost/graph/alpha_expansion_graphcut.h
+++ b/BGL/include/CGAL/boost/graph/alpha_expansion_graphcut.h
@@ -509,7 +509,8 @@ class Alpha_expansion_MaxFlow_impl;
      \cgalParamNEnd
    \cgalNamedParamsEnd
 
-   \note The `MaxFlow` implementation is provided by the \ref PkgSurfaceMeshSegmentation
+
+   \note The `MaxFlow` implementation is provided by the \ref PkgSurfaceMeshSegmentation package
    under GPL license. The header `<CGAL/boost/graph/Alpha_expansion_MaxFlow_tag.h>`
    must be included if users want to use this implementation.
 */

--- a/Barycentric_coordinates_2/doc/Barycentric_coordinates_2/Barycentric_coordinates_2.txt
+++ b/Barycentric_coordinates_2/doc/Barycentric_coordinates_2/Barycentric_coordinates_2.txt
@@ -53,7 +53,7 @@ All analytic barycentric coordinates for polygons can be computed either by inst
 or through one of the free functions. Harmonic coordinates can be computed only by
 instantiating a class that must be parameterized by a model of the concept `DiscretizedDomain_2`.
 Segment and triangle coordinates can be computed only through the free functions.
-For more information see the \ref PkgBarycentricCoordinates2Ref "Reference Manual".
+For more information see the \ref PkgBarycentricCoordinates2Ref.
 
 Any point in the plane may be taken as a query point. However, we do not recommend using
 Wachspress and discrete harmonic coordinates with query points outside the closure

--- a/Barycentric_coordinates_2/doc/Barycentric_coordinates_2/PackageDescription.txt
+++ b/Barycentric_coordinates_2/doc/Barycentric_coordinates_2/PackageDescription.txt
@@ -1,8 +1,5 @@
-namespace CGAL {
-namespace Barycentric_coordinates {
-
 /*!
-\defgroup PkgBarycentricCoordinates2Ref 2D Generalized Barycentric Coordinates Reference
+\defgroup PkgBarycentricCoordinates2Ref Reference Manual
 
 \defgroup PkgBarycentricCoordinates2RefConcepts Concepts
 \ingroup PkgBarycentricCoordinates2Ref
@@ -77,6 +74,3 @@ coordinates from the Package \ref PkgInterpolation2.}
 - `discrete_harmonic_coordinates_2()`
 - `boundary_coordinates_2()`
 */
-
-} /* namespace Barycentric_coordinates */
-} /* namespace CGAL */

--- a/Basic_viewer/doc/Basic_viewer/PackageDescription.txt
+++ b/Basic_viewer/doc/Basic_viewer/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgBasicViewerRef Basic Viewer Reference
+/// \defgroup PkgBasicViewerRef Reference Manual
 
 /// \defgroup PkgBasicViewerConcepts Concepts
 /// \ingroup PkgBasicViewerRef

--- a/Boolean_set_operations_2/doc/Boolean_set_operations_2/PackageDescription.txt
+++ b/Boolean_set_operations_2/doc/Boolean_set_operations_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgBooleanSetOperations2Ref 2D Regularized Boolean Set-Operations Reference
+/// \defgroup PkgBooleanSetOperations2Ref Reference Manual
 /// \defgroup PkgBooleanSetOperations2Concepts Concepts
 /// \ingroup PkgBooleanSetOperations2Ref
 

--- a/Bounding_volumes/doc/Bounding_volumes/PackageDescription.txt
+++ b/Bounding_volumes/doc/Bounding_volumes/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgBoundingVolumesRef Bounding Volumes Reference
+/// \defgroup PkgBoundingVolumesRef Reference Manual
 /// \defgroup PkgBoundingVolumesConcepts Concepts
 /// \ingroup PkgBoundingVolumesRef
 /*!

--- a/Box_intersection_d/doc/Box_intersection_d/PackageDescription.txt
+++ b/Box_intersection_d/doc/Box_intersection_d/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgBoxIntersectionDRef Intersecting Sequences of dD Iso-oriented Boxes Reference
+/// \defgroup PkgBoxIntersectionDRef Reference Manual
 /// \defgroup PkgBoxIntersectionDConcepts Concepts
 /// \ingroup PkgBoxIntersectionDRef
 

--- a/CGAL_ipelets/doc/CGAL_ipelets/PackageDescription.txt
+++ b/CGAL_ipelets/doc/CGAL_ipelets/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgCGALIpeletsRef CGAL Ipelets Reference
+/// \defgroup PkgCGALIpeletsRef Reference Manual
 /*!
 \addtogroup PkgCGALIpeletsRef
 \cgalPkgDescriptionBegin{CGAL Ipelets,PkgCGALIpelets}

--- a/Circular_kernel_2/doc/Circular_kernel_2/PackageDescription.txt
+++ b/Circular_kernel_2/doc/Circular_kernel_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgCircularKernel2Ref 2D Circular Geometry Kernel Reference
+/// \defgroup PkgCircularKernel2Ref Reference Manual
 
 /// \defgroup PkgCircularKernel2GeometricConcepts Geometric Concepts
 /// \ingroup PkgCircularKernel2Ref

--- a/Circular_kernel_3/doc/Circular_kernel_3/PackageDescription.txt
+++ b/Circular_kernel_3/doc/Circular_kernel_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgCircularKernel3Ref 3D Spherical Geometry Kernel Reference
+/// \defgroup PkgCircularKernel3Ref Reference Manual
 
 /// \defgroup PkgCircularKernel3GeometricConcepts Geometric Concepts
 /// \ingroup PkgCircularKernel3Ref

--- a/Circulator/doc/Circulator/PackageDescription.txt
+++ b/Circulator/doc/Circulator/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgHandlesAndCirculatorsRef Handles and Circulators Reference
+/// \defgroup PkgHandlesAndCirculatorsRef Reference Manual
 /// \defgroup PkgHandlesAndCirculatorsConcepts Concepts
 /// \ingroup PkgHandlesAndCirculatorsRef
 

--- a/Classification/doc/Classification/PackageDescription.txt
+++ b/Classification/doc/Classification/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgClassificationRef Classification Reference
+/// \defgroup PkgClassificationRef Reference Manual
 
 /*!
 \defgroup PkgClassificationConcepts Concepts

--- a/Combinatorial_map/doc/Combinatorial_map/PackageDescription.txt
+++ b/Combinatorial_map/doc/Combinatorial_map/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgCombinatorialMapsRef Combinatorial Maps Reference
+/// \defgroup PkgCombinatorialMapsRef Reference Manual
 
 /// \defgroup PkgCombinatorialMapsConcepts Concepts
 /// \ingroup PkgCombinatorialMapsRef

--- a/Cone_spanners_2/doc/Cone_spanners_2/PackageDescription.txt
+++ b/Cone_spanners_2/doc/Cone_spanners_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgConeSpanners2Ref Cone-Based Spanners Reference
+/// \defgroup PkgConeSpanners2Ref Reference Manual
 
 /*!
 \addtogroup PkgConeSpanners2Ref

--- a/Convex_decomposition_3/doc/Convex_decomposition_3/PackageDescription.txt
+++ b/Convex_decomposition_3/doc/Convex_decomposition_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgConvexDecomposition3Ref Convex Decomposition of Polyhedra Reference
+/// \defgroup PkgConvexDecomposition3Ref Reference Manual
 
 /*!
 \addtogroup PkgConvexDecomposition3Ref

--- a/Convex_hull_2/doc/Convex_hull_2/PackageDescription.txt
+++ b/Convex_hull_2/doc/Convex_hull_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgConvexHull2Ref 2D Convex Hulls and Extreme Points Reference
+/// \defgroup PkgConvexHull2Ref Reference Manual
 
 /// \defgroup PkgConvexHull2Concepts Concepts
 /// \ingroup PkgConvexHull2Ref

--- a/Convex_hull_3/doc/Convex_hull_3/PackageDescription.txt
+++ b/Convex_hull_3/doc/Convex_hull_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgConvexHull3Ref 3D Convex Hulls Reference
+/// \defgroup PkgConvexHull3Ref Reference Manual
 
 /// \defgroup PkgConvexHull3Concepts Concepts
 /// \ingroup PkgConvexHull3Ref

--- a/Convex_hull_d/doc/Convex_hull_d/PackageDescription.txt
+++ b/Convex_hull_d/doc/Convex_hull_d/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgConvexHullDRef dD Convex Hulls and Delaunay Triangulations Reference
+/// \defgroup PkgConvexHullDRef Reference Manual
 /// \defgroup PkgConvexHullDConcepts Concepts
 /// \ingroup PkgConvexHullDRef
 /*!

--- a/Documentation/doc/Documentation/Third_party.txt
+++ b/Documentation/doc/Documentation/Third_party.txt
@@ -143,7 +143,7 @@ The \eigen web site is <A HREF="https://eigen.tuxfamily.org/index.php?title=Main
 
 \opengr is a set C++ libraries for 3D Global Registration released under the terms of the APACHE V2 license.
 
-\cgal provides wrappers for the Super4PCS algorithm of \opengr in the \ref PkgPointSetProcessing3Ref
+\cgal provides wrappers for the Super4PCS algorithm of \opengr in the \ref PkgPointSetProcessing3
 packages. In order to use \opengr in \cgal programs, the executables should be linked with the CMake imported target `CGAL::OpenGR_support` provided in `CGAL_OpenGR_support.cmake`.
 
 The \opengr web site is <A HREF="https://github.com/STORM-IRIT/OpenGR">`https://github.com/STORM-IRIT/OpenGR`</A>.
@@ -152,7 +152,7 @@ The \opengr web site is <A HREF="https://github.com/STORM-IRIT/OpenGR">`https://
 
 \libpointmatcher is a modular library implementing the Iterative Closest Point (ICP) algorithm for aligning point clouds, released under a permissive BSD license.
 
-\cgal provides wrappers for the ICP algorithm of \libpointmatcher in the \ref PkgPointSetProcessing3Ref
+\cgal provides wrappers for the ICP algorithm of \libpointmatcher in the \ref PkgPointSetProcessing3
 packages. In order to use \libpointmatcher in \cgal programs, the
 executables should be linked with the CMake imported target
 `CGAL::pointmatcher_support` provided in
@@ -276,7 +276,7 @@ for instance, on Windows, you can download it from <A HREF="https://www.zlib.net
 
 \ceres is an open source C++ library for modeling and solving large, complicated optimization problems.
 
-In \cgal, \ceres is used by the \ref PkgPolygonMeshProcessingRef package for mesh smoothing, which
+In \cgal, \ceres is used by the \ref PkgPolygonMeshProcessing package for mesh smoothing, which
 requires solving complex non-linear least squares problems.
 
 Visit the official website of the library at <A HREF="http://ceres-solver.org/index.html">`ceres-solver.org`</A>

--- a/Documentation/doc/Documentation/Tutorials/Tutorial_GIS.txt
+++ b/Documentation/doc/Documentation/Tutorials/Tutorial_GIS.txt
@@ -303,14 +303,14 @@ described in this tutorial.
 
 This tutorial is based on the following \cgal packages:
 
-- \ref PkgTriangulation2Ref
-- \ref PkgPointSet3Ref
-- \ref PkgPointSetProcessing3Ref
+- \ref PkgTriangulation2
+- \ref PkgPointSet3
+- \ref PkgPointSetProcessing3
 - \ref PkgSurface_mesh
-- \ref PkgBGLRef
-- \ref PkgPolygonMeshProcessingRef
-- \ref PkgPolylineSimplification2Ref
-- \ref PkgClassificationRef
+- \ref PkgBGL
+- \ref PkgPolygonMeshProcessing
+- \ref PkgPolylineSimplification2
+- \ref PkgClassification
 
 The data set used throughout this tutorial comes from the
 https://www.usgs.gov/ database, licensed under the _US Government

--- a/Envelope_2/doc/Envelope_2/PackageDescription.txt
+++ b/Envelope_2/doc/Envelope_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgEnvelope2Ref 2D Envelopes Reference
+/// \defgroup PkgEnvelope2Ref Reference Manual
 /// \defgroup PkgEnvelope2Concepts Concepts
 /// \ingroup PkgEnvelope2Ref
 /*!

--- a/Envelope_3/doc/Envelope_3/PackageDescription.txt
+++ b/Envelope_3/doc/Envelope_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgEnvelope3Ref 3D Envelopes Reference
+/// \defgroup PkgEnvelope3Ref Reference Manual
 /// \defgroup PkgEnvelope3Concepts Concepts
 /// \ingroup PkgEnvelope3Ref
 /*!

--- a/Generalized_map/doc/Generalized_map/PackageDescription.txt
+++ b/Generalized_map/doc/Generalized_map/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgGeneralizedMapsRef Generalized Maps Reference
+/// \defgroup PkgGeneralizedMapsRef Reference Manual
 
 /// \defgroup PkgGeneralizedMapsConcepts Concepts
 /// \ingroup PkgGeneralizedMapsRef

--- a/Generator/doc/Generator/PackageDescription.txt
+++ b/Generator/doc/Generator/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgGeneratorsRef Geometric Object Generators Reference
+/// \defgroup PkgGeneratorsRef Reference Manual
 /// \defgroup PkgGeneratorsConcepts Concepts
 /// \ingroup PkgGeneratorsRef
 /*!

--- a/GraphicsView/doc/GraphicsView/PackageDescription.txt
+++ b/GraphicsView/doc/GraphicsView/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgGraphicsViewRef CGAL and the Qt Graphics View Framework Reference
+/// \defgroup PkgGraphicsViewRef Reference Manual
 /// \defgroup PkgGraphicsViewGraphicsItemClasses Graphics Item Classes
 /// \ingroup PkgGraphicsViewRef
 /// \defgroup PkgGraphicsViewInputClasses Input Classes

--- a/HalfedgeDS/doc/HalfedgeDS/PackageDescription.txt
+++ b/HalfedgeDS/doc/HalfedgeDS/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgHalfedgeDSRef Halfedge Data Structures Reference
+/// \defgroup PkgHalfedgeDSRef Reference Manual
 /// \defgroup PkgHalfedgeDSConcepts Concepts
 /// \ingroup PkgHalfedgeDSRef
 

--- a/Heat_method_3/doc/Heat_method_3/PackageDescription.txt
+++ b/Heat_method_3/doc/Heat_method_3/PackageDescription.txt
@@ -1,6 +1,4 @@
-// The Heat Method
-
-/// \defgroup PkgHeatMethodRef Heat Method Reference
+/// \defgroup PkgHeatMethodRef Reference Manual
 
 /// \defgroup PkgHeatMethodConcepts Concepts
 /// \ingroup PkgHeatMethodRef

--- a/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/PackageDescription.txt
+++ b/Hyperbolic_triangulation_2/doc/Hyperbolic_triangulation_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgHyperbolicTriangulation2Ref 2D Hyperbolic Delaunay Triangulations Reference
+/// \defgroup PkgHyperbolicTriangulation2Ref Reference Manual
 
 /// \defgroup PkgHyperbolicTriangulation2Concepts Concepts
 /// \ingroup PkgHyperbolicTriangulation2Ref

--- a/Inscribed_areas/doc/Inscribed_areas/PackageDescription.txt
+++ b/Inscribed_areas/doc/Inscribed_areas/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgInscribedAreasRef Inscribed Areas Reference
+/// \defgroup PkgInscribedAreasRef Reference Manual
 
 /// \defgroup PkgInscribedAreasConcepts Concepts
 /// \ingroup PkgInscribedAreasRef

--- a/Interpolation/doc/Interpolation/PackageDescription.txt
+++ b/Interpolation/doc/Interpolation/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgInterpolation2Ref 2D and Surface Function Interpolation Reference
+/// \defgroup PkgInterpolation2Ref Reference Manual
 
 /// \defgroup PkgInterpolation2Concepts Concepts
 /// \ingroup PkgInterpolation2Ref

--- a/Interval_skip_list/doc/Interval_skip_list/PackageDescription.txt
+++ b/Interval_skip_list/doc/Interval_skip_list/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgIntervalSkipListRef Interval Skip List Reference
+/// \defgroup PkgIntervalSkipListRef Reference Manual
 /// \defgroup PkgIntervalSkipListConcepts Concepts
 /// \ingroup PkgIntervalSkipListRef
 /*!

--- a/Isosurfacing_3/doc/Isosurfacing_3/PackageDescription.txt
+++ b/Isosurfacing_3/doc/Isosurfacing_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgIsosurfacing3Ref 3D Isosurfacing Reference
+/// \defgroup PkgIsosurfacing3Ref Reference Manual
 /// \defgroup PkgIsosurfacing3Concepts Concepts
 /// \ingroup PkgIsosurfacing3Ref
 

--- a/Jet_fitting_3/doc/Jet_fitting_3/PackageDescription.txt
+++ b/Jet_fitting_3/doc/Jet_fitting_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgJetFitting3Ref Estimation of Local Differential Properties  of Point-Sampled Surfaces Reference
+/// \defgroup PkgJetFitting3Ref Reference Manual
 /// \defgroup PkgJetFitting3Concepts Concepts
 /// \ingroup PkgJetFitting3Ref
 /*!

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgKernel23Ref 2D and 3D Linear Geometry Kernel Reference
+/// \defgroup PkgKernel23Ref Reference Manual
 
 /// \defgroup PkgKernel23Concepts Concepts
 /// \ingroup PkgKernel23Ref

--- a/Kernel_d/doc/Kernel_d/PackageDescription.txt
+++ b/Kernel_d/doc/Kernel_d/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgKernelDRef dD Geometry Kernel Reference
+/// \defgroup PkgKernelDRef Reference Manual
 
 /// \defgroup PkgKernelDLinAlgConcepts Linear Algebra Concepts
 /// \ingroup PkgKernelDRef

--- a/Kinetic_space_partition/doc/Kinetic_space_partition/PackageDescription.txt
+++ b/Kinetic_space_partition/doc/Kinetic_space_partition/PackageDescription.txt
@@ -1,5 +1,5 @@
 /*!
-\defgroup PkgKineticSpacePartitionRef Kinetic Space Partition Reference
+\defgroup PkgKineticSpacePartitionRef Reference Manual
 
 \defgroup PkgKineticSpacePartitionConcepts Concepts
 \ingroup PkgKineticSpacePartitionRef

--- a/Kinetic_surface_reconstruction/doc/Kinetic_surface_reconstruction/PackageDescription.txt
+++ b/Kinetic_surface_reconstruction/doc/Kinetic_surface_reconstruction/PackageDescription.txt
@@ -1,5 +1,5 @@
 /*!
-\defgroup PkgKineticSurfaceReconstructionRef Kinetic Surface Reconstruction Reference
+\defgroup PkgKineticSurfaceReconstructionRef Reference Manual
 
 \addtogroup PkgKineticSurfaceReconstructionRef
 \cgalPkgDescriptionBegin{Kinetic Surface Reconstruction, PkgKineticSurfaceReconstruction}

--- a/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgLinearCellComplexRef Linear Cell Complex Reference
+/// \defgroup PkgLinearCellComplexRef Reference Manual
 
 /// \defgroup PkgLinearCellComplexConcepts Concepts
 /// \ingroup PkgLinearCellComplexRef

--- a/Matrix_search/doc/Matrix_search/PackageDescription.txt
+++ b/Matrix_search/doc/Matrix_search/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgMatrixSearchRef Monotone and Sorted Matrix Search Reference
+/// \defgroup PkgMatrixSearchRef Reference Manual
 
 /// \defgroup PkgMatrixSearchConcepts Concepts
 /// \ingroup PkgMatrixSearchRef

--- a/Mesh_2/doc/Mesh_2/PackageDescription.txt
+++ b/Mesh_2/doc/Mesh_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgMesh2Ref 2D Conforming Triangulations and Meshes Reference
+/// \defgroup PkgMesh2Ref Reference Manual
 
 /// \defgroup PkgMesh2Concepts Concepts
 /// \ingroup PkgMesh2Ref

--- a/Mesh_3/doc/Mesh_3/PackageDescription.txt
+++ b/Mesh_3/doc/Mesh_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgMesh3Ref 3D Mesh Generation Reference
+/// \defgroup PkgMesh3Ref Reference Manual
 
 /// \defgroup PkgMesh3Concepts Main Concepts
 /// \ingroup PkgMesh3Ref

--- a/Minkowski_sum_2/doc/Minkowski_sum_2/PackageDescription.txt
+++ b/Minkowski_sum_2/doc/Minkowski_sum_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgMinkowskiSum2Ref 2D Minkowski Sums Reference
+/// \defgroup PkgMinkowskiSum2Ref Reference Manual
 /// \defgroup PkgMinkowskiSum2Concepts Concepts
 /// \ingroup PkgMinkowskiSum2Ref
 

--- a/Minkowski_sum_3/doc/Minkowski_sum_3/PackageDescription.txt
+++ b/Minkowski_sum_3/doc/Minkowski_sum_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgMinkowskiSum3Ref 3D Minkowski Sum of Polyhedra Reference
+/// \defgroup PkgMinkowskiSum3Ref Reference Manual
 
 /*!
 \addtogroup PkgMinkowskiSum3Ref

--- a/Miscellany/doc/Miscellany/PackageDescription.txt
+++ b/Miscellany/doc/Miscellany/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup MiscellanyRef Profiling Tools, Hash Map, Union-find, Modifiers Reference
+/// \defgroup MiscellanyRef Reference Manual
 /// \defgroup MiscellanyConcepts Concepts
 /// \ingroup MiscellanyRef
 /*!

--- a/Modular_arithmetic/doc/Modular_arithmetic/PackageDescription.txt
+++ b/Modular_arithmetic/doc/Modular_arithmetic/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgModularArithmeticRef Modular Arithmetic Reference
+/// \defgroup PkgModularArithmeticRef Reference Manual
 /// \defgroup PkgModularArithmeticConcepts Concepts
 /// \ingroup PkgModularArithmeticRef
 /*!

--- a/Nef_2/doc/Nef_2/PackageDescription.txt
+++ b/Nef_2/doc/Nef_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgNef2Ref 2D Boolean Operations on Nef Polygons Reference
+/// \defgroup PkgNef2Ref Reference Manual
 /// \defgroup PkgNef2Concepts Concepts
 /// \ingroup PkgNef2Ref
 /*!

--- a/Nef_3/doc/Nef_3/PackageDescription.txt
+++ b/Nef_3/doc/Nef_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgNef3Ref 3D Boolean Operations on  Nef Polyhedra Reference
+/// \defgroup PkgNef3Ref Reference Manual
 ///
 /// \defgroup PkgNef3IOFunctions I/O Functions
 /// \ingroup PkgNef3Ref

--- a/Nef_S2/doc/Nef_S2/PackageDescription.txt
+++ b/Nef_S2/doc/Nef_S2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgNefS2Ref 2D Boolean Operations on Nef Polygons Embedded on the Sphere Reference
+/// \defgroup PkgNefS2Ref Reference Manual
 /*!
 \addtogroup PkgNefS2Ref
 

--- a/Number_types/doc/Number_types/NumberTypeSupport.txt
+++ b/Number_types/doc/Number_types/NumberTypeSupport.txt
@@ -16,7 +16,7 @@ requirements, such that they can be successfully used in \cgal code.
 In general they are expected to be a model of an algebraic structure
 concepts and in case they model a subring of the real numbers they are
 also a model of `RealEmbeddable`. For an overview of the algebraic
-structure concepts see Section \ref PkgAlgebraicFoundationsRef.
+structure concepts see Section \ref PkgAlgebraicFoundations.
 
 \section Number_typesBuilt Built-in Number Types
 

--- a/Number_types/doc/Number_types/NumberTypeSupport.txt
+++ b/Number_types/doc/Number_types/NumberTypeSupport.txt
@@ -16,7 +16,7 @@ requirements, such that they can be successfully used in \cgal code.
 In general they are expected to be a model of an algebraic structure
 concepts and in case they model a subring of the real numbers they are
 also a model of `RealEmbeddable`. For an overview of the algebraic
-structure concepts see Section \ref PkgAlgebraicFoundations.
+structure concepts see the \ref PkgAlgebraicFoundationsAlgebraicStructuresConcepts section.
 
 \section Number_typesBuilt Built-in Number Types
 

--- a/Number_types/doc/Number_types/PackageDescription.txt
+++ b/Number_types/doc/Number_types/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgNumberTypesRef Number Types Reference
+/// \defgroup PkgNumberTypesRef Reference Manual
 
 /// \defgroup PkgNumberTypesConcepts Concepts
 /// \ingroup PkgNumberTypesRef

--- a/Optimal_bounding_box/doc/Optimal_bounding_box/PackageDescription.txt
+++ b/Optimal_bounding_box/doc/Optimal_bounding_box/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgOptimalBoundingBoxRef Optimal Bounding Box Reference
+/// \defgroup PkgOptimalBoundingBoxRef Reference Manual
 
 /// \defgroup PkgOptimalBoundingBoxConcepts Concepts
 /// \ingroup PkgOptimalBoundingBoxRef

--- a/Optimal_transportation_reconstruction_2/doc/Optimal_transportation_reconstruction_2/PackageDescription.txt
+++ b/Optimal_transportation_reconstruction_2/doc/Optimal_transportation_reconstruction_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgOptimalTransportationReconstruction2Ref Optimal Transportation Curve Reconstruction Reference
+/// \defgroup PkgOptimalTransportationReconstruction2Ref Reference Manual
 
 /// \defgroup PkgOptimalTransportationReconstruction2Concepts Concepts
 /// \ingroup PkgOptimalTransportationReconstruction2Ref

--- a/Orthtree/doc/Orthtree/PackageDescription.txt
+++ b/Orthtree/doc/Orthtree/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgOrthtreeRef Quadtrees, Octrees and Orthtrees Reference
+/// \defgroup PkgOrthtreeRef Reference Manual
 Quadtree, Octree and Orthtree Reference
 
 /// \defgroup PkgOrthtreeConcepts Concepts

--- a/Partition_2/doc/Partition_2/PackageDescription.txt
+++ b/Partition_2/doc/Partition_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPartition2Ref 2D Polygon Partitioning Reference
+/// \defgroup PkgPartition2Ref Reference Manual
 /// \defgroup PkgPartition2Concepts Concepts
 /// \ingroup PkgPartition2Ref
 /// \defgroup PkgPartition2FunctionObjectConcepts Function Object Concepts

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2TriangulationTraits_2.h
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/Concepts/Periodic_2TriangulationTraits_2.h
@@ -11,7 +11,7 @@ the geometric primitives used in the triangulation and some function
 object types for the required predicates on those primitives.
 
 It refines the concept
-`TriangulationTraits_2` from the \cgal \ref PkgTriangulation2Ref package. It redefines the
+`TriangulationTraits_2` from the \cgal \ref PkgTriangulation2 package. It redefines the
 geometric objects, predicates and constructions to work with
 point-offset pairs. In most cases the offsets will be (0,0) and the
 predicates from `TriangulationTraits_2` can be used

--- a/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/PackageDescription.txt
+++ b/Periodic_2_triangulation_2/doc/Periodic_2_triangulation_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPeriodic2Triangulation2Ref 2D Periodic Triangulations Reference
+/// \defgroup PkgPeriodic2Triangulation2Ref Reference Manual
 
 /// \defgroup PkgPeriodic2Triangulation2Concepts Concepts
 /// \ingroup PkgPeriodic2Triangulation2Ref

--- a/Periodic_3_mesh_3/doc/Periodic_3_mesh_3/PackageDescription.txt
+++ b/Periodic_3_mesh_3/doc/Periodic_3_mesh_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPeriodic3Mesh3Ref 3D Periodic Mesh Generation Reference
+/// \defgroup PkgPeriodic3Mesh3Ref Reference Manual
 
 /// \defgroup PkgPeriodic3Mesh3Concepts Concepts
 /// \ingroup PkgPeriodic3Mesh3Ref

--- a/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/PackageDescription.txt
+++ b/Periodic_3_triangulation_3/doc/Periodic_3_triangulation_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPeriodic3Triangulation3Ref 3D Periodic Triangulations Reference
+/// \defgroup PkgPeriodic3Triangulation3Ref Reference Manual
 
 /// \defgroup PkgPeriodic3Triangulation3Concepts Concepts
 /// \ingroup PkgPeriodic3Triangulation3Ref

--- a/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/PackageDescription.txt
+++ b/Periodic_4_hyperbolic_triangulation_2/doc/Periodic_4_hyperbolic_triangulation_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPeriodic4HyperbolicTriangulation2Ref 2D Periodic Hyperbolic Triangulations Reference
+/// \defgroup PkgPeriodic4HyperbolicTriangulation2Ref Reference Manual
 
 /// \defgroup PkgPeriodic4HyperbolicTriangulation2Concepts Concepts
 /// \ingroup PkgPeriodic4HyperbolicTriangulation2Ref

--- a/Point_set_2/doc/Point_set_2/PackageDescription.txt
+++ b/Point_set_2/doc/Point_set_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPointSet2Ref 2D Range and Neighbor Search Reference
+/// \defgroup PkgPointSet2Ref Reference Manual
 /// \defgroup PkgPointSet2Concepts Concepts
 /// \ingroup PkgPointSet2Ref
 

--- a/Point_set_3/doc/Point_set_3/PackageDescription.txt
+++ b/Point_set_3/doc/Point_set_3/PackageDescription.txt
@@ -25,7 +25,7 @@
 /// header or by the LAS standard.
 ///
 /// For a complete documentation of these functions, please refer to the
-/// \ref PkgPointSetProcessing3Ref manual.
+/// \ref PkgPointSetProcessing3Ref "Point Set Processing Reference Manual".
 
 /// \defgroup PkgPointSet3IOLAS Input/Output (LAS)
 /// I/O Functions for the \ref IOStreamLAS

--- a/Point_set_3/doc/Point_set_3/PackageDescription.txt
+++ b/Point_set_3/doc/Point_set_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPointSet3Ref 3D Point Set Reference
+/// \defgroup PkgPointSet3Ref Reference Manual
 
 /*!
 \cgalInclude{CGAL/draw_point_set_3.h}

--- a/Point_set_processing_3/doc/Point_set_processing_3/PackageDescription.txt
+++ b/Point_set_processing_3/doc/Point_set_processing_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPointSetProcessing3Ref Point Set Processing Reference
+/// \defgroup PkgPointSetProcessing3Ref Reference Manual
 
 /*!
 \defgroup PkgPointSetProcessing3Algorithms Algorithms

--- a/Point_set_processing_3/doc/Point_set_processing_3/Point_set_processing_3.txt
+++ b/Point_set_processing_3/doc/Point_set_processing_3/Point_set_processing_3.txt
@@ -139,7 +139,7 @@ CGAL::jet_estimate_normals<Concurrency_tag>
    normal_map (CGAL::Second_of_pair_property_map<PointVectorPair>()));
 \endcode
 
-Please refer to the [Reference Manual](@ref PkgPointSetProcessing3Ref) for
+Please refer to the @ref PkgPointSetProcessing3Ref for
 the detailed API of the Point Set Processing functions.
 
 
@@ -973,7 +973,7 @@ points that are on sharp edges:
 
 The function `structure_point_set()` generates a structured version of
 the input point set assigned to a set of planes. Such an input can be
-produced by a shape detection algorithm (see \ref PkgShapeDetectionRef).
+produced by a shape detection algorithm (see its \ref PkgShapeDetectionRef).
 Point set structuring is based on the article \cgalCite{cgal:la-srpss-13}.
 
 - __Planes__: inliers of each detected plane are replaced by sets of
@@ -1025,7 +1025,7 @@ point set:
 
 Several functions of this package provide a callback mechanism that enables the user to track the progress of the algorithms and to interrupt them if needed. A callback, in this package, is an instance of `std::function<bool(double)>` that takes the advancement as a parameter (between 0. when the algorithm begins to 1. when the algorithm is completed) and that returns `true` if the algorithm should carry on, `false` otherwise. It is passed as a named parameter with an empty function as default.
 
-Algorithms that support this mechanism are detailed in the [Reference Manual](@ref PkgPointSetProcessing3Ref), along with the effect that an early interruption has on the output.
+Algorithms that support this mechanism are detailed in the @ref PkgPointSetProcessing3Ref, along with the effect that an early interruption has on the output.
 
 \subsection Point_set_processing_3Example_callbacks Example
 

--- a/Poisson_surface_reconstruction_3/doc/Poisson_surface_reconstruction_3/PackageDescription.txt
+++ b/Poisson_surface_reconstruction_3/doc/Poisson_surface_reconstruction_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPoissonSurfaceReconstruction3Ref Poisson Surface Reconstruction Reference
+/// \defgroup PkgPoissonSurfaceReconstruction3Ref Reference Manual
 /*!
 \addtogroup PkgPoissonSurfaceReconstruction3Ref
 \cgalPkgDescriptionBegin{Poisson Surface Reconstruction,PkgPoissonSurfaceReconstruction3}

--- a/Polygon/doc/Polygon/PackageDescription.txt
+++ b/Polygon/doc/Polygon/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPolygon2Ref 2D Polygon Reference
+/// \defgroup PkgPolygon2Ref Reference Manual
 
 /// \defgroup PkgPolygon2Concepts Concepts
 /// \ingroup PkgPolygon2Ref

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPolygonMeshProcessingRef Polygon Mesh Processing Reference
+/// \defgroup PkgPolygonMeshProcessingRef Reference Manual
 /// \defgroup PkgPolygonMeshProcessingConcepts Concepts
 /// \ingroup PkgPolygonMeshProcessingRef
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Polygon_mesh_processing.txt
@@ -57,7 +57,7 @@ mesh, which includes point location and self intersection tests.
 \subsection PMPIO Reading and Writing Polygon Meshes
 
 In all functions of this package, the polygon meshes are required to be models
-of the graph concepts defined in the package \ref PkgBGLRef. Using common graph concepts
+of the graph concepts defined in the package \ref PkgBGL. Using common graph concepts
 enables having common input/output functions for all the models of these concepts.
 The page \ref PkgBGLIOFct provides an exhaustive description of the available I/O functions.
 In addition, this package offers the function `CGAL::Polygon_mesh_processing::IO::read_polygon_mesh()`,

--- a/Polygon_repair/doc/Polygon_repair/PackageDescription.txt
+++ b/Polygon_repair/doc/Polygon_repair/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPolygonRepairRef 2D Polygon Repair Reference
+/// \defgroup PkgPolygonRepairRef Reference Manual
 
 /// \defgroup PkgPolygonRepairFunctions Functions
 /// \ingroup PkgPolygonRepairRef

--- a/Polygonal_surface_reconstruction/doc/Polygonal_surface_reconstruction/PackageDescription.txt
+++ b/Polygonal_surface_reconstruction/doc/Polygonal_surface_reconstruction/PackageDescription.txt
@@ -1,6 +1,4 @@
-// Polygonal Surface Reconstruction should equal the project title in Doxyfile.in
-
-/// \defgroup PkgPolygonalSurfaceReconstructionRef Polygonal Surface Reconstruction Reference
+/// \defgroup PkgPolygonalSurfaceReconstructionRef Reference Manual
 
 /*!
 \addtogroup PkgPolygonalSurfaceReconstructionRef

--- a/Polyhedron/doc/Polyhedron/PackageDescription.txt
+++ b/Polyhedron/doc/Polyhedron/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPolyhedronRef 3D Polyhedral Surface  Reference
+/// \defgroup PkgPolyhedronRef Reference Manual
 /// \defgroup PkgPolyhedronConcepts Concepts
 /// \ingroup PkgPolyhedronRef
 

--- a/Polyline_simplification_2/doc/Polyline_simplification_2/PackageDescription.txt
+++ b/Polyline_simplification_2/doc/Polyline_simplification_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPolylineSimplification2Ref 2D Polyline Simplification Reference
+/// \defgroup PkgPolylineSimplification2Ref Reference Manual
 /// \defgroup PkgPolylineSimplification2Concepts Concepts
 /// \ingroup PkgPolylineSimplification2Ref
 

--- a/Polynomial/doc/Polynomial/PackageDescription.txt
+++ b/Polynomial/doc/Polynomial/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPolynomialRef Polynomial Reference
+/// \defgroup PkgPolynomialRef Reference Manual
 /// \defgroup PkgPolynomialConcepts Concepts
 /// \ingroup PkgPolynomialRef
 

--- a/Polytope_distance_d/doc/Polytope_distance_d/PackageDescription.txt
+++ b/Polytope_distance_d/doc/Polytope_distance_d/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPolytopeDistanceDRef Optimal Distances Reference
+/// \defgroup PkgPolytopeDistanceDRef Reference Manual
 /// \defgroup PkgPolytopeDistanceDConcepts Concepts
 /// \ingroup PkgPolytopeDistanceDRef
 

--- a/Principal_component_analysis/doc/Principal_component_analysis/PackageDescription.txt
+++ b/Principal_component_analysis/doc/Principal_component_analysis/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPrincipalComponentAnalysisDRef Principal Component Analysis Reference
+/// \defgroup PkgPrincipalComponentAnalysisDRef Reference Manual
 
 /// \defgroup PkgPrincipalComponentAnalysisDBary CGAL::barycenter()
 /// \ingroup PkgPrincipalComponentAnalysisDRef

--- a/Property_map/doc/Property_map/PackageDescription.txt
+++ b/Property_map/doc/Property_map/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgPropertyMapRef CGAL and Boost Property Maps Reference
+/// \defgroup PkgPropertyMapRef Reference Manual
 
 /*!
 \addtogroup PkgPropertyMapRef

--- a/QP_solver/doc/QP_solver/PackageDescription.txt
+++ b/QP_solver/doc/QP_solver/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgQPSolverRef Linear and Quadratic Programming Solver Reference
+/// \defgroup PkgQPSolverRef Reference Manual
 
 /*! \defgroup PkgQPSolverConcepts Concepts
  \ingroup PkgQPSolverRef

--- a/Ridges_3/doc/Ridges_3/PackageDescription.txt
+++ b/Ridges_3/doc/Ridges_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgRidges3Ref Approximation of Ridges and Umbilics on Triangulated Surface Meshes Reference
+/// \defgroup PkgRidges3Ref Reference Manual
 
 /// \defgroup PkgRidges3Enums Enums
 /// \ingroup PkgRidges3Ref

--- a/SMDS_3/doc/SMDS_3/PackageDescription.txt
+++ b/SMDS_3/doc/SMDS_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSMDS3Ref 3D Simplicial Mesh Data Structures Reference
+/// \defgroup PkgSMDS3Ref Reference Manual
 
 /// \defgroup PkgSMDS3Concepts Concepts
 /// \ingroup PkgSMDS3Ref

--- a/STL_Extension/doc/STL_Extension/PackageDescription.txt
+++ b/STL_Extension/doc/STL_Extension/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSTLExtensionRef STL Extensions for CGAL Reference
+/// \defgroup PkgSTLExtensionRef Reference Manual
 
 /// \defgroup PkgSTLExtensionConcepts Concepts
 /// \ingroup PkgSTLExtensionRef

--- a/Scale_space_reconstruction_3/doc/Scale_space_reconstruction_3/PackageDescription.txt
+++ b/Scale_space_reconstruction_3/doc/Scale_space_reconstruction_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgScaleSpaceReconstruction3Ref Scale-Space Surface Reconstruction Reference
+/// \defgroup PkgScaleSpaceReconstruction3Ref Reference Manual
 
 /// \defgroup PkgScaleSpaceReconstruction3Concepts Concepts
 /// \ingroup PkgScaleSpaceReconstruction3Ref

--- a/Scripts/developer_scripts/cgal_create_package_dir.py
+++ b/Scripts/developer_scripts/cgal_create_package_dir.py
@@ -33,7 +33,7 @@ PROJECT_NAME = "CGAL ${CGAL_DOC_VERSION} - Put title of project here"
 descrstring = \
 r"""// PRETTY PACKAGE NAME should equal the project title in Doxyfile.in
 
-/// \defgroup PkgPACKAGERef PRETTY PACKAGE NAME Reference
+/// \defgroup PkgPACKAGERef Reference Manual
 /// \defgroup PkgPACKAGEConcepts Concepts
 /// \ingroup PkgPACKAGERef
 

--- a/SearchStructures/doc/SearchStructures/PackageDescription.txt
+++ b/SearchStructures/doc/SearchStructures/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSearchStructuresRef dD Range and Segment Trees Reference
+/// \defgroup PkgSearchStructuresRef Reference Manual
 /// \defgroup PkgSearchStructuresConcepts Concepts
 /// \ingroup PkgSearchStructuresRef
 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/PackageDescription.txt
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSegmentDelaunayGraph2Ref 2D Segment Delaunay Graphs Reference
+/// \defgroup PkgSegmentDelaunayGraph2Ref Reference Manual
 /// \defgroup PkgSegmentDelaunayGraph2Concepts Concepts
 /// \ingroup PkgSegmentDelaunayGraph2Ref
 /*!

--- a/Segment_Delaunay_graph_Linf_2/doc/Segment_Delaunay_graph_Linf_2/PackageDescription.txt
+++ b/Segment_Delaunay_graph_Linf_2/doc/Segment_Delaunay_graph_Linf_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSegmentDelaunayGraphLinf2Ref L Infinity Segment Delaunay Graphs Reference
+/// \defgroup PkgSegmentDelaunayGraphLinf2Ref Reference Manual
 /// \defgroup PkgSegmentDelaunayGraphLinf2Concepts Concepts
 /// \ingroup PkgSegmentDelaunayGraphLinf2Ref
 

--- a/Set_movable_separability_2/doc/Set_movable_separability_2/PackageDescription.txt
+++ b/Set_movable_separability_2/doc/Set_movable_separability_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSetMovableSeparability2Ref 2D Movable Separability of Sets Reference
+/// \defgroup PkgSetMovableSeparability2Ref Reference Manual
 
 /// \defgroup top_edges_grp Top Edges
 /// These function determine whether a cavity (of a mold in the plane)

--- a/Shape_detection/doc/Shape_detection/PackageDescription.txt
+++ b/Shape_detection/doc/Shape_detection/PackageDescription.txt
@@ -1,7 +1,5 @@
-
-// RANSAC
 /*!
-\defgroup PkgShapeDetectionRef Shape Detection Reference
+\defgroup PkgShapeDetectionRef Reference Manual
 
 \defgroup PkgShapeDetectionRANSAC Efficient RANSAC
 \ingroup PkgShapeDetectionRef

--- a/Shape_regularization/doc/Shape_regularization/PackageDescription.txt
+++ b/Shape_regularization/doc/Shape_regularization/PackageDescription.txt
@@ -1,8 +1,5 @@
-namespace CGAL {
-namespace Shape_regularization {
-
 /*!
-\defgroup PkgShapeRegularizationRef Shape Regularization Reference
+\defgroup PkgShapeRegularizationRef Reference Manual
 
 \defgroup PkgShapeRegularizationRefConcepts Concepts
 \ingroup PkgShapeRegularizationRef
@@ -100,6 +97,3 @@ to the user-specified conditions.}
 ### QP Regularization ###
 - `QP_regularization<GeomTraits, InputRange, NeighQuery, RegType, QPSolver>`
 */
-
-} /* namespace Shape_regularization */
-} /* namespace CGAL */

--- a/Skin_surface_3/doc/Skin_surface_3/PackageDescription.txt
+++ b/Skin_surface_3/doc/Skin_surface_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSkinSurface3Ref 3D Skin Surface Meshing Reference
+/// \defgroup PkgSkinSurface3Ref Reference Manual
 /// \defgroup PkgSkinSurface3Concepts Concepts
 /// \ingroup PkgSkinSurface3Ref
 

--- a/Snap_rounding_2/doc/Snap_rounding_2/PackageDescription.txt
+++ b/Snap_rounding_2/doc/Snap_rounding_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSnapRounding2Ref 2D Snap Rounding Reference
+/// \defgroup PkgSnapRounding2Ref Reference Manual
 /// \defgroup PkgSnapRounding2Concepts Concepts
 /// \ingroup PkgSnapRounding2Ref
 /*!

--- a/Solver_interface/doc/Solver_interface/PackageDescription.txt
+++ b/Solver_interface/doc/Solver_interface/PackageDescription.txt
@@ -1,5 +1,5 @@
 /*!
-\defgroup PkgSolverInterfaceRef CGAL and Solvers Reference
+\defgroup PkgSolverInterfaceRef Reference Manual
 
 \defgroup PkgSolverInterfaceConcepts Concepts
 \ingroup PkgSolverInterfaceRef

--- a/Spatial_searching/doc/Spatial_searching/PackageDescription.txt
+++ b/Spatial_searching/doc/Spatial_searching/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSpatialSearchingDRef dD Spatial Searching Reference
+/// \defgroup PkgSpatialSearchingDRef Reference Manual
 
 /// \defgroup PkgSpatialSearchingDConcepts Concepts
 /// \ingroup PkgSpatialSearchingDRef

--- a/Spatial_sorting/doc/Spatial_sorting/PackageDescription.txt
+++ b/Spatial_sorting/doc/Spatial_sorting/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSpatialSortingRef Spatial Sorting Reference
+/// \defgroup PkgSpatialSortingRef Reference Manual
 
 /// \defgroup PkgSpatialSortingConcepts Concepts
 /// \ingroup PkgSpatialSortingRef

--- a/Straight_skeleton_2/doc/Straight_skeleton_2/PackageDescription.txt
+++ b/Straight_skeleton_2/doc/Straight_skeleton_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgStraightSkeleton2Ref 2D Straight Skeleton and Polygon Offsetting Reference
+/// \defgroup PkgStraightSkeleton2Ref Reference Manual
 /// \defgroup PkgStraightSkeleton2Concepts Concepts
 /// \ingroup PkgStraightSkeleton2Ref
 

--- a/Stream_lines_2/doc/Stream_lines_2/PackageDescription.txt
+++ b/Stream_lines_2/doc/Stream_lines_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgStreamLines2Ref 2D Placement of Streamlines Reference
+/// \defgroup PkgStreamLines2Ref Reference Manual
 /// \defgroup PkgStreamLines2Concepts Concepts
 /// \ingroup PkgStreamLines2Ref
 /*!

--- a/Stream_support/doc/Stream_support/PackageDescription.txt
+++ b/Stream_support/doc/Stream_support/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgStreamSupportRef I/O Streams Reference
+/// \defgroup PkgStreamSupportRef Reference Manual
 /// \defgroup IOstreamOperators Stream Operators
 /// \ingroup PkgStreamSupportRef
 /// \defgroup IOstreamFunctions I/O Functions

--- a/Subdivision_method_3/doc/Subdivision_method_3/PackageDescription.txt
+++ b/Subdivision_method_3/doc/Subdivision_method_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSurfaceSubdivisionMethod3Ref 3D Surface Subdivision Methods Reference
+/// \defgroup PkgSurfaceSubdivisionMethod3Ref Reference Manual
 
 /// \defgroup PkgSurfaceSubdivisionMethod3Concepts Concepts
 /// \ingroup PkgSurfaceSubdivisionMethod3Ref

--- a/Surface_mesh_approximation/doc/Surface_mesh_approximation/PackageDescription.txt
+++ b/Surface_mesh_approximation/doc/Surface_mesh_approximation/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgTSMARef Triangulated Surface Mesh Approximation Reference
+/// \defgroup PkgTSMARef Reference Manual
 
 /// \defgroup PkgTSMAConcepts Concepts
 /// \ingroup PkgTSMARef

--- a/Surface_mesh_deformation/doc/Surface_mesh_deformation/PackageDescription.txt
+++ b/Surface_mesh_deformation/doc/Surface_mesh_deformation/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSurfaceMeshDeformationRef Triangulated Surface Mesh Deformation Reference
+/// \defgroup PkgSurfaceMeshDeformationRef Reference Manual
 /// \defgroup PkgSurfaceMeshDeformationConcepts Concepts
 /// \ingroup PkgSurfaceMeshDeformationRef
 

--- a/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/PackageDescription.txt
+++ b/Surface_mesh_parameterization/doc/Surface_mesh_parameterization/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSurfaceMeshParameterizationRef Triangulated Surface Mesh Parameterization Reference
+/// \defgroup PkgSurfaceMeshParameterizationRef Reference Manual
 
 
 /*!

--- a/Surface_mesh_segmentation/doc/Surface_mesh_segmentation/PackageDescription.txt
+++ b/Surface_mesh_segmentation/doc/Surface_mesh_segmentation/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSurfaceMeshSegmentationRef Triangulated Surface Mesh Segmentation Reference
+/// \defgroup PkgSurfaceMeshSegmentationRef Reference Manual
 
 /// \defgroup PkgSurfaceMeshSegmentationConcepts Concepts
 /// \ingroup PkgSurfaceMeshSegmentationRef

--- a/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/PackageDescription.txt
+++ b/Surface_mesh_shortest_path/doc/Surface_mesh_shortest_path/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSurfaceMeshShortestPathRef Triangulated Surface Mesh Geodesic Shortest Paths Reference
+/// \defgroup PkgSurfaceMeshShortestPathRef Reference Manual
 
 /// \defgroup PkgSurfaceMeshShortestPathConcepts Concepts
 /// \ingroup PkgSurfaceMeshShortestPathRef

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/PackageDescription.txt
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSurfaceMeshSimplificationRef Triangulated Surface Mesh Simplification Reference
+/// \defgroup PkgSurfaceMeshSimplificationRef Reference Manual
 /// \defgroup PkgSurfaceMeshSimplificationConcepts Concepts
 /// \ingroup PkgSurfaceMeshSimplificationRef
 /*!

--- a/Surface_mesh_skeletonization/doc/Surface_mesh_skeletonization/PackageDescription.txt
+++ b/Surface_mesh_skeletonization/doc/Surface_mesh_skeletonization/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSurfaceMeshSkeletonizationRef Triangulated Surface Mesh Skeletonization Reference
+/// \defgroup PkgSurfaceMeshSkeletonizationRef Reference Manual
 /// \defgroup PkgSurfaceMeshSkeletonizationConcepts Concepts
 /// \ingroup PkgSurfaceMeshSkeletonizationRef
 

--- a/Surface_mesh_topology/doc/Surface_mesh_topology/PackageDescription.txt
+++ b/Surface_mesh_topology/doc/Surface_mesh_topology/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSurfaceMeshTopologyRef Surface Mesh Topology Reference
+/// \defgroup PkgSurfaceMeshTopologyRef Reference Manual
 
 /// \defgroup PkgSurfaceMeshTopologyConcepts Concepts
 /// \ingroup PkgSurfaceMeshTopologyRef

--- a/Surface_mesher/doc/Surface_mesher/PackageDescription.txt
+++ b/Surface_mesher/doc/Surface_mesher/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSurfaceMesher3Ref 3D Surface Mesh Generation Reference
+/// \defgroup PkgSurfaceMesher3Ref Reference Manual
 
 /// \defgroup PkgSurfaceMesher3Concepts Concepts
 /// \ingroup PkgSurfaceMesher3Ref

--- a/Surface_sweep_2/doc/Surface_sweep_2/PackageDescription.txt
+++ b/Surface_sweep_2/doc/Surface_sweep_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgSurfaceSweep2Ref 2D Intersection of Curves Reference
+/// \defgroup PkgSurfaceSweep2Ref Reference Manual
 /*!
 \addtogroup PkgSurfaceSweep2Ref
 \cgalPkgDescriptionBegin{2D Intersection of Curves,PkgSurfaceSweep2}

--- a/TDS_2/doc/TDS_2/PackageDescription.txt
+++ b/TDS_2/doc/TDS_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgTDS2Ref 2D Triangulation Data Structure Reference
+/// \defgroup PkgTDS2Ref Reference Manual
 /// \defgroup PkgTDS2Concepts Concepts
 /// \ingroup PkgTDS2Ref
 /*!

--- a/TDS_3/doc/TDS_3/PackageDescription.txt
+++ b/TDS_3/doc/TDS_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgTDS3Ref 3D Triangulation Data Structure Reference
+/// \defgroup PkgTDS3Ref Reference Manual
 
 /// \defgroup PkgTDS3Concepts Concepts
 /// \ingroup PkgTDS3Ref

--- a/Tetrahedral_remeshing/doc/Tetrahedral_remeshing/PackageDescription.txt
+++ b/Tetrahedral_remeshing/doc/Tetrahedral_remeshing/PackageDescription.txt
@@ -1,6 +1,4 @@
-// Tetrahedral Remeshing
-
-/// \defgroup PkgTetrahedralRemeshingRef Tetrahedral Remeshing Reference
+/// \defgroup PkgTetrahedralRemeshingRef Reference Manual
 /// \defgroup PkgTetrahedralRemeshingConcepts Concepts
 /// \ingroup PkgTetrahedralRemeshingRef
 

--- a/Three/doc/Three/PackageDescription.txt
+++ b/Three/doc/Three/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgThreeRef Three Reference
+/// \defgroup PkgThreeRef Reference Manual
 ///
 /*!
 \addtogroup PkgThreeRef

--- a/Triangulation/doc/Triangulation/PackageDescription.txt
+++ b/Triangulation/doc/Triangulation/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgTriangulationsRef dD Triangulations Reference
+/// \defgroup PkgTriangulationsRef Reference Manual
 /// \defgroup PkgTriangulationsConcepts Concepts
 /// \ingroup PkgTriangulationsRef
 

--- a/Triangulation_2/doc/Triangulation_2/PackageDescription.txt
+++ b/Triangulation_2/doc/Triangulation_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgTriangulation2Ref 2D Triangulations Reference
+/// \defgroup PkgTriangulation2Ref Reference Manual
 /// \defgroup PkgTriangulation2Concepts Concepts
 /// \ingroup PkgTriangulation2Ref
 

--- a/Triangulation_3/doc/Triangulation_3/PackageDescription.txt
+++ b/Triangulation_3/doc/Triangulation_3/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgTriangulation3Ref 3D Triangulations Reference
+/// \defgroup PkgTriangulation3Ref Reference Manual
 /// \defgroup PkgTriangulation3Concepts Concepts
 /// \ingroup PkgTriangulation3Ref
 

--- a/Triangulation_on_hyperbolic_surface_2/doc/Triangulation_on_hyperbolic_surface_2/PackageDescription.txt
+++ b/Triangulation_on_hyperbolic_surface_2/doc/Triangulation_on_hyperbolic_surface_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgHyperbolicSurfaceTriangulation2Ref 2D Triangulations on Hyperbolic Surfaces Reference
+/// \defgroup PkgHyperbolicSurfaceTriangulation2Ref Reference Manual
 
 /// \defgroup PkgHyperbolicSurfaceTriangulation2Concepts Concepts
 /// \ingroup PkgHyperbolicSurfaceTriangulation2Ref

--- a/Triangulation_on_sphere_2/doc/Triangulation_on_sphere_2/PackageDescription.txt
+++ b/Triangulation_on_sphere_2/doc/Triangulation_on_sphere_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgTriangulationOnSphere2Ref 2D Triangulation on the Sphere Reference
+/// \defgroup PkgTriangulationOnSphere2Ref Reference Manual
 
 /// \defgroup PkgTriangulationOnSphere2Concepts Concepts
 /// \ingroup PkgTriangulationOnSphere2Ref

--- a/Visibility_2/doc/Visibility_2/PackageDescription.txt
+++ b/Visibility_2/doc/Visibility_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgVisibility2Ref Visibility_2 Reference
+/// \defgroup PkgVisibility2Ref Reference Manual
 
 /// \defgroup PkgVisibility2Concepts Concepts
 /// \ingroup PkgVisibility2Ref

--- a/Voronoi_diagram_2/doc/Voronoi_diagram_2/PackageDescription.txt
+++ b/Voronoi_diagram_2/doc/Voronoi_diagram_2/PackageDescription.txt
@@ -1,4 +1,4 @@
-/// \defgroup PkgVoronoiDiagram2Ref 2D Voronoi Diagram Adaptor Reference
+/// \defgroup PkgVoronoiDiagram2Ref Reference Manual
 /// \defgroup PkgVoronoiDiagram2Concepts Concepts
 /// \ingroup PkgVoronoiDiagram2Ref
 

--- a/Weights/doc/Weights/PackageDescription.txt
+++ b/Weights/doc/Weights/PackageDescription.txt
@@ -2,7 +2,7 @@ namespace CGAL {
 namespace Weights {
 
 /*!
-\defgroup PkgWeightsRef Weight Interface Reference
+\defgroup PkgWeightsRef Reference Manual
 
 \defgroup PkgWeightsRefConcepts Concepts
 \ingroup PkgWeightsRef


### PR DESCRIPTION
Before: "Pkg Reference"
After: "Reference Manual"

No need to repeat the package name as it is on the line above.

Example output
![Screenshot from 2025-05-22 16-18-54](https://github.com/user-attachments/assets/ed285e12-d95c-4ec2-934d-12f4c7aa014c)
