### PR TITLE
Orthtree: Node insertion during orthtree build has linear complexity

### DIFF
--- a/Property_map/include/CGAL/Property_container.h
+++ b/Property_map/include/CGAL/Property_container.h
@@ -50,7 +50,7 @@ public:
 
   virtual void append(const Property_array_base<Index>& other) = 0;
 
-  virtual void reserve(std::size_t n) = 0;
+  virtual void resize(std::size_t n) = 0;
 
   virtual void shrink_to_fit() = 0;
 
@@ -89,7 +89,6 @@ public:
   Property_array(const std::vector<bool>& active_indices, const T& default_value) :
     m_data(), m_active_indices(active_indices), m_default_value(default_value) {
 
-    m_data.reserve(active_indices.capacity());
     m_data.resize(active_indices.size(), m_default_value);
   }
 
@@ -124,7 +123,7 @@ public:
     m_data.insert(m_data.end(), other.m_data.begin(), other.m_data.end());
   }
 
-  virtual void reserve(std::size_t n) override {
+  virtual void resize(std::size_t n) override {
     CGAL_precondition(m_active_indices.size() == n);
     m_data.resize(n, m_default_value);
   };
@@ -449,7 +448,7 @@ public:
 
     m_active_indices.resize(n);
     for (auto [name, array] : m_properties)
-      array->reserve(n);
+      array->resize(n);
 
     std::fill(m_active_indices.begin(), m_active_indices.end(), true);
 
@@ -466,7 +465,7 @@ public:
     m_active_indices.push_back(true);
 
     for (auto [name, array] : m_properties)
-      array->reserve(capacity());
+      array->resize(capacity());
 
     auto first_new_index = Index(capacity() - 1);
     reset(first_new_index);
@@ -498,7 +497,7 @@ public:
     m_active_indices.resize(capacity() + n, true);
 
     for (auto [name, array] : m_properties)
-      array->reserve(capacity());
+      array->resize(capacity());
 
     return Index(capacity() - n);
   }
@@ -623,7 +622,7 @@ public:
       if (it != range.second)
         array->append(*it->second.get());
       else
-        array->reserve(m_active_indices.size());
+        array->resize(m_active_indices.size());
     }
   }
 

--- a/Property_map/test/Property_map/test_Property_container.cpp
+++ b/Property_map/test/Property_map/test_Property_container.cpp
@@ -41,11 +41,6 @@ void test_element_access() {
 
   auto& integers = properties.add_property("integers", 5);
 
-  // Reserve space for 100 elements
-  properties.reserve(100);
-  assert(properties.capacity() == 100);
-  assert(properties.size() == 0);
-
   // Newly emplaced elements should go at the front
   assert(properties.emplace() == 0);
   assert(properties.emplace() == 1);
@@ -61,7 +56,6 @@ void test_element_access() {
   auto& floats = properties.add_property("floats", 6.0f);
 
   // The new property array should already be of the right size
-  assert(floats.capacity() == 100);
   assert(properties.size() == 3);
 
   // Pre-existing elements should contain the default value
@@ -87,9 +81,8 @@ void test_element_access() {
   // Erase an element, and the size should be reduced
   properties.erase(1);
   assert(properties.size() == 2);
-  assert(properties.capacity() == 100);
   assert(properties.active_list().size() == 2);
-  assert(properties.inactive_list().size() == 98);
+  assert(properties.inactive_list().size() == 1);
 
   // A newly emplaced element should take the empty slot
   assert(properties.emplace() == 1);


### PR DESCRIPTION
## Summary of Changes

Added inactive list for deleted nodes (nodes cannot be deleted for now)
avoiding linear search time for node insertion during Orthtree build

Reusing indices in properties from deleted nodes for insertion of a group of nodes (i.e., during Orthtree refinement) is deactivated. This has no impact as nodes cannot be deleted anyway.

## Release Management

* Affected package(s): Orthtree, Property_map
