### PR TITLE
SMDS_3-  `tet_soup_to_c3t3()` fix and test

### DIFF
--- a/SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h
+++ b/SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h
@@ -189,20 +189,24 @@ namespace CGAL {
                              internal_np::surface_facets_t,
                              NamedParameters,
                              Default_facet_map>::reference;
+    using Subdomain_index = typename Triangulation::Cell::Subdomain_index;
+    using Default_subdomains = std::vector<Subdomain_index>;
     using Subdomains_ref_type
       = typename internal_np::Lookup_named_param_def<
                               internal_np::subdomain_indices_t,
                               NamedParameters,
-                              int>::reference;
+                              Default_subdomains>::reference;
 
     Triangulation tr;
     Default_facet_map empty_map;
+    Default_subdomains subdomain_indices(tets.size(), Subdomain_index(1));
+
     const Facet_map_ref_type& facets = choose_parameter(
           get_parameter_reference(np, internal_np::surface_facets),
           empty_map);
     const Subdomains_ref_type& subdomains = choose_parameter(
           get_parameter_reference(np, internal_np::subdomain_indices),
-          1);
+          subdomain_indices);
     const bool non_manifold = choose_parameter(
           get_parameter(np, internal_np::allow_non_manifold),
           false);

--- a/SMDS_3/test/SMDS_3/CMakeLists.txt
+++ b/SMDS_3/test/SMDS_3/CMakeLists.txt
@@ -7,6 +7,7 @@ project(SMDS_3_Tests)
 find_package(CGAL REQUIRED)
 
 create_single_source_cgal_program( "test_simplicial_cb_vb.cpp")
+create_single_source_cgal_program( "test_tet_soup_to_c3t3.cpp")
 
 find_package(Eigen3 3.1.0 QUIET) #(requires 3.1.0 or greater)
 include(CGAL_Eigen3_support)

--- a/SMDS_3/test/SMDS_3/test_tet_soup_to_c3t3.cpp
+++ b/SMDS_3/test/SMDS_3/test_tet_soup_to_c3t3.cpp
@@ -1,0 +1,106 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/Delaunay_triangulation_3.h>
+#include <CGAL/point_generators_3.h>
+#include <CGAL/Tetrahedral_remeshing/Remeshing_triangulation_3.h>
+#include <CGAL/Mesh_complex_3_in_triangulation_3.h>
+
+#include <CGAL/tetrahedron_soup_to_triangulation_3.h>
+#include <CGAL/IO/File_medit.h>
+
+#include <vector>
+#include <unordered_map>
+#include <boost/unordered_map.hpp>
+
+using K = CGAL::Exact_predicates_inexact_constructions_kernel;
+
+using DT3 = CGAL::Delaunay_triangulation_3<K>;
+using Remeshing_triangulation = CGAL::Tetrahedral_remeshing::Remeshing_triangulation_3<K>;
+
+using Point_3 = K::Point_3;
+using Tetrahedron_3 = K::Tetrahedron_3;
+using Vertex_handle = DT3::Vertex_handle;
+using Subdomain_index = Remeshing_triangulation::Cell::Subdomain_index;
+using Surface_patch_index = Remeshing_triangulation::Cell::Surface_patch_index;
+
+int main(int , char* [])
+{
+  std::cout << "Random seed " << CGAL::get_default_random().get_seed() << std::endl;
+
+  const int nbv = 100;
+
+  //a triangulation
+  DT3 delaunay;
+  std::unordered_map<Vertex_handle, int> v2i;
+  std::vector<DT3::Point>                points(nbv);
+  std::vector<Tetrahedron_3>             tetrahedra;
+  std::vector<std::array<int, 4> >       tets_by_indices;
+  std::vector<Subdomain_index>           subdomains;
+  boost::unordered_map<std::array<int, 3>, Surface_patch_index> border_facets;
+
+  //insert random points
+  CGAL::Random_points_in_cube_3<Point_3> randp(2.);
+  int i = 0;
+  while (i < nbv)
+  {
+    points[i] = *randp++;
+    Vertex_handle v = delaunay.insert(points[i]);
+    v2i[v] = i++;
+  }
+
+  tetrahedra.reserve(delaunay.number_of_finite_cells());
+  tets_by_indices.reserve(delaunay.number_of_finite_cells());
+  subdomains.reserve(delaunay.number_of_finite_cells());
+  for (DT3::Cell_handle c : delaunay.finite_cell_handles())
+  {
+    tetrahedra.push_back(delaunay.tetrahedron(c));
+    tets_by_indices.push_back( { v2i.at(c->vertex(0)),
+                                 v2i.at(c->vertex(1)),
+                                 v2i.at(c->vertex(2)),
+                                 v2i.at(c->vertex(3)) } );
+    subdomains.push_back(Subdomain_index(1));
+  }
+
+  for (DT3::Cell_handle c : delaunay.all_cell_handles())
+  {
+    if(!delaunay.is_infinite(c))
+      continue;
+
+    //convex hull facet
+    const int infinite_index = c->index(delaunay.infinite_vertex());
+    DT3::Facet f(c, infinite_index);
+
+    std::array<int, 3> facet;
+    facet[0] = v2i.at(c->vertex((infinite_index + 1) % 4));
+    facet[1] = v2i.at(c->vertex((infinite_index + 2) % 4));
+    facet[2] = v2i.at(c->vertex((infinite_index + 3) % 4));
+    border_facets[facet] = Surface_patch_index(12);
+  }
+
+  //build triangulation from tetrahedra
+  Remeshing_triangulation tr
+    = CGAL::tetrahedron_soup_to_triangulation_3<Remeshing_triangulation>(tetrahedra);
+  assert(tr.is_valid());
+
+  //build triangulation from indices
+  Remeshing_triangulation tr2
+    = CGAL::tetrahedron_soup_to_triangulation_3<Remeshing_triangulation>(
+        points, tets_by_indices);
+  assert(tr2.is_valid());
+
+  //build triangulation from indices and subdomains
+  Remeshing_triangulation tr3
+    = CGAL::tetrahedron_soup_to_triangulation_3<Remeshing_triangulation>(
+        points, tets_by_indices, CGAL::parameters::subdomain_indices(std::cref(subdomains)));
+  assert(tr3.is_valid());
+
+  //build triangulation from indices, subdomains and surface facets
+  Remeshing_triangulation tr4
+    = CGAL::tetrahedron_soup_to_triangulation_3<Remeshing_triangulation>(
+        points, tets_by_indices,
+        CGAL::parameters::subdomain_indices(std::cref(subdomains))
+                         .surface_facets(std::cref(border_facets)));
+  assert(tr4.is_valid());
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
## Summary of Changes

There was a compilation error about `tetrahedron_soup_to_triangulation_3()` when no named parameter was given
It's fixed, and a test is added for different combinations of NP

## Release Management

* Affected package(s): SMDS_3
* License and copyright ownership: unchanged

