### PR TITLE
Tetrahedral_remeshing - make it determistic

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -1569,7 +1569,6 @@ auto midpoint_with_info(const typename C3t3::Edge& e,
                         const C3t3& c3t3)
 {
   using Tr = typename C3t3::Triangulation;
-  using Vertex_handle = typename Tr::Vertex_handle;
   using Gt = typename Tr::Geom_traits;
   using Point_3 = typename Gt::Point_3;
   using Index = typename C3t3::Index;

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -1439,6 +1439,7 @@ auto sizing_at_vertex(const Vertex_handle v,
 
 template<typename Sizing, typename C3t3, typename Cell_selector>
 auto sizing_at_midpoint(const typename C3t3::Edge& e,
+                        const typename C3t3::Triangulation::Geom_traits::Point_3& m, // edge midpoint
                         const int dim,
                         const typename C3t3::Index& index,
                         const Sizing& sizing,
@@ -1446,17 +1447,13 @@ auto sizing_at_midpoint(const typename C3t3::Edge& e,
                         const Cell_selector& cell_selector)
 {
   using FT = typename C3t3::Triangulation::Geom_traits::FT;
-  using Point_3 = typename C3t3::Triangulation::Geom_traits::Point_3;
-
   auto cp = c3t3.triangulation().geom_traits().construct_point_3_object();
-  const Point_3 m = CGAL::midpoint(cp(e.first->vertex(e.second)->point()),
-                                   cp(e.first->vertex(e.third)->point()));
+
   const FT size = sizing(m, dim, index);
 
   if (dim < 3 && size == 0)
   {
-    const auto u = e.first->vertex(e.second);
-    const auto v = e.first->vertex(e.third);
+    const auto [u, v] = make_vertex_pair(e);
 
     const FT size_at_u = sizing(cp(u->point()), u->in_dimension(), u->index());
     const FT size_at_v = sizing(cp(v->point()), v->in_dimension(), v->index());
@@ -1584,9 +1581,7 @@ auto midpoint_with_info(const typename C3t3::Edge& e,
     Index index;
   };
 
-  const auto vs = c3t3.triangulation().vertices(e);
-  const Vertex_handle u = vs[0];
-  const Vertex_handle v = vs[1];
+  const auto [u, v] = make_vertex_pair(e);
 
   const auto& gt = c3t3.triangulation().geom_traits();
   auto cp = gt.construct_point_3_object();

--- a/Tetrahedral_remeshing/test/Tetrahedral_remeshing/CMakeLists.txt
+++ b/Tetrahedral_remeshing/test/Tetrahedral_remeshing/CMakeLists.txt
@@ -16,6 +16,7 @@ create_single_source_cgal_program("test_tetrahedral_remeshing_with_features.cpp"
 create_single_source_cgal_program("test_tetrahedral_remeshing_of_one_subdomain.cpp")
 create_single_source_cgal_program("test_tetrahedral_remeshing_io.cpp")
 create_single_source_cgal_program("test_tetrahedral_remeshing_from_mesh_file.cpp")
+create_single_source_cgal_program("test_tetrahedral_remeshing_determinism.cpp")
 
 # Test MLS projection
 add_executable(test_tetrahedral_remeshing_mls

--- a/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_determinism.cpp
+++ b/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_determinism.cpp
@@ -1,6 +1,5 @@
-//#define CGAL_TETRAHEDRAL_REMESHING_VERBOSE
+#define CGAL_TETRAHEDRAL_REMESHING_VERBOSE
 //#define CGAL_TETRAHEDRAL_REMESHING_DEBUG
-//#define CGAL_TETRAHEDRAL_REMESHING_GENERATE_INPUT_FILES
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
@@ -65,7 +64,7 @@ int main(int argc, char* argv[])
   CGAL::IO::write_MEDIT(ofs0, tr);
   ofs0.close();
 
-  Remeshing_triangulation tr_ref = tr; // Keep a reference for comparison
+  const Remeshing_triangulation tr_ref = tr; // Keep a reference for comparison
 
   std::vector<std::string> output_tr;
   output_tr.reserve(nb_runs);
@@ -88,12 +87,15 @@ int main(int argc, char* argv[])
     {
       if(0 != output_tr[i-1].compare(output_tr[i]))
       {
-        std::cerr << "Run " << i << " differs from run " << i-1 << std::endl;
+        std::cerr << "******************************************" << std::endl;
+        std::cerr << "*** Run " << i << " differs from run " << i-1 << std::endl;
         assert(false); // This should not happen
       }
       else
       {
-        std::cout << "Run " << i << " is identical to run " << i-1 << std::endl;
+        std::cout << "******************************************" << std::endl;
+        std::cout << "*** Run " << i << " is identical to run " << i - 1 << std::endl;
+        std::cout << "******************************************" << std::endl;
       }
     }
   }

--- a/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_determinism.cpp
+++ b/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_determinism.cpp
@@ -1,0 +1,102 @@
+//#define CGAL_TETRAHEDRAL_REMESHING_VERBOSE
+//#define CGAL_TETRAHEDRAL_REMESHING_DEBUG
+//#define CGAL_TETRAHEDRAL_REMESHING_GENERATE_INPUT_FILES
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/Tetrahedral_remeshing/Remeshing_triangulation_3.h>
+#include <CGAL/tetrahedral_remeshing.h>
+#include <CGAL/Tetrahedral_remeshing/tetrahedral_remeshing_io.h>
+#include <CGAL/Random.h>
+
+#include <iostream>
+#include <fstream>
+#include <string>
+#include <vector>
+#include <cassert>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+
+typedef CGAL::Tetrahedral_remeshing::Remeshing_triangulation_3<K> Remeshing_triangulation;
+
+template<typename T3>
+void generate_input_one_subdomain(const std::size_t nbv, T3& tr)
+{
+  CGAL::Random rng;
+
+  typedef typename T3::Point Point;
+  std::vector<Point> pts;
+  while (pts.size() < nbv)
+  {
+    const float x = rng.uniform_real(-10.f, 10.f);
+    const float y = rng.uniform_real(-10.f, 10.f);
+    const float z = rng.uniform_real(-10.f, 10.f);
+
+    pts.push_back(Point(x, y, z));
+  }
+  tr.insert(pts.begin(), pts.end());
+
+  for (typename T3::Cell_handle c : tr.finite_cell_handles())
+    c->set_subdomain_index(1);
+
+  assert(tr.is_valid(true));
+
+#ifdef CGAL_TETRAHEDRAL_REMESHING_GENERATE_INPUT_FILES
+  std::ofstream out("data/triangulation_one_subdomain.binary.cgal",
+                    std::ios_base::out | std::ios_base::binary);
+  CGAL::save_binary_triangulation(out, tr);
+  out.close();
+#endif
+}
+
+int main(int argc, char* argv[])
+{
+  std::cout << "CGAL Random seed = " << CGAL::get_default_random().get_seed() << std::endl;
+
+  // Collect options
+  std::size_t nb_runs = 5;
+
+  Remeshing_triangulation tr;
+  generate_input_one_subdomain(1000, tr);
+
+  const int target_edge_length = (argc > 1) ? atoi(argv[1]) : 1;
+
+  std::ofstream ofs0("in.mesh");
+  CGAL::IO::write_MEDIT(ofs0, tr);
+  ofs0.close();
+
+  Remeshing_triangulation tr_ref = tr; // Keep a reference for comparison
+
+  std::vector<std::string> output_tr;
+  output_tr.reserve(nb_runs);
+
+  for(std::size_t i = 0; i < nb_runs; ++i)
+  {
+    std::cout << "Run " << i << " of " << nb_runs << std::endl;
+
+    tr = tr_ref; // Reset triangulation to reference
+    CGAL::tetrahedral_isotropic_remeshing(tr, target_edge_length);
+
+    std::ostringstream oss;
+    CGAL::IO::write_MEDIT(oss, tr);
+    output_tr.push_back(oss.str());
+    oss.clear();
+
+    if(i == 0)
+      continue; // skip first run, it is the reference
+    else
+    {
+      if(0 != output_tr[i-1].compare(output_tr[i]))
+      {
+        std::cerr << "Run " << i << " differs from run " << i-1 << std::endl;
+        assert(false); // This should not happen
+      }
+      else
+      {
+        std::cout << "Run " << i << " is identical to run " << i-1 << std::endl;
+      }
+    }
+  }
+
+  return EXIT_SUCCESS;
+}

--- a/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_determinism.cpp
+++ b/Tetrahedral_remeshing/test/Tetrahedral_remeshing/test_tetrahedral_remeshing_determinism.cpp
@@ -1,4 +1,4 @@
-#define CGAL_TETRAHEDRAL_REMESHING_VERBOSE
+//#define CGAL_TETRAHEDRAL_REMESHING_VERBOSE
 //#define CGAL_TETRAHEDRAL_REMESHING_DEBUG
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>


### PR DESCRIPTION
## Summary of Changes

Tetrahedral_remeshing is not deterministic (though outputs are very close in 2 consecutive runs).
Making it deterministic...

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged

