### PR TITLE
Allow Side_of_triangle to take ownership on an external AABB-tree

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Side_of_triangle_mesh.h
+++ b/Polygon_mesh_processing/include/CGAL/Side_of_triangle_mesh.h
@@ -164,7 +164,7 @@ public:
   * @param tree a \cgal `AABB_tree` with `AABB_face_graph_triangle_primitive` as `Primitive` type
   * @param gt an instance of the geometric traits class
   *
-  * @pre `CGAL::is_closed(tmesh) && CGAL::is_triangle_mesh(tmesh)`
+  * @pre `tree` contains a set of triangle faces representing a closed surface mesh
   */
   Side_of_triangle_mesh(const AABB_tree& tree,
                         const GeomTraits& gt = GeomTraits())
@@ -179,6 +179,34 @@ public:
 #endif
   {
     box = tree.bbox();
+  }
+
+  /**
+  * Constructor that takes a pre-built \cgal `AABB_tree`
+  * of the triangulated surface mesh primitives, and moves it.
+  *
+  * @param tree a \cgal `AABB_tree` with `AABB_face_graph_triangle_primitive` as `Primitive` type
+  * @param gt an instance of the geometric traits class
+  *
+  * @pre `tree` contains a set of triangle faces representing a closed surface mesh
+  */
+  Side_of_triangle_mesh(AABB_tree&& tree,
+                        const GeomTraits& gt = GeomTraits())
+  : ray_functor(gt.construct_ray_3_object())
+  , vector_functor(gt.construct_vector_3_object())
+  , tm_ptr(nullptr)
+  , own_tree(true)
+#ifdef CGAL_HAS_THREADS
+  , atomic_tree_ptr(new AABB_tree(std::forward<AABB_tree>(tree)))
+#else
+  , tree_ptr(new AABB_tree(std::forward<AABB_tree>(tree)))
+#endif
+  {
+#ifdef CGAL_HAS_THREADS
+    box = atomic_tree_ptr.load()->bbox();
+#else
+    box = tree_ptr->bbox();
+#endif
   }
 
   /**


### PR DESCRIPTION
Convenient for using only a subset of faces for example, or to force the building of the tree