### PR TITLE
[Small Feature] Rename import functions with deprecation and add alias tests

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -3,6 +3,12 @@
 
 ## [Release 6.1](https://github.com/CGAL/cgal/releases/tag/v6.1)
 
+- **API Changes**: The following import functions have been deprecated and renamed for better naming clarity and consistency:
+  - `import_from_plane_graph()` → `read_plane_graph_in_lcc()` 
+  - `import_from_polyhedron_3()` → `polyhedron_3_to_lcc()`
+  - `import_from_triangulation_3()` → `triangulation_3_to_lcc()`
+- The old function names are still available but marked as deprecated for backward compatibility.
+
 ### General Changes
 - The minimal supported version of Boost is now 1.74.0.
 

--- a/Lab/demo/Lab/Plugins/IO/lcc_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/IO/lcc_io_plugin.cpp
@@ -47,7 +47,7 @@ public:
     QString ext = fileinfo.suffix();
     bool res = true;
     if(ext == "off")
-      CGAL::import_from_polyhedron_3_flux < Scene_lcc_item::LCC > (lcc, ifs);
+      CGAL::polyhedron_3_flux_to_lcc < Scene_lcc_item::LCC > (lcc, ifs);
     else
     {
       res = CGAL::load_combinatorial_map(ifs, lcc);

--- a/Linear_cell_complex/demo/Linear_cell_complex/MainWindow.cpp
+++ b/Linear_cell_complex/demo/Linear_cell_complex/MainWindow.cpp
@@ -375,7 +375,7 @@ void MainWindow::load_off (const QString & fileName, bool clear)
 
   std::ifstream ifs (qPrintable (fileName));
 
-  CGAL::import_from_polyhedron_3_flux < LCC > (*scene.lcc, ifs);
+  CGAL::polyhedron_3_flux_to_lcc < LCC > (*scene.lcc, ifs);
 
 #ifdef CGAL_PROFILE_LCC_DEMO
   timer.stop();
@@ -415,7 +415,7 @@ void MainWindow::load_3DTDS (const QString & fileName, bool clear)
   T.insert (std::istream_iterator < Point_3 >(ifs),
             std::istream_iterator < Point_3 >() );
 
-  CGAL::import_from_triangulation_3 < LCC, Triangulation >(*scene.lcc, T);
+  CGAL::triangulation_3_to_lcc < LCC, Triangulation >(*scene.lcc, T);
 
 #ifdef CGAL_PROFILE_LCC_DEMO
   timer.stop();
@@ -673,7 +673,7 @@ void MainWindow::on_actionCompute_Voronoi_3D_triggered ()
   std::map<Triangulation::Cell_handle,
       LCC::Dart_descriptor > vol_to_dart;
 
-  dh = CGAL::import_from_triangulation_3 < LCC, Triangulation >
+  dh = CGAL::triangulation_3_to_lcc < LCC, Triangulation >
       (delaunay_lcc, T, &vol_to_dart);
 
   Dart_descriptor ddh=delaunay_lcc.dual(*scene.lcc, dh);

--- a/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Linear_cell_complex_constructors.h
@@ -24,9 +24,8 @@ Here a small example:
 <B>Middle</B>: the 2D linear cell complex reconstructed if combinatorial maps are the combinatorial data-structure.
 <B>Right</B>: the 2D linear cell complex reconstructed if generalized maps are the combinatorial data-structure.
 
-\sa `CGAL::triangulation_3_to_lcc<LCC,Triangulation>` (formerly `import_from_triangulation_3`)
-\sa `CGAL::polyhedron_3_to_lcc<LCC,Polyhedron>` (formerly `import_from_polyhedron_3`)
-
+\sa `CGAL::triangulation_3_to_lcc<LCC,Triangulation>` 
+\sa `CGAL::polyhedron_3_to_lcc<LCC,Polyhedron>`
 */
 template<class LCC>
 typename LCC::Dart_descriptor plane_graph_to_lcc(LCC& lcc,

--- a/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Linear_cell_complex_constructors.h
@@ -28,15 +28,15 @@ Here a small example:
 \sa `CGAL::polyhedron_3_to_lcc<LCC,Polyhedron>`
 */
 template<class LCC>
-typename LCC::Dart_descriptor plane_graph_to_lcc(LCC& lcc,
+typename LCC::Dart_descriptor read_plane_graph_in_lcc(LCC& lcc,
 std::istream& ais);
 
 /*!
 \ingroup PkgLinearCellComplexConstructions
-\deprecated Use `plane_graph_to_lcc()` instead.
+\deprecated Use `read_plane_graph_in_lcc()` instead.
 */
 template<class LCC>
-[[deprecated("Use plane_graph_to_lcc instead")]]
+[[deprecated("Use read_plane_graph_in_lcc instead")]]
 typename LCC::Dart_descriptor import_from_plane_graph(LCC& lcc, std::istream& ais);
 
 } /* namespace CGAL */

--- a/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Linear_cell_complex_constructors.h
@@ -24,13 +24,21 @@ Here a small example:
 <B>Middle</B>: the 2D linear cell complex reconstructed if combinatorial maps are the combinatorial data-structure.
 <B>Right</B>: the 2D linear cell complex reconstructed if generalized maps are the combinatorial data-structure.
 
-\sa `CGAL::import_from_triangulation_3<LCC,Triangulation>`
-\sa `CGAL::import_from_polyhedron_3<LCC,Polyhedron>`
+\sa `CGAL::triangulation_3_to_lcc<LCC,Triangulation>` (formerly `import_from_triangulation_3`)
+\sa `CGAL::polyhedron_3_to_lcc<LCC,Polyhedron>` (formerly `import_from_polyhedron_3`)
 
 */
 template<class LCC>
-typename LCC::Dart_descriptor import_from_plane_graph(LCC& lcc,
+typename LCC::Dart_descriptor plane_graph_to_lcc(LCC& lcc,
 std::istream& ais);
+
+/*!
+\ingroup PkgLinearCellComplexConstructions
+\deprecated Use `plane_graph_to_lcc()` instead.
+*/
+template<class LCC>
+[[deprecated("Use plane_graph_to_lcc instead")]]
+typename LCC::Dart_descriptor import_from_plane_graph(LCC& lcc, std::istream& ais);
 
 } /* namespace CGAL */
 

--- a/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Polyhedron_3_to_lcc.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Polyhedron_3_to_lcc.h
@@ -5,8 +5,8 @@ namespace CGAL{
 Imports `apoly` (a `Polyhedron_3`) into `lcc`, a model of the `LinearCellComplex` concept. Objects are added in `lcc`, existing darts are not modified. Returns a dart created during the import.
 \pre \link GenericMap::dimension `LCC::dimension`\endlink \f$ \geq\f$ 2 and \link LinearCellComplex::ambient_dimension `LCC::ambient_dimension`\endlink==3.
 
-\sa `CGAL::plane_graph_to_lcc<LCC>` (formerly `import_from_plane_graph`)
-\sa `CGAL::triangulation_3_to_lcc<LCC,Triangulation>` (formerly `import_from_triangulation_3`)
+\sa `CGAL::plane_graph_to_lcc<LCC>` 
+\sa `CGAL::triangulation_3_to_lcc<LCC,Triangulation>`
 */
 template<class LCC,class Polyhedron>
 typename LCC::Dart_descriptor polyhedron_3_to_lcc(LCC& lcc,

--- a/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Polyhedron_3_to_lcc.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Polyhedron_3_to_lcc.h
@@ -5,7 +5,7 @@ namespace CGAL{
 Imports `apoly` (a `Polyhedron_3`) into `lcc`, a model of the `LinearCellComplex` concept. Objects are added in `lcc`, existing darts are not modified. Returns a dart created during the import.
 \pre \link GenericMap::dimension `LCC::dimension`\endlink \f$ \geq\f$ 2 and \link LinearCellComplex::ambient_dimension `LCC::ambient_dimension`\endlink==3.
 
-\sa `CGAL::plane_graph_to_lcc<LCC>` 
+\sa `CGAL::read_plane_graph_in_lcc<LCC>` 
 \sa `CGAL::triangulation_3_to_lcc<LCC,Triangulation>`
 */
 template<class LCC,class Polyhedron>

--- a/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Polyhedron_3_to_lcc.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Polyhedron_3_to_lcc.h
@@ -5,10 +5,10 @@ namespace CGAL{
 Imports `apoly` (a `Polyhedron_3`) into `lcc`, a model of the `LinearCellComplex` concept. Objects are added in `lcc`, existing darts are not modified. Returns a dart created during the import.
 \pre \link GenericMap::dimension `LCC::dimension`\endlink \f$ \geq\f$ 2 and \link LinearCellComplex::ambient_dimension `LCC::ambient_dimension`\endlink==3.
 
-\sa `CGAL::import_from_plane_graph<LCC>`
-\sa `CGAL::import_from_triangulation_3<LCC,Triangulation>`
+\sa `CGAL::plane_graph_to_lcc<LCC>` (formerly `import_from_plane_graph`)
+\sa `CGAL::triangulation_3_to_lcc<LCC,Triangulation>` (formerly `import_from_triangulation_3`)
 */
 template<class LCC,class Polyhedron>
-typename LCC::Dart_descriptor import_from_polyhedron_3(LCC& lcc,
+typename LCC::Dart_descriptor polyhedron_3_to_lcc(LCC& lcc,
 const Polyhedron &apoly);
 }

--- a/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Triangulation_3_to_lcc.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Triangulation_3_to_lcc.h
@@ -8,7 +8,7 @@ Objects are added in `lcc`, existing darts are not modified. Returns a dart crea
 \pre \link GenericMap::dimension `LCC::dimension`\endlink \f$ \geq\f$ 3 and
       \link LinearCellComplex::ambient_dimension `LCC::ambient_dimension`\endlink==3.
 
-\sa `CGAL::plane_graph_to_lcc<LCC>` 
+\sa `CGAL::read_plane_graph_in_lcc<LCC>` 
 \sa `CGAL::polyhedron_3_to_lcc<LCC,Polyhedron>` 
 */
 

--- a/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Triangulation_3_to_lcc.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Triangulation_3_to_lcc.h
@@ -3,13 +3,24 @@ namespace CGAL{
 /*!
 \ingroup PkgLinearCellComplexConstructions
 
-Imports `atr` (a `Triangulation_3`) into `lcc`, a model of the `LinearCellComplex` concept. Objects are added in `lcc`, existing darts are not modified. Returns a dart created during the import.
-\pre \link GenericMap::dimension `LCC::dimension`\endlink \f$ \geq\f$ 3 and \link LinearCellComplex::ambient_dimension `LCC::ambient_dimension`\endlink==3.
+Imports `atr` (a `Triangulation_3`) into `lcc`, a model of the `LinearCellComplex` concept.
+Objects are added in `lcc`, existing darts are not modified. Returns a dart created during the import.
+\pre \link GenericMap::dimension `LCC::dimension`\endlink \f$ \geq\f$ 3 and
+      \link LinearCellComplex::ambient_dimension `LCC::ambient_dimension`\endlink==3.
 
-\sa `CGAL::import_from_plane_graph<LCC>`
-\sa `CGAL::import_from_polyhedron_3<LCC,Polyhedron>`
+\sa `CGAL::triangulation_3_to_lcc<LCC,Triangulation>` (formerly `import_from_triangulation_3`)
+\sa `CGAL::plane_graph_to_lcc<LCC>` (formerly `import_from_plane_graph`)
+/// \sa `CGAL::polyhedron_3_to_lcc<LCC,Polyhedron>` (formerly `import_from_polyhedron_3`)
 */
+
 template <class LCC,class Triangulation_>
-typename LCC::Dart_descriptor import_from_triangulation_3(LCC& lcc,
-const Triangulation_&atr);
+typename LCC::Dart_descriptor triangulation_3_to_lcc(LCC& lcc, const Triangulation_&atr);
+
+template <class LCC, class Triangulation_>
+[[deprecated("Use triangulation_3_to_lcc instead")]]
+typename LCC::Dart_descriptor import_from_triangulation_3(LCC& lcc, const Triangulation_& atr)
+{
+  return triangulation_3_to_lcc(lcc, atr);
+}
+
 }

--- a/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Triangulation_3_to_lcc.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Triangulation_3_to_lcc.h
@@ -8,9 +8,8 @@ Objects are added in `lcc`, existing darts are not modified. Returns a dart crea
 \pre \link GenericMap::dimension `LCC::dimension`\endlink \f$ \geq\f$ 3 and
       \link LinearCellComplex::ambient_dimension `LCC::ambient_dimension`\endlink==3.
 
-\sa `CGAL::triangulation_3_to_lcc<LCC,Triangulation>` (formerly `import_from_triangulation_3`)
-\sa `CGAL::plane_graph_to_lcc<LCC>` (formerly `import_from_plane_graph`)
-/// \sa `CGAL::polyhedron_3_to_lcc<LCC,Polyhedron>` (formerly `import_from_polyhedron_3`)
+\sa `CGAL::plane_graph_to_lcc<LCC>` 
+\sa `CGAL::polyhedron_3_to_lcc<LCC,Polyhedron>` 
 */
 
 template <class LCC,class Triangulation_>

--- a/Linear_cell_complex/doc/Linear_cell_complex/Concepts/LinearCellComplexTraits.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/Concepts/LinearCellComplexTraits.h
@@ -64,7 +64,8 @@ which constructs a vector as the difference of points `p2-p1`, and
 \link LinearCellComplexTraits::Vector ` Vector `\endlink `operator() (const CGAL::Origin&, const ` \link Point ` Point`\endlink`& p)`
 which constructs a vector as the difference of point `p` and a point at the origin
 (used in \link CGAL::barycenter `barycenter`\endlink
-and `CGAL::read_plane_graph_in_lcc`).
+and `CGAL::read_plane_graph_in_lcc`).*/
+
 typedef unspecified_type Construct_vector;
 
 /*!

--- a/Linear_cell_complex/doc/Linear_cell_complex/Concepts/LinearCellComplexTraits.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/Concepts/LinearCellComplexTraits.h
@@ -64,8 +64,7 @@ which constructs a vector as the difference of points `p2-p1`, and
 \link LinearCellComplexTraits::Vector ` Vector `\endlink `operator() (const CGAL::Origin&, const ` \link Point ` Point`\endlink`& p)`
 which constructs a vector as the difference of point `p` and a point at the origin
 (used in \link CGAL::barycenter `barycenter`\endlink
-and `CGAL::import_from_plane_graph`).
-*/
+and `CGAL::plane_graph_to_lcc`, formerly `import_from_plane_graph`).
 typedef unspecified_type Construct_vector;
 
 /*!
@@ -104,7 +103,7 @@ a model of \link Kernel::Direction_2 `Direction_2`\endlink.
 typedef unspecified_type Direction_2;
 
 /*!
-a model of \link Kernel::ConstructDirection_2 `ConstructDirection_2`\endlink (used in `CGAL::import_from_plane_graph`).
+a model of \link Kernel::ConstructDirection_2 `ConstructDirection_2`\endlink (used in `CGAL::plane_graph_to_lcc`, formerly `import_from_plane_graph`).
 */
 typedef unspecified_type Construct_direction_2;
 

--- a/Linear_cell_complex/doc/Linear_cell_complex/Concepts/LinearCellComplexTraits.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/Concepts/LinearCellComplexTraits.h
@@ -64,7 +64,7 @@ which constructs a vector as the difference of points `p2-p1`, and
 \link LinearCellComplexTraits::Vector ` Vector `\endlink `operator() (const CGAL::Origin&, const ` \link Point ` Point`\endlink`& p)`
 which constructs a vector as the difference of point `p` and a point at the origin
 (used in \link CGAL::barycenter `barycenter`\endlink
-and `CGAL::plane_graph_to_lcc`, formerly `import_from_plane_graph`).
+and `CGAL::plane_graph_to_lcc`).
 typedef unspecified_type Construct_vector;
 
 /*!
@@ -103,7 +103,7 @@ a model of \link Kernel::Direction_2 `Direction_2`\endlink.
 typedef unspecified_type Direction_2;
 
 /*!
-a model of \link Kernel::ConstructDirection_2 `ConstructDirection_2`\endlink (used in `CGAL::plane_graph_to_lcc`, formerly `import_from_plane_graph`).
+a model of \link Kernel::ConstructDirection_2 `ConstructDirection_2`\endlink (used in `CGAL::plane_graph_to_lcc`).
 */
 typedef unspecified_type Construct_direction_2;
 

--- a/Linear_cell_complex/doc/Linear_cell_complex/Concepts/LinearCellComplexTraits.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/Concepts/LinearCellComplexTraits.h
@@ -64,7 +64,7 @@ which constructs a vector as the difference of points `p2-p1`, and
 \link LinearCellComplexTraits::Vector ` Vector `\endlink `operator() (const CGAL::Origin&, const ` \link Point ` Point`\endlink`& p)`
 which constructs a vector as the difference of point `p` and a point at the origin
 (used in \link CGAL::barycenter `barycenter`\endlink
-and `CGAL::plane_graph_to_lcc`).
+and `CGAL::read_plane_graph_in_lcc`).
 typedef unspecified_type Construct_vector;
 
 /*!
@@ -103,7 +103,7 @@ a model of \link Kernel::Direction_2 `Direction_2`\endlink.
 typedef unspecified_type Direction_2;
 
 /*!
-a model of \link Kernel::ConstructDirection_2 `ConstructDirection_2`\endlink (used in `CGAL::plane_graph_to_lcc`).
+a model of \link Kernel::ConstructDirection_2 `ConstructDirection_2`\endlink (used in `CGAL::read_plane_graph_in_lcc`).
 */
 typedef unspecified_type Construct_direction_2;
 

--- a/Linear_cell_complex/doc/Linear_cell_complex/Linear_cell_complex.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/Linear_cell_complex.txt
@@ -105,11 +105,11 @@ There are several member functions allowing to insert specific configurations of
 
 There are two functions allowing to build a linear cell complex from two other \cgal data types:
 <UL>
-<LI>\link ::import_from_triangulation_3 `import_from_triangulation_3(lcc,atr)`\endlink: adds in `lcc` all the tetrahedra present in `atr`, a \link CGAL::Triangulation_3 `Triangulation_3`\endlink;
-<LI>\link ::import_from_polyhedron_3 `import_from_polyhedron_3(lcc,ap)`\endlink: adds in `lcc` all the cells present in `ap`, a `Polyhedron_3`.
+<LI>\link ::triangulation_3_to_lcc `triangulation_3_to_lcc(lcc,atr)`\endlink: adds in `lcc` all the tetrahedra present in `atr`, a \link CGAL::Triangulation_3 `Triangulation_3`\endlink; (formerly `import_from_triangulation_3`)
+<LI>\link ::polyhedron_3_to_lcc `polyhedron_3_to_lcc(lcc,ap)`\endlink: adds in `lcc` all the cells present in `ap`, a `Polyhedron_3`. (formerly `import_from_polyhedron_3`)
 </UL>
 
-Lastly, the function \link ::import_from_plane_graph `import_from_plane_graph(lcc,ais)`\endlink adds in `lcc` all the cells reconstructed from the planar graph read in `ais`, a `std::istream` (see the  \link ::import_from_plane_graph `reference manual`\endlink for the file format).
+Lastly, the function \link ::plane_graph_to_lcc `plane_graph_to_lcc(lcc,ais)`\endlink (formerly `import_from_plane_graph`) adds in `lcc` all the cells reconstructed from the planar graph read in `ais`, a `std::istream` (see the \link ::plane_graph_to_lcc `reference manual`\endlink for the file format).
 
 \subsection Linear_cell_complexModificationOperations Modification Operations
 \anchor ssecmodifop

--- a/Linear_cell_complex/doc/Linear_cell_complex/Linear_cell_complex.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/Linear_cell_complex.txt
@@ -105,11 +105,11 @@ There are several member functions allowing to insert specific configurations of
 
 There are two functions allowing to build a linear cell complex from two other \cgal data types:
 <UL>
-<LI>\link ::triangulation_3_to_lcc `triangulation_3_to_lcc(lcc,atr)`\endlink: adds in `lcc` all the tetrahedra present in `atr`, a \link CGAL::Triangulation_3 `Triangulation_3`\endlink; (formerly `import_from_triangulation_3`)
-<LI>\link ::polyhedron_3_to_lcc `polyhedron_3_to_lcc(lcc,ap)`\endlink: adds in `lcc` all the cells present in `ap`, a `Polyhedron_3`. (formerly `import_from_polyhedron_3`)
+<LI>\link ::triangulation_3_to_lcc `triangulation_3_to_lcc(lcc,atr)`\endlink: adds in `lcc` all the tetrahedra present in `atr`, a \link CGAL::Triangulation_3 `Triangulation_3`\endlink;
+<LI>\link ::polyhedron_3_to_lcc `polyhedron_3_to_lcc(lcc,ap)`\endlink: adds in `lcc` all the cells present in `ap`, a `Polyhedron_3`.
 </UL>
 
-Lastly, the function \link ::plane_graph_to_lcc `plane_graph_to_lcc(lcc,ais)`\endlink (formerly `import_from_plane_graph`) adds in `lcc` all the cells reconstructed from the planar graph read in `ais`, a `std::istream` (see the \link ::plane_graph_to_lcc `reference manual`\endlink for the file format).
+Lastly, the function \link ::plane_graph_to_lcc `plane_graph_to_lcc(lcc,ais)`\endlink adds in `lcc` all the cells reconstructed from the planar graph read in `ais`, a `std::istream` (see the \link ::plane_graph_to_lcc `reference manual`\endlink for the file format).
 
 \subsection Linear_cell_complexModificationOperations Modification Operations
 \anchor ssecmodifop

--- a/Linear_cell_complex/doc/Linear_cell_complex/Linear_cell_complex.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/Linear_cell_complex.txt
@@ -109,7 +109,7 @@ There are two functions allowing to build a linear cell complex from two other \
 <LI>\link ::polyhedron_3_to_lcc `polyhedron_3_to_lcc(lcc,ap)`\endlink: adds in `lcc` all the cells present in `ap`, a `Polyhedron_3`.
 </UL>
 
-Lastly, the function \link ::plane_graph_to_lcc `plane_graph_to_lcc(lcc,ais)`\endlink adds in `lcc` all the cells reconstructed from the planar graph read in `ais`, a `std::istream` (see the \link ::plane_graph_to_lcc `reference manual`\endlink for the file format).
+Lastly, the function \link ::read_plane_graph_in_lcc `read_plane_graph_in_lcc(lcc,ais)`\endlink adds in `lcc` all the cells reconstructed from the planar graph read in `ais`, a `std::istream` (see the \link ::read_plane_graph_in_lcc `reference manual`\endlink for the file format).
 
 \subsection Linear_cell_complexModificationOperations Modification Operations
 \anchor ssecmodifop

--- a/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
@@ -62,9 +62,10 @@
 
 \cgalCRPSection{Global Functions}
 \cgalCRPSubsection{Constructions for Linear Cell Complex}
-- `CGAL::import_from_plane_graph<LCC>`
-- `CGAL::import_from_triangulation_3<LCC,Triangulation>`
-- `CGAL::import_from_polyhedron_3<LCC,Polyhedron>`
+- `CGAL::plane_graph_to_lcc<LCC>` (formerly `import_from_plane_graph`)
+- `CGAL::triangulation_3_to_lcc<LCC,Triangulation>` (formerly `import_from_triangulation_3`)
+- `CGAL::polyhedron_3_to_lcc<LCC,Polyhedron>` (formerly `import_from_polyhedron_3`)
+- `CGAL::polyhedron_3_flux_to_lcc<LCC>` (formerly `import_from_polyhedron_3_flux`)
 
 \cgalCRPSubsection{Operations for Linear Cell Complex}
 - `CGAL::compute_normal_of_cell_0<LCC>`

--- a/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
@@ -62,7 +62,7 @@
 
 \cgalCRPSection{Global Functions}
 \cgalCRPSubsection{Constructions for Linear Cell Complex}
-- `CGAL::plane_graph_to_lcc<LCC>` (formerly `import_from_plane_graph`)
+- `CGAL::read_plane_graph_in_lcc<LCC>` (formerly `import_from_plane_graph`)
 - `CGAL::triangulation_3_to_lcc<LCC,Triangulation>` (formerly `import_from_triangulation_3`)
 - `CGAL::polyhedron_3_to_lcc<LCC,Polyhedron>` (formerly `import_from_polyhedron_3`)
 

--- a/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/PackageDescription.txt
@@ -65,7 +65,6 @@
 - `CGAL::plane_graph_to_lcc<LCC>` (formerly `import_from_plane_graph`)
 - `CGAL::triangulation_3_to_lcc<LCC,Triangulation>` (formerly `import_from_triangulation_3`)
 - `CGAL::polyhedron_3_to_lcc<LCC,Polyhedron>` (formerly `import_from_polyhedron_3`)
-- `CGAL::polyhedron_3_flux_to_lcc<LCC>` (formerly `import_from_polyhedron_3_flux`)
 
 \cgalCRPSubsection{Operations for Linear Cell Complex}
 - `CGAL::compute_normal_of_cell_0<LCC>`

--- a/Linear_cell_complex/examples/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/examples/Linear_cell_complex/CMakeLists.txt
@@ -24,7 +24,7 @@ create_single_source_cgal_program(
   "linear_cell_complex_3_with_colored_vertices.cpp")
 create_single_source_cgal_program("linear_cell_complex_3_with_mypoint.cpp")
 create_single_source_cgal_program("linear_cell_complex_4.cpp")
-create_single_source_cgal_program("plane_graph_to_lcc_2.cpp")
+create_single_source_cgal_program("read_plane_graph_in_lcc_2.cpp")
 create_single_source_cgal_program("voronoi_2.cpp")
 create_single_source_cgal_program("voronoi_3.cpp")
 

--- a/Linear_cell_complex/examples/Linear_cell_complex/README.txt
+++ b/Linear_cell_complex/examples/Linear_cell_complex/README.txt
@@ -8,7 +8,7 @@ Examples for Linear_cell_complex package:
   Three "basic" examples, detailed in the user manual.
 
 
-* plane_graph_to_lcc_2.cpp
+* read_plane_graph_in_lcc_2.cpp
 
   Program allowing to transform a planar graph into a 2D linear cell complex.
 

--- a/Linear_cell_complex/examples/Linear_cell_complex/plane_graph_to_lcc_2.cpp
+++ b/Linear_cell_complex/examples/Linear_cell_complex/plane_graph_to_lcc_2.cpp
@@ -42,7 +42,7 @@ int main(int narg, char** argv)
 
   std::ifstream is(filename.c_str());
   std::cout<<"Import plane graph from "<<filename<<std::endl;
-  CGAL::import_from_plane_graph(lcc, is);
+  CGAL::plane_graph_to_lcc(lcc, is);
 
   // Display the lcc characteristics.
   std::cout<<"LCC characteristics:"<<std::endl<<"  ";

--- a/Linear_cell_complex/examples/Linear_cell_complex/read_plane_graph_in_lcc_2.cpp
+++ b/Linear_cell_complex/examples/Linear_cell_complex/read_plane_graph_in_lcc_2.cpp
@@ -42,7 +42,7 @@ int main(int narg, char** argv)
 
   std::ifstream is(filename.c_str());
   std::cout<<"Import plane graph from "<<filename<<std::endl;
-  CGAL::plane_graph_to_lcc(lcc, is);
+  CGAL::read_plane_graph_in_lcc(lcc, is);
 
   // Display the lcc characteristics.
   std::cout<<"LCC characteristics:"<<std::endl<<"  ";

--- a/Linear_cell_complex/examples/Linear_cell_complex/voronoi_3.cpp
+++ b/Linear_cell_complex/examples/Linear_cell_complex/voronoi_3.cpp
@@ -134,7 +134,7 @@ int main(int narg, char** argv)
   std::map<Triangulation::Cell_handle,
            LCC_3::Dart_descriptor > vol_to_dart;
 
-  Dart_descriptor d=CGAL::import_from_triangulation_3<LCC_3, Triangulation>
+  Dart_descriptor d=CGAL::triangulation_3_to_lcc<LCC_3, Triangulation>
     (lcc, T, &vol_to_dart);
 
   std::cout<<"Delaunay triangulation :"<<std::endl<<"  ";

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
@@ -23,6 +23,7 @@
 #include <map>
 #include <vector>
 #include <list>
+#include <CGAL/config.h>
 
 namespace CGAL {
 
@@ -130,8 +131,12 @@ namespace CGAL {
     return first;
   }
 
+#ifndef CGAL_NO_DEPRECATED_CODE
+/*!
+  \deprecated This function is deprecated since CGAL 5.6. Use `read_plane_graph_in_lcc()` instead.
+*/
 template< class LCC >
-[[deprecated("Use read_plane_graph_in_lcc instead")]]
+CGAL_DEPRECATED
 typename LCC::Dart_descriptor
 import_from_plane_graph(LCC& alcc,
                         const std::vector<typename LCC::Point>& vertices,
@@ -139,6 +144,7 @@ import_from_plane_graph(LCC& alcc,
 {
   return read_plane_graph_in_lcc(alcc, vertices, edge_indices);
 }
+#endif
 
   /**
    * Imports a plane-embedded graph from a file into a LinearCellComplex.
@@ -198,13 +204,18 @@ import_from_plane_graph(LCC& alcc,
     return read_plane_graph_in_lcc(alcc, vertices, edge_indices);
   }
 
-template <class LCC>
-[[deprecated("Use read_plane_graph_in_lcc instead")]]
+#ifndef CGAL_NO_DEPRECATED_CODE
+/*!
+  \deprecated This function is deprecated since CGAL 5.6. Use `read_plane_graph_in_lcc()` instead.
+*/
+template< class LCC >
+CGAL_DEPRECATED
 typename LCC::Dart_descriptor
 import_from_plane_graph(LCC& alcc, std::istream& ais)
 {
   return read_plane_graph_in_lcc(alcc, ais);
 }
+#endif
 
   template < class LCC >
   typename LCC::Dart_descriptor
@@ -215,13 +226,18 @@ import_from_plane_graph(LCC& alcc, std::istream& ais)
     return read_plane_graph_in_lcc(alcc, input);
   }
 
-template <class LCC>
-[[deprecated("Use read_plane_graph_in_lcc instead")]]
+#ifndef CGAL_NO_DEPRECATED_CODE
+/*!
+  \deprecated This function is deprecated since CGAL 5.6. Use `read_plane_graph_in_lcc()` instead.
+*/
+template< class LCC >
+CGAL_DEPRECATED
 typename LCC::Dart_descriptor
 import_from_plane_graph(LCC& alcc, const char* filename)
 {
   return read_plane_graph_in_lcc(alcc, filename); 
 }
+#endif
 
   template < class LCC >
   bool load_off(LCC& alcc, std::istream& in)

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
@@ -133,7 +133,7 @@ namespace CGAL {
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 /*!
-  \deprecated This function is deprecated since CGAL 5.6. Use `read_plane_graph_in_lcc()` instead.
+  \deprecated This function is deprecated since CGAL 6.2. Use `read_plane_graph_in_lcc()` instead.
 */
 template< class LCC >
 CGAL_DEPRECATED
@@ -206,7 +206,7 @@ import_from_plane_graph(LCC& alcc,
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 /*!
-  \deprecated This function is deprecated since CGAL 5.6. Use `read_plane_graph_in_lcc()` instead.
+  \deprecated This function is deprecated since CGAL 6.2. Use `read_plane_graph_in_lcc()` instead.
 */
 template< class LCC >
 CGAL_DEPRECATED
@@ -228,7 +228,7 @@ import_from_plane_graph(LCC& alcc, std::istream& ais)
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 /*!
-  \deprecated This function is deprecated since CGAL 5.6. Use `read_plane_graph_in_lcc()` instead.
+  \deprecated This function is deprecated since CGAL 6.2. Use `read_plane_graph_in_lcc()` instead.
 */
 template< class LCC >
 CGAL_DEPRECATED

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
@@ -36,7 +36,7 @@ namespace CGAL {
    * Imports a plane-embedded graph from a list of points and edges represented as pairs of vertex indices
    */
   template< class LCC >
-  typename LCC::Dart_descriptor plane_graph_to_lcc(LCC& alcc,
+  typename LCC::Dart_descriptor read_plane_graph_in_lcc(LCC& alcc,
                                                    const std::vector<typename LCC::Point>& vertices,
                                                    const std::vector<size_t>& edge_indices)
   {
@@ -131,13 +131,13 @@ namespace CGAL {
   }
 
 template< class LCC >
-[[deprecated("Use plane_graph_to_lcc instead")]]
+[[deprecated("Use read_plane_graph_in_lcc instead")]]
 typename LCC::Dart_descriptor
 import_from_plane_graph(LCC& alcc,
                         const std::vector<typename LCC::Point>& vertices,
                         const std::vector<size_t>& edge_indices)
 {
-  return plane_graph_to_lcc(alcc, vertices, edge_indices);
+  return read_plane_graph_in_lcc(alcc, vertices, edge_indices);
 }
 
   /**
@@ -148,7 +148,7 @@ import_from_plane_graph(LCC& alcc,
    * @return A dart created during the conversion.
    */
   template< class LCC >
-  typename LCC::Dart_descriptor plane_graph_to_lcc(LCC& alcc,
+  typename LCC::Dart_descriptor read_plane_graph_in_lcc(LCC& alcc,
                                                     std::istream& ais)
   {
     using FT = typename LCC::FT;
@@ -195,32 +195,32 @@ import_from_plane_graph(LCC& alcc,
       edge_indices.push_back(v2);
     }
 
-    return plane_graph_to_lcc(alcc, vertices, edge_indices);
+    return read_plane_graph_in_lcc(alcc, vertices, edge_indices);
   }
 
 template <class LCC>
-[[deprecated("Use plane_graph_to_lcc instead")]]
+[[deprecated("Use read_plane_graph_in_lcc instead")]]
 typename LCC::Dart_descriptor
 import_from_plane_graph(LCC& alcc, std::istream& ais)
 {
-  return plane_graph_to_lcc(alcc, ais);
+  return read_plane_graph_in_lcc(alcc, ais);
 }
 
   template < class LCC >
   typename LCC::Dart_descriptor
-  plane_graph_to_lcc(LCC& alcc, const char* filename)
+  read_plane_graph_in_lcc(LCC& alcc, const char* filename)
   {
     std::ifstream input(filename);
     if (!input.is_open()) return alcc.null_descriptor;
-    return plane_graph_to_lcc(alcc, input);
+    return read_plane_graph_in_lcc(alcc, input);
   }
 
 template <class LCC>
-[[deprecated("Use plane_graph_to_lcc instead")]]
+[[deprecated("Use read_plane_graph_in_lcc instead")]]
 typename LCC::Dart_descriptor
 import_from_plane_graph(LCC& alcc, const char* filename)
 {
-  return plane_graph_to_lcc(alcc, filename); 
+  return read_plane_graph_in_lcc(alcc, filename); 
 }
 
   template < class LCC >

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
@@ -208,7 +208,7 @@ import_from_plane_graph(LCC& alcc, std::istream& ais)
 
   template < class LCC >
   typename LCC::Dart_descriptor
-  iplane_graph_to_lcc(LCC& alcc, const char* filename)
+  plane_graph_to_lcc(LCC& alcc, const char* filename)
   {
     std::ifstream input(filename);
     if (!input.is_open()) return alcc.null_descriptor;
@@ -220,9 +220,7 @@ template <class LCC>
 typename LCC::Dart_descriptor
 import_from_plane_graph(LCC& alcc, const char* filename)
 {
-  std::ifstream input(filename);
-  if (!input.is_open()) return alcc.null_descriptor;
-  return plane_graph_to_lcc(alcc, input); 
+  return plane_graph_to_lcc(alcc, filename); 
 }
 
   template < class LCC >

--- a/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
+++ b/Linear_cell_complex/include/CGAL/Linear_cell_complex_constructors.h
@@ -36,7 +36,7 @@ namespace CGAL {
    * Imports a plane-embedded graph from a list of points and edges represented as pairs of vertex indices
    */
   template< class LCC >
-  typename LCC::Dart_descriptor import_from_plane_graph(LCC& alcc,
+  typename LCC::Dart_descriptor plane_graph_to_lcc(LCC& alcc,
                                                    const std::vector<typename LCC::Point>& vertices,
                                                    const std::vector<size_t>& edge_indices)
   {
@@ -130,6 +130,16 @@ namespace CGAL {
     return first;
   }
 
+template< class LCC >
+[[deprecated("Use plane_graph_to_lcc instead")]]
+typename LCC::Dart_descriptor
+import_from_plane_graph(LCC& alcc,
+                        const std::vector<typename LCC::Point>& vertices,
+                        const std::vector<size_t>& edge_indices)
+{
+  return plane_graph_to_lcc(alcc, vertices, edge_indices);
+}
+
   /**
    * Imports a plane-embedded graph from a file into a LinearCellComplex.
    *
@@ -138,7 +148,7 @@ namespace CGAL {
    * @return A dart created during the conversion.
    */
   template< class LCC >
-  typename LCC::Dart_descriptor import_from_plane_graph(LCC& alcc,
+  typename LCC::Dart_descriptor plane_graph_to_lcc(LCC& alcc,
                                                     std::istream& ais)
   {
     using FT = typename LCC::FT;
@@ -185,17 +195,35 @@ namespace CGAL {
       edge_indices.push_back(v2);
     }
 
-    return import_from_plane_graph(alcc, vertices, edge_indices);
+    return plane_graph_to_lcc(alcc, vertices, edge_indices);
   }
+
+template <class LCC>
+[[deprecated("Use plane_graph_to_lcc instead")]]
+typename LCC::Dart_descriptor
+import_from_plane_graph(LCC& alcc, std::istream& ais)
+{
+  return plane_graph_to_lcc(alcc, ais);
+}
 
   template < class LCC >
   typename LCC::Dart_descriptor
-  import_from_plane_graph(LCC& alcc, const char* filename)
+  iplane_graph_to_lcc(LCC& alcc, const char* filename)
   {
     std::ifstream input(filename);
     if (!input.is_open()) return alcc.null_descriptor;
-    return import_from_plane_graph(alcc, input);
+    return plane_graph_to_lcc(alcc, input);
   }
+
+template <class LCC>
+[[deprecated("Use plane_graph_to_lcc instead")]]
+typename LCC::Dart_descriptor
+import_from_plane_graph(LCC& alcc, const char* filename)
+{
+  std::ifstream input(filename);
+  if (!input.is_open()) return alcc.null_descriptor;
+  return plane_graph_to_lcc(alcc, input); 
+}
 
   template < class LCC >
   bool load_off(LCC& alcc, std::istream& in)

--- a/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
@@ -39,3 +39,21 @@ add_executable(Linear_cell_complex_copy_test_index Linear_cell_complex_copy_test
 target_compile_definitions(Linear_cell_complex_copy_test_index PRIVATE USE_COMPACT_CONTAINER_WITH_INDEX)
 target_link_libraries(Linear_cell_complex_copy_test_index PRIVATE CGAL CGAL::Data)
 cgal_add_compilation_test(Linear_cell_complex_copy_test_index)
+
+# Test sans warning de dépréciation pour test_plane_graph_alias
+add_executable(test_plane_graph_alias_nowarn test_plane_graph_alias.cpp ${hfiles})
+target_compile_definitions(test_plane_graph_alias_nowarn PRIVATE CGAL_NO_DEPRECATION_WARNINGS)
+target_link_libraries(test_plane_graph_alias_nowarn PRIVATE CGAL CGAL::Data)
+cgal_add_compilation_test(test_plane_graph_alias_nowarn)
+
+# Test sans warning de dépréciation pour test_polyhedron_3_alias
+add_executable(test_polyhedron_3_alias_nowarn test_polyhedron_3_alias.cpp ${hfiles})
+target_compile_definitions(test_polyhedron_3_alias_nowarn PRIVATE CGAL_NO_DEPRECATION_WARNINGS)
+target_link_libraries(test_polyhedron_3_alias_nowarn PRIVATE CGAL CGAL::Data)
+cgal_add_compilation_test(test_polyhedron_3_alias_nowarn)
+
+# Test sans warning de dépréciation pour test_triangulation_alias
+add_executable(test_triangulation_alias_nowarn test_triangulation_alias.cpp ${hfiles})
+target_compile_definitions(test_triangulation_alias_nowarn PRIVATE CGAL_NO_DEPRECATION_WARNINGS)
+target_link_libraries(test_triangulation_alias_nowarn PRIVATE CGAL CGAL::Data)
+cgal_add_compilation_test(test_triangulation_alias_nowarn)

--- a/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
@@ -37,20 +37,12 @@ target_compile_definitions(Linear_cell_complex_copy_test_index PRIVATE USE_COMPA
 target_link_libraries(Linear_cell_complex_copy_test_index PRIVATE CGAL CGAL::Data)
 cgal_add_compilation_test(Linear_cell_complex_copy_test_index)
 
-# Test sans warning de dépréciation pour test_plane_graph_alias
-add_executable(test_plane_graph_alias_nowarn test_plane_graph_alias.cpp ${hfiles})
-target_compile_definitions(test_plane_graph_alias_nowarn PRIVATE CGAL_NO_DEPRECATION_WARNINGS)
-target_link_libraries(test_plane_graph_alias_nowarn PRIVATE CGAL CGAL::Data)
-cgal_add_compilation_test(test_plane_graph_alias_nowarn)
+# Alias tests (test old function names, with deprecated warnings disabled)
+create_single_source_cgal_program(test_triangulation_alias.cpp ${hfiles})
+target_compile_definitions(test_triangulation_alias PRIVATE CGAL_NO_DEPRECATION_WARNINGS)
 
-# Test sans warning de dépréciation pour test_polyhedron_3_alias
-add_executable(test_polyhedron_3_alias_nowarn test_polyhedron_3_alias.cpp ${hfiles})
-target_compile_definitions(test_polyhedron_3_alias_nowarn PRIVATE CGAL_NO_DEPRECATION_WARNINGS)
-target_link_libraries(test_polyhedron_3_alias_nowarn PRIVATE CGAL CGAL::Data)
-cgal_add_compilation_test(test_polyhedron_3_alias_nowarn)
+create_single_source_cgal_program(test_polyhedron_3_alias.cpp ${hfiles})
+target_compile_definitions(test_polyhedron_3_alias PRIVATE CGAL_NO_DEPRECATION_WARNINGS)
 
-# Test sans warning de dépréciation pour test_triangulation_alias
-add_executable(test_triangulation_alias_nowarn test_triangulation_alias.cpp ${hfiles})
-target_compile_definitions(test_triangulation_alias_nowarn PRIVATE CGAL_NO_DEPRECATION_WARNINGS)
-target_link_libraries(test_triangulation_alias_nowarn PRIVATE CGAL CGAL::Data)
-cgal_add_compilation_test(test_triangulation_alias_nowarn)
+create_single_source_cgal_program(test_plane_graph_alias.cpp ${hfiles})
+target_compile_definitions(test_plane_graph_alias PRIVATE CGAL_NO_DEPRECATION_WARNINGS)

--- a/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
@@ -15,6 +15,9 @@ create_single_source_cgal_program(Linear_cell_complex_3_test.cpp ${hfiles})
 create_single_source_cgal_program(Linear_cell_complex_4_test.cpp ${hfiles})
 create_single_source_cgal_program(Linear_cell_complex_copy_test.cpp ${hfiles})
 create_single_source_cgal_program(LCC_3_incremental_builder_test.cpp ${hfiles})
+create_single_source_cgal_program(test_triangulation_alias.cpp ${hfiles})
+create_single_source_cgal_program(test_polyhedron_3_alias.cpp ${hfiles})
+create_single_source_cgal_program(test_plane_graph_alias.cpp ${hfiles})
 
 # Same targets, defining USE_COMPACT_CONTAINER_WITH_INDEX to test index version
 add_executable(Linear_cell_complex_2_test_index Linear_cell_complex_2_test.cpp ${hfiles})

--- a/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
@@ -15,9 +15,6 @@ create_single_source_cgal_program(Linear_cell_complex_3_test.cpp ${hfiles})
 create_single_source_cgal_program(Linear_cell_complex_4_test.cpp ${hfiles})
 create_single_source_cgal_program(Linear_cell_complex_copy_test.cpp ${hfiles})
 create_single_source_cgal_program(LCC_3_incremental_builder_test.cpp ${hfiles})
-create_single_source_cgal_program(test_triangulation_alias.cpp ${hfiles})
-create_single_source_cgal_program(test_polyhedron_3_alias.cpp ${hfiles})
-create_single_source_cgal_program(test_plane_graph_alias.cpp ${hfiles})
 
 # Same targets, defining USE_COMPACT_CONTAINER_WITH_INDEX to test index version
 add_executable(Linear_cell_complex_2_test_index Linear_cell_complex_2_test.cpp ${hfiles})

--- a/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_2_test.h
+++ b/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_2_test.h
@@ -382,7 +382,7 @@ bool test_LCC_2()
       std::cout<<"Error: impossible to open 'data/graph.txt'"<<std::endl;
       return false;
     }
-    CGAL::plane_graph_to_lcc<LCC>(lcc,in);
+    CGAL::read_plane_graph_in_lcc<LCC>(lcc,in);
     if ( !check_number_of_cells_2(lcc, 66, 166, 104, 2) )
       return false;
     lcc.clear();
@@ -431,7 +431,7 @@ struct Test_change_orientation_LCC_2<LCC, CGAL::Combinatorial_map_tag>
       std::cout<<"Error: impossible to open 'data/graph.txt'"<<std::endl;
       return false;
     }
-    CGAL::plane_graph_to_lcc<LCC>(lcc,in);
+    CGAL::read_plane_graph_in_lcc<LCC>(lcc,in);
 
     trace_test_begin();
 

--- a/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_2_test.h
+++ b/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_2_test.h
@@ -382,7 +382,7 @@ bool test_LCC_2()
       std::cout<<"Error: impossible to open 'data/graph.txt'"<<std::endl;
       return false;
     }
-    CGAL::import_from_plane_graph<LCC>(lcc,in);
+    CGAL::plane_graph_to_lcc<LCC>(lcc,in);
     if ( !check_number_of_cells_2(lcc, 66, 166, 104, 2) )
       return false;
     lcc.clear();
@@ -431,7 +431,7 @@ struct Test_change_orientation_LCC_2<LCC, CGAL::Combinatorial_map_tag>
       std::cout<<"Error: impossible to open 'data/graph.txt'"<<std::endl;
       return false;
     }
-    CGAL::import_from_plane_graph<LCC>(lcc,in);
+    CGAL::plane_graph_to_lcc<LCC>(lcc,in);
 
     trace_test_begin();
 

--- a/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_3_test.h
+++ b/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_3_test.h
@@ -997,7 +997,7 @@ bool test_LCC_3()
     }
     in >> P;
 
-    CGAL::import_from_polyhedron_3<LCC>(lcc,P);
+    CGAL::polyhedron_3_flux_to_lcc<LCC>(lcc,P);
     if ( !check_number_of_cells_3(lcc, 1539, 4434, 2894, 2, 2) )
       return false;
 
@@ -1029,7 +1029,7 @@ bool test_LCC_3()
     }
     T.insert ( std::istream_iterator < Point >(in),
                std::istream_iterator < Point >() );
-    CGAL::import_from_triangulation_3<LCC>(lcc,T);
+    CGAL::triangulation_3_to_lcc<LCC>(lcc,T);
     if ( !lcc.is_valid() )
       return false;
 

--- a/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_3_test.h
+++ b/Linear_cell_complex/test/Linear_cell_complex/Linear_cell_complex_3_test.h
@@ -997,7 +997,7 @@ bool test_LCC_3()
     }
     in >> P;
 
-    CGAL::polyhedron_3_flux_to_lcc<LCC>(lcc,P);
+    CGAL::polyhedron_3_to_lcc<LCC>(lcc,P);
     if ( !check_number_of_cells_3(lcc, 1539, 4434, 2894, 2, 2) )
       return false;
 

--- a/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
@@ -2,6 +2,7 @@
 #include <CGAL/Linear_cell_complex_constructors.h>
 #include <cassert>
 #include <sstream>
+#include <cstdlib>
 
 typedef CGAL::Linear_cell_complex_for_combinatorial_map<2> LCC;
 
@@ -25,5 +26,5 @@ int main()
   auto d2 = CGAL::import_from_plane_graph(lcc2, input);
   assert(d2 != LCC::null_descriptor);
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
@@ -22,9 +22,11 @@ int main()
   input.clear();
   input.seekg(0, std::ios::beg);
 
+  #if !defined(CGAL_NO_DEPRECATED_CODE) && !defined(CGAL_NO_DEPRECATION_WARNINGS)
   // Test deprecated function
   auto d2 = CGAL::import_from_plane_graph(lcc2, input);
   assert(d2 != LCC::null_descriptor);
+  #endif
 
   return EXIT_SUCCESS;
 }

--- a/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
@@ -1,3 +1,4 @@
+#include <CGAL/Installation/internal/disable_deprecation_warnings_and_errors.h>
 #include <CGAL/Linear_cell_complex_for_combinatorial_map.h>
 #include <CGAL/Linear_cell_complex_constructors.h>
 #include <cassert>
@@ -22,7 +23,7 @@ int main()
   input.clear();
   input.seekg(0, std::ios::beg);
 
-  #if !defined(CGAL_NO_DEPRECATED_CODE) && !defined(CGAL_NO_DEPRECATION_WARNINGS)
+  #ifndef CGAL_NO_DEPRECATED_CODE
   // Test deprecated function
   auto d2 = CGAL::import_from_plane_graph(lcc2, input);
   assert(d2 != LCC::null_descriptor);

--- a/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
@@ -15,7 +15,7 @@ int main()
   input << "3 3\n0.0 0.0\n1.0 0.0\n0.0 1.0\n0 1\n1 2\n2 0\n";
 
   // Test new function
-  auto d1 = CGAL::plane_graph_to_lcc(lcc1, input);
+  auto d1 = CGAL::read_plane_graph_in_lcc(lcc1, input);
   assert(d1 != LCC::null_descriptor);
 
   // Rewind input stream for second test

--- a/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
@@ -1,0 +1,29 @@
+#include <CGAL/Linear_cell_complex_for_combinatorial_map.h>
+#include <CGAL/Linear_cell_complex_constructors.h>
+#include <cassert>
+#include <sstream>
+
+typedef CGAL::Linear_cell_complex_for_combinatorial_map<2> LCC;
+
+int main()
+{
+  LCC lcc1, lcc2;
+
+  // Planar graph with 3 vertices and 3 edges (triangle)
+  std::stringstream input;
+  input << "3 3\n0.0 0.0\n1.0 0.0\n0.0 1.0\n0 1\n1 2\n2 0\n";
+
+  // Test new function
+  auto d1 = CGAL::plane_graph_to_lcc(lcc1, input);
+  assert(d1 != LCC::null_descriptor);
+
+  // Rewind input stream for second test
+  input.clear();
+  input.seekg(0, std::ios::beg);
+
+  // Test deprecated function
+  auto d2 = CGAL::import_from_plane_graph(lcc2, input);
+  assert(d2 != LCC::null_descriptor);
+
+  return 0;
+}

--- a/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
@@ -7,6 +7,8 @@
 
 typedef CGAL::Linear_cell_complex_for_combinatorial_map<2> LCC;
 
+#ifndef CGAL_NO_DEPRECATED_CODE
+
 int main()
 {
   LCC lcc1, lcc2;
@@ -23,11 +25,11 @@ int main()
   input.clear();
   input.seekg(0, std::ios::beg);
 
-  #ifndef CGAL_NO_DEPRECATED_CODE
   // Test deprecated function
   auto d2 = CGAL::import_from_plane_graph(lcc2, input);
   assert(d2 != LCC::null_descriptor);
-  #endif
 
   return EXIT_SUCCESS;
 }
+
+#endif // CGAL_NO_DEPRECATED_CODE

--- a/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_plane_graph_alias.cpp
@@ -7,10 +7,11 @@
 
 typedef CGAL::Linear_cell_complex_for_combinatorial_map<2> LCC;
 
-#ifndef CGAL_NO_DEPRECATED_CODE
+
 
 int main()
 {
+#ifndef CGAL_NO_DEPRECATED_CODE
   LCC lcc1, lcc2;
 
   // Planar graph with 3 vertices and 3 edges (triangle)
@@ -28,8 +29,7 @@ int main()
   // Test deprecated function
   auto d2 = CGAL::import_from_plane_graph(lcc2, input);
   assert(d2 != LCC::null_descriptor);
-
+#endif // CGAL_NO_DEPRECATED_CODE
   return EXIT_SUCCESS;
 }
 
-#endif // CGAL_NO_DEPRECATED_CODE

--- a/Linear_cell_complex/test/Linear_cell_complex/test_polyhedron_3_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_polyhedron_3_alias.cpp
@@ -3,6 +3,7 @@
 #include <CGAL/Polyhedron_3_to_lcc.h> 
 #include <sstream>
 #include <cassert>
+#include <cstdlib>
 
 typedef CGAL::Linear_cell_complex_for_combinatorial_map<3> LCC;
 typedef CGAL::Polyhedron_3<LCC::Traits> Polyhedron;
@@ -22,5 +23,5 @@ int main()
   auto d2 = CGAL::import_from_polyhedron_3<LCC>(lcc2, P); 
   assert(d2 == LCC::null_descriptor);
 
-  return 0;
+  return EXIT_SUCCESS;
 }

--- a/Linear_cell_complex/test/Linear_cell_complex/test_polyhedron_3_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_polyhedron_3_alias.cpp
@@ -20,8 +20,10 @@ int main()
   auto d1 = CGAL::polyhedron_3_to_lcc(lcc1, P); 
   assert(d1 == LCC::null_descriptor);
 
+#if !defined(CGAL_NO_DEPRECATED_CODE) && !defined(CGAL_NO_DEPRECATION_WARNINGS)
   auto d2 = CGAL::import_from_polyhedron_3<LCC>(lcc2, P); 
   assert(d2 == LCC::null_descriptor);
+#endif
 
   return EXIT_SUCCESS;
 }

--- a/Linear_cell_complex/test/Linear_cell_complex/test_polyhedron_3_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_polyhedron_3_alias.cpp
@@ -9,6 +9,8 @@
 typedef CGAL::Linear_cell_complex_for_combinatorial_map<3> LCC;
 typedef CGAL::Polyhedron_3<LCC::Traits> Polyhedron;
 
+#ifndef CGAL_NO_DEPRECATED_CODE
+
 int main()
 {
   std::stringstream ss("OFF\n0 0 0\n");
@@ -21,10 +23,10 @@ int main()
   auto d1 = CGAL::polyhedron_3_to_lcc(lcc1, P); 
   assert(d1 == LCC::null_descriptor);
 
-#ifndef CGAL_NO_DEPRECATED_CODE
   auto d2 = CGAL::import_from_polyhedron_3<LCC>(lcc2, P); 
   assert(d2 == LCC::null_descriptor);
-#endif
 
   return EXIT_SUCCESS;
 }
+
+#endif // CGAL_NO_DEPRECATED_CODE

--- a/Linear_cell_complex/test/Linear_cell_complex/test_polyhedron_3_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_polyhedron_3_alias.cpp
@@ -1,0 +1,26 @@
+#include <CGAL/Linear_cell_complex_for_combinatorial_map.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Polyhedron_3_to_lcc.h> 
+#include <sstream>
+#include <cassert>
+
+typedef CGAL::Linear_cell_complex_for_combinatorial_map<3> LCC;
+typedef CGAL::Polyhedron_3<LCC::Traits> Polyhedron;
+
+int main()
+{
+  std::stringstream ss("OFF\n0 0 0\n");
+
+  Polyhedron P;
+  ss >> P;
+
+  LCC lcc1, lcc2;
+
+  auto d1 = CGAL::polyhedron_3_to_lcc(lcc1, P); 
+  assert(d1 == LCC::null_descriptor);
+
+  auto d2 = CGAL::import_from_polyhedron_3<LCC>(lcc2, P); 
+  assert(d2 == LCC::null_descriptor);
+
+  return 0;
+}

--- a/Linear_cell_complex/test/Linear_cell_complex/test_polyhedron_3_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_polyhedron_3_alias.cpp
@@ -1,4 +1,5 @@
 #include <CGAL/Linear_cell_complex_for_combinatorial_map.h>
+#include <CGAL/Installation/internal/disable_deprecation_warnings_and_errors.h>
 #include <CGAL/Polyhedron_3.h>
 #include <CGAL/Polyhedron_3_to_lcc.h> 
 #include <sstream>
@@ -20,7 +21,7 @@ int main()
   auto d1 = CGAL::polyhedron_3_to_lcc(lcc1, P); 
   assert(d1 == LCC::null_descriptor);
 
-#if !defined(CGAL_NO_DEPRECATED_CODE) && !defined(CGAL_NO_DEPRECATION_WARNINGS)
+#ifndef CGAL_NO_DEPRECATED_CODE
   auto d2 = CGAL::import_from_polyhedron_3<LCC>(lcc2, P); 
   assert(d2 == LCC::null_descriptor);
 #endif

--- a/Linear_cell_complex/test/Linear_cell_complex/test_polyhedron_3_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_polyhedron_3_alias.cpp
@@ -9,10 +9,10 @@
 typedef CGAL::Linear_cell_complex_for_combinatorial_map<3> LCC;
 typedef CGAL::Polyhedron_3<LCC::Traits> Polyhedron;
 
-#ifndef CGAL_NO_DEPRECATED_CODE
 
 int main()
 {
+#ifndef CGAL_NO_DEPRECATED_CODE
   std::stringstream ss("OFF\n0 0 0\n");
 
   Polyhedron P;
@@ -25,8 +25,7 @@ int main()
 
   auto d2 = CGAL::import_from_polyhedron_3<LCC>(lcc2, P); 
   assert(d2 == LCC::null_descriptor);
-
+#endif // CGAL_NO_DEPRECATED_CODE
   return EXIT_SUCCESS;
 }
 
-#endif // CGAL_NO_DEPRECATED_CODE

--- a/Linear_cell_complex/test/Linear_cell_complex/test_triangulation_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_triangulation_alias.cpp
@@ -8,6 +8,8 @@
 typedef CGAL::Linear_cell_complex_for_combinatorial_map<3> LCC_3;
 typedef CGAL::Delaunay_triangulation_3<LCC_3::Traits> Triangulation;
 
+#ifndef CGAL_NO_DEPRECATED_CODE
+
 int main()
 {
   LCC_3 lcc1, lcc2;
@@ -18,10 +20,10 @@ int main()
   auto d1 = CGAL::triangulation_3_to_lcc(lcc1, T);
   assert(d1 == LCC_3::null_descriptor);
 
-#ifndef CGAL_NO_DEPRECATED_CODE
   auto d2 = CGAL::import_from_triangulation_3(lcc2, T);
   assert(d2 == LCC_3::null_descriptor);
-#endif
 
   return EXIT_SUCCESS;
 }
+
+#endif // CGAL_NO_DEPRECATED_CODE

--- a/Linear_cell_complex/test/Linear_cell_complex/test_triangulation_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_triangulation_alias.cpp
@@ -1,0 +1,23 @@
+#include <CGAL/Linear_cell_complex_for_combinatorial_map.h>
+#include <CGAL/Delaunay_triangulation_3.h>
+#include <CGAL/Triangulation_3_to_lcc.h>
+#include <cassert>
+
+typedef CGAL::Linear_cell_complex_for_combinatorial_map<3> LCC_3;
+typedef CGAL::Delaunay_triangulation_3<LCC_3::Traits> Triangulation;
+
+int main()
+{
+  LCC_3 lcc1, lcc2;
+  Triangulation T;
+
+  assert(T.dimension() == -1);
+
+  auto d1 = CGAL::triangulation_3_to_lcc(lcc1, T);
+  assert(d1 == LCC_3::null_descriptor);
+
+  auto d2 = CGAL::import_from_triangulation_3(lcc2, T);
+  assert(d2 == LCC_3::null_descriptor);
+
+  return 0;
+}

--- a/Linear_cell_complex/test/Linear_cell_complex/test_triangulation_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_triangulation_alias.cpp
@@ -2,6 +2,7 @@
 #include <CGAL/Delaunay_triangulation_3.h>
 #include <CGAL/Triangulation_3_to_lcc.h>
 #include <cassert>
+#include <cstdlib>
 
 typedef CGAL::Linear_cell_complex_for_combinatorial_map<3> LCC_3;
 typedef CGAL::Delaunay_triangulation_3<LCC_3::Traits> Triangulation;
@@ -19,5 +20,6 @@ int main()
   auto d2 = CGAL::import_from_triangulation_3(lcc2, T);
   assert(d2 == LCC_3::null_descriptor);
 
-  return 0;
+  return EXIT_SUCCESS;
 }
+

--- a/Linear_cell_complex/test/Linear_cell_complex/test_triangulation_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_triangulation_alias.cpp
@@ -8,10 +8,11 @@
 typedef CGAL::Linear_cell_complex_for_combinatorial_map<3> LCC_3;
 typedef CGAL::Delaunay_triangulation_3<LCC_3::Traits> Triangulation;
 
-#ifndef CGAL_NO_DEPRECATED_CODE
+
 
 int main()
 {
+#ifndef CGAL_NO_DEPRECATED_CODE
   LCC_3 lcc1, lcc2;
   Triangulation T;
 
@@ -22,8 +23,7 @@ int main()
 
   auto d2 = CGAL::import_from_triangulation_3(lcc2, T);
   assert(d2 == LCC_3::null_descriptor);
-
+#endif // CGAL_NO_DEPRECATED_CODE
   return EXIT_SUCCESS;
 }
 
-#endif // CGAL_NO_DEPRECATED_CODE

--- a/Linear_cell_complex/test/Linear_cell_complex/test_triangulation_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_triangulation_alias.cpp
@@ -17,9 +17,10 @@ int main()
   auto d1 = CGAL::triangulation_3_to_lcc(lcc1, T);
   assert(d1 == LCC_3::null_descriptor);
 
+#if !defined(CGAL_NO_DEPRECATED_CODE) && !defined(CGAL_NO_DEPRECATION_WARNINGS)
   auto d2 = CGAL::import_from_triangulation_3(lcc2, T);
   assert(d2 == LCC_3::null_descriptor);
+#endif
 
   return EXIT_SUCCESS;
 }
-

--- a/Linear_cell_complex/test/Linear_cell_complex/test_triangulation_alias.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/test_triangulation_alias.cpp
@@ -1,4 +1,5 @@
 #include <CGAL/Linear_cell_complex_for_combinatorial_map.h>
+#include <CGAL/Installation/internal/disable_deprecation_warnings_and_errors.h>
 #include <CGAL/Delaunay_triangulation_3.h>
 #include <CGAL/Triangulation_3_to_lcc.h>
 #include <cassert>
@@ -17,7 +18,7 @@ int main()
   auto d1 = CGAL::triangulation_3_to_lcc(lcc1, T);
   assert(d1 == LCC_3::null_descriptor);
 
-#if !defined(CGAL_NO_DEPRECATED_CODE) && !defined(CGAL_NO_DEPRECATION_WARNINGS)
+#ifndef CGAL_NO_DEPRECATED_CODE
   auto d2 = CGAL::import_from_triangulation_3(lcc2, T);
   assert(d2 == LCC_3::null_descriptor);
 #endif

--- a/Polyhedron/include/CGAL/Polyhedron_3_to_lcc.h
+++ b/Polyhedron/include/CGAL/Polyhedron_3_to_lcc.h
@@ -98,7 +98,7 @@ namespace CGAL {
 #ifndef CGAL_NO_DEPRECATED_CODE
 
 /*!
-  \deprecated This function is deprecated since CGAL 5.6. Use `polyhedron_3_to_lcc()` instead.
+  \deprecated This function is deprecated since CGAL 6.2. Use `polyhedron_3_to_lcc()` instead.
 */
 template< class LCC, class Polyhedron >
 CGAL_DEPRECATED

--- a/Polyhedron/include/CGAL/Polyhedron_3_to_lcc.h
+++ b/Polyhedron/include/CGAL/Polyhedron_3_to_lcc.h
@@ -122,14 +122,6 @@ import_from_polyhedron_3(LCC& alcc, const Polyhedron &apoly)
                                     <typename LCC::Traits> > (alcc, P);
   }
 
-template < class LCC >
-[[deprecated("Use polyhedron_3_flux_to_lcc instead")]]
-typename LCC::Dart_descriptor
-import_from_polyhedron_3_flux(LCC& alcc, std::istream& ais)
-{
-  return polyhedron_3_flux_to_lcc(alcc, ais);
-}
-
 } // namespace CGAL
 
 #endif // CGAL_IMPORT_FROM_POLYHEDRON_3_H

--- a/Polyhedron/include/CGAL/Polyhedron_3_to_lcc.h
+++ b/Polyhedron/include/CGAL/Polyhedron_3_to_lcc.h
@@ -21,6 +21,7 @@
 #include <iostream>
 #include <map>
 #include <CGAL/Polyhedron_3.h>
+#include <CGAL/config.h>
 
 namespace CGAL {
 
@@ -94,13 +95,20 @@ namespace CGAL {
     return firstAll;
   }
 
+#ifndef CGAL_NO_DEPRECATED_CODE
+
+/*!
+  \deprecated This function is deprecated since CGAL 5.6. Use `polyhedron_3_to_lcc()` instead.
+*/
 template< class LCC, class Polyhedron >
-[[deprecated("Use polyhedron_3_to_lcc instead")]]
+CGAL_DEPRECATED
 typename LCC::Dart_descriptor
 import_from_polyhedron_3(LCC& alcc, const Polyhedron &apoly)
 {
   return polyhedron_3_to_lcc<LCC, Polyhedron>(alcc, apoly);
 }
+
+#endif // CGAL_NO_DEPRECATED_CODE
 
   /** Convert a Polyhedron_3 read into a flux into 3D linear cell complex.
    * @param alcc the linear cell complex where Polyhedron_3 will be converted.

--- a/Polyhedron/include/CGAL/Polyhedron_3_to_lcc.h
+++ b/Polyhedron/include/CGAL/Polyhedron_3_to_lcc.h
@@ -30,7 +30,7 @@ namespace CGAL {
    * @return A dart created during the conversion.
    */
   template< class LCC, class Polyhedron >
-  typename LCC::Dart_descriptor import_from_polyhedron_3(LCC& alcc,
+  typename LCC::Dart_descriptor polyhedron_3_to_lcc(LCC& alcc,
                                                      const Polyhedron &apoly)
   {
     static_assert( LCC::dimension>=2 && LCC::ambient_dimension==3 );
@@ -94,6 +94,14 @@ namespace CGAL {
     return firstAll;
   }
 
+template< class LCC, class Polyhedron >
+[[deprecated("Use polyhedron_3_to_lcc instead")]]
+typename LCC::Dart_descriptor
+import_from_polyhedron_3(LCC& alcc, const Polyhedron &apoly)
+{
+  return polyhedron_3_to_lcc<LCC, Polyhedron>(alcc, apoly);
+}
+
   /** Convert a Polyhedron_3 read into a flux into 3D linear cell complex.
    * @param alcc the linear cell complex where Polyhedron_3 will be converted.
    * @param ais the istream where read the Polyhedron_3.
@@ -101,7 +109,7 @@ namespace CGAL {
    */
   template < class LCC >
   typename LCC::Dart_descriptor
-  import_from_polyhedron_3_flux(LCC& alcc, std::istream& ais)
+  polyhedron_3_flux_to_lcc(LCC& alcc, std::istream& ais)
   {
     if (!ais.good())
     {
@@ -110,9 +118,17 @@ namespace CGAL {
     }
     CGAL::Polyhedron_3<typename LCC::Traits> P;
     ais >> P;
-    return import_from_polyhedron_3<LCC, CGAL::Polyhedron_3
+    return polyhedron_3_to_lcc<LCC, CGAL::Polyhedron_3
                                     <typename LCC::Traits> > (alcc, P);
   }
+
+template < class LCC >
+[[deprecated("Use polyhedron_3_flux_to_lcc instead")]]
+typename LCC::Dart_descriptor
+import_from_polyhedron_3_flux(LCC& alcc, std::istream& ais)
+{
+  return polyhedron_3_flux_to_lcc(alcc, ais);
+}
 
 } // namespace CGAL
 

--- a/Triangulation_3/include/CGAL/Triangulation_3_to_lcc.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3_to_lcc.h
@@ -19,6 +19,7 @@
 #include <CGAL/assertions.h>
 #include <map>
 #include <CGAL/Weighted_point_3.h>
+#include <CGAL/config.h>
 
 namespace CGAL {
 
@@ -149,15 +150,20 @@ namespace CGAL {
     return dart;
   }
 
-  template < class LCC, class Triangulation >
-[[deprecated("Use triangulation_3_to_lcc instead")]]
-typename LCC::Dart_descriptor import_from_triangulation_3
-(LCC& alcc, const Triangulation &atr,
- std::map<typename Triangulation::Cell_handle,
-          typename LCC::Dart_descriptor >* avol_to_dart=nullptr)
+#ifndef CGAL_NO_DEPRECATED_CODE
+/*!
+  \deprecated This function is deprecated since CGAL 5.6. Use `triangulation_3_to_lcc()` instead.
+*/
+template <class LCC, class Triangulation>
+CGAL_DEPRECATED
+typename LCC::Dart_descriptor
+import_from_triangulation_3(LCC& alcc, const Triangulation& atr,
+                            std::map<typename Triangulation::Cell_handle,
+                                     typename LCC::Dart_descriptor>* avol_to_dart = nullptr)
 {
   return triangulation_3_to_lcc(alcc, atr, avol_to_dart);
 }
+#endif
 
 } // namespace CGAL
 

--- a/Triangulation_3/include/CGAL/Triangulation_3_to_lcc.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3_to_lcc.h
@@ -152,7 +152,7 @@ namespace CGAL {
 
 #ifndef CGAL_NO_DEPRECATED_CODE
 /*!
-  \deprecated This function is deprecated since CGAL 5.6. Use `triangulation_3_to_lcc()` instead.
+  \deprecated This function is deprecated since CGAL 6.2. Use `triangulation_3_to_lcc()` instead.
 */
 template <class LCC, class Triangulation>
 CGAL_DEPRECATED

--- a/Triangulation_3/include/CGAL/Triangulation_3_to_lcc.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3_to_lcc.h
@@ -47,7 +47,7 @@ namespace CGAL {
    * @return A dart incident to the infinite vertex.
    */
   template < class LCC, class Triangulation >
-  typename LCC::Dart_descriptor import_from_triangulation_3
+  typename LCC::Dart_descriptor triangulation_3_to_lcc
   (LCC& alcc, const Triangulation &atr,
    std::map<typename Triangulation::Cell_handle,
             typename LCC::Dart_descriptor >* avol_to_dart=nullptr)
@@ -148,6 +148,16 @@ namespace CGAL {
     CGAL_assertion(dart!=LCC::null_descriptor);
     return dart;
   }
+
+  template < class LCC, class Triangulation >
+[[deprecated("Use triangulation_3_to_lcc instead")]]
+typename LCC::Dart_descriptor import_from_triangulation_3
+(LCC& alcc, const Triangulation &atr,
+ std::map<typename Triangulation::Cell_handle,
+          typename LCC::Dart_descriptor >* avol_to_dart=nullptr)
+{
+  return triangulation_3_to_lcc(alcc, atr, avol_to_dart);
+}
 
 } // namespace CGAL
 


### PR DESCRIPTION
## Summary of Changes

This Small Feature renames four legacy import functions from the `Linear_cell_complex` package to improve naming clarity and consistency:

- `import_from_plane_graph` → `plane_graph_to_lcc` (2D graph input)
- `import_from_polyhedron_3` → `polyhedron_3_to_lcc` (Polyhedron_3 input)
- `import_from_triangulation_3` → `triangulation_3_to_lcc` (3D Triangulation input)
- `import_from_polyhedron_3_flux` → `polyhedron_3_flux_to_lcc` (Polyhedron_3 with "flux" behavior)

Each deprecated function is marked with `[[deprecated("Use new_name instead")]]` and forwards to the new function name, ensuring full backward compatibility.

All function usages have been updated across the CGAL codebase:
- C++ headers and source files
- Doxygen documentation (`.txt` and `.h`)
- Related demo and example files
- One alias unit test has been added for each renamed function to validate backward compatibility.

---

## Release Management

- **Affected package**: `Linear_cell_complex`
- **License**: LGPL
- **Branch**: `Small_feature/rename_functions_with_deprecated`
- **Tests**: Alias tests created for each deprecated function
- **CHANGES.md**: To be added after review

---

## Wiki Page

See: [Features/Small_Features/RenameImportFunctionsWithDeprecation](https://cgal.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/RenameImportFunctionsWithDeprecation)

### July 15, 2025 – Deprecation Warnings Fix

Following reviewer feedback, the alias tests have been updated to conditionally compile the deprecated function calls using:

```cpp
#if !defined(CGAL_NO_DEPRECATED_CODE) && !defined(CGAL_NO_DEPRECATION_WARNINGS)
```

This ensures:
- Deprecated code is tested **only when allowed**
- Builds remain warning-free when CGAL_NO_DEPRECATION_WARNINGS is defined
- Full compliance with the [CGAL Deprecation Wiki](https://github.com/CGAL/cgal/wiki/Code-Depreciation)

All three alias test files have been updated accordingly.