### PR TITLE
Apollonius_graph: Clean Up Documentation

### DIFF
--- a/Apollonius_graph_2/doc/Apollonius_graph_2/CGAL/Apollonius_site_2.h
+++ b/Apollonius_graph_2/doc/Apollonius_graph_2/CGAL/Apollonius_site_2.h
@@ -17,12 +17,11 @@ concept `ApolloniusSite_2`.
 
 \cgalHeading{I/O}
 
-The I/O operators are defined for `iostream`.
+The I/O operators are defined for `std::iostream`.
 
-The information output in the `iostream` is: the point of the
+The information output in the `std::iostream` is: the point of the
 Apollonius site and its weight.
 
-\sa `CGAL::Qt_widget`
 \sa `CGAL::Apollonius_graph_traits_2<K,Method_tag>`
 \sa `CGAL::Apollonius_graph_filtered_traits_2<CK,CM,EK,EM,FK,FM>`
 */
@@ -50,7 +49,6 @@ Apollonius_site_2(const Apollonius_site_2<K>& other);
 /*!
 Inserts the
 Apollonius site `s` into the stream `os`.
-\note Included through `CGAL/IO/Qt_widget_Apollonius_site_2.h`.
 \pre The insert operator must be defined for `Point_2` and `Weight`.
 \relates Apollonius_site_2
 */
@@ -59,18 +57,9 @@ std::ostream& operator<<(std::ostream& os, const Apollonius_site_2<K>& s) const;
 /*!
 Reads an Apollonius site from the stream `is` and assigns it
 to `s`.
-\note Included through `CGAL/IO/Qt_widget_Apollonius_site_2.h`.
 \pre The extract operator must be defined for `Point_2` and `Weight`.
 \relates Apollonius_site_2
 */
 std::istream& operator>>(std::istream& is, const Apollonius_site_2<K>& s);
-
-/*!
-Inserts the Apollonius site `s` into the `Qt_widget` stream `w`.
-\note Included through `CGAL/IO/Qt_widget_Apollonius_site_2.h`.
-\pre The insert operator must be defined for `K::Circle_2`.
-\relates Apollonius_site_2
-*/
-Qt_widget& operator<<(Qt_widget& w, const Apollonius_site_2<K>& s) const;
 
 } /* end namespace CGAL */


### PR DESCRIPTION
## Summary of Changes

Remove references to visualization that was removed earlier in class [`Apollonius_graph_site_2`](https://doc.cgal.org/latest/Apollonius_graph_2/classCGAL_1_1Apollonius__site__2.html).

## Release Management

* Affected package(s): Apollonius_graph
* License and copyright ownership: unchanged

