### PR TITLE
disable Check_FPU_rounding_mode_is_restored on demand

### DIFF
--- a/Number_types/include/CGAL/test_FPU_rounding_mode_impl.h
+++ b/Number_types/include/CGAL/test_FPU_rounding_mode_impl.h
@@ -51,11 +51,13 @@ get_static_check_fpu_rounding_mode_is_restored()
   return check_fpu_rounding_mode_is_restored;
 }
 
+#ifndef CGAL_DISABLE_ROUNDING_MATH_CHECK
 namespace {
   CGAL_UNUSED const Check_FPU_rounding_mode_is_restored &
     check_fpu_rounding_mode_is_restored
     = get_static_check_fpu_rounding_mode_is_restored();
 }
+#endif
 
 #else
 

--- a/Number_types/test/Number_types/Interval_nt_new.cpp
+++ b/Number_types/test/Number_types/Interval_nt_new.cpp
@@ -1,3 +1,4 @@
+#define CGAL_DISABLE_ROUNDING_MATH_CHECK 1
 #include <iostream>
 #include <CGAL/config.h>
 #include <CGAL/Interval_nt.h>


### PR DESCRIPTION
## Summary of Changes

Allow to disable all FPU rounding mode runtime-checks with the macro `CGAL_DISABLE_ROUNDING_MATH_CHECK`.

## Release Management

* Affected package(s): Number_types
* License and copyright ownership: maintenance by GeometryFactory

