### PR TITLE
Fix OBJ loader crashing the demo on reading failure

### DIFF
--- a/Lab/demo/Lab/Plugins/IO/OFF_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/IO/OFF_io_plugin.cpp
@@ -96,7 +96,7 @@ load(QFileInfo fileinfo, bool& ok, bool add_to_scene) {
     }
     else
     {
-      ok = true;
+      ok = false;
       return QList<Scene_item*>();
     }
   }

--- a/Lab/demo/Lab/Scene_surface_mesh_item.cpp
+++ b/Lab/demo/Lab/Scene_surface_mesh_item.cpp
@@ -1563,7 +1563,7 @@ bool
 Scene_surface_mesh_item::load_obj(std::istream& in)
 {
   typedef SMesh::Point Point;
-  bool failed = !CGAL::IO::read_OBJ(in, *(d->smesh_));
+  bool failed = !CGAL::IO::read_OBJ(in, *(d->smesh_), CGAL::parameters::verbose(true));
   if(failed)
   {
     in.clear();

--- a/Stream_support/include/CGAL/IO/OBJ.h
+++ b/Stream_support/include/CGAL/IO/OBJ.h
@@ -118,7 +118,13 @@ bool read_OBJ(std::istream& is,
       polygons.emplace_back();
       while(iss >> i)
       {
-        if(i < 1)
+        if (i == 0)
+        {
+          if(verbose)
+            std::cerr << "error: vertex index of face cannot be 0" << std::endl;
+          return false;
+        }
+        else if(i < 1)
         {
           const std::size_t n = polygons.back().size();
           ::CGAL::internal::resize(polygons.back(), n + 1);


### PR DESCRIPTION
## Release Management

* Affected package(s): `Lab`
* Issue(s) solved (if any): a few entries in #6690 
* Feature/Small Feature (if any): n/a
* License and copyright ownership: no change

