### PR TITLE
Documentation correction

### DIFF
--- a/Mesh_3/include/CGAL/refine_mesh_3.h
+++ b/Mesh_3/include/CGAL/refine_mesh_3.h
@@ -151,7 +151,7 @@ private:
  * \tparam MC either a model of the concept `MeshCriteria_3` or a model
  *            of `MeshCriteriaWithFeatures_3` if the domain has exposed features.
  *
- * \tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters
+ * \tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
  *
  * \param c3t3 the mesh to be refined that is modified by the refinement process.
  *             As the refinement process only adds points to the triangulation, all

--- a/Periodic_3_mesh_3/include/CGAL/refine_periodic_3_mesh_3.h
+++ b/Periodic_3_mesh_3/include/CGAL/refine_periodic_3_mesh_3.h
@@ -270,7 +270,7 @@ void project_dummy_points_of_surface(C3T3& c3t3,
  * `criteria` provides a sizing field to guide the discretization
  * of 1-dimensional exposed features.
  *
- * \tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters
+ * \tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
  *
  * \param c3t3 the mesh to be refined.
  * \param domain the domain to be discretized


### PR DESCRIPTION
Added missing end double quotes as noted in (a.o.) overnight documentation build: https://cgal.geometryfactory.com/CGAL/Manual_doxygen_test/CGAL-6.2-I-22/index.html

