### PR TITLE
Lab - fix "save as" for a `c3t3` that was loaded

### DIFF
--- a/Lab/demo/Lab/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -196,14 +196,8 @@ CGAL_Lab_c3t3_binary_io_plugin::
 save(QFileInfo fileinfo, QList<Scene_item *> &items)
 {
   Scene_item* item = items.front();
-  if(!qobject_cast<Scene_c3t3_item*>(item)->is_valid())
-  {
-    QMessageBox::warning(CGAL::Three::Three::mainWindow(), "", "The c3t3_item is not valid. You cannot save it.");
-    return false;
-  }
   const Scene_c3t3_item* c3t3_item = qobject_cast<const Scene_c3t3_item*>(item);
-  if ( NULL == c3t3_item )
-  {
+  if(nullptr == c3t3_item) {
     return false;
   }
 
@@ -211,9 +205,14 @@ save(QFileInfo fileinfo, QList<Scene_item *> &items)
 
   if(path.endsWith(".cgal"))
   {
+    if(!c3t3_item->is_valid())
+    {
+      QMessageBox::warning(CGAL::Three::Three::mainWindow(), "",
+                           "The c3t3_item is not valid. You cannot save it in binary cgal format.");
+      return false;
+    }
     std::ofstream out(fileinfo.filePath().toUtf8(),
                       std::ios_base::out|std::ios_base::binary);
-
     bool ok = out && c3t3_item->save_binary(out);
     if(!ok)
       return false;


### PR DESCRIPTION
## Summary of Changes

Load a `.mesh` file, remesh it or do nothing, and "save as..." fails because the `c3t3` has its `is_valid` field set to `false`.

This PR fixes that issue : now only `.binary.cgal` requires being certainly valid, i.e. generated by Mesh_3

thanks @IasonManolas for the report

## Release Management

* Affected package(s): Lab
* License and copyright ownership: unchanged

