### PR TITLE
fix a warning in Qt demos

### DIFF
--- a/GraphicsView/include/CGAL/Qt/DemosMainWindow_impl.h
+++ b/GraphicsView/include/CGAL/Qt/DemosMainWindow_impl.h
@@ -221,7 +221,11 @@ void
 DemosMainWindow::popupAboutBox(QString title, QString html_resource_name)
 {
   QFile about_CGAL(html_resource_name);
-  about_CGAL.open(QIODevice::ReadOnly);
+  bool openabout_CGAL = about_CGAL.open(QIODevice::ReadOnly);
+  if(!openabout_CGAL) {
+    std::cerr << "Cannot open resource " << html_resource_name.toStdString() << "\n";
+    return;
+  }
   QString about_CGAL_txt = QTextStream(&about_CGAL).readAll();
 #ifdef CGAL_VERSION_STR
   QString cgal_version(CGAL_VERSION_STR);


### PR DESCRIPTION
## Summary of Changes

Fix that warning:

```
include/CGAL/Qt/DemosMainWindow_impl.h:224:3: warning: ignoring return value of function declared with 'nodiscard' attribute [-Wunused-result]
  224 |   about_CGAL.open(QIODevice::ReadOnly);
      |   ^~~~~~~~~~~~~~~ ~~~~~~~~~~~~~~~~~~~
```

## Release Management

* Affected package(s): all CGAL demos
* License and copyright ownership: N/A

