### PR TITLE
Warning on no matching class member

### DIFF
--- a/Frechet_distance/include/CGAL/Frechet_distance/Neighbor_search.h
+++ b/Frechet_distance/include/CGAL/Frechet_distance/Neighbor_search.h
@@ -87,9 +87,9 @@ public:
 private:
 
 
-    std::vector<std::size_t> get_close_curves(const PointRange& query, double distance, Sequential_tag);
+    auto get_close_curves(const PointRange& query, double distance, Sequential_tag) -> std::vector<std::size_t>;
 #ifdef CGAL_LINKED_WITH_TBB
-    std::vector<std::size_t> get_close_curves(const PointRange& query, double distance, Parallel_tag);
+    auto get_close_curves(const PointRange& query, double distance, Parallel_tag) -> std::vector<std::size_t>;
 #endif
 
     Polylines curves;
@@ -98,12 +98,7 @@ private:
 
 
 template <class PointRange, class Traits>
-#ifdef DOXYGEN_RUNNING
-std::vector<std::size_t>
-#else
-auto
-#endif
-Neighbor_search<PointRange, Traits>::get_close_curves(
+auto Neighbor_search<PointRange, Traits>::get_close_curves(
     const PointRange& curve, double distance, Sequential_tag) -> std::vector<std::size_t>
 {
     auto result = kd_tree.search(curve, distance);
@@ -124,12 +119,7 @@ Neighbor_search<PointRange, Traits>::get_close_curves(
 
 #ifdef CGAL_LINKED_WITH_TBB
 template <class PointRange, class Traits>
-#ifdef DOXYGEN_RUNNING
-std::vector<std::size_t>
-#else
-auto
-#endif
-Neighbor_search<PointRange, Traits>::get_close_curves(
+auto Neighbor_search<PointRange, Traits>::get_close_curves(
     const PointRange& curve, double distance, Parallel_tag) -> std::vector<std::size_t>
 {
     std::vector<std::size_t> result;


### PR DESCRIPTION
The overnight documentation build gives a warning (with the doxygen master version):
```
/home/cgal-testsuite/cgal_doc_build/CGAL-6.2-Ic-24/include/CGAL/Frechet_distance/Neighbor_search.h:106: warning: no matching class member found for
  template < PointRange, Traits >
  std::vector< std::size_t > CGAL::Frechet_distance::Neighbor_search< PointRange, Traits >::get_close_curves(const PointRange &curve, double distance, Sequential_tag) ->std::vector< std::size_t >
Possible candidates:
  'template < ConcurrencyTag >
  std::vector< std::size_t > CGAL::Frechet_distance::Neighbor_search< PointRange, Traits >::get_close_curves(const PointRange &query, double distance)' at line 79 of file /home/cgal-testsuite/cgal_doc_build/CGAL-6.2-Ic-24/include/CGAL/Frechet_distance/Neighbor_search.h
  'std::vector< std::size_t > CGAL::Frechet_distance::Neighbor_search< PointRange, Traits >::get_close_curves(const PointRange &query, double distance, Sequential_tag)' at line 90 of file /home/cgal-testsuite/cgal_doc_build/CGAL-6.2-Ic-24/include/CGAL/Frechet_distance/Neighbor_search.h
```

In principle the code is correct but due to the double usage of `std::vector< std::size_t >` doxygen has a small problem (since the integration of the fix for https://github.com/doxygen/doxygen/issues/11787). The workaround as used by CGAL is not necessary.

(tested documentation against doxygen master version and dixygen 1.9.6)



