### PR TITLE
Fixes incorrect logic in triangle mesh validation (Issue #<8972>)

### DIFF
--- a/AABB_tree/examples/AABB_tree/AABB_cached_bbox_example.cpp
+++ b/AABB_tree/examples/AABB_tree/AABB_cached_bbox_example.cpp
@@ -27,7 +27,7 @@ void triangle_mesh(std::string fname)
   typedef CGAL::AABB_tree<Traits> Tree;
 
   TriangleMesh tmesh;
-  if(!CGAL::IO::read_polygon_mesh(fname, tmesh) || CGAL::is_triangle_mesh(tmesh))
+  if(!CGAL::IO::read_polygon_mesh(fname, tmesh) || !CGAL::is_triangle_mesh(tmesh))
   {
     std::cerr << "Invalid input." << std::endl;
     return;


### PR DESCRIPTION
## Summary
Fixes incorrect logic in triangle mesh validation (Issue #<8972>)

## Changes
- Added negation to `CGAL::is_triangle_mesh()` check
- Ensures non-triangle meshes are properly rejected

## Testing
- Verified with both triangle and quad meshes
- All existing tests pass (if applicable)