### PR TITLE
Drop bad const& in documentation

### DIFF
--- a/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_cell_base_3.h
+++ b/Triangulation_3/doc/Triangulation_3/CGAL/Regular_triangulation_cell_base_3.h
@@ -75,7 +75,7 @@ circumcenter is not supposed to be computed
 by the constructor `Construct_weighted_circumcenter_3` of the traits
 class, hence the returned point has no weight.
 */
-const Point_3& weighted_circumcenter(const Traits& gt = Traits()) const;
+Point_3 weighted_circumcenter(const Traits& gt = Traits()) const;
 
 /// @}
 


### PR DESCRIPTION
## Summary of Changes

There is no const & in the actual code

## Release Management

* Affected package(s): `Triangulation_3`
* Issue(s) solved (if any): fix #8996
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

