### PR TITLE
Triangulation_3: Documentation fixes

### DIFF
--- a/Triangulation_3/doc/Triangulation_3/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Delaunay_triangulation_3.h
@@ -39,7 +39,7 @@ manual \ref Triangulation3exfastlocation.
 
 \tparam SLDS is an optional parameter to specify the type of the spatial lock data structure.
         It must be a model of the `SurjectiveLockDataStructure` concept,
-        with `Object` being a `Point` (as defined below).
+        with `object` being a `Point` (as defined below).
         It is only used if the triangulation data structure used is concurrency-safe (i.e.\ when
         `TDS::Concurrency_tag` is `CGAL::Parallel_tag`).
         The default value is `Spatial_lock_grid_3<Tag_priority_blocking>` if

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Delaunay_triangulation_cell_base_with_circumcenter_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Delaunay_triangulation_cell_base_with_circumcenter_3.h
@@ -16,7 +16,7 @@ circumcenter.
 \tparam Traits is the geometric traits class and must be a model of `DelaunayTriangulationTraits_3`.
 
 \tparam Cb is a cell base class from which
-`Delaunay_triangulation_cell_base_with_circumcenter_3` derives. Cb should
+`Delaunay_triangulation_cell_base_with_circumcenter_3` derives. Cb must
 be a model of `DelaunayTriangulationCellBase_3`.
 It has the default value `Delaunay_triangulation_cell_base_3<Traits>`.
 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Delaunay_triangulation_cell_base_with_circumcenter_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Delaunay_triangulation_cell_base_with_circumcenter_3.h
@@ -49,7 +49,7 @@ If it has already been computed in the past, the cached value is returned.
 Computes the circumcenter of the tetrahedron, or retrieves it if already
 computed
 */
-const Point& circumcenter(Traits&gt = Traits()) const;
+const Point& circumcenter(const Traits&gt = Traits()) const;
 
 /// @}
 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_3.h
@@ -38,7 +38,7 @@ respectively.
 
 \tparam SLDS is an optional parameter to specify the type of the spatial lock data structure.
         It must be a model of the `SurjectiveLockDataStructure` concept,
-        with `Object` being a `Point`.
+        with `object` being a `Point`.
         It is only used if the triangulation data structure used is concurrency-safe (i.e.\ when
         `TDS::Concurrency_tag` is `Parallel_tag`).
         The default value is `Spatial_lock_grid_3<Tag_priority_blocking>` if

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_cell_base_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_cell_base_3.h
@@ -4,7 +4,7 @@ namespace CGAL {
 /*!
 \ingroup PkgTriangulation3VertexCellClasses
 
-The class `Regular_triangulation_cell_base_with_weighted_circumcenter_3` derives from
+The class `Regular_triangulation_cell_base_3` derives from
 `Cb`, a cell base class of a 3D triangulation.
 It is the default cell base class of regular triangulations.
 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_cell_base_with_weighted_circumcenter_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_cell_base_with_weighted_circumcenter_3.h
@@ -16,7 +16,7 @@ circumcenter.
 \tparam Traits is the geometric traits class and must be a model of `RegularTriangulationTraits_3`.
 
 \tparam Cb is a cell base class from which
-`Regular_triangulation_cell_base_with_weighted_circumcenter_3` derives. Cb should
+`Regular_triangulation_cell_base_with_weighted_circumcenter_3` derives. Cb must
 be a model of `RegularTriangulationCellBase_3`.
 It has the default value `Regular_triangulation_cell_base_3<RT>`.
 

--- a/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Triangulation_3.h
@@ -19,7 +19,7 @@ respectively.
 
 \tparam SLDS is an optional parameter to specify the type of the spatial lock data structure.
         It must be a model of the `SurjectiveLockDataStructure` concept,
-        with `Object` being a `Point` (as defined below).
+        with `object` being a `Point` (as defined below).
         It is only used if the triangulation data structure used is concurrency-safe (i.e.\ when
         `TriangulationDataStructure_3::Concurrency_tag` is `Parallel_tag`).
         The default value is `Spatial_lock_grid_3<Tag_priority_blocking>` if

--- a/Triangulation_3/doc/Triangulation_3/Concepts/DelaunayTriangulationCellBase_3.h
+++ b/Triangulation_3/doc/Triangulation_3/Concepts/DelaunayTriangulationCellBase_3.h
@@ -34,9 +34,9 @@ typedef DelaunayTriangulationTraits_3::Point_3 Point;
 Returns the circumcenter of the cell.
 `DelaunayTriangulationTraits_3` is the geometric traits class of the triangulation.
 
-This operator is required only when the dual functions are called.
+This operator is required only when the `dual()` functions are called.
 */
-const Point& circumcenter(DelaunayTriangulationTraits_3&gt = DelaunayTriangulationTraits_3()) const;
+const Point& circumcenter(const DelaunayTriangulationTraits_3&gt = DelaunayTriangulationTraits_3()) const;
 /// @}
 
 

--- a/Triangulation_3/doc/Triangulation_3/Concepts/RegularTriangulationCellBase_3.h
+++ b/Triangulation_3/doc/Triangulation_3/Concepts/RegularTriangulationCellBase_3.h
@@ -37,6 +37,7 @@ and an operator to compute its weighted circumcenter.
 
 \cgalHasModelsBegin
 \cgalHasModels{CGAL::Regular_triangulation_cell_base_3}
+\cgalHasModels{CGAL::Regular_triangulation_cell_base_with_weighted_circumcenter_3}
 \cgalHasModelsEnd
 
 \sa `RegularTriangulationTraits_3`


### PR DESCRIPTION
## Summary of Changes

Just typos  in the documentation (not even headers)

## Release Management

* Affected package(s): Triangulation_3
* License and copyright ownership:  unchanged

