### PR TITLE
Lab: APIENTRY undefined (Qt 6.9.1)

### DIFF
--- a/GraphicsView/include/CGAL/Qt/qglviewer.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer.h
@@ -34,6 +34,13 @@
 #include <QMouseEvent>
 #include <QKeyCombination>
 
+#ifndef APIENTRY
+#define APIENTRY QT_APIENTRY
+#endif
+#ifndef APIENTRYP
+#define APIENTRYP APIENTRY *
+#endif
+
 class QTabWidget;
 class QImage;
 class QOpenGLFramebufferObject;


### PR DESCRIPTION
## Summary of Changes

Behavior of QOpenGL.h changed, with 6.9.1 it does not provide APIENTRY from windows.h anymore, but QT_APIENTRY instead

added redefinition of APIENTRY in qglviewer.h based on QT_APIENTRY

## Release Management

* Affected package(s): Lab, GraphicsView

