### PR TITLE
Compact_container fix a warning

### DIFF
--- a/STL_Extension/include/CGAL/Compact_container.h
+++ b/STL_Extension/include/CGAL/Compact_container.h
@@ -582,7 +582,7 @@ public:
 
     const_pointer ptr = &*cit;
 
-    for (const auto [chunk_ptr, size] : all_items) {
+    for (const auto& [chunk_ptr, size] : all_items) {
 
       // Are we in the address range of this block (excluding first and last
       // elements) ?


### PR DESCRIPTION
## Summary of Changes

`Compact_container`: fix a warning

```text
include/CGAL/Compact_container.h:585:21: warning: loop variable ‘<structured bindings>’ creates a copy from type ‘const
```
