### PR TITLE
Fix: Merge duplicate points and orient polygons before triangulation to prevent invalid meshes

### DIFF
--- a/Constrained_triangulation_3/include/CGAL/make_conforming_constrained_Delaunay_triangulation_3.h
+++ b/Constrained_triangulation_3/include/CGAL/make_conforming_constrained_Delaunay_triangulation_3.h
@@ -216,6 +216,10 @@ auto make_conforming_constrained_Delaunay_triangulation_3(const PointRange &poin
                                                           const PolygonRange &polygons,
                                                           const NamedParameters &np = parameters::default_values())
 {
+  namespace PMP = CGAL::Polygon_mesh_processing;
+  PMP::merge_duplicate_points(points, polygons);
+  PMP::orient_polygon_soup(points, polygons);
+  
   using Geom_traits = typename GetPolygonGeomTraits<PointRange, PolygonRange, NamedParameters>::type;
 
   using Default_CDT = Conforming_constrained_Delaunay_triangulation_3<Geom_traits>;


### PR DESCRIPTION
Fix: #8962 Clean polygon soup before triangulation

- Merge duplicate points to avoid degenerate vertices
- Orient polygon soup for consistent face winding
- Prevents invalid meshes and triangulation failures in
  make_conforming_constrained_Delaunay_triangulation_3()


