### PR TITLE
Do not define _USE_MATH_DEFINES

### DIFF
--- a/Bounding_volumes/include/CGAL/pierce_rectangles_2.h
+++ b/Bounding_volumes/include/CGAL/pierce_rectangles_2.h
@@ -892,8 +892,8 @@ four_cover_points(Staircases< Traits >& d, OutputIterator o, bool& ok)
                  sdistx(*(shf - 1), bottom) <= FT(2) * d.r))))
     #else
           if (sdistx(bottom_i.second, bottom) <= FT(2) * d.r &&
-              ((!d.is_x_greater_y() ||
-               (shl == Citerator(share.end()) ||
+              (!d.is_x_greater_y() ||
+               ((shl == Citerator(share.end()) ||
                 sdistx(share.back(), bottom) <= FT(2) * d.r) &&
                (shf == Citerator(share.begin()) ||
                 sdistx(*(shf - 1), bottom) <= FT(2) * d.r))))

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/include/types.h
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/include/types.h
@@ -4,8 +4,6 @@
 #ifndef P2T2_UNIT_TEST_TYPES_H
 #define P2T2_UNIT_TEST_TYPES_H
 
-#define _USE_MATH_DEFINES
-#include <math.h>
 
 #include <CGAL/Periodic_2_triangulation_2.h>
 #include <CGAL/Periodic_2_triangulation_traits_2.h>

--- a/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_delaunay_remove.cpp
+++ b/Periodic_2_triangulation_2/test/Periodic_2_triangulation_2/test_p2t2_delaunay_remove.cpp
@@ -30,7 +30,7 @@ int main()
       vh_midpoint = t.insert(Point(0, 0) + midpoint);
       for (int i = 0; i < n; ++i)
         {
-          t.insert(Point(0.3 * sin(i * 1.0 / n * 2 * M_PI), 0.3 * cos(i * 1.0 / n * 2 * M_PI)) + midpoint);
+          t.insert(Point(0.3 * sin(i * 1.0 / n * 2 * CGAL_PI), 0.3 * cos(i * 1.0 / n * 2 * CGAL_PI)) + midpoint);
         }
       t.remove(vh_midpoint);
       assert(t.is_valid(true));


### PR DESCRIPTION
## Summary of Changes

This leads to a warning in the [testsuite](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.2-Ic-11/Periodic_2_triangulation_2/TestReport_Christo_ICPC-2025.1-Release.gz)
Also it is a weaker test as this `#define`  is not required.

## Release Management

* Affected package(s): Periodic_2_triangulation_2
* License and copyright ownership: unchanged

