### PR TITLE
Mesh_3 - fix "facet is not in its conflict zone" crash

### DIFF
--- a/Triangulation_3/include/CGAL/Regular_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Regular_triangulation_3.h
@@ -667,6 +667,9 @@ public:
   {
     CGAL_precondition(dimension() >= 2);
 
+    if(the_facet_is_in_its_cz)
+      *the_facet_is_in_its_cz = false;
+
     std::vector<Cell_handle> cells;
     cells.reserve(32);
     std::vector<Facet> facets;


### PR DESCRIPTION
## Summary of Changes

In theory in Mesh_3, a Steiner point cannot be hidden.
In practice with inexact constructions (even with the robust circumcenter), it can happen that the Steiner point is hidden.
This case leads to an early exit of `RT3::find_conflicts()` which was inconsistent with `facet_is_in_its_cz`

This PR fixes it

## Release Management

* Affected package(s): Triangulation_3, Mesh_3
* License and copyright ownership: unchanged

