### PR TITLE
Thirdparty: bugfix for libpointmatcher

### DIFF
--- a/Documentation/doc/Documentation/Third_party.txt
+++ b/Documentation/doc/Documentation/Third_party.txt
@@ -161,10 +161,11 @@ executables should be linked with the CMake imported target
 
 The \libpointmatcher web site is <A
 HREF="https://github.com/ethz-asl/libpointmatcher">`https://github.com/ethz-asl/libpointmatcher`</A>.
-\attention On Windows, we only support version 1.3.1 of PointMatcher with version 3.3.7 of Eigen, with some changes to the recipe at
+\attention On Windows, \libpointmatcher needs to be compiled with the flag BOOST_TIMER_ENABLE_DEPRECATED set as it uses a deprecated module from \boost.
+\attention On Windows, we support version 1.4.4 of \libpointmatcher with version 3.4.0 of Eigen.
+Alternatively, version 1.3.1 of \libpointmatcher is supported with version 3.3.7 of Eigen, with some changes to the recipe at
 `https://github.com/ethz-asl/libpointmatcher/blob/master/doc/Compilation.md`:`NABO_INCLUDE_DIR` becomes `libnabo_INCLUDE_DIRS`
 and `NABO_LIBRARY` becomes `libnabo_LIBRARIES` in the "Build libpointmatcher" section.
-
 
 \subsection thirdpartyLeda LEDA
 <b>Version 6.2 or later</b>

--- a/Installation/cmake/modules/CGAL_pointmatcher_support.cmake
+++ b/Installation/cmake/modules/CGAL_pointmatcher_support.cmake
@@ -1,16 +1,26 @@
 if(libpointmatcher_FOUND AND NOT TARGET CGAL::pointmatcher_support)
-  find_package(Boost COMPONENTS thread filesystem system program_options date_time chrono)
+  if (libpointmatcher_VERSION VERSION_GREATER_EQUAL "1.4.4")
+    find_package(Boost COMPONENTS thread system program_options date_time chrono)
+   else()
+    find_package(Boost COMPONENTS thread filesystem system program_options date_time chrono)
+  endif()
+
   if(Boost_chrono_FOUND
-      AND Boost_thread_FOUND
-      AND Boost_filesystem_FOUND
-      AND Boost_system_FOUND
-      AND Boost_program_options_FOUND
-      AND Boost_date_time_FOUND)
+       AND Boost_thread_FOUND
+       AND Boost_system_FOUND
+       AND Boost_program_options_FOUND
+       AND Boost_date_time_FOUND
+       AND (libpointmatcher_VERSION VERSION_GREATER_EQUAL "1.4.4" OR Boost_filesystem_FOUND))
     add_library(CGAL::pointmatcher_support INTERFACE IMPORTED)
+    target_compile_options(CGAL::pointmatcher_support INTERFACE "-D_USE_MATH_DEFINES")
     target_compile_definitions(CGAL::pointmatcher_support INTERFACE "CGAL_LINKED_WITH_POINTMATCHER")
     target_include_directories(CGAL::pointmatcher_support INTERFACE "${libpointmatcher_INCLUDE_DIRS}")
     target_link_libraries(CGAL::pointmatcher_support INTERFACE ${libpointmatcher_LIBRARIES} libnabo::nabo)
   else()
-    message(STATUS "NOTICE: the libpointmatcher library requires the following boost components: thread filesystem system program_options date_time chrono.")
+    if (libpointmatcher_VERSION VERSION_GREATER_EQUAL "1.4.4")
+      message(STATUS "NOTICE: the libpointmatcher library requires the following boost components: thread system program_options date_time chrono.")
+    else()
+      message(STATUS "NOTICE: the libpointmatcher library requires the following boost components: thread filesystem system program_options date_time chrono.")
+    endif()
   endif()
 endif()


### PR DESCRIPTION
## Summary of Changes

Added support for latest version of libpointmatcher.
Updated doc as libpointmatcher uses the deprecated boost/timer.hpp which can cause a compilation error when building the library.

There is a PR at libpointmatcher to fix the deprecation bug since months, but it still needs to be reviewed.

## Release Management

* Affected package(s): Installation