### PR TITLE
Fix PMP on i386/i686 (32 bits, with the x87 FPU)

### DIFF
--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -486,11 +486,10 @@ FPU_CW_t
 FPU_get_cw (void)
 {
 #ifdef CGAL_ALWAYS_ROUND_TO_NEAREST
-    FPU_CW_t cw;
-    CGAL_IA_GETFPCW(cw);
+    CGAL_assertion_code(FPU_CW_t cw; CGAL_IA_GETFPCW(cw);)
     CGAL_assertion_code(FPU_CW_t mask = CGAL_FE_ROUNDING_MASK;)
     CGAL_assertion((cw & mask) == (CGAL_FE_TONEAREST & mask));
-    return cw;
+    return CGAL_FE_TONEAREST;
 #else
     FPU_CW_t cw;
     CGAL_IA_GETFPCW(cw);

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -486,7 +486,8 @@ FPU_CW_t
 FPU_get_cw (void)
 {
 #ifdef CGAL_ALWAYS_ROUND_TO_NEAREST
-    CGAL_assertion_code(FPU_CW_t cw; CGAL_IA_GETFPCW(cw);)
+    FPU_CW_t cw;
+    CGAL_IA_GETFPCW(cw);
     CGAL_assertion_code(FPU_CW_t mask = CGAL_FE_ROUNDING_MASK;)
     CGAL_assertion((cw & mask) == (CGAL_FE_TONEAREST & mask));
     return cw;

--- a/Number_types/include/CGAL/FPU.h
+++ b/Number_types/include/CGAL/FPU.h
@@ -476,6 +476,9 @@ typedef int FPU_CW_t;
 #define CGAL_FE_DOWNWARD     FE_DOWNWARD
 #endif
 
+#define CGAL_FE_ROUNDING_MASK ((CGAL_FE_TONEAREST | CGAL_FE_TOWARDZERO | CGAL_FE_UPWARD | CGAL_FE_DOWNWARD) \
+  & ~(CGAL_FE_TONEAREST & CGAL_FE_TOWARDZERO & CGAL_FE_UPWARD & CGAL_FE_DOWNWARD)) // mask for rounding bits
+
 // User interface:
 
 inline
@@ -484,8 +487,9 @@ FPU_get_cw (void)
 {
 #ifdef CGAL_ALWAYS_ROUND_TO_NEAREST
     CGAL_assertion_code(FPU_CW_t cw; CGAL_IA_GETFPCW(cw);)
-    CGAL_assertion(cw == CGAL_FE_TONEAREST);
-    return CGAL_FE_TONEAREST;
+    CGAL_assertion_code(FPU_CW_t mask = CGAL_FE_ROUNDING_MASK;)
+    CGAL_assertion((cw & mask) == (CGAL_FE_TONEAREST & mask));
+    return cw;
 #else
     FPU_CW_t cw;
     CGAL_IA_GETFPCW(cw);

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -1471,7 +1471,7 @@ bounded_error_squared_Hausdorff_distance_impl(const TriangleMesh1& tm1,
   using Candidate = Candidate_triangle<Kernel, Face_handle_1, Face_handle_2>;
 
   if constexpr(std::is_floating_point_v<FT>) {
-    CGAL_precondition(std::nextafter(sq_initial_bound, std::numeric_limits<FT>::max()) >= square(FT(error_bound)));
+    CGAL_precondition(std::nextafter(sq_initial_bound, (std::numeric_limits<FT>::max)()) >= square(FT(error_bound)));
   } else {
     CGAL_precondition(sq_initial_bound >= square(FT(error_bound)));
   }


### PR DESCRIPTION
## Summary of Changes

Fix PMP on i386/i686 (32 bits, with the x87 FPU).

## Release Management

* Affected package(s): PMP, Number_types

