### PR TITLE
Fix bad 'if' condition & warning

### DIFF
--- a/Stream_support/test/Stream_support/issue8155.cpp
+++ b/Stream_support/test/Stream_support/issue8155.cpp
@@ -23,12 +23,13 @@ int main()
   std::vector<PointVectorPair> pv_pairs;
   const std::function<void(const PointVectorPair& p)> lambda =
     [&](const PointVectorPair& p) {
-    FT len = p.second.squared_length();
-    if (len > 0 || len != 1.0) {
-      Vector_3 n = p.second * (1.0 / CGAL::sqrt(len));
-      pv_pairs.push_back(std::make_pair(p.first, n));
-    }
-    else pv_pairs.push_back(p);
+      const FT len = CGAL::sqrt(p.second.squared_length());
+      if (len > 0) {
+        Vector_3 n = p.second / len;
+        pv_pairs.push_back(std::make_pair(p.first, n));
+      } else {
+        pv_pairs.push_back(p);
+      }
     };
 
   pv_pairs.clear();


### PR DESCRIPTION
## Summary of Changes

```
Building CXX object test/Stream_support/CMakeFiles/issue8155.dir/issue8155.cpp.o
cd /home/cgal_tester/build/src/cmake/platforms/ArchLinux-clang-CXX20-Release/test/Stream_support && /bin/clang++ -DCGAL_DATA_DIR=\"/mnt/testsuite/data\" -DCGAL_TEST_SUITE=1 -DCGAL_USE_GMPXX=1 -I/home/cgal_tester/build/src/cmake/platforms/ArchLinux-clang-CXX20-Release/include -I/mnt/testsuite/include -isystem /usr/local/boost/include -Wall -O3 -std=c++20 -DCGAL_NDEBUG -MD -MT test/Stream_support/CMakeFiles/issue8155.dir/issue8155.cpp.o -MF CMakeFiles/issue8155.dir/issue8155.cpp.o.d -o CMakeFiles/issue8155.dir/issue8155.cpp.o -c /mnt/testsuite/test/Stream_support/issue8155.cpp
/mnt/testsuite/test/Stream_support/issue8155.cpp:27:17: warning: overlapping comparisons always evaluate to true [-Wtautological-overlap-compare]
   27 |     if (len > 0 || len != 1.0) {
      |         ~~~~~~~~^~~~~~~~~~~~~
1 warning generated.
```

https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.2-Ic-36/Stream_support/TestReport_cgaltest_ArchLinux-clang-CXX20-Release.gz

## Release Management

* Affected package(s): `Stream_support`
* Issue(s) solved (if any): n/a
* Feature/Small Feature (if any): n/a
* License and copyright ownership: no change

