### PR TITLE
CGAL Lab: fix linter warnings and CMake ITK warning

### DIFF
--- a/Lab/demo/Lab/Plugins/Mesh_3/CMakeLists.txt
+++ b/Lab/demo/Lab/Plugins/Mesh_3/CMakeLists.txt
@@ -39,6 +39,7 @@ if(ITK_FOUND)
   message(STATUS "ITK found")
   include(${ITK_USE_FILE})
   target_link_libraries(mesh_3_plugin PRIVATE CGAL::ITK_support)
+  target_compile_definitions(mesh_3_plugin PRIVATE ITK_LEGACY_FUTURE_REMOVE)
 endif(ITK_FOUND)
 
 find_package(VTK 9.0 QUIET COMPONENTS ImagingGeneral IOImage IOXML NO_MODULE)

--- a/Lab/demo/Lab/Scene_polygon_soup_item.cpp
+++ b/Lab/demo/Lab/Scene_polygon_soup_item.cpp
@@ -39,11 +39,7 @@
 
 #include <algorithm>
 #include <iostream>
-#include <map>
-#include <queue>
 #include <set>
-#include <stack>
-#include <streambuf>
 #include <vector>
 
 using namespace CGAL::Three;
@@ -565,7 +561,7 @@ Scene_polygon_soup_item::save(std::ostream& out) const
   }
   writer.write_footer();
 
-  return (bool) out;
+  return false == out.fail();
 }
 
 bool


### PR DESCRIPTION
## Summary of Changes

- fix linter warnings in `Scene_polygon_soup_item.cpp`
- fix a CMake warning about ITK using deprecated headers

## Release Management

* Affected package(s): Lab
* License and copyright ownership: N/A, maintenance by GF
