### PR TITLE
Handle case of identical projected points

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -1447,6 +1447,12 @@ triangulate_hole_polyline_with_cdt(const PointRange& points,
     vertices[v->info()] = v;
   }
 
+  if (vertices.size()!=cdt.number_of_vertices())
+  {
+    visitor.end_planar_phase(false);
+    return false;
+  }
+
   try
   {
     for (std::size_t i = 0; i < size; ++i) {


### PR DESCRIPTION
Do not try to insert constraint if two points are projected onto the same 2D vertex