### PR TITLE
Shape_detection: Plane and line region angle check bugfix

### DIFF
--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_line_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Point_set/Least_squares_line_fit_region.h
@@ -241,6 +241,10 @@ namespace Point_set {
 
       const FT cos_value =
         m_scalar_product_2(query_normal, m_normal_of_best_fit);
+
+      if (cos_value < 0)
+        return false;
+
       const FT squared_cos_value = cos_value * cos_value;
 
       FT squared_cos_value_threshold =

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Polygon_mesh/Least_squares_plane_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Polygon_mesh/Least_squares_plane_fit_region.h
@@ -287,6 +287,10 @@ namespace Polygon_mesh {
 
       const Vector_3 face_normal = get(m_face_normals, query);
       const FT cos_value = m_scalar_product_3(face_normal, m_normal_of_best_fit);
+
+      if (cos_value < 0)
+        return false;
+
       const FT squared_cos_value = cos_value * cos_value;
 
       FT squared_cos_value_threshold =

--- a/Shape_detection/include/CGAL/Shape_detection/Region_growing/Segment_set/Least_squares_line_fit_region.h
+++ b/Shape_detection/include/CGAL/Shape_detection/Region_growing/Segment_set/Least_squares_line_fit_region.h
@@ -244,6 +244,10 @@ namespace Segment_set {
 
       const FT cos_value =
         m_scalar_product(query_direction, m_direction_of_best_fit);
+
+      if (cos_value < 0)
+        return false;
+
       const FT squared_cos_value = cos_value * cos_value;
 
       FT squared_cos_value_threshold =


### PR DESCRIPTION
## Summary of Changes

Checking sign before using squared cos angle
The squared cos angle is used to avoid sqrt for vector normalization.

This changes the behavior to be more strict regarding unoriented normals. Maybe, a parameter to decide whether to use the absolute value of the cos(angle) is better?

## Release Management

* Affected package(s): Shape_detection
