### PR TITLE
Hole filling: extra parameter to allow a control from the user on face validity

### DIFF
--- a/BGL/test/BGL/test_Prefix.h
+++ b/BGL/test/BGL/test_Prefix.h
@@ -461,8 +461,6 @@ struct Surface_fixture_6 {
     assert(is_reading_successful);
     assert(CGAL::is_valid_polygon_mesh(m));
 
-    typename boost::graph_traits<Graph>::halfedge_descriptor h;
-
     h1 = halfedge(*faces(m).first, m);
 
     h2 = next(next(h1,m),m);

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -11,6 +11,8 @@ Release date: July 2026
 
 ### [Polygon Mesh Processing](https://doc.cgal.org/6.2/Manual/packages.html#PkgPolygonMeshProcessing) (major changes)
 
+- **Breaking change**: Update the visitor concepts `PMPTriangulateFaceVisitor` and `PMPHolefillingVisitor` to request functions `accept_face()` and `accept_triangle()`, respectively. These functions can be used to tweak the way faces and holes are triangles by black listing some candidate triangles.
+    User visitors inheriting from the default visitors do not require any update.
 -   The "Polygon Mesh Processing" package has been reorganized into several packages.
     "Polygon Mesh Processing" retains the core functionalities, while advanced and specialized features
     have been moved to dedicated packages:
@@ -54,7 +56,7 @@ Release date: July 2026
 
   - added function `intersected_nodes()` with an intersection functor and a convenience overload for a ball query.
 
-### [Shape Detection](https://doc.cgal.org/6.2/Manual/packages.html#PkgShapeDetection) 
+### [Shape Detection](https://doc.cgal.org/6.2/Manual/packages.html#PkgShapeDetection)
 
 - Added the region type [`CGAL::Shape_detection::Polygon_mesh::Plane_face_region`](https://doc.cgal.org/6.2/Shape_detection/class_c_g_a_l_1_1_shape__detection_1_1_polygon__mesh_1_1_plane__face__region.html) that extends the support plane of the seed face without refitting the plane to the region
 - Added the region type [`CGAL::Shape_detection::Polygon_mesh::Line_segment_region`](https://doc.cgal.org/6.2/Shape_detection/classCGAL_1_1Shape__detection_1_1Segment__set_1_1Line__segment__region.html) that extends the support line of the seed segment without refitting the line to the region

--- a/Lab/demo/Lab/Plugins/PMP/Isotropic_remeshing_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/PMP/Isotropic_remeshing_plugin.cpp
@@ -180,7 +180,7 @@ class CGAL_Lab_isotropic_remeshing_plugin :
   typedef Scene_polyhedron_selection_item::Is_constrained_map<Edge_set> Edge_constrained_pmap;
 
   struct Selection_updater_visitor
-    : public CGAL::Polygon_mesh_processing::Hole_filling::Default_visitor
+    : public CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor<SMesh>
   {
     typedef typename Scene_polyhedron_selection_item::Selection_set_facet Container;
     Container& faces;

--- a/Lab/demo/Lab/Plugins/PMP/Triangulate_facets_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/PMP/Triangulate_facets_plugin.cpp
@@ -24,7 +24,7 @@ class CGAL_Lab_triangulate_facets_plugin :
   typedef boost::graph_traits<FaceGraph>::face_descriptor face_descriptor;
 
   struct Selection_updater_visitor
-    : public CGAL::Polygon_mesh_processing::Hole_filling::Default_visitor
+    : public CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor<SMesh>
   {
     typedef typename Scene_polyhedron_selection_item::Selection_set_facet Container;
     Container& faces;

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polygon_mesh.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polygon_mesh.h
@@ -195,7 +195,7 @@ triangulate_hole_polygon_mesh(PolygonMesh& pmesh,
   Tracer_polyhedron<PolygonMesh, OutputIterator> tracer(out, pmesh, P_edges);
 
 #ifndef CGAL_HOLE_FILLING_DO_NOT_USE_CDT2
-  if(use_cdt && triangulate_hole_polyline_with_cdt(P, tracer, visitor, k, max_squared_distance))
+  if(use_cdt && ::CGAL::internal::triangulate_hole_polyline_with_cdt(P, tracer, visitor, is_valid, k, max_squared_distance))
     return std::make_pair(tracer.out, CGAL::internal::Weight_min_max_dihedral_and_area(0,0));
 #endif
   CGAL::internal::Weight_min_max_dihedral_and_area weight =

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polygon_mesh.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polygon_mesh.h
@@ -178,22 +178,24 @@ triangulate_hole_polygon_mesh(PolygonMesh& pmesh,
     } while(++circ_vertex != done_vertex);
   }
 
+  using Is_valid_base = CGAL::internal::Is_valid_existing_edges_and_degenerate_triangle;
+  Is_valid_base is_valid_base(existing_edges);
+  CGAL::internal::Is_valid_compose is_valid(is_valid_base, visitor);
+
 //#define CGAL_USE_WEIGHT_INCOMPLETE
 #ifdef CGAL_USE_WEIGHT_INCOMPLETE
   typedef CGAL::internal::Weight_calculator<CGAL::internal::Weight_incomplete<CGAL::internal::Weight_min_max_dihedral_and_area>,
-        CGAL::internal::Is_valid_existing_edges_and_degenerate_triangle> WC;
+        decltype(is_valid)> WC;
 #else
   typedef CGAL::internal::Weight_calculator<CGAL::internal::Weight_min_max_dihedral_and_area,
-        CGAL::internal::Is_valid_existing_edges_and_degenerate_triangle> WC;
+        decltype(is_valid)> WC;
 #endif
-
-  CGAL::internal::Is_valid_existing_edges_and_degenerate_triangle is_valid(existing_edges);
 
   // fill hole using polyline function, with custom tracer for PolygonMesh
   Tracer_polyhedron<PolygonMesh, OutputIterator> tracer(out, pmesh, P_edges);
 
 #ifndef CGAL_HOLE_FILLING_DO_NOT_USE_CDT2
-  if(use_cdt && triangulate_hole_polyline_with_cdt(P, tracer, visitor, is_valid, k, max_squared_distance))
+  if(use_cdt && triangulate_hole_polyline_with_cdt(P, tracer, visitor, k, max_squared_distance))
     return std::make_pair(tracer.out, CGAL::internal::Weight_min_max_dihedral_and_area(0,0));
 #endif
   CGAL::internal::Weight_min_max_dihedral_and_area weight =

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -66,7 +66,7 @@ struct Is_valid_compose
   bool operator()(const std::vector<Point_3>& pts,
                   int v0, int v1, int v2) const
   {
-    if (visitor.accept_face(v0, v1, v2))
+    if (visitor.accept_triangle(v0, v1, v2))
       return base(pts, v0, v1, v2);
     return false;
   }
@@ -1524,7 +1524,7 @@ triangulate_hole_polyline_with_cdt(const PointRange& points,
 
       std::sort(is.begin(), is.end());
       lambda.put(is[0], is[2], is[1]);
-      if (!visitor.accept_face(is[0], is[1], is[2]))
+      if (!visitor.accept_triangle(is[0], is[1], is[2]))
       {
         // std::cerr << "WARNING: validity, cdt 2 falls back to the original solution!" << std::endl;
         visitor.end_planar_phase(false);

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -1352,12 +1352,14 @@ template <
   typename PointRange, // need size()
   typename Tracer,
   typename Visitor,
+  typename Validity_checker,
   typename Traits
 >
 bool
 triangulate_hole_polyline_with_cdt(const PointRange& points,
                                    Tracer& tracer,
                                    Visitor& visitor,
+                                   const Validity_checker& is_valid,
                                    const Traits& traits,
                                    const typename Traits::FT max_squared_distance)
 {
@@ -1467,6 +1469,12 @@ triangulate_hole_polyline_with_cdt(const PointRange& points,
     vertices[v->info()] = v;
   }
 
+  if (vertices.size()!=cdt.number_of_vertices())
+  {
+    visitor.end_planar_phase(false);
+    return false;
+  }
+
   try
   {
     for (std::size_t i = 0; i < size; ++i) {
@@ -1524,7 +1532,7 @@ triangulate_hole_polyline_with_cdt(const PointRange& points,
 
       std::sort(is.begin(), is.end());
       lambda.put(is[0], is[2], is[1]);
-      if (!visitor.accept_triangle(is[0], is[1], is[2]))
+      if (!is_valid(P, is[0], is[1], is[2]))
       {
         // std::cerr << "WARNING: validity, cdt 2 falls back to the original solution!" << std::endl;
         visitor.end_planar_phase(false);

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -914,7 +914,7 @@ private:
     CGAL_assertion(v0 != -1); // edge can not be incident to infinite vertex
 
     if( v0 + 1 == v1 || // border edge - should not check v0 = 0, v1 = n-1, because it is the initial edge where the algorithm starts
-        W.get(v0, v1) != Weight::DEFAULT() ) // the range is previously processed // TODO: try to call accept_face() only here!
+        W.get(v0, v1) != Weight::DEFAULT() ) // the range is previously processed
     { return; }
 
     visitor.quadratic_step();

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -54,6 +54,28 @@
 namespace CGAL {
 namespace internal {
 
+template <class Base, class Visitor>
+struct Is_valid_compose
+{
+  Is_valid_compose(const Base& base, const Visitor& visitor)
+    : base(base)
+    , visitor(visitor)
+  {}
+
+  template<class Point_3>
+  bool operator()(const std::vector<Point_3>& pts,
+                  int v0, int v1, int v2) const
+  {
+    if (visitor.accept_face(v0, v1, v2))
+      return base(pts, v0, v1, v2);
+    return false;
+  }
+
+  const Base& base;
+  const Visitor& visitor;
+};
+
+
 /************************************************************************
  * Lookup tables
  ************************************************************************/
@@ -892,7 +914,7 @@ private:
     CGAL_assertion(v0 != -1); // edge can not be incident to infinite vertex
 
     if( v0 + 1 == v1 || // border edge - should not check v0 = 0, v1 = n-1, because it is the initial edge where the algorithm starts
-        W.get(v0, v1) != Weight::DEFAULT() ) // the range is previously processed
+        W.get(v0, v1) != Weight::DEFAULT() ) // the range is previously processed // TODO: try to call accept_face() only here!
     { return; }
 
     visitor.quadratic_step();
@@ -1330,14 +1352,12 @@ template <
   typename PointRange, // need size()
   typename Tracer,
   typename Visitor,
-  typename Validity_checker,
   typename Traits
 >
 bool
 triangulate_hole_polyline_with_cdt(const PointRange& points,
                                    Tracer& tracer,
                                    Visitor& visitor,
-                                   const Validity_checker& is_valid,
                                    const Traits& traits,
                                    const typename Traits::FT max_squared_distance)
 {
@@ -1447,12 +1467,6 @@ triangulate_hole_polyline_with_cdt(const PointRange& points,
     vertices[v->info()] = v;
   }
 
-  if (vertices.size()!=cdt.number_of_vertices())
-  {
-    visitor.end_planar_phase(false);
-    return false;
-  }
-
   try
   {
     for (std::size_t i = 0; i < size; ++i) {
@@ -1510,7 +1524,8 @@ triangulate_hole_polyline_with_cdt(const PointRange& points,
 
       std::sort(is.begin(), is.end());
       lambda.put(is[0], is[2], is[1]);
-      if (!is_valid(P, is[0], is[1], is[2])) {
+      if (!visitor.accept_face(is[0], is[1], is[2]))
+      {
         // std::cerr << "WARNING: validity, cdt 2 falls back to the original solution!" << std::endl;
         visitor.end_planar_phase(false);
         return false;

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
@@ -59,20 +59,6 @@ namespace Polygon_mesh_processing {
       constexpr bool accept_triangle(int,int,int) const { return true; }
     #endif
     };
-
-
-#ifndef DOXYGEN_RUNNING
-  // probably not needed if we're using c++17 constexpr
-  struct Default_user_is_face_valid
-  {
-    constexpr
-    bool accept_triangle( int /* v0 */, int /* v1 */, int /* v2 */) const
-    {
-      return true;
-    }
-  };
-#endif
-
   } // namespace Hole_filling
 
   /*!
@@ -793,6 +779,7 @@ bool use_dt3 =
            points,
            tracer,
            visitor,
+           is_valid,
            choose_parameter<Kernel>(get_parameter(np, internal_np::geom_traits)),
            max_squared_distance))
       {

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
@@ -56,7 +56,7 @@ namespace Polygon_mesh_processing {
       void end_refine_phase() const {}
       void start_fair_phase() const {}
       void end_fair_phase() const {}
-      constexpr bool accept_face(int,int,int) const { return true; }
+      constexpr bool accept_triangle(int,int,int) const { return true; }
     #endif
     };
 
@@ -66,7 +66,7 @@ namespace Polygon_mesh_processing {
   struct Default_user_is_face_valid
   {
     constexpr
-    bool accept_face( int /* v0 */, int /* v1 */, int /* v2 */) const
+    bool accept_triangle( int /* v0 */, int /* v1 */, int /* v2 */) const
     {
       return true;
     }

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
@@ -653,7 +653,9 @@ namespace Polygon_mesh_processing {
 
   @pre `third_points.size() == points.size()`
 
-  @tparam PointRange range of points, model of `Range`.
+  @tparam PointRange1 range of points, model of `Range`.
+    Its iterator type is `InputIterator`.
+  @tparam PointRange2 range of points, model of `Range`.
     Its iterator type is `InputIterator`.
   @tparam OutputIterator model of `OutputIterator`, to collect patch faces.
      A specialization for `CGAL::value_type_traits<OutputIterator>` must be available,

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/triangulate_hole.h
@@ -56,8 +56,23 @@ namespace Polygon_mesh_processing {
       void end_refine_phase() const {}
       void start_fair_phase() const {}
       void end_fair_phase() const {}
+      constexpr bool accept_face(int,int,int) const { return true; }
     #endif
     };
+
+
+#ifndef DOXYGEN_RUNNING
+  // probably not needed if we're using c++17 constexpr
+  struct Default_user_is_face_valid
+  {
+    constexpr
+    bool accept_face( int /* v0 */, int /* v1 */, int /* v2 */) const
+    {
+      return true;
+    }
+  };
+#endif
+
   } // namespace Hole_filling
 
   /*!
@@ -652,9 +667,7 @@ namespace Polygon_mesh_processing {
 
   @pre `third_points.size() == points.size()`
 
-  @tparam PointRange1 range of points, model of `Range`.
-    Its iterator type is `InputIterator`.
-  @tparam PointRange2 range of points, model of `Range`.
+  @tparam PointRange range of points, model of `Range`.
     Its iterator type is `InputIterator`.
   @tparam OutputIterator model of `OutputIterator`, to collect patch faces.
      A specialization for `CGAL::value_type_traits<OutputIterator>` must be available,
@@ -741,9 +754,14 @@ bool use_dt3 =
       choose_parameter(get_parameter(np, internal_np::use_delaunay_triangulation), true);
 #endif
 
+    Hole_filling::Default_visitor default_visitor;
+    auto visitor = choose_parameter(get_parameter_reference(np, internal_np::visitor), default_visitor);
+
+    CGAL::internal::Is_not_degenerate_triangle is_valid_base;
+    CGAL::internal::Is_valid_compose is_valid(is_valid_base, visitor);
+
     typedef CGAL::internal::Weight_min_max_dihedral_and_area      Weight;
-    typedef CGAL::internal::Weight_calculator<Weight,
-                  CGAL::internal::Is_not_degenerate_triangle>  WC;
+    typedef CGAL::internal::Weight_calculator<Weight, decltype(is_valid)>  WC;
     typedef std::vector<std::pair<int, int> > Holes;
     typedef std::back_insert_iterator<Holes>  Holes_out;
 
@@ -757,17 +775,9 @@ bool use_dt3 =
     typedef typename std::iterator_traits<InIterator>::value_type Point;
     typedef typename CGAL::Kernel_traits<Point>::Kernel Kernel;
 
-    Hole_filling::Default_visitor default_visitor;
-
 #ifndef CGAL_HOLE_FILLING_DO_NOT_USE_CDT2
     if (use_cdt)
     {
-      struct Always_valid
-      {
-        bool operator()(const std::vector<Point>&, int,int,int) const { return true; }
-      };
-      Always_valid is_valid;
-
       const typename Kernel::Iso_cuboid_3 bbox = CGAL::bounding_box(points.begin(), points.end());
       typename Kernel::FT default_squared_distance = CGAL::abs(CGAL::squared_distance(bbox.vertex(0), bbox.vertex(5)));
       default_squared_distance /= typename Kernel::FT(16); // one quarter of the bbox height
@@ -782,8 +792,7 @@ bool use_dt3 =
       if (triangulate_hole_polyline_with_cdt(
            points,
            tracer,
-           choose_parameter(get_parameter_reference(np, internal_np::visitor), default_visitor),
-           is_valid,
+           visitor,
            choose_parameter<Kernel>(get_parameter(np, internal_np::geom_traits)),
            max_squared_distance))
       {
@@ -792,8 +801,8 @@ bool use_dt3 =
       }
     }
 #endif
-    triangulate_hole_polyline(points, third_points, tracer, WC(),
-                              choose_parameter(get_parameter_reference(np, internal_np::visitor), default_visitor),
+    triangulate_hole_polyline(points, third_points, tracer, WC(is_valid),
+                              visitor,
                               use_dt3,
                               choose_parameter(get_parameter(np, internal_np::do_not_use_cubic_algorithm), false),
                               choose_parameter<Kernel>(get_parameter(np, internal_np::geom_traits)));

--- a/PMP_Mesh_repair/test/PMP_Mesh_repair/triangulate_hole_Polyhedron_3_test.cpp
+++ b/PMP_Mesh_repair/test/PMP_Mesh_repair/triangulate_hole_Polyhedron_3_test.cpp
@@ -3,16 +3,15 @@
 #include <CGAL/Polygon_mesh_processing/triangulate_hole.h>
 
 
-#ifdef POLY
 #include <CGAL/Polyhedron_3.h>
-#else
 #include <CGAL/Surface_mesh.h>
-#endif
 
 #include <CGAL/boost/graph/helpers.h>
 #include <CGAL/assertions.h>
 #include <CGAL/boost/graph/Euler_operations.h>
 #include <CGAL/Weights/uniform_weights.h>
+#include <CGAL/boost/graph/generators.h>
+#include <CGAL/Polygon_mesh_processing/triangulate_faces.h>
 
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
@@ -389,11 +388,224 @@ void generate_elephant_with_hole()
     }
 }
 
+struct Triangulate_face_visitor
+  : public CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor<Polyhedron>
+{
+  using Mesh = CGAL::Surface_mesh<Kernel::Point_3>;
+  using Vertex_index = Mesh::Vertex_index;
+  using Face_index = Mesh::Face_index;
+
+  std::array<Vertex_handle,3> forbidden_face;
+  Triangulate_face_visitor(Vertex_index v0, Vertex_index v1, Vertex_index v2)
+  {
+    forbidden_face=CGAL::make_array(v0,v1,v2);
+    std::sort(forbidden_face.begin(), forbidden_face.end());
+  }
+
+  bool accept_face(Face_index,
+                   Vertex_index v0, Vertex_index v1, Vertex_index v2) const
+  {
+    auto a = CGAL::make_array(v0, v1, v2);
+    std::sort(a.begin(), a.end());
+
+    return a!=forbidden_face;
+  }
+
+  using CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor<Polyhedron>::accept_face; // TODO doc me
+};
+
+struct Triangulate_face_visitor_reject_all
+  : public CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor<Polyhedron>
+{
+  using Mesh = CGAL::Surface_mesh<Kernel::Point_3>;
+  using Vertex_index = Mesh::Vertex_index;
+  using Face_index = Mesh::Face_index;
+
+  constexpr
+  bool accept_face(Face_index,
+                   Vertex_index , Vertex_index , Vertex_index) const
+  {
+    return false;
+  }
+
+  using CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor<Polyhedron>::accept_face;
+};
+
+struct Hole_filling_visitor
+  : public CGAL::Polygon_mesh_processing::Hole_filling::Default_visitor
+{
+  std::array<int, 3> forbidden_face;
+  Hole_filling_visitor(int i0, int i1, int i2)
+  {
+    forbidden_face=CGAL::make_array(i0,i1,i2);
+    std::sort(forbidden_face.begin(), forbidden_face.end());
+  }
+
+
+  bool accept_face(int i0, int i1, int i2) const
+  {
+    auto a =CGAL::make_array(i0,i1,i2);
+    std::sort(a.begin(), a.end());
+    return a!=forbidden_face;
+  }
+};
+
+struct Hole_filling_visitor_reject_all
+  : public CGAL::Polygon_mesh_processing::Hole_filling::Default_visitor
+{
+  bool accept_face(int , int , int ) const
+  {
+    return false;
+  }
+};
+
+void test_with_forbidden_triangles()
+{
+  using Mesh = CGAL::Surface_mesh<Kernel::Point_3>;
+
+  Mesh mesh;
+  auto vpm = get(CGAL::vertex_point, mesh);
+  CGAL::make_hexahedron(CGAL::Bbox_3(-1,-1,-1,1,1,1), mesh, CGAL::parameters::do_not_triangulate_faces(true));
+  auto fit = faces(mesh).begin();
+  while (fit!=faces(mesh).end())
+  {
+    auto h = halfedge(*fit, mesh);
+    if (get(vpm, source(h,mesh)).z()==1 && get(vpm, target(h,mesh)).z()==1 && get(vpm, target(next(h,mesh),mesh)).z()==1)
+      break;
+    ++fit;
+  }
+
+  auto hv = CGAL::Euler::add_center_vertex(halfedge(*fit, mesh), mesh);
+  auto v = target(hv, mesh);
+  put(vpm, v, Kernel::Point_3(0.5,0.5,1));
+  std::vector<Halfedge_handle> hedges;
+  for (auto h : CGAL::halfedges_around_target(hv, mesh))
+    hedges.push_back(h);
+  for (Halfedge_handle h : hedges)
+  {
+    Kernel::Point_3 mp = CGAL::midpoint(get(vpm, source(h, mesh)), get(vpm, target(h, mesh)));
+    auto hnew = CGAL::Euler::split_edge(h, mesh);
+    put(vpm, target(hnew, mesh), mp);
+  }
+  CGAL::Polygon_mesh_processing::triangulate_faces(mesh);
+  auto h = CGAL::Euler::remove_center_vertex(halfedge(v, mesh), mesh);
+
+  // testing triangulate_faces
+  {
+    auto m1=mesh;
+    m1.collect_garbage();
+    auto m2=m1;
+    auto m3=m1;
+    auto m4=m1;
+
+    //look for the quad face
+    Mesh::Halfedge_index hq;
+    for (Mesh::Halfedge_index h : halfedges(m1))
+    {
+      if (!CGAL::is_triangle(h, m1))
+      {
+        hq=h;
+      }
+    }
+
+    std::pair diag1(source(hq,m1), target(next(hq,m1), m1));
+    std::pair diag2(target(hq,m2), source(prev(hq,m2), m2));
+    Triangulate_face_visitor vis1(source(hq,m1), target(hq,m1), target(next(hq,m1), m1));
+    Triangulate_face_visitor vis2(source(hq,m2), target(hq,m2), source(prev(hq,m2), m2));
+
+    CGAL::Polygon_mesh_processing::triangulate_faces(m1, CGAL::parameters::visitor(vis1));
+    CGAL::Polygon_mesh_processing::triangulate_faces(m2, CGAL::parameters::visitor(vis2));
+    CGAL::Polygon_mesh_processing::triangulate_faces(m3, CGAL::parameters::visitor(Triangulate_face_visitor_reject_all()));
+
+    assert(CGAL::is_triangle_mesh(m1));
+    assert(CGAL::is_triangle_mesh(m2));
+    assert(!CGAL::is_triangle_mesh(m3));
+
+    assert(!halfedge(diag1.first, diag1.second, m1).second);
+    assert(!halfedge(diag2.first, diag2.second, m2).second);
+
+    auto mp = CGAL::midpoint(m4.point(source(hq,m4)), m4.point(target(hq, m4)));
+    m4.point(target(CGAL::Euler::split_edge(hq, m4), m4))=mp;
+
+    auto m5=m4;
+    auto m6=m4;
+
+    CGAL::Polygon_mesh_processing::triangulate_faces(m4);
+
+    Triangulate_face_visitor vis5(source(hq,m4), target(hq,m4), target(next(hq,m4), m4)); // m4 on purpose
+    std::pair diag5(source(hq,m4), source(prev(hq,m4), m4));
+    CGAL::Polygon_mesh_processing::triangulate_faces(m5, CGAL::parameters::visitor(vis5));
+    CGAL::Polygon_mesh_processing::triangulate_faces(m6, CGAL::parameters::visitor(Triangulate_face_visitor_reject_all()));
+    assert(CGAL::is_triangle_mesh(m4));
+    assert(CGAL::is_triangle_mesh(m5));
+    assert(!CGAL::is_triangle_mesh(m6));
+    assert(!halfedge(diag5.first, diag5.second, m5).second);
+  }
+
+  CGAL::Euler::remove_face(h, mesh);
+  mesh.collect_garbage();
+
+  for (auto h2 : halfedges(mesh))
+  {
+    if (is_border(h2, mesh))
+    {
+      h=h2;
+      break;
+    }
+  }
+
+  std::array< std::pair<bool, bool>, 4 > configs = {{ {true, true}, {true, false}, {false, true}, {false, false}}};
+
+  for (auto c : configs)
+  {
+    auto mesh0 = mesh;
+    auto mesh1 = mesh;
+    auto mesh2 = mesh;
+    auto mesh3 = mesh;
+    std::pair diag(target(h, mesh), target(next(next(h,mesh),mesh),mesh));
+    std::pair diag1(source(h, mesh), target(next(h,mesh),mesh));
+  // TODO: test that the visitor is using the vertices as documented!
+    CGAL::Polygon_mesh_processing::triangulate_hole(mesh0, h, CGAL::parameters::visitor(Hole_filling_visitor(0,1,2)).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
+    CGAL::Polygon_mesh_processing::triangulate_hole(mesh1, h, CGAL::parameters::visitor(Hole_filling_visitor(0,1,3)).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
+    CGAL::Polygon_mesh_processing::triangulate_hole(mesh2, h, CGAL::parameters::visitor(Hole_filling_visitor_reject_all()).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
+
+    assert(CGAL::is_closed(mesh0));
+    assert(CGAL::is_closed(mesh1));
+    assert(!CGAL::is_closed(mesh2));
+    assert(!halfedge(diag.first, diag.second, mesh0).second);
+    assert(!halfedge(diag1.first, diag1.second, mesh1).second);
+
+    auto mp = CGAL::midpoint(mesh3.point(source(h,mesh3)), mesh3.point(target(h, mesh3)));
+    mesh3.point(target(CGAL::Euler::split_edge(h, mesh3), mesh3))=mp;
+
+    auto mesh4=mesh3;
+    auto mesh5=mesh3;
+
+    std::map<Mesh::Vertex_index, int> vmap;
+    int i=0;
+    for (auto haf : CGAL::halfedges_around_face(h, mesh3))
+      vmap[target(haf,mesh3)]=i++;
+
+    CGAL::Polygon_mesh_processing::triangulate_hole(mesh3, h, CGAL::parameters::use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
+    Hole_filling_visitor vis4(vmap.at(source(h,mesh3)), vmap.at(target(h,mesh3)), vmap.at(target(next(h,mesh3), mesh3))); // mesh3 on purpose
+    std::pair diag4(source(h,mesh3), source(prev(h,mesh3), mesh3));
+
+    CGAL::Polygon_mesh_processing::triangulate_hole(mesh4, h, CGAL::parameters::visitor(vis4).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
+    CGAL::Polygon_mesh_processing::triangulate_hole(mesh5, h, CGAL::parameters::visitor(Hole_filling_visitor_reject_all()).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
+
+    assert(CGAL::is_closed(mesh3));
+    assert(CGAL::is_closed(mesh4));
+    assert(!CGAL::is_closed(mesh5));
+    assert(!halfedge(diag4.first, diag4.second, mesh4).second);
+  }
+}
+
+
 int main()
 {
   std::cout.precision(17);
   std::cerr.precision(17);
-
+  test_with_forbidden_triangles();
   generate_elephant_with_hole();
   std::vector<std::string> input_files;
   input_files.push_back("elephant_triangle_hole.off");

--- a/PMP_Mesh_repair/test/PMP_Mesh_repair/triangulate_hole_Polyhedron_3_test.cpp
+++ b/PMP_Mesh_repair/test/PMP_Mesh_repair/triangulate_hole_Polyhedron_3_test.cpp
@@ -410,8 +410,6 @@ struct Triangulate_face_visitor
 
     return a!=forbidden_face;
   }
-
-  using CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor<Polyhedron>::accept_face; // TODO doc me
 };
 
 struct Triangulate_face_visitor_reject_all
@@ -427,8 +425,6 @@ struct Triangulate_face_visitor_reject_all
   {
     return false;
   }
-
-  using CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor<Polyhedron>::accept_face;
 };
 
 struct Hole_filling_visitor

--- a/PMP_Mesh_repair/test/PMP_Mesh_repair/triangulate_hole_Polyhedron_3_test.cpp
+++ b/PMP_Mesh_repair/test/PMP_Mesh_repair/triangulate_hole_Polyhedron_3_test.cpp
@@ -438,7 +438,7 @@ struct Hole_filling_visitor
   }
 
 
-  bool accept_face(int i0, int i1, int i2) const
+  bool accept_triangle(int i0, int i1, int i2) const
   {
     auto a =CGAL::make_array(i0,i1,i2);
     std::sort(a.begin(), a.end());
@@ -449,7 +449,7 @@ struct Hole_filling_visitor
 struct Hole_filling_visitor_reject_all
   : public CGAL::Polygon_mesh_processing::Hole_filling::Default_visitor
 {
-  bool accept_face(int , int , int ) const
+  bool accept_triangle(int , int , int ) const
   {
     return false;
   }

--- a/PMP_Mesh_repair/test/PMP_Mesh_repair/triangulate_hole_Polyhedron_3_test.cpp
+++ b/PMP_Mesh_repair/test/PMP_Mesh_repair/triangulate_hole_Polyhedron_3_test.cpp
@@ -420,7 +420,6 @@ struct Triangulate_face_visitor_reject_all
   using Vertex_index = Mesh::Vertex_index;
   using Face_index = Mesh::Face_index;
 
-  constexpr
   bool accept_face(Face_index,
                    Vertex_index , Vertex_index , Vertex_index) const
   {

--- a/PMP_Mesh_repair/test/PMP_Mesh_repair/triangulate_hole_Polyhedron_3_test.cpp
+++ b/PMP_Mesh_repair/test/PMP_Mesh_repair/triangulate_hole_Polyhedron_3_test.cpp
@@ -387,7 +387,7 @@ void generate_elephant_with_hole()
       return;
     }
 }
-
+// visitors for triangulate_faces
 struct Triangulate_face_visitor
   : public CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor<Polyhedron>
 {
@@ -412,6 +412,7 @@ struct Triangulate_face_visitor
   }
 };
 
+//visitors for triangulate_hole_polyline
 struct Triangulate_face_visitor_reject_all
   : public CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor<Polyhedron>
 {
@@ -455,13 +456,46 @@ struct Hole_filling_visitor_reject_all
   }
 };
 
+// visitors for triangulate_polygons()
+struct Triangulate_polygon_visitor
+  : public CGAL::Polygon_mesh_processing::Triangulate_polygons::Default_visitor
+{
+  std::array<std::size_t,3> forbidden_face;
+  Triangulate_polygon_visitor(std::size_t v0, std::size_t v1, std::size_t v2)
+  {
+    forbidden_face=CGAL::make_array(v0,v1,v2);
+    std::sort(forbidden_face.begin(), forbidden_face.end());
+  }
+
+  bool accept_face(std::size_t,
+                   std::size_t v0, std::size_t v1, std::size_t v2) const
+  {
+    auto a = CGAL::make_array(v0, v1, v2);
+    std::sort(a.begin(), a.end());
+
+    return a!=forbidden_face;
+  }
+};
+
+struct Triangulate_polygon_visitor_reject_all
+  : public CGAL::Polygon_mesh_processing::Triangulate_polygons::Default_visitor
+{
+  constexpr
+  bool accept_face(std::size_t,std::size_t,std::size_t,std::size_t) const
+  {
+    return false;
+  }
+};
+
 void test_with_forbidden_triangles()
 {
   using Mesh = CGAL::Surface_mesh<Kernel::Point_3>;
+  namespace PMP = CGAL::Polygon_mesh_processing;
+  namespace params = CGAL::parameters;
 
   Mesh mesh;
   auto vpm = get(CGAL::vertex_point, mesh);
-  CGAL::make_hexahedron(CGAL::Bbox_3(-1,-1,-1,1,1,1), mesh, CGAL::parameters::do_not_triangulate_faces(true));
+  CGAL::make_hexahedron(CGAL::Bbox_3(-1,-1,-1,1,1,1), mesh, params::do_not_triangulate_faces(true));
   auto fit = faces(mesh).begin();
   while (fit!=faces(mesh).end())
   {
@@ -483,7 +517,7 @@ void test_with_forbidden_triangles()
     auto hnew = CGAL::Euler::split_edge(h, mesh);
     put(vpm, target(hnew, mesh), mp);
   }
-  CGAL::Polygon_mesh_processing::triangulate_faces(mesh);
+  PMP::triangulate_faces(mesh);
   auto h = CGAL::Euler::remove_center_vertex(halfedge(v, mesh), mesh);
 
   // testing triangulate_faces
@@ -509,9 +543,9 @@ void test_with_forbidden_triangles()
     Triangulate_face_visitor vis1(source(hq,m1), target(hq,m1), target(next(hq,m1), m1));
     Triangulate_face_visitor vis2(source(hq,m2), target(hq,m2), source(prev(hq,m2), m2));
 
-    CGAL::Polygon_mesh_processing::triangulate_faces(m1, CGAL::parameters::visitor(vis1));
-    CGAL::Polygon_mesh_processing::triangulate_faces(m2, CGAL::parameters::visitor(vis2));
-    CGAL::Polygon_mesh_processing::triangulate_faces(m3, CGAL::parameters::visitor(Triangulate_face_visitor_reject_all()));
+    PMP::triangulate_faces(m1, params::visitor(vis1));
+    PMP::triangulate_faces(m2, params::visitor(vis2));
+    PMP::triangulate_faces(m3, params::visitor(Triangulate_face_visitor_reject_all()));
 
     assert(CGAL::is_triangle_mesh(m1));
     assert(CGAL::is_triangle_mesh(m2));
@@ -526,12 +560,12 @@ void test_with_forbidden_triangles()
     auto m5=m4;
     auto m6=m4;
 
-    CGAL::Polygon_mesh_processing::triangulate_faces(m4);
+    PMP::triangulate_faces(m4);
 
     Triangulate_face_visitor vis5(source(hq,m4), target(hq,m4), target(next(hq,m4), m4)); // m4 on purpose
     std::pair diag5(source(hq,m4), source(prev(hq,m4), m4));
-    CGAL::Polygon_mesh_processing::triangulate_faces(m5, CGAL::parameters::visitor(vis5));
-    CGAL::Polygon_mesh_processing::triangulate_faces(m6, CGAL::parameters::visitor(Triangulate_face_visitor_reject_all()));
+    PMP::triangulate_faces(m5, params::visitor(vis5));
+    PMP::triangulate_faces(m6, params::visitor(Triangulate_face_visitor_reject_all()));
     assert(CGAL::is_triangle_mesh(m4));
     assert(CGAL::is_triangle_mesh(m5));
     assert(!CGAL::is_triangle_mesh(m6));
@@ -561,9 +595,9 @@ void test_with_forbidden_triangles()
     std::pair diag(target(h, mesh), target(next(next(h,mesh),mesh),mesh));
     std::pair diag1(source(h, mesh), target(next(h,mesh),mesh));
   // TODO: test that the visitor is using the vertices as documented!
-    CGAL::Polygon_mesh_processing::triangulate_hole(mesh0, h, CGAL::parameters::visitor(Hole_filling_visitor(0,1,2)).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
-    CGAL::Polygon_mesh_processing::triangulate_hole(mesh1, h, CGAL::parameters::visitor(Hole_filling_visitor(0,1,3)).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
-    CGAL::Polygon_mesh_processing::triangulate_hole(mesh2, h, CGAL::parameters::visitor(Hole_filling_visitor_reject_all()).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
+    PMP::triangulate_hole(mesh0, h, params::visitor(Hole_filling_visitor(0,1,2)).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
+    PMP::triangulate_hole(mesh1, h, params::visitor(Hole_filling_visitor(0,1,3)).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
+    PMP::triangulate_hole(mesh2, h, params::visitor(Hole_filling_visitor_reject_all()).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
 
     assert(CGAL::is_closed(mesh0));
     assert(CGAL::is_closed(mesh1));
@@ -582,18 +616,92 @@ void test_with_forbidden_triangles()
     for (auto haf : CGAL::halfedges_around_face(h, mesh3))
       vmap[target(haf,mesh3)]=i++;
 
-    CGAL::Polygon_mesh_processing::triangulate_hole(mesh3, h, CGAL::parameters::use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
+    PMP::triangulate_hole(mesh3, h, params::use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
     Hole_filling_visitor vis4(vmap.at(source(h,mesh3)), vmap.at(target(h,mesh3)), vmap.at(target(next(h,mesh3), mesh3))); // mesh3 on purpose
     std::pair diag4(source(h,mesh3), source(prev(h,mesh3), mesh3));
 
-    CGAL::Polygon_mesh_processing::triangulate_hole(mesh4, h, CGAL::parameters::visitor(vis4).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
-    CGAL::Polygon_mesh_processing::triangulate_hole(mesh5, h, CGAL::parameters::visitor(Hole_filling_visitor_reject_all()).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
+    PMP::triangulate_hole(mesh4, h, params::visitor(vis4).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
+    PMP::triangulate_hole(mesh5, h, params::visitor(Hole_filling_visitor_reject_all()).use_delaunay_triangulation(c.first).use_2d_constrained_delaunay_triangulation(c.second));
 
     assert(CGAL::is_closed(mesh3));
     assert(CGAL::is_closed(mesh4));
     assert(!CGAL::is_closed(mesh5));
     assert(!halfedge(diag4.first, diag4.second, mesh4).second);
   }
+
+  // now test triangulate_hole_polyline
+  using P = Kernel::Point_3;
+  std::vector<P> quad = {P(0,0,0), P(1,0,0), P(1,1,0), P(0,1,0)};
+  std::vector<std::tuple<int,int,int> > triangles1, triangles2, triangles3;
+  PMP::triangulate_hole_polyline(quad, std::back_inserter(triangles1), params::visitor(Hole_filling_visitor(0,1,2)));
+  PMP::triangulate_hole_polyline(quad, std::back_inserter(triangles2), params::visitor(Hole_filling_visitor(0,1,3)));
+  PMP::triangulate_hole_polyline(quad, std::back_inserter(triangles3), params::visitor(Hole_filling_visitor_reject_all()));
+
+  auto triangle_not_present = [](std::tuple<int,int,int> t, int i0, int i1, int i2)
+  {
+    auto a = CGAL::make_array(get<0>(t), get<1>(t), get<2>(t));
+    std::sort(a.begin(), a.end());
+    return a[0]!=i0 || a[1]!=i1 || a[2]!=i2;
+  };
+
+  assert(triangles1.size()==2);
+  assert(triangles2.size()==2);
+  assert(triangles3.empty());
+
+  assert(triangle_not_present(triangles1[0], 0, 1, 2) && triangle_not_present(triangles1[1], 0, 1, 2));
+  assert(triangle_not_present(triangles2[0], 0, 1, 3) && triangle_not_present(triangles2[1], 0, 1, 3));
+
+  std::vector<P> octo = {P(0,0,0), P(0.5,-0.5,0), P(1,0,0), P(1.5,0.5,0), P(1,1,0), P(0.5, 1.5, 0), P(0,1,0), P(-0.5,0.5,0)};
+  std::vector<std::tuple<int,int,int> > triangles4, triangles5, triangles6;
+  PMP::triangulate_hole_polyline(octo, std::back_inserter(triangles4));
+  assert(triangles4.size()==6);
+  auto [i0,i1,i2] = triangles4[0];
+  PMP::triangulate_hole_polyline(octo, std::back_inserter(triangles5), params::visitor(Hole_filling_visitor(i0,i1,i2)));
+  PMP::triangulate_hole_polyline(octo, std::back_inserter(triangles6), params::visitor(Hole_filling_visitor_reject_all()));
+  assert(triangles5.size()==6);
+  assert(triangles6.empty());
+  if (i2<i0) std::swap(i0,i2);
+  if (i1<i0) std::swap(i0,i1);
+  if (i2<i1) std::swap(i2,i1);
+  assert(triangle_not_present(triangles1[0], i0, i1, i2) && triangle_not_present(triangles1[1], i0, i1, i2));
+
+  // finally test triangulate_polygons
+  std::vector<P> points_quad = { P(-1,0,0), P(0,0,0), P(1,0,0), P(1,1,0), P(0,1,0)};
+  std::vector<std::vector<std::size_t>> polygons_quad1 = {{0,1,4}, {1,2,3,4}}, polygons_quad2=polygons_quad1, polygons_quad3=polygons_quad1;
+  PMP::triangulate_polygons(points_quad, polygons_quad1, params::visitor(Triangulate_polygon_visitor(1,2,3)));
+  PMP::triangulate_polygons(points_quad, polygons_quad2, params::visitor(Triangulate_polygon_visitor(1,2,4)));
+  PMP::triangulate_polygons(points_quad, polygons_quad3, params::visitor(Triangulate_polygon_visitor_reject_all()));
+
+  assert(polygons_quad1.size()==3);
+  assert(polygons_quad2.size()==3);
+  assert(polygons_quad3.size()==2);
+
+  auto polygon_not_present = [](std::vector<std::size_t> v, std::size_t i0, std::size_t i1, std::size_t i2)
+  {
+    std::sort(v.begin(), v.end());
+    return v[0]!=i0 || v[1]!=i1 || v[2]!=i2;
+  };
+
+  assert(polygon_not_present(polygons_quad1[0], 1, 2, 3) && polygon_not_present(polygons_quad1[1], 1, 2, 3));
+  assert(polygon_not_present(polygons_quad2[0], 1, 2, 4) && polygon_not_present(polygons_quad2[1], 1, 2, 4));
+
+  std::vector<P> points_octo = {P(-1,0,0), P(0,0,0), P(0.5,-0.5,0), P(1,0,0), P(1.5,0.5,0), P(1,1,0), P(0.5, 1.5, 0), P(0,1,0), P(-0.5,0.5,0)};
+  std::vector<std::vector<std::size_t>> polygons_octo1 ={{0,1,7}, {1,2,3,4,5,6,7,8}}, polygons_octo2=polygons_octo1, polygons_octo3=polygons_octo1;
+
+
+  PMP::triangulate_polygons(points_octo, polygons_octo1, params::visitor(Triangulate_polygon_visitor(1,2,3)));
+  assert(polygons_octo1.size()==7);
+  auto vals = polygons_octo1[1];
+  std::sort(vals.begin(), vals.end());
+  PMP::triangulate_polygons(points_octo, polygons_octo2, params::visitor(Triangulate_polygon_visitor(vals[0],vals[1],vals[2])));
+  PMP::triangulate_polygons(points_octo, polygons_octo3, params::visitor(Triangulate_polygon_visitor_reject_all()));
+  assert(polygons_octo2.size()==7);
+  assert(polygons_octo3.size()==2);
+  for (int i=0;i<7;++i)
+  {
+    assert(polygon_not_present(polygons_octo2[i], vals[0],vals[1],vals[2]));
+  }
+
 }
 
 

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -445,7 +445,7 @@ bool triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descriptor
 template <typename FaceRange,
           typename PolygonMesh,
           typename NamedParameters = parameters::Default_named_parameters>
-bool triangulate_faces(FaceRange face_range,
+bool triangulate_faces(const FaceRange& face_range,
                        PolygonMesh& pmesh,
                        const NamedParameters& np = parameters::default_values())
 {

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -37,7 +37,8 @@ namespace Polygon_mesh_processing {
 namespace Triangulate_faces {
 
 /** \ingroup PMP_meshing_grp
-*   %Default new face visitor model of `PMPTriangulateFaceVisitor`.
+*   %Default visitor model for the functions `triangulate_face()` and `triangulate_faces()`, model of `PMPTriangulateFaceVisitor`.
+*   \tparam PolygonMesh a model of `FaceListGraph` and `MutableFaceGraph`
 *   All its functions have an empty body. This class can be used as a
 *   base class if only some of the functions of the concept require to be
 *   overridden.
@@ -46,9 +47,10 @@ template<class PolygonMesh>
 struct Default_visitor
   : public Hole_filling::Default_visitor
 {
-  typedef boost::graph_traits<PolygonMesh> GT;
-  typedef typename GT::face_descriptor face_descriptor;
-  typedef typename GT::vertex_descriptor vertex_descriptor;
+  /// face descriptor type
+  typedef typename boost::graph_traits<PolygonMesh>::face_descriptor face_descriptor;
+  /// vertex descriptor type
+  typedef typename boost::graph_traits<PolygonMesh>::vertex_descriptor vertex_descriptor;
 
   void before_subface_creations(face_descriptor /*f_old*/) {}
   void after_subface_creations() {}
@@ -360,7 +362,9 @@ public:
 *
 *   \cgalParamNBegin{visitor}
 *     \cgalParamDescription{a visitor that enables to track how faces are triangulated into subfaces}
-*     \cgalParamType{a class model of `PMPTriangulateFaceVisitor` and `PMPHolefillingVisitor`}
+*     \cgalParamType{a class model of `PMPTriangulateFaceVisitor` and `PMPHolefillingVisitor`,
+*                    with `PMPTriangulateFaceVisitor::face_descriptor` and `PMPTriangulateFaceVisitor::vertex_descriptor` being
+*                    the corresponding descriptor types of `booost::graph_traits<PolygonMesh>`}
 *     \cgalParamDefault{`Triangulate_faces::Default_visitor<PolygonMesh>`}
 *     \cgalParamExtra{Note that the visitor will be copied, so
 *                     it must not have any data member that does not have a reference-like type.}
@@ -419,7 +423,9 @@ bool triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descriptor
 *
 *   \cgalParamNBegin{visitor}
 *     \cgalParamDescription{a visitor that enables to track how faces are triangulated into subfaces}
-*     \cgalParamType{a class model of `PMPTriangulateFaceVisitor` and `PMPHolefillingVisitor`}
+*     \cgalParamType{a class model of `PMPTriangulateFaceVisitor` and `PMPHolefillingVisitor`,
+*                    with `PMPTriangulateFaceVisitor::face_descriptor` and `PMPTriangulateFaceVisitor::vertex_descriptor` being
+*                    the corresponding descriptor types of `booost::graph_traits<PolygonMesh>`}
 *     \cgalParamDefault{`Triangulate_faces::Default_visitor<PolygonMesh>`}
 *     \cgalParamExtra{Note that the visitor will be copied, so
 *                     it must not have any data member that does not have a reference-like type.}
@@ -492,7 +498,8 @@ bool triangulate_faces(FaceRange face_range,
 *
 *   \cgalParamNBegin{visitor}
 *     \cgalParamDescription{a visitor that enables to track how faces are triangulated into subfaces}
-*     \cgalParamType{a class model of `PMPTriangulateFaceVisitor` and `PMPHolefillingVisitor`}
+*     \cgalParamType{a class model of `PMPTriangulateFaceVisitor` and `PMPHolefillingVisitor`,
+*                    with `PMPTriangulateFaceVisitor::face_descriptor` and `PMPTriangulateFaceVisitor::vertex_descriptor` being `std::size_t`.}
 *     \cgalParamDefault{`Triangulate_faces::Default_visitor<PolygonMesh>`}
 *     \cgalParamExtra{Note that the visitor will be copied, so
 *                     it must not have any data member that does not have a reference-like type.}
@@ -524,7 +531,7 @@ bool triangulate_faces(PolygonMesh& pmesh,
 namespace Triangulate_polygons {
 
 /** \ingroup PMP_meshing_grp
-*   %Default new polygon visitor model of `PMPTriangulateFaceVisitor`.
+*   %Default visitor for the function `triangulate_polygons()`, model of `PMPTriangulateFaceVisitor`.
 *   All its functions have an empty body. This class can be used as a
 *   base class if only some of the functions of the concept require to be
 *   overridden.
@@ -532,18 +539,46 @@ namespace Triangulate_polygons {
 struct Default_visitor
   : public Hole_filling::Default_visitor
 {
-  template <typename Polygon>
-  void before_subface_creations(const Polygon& /*f_old*/) {}
+  /// face id type, refering to the position of the polygon in the input range
+  using face_descriptor = std::size_t;
+  /// vertex id type
+  using vertex_descriptor = std::size_t;
 
-  template <typename Polygon>
-  void after_subface_created(const Polygon& /*f_new*/) {}
+  void before_subface_creations(face_descriptor) {}
+
+  void after_subface_created(face_descriptor) {}
 
   void after_subface_creations() {}
+
+  constexpr
+  bool accept_face(face_descriptor /*f*/, vertex_descriptor /*v0*/, vertex_descriptor /*v1*/, vertex_descriptor /*v2*/) const
+  {
+    return true;
+  }
 };
 
 } // namespace Triangulate_polygons
 
 namespace internal {
+
+template <class Triangulation_visitor>
+struct Visitor_Wrapper
+  : public Triangulation_visitor
+{
+  std::size_t poly_id;
+  const std::vector<std::size_t>& pid_map;
+
+  bool accept_triangle(int i0, int i1, int i2) const
+  {
+    if (!static_cast<const Triangulation_visitor*>(this)->accept_triangle(i0, i1, i2))
+      return false;
+    return static_cast<const Triangulation_visitor*>(this)->accept_face(poly_id, pid_map[i0], pid_map[i1], pid_map[i2]);
+  }
+
+  Visitor_Wrapper(std::size_t poly_id,  const std::vector<std::size_t>& pid_map, Triangulation_visitor& tvisitor)
+    : Triangulation_visitor(tvisitor), poly_id(poly_id), pid_map(pid_map)
+  {}
+};
 
 class Triangulate_polygon_soup_modifier
 {
@@ -556,9 +591,10 @@ private:
            typename NamedParameters>
   bool triangulate_polygon_with_hole_filling(const Polygon& polygon,
                                              const PointRange& points,
+                                             std::size_t poly_id,
                                              PolygonRange& triangulated_polygons, // output
                                              PMap pm,
-                                             Visitor visitor,
+                                             Visitor& visitor,
                                              const NamedParameters& np)
   {
     namespace PMP = CGAL::Polygon_mesh_processing;
@@ -578,22 +614,19 @@ private:
     // use hole filling
     typedef CGAL::Triple<int, int, int> Face_indices;
     std::vector<Face_indices> patch;
-    PMP::triangulate_hole_polyline(hole_points, std::back_inserter(patch), np);
+    Visitor_Wrapper new_visitor(poly_id, polygon, visitor);
+    PMP::triangulate_hole_polyline(hole_points, std::back_inserter(patch), np.visitor(new_visitor));
 
     if(patch.empty())
       return false;
-
-    visitor.before_subface_creations(polygon);
 
     for(const Face_indices& triangle : patch)
     {
       triangulated_polygons.push_back({hole_points_indices[triangle.first],
                                        hole_points_indices[triangle.second],
                                        hole_points_indices[triangle.third]});
-      visitor.after_subface_created(triangulated_polygons.back());
+      visitor.after_subface_created(triangulated_polygons.size()-1);
     }
-
-    visitor.after_subface_creations();
     return true;
   }
 
@@ -601,10 +634,13 @@ public:
   template <typename Polygon,
             typename PointRange,
             typename PolygonRange,
+            typename Visitor,
             typename NamedParameters>
   bool operator()(const Polygon& polygon,
                   const PointRange& points,
+                  std::size_t poly_id,
                   PolygonRange& triangulated_polygons,
+                  Visitor& visitor,
                   const NamedParameters& np)
   {
     // PointMap
@@ -621,20 +657,11 @@ public:
     using FT = typename Traits::FT;
     using PID = typename std::iterator_traits<typename Polygon::const_iterator>::value_type;
 
-    // Visitor
-    using Visitor = typename internal_np::Lookup_named_param_def<
-                                            internal_np::visitor_t,
-                                            NamedParameters,
-                                            Triangulate_polygons::Default_visitor // default
-                                          >::type;
-
     using parameters::choose_parameter;
     using parameters::get_parameter;
 
     PMap pm = choose_parameter<PMap>(get_parameter(np, internal_np::point_map));
     Traits traits = choose_parameter<Traits>(get_parameter(np, internal_np::geom_traits));
-    Visitor visitor = choose_parameter<Visitor>(get_parameter(np, internal_np::visitor),
-                                                Triangulate_polygons::Default_visitor());
 
     typename Traits::Construct_cross_product_vector_3 cross_product =
       traits.construct_cross_product_vector_3_object();
@@ -647,6 +674,30 @@ public:
       Point_ref p2 = get(pm, points[polygon[2]]);
       Point_ref p3 = get(pm, points[polygon[3]]);
 
+      if (!visitor.accept_face(poly_id, polygon[0], polygon[1], polygon[3]) ||
+          !visitor.accept_face(poly_id, polygon[0], polygon[2], polygon[3]))
+      {
+        if (!visitor.accept_face(poly_id, polygon[0], polygon[1], polygon[2]) ||
+            !visitor.accept_face(poly_id, polygon[0], polygon[2], polygon[3]))
+        {
+          return false;
+        }
+        triangulated_polygons.push_back({polygon[0], polygon[1], polygon[2]});
+        triangulated_polygons.push_back({polygon[0], polygon[2], polygon[3]});
+        visitor.after_subface_created(triangulated_polygons.size()-2);
+        visitor.after_subface_created(triangulated_polygons.size()-1);
+        return true;
+      }
+
+      if (!visitor.accept_face(poly_id, polygon[0], polygon[1], polygon[2]) ||
+          !visitor.accept_face(poly_id, polygon[0], polygon[2], polygon[3]))
+      {
+        triangulated_polygons.push_back({polygon[0], polygon[1], polygon[3]});
+        triangulated_polygons.push_back({polygon[1], polygon[2], polygon[3]});
+        visitor.after_subface_created(triangulated_polygons.size()-2);
+        visitor.after_subface_created(triangulated_polygons.size()-1);
+        return true;
+      }
       /* Chooses the diagonal that will split the quad in two triangles that maximize
        * the scalar product of the un-normalized normals of the two triangles.
        * The lengths of the un-normalized normals (computed using cross-products of two vectors)
@@ -656,9 +707,6 @@ public:
        * In particular, if the two triangles are oriented in different directions,
        * the scalar product will be negative.
        */
-      visitor.before_subface_creations(polygon);
-
-
       typename Traits::Vector_3 p0p1=p1-p0;
       typename Traits::Vector_3 p1p2=p2-p1;
       typename Traits::Vector_3 p2p3=p3-p2;
@@ -699,16 +747,13 @@ public:
           triangulated_polygons.push_back({polygon[1], polygon[2], polygon[3]});
         }
       }
-
-      visitor.after_subface_created(triangulated_polygons[triangulated_polygons.size()-2]);
-      visitor.after_subface_created(triangulated_polygons[triangulated_polygons.size()-1]);
-
-      visitor.after_subface_creations();
+      visitor.after_subface_created(triangulated_polygons.size()-2);
+      visitor.after_subface_created(triangulated_polygons.size()-1);
 
       return true;
     }
 
-    return triangulate_polygon_with_hole_filling(polygon, points, triangulated_polygons, pm, visitor, np);
+    return triangulate_polygon_with_hole_filling(polygon, points, poly_id, triangulated_polygons, pm, visitor, np);
   }
 }; // class Triangulate_polygon_soup_modifier
 
@@ -774,19 +819,31 @@ bool triangulate_polygons(const PointRange& points,
   PolygonRange triangulated_polygons;
   triangulated_polygons.reserve(polygons.size());
 
+  auto visitor = parameters::choose_parameter<Triangulate_polygons::Default_visitor>(
+                   parameters::get_parameter(np, internal_np::visitor));
+
   bool success = true;
 
   internal::Triangulate_polygon_soup_modifier modifier;
-  for(const Polygon& polygon : polygons)
+  for(std::size_t poly_id=0; poly_id<polygons.size(); ++poly_id)
   {
+    Polygon& polygon = polygons[poly_id];
+
+    visitor.before_subface_creations(poly_id);
     if(polygon.size() <= 3)
     {
-      triangulated_polygons.push_back(polygon);
-      continue;
+      triangulated_polygons.push_back(std::move(polygon));
+      visitor.after_subface_created(triangulated_polygons.size()-1);
     }
+    else
+      if(!modifier(polygon, points, poly_id, triangulated_polygons, visitor, np))
+      {
+        success = false;
+        triangulated_polygons.push_back(std::move(polygon));
+        visitor.after_subface_created(triangulated_polygons.size()-1);
+      }
 
-    if(!modifier(polygon, points, triangulated_polygons, np))
-      success = false;
+    visitor.after_subface_creations();
   }
 
   std::swap(polygons, triangulated_polygons);

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -36,8 +36,7 @@ namespace CGAL {
 namespace Polygon_mesh_processing {
 namespace Triangulate_faces {
 
-/** \ingroup PMP_combi_remeshing_grp
-*
+/** \ingroup PMP_meshing_grp
 *   %Default new face visitor model of `PMPTriangulateFaceVisitor`.
 *   All its functions have an empty body. This class can be used as a
 *   base class if only some of the functions of the concept require to be
@@ -45,20 +44,51 @@ namespace Triangulate_faces {
 */
 template<class PolygonMesh>
 struct Default_visitor
-#ifndef DOXYGEN_RUNNING
   : public Hole_filling::Default_visitor
 {
-
   typedef boost::graph_traits<PolygonMesh> GT;
   typedef typename GT::face_descriptor face_descriptor;
+  typedef typename GT::vertex_descriptor vertex_descriptor;
 
   void before_subface_creations(face_descriptor /*f_old*/) {}
   void after_subface_creations() {}
   void after_subface_created(face_descriptor /*f_new*/) {}
+  constexpr
+  bool accept_face(face_descriptor /*f*/, vertex_descriptor /*v0*/, vertex_descriptor /*v1*/, vertex_descriptor /*v2*/) const
+  {
+    return true;
+  }
+  using Hole_filling::Default_visitor::accept_face;
 };
-#else
-;
-#endif
+
+template <class PolygonMesh, class Triangulation_visitor>
+struct Visitor_Wrapper
+  : public Triangulation_visitor
+{
+  using vertex_descriptor = typename boost::graph_traits<PolygonMesh>::vertex_descriptor;
+  using face_descriptor = typename boost::graph_traits<PolygonMesh>::face_descriptor;
+
+  face_descriptor f;
+  std::vector<vertex_descriptor> verts;
+
+  bool accept_face(int i0, int i1, int i2) const
+  {
+    if (!static_cast<const Triangulation_visitor*>(this)->accept_face(i0, i1, i2))
+      return false;
+    return static_cast<const Triangulation_visitor*>(this)->accept_face(f, verts[i0], verts[i1], verts[i2]);
+  }
+
+  Visitor_Wrapper(PolygonMesh& pmesh, face_descriptor f, Triangulation_visitor& tvisitor)
+    : Triangulation_visitor(tvisitor), f(f)
+  {
+    auto h = halfedge(f, pmesh), hstart=h;
+    do{
+      verts.push_back(target(h, pmesh));
+      h = next(h, pmesh);
+    }
+    while(h!=hstart);
+  }
+};
 
 } // namespace Triangulate_faces
 
@@ -72,47 +102,44 @@ class Triangulate_polygon_mesh_modifier
   using face_descriptor = typename boost::graph_traits<PolygonMesh>::face_descriptor;
 
 private:
-  template <typename VPM,
+  template <typename Point,
             typename Visitor,
             typename NamedParameters>
   bool triangulate_face_with_hole_filling(face_descriptor f,
                                           PolygonMesh& pmesh,
-                                          const VPM vpm,
+                                          const std::vector<vertex_descriptor>& border_vertices,
+                                          const std::vector<Point>& hole_points,
                                           Visitor visitor,
                                           const NamedParameters& np)
   {
     namespace PMP = CGAL::Polygon_mesh_processing;
 
-    using Point = typename boost::property_traits<VPM>::value_type;
-
-    // gather halfedges around the face
-    std::vector<Point> hole_points;
-    std::vector<vertex_descriptor> border_vertices;
-    CGAL_assertion(CGAL::halfedges_around_face(halfedge(f, pmesh), pmesh).size() > 0);
-    for (halfedge_descriptor h : CGAL::halfedges_around_face(halfedge(f, pmesh), pmesh))
-    {
-      vertex_descriptor v = source(h, pmesh);
-      hole_points.push_back(get(vpm, v));
-      border_vertices.push_back(v);
-    }
-
     // use hole filling
     typedef CGAL::Triple<int, int, int> Face_indices;
     std::vector<Face_indices> patch;
-    PMP::triangulate_hole_polyline(hole_points, std::back_inserter(patch),
-                                   np.use_2d_constrained_delaunay_triangulation(true));
+
+    auto gt_np = parameters::get_parameter(np, internal_np::geom_traits);
+    auto dt_np = parameters::get_parameter(np, internal_np::use_delaunay_triangulation);
+    auto threshold_np = parameters::get_parameter(np, internal_np::threshold_distance);
+
+    auto new_np = parameters::visitor(visitor)
+                             .use_2d_constrained_delaunay_triangulation(true)
+                             .combine(gt_np, dt_np, threshold_np);
+
+    PMP::triangulate_hole_polyline(hole_points, std::back_inserter(patch), new_np);
 
     if(patch.empty())
       return false;
 
     // triangulate the hole
     std::map<std::pair<int, int>, halfedge_descriptor > halfedge_map;
-    int i = 0;
-    for (halfedge_descriptor h : CGAL::halfedges_around_face(halfedge(f, pmesh), pmesh))
+    int i = static_cast<int>(hole_points.size())-1;
+    int j = 0;
+    for(halfedge_descriptor h : CGAL::halfedges_around_face(halfedge(f, pmesh), pmesh))
     {
-      int j = std::size_t(i+1) == hole_points.size() ? 0 : i+1;
       halfedge_map[std::make_pair(i, j)] = h;
-      ++i;
+      i = j;
+      ++j;
     }
 
     visitor.before_subface_creations(f);
@@ -120,12 +147,10 @@ private:
     bool first = true;
     std::vector<halfedge_descriptor> hedges;
     hedges.reserve(4);
-    for (const Face_indices& triangle : patch)
+    for(const Face_indices& triangle : patch)
     {
       if(first)
-      {
         first = false;
-      }
       else
       {
         f = add_face(pmesh);
@@ -141,7 +166,7 @@ private:
         typename std::map< std::pair<int, int> , halfedge_descriptor >::iterator insert_res =
           halfedge_map.emplace(std::make_pair(indices[i], indices[i+1]),
                                boost::graph_traits<PolygonMesh>::null_halfedge()).first;
-        if (insert_res->second == boost::graph_traits<PolygonMesh>::null_halfedge())
+        if(insert_res->second == boost::graph_traits<PolygonMesh>::null_halfedge())
         {
           halfedge_descriptor nh = halfedge(add_edge(pmesh), pmesh);
           insert_res->second = nh;
@@ -151,7 +176,7 @@ private:
       }
 
       hedges.push_back(hedges.front());
-      for (int i=0; i<3;++i)
+      for(int i=0; i<3;++i)
       {
         set_next(hedges[i], hedges[i+1], pmesh);
         set_face(hedges[i], f, pmesh);
@@ -199,21 +224,59 @@ public:
     typename Traits::Construct_cross_product_vector_3 cross_product =
       traits.construct_cross_product_vector_3_object();
 
-    typename boost::graph_traits<PolygonMesh>::degree_size_type  original_size = degree(f, pmesh);
-    if(original_size <= 3)
+    using Point = typename boost::property_traits<VPM>::value_type;
+
+
+    std::vector<Point> hole_points;
+    std::vector<vertex_descriptor> border_vertices;
+    CGAL_assertion(CGAL::halfedges_around_face(halfedge(f, pmesh), pmesh).size() > 0);
+    for(halfedge_descriptor h : CGAL::halfedges_around_face(halfedge(f, pmesh), pmesh))
+    {
+      vertex_descriptor v = target(h, pmesh);
+      hole_points.push_back(get(vpm, v));
+      border_vertices.push_back(v);
+    }
+    if(border_vertices.size() <= 3)
       return true;
 
-    if(original_size == 4)
+    if(border_vertices.size() == 4) // TODO: also use is_valid
     {
-      std::array<halfedge_descriptor,4> verts;
-      verts[0] = halfedge(f, pmesh);
-      verts[1] = next(verts[0], pmesh);
-      verts[2] = next(verts[1], pmesh);
-      verts[3] = next(verts[2], pmesh);
-      Point_ref p0 = get(vpm, target(verts[0], pmesh));
-      Point_ref p1 = get(vpm, target(verts[1], pmesh));
-      Point_ref p2 = get(vpm, target(verts[2], pmesh));
-      Point_ref p3 = get(vpm, target(verts[3], pmesh));
+      std::array<halfedge_descriptor,4> hverts;
+      hverts[0] = halfedge(f, pmesh);
+      hverts[1] = next(hverts[0], pmesh);
+      hverts[2] = next(hverts[1], pmesh);
+      hverts[3] = next(hverts[2], pmesh);
+      auto verts = make_array(target(hverts[0],pmesh), target(hverts[1],pmesh),
+                              target(hverts[2],pmesh), target(hverts[3],pmesh));
+
+      if ( !visitor.accept_face(f,verts[0],verts[1],verts[3]) ||
+           !visitor.accept_face(f,verts[1],verts[2],verts[3]) )
+      {
+        if ( !visitor.accept_face(f,verts[0],verts[1],verts[2]) ||
+             !visitor.accept_face(f,verts[0],verts[2],verts[3]) )
+          return false;
+        visitor.before_subface_creations(f);
+        halfedge_descriptor res = CGAL::Euler::split_face(hverts[0], hverts[2], pmesh);
+        visitor.after_subface_created(face(res, pmesh));
+        visitor.after_subface_created(face(opposite(res, pmesh), pmesh));
+        visitor.after_subface_creations();
+        return true;
+      }
+      if ( !visitor.accept_face(f,verts[0],verts[1],verts[2]) ||
+           !visitor.accept_face(f,verts[0],verts[2],verts[3]) )
+      {
+        visitor.before_subface_creations(f);
+        halfedge_descriptor res = CGAL::Euler::split_face(hverts[1], hverts[3], pmesh);
+        visitor.after_subface_created(face(res, pmesh));
+        visitor.after_subface_created(face(opposite(res, pmesh), pmesh));
+        visitor.after_subface_creations();
+        return true;
+      }
+
+      Point_ref p0 = get(vpm, target(hverts[0], pmesh));
+      Point_ref p1 = get(vpm, target(hverts[1], pmesh));
+      Point_ref p2 = get(vpm, target(hverts[2], pmesh));
+      Point_ref p3 = get(vpm, target(hverts[3], pmesh));
 
       /* Chooses the diagonal that will split the quad in two triangles that maximize
        * the scalar product of the un-normalized normals of the two triangles.
@@ -238,20 +301,20 @@ public:
 
       if (delta1!=delta2)
         res = (delta2>delta1)
-            ?  CGAL::Euler::split_face(verts[0], verts[2], pmesh)
-            :  CGAL::Euler::split_face(verts[1], verts[3], pmesh);
+            ?  CGAL::Euler::split_face(hverts[0], hverts[2], pmesh)
+            :  CGAL::Euler::split_face(hverts[1], hverts[3], pmesh);
       else
       {
         halfedge_descriptor m =
-          *(std::min_element)(verts.begin(), verts.end(),
+          *(std::min_element)(hverts.begin(), hverts.end(),
                               [&pmesh,vpm](halfedge_descriptor v0, halfedge_descriptor v1)
                               {
                                 return lexicographically_xyz_smaller(get(vpm, target(v0, pmesh)),
                                                                      get(vpm, target(v1, pmesh)));
                               });
-        res = (m==verts[0] || m==verts[2])
-            ? CGAL::Euler::split_face(verts[0], verts[2], pmesh)
-            : CGAL::Euler::split_face(verts[1], verts[3], pmesh);
+        res = (m==hverts[0] || m==hverts[2])
+            ? CGAL::Euler::split_face(hverts[0], hverts[2], pmesh)
+            : CGAL::Euler::split_face(hverts[1], hverts[3], pmesh);
       }
 
       visitor.after_subface_created(face(res, pmesh));
@@ -262,14 +325,16 @@ public:
       return true;
     }
 
-    return triangulate_face_with_hole_filling(f, pmesh, vpm, visitor, np);
+    Triangulate_faces::Visitor_Wrapper<PolygonMesh,Visitor> visitor_wrapper(pmesh, f, visitor);
+
+    return triangulate_face_with_hole_filling(f, pmesh, border_vertices, hole_points, visitor_wrapper, np);
   }
 }; // class Triangulate_polygon_mesh_modifier
 
 } // namespace internal
 
 /**
-* \ingroup PMP_combi_remeshing_grp
+* \ingroup PMP_meshing_grp
 *
 * triangulates a single face of a polygon mesh. This function depends on the package \ref PkgTriangulation2.
 *
@@ -326,7 +391,7 @@ bool triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descriptor
 }
 
 /**
-* \ingroup PMP_combi_remeshing_grp
+* \ingroup PMP_meshing_grp
 *
 * triangulates given faces of a polygon mesh. This function depends on the package \ref PkgTriangulation2.
 *
@@ -378,7 +443,7 @@ bool triangulate_face(typename boost::graph_traits<PolygonMesh>::face_descriptor
 template <typename FaceRange,
           typename PolygonMesh,
           typename NamedParameters = parameters::Default_named_parameters>
-bool triangulate_faces(const FaceRange& face_range,
+bool triangulate_faces(FaceRange face_range,
                        PolygonMesh& pmesh,
                        const NamedParameters& np = parameters::default_values())
 {
@@ -402,7 +467,7 @@ bool triangulate_faces(const FaceRange& face_range,
 }
 
 /**
-* \ingroup PMP_combi_remeshing_grp
+* \ingroup PMP_meshing_grp
 *
 * triangulates all faces of a polygon mesh. This function depends on the package \ref PkgTriangulation2.
 *
@@ -462,15 +527,13 @@ bool triangulate_faces(PolygonMesh& pmesh,
 
 namespace Triangulate_polygons {
 
-/** \ingroup PMP_combi_remeshing_grp
-*
+/** \ingroup PMP_meshing_grp
 *   %Default new polygon visitor model of `PMPTriangulateFaceVisitor`.
 *   All its functions have an empty body. This class can be used as a
 *   base class if only some of the functions of the concept require to be
 *   overridden.
 */
 struct Default_visitor
-#ifndef DOXYGEN_RUNNING
   : public Hole_filling::Default_visitor
 {
   template <typename Polygon>
@@ -481,9 +544,6 @@ struct Default_visitor
 
   void after_subface_creations() {}
 };
-#else
-;
-#endif
 
 } // namespace Triangulate_polygons
 
@@ -659,7 +719,7 @@ public:
 } // namespace internal
 
 /**
-* \ingroup PMP_combi_remeshing_grp
+* \ingroup PMP_meshing_grp
 *
 * triangulates all polygons of a polygon soup. This function depends on the package \ref PkgTriangulation2.
 *

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -235,7 +235,7 @@ public:
     if(border_vertices.size() <= 3)
       return true;
 
-    if(border_vertices.size() == 4) // TODO: also use is_valid
+    if(border_vertices.size() == 4)
     {
       std::array<halfedge_descriptor,4> hverts;
       hverts[0] = halfedge(f, pmesh);

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -117,13 +117,10 @@ private:
     typedef CGAL::Triple<int, int, int> Face_indices;
     std::vector<Face_indices> patch;
 
-    auto gt_np = parameters::get_parameter(np, internal_np::geom_traits);
-    auto dt_np = parameters::get_parameter(np, internal_np::use_delaunay_triangulation);
-    auto threshold_np = parameters::get_parameter(np, internal_np::threshold_distance);
-
-    auto new_np = parameters::visitor(visitor)
-                             .use_2d_constrained_delaunay_triangulation(true)
-                             .combine(gt_np, dt_np, threshold_np);
+    // visitor and bool are "replaced" if they already exist in `np` because we will
+    // return the first one seen while unstacking the NP inheritance stack
+    auto new_np = np.visitor(visitor)
+                    .use_2d_constrained_delaunay_triangulation(true);
 
     PMP::triangulate_hole_polyline(hole_points, std::back_inserter(patch), new_np);
 

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -561,12 +561,12 @@ struct Default_visitor
 
 namespace internal {
 
-template <class Triangulation_visitor>
+template <class Triangulation_visitor, class Polygon>
 struct Visitor_wrapper
   : public Triangulation_visitor
 {
   std::size_t poly_id;
-  const std::vector<std::size_t>& pid_map;
+  const Polygon& pid_map;
 
   bool accept_triangle(int i0, int i1, int i2) const
   {
@@ -575,7 +575,7 @@ struct Visitor_wrapper
     return static_cast<const Triangulation_visitor*>(this)->accept_face(poly_id, pid_map[i0], pid_map[i1], pid_map[i2]);
   }
 
-  Visitor_wrapper(std::size_t poly_id,  const std::vector<std::size_t>& pid_map, Triangulation_visitor& tvisitor)
+  Visitor_wrapper(std::size_t poly_id,  const Polygon& pid_map, Triangulation_visitor& tvisitor)
     : Triangulation_visitor(tvisitor), poly_id(poly_id), pid_map(pid_map)
   {}
 };

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -63,7 +63,7 @@ struct Default_visitor
 };
 
 template <class PolygonMesh, class Triangulation_visitor>
-struct Visitor_Wrapper
+struct Visitor_wrapper
   : public Triangulation_visitor
 {
   using vertex_descriptor = typename boost::graph_traits<PolygonMesh>::vertex_descriptor;
@@ -79,7 +79,7 @@ struct Visitor_Wrapper
     return static_cast<const Triangulation_visitor*>(this)->accept_face(f, verts[i0], verts[i1], verts[i2]);
   }
 
-  Visitor_Wrapper(PolygonMesh& pmesh, face_descriptor f, Triangulation_visitor& tvisitor)
+  Visitor_wrapper(PolygonMesh& pmesh, face_descriptor f, Triangulation_visitor& tvisitor)
     : Triangulation_visitor(tvisitor), f(f)
   {
     auto h = halfedge(f, pmesh), hstart=h;
@@ -323,9 +323,9 @@ public:
       return true;
     }
 
-    Triangulate_faces::Visitor_Wrapper<PolygonMesh,Visitor> visitor_wrapper(pmesh, f, visitor);
+    Triangulate_faces::Visitor_wrapper<PolygonMesh,Visitor> Visitor_wrapper(pmesh, f, visitor);
 
-    return triangulate_face_with_hole_filling(f, pmesh, border_vertices, hole_points, visitor_wrapper, np);
+    return triangulate_face_with_hole_filling(f, pmesh, border_vertices, hole_points, Visitor_wrapper, np);
   }
 }; // class Triangulate_polygon_mesh_modifier
 
@@ -562,7 +562,7 @@ struct Default_visitor
 namespace internal {
 
 template <class Triangulation_visitor>
-struct Visitor_Wrapper
+struct Visitor_wrapper
   : public Triangulation_visitor
 {
   std::size_t poly_id;
@@ -575,7 +575,7 @@ struct Visitor_Wrapper
     return static_cast<const Triangulation_visitor*>(this)->accept_face(poly_id, pid_map[i0], pid_map[i1], pid_map[i2]);
   }
 
-  Visitor_Wrapper(std::size_t poly_id,  const std::vector<std::size_t>& pid_map, Triangulation_visitor& tvisitor)
+  Visitor_wrapper(std::size_t poly_id,  const std::vector<std::size_t>& pid_map, Triangulation_visitor& tvisitor)
     : Triangulation_visitor(tvisitor), poly_id(poly_id), pid_map(pid_map)
   {}
 };
@@ -614,7 +614,7 @@ private:
     // use hole filling
     typedef CGAL::Triple<int, int, int> Face_indices;
     std::vector<Face_indices> patch;
-    Visitor_Wrapper new_visitor(poly_id, polygon, visitor);
+    Visitor_wrapper new_visitor(poly_id, polygon, visitor);
     PMP::triangulate_hole_polyline(hole_points, std::back_inserter(patch), np.visitor(new_visitor));
 
     if(patch.empty())

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -58,7 +58,6 @@ struct Default_visitor
   {
     return true;
   }
-  using Hole_filling::Default_visitor::accept_face;
 };
 
 template <class PolygonMesh, class Triangulation_visitor>
@@ -71,9 +70,9 @@ struct Visitor_Wrapper
   face_descriptor f;
   std::vector<vertex_descriptor> verts;
 
-  bool accept_face(int i0, int i1, int i2) const
+  bool accept_triangle(int i0, int i1, int i2) const
   {
-    if (!static_cast<const Triangulation_visitor*>(this)->accept_face(i0, i1, i2))
+    if (!static_cast<const Triangulation_visitor*>(this)->accept_triangle(i0, i1, i2))
       return false;
     return static_cast<const Triangulation_visitor*>(this)->accept_face(f, verts[i0], verts[i1], verts[i2]);
   }

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPHolefillingVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPHolefillingVisitor.h
@@ -68,7 +68,7 @@ public:
   /// in a polygon mesh (`0` being the target of the input border halfedge, `1` the target of the next border halfedge, ...).
   /// If `false` is returned, the triangle will not be used. If `true` is returned, the triangle will be
   /// added to the candidate triangles.
-  bool accept_face(int i0, int i1, int i2);
+  bool accept_triangle(int i0, int i1, int i2);
 
 
 };

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPHolefillingVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPHolefillingVisitor.h
@@ -62,4 +62,13 @@ public:
   ///(`triangulate_refine_and_fair_hole()` only)
   void end_fair_phase();
 
+  /// called before considering a triangle made from the points with indices i0, i1, and i2 to triangulate a hole.
+  /// The indices refers to the position of the points in the input point range if trangulating a polyline, or to
+  /// the position of the vertices along the cycle of halfedges of the input border halfedge if triangulating a hole
+  /// in a polygon mesh (`0` being the target of the input border halfedge, `1` the target of the next border halfedge, ...).
+  /// If `false` is returned, the triangle will not be used. If `true` is returned, the triangle will be
+  /// added to the candidate triangles.
+  bool accept_face(int i0, int i1, int i2);
+
+
 };

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPTriangulateFaceVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPTriangulateFaceVisitor.h
@@ -15,6 +15,8 @@ class PMPTriangulateFaceVisitor {
 public:
 /// Face descriptor type
 typedef unspecified_type face_descriptor;
+/// Vertex descriptor type
+typedef unspecified_type vertex_descriptor;
 
 /// @name Functions used by triangulate_face() and triangulate_faces()
 /// @{
@@ -30,6 +32,11 @@ typedef unspecified_type face_descriptor;
   /// called after creating a new triangle face `f_new` to triangulate the face passed to `before_subface_creations()`.
   /// Note that the call is placed just after a call to `add_face()` so the halfedge pointer is not set yet.
   void after_subface_created(face_descriptor f_new);
+
+  /// called before considering a triangle made of vertices `(v0,v1,v2)` to triangulate `f`.
+  /// If `false` is returned, the triangle will not be used. If `true` is returned, the triangle will be
+  /// added to the candidate triangles.
+  bool accept_face(face_descriptor f, vertex_descriptor v0, vertex_descriptor v1, vertex_descriptor v2);
 
   /// @}
 

--- a/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPTriangulateFaceVisitor.h
+++ b/Polygon_mesh_processing/doc/Polygon_mesh_processing/Concepts/PMPTriangulateFaceVisitor.h
@@ -1,3 +1,4 @@
+
 /// \ingroup PkgPolygonMeshProcessingConcepts
 /// \cgalConcept
 ///
@@ -7,7 +8,7 @@
 ///
 /// \cgalRefines{CopyConstructible}
 /// \cgalHasModelsBegin
-/// \cgalHasModels{CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor}
+/// \cgalHasModels{CGAL::Polygon_mesh_processing::Triangulate_faces::Default_visitor,CGAL::Polygon_mesh_processing::Triangulate_polygons::Default_visitor}
 /// \cgalHasModelsEnd
 
 

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/point_inside_helpers.h
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/point_inside_helpers.h
@@ -33,8 +33,6 @@ void generate_near_boundary(const PolygonMesh& mesh,
 
   Ppmap ppmap = get(boost::vertex_point, mesh);
   // put vertices
-  vertex_descriptor vd;
-
   for(vertex_descriptor vb : vertices(mesh)) {
     points.push_back(ppmap[vb]);
     on_boundary.push_back(true);

--- a/STL_Extension/include/CGAL/Named_function_parameters.h
+++ b/STL_Extension/include/CGAL/Named_function_parameters.h
@@ -419,19 +419,6 @@ struct Named_function_parameters
     return Named_function_parameters<OT, OTag, self>(np.v,*this).combine(nps...);
   }
 
-  template <typename ... NPS>
-  auto
-  combine(internal_np::Param_not_found, const NPS& ... nps) const
-  {
-    return this->combine(nps...);
-  }
-
-  auto
-  combine(internal_np::Param_not_found) const
-  {
-    return *this;
-  }
-
   // typedef for SFINAE
   typedef int CGAL_Named_function_parameters_class;
 };

--- a/STL_Extension/include/CGAL/Named_function_parameters.h
+++ b/STL_Extension/include/CGAL/Named_function_parameters.h
@@ -419,6 +419,19 @@ struct Named_function_parameters
     return Named_function_parameters<OT, OTag, self>(np.v,*this).combine(nps...);
   }
 
+  template <typename ... NPS>
+  auto
+  combine(internal_np::Param_not_found, const NPS& ... nps) const
+  {
+    return this->combine(nps...);
+  }
+
+  auto
+  combine(internal_np::Param_not_found) const
+  {
+    return *this;
+  }
+
   // typedef for SFINAE
   typedef int CGAL_Named_function_parameters_class;
 };

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -65,7 +65,10 @@ namespace CGAL {
         /// We write -1, which is <a href="https://en.cppreference.com/w/cpp/types/numeric_limits">
         /// <tt>(std::numeric_limits<size_type>::max)()</tt></a>
         /// as `size_type` is an unsigned type.
-        explicit SM_Index(size_type _idx=(std::numeric_limits<size_type>::max)()) : idx_(_idx) {}
+        constexpr
+        SM_Index() : idx_((std::numeric_limits<size_type>::max)()) {}
+
+        explicit SM_Index(size_type _idx) : idx_(_idx) {}
 
         /// Get the underlying index of this index
         operator size_type() const { return idx_; }
@@ -126,7 +129,7 @@ namespace CGAL {
     {
     public:
 
-        SM_Vertex_index() : SM_Index<SM_Vertex_index>((std::numeric_limits<size_type>::max)()) {}
+        SM_Vertex_index() = default;
 
         explicit SM_Vertex_index(size_type _idx) : SM_Index<SM_Vertex_index>(_idx) {}
 
@@ -171,7 +174,7 @@ namespace CGAL {
         typedef void pointer;
         typedef void reference;
 
-        SM_Halfedge_index() : SM_Index<SM_Halfedge_index>((std::numeric_limits<size_type>::max)()) {}
+        SM_Halfedge_index() = default;
 
         explicit SM_Halfedge_index(size_type _idx) : SM_Index<SM_Halfedge_index>(_idx) {}
 
@@ -206,7 +209,7 @@ namespace CGAL {
     {
     public:
 
-        SM_Face_index() : SM_Index<SM_Face_index>((std::numeric_limits<size_type>::max)()) {}
+        SM_Face_index() = default;
 
         explicit SM_Face_index(size_type _idx) : SM_Index<SM_Face_index>(_idx) {}
 
@@ -241,7 +244,7 @@ namespace CGAL {
     public:
         typedef std::uint32_t size_type;
 
-        SM_Edge_index() : halfedge_((std::numeric_limits<size_type>::max)()) { }
+        SM_Edge_index() = default;
 
         explicit SM_Edge_index(size_type idx) : halfedge_(idx * 2) { }
 

--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -1012,7 +1012,6 @@ public:
     /// adds a new edge, and resizes edge and halfedge properties if necessary.
     Halfedge_index add_edge()
     {
-      Halfedge_index h0, h1;
       size_type inf = (std::numeric_limits<size_type>::max)();
       if(recycle_ && (edges_freelist_ != inf)){
         size_type idx = edges_freelist_;

--- a/Surface_mesh_topology/include/CGAL/Surface_mesh_topology/internal/Minimal_quadrangulation.h
+++ b/Surface_mesh_topology/include/CGAL/Surface_mesh_topology/internal/Minimal_quadrangulation.h
@@ -930,7 +930,7 @@ protected:
   {
     // std::cout<<"************************************************"<<std::endl;
     Dart_descriptor initdart, curdart;
-    Original_dart_const_descriptor d1, d2;
+    Original_dart_const_descriptor d1;
     for (typename Local_map::Dart_range::iterator
          it=get_local_map().darts().begin();
          it!=get_local_map().darts().end(); ++it)


### PR DESCRIPTION
## Summary of Changes
Add an extra requirement in the visitors so that it is possible to prevent some triangle faces to appear in the output.

It is not clear yet how to deal with the backward compatibility

The triangulate face visitor and triangulate hole visitor have different function names (`accept_face()` vs `accept_triangle()` in order to avoid the need for the user to add a using `Base::accept_face()` in visitors inheriting the default one)

## Release Management

* Affected package(s): PMP_Mesh_repair PMP_Remeshing
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:





