### PR TITLE
Add to way to indicate that features were detected outside of the class

### DIFF
--- a/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Polyhedral_complex_mesh_domain_3.h
@@ -283,6 +283,11 @@ public:
     return this->BaseBase::construct_initial_points_object();
   }
 
+  void set_borders_detected()
+  {
+    borders_detected_=true;
+  }
+
   void detect_features(FT angle_in_degree,
                        std::vector<Polyhedron_type>& p,
                        const bool dont_protect);//if true, features will not be protected


### PR DESCRIPTION
This is an issue for the default initialization that will redo the feature detection and overwrite the face patch ids