### PR TITLE
Aos 2 fixes efif

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_circle_segment_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_circle_segment_traits_2.h
@@ -30,7 +30,7 @@
 
 #include <CGAL/tags.h>
 #include <CGAL/Arr_tags.h>
-#include <CGAL/Cartesian.h>
+#include <CGAL/Simple_cartesian.h>
 #include <CGAL/Arr_geometry_traits/Circle_segment_2.h>
 
 namespace CGAL {
@@ -41,31 +41,31 @@ namespace CGAL {
 template <typename Kernel_, bool Filter = true>
 class Arr_circle_segment_traits_2 {
 public:
-  typedef Kernel_                                        Kernel;
-  typedef typename Kernel::FT                            NT;
-  typedef typename Kernel::Point_2                       Rational_point_2;
-  typedef typename Kernel::Segment_2                     Rational_segment_2;
-  typedef typename Kernel::Circle_2                      Rational_circle_2;
-  typedef _One_root_point_2<NT, Filter>                  Point_2;
-  typedef typename Point_2::CoordNT                      CoordNT;
-  typedef _Circle_segment_2<Kernel, Filter>              Curve_2;
-  typedef _X_monotone_circle_segment_2<Kernel, Filter>   X_monotone_curve_2;
-  typedef unsigned int                                   Multiplicity;
-  typedef Arr_circle_segment_traits_2<Kernel, Filter>    Self;
+  using Kernel = Kernel_;
+  using NT = typename Kernel::FT;
+  using Rational_point_2 = typename Kernel::Point_2;
+  using Rational_segment_2 = typename Kernel::Segment_2;
+  using Rational_circle_2 = typename Kernel::Circle_2;
+  using Point_2 = _One_root_point_2<NT, Filter>;
+  using CoordNT = typename Point_2::CoordNT;
+  using Curve_2 = _Circle_segment_2<Kernel, Filter>;
+  using X_monotone_curve_2 = _X_monotone_circle_segment_2<Kernel, Filter>;
+  using Multiplicity = std::size_t;
+  using Self = Arr_circle_segment_traits_2<Kernel, Filter>;
 
   // Category tags:
-  typedef Tag_true                                   Has_left_category;
-  typedef Tag_true                                   Has_merge_category;
-  typedef Tag_false                                  Has_do_intersect_category;
+  using Has_left_category = Tag_true;
+  using Has_merge_category = Tag_true;
+  using Has_do_intersect_category = Tag_false;
 
-  typedef Arr_oblivious_side_tag                     Left_side_category;
-  typedef Arr_oblivious_side_tag                     Bottom_side_category;
-  typedef Arr_oblivious_side_tag                     Top_side_category;
-  typedef Arr_oblivious_side_tag                     Right_side_category;
+  using Left_side_category = Arr_oblivious_side_tag;
+  using Bottom_side_category = Arr_oblivious_side_tag;
+  using Top_side_category = Arr_oblivious_side_tag;
+  using Right_side_category = Arr_oblivious_side_tag;
 
 protected:
   // Type definition for the intersection points mapping.
-  typedef typename X_monotone_curve_2::Intersection_map   Intersection_map;
+  using Intersection_map = typename X_monotone_curve_2::Intersection_map;
 
   mutable Intersection_map inter_map;   // Mapping pairs of curve IDs to their
                                         // intersection points.
@@ -78,8 +78,7 @@ public:
   {}
 
   /*! obtains the next curve index. */
-  static unsigned int get_index ()
-  {
+  static unsigned int get_index() {
 #ifdef CGAL_NO_ATOMIC
     static unsigned int index;
 #else
@@ -91,8 +90,7 @@ public:
   /// \name Basic functor definitions.
   //@{
 
-  class Compare_x_2
-  {
+  class Compare_x_2 {
   public:
     /*! compares the \f$x\f$-coordinates of two points.
      * \param p1 The first point.
@@ -101,23 +99,17 @@ public:
      *         SMALLER if x(p1) < x(p2);
      *         EQUAL if x(p1) = x(p2).
      */
-    Comparison_result operator() (const Point_2& p1, const Point_2& p2) const
-    {
-      if (p1.identical (p2))
-        return (EQUAL);
+    Comparison_result operator() (const Point_2& p1, const Point_2& p2) const {
+      if (p1.identical (p2)) return (EQUAL);
 
       return (CGAL::compare (p1.x(), p2.x()));
     }
   };
 
   /*! obtains a `Compare_x_2` functor object. */
-  Compare_x_2 compare_x_2_object () const
-  {
-    return Compare_x_2();
-  }
+  Compare_x_2 compare_x_2_object () const { return Compare_x_2(); }
 
-  class Compare_xy_2
-  {
+  class Compare_xy_2 {
   public:
     /*! compares two points lexigoraphically: by x, then by y.
      * \param p1 The first point.
@@ -126,15 +118,11 @@ public:
      *         SMALLER if x(p1) < x(p2), or if x(p1) = x(p2) and y(p1) < y(p2);
      *         EQUAL if the two points are equal.
      */
-    Comparison_result operator() (const Point_2& p1, const Point_2& p2) const
-    {
-      if (p1.identical (p2))
-        return (EQUAL);
+    Comparison_result operator() (const Point_2& p1, const Point_2& p2) const {
+      if (p1.identical (p2)) return (EQUAL);
 
-      Comparison_result  res = CGAL::compare (p1.x(), p2.x());
-
-      if (res != EQUAL)
-        return (res);
+      Comparison_result res = CGAL::compare(p1.x(), p2.x());
+      if (res != EQUAL) return (res);
 
       return (CGAL::compare (p1.y(), p2.y()));
     }
@@ -142,69 +130,51 @@ public:
 
   /*! obtains a Compare_xy_2 functor object. */
   Compare_xy_2 compare_xy_2_object () const
-  {
-    return Compare_xy_2();
-  }
+  { return Compare_xy_2(); }
 
-  class Construct_min_vertex_2
-  {
+  class Construct_min_vertex_2 {
   public:
     /*! obtains the left endpoint of the \f$x\f$-monotone curve (segment).
      * \param cv The curve.
      * \return The left endpoint.
      */
     const Point_2& operator() (const X_monotone_curve_2 & cv) const
-    {
-      return (cv.left());
-    }
+    { return (cv.left()); }
   };
 
   /*! obtains a `Construct_min_vertex_2` functor object. */
   Construct_min_vertex_2 construct_min_vertex_2_object () const
-  {
-    return Construct_min_vertex_2();
-  }
+  { return Construct_min_vertex_2(); }
 
-  class Construct_max_vertex_2
-  {
+  class Construct_max_vertex_2 {
   public:
     /*! obtains the right endpoint of the \f$x\f$-monotone curve (segment).
      * \param cv The curve.
      * \return The right endpoint.
      */
     const Point_2& operator() (const X_monotone_curve_2 & cv) const
-    {
-      return (cv.right());
-    }
+    { return (cv.right()); }
   };
 
   /*! obtains a Construct_max_vertex_2 functor object. */
   Construct_max_vertex_2 construct_max_vertex_2_object () const
-  {
-    return Construct_max_vertex_2();
-  }
+  { return Construct_max_vertex_2(); }
 
-  class Is_vertical_2
-  {
+  class Is_vertical_2 {
   public:
     /*! checks whether the given \f$x\f$-monotone curve is a vertical segment.
      * \param cv The curve.
      * \return (true) if the curve is a vertical segment; (false) otherwise.
      */
     bool operator() (const X_monotone_curve_2& cv) const
-    {
-      return (cv.is_vertical());
-    }
+    { return (cv.is_vertical()); }
   };
 
   /*! obtains an `Is_vertical_2` functor object. */
   Is_vertical_2 is_vertical_2_object () const
-  {
-    return Is_vertical_2();
-  }
+  { return Is_vertical_2(); }
 
-  class Compare_y_at_x_2
-  {
+  class Compare_y_at_x_2 {
   public:
     /*! returns the location of the given point with respect to the input curve.
      * \param cv The curve.
@@ -214,23 +184,19 @@ public:
      *         LARGER if y(p) > cv(x(p)), i.e. the point is above the curve;
      *         EQUAL if p lies on the curve.
      */
-    Comparison_result operator() (const Point_2& p,
-                                  const X_monotone_curve_2& cv) const
-    {
-      CGAL_precondition (cv.is_in_x_range (p));
+    Comparison_result operator()(const Point_2& p,
+                                 const X_monotone_curve_2& cv) const {
+      CGAL_precondition (cv.is_in_x_range(p));
 
-      return (cv.point_position (p));
+      return (cv.point_position(p));
     }
   };
 
   /*! obtains a `Compare_y_at_x_2` functor object. */
   Compare_y_at_x_2 compare_y_at_x_2_object () const
-  {
-    return Compare_y_at_x_2();
-  }
+  { return Compare_y_at_x_2(); }
 
-  class Compare_y_at_x_right_2
-  {
+  class Compare_y_at_x_right_2 {
   public:
     /*! compares the y value of two \f$x\f$-monotone curves immediately to the
      * right of their intersection point.
@@ -244,30 +210,29 @@ public:
      */
     Comparison_result operator() (const X_monotone_curve_2& cv1,
                                   const X_monotone_curve_2& cv2,
-                                  const Point_2& p) const
-    {
+                                  const Point_2& p) const {
       // Make sure that p lies on both curves, and that both are defined to its
       // right (so their right endpoint is lexicographically larger than p).
       CGAL_precondition (cv1.point_position (p) == EQUAL &&
                          cv2.point_position (p) == EQUAL);
 
       if ((CGAL::compare (cv1.left().x(),cv1.right().x()) == EQUAL) &&
-          (CGAL::compare (cv2.left().x(),cv2.right().x()) == EQUAL))
-      { //both cv1 and cv2 are vertical
+          (CGAL::compare (cv2.left().x(),cv2.right().x()) == EQUAL)) {
+        //both cv1 and cv2 are vertical
         CGAL_precondition (!(cv1.right()).equals(p) && !(cv2.right()).equals(p));
       }
       else if ((CGAL::compare (cv1.left().x(),cv1.right().x()) != EQUAL) &&
-               (CGAL::compare (cv2.left().x(),cv2.right().x()) == EQUAL))
-      { //only cv1 is vertical
+               (CGAL::compare (cv2.left().x(),cv2.right().x()) == EQUAL)) {
+        //only cv1 is vertical
         CGAL_precondition (!(cv1.right()).equals(p));
       }
       else if ((CGAL::compare (cv1.left().x(),cv1.right().x()) == EQUAL) &&
-               (CGAL::compare (cv2.left().x(),cv2.right().x()) != EQUAL))
-      { //only cv2 is vertical
+               (CGAL::compare (cv2.left().x(),cv2.right().x()) != EQUAL)) {
+        //only cv2 is vertical
         CGAL_precondition (!(cv2.right()).equals(p));
       }
-      else
-      { //both cv1 and cv2 are non vertical
+      else {
+        //both cv1 and cv2 are non vertical
         CGAL_precondition (CGAL::compare (cv1.right().x(),p.x()) == LARGER &&
                            CGAL::compare (cv2.right().x(),p.x()) == LARGER);
       }
@@ -278,12 +243,9 @@ public:
 
   /*! obtains a `Compare_y_at_x_right_2` functor object. */
   Compare_y_at_x_right_2 compare_y_at_x_right_2_object () const
-  {
-    return Compare_y_at_x_right_2();
-  }
+  { return Compare_y_at_x_right_2(); }
 
-  class Compare_y_at_x_left_2
-  {
+  class Compare_y_at_x_left_2 {
   public:
     /*! compares the \f$y\f$-value of two \f$x\f$-monotone curves immediately to
      * the left of their intersection point.
@@ -297,8 +259,7 @@ public:
      */
     Comparison_result operator() (const X_monotone_curve_2& cv1,
                                   const X_monotone_curve_2& cv2,
-                                  const Point_2& p) const
-    {
+                                  const Point_2& p) const {
       // Make sure that p lies on both curves, and that both are defined to its
       // left (so their left endpoint is lexicographically smaller than p).
 
@@ -306,25 +267,25 @@ public:
                          cv2.point_position (p) == EQUAL);
 
       if ((CGAL::compare (cv1.left().x(),cv1.right().x()) == EQUAL) &&
-          (CGAL::compare (cv2.left().x(),cv2.right().x()) == EQUAL))
-          { //both cv1 and cv2 are vertical
-         CGAL_precondition (!(cv1.left()).equals(p) && !(cv2.left()).equals(p));
-          }
-          else if ((CGAL::compare (cv1.left().x(),cv1.right().x()) != EQUAL) &&
-                   (CGAL::compare (cv2.left().x(),cv2.right().x()) == EQUAL))
-          { //only cv1 is vertical
-         CGAL_precondition (!(cv1.left()).equals(p));
-          }
-          else if ((CGAL::compare (cv1.left().x(),cv1.right().x()) == EQUAL) &&
-                   (CGAL::compare (cv2.left().x(),cv2.right().x()) != EQUAL))
-          { //only cv2 is vertical
-         CGAL_precondition (!(cv2.left()).equals(p));
-          }
-          else
-          { //both cv1 and cv2 are non vertical
+          (CGAL::compare (cv2.left().x(),cv2.right().x()) == EQUAL)) {
+        //both cv1 and cv2 are vertical
+        CGAL_precondition (!(cv1.left()).equals(p) && !(cv2.left()).equals(p));
+      }
+      else if ((CGAL::compare (cv1.left().x(),cv1.right().x()) != EQUAL) &&
+               (CGAL::compare (cv2.left().x(),cv2.right().x()) == EQUAL)) {
+        //only cv1 is vertical
+        CGAL_precondition (!(cv1.left()).equals(p));
+      }
+      else if ((CGAL::compare (cv1.left().x(),cv1.right().x()) == EQUAL) &&
+               (CGAL::compare (cv2.left().x(),cv2.right().x()) != EQUAL)) {
+        //only cv2 is vertical
+        CGAL_precondition (!(cv2.left()).equals(p));
+      }
+      else {
+        //both cv1 and cv2 are non vertical
         CGAL_precondition (CGAL::compare (cv1.left().x(),p.x()) == SMALLER &&
                            CGAL::compare (cv2.left().x(),p.x()) == SMALLER);
-          }
+      }
       // Compare the two curves immediately to the left of p:
       return (cv1.compare_to_left (cv2, p));
     }
@@ -332,12 +293,9 @@ public:
 
   /*! obtains a `Compare_y_at_x_left_2` functor object. */
   Compare_y_at_x_left_2 compare_y_at_x_left_2_object () const
-  {
-    return Compare_y_at_x_left_2();
-  }
+  { return Compare_y_at_x_left_2(); }
 
-  class Equal_2
-  {
+  class Equal_2 {
   public:
     /*! checks if the two \f$x\f$-monotone curves are the same (have the same
      * graph).
@@ -346,10 +304,8 @@ public:
      * \return (true) if the two curves are the same; (false) otherwise.
      */
     bool operator() (const X_monotone_curve_2& cv1,
-                     const X_monotone_curve_2& cv2) const
-    {
-      if (&cv1 == &cv2)
-        return (true);
+                     const X_monotone_curve_2& cv2) const {
+      if (&cv1 == &cv2) return (true);
 
       return (cv1.equals (cv2));
     }
@@ -360,24 +316,20 @@ public:
      * \return (true) if the two point are the same; (false) otherwise.
      */
     bool operator() (const Point_2& p1, const Point_2& p2) const
-    {
-      return (p1.equals (p2));
-    }
+    { return (p1.equals (p2)); }
   };
 
   /*! obtains an `Equal_2` functor object. */
   Equal_2 equal_2_object () const
-  {
-    return Equal_2();
-  }
+  { return Equal_2(); }
   //@}
 
   /// \name Functor definitions for approximations. Used by the landmarks
   // point-location strategy and the drawing procedure.
   //@{
-  typedef double                                        Approximate_number_type;
-  typedef CGAL::Cartesian<Approximate_number_type>      Approximate_kernel;
-  typedef Approximate_kernel::Point_2                   Approximate_point_2;
+  using Approximate_number_type = double;
+  using Approximate_kernel = CGAL::Simple_cartesian<Approximate_number_type>;
+  using Approximate_point_2 = Approximate_kernel::Point_2;
 
   class Approximate_2 {
   protected:
@@ -557,7 +509,7 @@ public:
    */
   class Make_x_monotone_2 {
   private:
-    typedef Arr_circle_segment_traits_2<Kernel_, Filter> Self;
+    using Self = Arr_circle_segment_traits_2<Kernel_, Filter>;
 
     bool m_use_cache;
 
@@ -573,8 +525,7 @@ public:
      * \return the past-the-end iterator.
      */
     template <typename OutputIterator>
-    OutputIterator operator()(const Curve_2& cv, OutputIterator oi) const
-    {
+    OutputIterator operator()(const Curve_2& cv, OutputIterator oi) const {
       // Increment the serial number of the curve cv, which will serve as its
       // unique identifier.
       unsigned int index = 0;
@@ -591,7 +542,7 @@ public:
 
       // Check the case of a degenerate circle (a point).
       const typename Kernel::Circle_2&  circ = cv.supporting_circle();
-      CGAL::Sign   sign_rad = CGAL::sign (circ.squared_radius());
+      CGAL::Sign sign_rad = CGAL::sign (circ.squared_radius());
       CGAL_precondition (sign_rad != NEGATIVE);
 
       if (sign_rad == ZERO) {
@@ -603,8 +554,8 @@ public:
 
       // The curve is circular: compute the to vertical tangency points
       // of the supporting circle.
-      Point_2         vpts[2];
-      unsigned int    n_vpts = cv.vertical_tangency_points (vpts);
+      Point_2 vpts[2];
+      unsigned int n_vpts = cv.vertical_tangency_points (vpts);
 
       if (cv.is_full()) {
         CGAL_assertion (n_vpts == 2);
@@ -674,8 +625,7 @@ public:
   Make_x_monotone_2 make_x_monotone_2_object() const
   { return Make_x_monotone_2(m_use_cache); }
 
-  class Split_2
-  {
+  class Split_2 {
   public:
 
     /*! splits a given \f$x\f$-monotone curve at a given point into two
@@ -687,8 +637,7 @@ public:
      * \pre `p` lies on cv but is not one of its end-points.
      */
     void operator() (const X_monotone_curve_2& cv, const Point_2& p,
-                     X_monotone_curve_2& c1, X_monotone_curve_2& c2) const
-    {
+                     X_monotone_curve_2& c1, X_monotone_curve_2& c2) const {
       CGAL_precondition (cv.point_position(p)==EQUAL &&
       ! p.equals (cv.source()) &&
       ! p.equals (cv.target()));
@@ -699,10 +648,7 @@ public:
   };
 
   /*! obtains a `Split_2` functor object. */
-  Split_2 split_2_object () const
-  {
-    return Split_2();
-  }
+  Split_2 split_2_object () const { return Split_2(); }
 
   class Intersect_2 {
   private:
@@ -730,8 +676,7 @@ public:
   /*! obtains an `Intersect_2` functor object. */
   Intersect_2 intersect_2_object() const { return (Intersect_2(inter_map)); }
 
-  class Are_mergeable_2
-  {
+  class Are_mergeable_2 {
   public:
     /*! checks whether it is possible to merge two given \f$x\f$-monotone curves.
      * \param cv1 The first curve.
@@ -742,24 +687,19 @@ public:
      */
     bool operator() (const X_monotone_curve_2& cv1,
                      const X_monotone_curve_2& cv2) const
-    {
-      return (cv1.can_merge_with (cv2));
-    }
+    { return (cv1.can_merge_with (cv2)); }
   };
 
   /*! obtains an `Are_mergeable_2` functor object. */
   Are_mergeable_2 are_mergeable_2_object () const
-  {
-    return Are_mergeable_2();
-  }
+  { return Are_mergeable_2(); }
 
   /*! \class Merge_2
    * A functor that merges two \f$x\f$-monotone arcs into one.
    */
-  class Merge_2
-  {
+  class Merge_2 {
   protected:
-    typedef Arr_circle_segment_traits_2<Kernel, Filter> Traits;
+    using Traits = Arr_circle_segment_traits_2<Kernel, Filter>;
 
     /*! The traits (in case it has state) */
     const Traits* m_traits;
@@ -780,8 +720,7 @@ public:
      */
     void operator() (const X_monotone_curve_2& cv1,
                      const X_monotone_curve_2& cv2,
-                     X_monotone_curve_2& c) const
-    {
+                     X_monotone_curve_2& c) const {
       CGAL_precondition(m_traits->are_mergeable_2_object()(cv2, cv1));
 
       c = cv1;
@@ -790,20 +729,15 @@ public:
   };
 
   /*! obtains a `Merge_2` functor object. */
-  Merge_2 merge_2_object () const
-  {
-    return Merge_2(this);
-  }
+  Merge_2 merge_2_object () const { return Merge_2(this); }
 
-  class Compare_endpoints_xy_2
-  {
+  class Compare_endpoints_xy_2 {
   public:
     /*! compares lexicogrphic the endpoints of a \f$x\f$-monotone curve.
      * \param cv the curve
      * \return `SMALLER` if the curve is directed right, else return `LARGER`.
      */
-    Comparison_result operator()(const X_monotone_curve_2& cv) const
-    {
+    Comparison_result operator()(const X_monotone_curve_2& cv) const {
       if(cv.is_directed_right())
         return(SMALLER);
       return (LARGER);
@@ -812,32 +746,25 @@ public:
 
   /*! obtains a `Compare_endpoints_xy_2` functor object. */
   Compare_endpoints_xy_2 compare_endpoints_xy_2_object() const
-  {
-    return Compare_endpoints_xy_2();
-  }
+  { return Compare_endpoints_xy_2(); }
 
-  class Construct_opposite_2
-  {
+  class Construct_opposite_2 {
   public:
     /*! constructs an opposite \f$x\f$-monotone curve.
      * \param cv the curve
      * \return an opposite \f$x\f$-monotone curve.
      */
     X_monotone_curve_2 operator()(const X_monotone_curve_2& cv) const
-    {
-      return cv.construct_opposite();
-    }
+    { return cv.construct_opposite(); }
   };
 
   /*! obtains a `Construct_opposite_2` functor object. */
   Construct_opposite_2 construct_opposite_2_object() const
-  {
-    return Construct_opposite_2();
-  }
+  { return Construct_opposite_2(); }
 
   class Trim_2 {
   protected:
-    typedef Arr_circle_segment_traits_2<Kernel, Filter> Traits;
+    using Traits = Arr_circle_segment_traits_2<Kernel, Filter>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -860,8 +787,7 @@ public:
      */
     X_monotone_curve_2 operator()(const X_monotone_curve_2& xcv,
                                   const Point_2& src,
-                                  const Point_2& tgt)const
-    {
+                                  const Point_2& tgt)const {
       // make functor objects
       CGAL_precondition_code(Compare_y_at_x_2 compare_y_at_x_2 =
                              m_traits.compare_y_at_x_2_object());
@@ -885,7 +811,6 @@ public:
   Trim_2 trim_2_object() const { return Trim_2(*this); }
 
   // @}
-
 };
 
 } // namespace CGAL

--- a/Arrangement_on_surface_2/include/CGAL/Arr_circular_arc_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_circular_arc_traits_2.h
@@ -40,55 +40,54 @@
 namespace CGAL {
 
 namespace internal{
-template <class CircularKernel>
-class Non_x_monotonic_Circular_arc_2
-  : public CircularKernel::Circular_arc_2
-{
-  typedef typename CircularKernel::FT             FT;
-  typedef typename CircularKernel::Point_2        Point_2;
-  typedef typename CircularKernel::Line_2         Line_2;
-  typedef typename CircularKernel::Circle_2       Circle_2;
-  typedef typename CircularKernel::Circular_arc_point_2
-                                                Circular_arc_point_2;
 
-  typedef typename CircularKernel::Circular_arc_2 Base;
+template <typename CircularKernel>
+class Non_x_monotonic_Circular_arc_2 :
+    public CircularKernel::Circular_arc_2 {
+  using FT = typename CircularKernel::FT;
+  using Point_2 = typename CircularKernel::Point_2;
+  using Line_2 = typename CircularKernel::Line_2;
+  using Circle_2 = typename CircularKernel::Circle_2;
+  using Circular_arc_point_2 = typename CircularKernel::Circular_arc_point_2;
+
+  using Base = typename CircularKernel::Circular_arc_2;
 
 public:
   Non_x_monotonic_Circular_arc_2(): Base(){}
 
-  Non_x_monotonic_Circular_arc_2(const Circle_2 &c): Base(c){}
+  Non_x_monotonic_Circular_arc_2(const Circle_2& c): Base(c){}
   // Not Documented
-  Non_x_monotonic_Circular_arc_2(const Circle_2 &support,
-                                 const Line_2 &l1, const bool b_l1,
-                                 const Line_2 &l2, const bool b_l2)
-    : Base(support,l1,b_l1,l2,b_l2){}
+  Non_x_monotonic_Circular_arc_2(const Circle_2& support,
+                                 const Line_2& l1, const bool b_l1,
+                                 const Line_2& l2, const bool b_l2) :
+    Base(support,l1,b_l1,l2,b_l2){}
 
   // Not Documented
-  Non_x_monotonic_Circular_arc_2(const Circle_2 &c,
-                                 const Circle_2 &c1, const bool b_1,
-                                 const Circle_2 &c2, const bool b_2)
-    : Base(c,c1,b_1,c2,b_2)
+  Non_x_monotonic_Circular_arc_2(const Circle_2& c,
+                                 const Circle_2& c1, const bool b_1,
+                                 const Circle_2& c2, const bool b_2) :
+    Base(c,c1,b_1,c2,b_2)
   {}
 
-  Non_x_monotonic_Circular_arc_2(const Point_2 &start,
-                                 const Point_2 &middle,
-                                 const Point_2 &end)
-    : Base(start,middle,end)
+  Non_x_monotonic_Circular_arc_2(const Point_2& start,
+                                 const Point_2& middle,
+                                 const Point_2& end) :
+    Base(start,middle,end)
   {}
 
-  Non_x_monotonic_Circular_arc_2(const Circle_2 &support,
-                                 const Circular_arc_point_2 &begin,
-                                 const Circular_arc_point_2 &end)
-    : Base(support,begin,end)
+  Non_x_monotonic_Circular_arc_2(const Circle_2& support,
+                                 const Circular_arc_point_2& begin,
+                                 const Circular_arc_point_2& end) :
+    Base(support,begin,end)
   {}
 
-  Non_x_monotonic_Circular_arc_2(const Point_2 &start,
-                                 const Point_2 &end,
-                                 const FT &bulge)
-    : Base(start,end,bulge)
+  Non_x_monotonic_Circular_arc_2(const Point_2& start,
+                                 const Point_2& end,
+                                 const FT& bulge) :
+    Base(start,end,bulge)
   {}
 
- Non_x_monotonic_Circular_arc_2(const Base& a) : Base(a) {}
+  Non_x_monotonic_Circular_arc_2(const Base& a) : Base(a) {}
 };
 
 } //namespace internal
@@ -98,45 +97,40 @@ public:
 
 template < typename CircularKernel >
 class Arr_circular_arc_traits_2 {
-
   CircularKernel ck;
 
 public:
+  using Kernel = CircularKernel;
+  using Curve_2 = internal::Non_x_monotonic_Circular_arc_2<CircularKernel>;
+  using X_monotone_curve_2 = typename CircularKernel::Circular_arc_2;
 
-  typedef CircularKernel Kernel;
-  typedef internal::Non_x_monotonic_Circular_arc_2<CircularKernel>  Curve_2;
-  typedef typename CircularKernel::Circular_arc_2                   X_monotone_curve_2;
+  using Point = typename CircularKernel::Circular_arc_point_2;
+  using Point_2 = typename CircularKernel::Circular_arc_point_2;
 
-  typedef typename CircularKernel::Circular_arc_point_2 Point;
-  typedef typename CircularKernel::Circular_arc_point_2 Point_2;
+  using Multiplicity = std::size_t;
 
-  typedef unsigned int                           Multiplicity;
+  using Has_left_category = CGAL::Tag_false;
+  using Has_merge_category = CGAL::Tag_false;
+  using Has_do_intersect_category = CGAL::Tag_false;
 
-  typedef CGAL::Tag_false                        Has_left_category;
-  typedef CGAL::Tag_false                        Has_merge_category;
-  typedef CGAL::Tag_false                        Has_do_intersect_category;
+  using Left_side_category = Arr_oblivious_side_tag;
+  using Bottom_side_category = Arr_oblivious_side_tag;
+  using Top_side_category = Arr_oblivious_side_tag;
+  using Right_side_category = Arr_oblivious_side_tag;
 
-  typedef Arr_oblivious_side_tag                 Left_side_category;
-  typedef Arr_oblivious_side_tag                 Bottom_side_category;
-  typedef Arr_oblivious_side_tag                 Top_side_category;
-  typedef Arr_oblivious_side_tag                 Right_side_category;
+  Arr_circular_arc_traits_2(const CircularKernel& k = CircularKernel()) : ck(k) {}
 
-  Arr_circular_arc_traits_2(const CircularKernel &k = CircularKernel())
-    : ck(k) {}
-
-  typedef typename CircularKernel::Compare_x_2          Compare_x_2;
-  typedef typename CircularKernel::Compare_xy_2         Compare_xy_2;
-  typedef typename CircularKernel::Compare_y_at_x_2     Compare_y_at_x_2;
-  typedef typename CircularKernel::Compare_y_to_right_2 Compare_y_at_x_right_2;
-  typedef typename CircularKernel::Construct_circular_max_vertex_2
-                                                        Construct_max_vertex_2;
-  typedef typename CircularKernel::Construct_circular_min_vertex_2
-                                                        Construct_min_vertex_2;
-  typedef typename CircularKernel::Equal_2              Equal_2;
+  using Compare_x_2 = typename CircularKernel::Compare_x_2;
+  using Compare_xy_2 = typename CircularKernel::Compare_xy_2;
+  using Compare_y_at_x_2 = typename CircularKernel::Compare_y_at_x_2;
+  using Compare_y_at_x_right_2 = typename CircularKernel::Compare_y_to_right_2;
+  using Construct_max_vertex_2 = typename CircularKernel::Construct_circular_max_vertex_2;
+  using Construct_min_vertex_2 = typename CircularKernel::Construct_circular_min_vertex_2;
+  using Equal_2 = typename CircularKernel::Equal_2;
   // typedef typename CircularKernel::Make_x_monotone_2    Make_x_monotone_2;
-  typedef typename CircularKernel::Split_2              Split_2;
-  typedef typename CircularKernel::Intersect_2          Intersect_2;
-  typedef typename CircularKernel::Is_vertical_2        Is_vertical_2;
+  using Split_2 = typename CircularKernel::Split_2;
+  using Intersect_2 = typename CircularKernel::Intersect_2;
+  using Is_vertical_2 = typename CircularKernel::Is_vertical_2;
 
   Compare_x_2 compare_x_2_object() const
   { return ck.compare_x_2_object(); }
@@ -160,26 +154,23 @@ public:
   { return ck.split_2_object(); }
 
   Intersect_2 intersect_2_object() const
-    { return ck.intersect_2_object(); }
+  { return ck.intersect_2_object(); }
 
   Construct_max_vertex_2 construct_max_vertex_2_object() const
-    { return ck.construct_circular_max_vertex_2_object(); }
+  { return ck.construct_circular_max_vertex_2_object(); }
 
   Construct_min_vertex_2 construct_min_vertex_2_object() const
-    { return ck.construct_circular_min_vertex_2_object(); }
+  { return ck.construct_circular_min_vertex_2_object(); }
 
   Is_vertical_2 is_vertical_2_object() const
-    { return ck.is_vertical_2_object();  }
-
+  { return ck.is_vertical_2_object();  }
 
   //! A functor for subdividing curves into x-monotone curves.
   class Make_x_monotone_2 {
   public:
     template <typename OutputIterator>
-    OutputIterator operator()(const Curve_2& arc, OutputIterator oi) const
-    {
-      typedef std::variant<Point_2, X_monotone_curve_2>
-        Make_x_monotone_result;
+    OutputIterator operator()(const Curve_2& arc, OutputIterator oi) const {
+      using Make_x_monotone_result = std::variant<Point_2, X_monotone_curve_2>;
 
       std::vector<Make_x_monotone_result> objs;
       CircularKernel().make_x_monotone_2_object()(arc, std::back_inserter(objs));

--- a/Arrangement_on_surface_2/include/CGAL/Arr_conic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_conic_traits_2.h
@@ -32,7 +32,7 @@
 
 #include <boost/math/constants/constants.hpp>
 
-#include <CGAL/Cartesian.h>
+#include <CGAL/Simple_cartesian.h>
 #include <CGAL/tags.h>
 #include <CGAL/Arr_tags.h>
 #include <CGAL/Arr_enums.h>
@@ -59,37 +59,37 @@ namespace CGAL {
 template <typename RatKernel, typename AlgKernel, typename NtTraits>
 class Arr_conic_traits_2 {
 public:
-  typedef RatKernel                       Rat_kernel;
-  typedef AlgKernel                       Alg_kernel;
-  typedef NtTraits                        Nt_traits;
+  using Rat_kernel = RatKernel;
+  using Alg_kernel = AlgKernel;
+  using Nt_traits = NtTraits;
 
-  typedef typename Rat_kernel::FT         Rational;
-  typedef typename Rat_kernel::Point_2    Rat_point_2;
-  typedef typename Rat_kernel::Segment_2  Rat_segment_2;
-  typedef typename Rat_kernel::Line_2     Rat_line_2;
-  typedef typename Rat_kernel::Circle_2   Rat_circle_2;
+  using Rational = typename Rat_kernel::FT;
+  using Rat_point_2 = typename Rat_kernel::Point_2;
+  using Rat_segment_2 = typename Rat_kernel::Segment_2;
+  using Rat_line_2 = typename Rat_kernel::Line_2;
+  using Rat_circle_2 = typename Rat_kernel::Circle_2;
 
-  typedef typename Alg_kernel::FT         Algebraic;
-  typedef typename Alg_kernel::Point_2    Alg_point_2;
+  using Algebraic = typename Alg_kernel::FT;
+  using Alg_point_2 = typename Alg_kernel::Point_2;
 
-  typedef typename Nt_traits::Integer     Integer;
+  using Integer = typename Nt_traits::Integer;
 
   // Category tags:
-  typedef Tag_true                        Has_left_category;
-  typedef Tag_true                        Has_merge_category;
-  typedef Tag_false                       Has_do_intersect_category;
+  using Has_left_category = Tag_true;
+  using Has_merge_category = Tag_true;
+  using Has_do_intersect_category = Tag_false;
   //typedef std::true_type                Has_line_segment_constructor;
 
-  typedef Arr_oblivious_side_tag          Left_side_category;
-  typedef Arr_oblivious_side_tag          Bottom_side_category;
-  typedef Arr_oblivious_side_tag          Top_side_category;
-  typedef Arr_oblivious_side_tag          Right_side_category;
+  using Left_side_category = Arr_oblivious_side_tag;
+  using Bottom_side_category = Arr_oblivious_side_tag;
+  using Top_side_category = Arr_oblivious_side_tag;
+  using Right_side_category = Arr_oblivious_side_tag;
 
   // Traits objects:
-  typedef Conic_arc_2<Rat_kernel, Alg_kernel, Nt_traits>  Curve_2;
-  typedef Conic_x_monotone_arc_2<Curve_2>                 X_monotone_curve_2;
-  typedef Conic_point_2<Alg_kernel>                       Point_2;
-  typedef size_t                                          Multiplicity;
+  using Curve_2 = Conic_arc_2<Rat_kernel, Alg_kernel, Nt_traits>;
+  using X_monotone_curve_2 = Conic_x_monotone_arc_2<Curve_2>;
+  using Point_2 = Conic_point_2<Alg_kernel>;
+  using Multiplicity = std::size_t;
 
 private:
   // Type definition for the intersection points mapping.
@@ -106,16 +106,14 @@ private:
     }
   };
 
-  typedef std::pair<Point_2, Multiplicity>          Intersection_point;
-  typedef std::list<Intersection_point>             Intersection_list;
-  typedef std::map<Conic_pair, Intersection_list, Less_conic_pair>
-                                                    Intersection_map;
-  typedef typename Intersection_map::iterator       Intersection_map_iterator;
+  using Intersection_point = std::pair<Point_2, Multiplicity>;
+  using Intersection_list = std::list<Intersection_point>;
+  using Intersection_map = std::map<Conic_pair, Intersection_list, Less_conic_pair>;
+  using Intersection_map_iterator = typename Intersection_map::iterator;
 
-
-  typedef std::shared_ptr<Rat_kernel>               Shared_rat_kernel;
-  typedef std::shared_ptr<Alg_kernel>               Shared_alg_kernel;
-  typedef std::shared_ptr<Nt_traits>                Shared_nt_traits;
+  using Shared_rat_kernel = std::shared_ptr<Rat_kernel>;
+  using Shared_alg_kernel = std::shared_ptr<Alg_kernel>;
+  using Shared_nt_traits = std::shared_ptr<Nt_traits>;
 
   const Shared_rat_kernel m_rat_kernel;
   const Shared_alg_kernel m_alg_kernel;
@@ -127,10 +125,10 @@ private:
 public:
   /*! constructs default.
    */
-  Arr_conic_traits_2()
-   : m_rat_kernel(std::make_shared<Rat_kernel>()),
-     m_alg_kernel(std::make_shared<Alg_kernel>()),
-     m_nt_traits(std::make_shared<Nt_traits>())
+  Arr_conic_traits_2() :
+    m_rat_kernel(std::make_shared<Rat_kernel>()),
+    m_alg_kernel(std::make_shared<Alg_kernel>()),
+    m_nt_traits(std::make_shared<Nt_traits>())
   {}
 
   /*! constructs from resources.
@@ -360,8 +358,7 @@ public:
      */
     Comparison_result operator()(const X_monotone_curve_2& xcv1,
                                  const X_monotone_curve_2& xcv2,
-                                 const Point_2& p) const
-    {
+                                 const Point_2& p) const {
       // Make sure that p lies on both curves, and that both are defined to its
       // left (so their left endpoint is lexicographically smaller than p).
       CGAL_precondition(m_traits.contains_point(xcv1, p) &&
@@ -538,8 +535,7 @@ public:
      */
     Comparison_result operator()(const X_monotone_curve_2& xcv1,
                                  const X_monotone_curve_2& xcv2,
-                                 const Point_2& p) const
-    {
+                                 const Point_2& p) const {
       // Make sure that p lies on both curves, and that both are defined to its
       // left (so their left endpoint is lexicographically smaller than p).
       CGAL_precondition(m_traits.contains_point(xcv1, p) &&
@@ -703,8 +699,7 @@ public:
      * \return `true` if the two curves are the same; `false` otherwise.
      */
     bool operator()(const X_monotone_curve_2& xcv1,
-                    const X_monotone_curve_2& xcv2) const
-    {
+                    const X_monotone_curve_2& xcv2) const {
       if (&xcv1 == &xcv2) return true;
       return equals(xcv1, xcv2);
     }
@@ -924,8 +919,7 @@ public:
 
           if (((cv.orientation() == COUNTERCLOCKWISE) &&
                (start_pos == order_vpts)) ||
-              ((cv.orientation() == CLOCKWISE) && (start_pos != order_vpts)))
-          {
+              ((cv.orientation() == CLOCKWISE) && (start_pos != order_vpts))) {
             ind_first = 1;
             ind_second = 0;
           }
@@ -1101,8 +1095,7 @@ public:
       else if (m_traits.is_between_endpoints(xcv2, xcv1.source()) &&
                m_traits.is_between_endpoints(xcv2, xcv1.target()) &&
                (m_traits.is_strictly_between_endpoints(xcv2, xcv1.source()) ||
-                m_traits.is_strictly_between_endpoints(xcv2, xcv1.target())))
-      {
+                m_traits.is_strictly_between_endpoints(xcv2, xcv1.target()))) {
         // Case 4 - *this:     +----------->
         //            arc:   +================>
         overlap = xcv1;
@@ -1285,8 +1278,7 @@ public:
       for (i = 0; i < n_xs; ++i) {
         for (j = 0; j < n_ys; ++j) {
           if (xcv1.is_on_supporting_conic(xs[i], ys[j]) &&
-              xcv2.is_on_supporting_conic(xs[i], ys[j]))
-          {
+              xcv2.is_on_supporting_conic(xs[i], ys[j])) {
             // Create the intersection point and set its generating conics.
             Point_2 ip(xs[i], ys[j]);
 
@@ -1314,8 +1306,7 @@ public:
     OutputIterator intersect(const X_monotone_curve_2& xcv1,
                              const X_monotone_curve_2& xcv2,
                              Intersection_map& inter_map,
-                             OutputIterator oi) const
-    {
+                             OutputIterator oi) const {
       if (m_traits.has_same_supporting_conic(xcv1, xcv2)) {
         // Check for overlaps between the two arcs.
         X_monotone_curve_2 overlap;
@@ -1392,8 +1383,7 @@ public:
       // both \f$x\f$-monotone arcs.
       for (auto iter = inter_list.begin(); iter != inter_list.end(); ++iter) {
         if (m_traits.is_between_endpoints(xcv1, (*iter).first) &&
-            m_traits.is_between_endpoints(xcv2, (*iter).first))
-        {
+            m_traits.is_between_endpoints(xcv2, (*iter).first)) {
           *oi++ = *iter;
         }
       }
@@ -1481,8 +1471,7 @@ public:
      */
     void operator()(const X_monotone_curve_2& xcv1,
                     const X_monotone_curve_2& xcv2,
-                    X_monotone_curve_2& xcv) const
-    {
+                    X_monotone_curve_2& xcv) const {
       CGAL_precondition(m_traits.are_mergeable_2_object()(xcv2, xcv1));
       xcv = xcv1;
       merge(xcv, xcv2);
@@ -1523,9 +1512,9 @@ public:
    * point-location strategy and the drawing function.
    */
   //@{
-  typedef double                                        Approximate_number_type;
-  typedef CGAL::Cartesian<Approximate_number_type>      Approximate_kernel;
-  typedef Approximate_kernel::Point_2                   Approximate_point_2;
+  using Approximate_number_type = double;
+  using Approximate_kernel = CGAL::Simple_cartesian<Approximate_number_type>;
+  using Approximate_point_2 = Approximate_kernel::Point_2;
 
   class Approximate_curve_length_2 {
   protected:
@@ -1901,8 +1890,7 @@ public:
     template <typename OutputIterator>
     OutputIterator approximate_parabola(const X_monotone_curve_2& xcv,
                                         double error, OutputIterator oi,
-                                        bool l2r = true)
-      const {
+                                        bool l2r = true) const {
       // std::cout << "PARABOLA\n";
       auto min_vertex = m_traits.construct_min_vertex_2_object();
       auto max_vertex = m_traits.construct_max_vertex_2_object();
@@ -2104,8 +2092,7 @@ public:
      */
     X_monotone_curve_2 operator()(const Curve_2& cv,
                                   const Point_2& source, const Point_2& target,
-                                  const Conic_id& id) const
-    {
+                                  const Conic_id& id) const {
       // Set the two endpoints.
       X_monotone_curve_2 xcv(cv, id);
       xcv.set_source(source);
@@ -2122,8 +2109,7 @@ public:
      * \return A segment connecting `source` and `target`.
      */
     X_monotone_curve_2 operator()(const Point_2& source, const Point_2& target)
-      const
-    {
+      const {
       X_monotone_curve_2 xcv;
 
       // Set the basic properties.
@@ -2157,8 +2143,7 @@ public:
     X_monotone_curve_2 operator()(const Algebraic& a, const Algebraic& b,
                                   const Algebraic& c,
                                   const Point_2& source, const Point_2& target)
-      const
-    {
+      const {
       auto cmp_xy = m_traits.m_alg_kernel->compare_xy_2_object();
       Comparison_result res = cmp_xy(source, target);
       CGAL_precondition(res != EQUAL);
@@ -2238,8 +2223,7 @@ public:
      */
     Curve_2 operator()(const Rational& r, const Rational& s, const Rational& t,
                        const Rational& u, const Rational& v, const Rational& w)
-      const
-    {
+      const {
       // Ensure that the given curve is an ellipse (4rs - t^2 is positive).
       CGAL_precondition(CGAL::sign(4*r*s - t*t) == POSITIVE);
 
@@ -2445,8 +2429,7 @@ public:
 
       if (! m_traits.is_strictly_between_endpoints(arc, mp2) ||
           ! m_traits.is_strictly_between_endpoints(arc, mp3) ||
-          ! m_traits.is_strictly_between_endpoints(arc, mp4))
-      {
+          ! m_traits.is_strictly_between_endpoints(arc, mp4)) {
         arc.reset_flags();            // invalid arc
         return arc;
       }
@@ -2853,8 +2836,7 @@ public:
      * \pre both points must be interior and must lie on \c cv
      */
     X_monotone_curve_2 operator()(const X_monotone_curve_2& xcv,
-                                  const Point_2& src, const Point_2& tgt) const
-    {
+                                  const Point_2& src, const Point_2& tgt) const {
       // make functor objects
       CGAL_precondition_code(Compare_y_at_x_2 compare_y_at_x_2 =
                              m_traits.compare_y_at_x_2_object());
@@ -3084,16 +3066,14 @@ public:
     const auto& target = cv.target();
     // Make sure both endpoint lie on the supporting conic.
     if (! is_on_supporting_conic(cv, source) ||
-        ! is_on_supporting_conic(cv, target))
-    {
+        ! is_on_supporting_conic(cv, target)) {
       cv.reset_flags();            // invalid arc
       return;
     }
 
     // Check whether we have a degree 2 curve.
     if ((CGAL::sign(r) != ZERO) || (CGAL::sign(s) != ZERO) ||
-        (CGAL::sign(t) != ZERO))
-    {
+        (CGAL::sign(t) != ZERO)) {
       if (cv.orientation() == COLLINEAR) {
         // Make sure the midpoint is on the line pair (thus making sure that
         // the two points are not taken from different lines).
@@ -3105,8 +3085,7 @@ public:
                         m_nt_traits->convert(u)) * p_mid.x() +
                        (m_nt_traits->convert(s)*p_mid.y() +
                         m_nt_traits->convert(v)) * p_mid.y() +
-                       m_nt_traits->convert(w)) != ZERO)
-        {
+                       m_nt_traits->convert(w)) != ZERO) {
           cv.reset_flags();    // invalid arc
           return;
         }
@@ -3645,8 +3624,7 @@ public:
       // Compute the degree of the underlying conic.
       if ((CGAL::sign(xcv.r()) != ZERO) ||
           (CGAL::sign(xcv.s()) != ZERO) ||
-          (CGAL::sign(xcv.t()) != ZERO))
-      {
+          (CGAL::sign(xcv.t()) != ZERO)) {
         xcv.set_flag(X_monotone_curve_2::DEGREE_2);
         xcv.set_flag(X_monotone_curve_2::IS_SPECIAL_SEGMENT);
       }
@@ -3856,8 +3834,7 @@ public:
         for (int j = 0; j < n_ys; ++j) {
           if (CGAL::compare(m_nt_traits->convert(Integer(two*s)) * ys[j],
                             -(m_nt_traits->convert(t) * xs[i] +
-                              m_nt_traits->convert(v))) == EQUAL)
-          {
+                              m_nt_traits->convert(v))) == EQUAL) {
             ps[n++] = Point_2(xs[i], ys[j]);
             break;
           }
@@ -4128,8 +4105,7 @@ public:
                            double& xs_t, double& ys_t, double& ts,
                            double& xt_t, double& yt_t, double& tt,
                            double& a, double& b, double& cx, double& cy,
-                           bool l2r = true)
-    const {
+                           bool l2r = true) const {
     auto min_vertex = construct_min_vertex_2_object();
     auto max_vertex = construct_max_vertex_2_object();
     const auto& src = (l2r) ? min_vertex(xcv) : max_vertex(xcv);
@@ -4206,8 +4182,7 @@ public:
                              double& xs_t, double& ys_t, double& ts,
                              double& xt_t, double& yt_t, double& tt,
                              double& a, double& b, double& cx, double& cy,
-                             bool l2r = true)
-    const {
+                             bool l2r = true) const {
     auto min_vertex = construct_min_vertex_2_object();
     auto max_vertex = construct_max_vertex_2_object();
     const auto& src = (l2r) ? min_vertex(xcv) : max_vertex(xcv);

--- a/Arrangement_on_surface_2/include/CGAL/Arr_conic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_conic_traits_2.h
@@ -1516,7 +1516,7 @@ public:
   using Approximate_kernel = CGAL::Simple_cartesian<Approximate_number_type>;
   using Approximate_point_2 = Approximate_kernel::Point_2;
 
-  class Approximate_curve_length_2 {
+  class Approximate_length_2 {
   protected:
     using Traits = Arr_conic_traits_2<Rat_kernel, Alg_kernel, Nt_traits>;
 
@@ -1526,7 +1526,7 @@ public:
     /*! constructs
      * \param traits the traits.
      */
-    Approximate_curve_length_2(const Traits& traits) : m_traits(traits) {}
+    Approximate_length_2(const Traits& traits) : m_traits(traits) {}
 
     friend class Arr_conic_traits_2<Rat_kernel, Alg_kernel, Nt_traits>;
 
@@ -1546,7 +1546,7 @@ public:
   private:
     /*! obtains the segment length.
      */
-    double segment_length(const X_monotone_curve_2& xcv) {
+    double segment_length(const X_monotone_curve_2& xcv) const {
       auto min_vertex = m_traits.construct_min_vertex_2_object();
       auto max_vertex = m_traits.construct_max_vertex_2_object();
       const auto& minv = min_vertex(xcv);
@@ -1586,7 +1586,7 @@ public:
 
     /*! obtains the parabolic arc length.
      */
-    double parabola_length(const X_monotone_curve_2& xcv) {
+    double parabola_length(const X_monotone_curve_2& xcv) const {
       double r_m, t_m, s_m, u_m, v_m, w_m;
       double cost, sint;
       double xs_t, ys_t, xt_t, yt_t;
@@ -1606,7 +1606,7 @@ public:
       return d;
     }
 
-    double ellipse_length(const X_monotone_curve_2& xcv) {
+    double ellipse_length(const X_monotone_curve_2& xcv) const {
       double r_m, t_m, s_m, u_m, v_m, w_m;
       double cost, sint;
       double xs_t, ys_t, xt_t, yt_t;
@@ -1627,7 +1627,7 @@ public:
       return d;
     }
 
-    double hyperbola_length(const X_monotone_curve_2& /* xcv */) {
+    double hyperbola_length(const X_monotone_curve_2& /* xcv */) const {
       CGAL_error_msg("Not implemented yet!");
       double l(0.0);
       return l;

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geodesic_arc_on_sphere_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geodesic_arc_on_sphere_traits_2.h
@@ -28,7 +28,7 @@
 #include <variant>
 
 #include <CGAL/config.h>
-#include <CGAL/Cartesian.h>
+#include <CGAL/Simple_cartesian.h>
 #include <CGAL/tags.h>
 #include <CGAL/tss.h>
 #include <CGAL/intersections.h>
@@ -2856,7 +2856,7 @@ public:
   /// \name Functor definitions for the landmarks point-location strategy.
   //@{
   using Approximate_number_type = double;
-  using Approximate_kernel = CGAL::Cartesian<Approximate_number_type>;
+  using Approximate_kernel = CGAL::Simple_cartesian<Approximate_number_type>;
   using Approximate_point_2 = Arr_extended_direction_3<Approximate_kernel>;
   using Approximate_kernel_vector_3 = Approximate_kernel::Vector_3;
   using Approximate_kernel_direction_3 = Approximate_kernel::Direction_3;

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_bounding_rational_traits.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_bounding_rational_traits.h
@@ -21,7 +21,6 @@
  * Definition of the Bezier_bounding_rational_traits<Kernel> class.
  */
 
-#include <CGAL/Cartesian.h>
 #include <CGAL/Polygon_2_algorithms.h>
 #include <CGAL/Arr_geometry_traits/de_Casteljau_2.h>
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h
@@ -32,60 +32,48 @@ namespace CGAL {
  * Representation of an x-monotone Bezier subcurve, specified by a Bezier curve
  * and two end points.
  */
-template <class Rat_kernel_, class Alg_kernel_, class Nt_traits_,
-          class Bounding_traits_>
-class _Bezier_x_monotone_2
-{
+template <typename Rat_kernel_, typename Alg_kernel_, typename Nt_traits_,
+          typename Bounding_traits_>
+class _Bezier_x_monotone_2 {
 public:
+  using Rat_kernel = Rat_kernel_;
+  using Alg_kernel = Alg_kernel_;
+  using Nt_traits = Nt_traits_;
+  using Bounding_traits = Bounding_traits_;
+  using Curve_2 = _Bezier_curve_2<Rat_kernel, Alg_kernel, Nt_traits, Bounding_traits>;
+  using Point_2 = _Bezier_point_2<Rat_kernel, Alg_kernel, Nt_traits, Bounding_traits>;
+  using Self = _Bezier_x_monotone_2<Rat_kernel, Alg_kernel, Nt_traits, Bounding_traits>;
 
-  typedef Rat_kernel_                             Rat_kernel;
-  typedef Alg_kernel_                             Alg_kernel;
-  typedef Nt_traits_                              Nt_traits;
-  typedef Bounding_traits_                        Bounding_traits;
-  typedef _Bezier_curve_2<Rat_kernel,
-                          Alg_kernel,
-                          Nt_traits,
-                          Bounding_traits>              Curve_2;
-  typedef _Bezier_point_2<Rat_kernel,
-                          Alg_kernel,
-                          Nt_traits,
-                          Bounding_traits>              Point_2;
-  typedef _Bezier_x_monotone_2<Rat_kernel,
-                               Alg_kernel,
-                               Nt_traits,
-                               Bounding_traits>         Self;
+  using Multiplicity = std::size_t;
 
-  typedef unsigned int                                  Multiplicity;
-
-  typedef _Bezier_cache<Nt_traits>                      Bezier_cache;
+  using Bezier_cache = _Bezier_cache<Nt_traits>;
 
 private:
+  using Alg_point_2 = typename Alg_kernel::Point_2;
+  using Rat_point_2 = typename Rat_kernel::Point_2;
 
-  typedef typename Alg_kernel::Point_2            Alg_point_2;
-  typedef typename Rat_kernel::Point_2            Rat_point_2;
+  using Integer = typename Nt_traits::Integer;
+  using Rational = typename Nt_traits::Rational;
+  using Algebraic = typename Nt_traits::Algebraic;
+  using Polynomial = typename Nt_traits::Polynomial;
 
-  typedef typename Nt_traits::Integer             Integer;
-  typedef typename Nt_traits::Rational            Rational;
-  typedef typename Nt_traits::Algebraic           Algebraic;
-  typedef typename Nt_traits::Polynomial          Polynomial;
-
-  typedef typename Point_2::Originator               Originator;
-  typedef typename Point_2::Originator_iterator      Originator_iterator;
-  typedef typename Bounding_traits::Bez_point_bound  Bez_point_bound;
-  typedef typename Bounding_traits::Bez_point_bbox   Bez_point_bbox;
+  using Originator = typename Point_2::Originator;
+  using Originator_iterator = typename Point_2::Originator_iterator;
+  using Bez_point_bound = typename Bounding_traits::Bez_point_bound;
+  using Bez_point_bbox = typename Bounding_traits::Bez_point_bbox;
 
   // Type definition for the vertical tangency-point mapping.
-  typedef typename Bezier_cache::Curve_id                 Curve_id;
-  typedef std::pair<Curve_id, Curve_id>                   Curve_pair;
-  typedef typename Bezier_cache::Vertical_tangency_list   Vert_tang_list;
-  typedef typename Bezier_cache::Vertical_tangency_iter   Vert_tang_iter;
+  using Curve_id = typename Bezier_cache::Curve_id;
+  using Curve_pair = std::pair<Curve_id, Curve_id>;
+  using Vert_tang_list = typename Bezier_cache::Vertical_tangency_list;
+  using Vert_tang_iter = typename Bezier_cache::Vertical_tangency_iter;
 
   // Type definition for the intersection-point mapping.
-  typedef typename Bezier_cache::Intersection_list        Intersect_list;
-  typedef typename Bezier_cache::Intersection_iter        Intersect_iter;
+  using Intersect_list = typename Bezier_cache::Intersection_list;
+  using Intersect_iter = typename Bezier_cache::Intersection_iter;
 
   // Representation of an intersection point with its multiplicity:
-  typedef std::pair<Point_2, Multiplicity>                Intersection_point;
+  using Intersection_point = std::pair<Point_2, Multiplicity>;
 
   /*! \class Less_intersection_point
    * Comparison functor for intersection points.
@@ -95,27 +83,23 @@ private:
     Bezier_cache* p_cache;
 
   public:
-
     Less_intersection_point(Bezier_cache& cache) : p_cache(&cache) {}
 
     bool operator()(const Intersection_point& ip1,
-                    const Intersection_point& ip2) const
-    {
+                    const Intersection_point& ip2) const {
       // Use an xy-lexicographic comparison.
       return (ip1.first.compare_xy(ip2.first, *p_cache) == SMALLER);
     }
   };
 
   // Type definition for the bounded intersection-point mapping.
-  typedef std::list<Point_2>                          Intersection_list;
+  using Intersection_list = std::list<Point_2>;
 
   /*! \struct Less_curve_pair
    * An auxiliary functor for comparing a pair of curve IDs.
    */
-  struct Less_curve_pair
-  {
-    bool operator()(const Curve_pair& cp1, const Curve_pair& cp2) const
-    {
+  struct Less_curve_pair {
+    bool operator()(const Curve_pair& cp1, const Curve_pair& cp2) const {
       // Compare the pairs of IDs lexicographically.
       return (cp1.first < cp2.first ||
               (cp1.first == cp2.first && cp1.second < cp2.second));
@@ -132,8 +116,7 @@ private:
 
     /*! obtains the rational bounding box of the subcurve. */
     void bbox(Rational& x_min, Rational& y_min,
-              Rational& x_max, Rational& y_max) const
-    {
+              Rational& x_max, Rational& y_max) const {
       typename std::list<Rat_point_2>::const_iterator pit =
         control_points.begin();
 
@@ -159,30 +142,24 @@ private:
   };
 
 public:
-
-  typedef std::map<Curve_pair,
-                   Intersection_list,
-                   Less_curve_pair>               Intersection_map;
-  typedef typename Intersection_map::value_type   Intersection_map_entry;
-  typedef typename Intersection_map::iterator     Intersection_map_iterator;
+  using Intersection_map = std::map<Curve_pair, Intersection_list, Less_curve_pair>;
+  using Intersection_map_entry = typename Intersection_map::value_type;
+  using Intersection_map_iterator = typename Intersection_map::iterator;
 
 private:
-
-  // Data members:
-  Curve_2       _curve;        /*!< The supporting Bezier curve. */
-  unsigned int  _xid;          /*!< The serial number of the basic x-monotone
-                                    subcurve of the Bezier curve. */
-  Point_2       _ps;           /*!< The source point. */
-  Point_2       _pt;           /*!< The target point. */
-  bool          _dir_right;    /*!< Is the subcurve directed right
-                                    (or left). */
-  bool          _inc_to_right; /*!< Does the parameter value increase when
-                                    traversing the subcurve from left to
-                                    right. */
-  bool          _is_vert;      /*!< Is the subcurve a vertical segment. */
+  Curve_2 _curve;               //!< The supporting Bezier curve
+  unsigned int _xid;            //!< The serial number of the basic x-monotone
+                                //   subcurve of the Bezier curve
+  Point_2 _ps;                  //!< The source point
+  Point_2 _pt;                  //!< The target point
+  bool _dir_right;              //!< Is the subcurve directed right
+                                //   (or left)
+  bool _inc_to_right;           //!< Does the parameter value increase when
+                                //   traversing the subcurve from left to
+                                //   right
+  bool _is_vert;                //!< Is the subcurve a vertical segment
 
 public:
-
   /*! Default constructor. */
   _Bezier_x_monotone_2() :
     _xid(0),
@@ -190,8 +167,7 @@ public:
     _is_vert(false)
   {}
 
-  /*!
-   * Constructor given two endpoints.
+  /*! Constructor given two endpoints.
    * \param B The supporting Bezier curve.
    * \param xid The serial number of the x-monotone subcurve with respect to
    *            the parameter range of the Bezier curve.
@@ -208,55 +184,45 @@ public:
                        const Point_2& ps, const Point_2& pt,
                        Bezier_cache& cache);
 
-  /*!
-   * Get the supporting Bezier curve.
+  /*! obtains the supporting Bezier curve.
    */
   const Curve_2& supporting_curve() const { return (_curve); }
 
-  /*!
-   * Get the x-monotone ID of the curve.
+  /*! obtains the x-monotone ID of the curve.
    */
   unsigned int xid() const { return (_xid); }
 
-  /*!
-   * Get the source point.
+  /*! obtains the source point.
    */
   const Point_2& source() const { return (_ps); }
 
-  /*!
-   * Get the target point.
+  /*! obtains the target point.
    */
   const Point_2& target() const { return (_pt); }
 
-  /*!
-   * Get the left endpoint (the lexicographically smaller one).
+  /*! obtains the left endpoint (the lexicographically smaller one).
    */
   const Point_2& left() const { return (_dir_right ? _ps : _pt); }
 
-  /*!
-   * Get the right endpoint (the lexicographically larger one).
+  /*! obtains the right endpoint (the lexicographically larger one).
    */
   const Point_2& right() const { return (_dir_right ? _pt : _ps); }
 
-  /*!
-   * Check if the subcurve is a vertical segment.
+  /*! determines whether the subcurve is a vertical segment.
    */
   bool is_vertical() const { return (_is_vert); }
 
-  /*!
-   * Check if the subcurve is directed from left to right.
+  /*! determines whether the subcurve is directed from left to right.
    */
   bool is_directed_right() const { return (_dir_right); }
 
-  /*!
-   * Get the approximate parameter range defining the curve.
+  /*! obtains the approximate parameter range defining the curve.
    * \return A pair of t_src and t_trg, where B(t_src) is the source point
    *         and B(t_trg) is the target point.
    */
   std::pair<double, double> parameter_range() const;
 
-  /*!
-   * Get the relative position of the query point with respect to the subcurve.
+  /*! obtains the relative position of the query point with respect to the subcurve.
    * \param p The query point.
    * \param cache Caches the vertical tangency points and intersection points.
    * \pre p is in the x-range of the arc.
@@ -267,8 +233,7 @@ public:
   Comparison_result point_position(const Point_2& p,
                                    Bezier_cache& cache) const;
 
-  /*!
-   * Compare the relative y-position of two x-monotone subcurve to the right
+  /*! compares the relative y-position of two x-monotone subcurve to the right
    * of their intersection point.
    * \param cv The other subcurve.
    * \param p The intersection point.
@@ -282,8 +247,7 @@ public:
                                      const Point_2& p,
                                      Bezier_cache& cache) const;
 
-  /*!
-   * Compare the relative y-position of two x-monotone subcurve to the left
+  /*! compares the relative y-position of two x-monotone subcurve to the left
    * of their intersection point.
    * \param cv The other subcurve.
    * \param p The intersection point.
@@ -297,7 +261,7 @@ public:
                                     const Point_2& p,
                                     Bezier_cache& cache) const;
 
-  /*! Check whether the two subcurves are equal (have the same graph).
+  /*! determines whether the two subcurves are equal (have the same graph).
    * \param cv The other subcurve.
    * \param cache Caches the vertical tangency points and intersection points.
    * \return (true) if the two subcurves have the same graph;
@@ -305,7 +269,7 @@ public:
    */
   bool equals(const Self& cv, Bezier_cache& cache) const;
 
-  /*! Compute the intersections with the given subcurve.
+  /*! computes the intersections with the given subcurve.
    * \param cv The other subcurve.
    * \param inter_map Caches the bounded intersection points.
    * \param cache Caches the vertical tangency points and intersection points.
@@ -316,8 +280,7 @@ public:
   OutputIterator intersect(const Self& cv,
                            Intersection_map& inter_map,
                            Bezier_cache& cache,
-                           OutputIterator oi) const
-  {
+                           OutputIterator oi) const {
     // In case we have two x-monotone subcurves of the same Bezier curve,
     // check if they have a common left endpoint.
     if (_curve.is_same(cv._curve)) {
@@ -361,7 +324,7 @@ public:
     return oi;
   }
 
-  /*! Split the subcurve into two at a given split point.
+  /*! splits the subcurve into two at a given split point.
    * \param p The split point.
    * \param c1 Output: The first resulting arc, lying to the left of p.
    * \param c2 Output: The first resulting arc, lying to the right of p.
@@ -369,27 +332,23 @@ public:
    */
   void split(const Point_2& p, Self& c1, Self& c2) const;
 
-  /*!
-   * Check if the two subcurves are mergeable.
+  /*! determines whether the two subcurves are mergeable.
    * \param cv The other subcurve.
    * \return Whether the two subcurves can be merged.
    */
   bool can_merge_with(const Self& cv) const;
 
-  /*!
-   * Merge the current arc with the given arc.
+  /*! merges the current arc with the given arc.
    * \param cv The other subcurve.
    * \pre The two arcs are mergeable.
    * \return The merged arc.
    */
   Self merge(const Self& cv) const;
 
-  /*!
-   * Flip the subcurve (swap its source and target points).
+  /*! flips the subcurve (swap its source and target points).
    * \return The flipped subcurve.
    */
-  Self flip() const
-  {
+  Self flip() const {
     // Note that we just swap the source and target of the original subcurve
     // and do not touch the supporting Beizer curve.
     Self  cv = *this;
@@ -401,8 +360,9 @@ public:
     return cv;
   }
 
-  Self trim(const Point_2& src, const Point_2& tgt) const
-  {
+  /*! trims a curve
+   */
+  Self trim(const Point_2& src, const Point_2& tgt) const {
     //this will make a copy.
     Self cv = *this;
 
@@ -413,14 +373,14 @@ public:
   }
 
 private:
-  /*! Check if the given t-value is in the range of the subcurve.
+  /*! determines whether the given t-value is in the range of the subcurve.
    * \param t The parameter value.
    * \param cache Caches the vertical tangency points and intersection points.
    * \return If t in the parameter-range of the subcurve.
    */
   bool _is_in_range(const Algebraic& t, Bezier_cache& cache) const;
 
-  /*! Check if the given point lies in the range of this x-monotone subcurve.
+  /*! determines whether the given point lies in the range of this x-monotone subcurve.
    * \param p The point, which lies on the supporting Bezier curve.
    * \param is_certain Output: Is the answer we provide is certain.
    * \return Whether p is on the x-monotone subcurve.
@@ -441,7 +401,7 @@ private:
                     Algebraic& t0,
                     bool& is_endpoint) const;
 
-  /*! Compute a y-coordinate of a point on the x-monotone subcurve with a
+  /*! computes a y-coordinate of a point on the x-monotone subcurve with a
    * given x-coordinate.
    * \param x0 The given x-coodinate.
    * \param cache Caches the vertical tangency points and intersection points.
@@ -449,7 +409,7 @@ private:
    */
   Algebraic _get_y(const Rational& x0, Bezier_cache& cache) const;
 
-  /*! Compare the slopes of the subcurve with another given Bezier subcurve at
+  /*! compares the slopes of the subcurve with another given Bezier subcurve at
    * their given intersection point.
    * \param cv The other subcurve.
    * \param p The intersection point.
@@ -471,7 +431,7 @@ private:
    */
   std::pair<Algebraic, Algebraic> _t_range(Bezier_cache& cache) const;
 
-  /*! Compare the relative y-position of two x-monotone subcurve to the right
+  /*! compares the relative y-position of two x-monotone subcurve to the right
    * (or to the left) of their intersection point, whose multiplicity is
    * greater than 1.
    * \param cv The other subcurve.
@@ -491,7 +451,7 @@ private:
                                      bool to_right,
                                      Bezier_cache& cache) const;
 
-  /*! Clip the control polygon of the supporting Bezier curve such that it
+  /*! clips the control polygon of the supporting Bezier curve such that it
    * fits the current x-monotone subcurve.
    * \param ctrl Output: The clipped control polygon.
    * \param t_min Output: The minimal t-value of the clipped curve.
@@ -501,7 +461,7 @@ private:
                              typename Bounding_traits::NT& t_min,
                              typename Bounding_traits::NT& t_max) const;
 
-  /*! Approximate the intersection points between the supporting Bezier curves
+  /*! approximates the intersection points between the supporting Bezier curves
    * of the given x-monotone curves.
    * \param cv The x-monotone curve we intersect.
    * \param inter_pts Output: An output list of intersection points between
@@ -514,7 +474,7 @@ private:
   bool _approximate_intersection_points(const Self& cv,
                                         std::list<Point_2>& inter_pts) const;
 
-  /*! Compute the intersections with the given subcurve.
+  /*! computes the intersections with the given subcurve.
    * \param cv The other subcurve.
    * \param inter_map Caches the bounded intersection points.
    * \param cache Caches the vertical tangency points and intersection points.
@@ -528,7 +488,7 @@ private:
                   std::vector<Intersection_point>& ipts,
                   Self& ovlp_cv) const;
 
-  /*! Compute the exact vertical position of the given point with respect to
+  /*! computes the exact vertical position of the given point with respect to
    * the x-monotone curve.
    * \param p The point.
    * \param force_exact Should we force an exact result.
@@ -545,16 +505,14 @@ private:
 
 };
 
-/*!
- * Exporter for Bezier curves.
+/*! Exporter for Bezier curves.
  */
 template <typename Rat_kernel, typename Alg_kernel, typename Nt_traits,
           typename Bounding_traits>
 std::ostream&
 operator<<(std::ostream& os,
            const _Bezier_x_monotone_2
-           <Rat_kernel, Alg_kernel, Nt_traits, Bounding_traits>& cv)
-{
+           <Rat_kernel, Alg_kernel, Nt_traits, Bounding_traits>& cv) {
   os << cv.supporting_curve()
      << " [" << cv.xid()
      << "] | " << cv.source()
@@ -575,8 +533,7 @@ _Bezier_x_monotone_2(const Curve_2& B, unsigned int xid,
   _xid(xid),
   _ps(ps),
   _pt(pt),
-  _is_vert(false)
-{
+  _is_vert(false) {
   CGAL_precondition(xid > 0);
 
   // Get the originators of the point that correspond to the curve B.
@@ -594,8 +551,7 @@ _Bezier_x_monotone_2(const Curve_2& B, unsigned int xid,
     _is_vert = true;
     _dir_right = (CGAL::compare(_ps.y(), _pt.y()) == SMALLER);
   }
-  else
-  {
+  else {
     _dir_right = (res == SMALLER);
   }
 
@@ -607,12 +563,11 @@ _Bezier_x_monotone_2(const Curve_2& B, unsigned int xid,
   if (CGAL::compare(ps_org->point_bound().t_max,
                     pt_org->point_bound().t_min) == SMALLER ||
       CGAL::compare(ps_org->point_bound().t_min,
-                    pt_org->point_bound().t_max) == LARGER)
-  {
+                    pt_org->point_bound().t_max) == LARGER) {
     // Perform the comparison assuming that the possible parameter
     // values do not overlap.
     t_res = CGAL::compare(ps_org->point_bound().t_min,
-                           pt_org->point_bound().t_min);
+                          pt_org->point_bound().t_min);
   }
   else {
     // In this case both exact parameter values must be known.
@@ -633,8 +588,7 @@ _Bezier_x_monotone_2(const Curve_2& B, unsigned int xid,
 //
 template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
 std::pair<double, double>
-_Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::parameter_range() const
-{
+_Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::parameter_range() const {
   // First try to use the approximate representation of the endpoints.
   Originator_iterator  s_org = _ps.get_originator(_curve, _xid);
   CGAL_assertion(s_org != _ps.originators_end());
@@ -656,8 +610,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::parameter_range() const
 template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
 Comparison_result
 _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
-point_position(const Point_2& p, Bezier_cache& cache) const
-{
+point_position(const Point_2& p, Bezier_cache& cache) const {
   Nt_traits nt_traits;
 
   //First check if the bezier is a vertical segment
@@ -690,14 +643,12 @@ point_position(const Point_2& p, Bezier_cache& cache) const
 
   const Comparison_result  res1 =  p.compare_x(_ps, cache);
 
-  if (res1 == EQUAL || nt_traits.degree(_curve.y_polynomial()) <= 0)
-  {
+  if (res1 == EQUAL || nt_traits.degree(_curve.y_polynomial()) <= 0) {
     if (! p.is_exact()) p.make_exact(cache);
     if (! _ps.is_exact()) _ps.make_exact(cache);
 
     // If both point are rational, compare their rational y-coordinates.
-    if (p.is_rational() && _ps.is_rational())
-    {
+    if (p.is_rational() && _ps.is_rational()) {
       const Rat_point_2& rat_p = (Rat_point_2) p;
       const Rat_point_2& rat_ps = (Rat_point_2) _ps;
 
@@ -781,15 +732,13 @@ point_position(const Point_2& p, Bezier_cache& cache) const
   p.get_bbox(x_min, y_min, x_max, y_max);
 
   if (CGAL::compare(ps_org->point_bound().t_max,
-                     pt_org->point_bound().t_min) == SMALLER)
-  {
+                     pt_org->point_bound().t_min) == SMALLER) {
     // Examine the parameter range of the originator of the source point
     // with respect to the current subcurve B, and make sure that B(t_max)
     // lies to the left of p if the curve is directed from left to right
     // (or to the right of p, if the subcurve is directed from right to left).
     can_refine = ! _ps.is_exact();
-    do
-    {
+    do {
       const Rat_point_2&  ps = _curve(ps_org->point_bound().t_max);
 
       if ((_dir_right && CGAL::compare(ps.x(), x_min) != LARGER) ||
@@ -804,8 +753,7 @@ point_position(const Point_2& p, Bezier_cache& cache) const
     // lies to the right of p if the curve is directed from left to right
     // (or to the left of p, if the subcurve is directed from right to left).
     can_refine = ! _pt.is_exact();
-    do
-    {
+    do {
       const Rat_point_2&  pt = _curve(pt_org->point_bound().t_min);
 
       if ((_dir_right && CGAL::compare(pt.x(), x_max) != SMALLER) ||
@@ -824,8 +772,7 @@ point_position(const Point_2& p, Bezier_cache& cache) const
                                      pt_org->point_bound().t_min);
   }
   else if (CGAL::compare(pt_org->point_bound().t_max,
-                          ps_org->point_bound().t_min) == SMALLER)
-  {
+                          ps_org->point_bound().t_min) == SMALLER) {
     // Examine the parameter range of the originator of the source point
     // with respect to the current subcurve B, and make sure that B(t_min)
     // lies to the left of p if the curve is directed from left to right
@@ -866,8 +813,7 @@ point_position(const Point_2& p, Bezier_cache& cache) const
                                      ps_org->point_bound().t_min);
   }
 
-  if (res_bound != EQUAL)
-    return (res_bound);
+  if (res_bound != EQUAL) return (res_bound);
 
 
   if ( p.is_rational() ){
@@ -900,9 +846,9 @@ point_position(const Point_2& p, Bezier_cache& cache) const
 
   CGAL_assertion(p.originators_begin() != p.originators_end());
 
-  Originator   org = *(p.originators_begin());
-  bool         do_ovlp;
-  bool         swap_order = (_curve.id() > org.curve().id());
+  Originator org = *(p.originators_begin());
+  bool do_ovlp;
+  bool swap_order = (_curve.id() > org.curve().id());
   const Intersect_list&  inter_list = (! swap_order ?
     (cache.get_intersections(_curve.id(),
                               _curve.x_polynomial(), _curve.x_norm(),
@@ -959,13 +905,12 @@ point_position(const Point_2& p, Bezier_cache& cache) const
 // Compare the relative y-position of two x-monotone subcurves to the right
 // of their intersection point.
 //
-template <class RatKer, class AlgKer, class NtTrt, class BndTrt>
+template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
 Comparison_result
 _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
 compare_to_right(const Self& cv,
                  const Point_2& p,
-                 Bezier_cache& cache) const
-{
+                 Bezier_cache& cache) const {
   CGAL_precondition (p.compare_xy (right(), cache) != LARGER);
   CGAL_precondition (p.compare_xy (cv.right(), cache) != LARGER);
 
@@ -1056,18 +1001,13 @@ compare_to_right(const Self& cv,
   // and comparing the vertical position there.
   Comparison_result   right_res;
 
-  if (right().compare_x(cv.right(), cache) != LARGER)
-  {
-    right_res = _compare_to_side(cv, p,
-                                  true,           // Compare to p's right.
-                                  cache);
+  if (right().compare_x(cv.right(), cache) != LARGER) {
+    // Compare to p's right.
+    right_res = _compare_to_side(cv, p, true, cache);
   }
-  else
-  {
-    right_res = cv._compare_to_side(*this, p,
-                                     true,        // Compare to p's right.
-                                     cache);
-
+  else {
+    // Compare to p's right.
+    right_res = cv._compare_to_side(*this, p, true, cache);
     right_res = CGAL::opposite(right_res);
   }
 
@@ -1078,59 +1018,50 @@ compare_to_right(const Self& cv,
 // Compare the relative y-position of two x-monotone subcurve to the left
 // of their intersection point.
 //
-template <class RatKer, class AlgKer, class NtTrt, class BndTrt>
+template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
 Comparison_result
-_Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_left
-        (const Self& cv,
-         const Point_2& p,
-         Bezier_cache& cache) const
-{
+_Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
+compare_to_left(const Self& cv,
+                const Point_2& p,
+                Bezier_cache& cache) const {
   CGAL_precondition(p.compare_xy(left(), cache) != SMALLER);
   CGAL_precondition(p.compare_xy(cv.left(), cache) != SMALLER);
 
-  if (this == &cv)
-    return (EQUAL);
+  if (this == &cv) return (EQUAL);
 
   // Make sure that p is incident to both curves (either equals the right
   // endpoint or lies in the curve interior). Note that this is important to
   // carry out these tests, as it assures us the eventually both curves are
   // originators of p.
-  if (! p.equals(right(), cache))
-  {
-    if (point_position(p, cache) != EQUAL)
-    {
+  if (! p.equals(right(), cache)) {
+    if (point_position(p, cache) != EQUAL) {
       CGAL_precondition_msg(false, "p is not on cv1");
     }
   }
 
-  if (! p.equals(cv.right(), cache))
-  {
-    if (cv.point_position(p, cache) != EQUAL)
-    {
+  if (! p.equals(cv.right(), cache)) {
+    if (cv.point_position(p, cache) != EQUAL) {
       CGAL_precondition_msg(false, "p is not on cv2");
     }
   }
 
   // Check for vertical subcurves. A vertical segment is below any other
   // x-monotone subcurve to the left of their common endpoint.
-  if (is_vertical())
-  {
+  if (is_vertical()) {
     if (cv.is_vertical())
       // Both are vertical segments with a common endpoint, so they overlap:
       return (EQUAL);
 
     return (SMALLER);
   }
-  else if (cv.is_vertical())
-  {
+  else if (cv.is_vertical()) {
     return (LARGER);
   }
 
   // Check if both subcurves originate from the same Bezier curve.
-  Nt_traits       nt_traits;
+  Nt_traits nt_traits;
 
-  if (_curve.is_same(cv._curve))
-  {
+  if (_curve.is_same(cv._curve)) {
     // Get the originator, and check whether p is a vertical tangency
     // point of this originator (otherwise it is a self-intersection point,
     // and we proceed as if it is a regular intersection point).
@@ -1138,23 +1069,19 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_left
 
     CGAL_assertion(org != p.originators_end());
 
-    if (org->point_bound().type == Bez_point_bound::VERTICAL_TANGENCY_PT)
-    {
+    if (org->point_bound().type == Bez_point_bound::VERTICAL_TANGENCY_PT) {
       CGAL_assertion(_inc_to_right != cv._inc_to_right);
 
-      if (! p.is_exact())
-      {
+      if (! p.is_exact()) {
         // Comparison based on the control polygon of the bounded vertical
         // tangency point, using the fact this polygon is y-monotone.
         const typename Bounding_traits::Control_points& cp =
           org->point_bound().ctrl;
 
-        if (_inc_to_right)
-        {
+        if (_inc_to_right) {
           return (CGAL::compare(cp.front().y(), cp.back().y()));
         }
-        else
-        {
+        else {
           return (CGAL::compare(cp.back().y(), cp.front().y()));
         }
       }
@@ -1166,9 +1093,9 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_left
       // vertical position of the two subcurves to the right of this point.
       CGAL_assertion(org->has_parameter());
 
-      const Algebraic&  t0 = org->parameter();
-      Polynomial        polyY_der = nt_traits.derive(_curve.y_polynomial());
-      const CGAL::Sign  sign_der =
+      const Algebraic& t0 = org->parameter();
+      Polynomial polyY_der = nt_traits.derive(_curve.y_polynomial());
+      const CGAL::Sign sign_der =
         CGAL::sign(nt_traits.evaluate_at(polyY_der, t0));
 
       CGAL_assertion(sign_der != CGAL::ZERO);
@@ -1184,26 +1111,22 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_left
   // case, the slopes are not equal and their comparison gives us the
   // vertical order to p's right; note that we swap the order of the curves
   // to obtains their position to the left.
-  Comparison_result   slope_res = cv._compare_slopes(*this, p, cache);
+  Comparison_result slope_res = cv._compare_slopes(*this, p, cache);
 
   if (slope_res != EQUAL)
     return (slope_res);
 
   // Compare the two subcurves by choosing some point to the left of p
   // and comparing the vertical position there.
-  Comparison_result   left_res;
+  Comparison_result left_res;
 
-  if (left().compare_x(cv.left(), cache) != SMALLER)
-  {
-    left_res = _compare_to_side(cv, p,
-                                 false,          // Compare to p's left.
-                                 cache);
+  if (left().compare_x(cv.left(), cache) != SMALLER) {
+    // Compare to p's left.
+    left_res = _compare_to_side(cv, p, false, cache);
   }
-  else
-  {
-    left_res = cv._compare_to_side(*this, p,
-                                    false,       // Compare to p's left.
-                                    cache);
+  else {
+    // Compare to p's left.
+    left_res = cv._compare_to_side(*this, p, false, cache);
     left_res = CGAL::opposite(left_res);
   }
 
@@ -1213,14 +1136,11 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::compare_to_left
 // ---------------------------------------------------------------------------
 // Check whether the two subcurves are equal (have the same graph).
 //
-template <class RatKer, class AlgKer, class NtTrt, class BndTrt>
-bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::equals
-        (const Self& cv,
-         Bezier_cache& cache) const
-{
+template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
+bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
+equals(const Self& cv, Bezier_cache& cache) const {
   // Check if the two subcurves have overlapping supporting curves.
-  if (! _curve.is_same(cv._curve))
-  {
+  if (! _curve.is_same(cv._curve)) {
     //special case when curves are vertical
     if (cv.is_vertical()){
       if (is_vertical())
@@ -1233,8 +1153,8 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::equals
       return (false);
 
     // Mark that the two curves overlap in the cache.
-    const Curve_id               id1 = _curve.id();
-    const Curve_id               id2 = cv._curve.id();
+    const Curve_id id1 = _curve.id();
+    const Curve_id id2 = cv._curve.id();
 
     if (id1 < id2)
       cache.mark_as_overlapping(id1, id2);
@@ -1250,10 +1170,9 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::equals
 // ---------------------------------------------------------------------------
 // Split the subcurve into two at a given split point.
 //
-template <class RatKer, class AlgKer, class NtTrt, class BndTrt>
+template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
 void _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
-split(const Point_2& p, Self& c1, Self& c2) const
-{
+split(const Point_2& p, Self& c1, Self& c2) const {
   //this was added to handle the case where p is the endpoint of another
   //Bezier curve and the curve is vertical
   if ( p.is_rational() && is_vertical() ){
@@ -1279,8 +1198,7 @@ split(const Point_2& p, Self& c1, Self& c2) const
   c1 = c2 = *this;
 
   // Perform the split.
-  if (_dir_right)
-  {
+  if (_dir_right) {
     c1._pt = p;
     c2._ps = p;
   }
@@ -1294,10 +1212,9 @@ split(const Point_2& p, Self& c1, Self& c2) const
 // ---------------------------------------------------------------------------
 // Check if the two subcurves are mergeable.
 //
-template <class RatKer, class AlgKer, class NtTrt, class BndTrt>
-bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::can_merge_with
-        (const Self& cv) const
-{
+template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
+bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
+can_merge_with(const Self& cv) const {
   // Note that we only allow merging subcurves of the same originating
   // Bezier curve (overlapping curves will not do in this case).
   return (_curve.is_same(cv._curve) &&
@@ -1310,11 +1227,10 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::can_merge_with
 // ---------------------------------------------------------------------------
 // Merge the current arc with the given arc.
 //
-template <class RatKer, class AlgKer, class NtTrt, class BndTrt>
+template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
 typename _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::Self
-_Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::merge
-        (const Self& cv) const
-{
+_Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
+merge(const Self& cv) const {
   CGAL_precondition(_curve.is_same(cv._curve));
   CGAL_precondition(_xid == cv._xid);
 
@@ -1341,8 +1257,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::merge
 //
 template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
 bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
-_is_in_range(const Algebraic& t, Bezier_cache& cache) const
-{
+_is_in_range(const Algebraic& t, Bezier_cache& cache) const {
   // First try to use the approximate representation of the endpoints.
   Originator_iterator s_org = _ps.get_originator(_curve, _xid);
   CGAL_assertion(s_org != _ps.originators_end());
@@ -1376,8 +1291,8 @@ _is_in_range(const Algebraic& t, Bezier_cache& cache) const
 
   // Obtain the exact t-range of the curve and perform an exact comparison.
   std::pair<Algebraic, Algebraic> range = _t_range (cache);
-  const Algebraic&                t_src = range.first;
-  const Algebraic&                t_trg = range.second;
+  const Algebraic& t_src = range.first;
+  const Algebraic& t_trg = range.second;
 
   const Comparison_result  res1 = CGAL::compare (t, t_src);
   const Comparison_result  res2 = CGAL::compare (t, t_trg);
@@ -1390,8 +1305,7 @@ _is_in_range(const Algebraic& t, Bezier_cache& cache) const
 //
 template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
 bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
-_is_in_range(const Point_2& p, bool& is_certain) const
-{
+_is_in_range(const Point_2& p, bool& is_certain) const {
   is_certain = true;
 
   // Check the easy case that p is one of the subcurve endpoints.
@@ -1463,8 +1377,7 @@ bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
 _is_in_range(const Point_2& p,
              Bezier_cache& cache,
              Algebraic& t0,
-             bool& is_endpoint) const
-{
+             bool& is_endpoint) const {
   // The given point p must be rational, otherwise there is no point checking
   // whether it lies in the interior of the curve.
   if (! p.is_rational()) {
@@ -1583,8 +1496,7 @@ _is_in_range(const Point_2& p,
 template <typename RatKer, typename AlgKer, typename NtTrt,typename BndTrt>
 typename _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::Algebraic
 _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
-_get_y(const Rational& x0, Bezier_cache& cache) const
-{
+_get_y(const Rational& x0, Bezier_cache& cache) const {
   // Obtain the t-values for with the x-coordinates of the supporting
   // curve equal x0.
   std::list<Algebraic> t_vals;
@@ -1634,8 +1546,7 @@ _get_y(const Rational& x0, Bezier_cache& cache) const
 template <typename RatKer, typename AlgKer,typename NtTrt, typename BndTrt>
 Comparison_result
 _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
-_compare_slopes(const Self& cv, const Point_2& p, Bezier_cache& cache) const
-{
+_compare_slopes(const Self& cv, const Point_2& p, Bezier_cache& cache) const {
   // Get the originators of p.
   Originator_iterator org1 = p.get_originator(_curve, _xid);
   const bool valid_org1 = (org1 != p.originators_end());
@@ -1761,8 +1672,7 @@ std::pair<typename _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt,
           typename _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt,
                                         BndTrt>::Algebraic>
 _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
-_t_range(Bezier_cache& cache) const
-{
+_t_range(Bezier_cache& cache) const {
   Originator_iterator ps_org = _ps.get_originator(_curve, _xid);
   CGAL_assertion(ps_org != _ps.originators_end());
 
@@ -1787,8 +1697,7 @@ _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
 _compare_to_side(const Self& cv,
                  const Point_2& p,
                  bool to_right,
-                 Bezier_cache& cache) const
-{
+                 Bezier_cache& cache) const {
   // Get the intersection points of the two curves from the cache. Note that
   // we make sure that the ID of this->_curve is smaller than of cv's curve ID.
   const bool no_swap_curves = (_curve.id() <= cv._curve.id());
@@ -1839,8 +1748,7 @@ _compare_to_side(const Self& cv,
     if ((to_right && ((_inc_to_right && res == LARGER) ||
                       (! _inc_to_right && res == SMALLER))) ||
         (! to_right && ((_inc_to_right && res == SMALLER) ||
-                        (! _inc_to_right && res == LARGER))))
-    {
+                        (! _inc_to_right && res == LARGER)))) {
       if (! found) {
         next_t = t;
         found = true;
@@ -1852,8 +1760,7 @@ _compare_to_side(const Self& cv,
         if ((to_right && ((_inc_to_right && res == SMALLER) ||
                           (! _inc_to_right && res == LARGER))) ||
             (! to_right && ((_inc_to_right && res == LARGER) ||
-                            (! _inc_to_right && res == SMALLER))))
-        {
+                            (! _inc_to_right && res == SMALLER)))) {
           next_t = t;
         }
       }
@@ -1872,8 +1779,7 @@ _compare_to_side(const Self& cv,
       (to_right && ((_inc_to_right && res == SMALLER) ||
                     (! _inc_to_right && res == LARGER))) ||
       (! to_right && ((_inc_to_right && res == LARGER) ||
-                      (! _inc_to_right && res == SMALLER))))
-  {
+                      (! _inc_to_right && res == SMALLER)))) {
     next_t = ((to_right == _dir_right) ? t_trg : t_src);
   }
 
@@ -1898,8 +1804,7 @@ template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
 void _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
 _clip_control_polygon(typename Bounding_traits::Control_points& ctrl,
                       typename Bounding_traits::NT& t_min,
-                      typename Bounding_traits::NT& t_max) const
-{
+                      typename Bounding_traits::NT& t_max) const {
   // Start from the control polygon of the supporting curve.
   ctrl.clear();
   std::copy(_curve.control_points_begin(), _curve.control_points_end(),
@@ -1919,8 +1824,7 @@ _clip_control_polygon(typename Bounding_traits::Control_points& ctrl,
 
   // Check if t_min = 0. If so, there is no need to clip.
   if (! (org_min->point_bound().type == Bez_point_bound::RATIONAL_PT &&
-         CGAL::sign(org_min->point_bound().t_min) == CGAL::ZERO))
-  {
+         CGAL::sign(org_min->point_bound().t_min) == CGAL::ZERO)) {
     // It is possible that the parameter range of the originator is too large.
     // We therefore make sure it fits the current bounding box of the point
     // (which we know is tight enough).
@@ -1947,8 +1851,7 @@ _clip_control_polygon(typename Bounding_traits::Control_points& ctrl,
 
   // Check if t_max = 1. If so, there is no need to clip.
   if (! (org_max->point_bound().type == Bez_point_bound::RATIONAL_PT &&
-         CGAL::compare (org_max->point_bound().t_max, 1) == CGAL::EQUAL))
-  {
+         CGAL::compare (org_max->point_bound().t_max, 1) == CGAL::EQUAL)) {
     // It is possible that the parameter range of the originator is too large.
     // We therefore make sure it fits the current bounding box of the point
     // (which we know is tight enough).
@@ -1986,9 +1889,8 @@ _clip_control_polygon(typename Bounding_traits::Control_points& ctrl,
 template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
 bool _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
 _approximate_intersection_points(const Self& cv,
-                                 std::list<Point_2>& inter_pts) const
-{
-  typedef typename Bounding_traits::Intersection_point  Intersection_point;
+                                 std::list<Point_2>& inter_pts) const {
+  using Intersection_point = typename Bounding_traits::Intersection_point;
 
   inter_pts.clear();
 
@@ -2039,8 +1941,7 @@ _approximate_intersection_points(const Self& cv,
     Point_2 pt;
 
     if (bound1.type == Bounding_traits::Bez_point_bound::RATIONAL_PT &&
-        bound2.type == Bounding_traits::Bez_point_bound::RATIONAL_PT)
-    {
+        bound2.type == Bounding_traits::Bez_point_bound::RATIONAL_PT) {
       CGAL_assertion (CGAL::compare(bound1.t_min, bound1.t_max) == EQUAL);
       CGAL_assertion (CGAL::compare(bound2.t_min, bound2.t_max) == EQUAL);
       Rational t1 = bound1.t_min;
@@ -2082,8 +1983,7 @@ _approximate_intersection_points(const Self& cv,
         sc_bound2.t_max = t_min2 + bound2.t_max * (t_max2 - t_min2);
         pt.add_originator(Originator (B2, cv._xid, sc_bound2));
       }
-      else
-      {
+      else {
         // Set the originators with the curve x-monotone IDs.
         pt.add_originator(Originator (B1, bound1));
         pt.add_originator(Originator (B2, bound2));
@@ -2107,8 +2007,7 @@ _intersect(const Self& cv,
            Intersection_map& inter_map,
            Bezier_cache& cache,
            std::vector<Intersection_point>& ipts,
-           Self& ovlp_cv) const
-{
+           Self& ovlp_cv) const {
   CGAL_precondition(_curve.id() <= cv._curve.id());
 
   ipts.clear();
@@ -2333,8 +2232,7 @@ _intersect(const Self& cv,
     bool is_endpoint = false;
 
     if (_is_in_range (cv._ps, cache, t_cv_src, is_endpoint) && ! is_endpoint) {
-      if (_is_in_range (cv._pt, cache, t_cv_trg, is_endpoint) && ! is_endpoint)
-      {
+      if (_is_in_range (cv._pt, cache, t_cv_trg, is_endpoint) && ! is_endpoint) {
         // Case 5 - *this:   s +-----------+ t
         //             cv:     s' +=====+ t'
         //
@@ -2364,8 +2262,7 @@ _intersect(const Self& cv,
         return true;
       }
     }
-    else if (_is_in_range(cv._pt, cache, t_cv_trg, is_endpoint) && ! is_endpoint)
-    {
+    else if (_is_in_range(cv._pt, cache, t_cv_trg, is_endpoint) && ! is_endpoint) {
       // Case 7 - *this:      s +-----------+ t
       //             cv:   s' +=====+ t'
       //
@@ -2383,8 +2280,7 @@ _intersect(const Self& cv,
       return (true);
     }
     else if (cv._is_in_range(_ps, cache, t_cv_src, is_endpoint) &&
-             cv._is_in_range(_pt, cache, t_cv_trg, is_endpoint))
-    {
+             cv._is_in_range(_pt, cache, t_cv_trg, is_endpoint)) {
       // Case 8 - *this:      s +---------+ t
       //             cv:  s' +================+ t'
       //
@@ -2423,7 +2319,7 @@ _intersect(const Self& cv,
 // Compute the exact vertical position of the point p with respect to the
 // curve.
 //
-template <class RatKer, class AlgKer, class NtTrt, class BndTrt>
+template <typename RatKer, typename AlgKer, typename NtTrt, typename BndTrt>
 Comparison_result
 _Bezier_x_monotone_2<RatKer, AlgKer, NtTrt, BndTrt>::
 _exact_vertical_position(const Point_2& p,
@@ -2434,7 +2330,7 @@ _exact_vertical_position(const Point_2& p,
                          ) const
 {
   // If it is a rational point, obtain its rational representation.
-  Rat_point_2              rat_p;
+  Rat_point_2 rat_p;
 
   if (p.is_rational())
     rat_p = (Rat_point_2) p;
@@ -2455,8 +2351,7 @@ _exact_vertical_position(const Point_2& p,
 
   do {
     if (CGAL::compare(ps_org->point_bound().t_max,
-                      pt_org->point_bound().t_min) == SMALLER)
-    {
+                      pt_org->point_bound().t_min) == SMALLER) {
       // In case the parameter value of the source is smaller than the target's.
       my_t_min = ps_org->point_bound().t_max;
       my_t_max = pt_org->point_bound().t_min;
@@ -2464,8 +2359,7 @@ _exact_vertical_position(const Point_2& p,
     }
     else
       if (CGAL::compare (pt_org->point_bound().t_max,
-                                     ps_org->point_bound().t_min) == SMALLER)
-    {
+                                     ps_org->point_bound().t_min) == SMALLER) {
       // In case the parameter value of the target is smaller than the source's.
       my_t_min = pt_org->point_bound().t_max;
       my_t_max = ps_org->point_bound().t_min;
@@ -2494,8 +2388,7 @@ _exact_vertical_position(const Point_2& p,
   init_scv.t_max = 1;
   subcurves.push_back (init_scv);
 
-  while (! subcurves.empty())
-  {
+  while (! subcurves.empty()) {
     // Go over the list of subcurves and consider only those lying in the
     // given [t_min, t_max] bound.
     typename std::list<Subcurve>::iterator iter = subcurves.begin();
@@ -2503,8 +2396,7 @@ _exact_vertical_position(const Point_2& p,
 
     while (iter != subcurves.end()) {
       if (CGAL::compare(iter->t_max, my_t_min) == SMALLER ||
-          CGAL::compare(iter->t_min, my_t_max) == LARGER)
-      {
+          CGAL::compare(iter->t_min, my_t_max) == LARGER) {
         // Subcurve out of bounds of the x-monotone curve we consider - erase
         // it and continue to next subcurve.
         subcurves.erase(iter++);

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Circle_segment_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Circle_segment_2.h
@@ -41,9 +41,9 @@ class _One_root_point_2_rep {
   friend class _One_root_point_2<NumberType_, Filter_>;
 
 public:
-  typedef NumberType_                               NT;
-  typedef _One_root_point_2_rep<NT, Filter_>        Self;
-  typedef Sqrt_extension<NT, NT, Tag_true,Boolean_tag<Filter_> >    CoordNT;
+  using NT = NumberType_;
+  using Self = _One_root_point_2_rep<NT, Filter_>;
+  using CoordNT = Sqrt_extension<NT, NT, Tag_true,Boolean_tag<Filter_> >;
 
 private:
   CoordNT _x;            // The coordinates.
@@ -70,18 +70,17 @@ public:
  */
 template <typename NumberType_, bool Filter_>
 class _One_root_point_2 :
-  public Handle_for<_One_root_point_2_rep<NumberType_, Filter_> >
-{
+  public Handle_for<_One_root_point_2_rep<NumberType_, Filter_>> {
 public:
-  typedef NumberType_                           NT;
-  typedef _One_root_point_2<NT, Filter_>        Self;
+  using NT = NumberType_;
+  using Self = _One_root_point_2<NT, Filter_>;
 
 private:
-  typedef _One_root_point_2_rep<NT, Filter_>    Point_rep;
-  typedef Handle_for<Point_rep>                 Point_handle;
+  using Point_rep = _One_root_point_2_rep<NT, Filter_>;
+  using Point_handle = Handle_for<Point_rep>;
 
 public:
-  typedef typename Point_rep::CoordNT           CoordNT;
+  using CoordNT = typename Point_rep::CoordNT;
 
   /*! constructs default. */
   _One_root_point_2() : Point_handle(Point_rep()) {}
@@ -106,8 +105,7 @@ public:
   const CoordNT& y() const { return (this->ptr()->_y); }
 
   /*! checks for equality. */
-  bool equals(const Self& p) const
-  {
+  bool equals(const Self& p) const {
     if (this->identical(p)) return (true);
 
     return (CGAL::compare(this->ptr()->_x, p.ptr()->_x) == EQUAL &&
@@ -119,8 +117,7 @@ public:
   bool operator == (const Self& p) const { return equals(p); }
 
   /*! sets the point coordinates. */
-  void set(const NT& x, const NT& y)
-  {
+  void set(const NT& x, const NT& y) {
     this->copy_on_write();
     this->ptr()->_x = CoordNT(x);
     this->ptr()->_y = CoordNT(y);
@@ -128,8 +125,7 @@ public:
   }
 
   /*! sets the point coordinates. */
-  void set(const CoordNT& x, const CoordNT& y)
-  {
+  void set(const CoordNT& x, const CoordNT& y) {
     this->copy_on_write();
     this->ptr()->_x = x;
     this->ptr()->_y = y;
@@ -141,8 +137,7 @@ public:
  */
 template <typename NT, bool Filter>
 std::ostream& operator<<(std::ostream& os,
-                         const _One_root_point_2<NT, Filter>& p)
-{
+                         const _One_root_point_2<NT, Filter>& p) {
   os << CGAL::to_double(p.x()) << ' ' << CGAL::to_double(p.y());
   return (os);
 }
@@ -165,15 +160,15 @@ std::istream & operator >> (std::istream & is,
 template <typename Kernel_, bool Filter_>
 class _Circle_segment_2 {
 public:
-  typedef Kernel_                                          Kernel;
-  typedef typename Kernel::FT                              NT;
-  typedef _One_root_point_2<NT, Filter_>                   Point_2;
-  typedef typename Kernel::Circle_2                        Circle_2;
-  typedef typename Kernel::Segment_2                       Segment_2;
-  typedef typename Kernel::Line_2                          Line_2;
+  using Kernel = Kernel_;
+  using NT = typename Kernel::FT;
+  using Point_2 = _One_root_point_2<NT, Filter_>;
+  using Circle_2 = typename Kernel::Circle_2;
+  using Segment_2 = typename Kernel::Segment_2;
+  using Line_2 = typename Kernel::Line_2;
 
 protected:
-  typedef typename Point_2::CoordNT                        CoordNT;
+  using CoordNT = typename Point_2::CoordNT;
 
   // Data members:
   Line_2 m_line;              // The supporting line (for line segments).
@@ -234,8 +229,7 @@ public:
     m_has_radius(false),
     m_source(source),
     m_target(target),
-    m_orient(COLLINEAR)
-  {
+    m_orient(COLLINEAR) {
     CGAL_precondition(CGAL::compare(source.x() * line.a() + line.c(),
                                     -source.y() * line.b()) == EQUAL);
 
@@ -282,8 +276,7 @@ public:
     m_has_radius(false),
     m_source(source),
     m_target(target),
-    m_orient(circ.orientation())
-  {
+    m_orient(circ.orientation()) {
     CGAL_assertion(m_orient != COLLINEAR);
 
     CGAL_precondition
@@ -315,8 +308,7 @@ public:
     m_radius(r),
     m_source(source),
     m_target(target),
-    m_orient(orient)
-  {
+    m_orient(orient) {
     CGAL_assertion(orient != COLLINEAR);
 
     CGAL_precondition
@@ -343,8 +335,7 @@ public:
      m_is_full(false),
      m_has_radius(false),
      m_source(p1.x(), p1.y()),
-     m_target(p3.x(), p3.y())
-  {
+     m_target(p3.x(), p3.y()) {
     // Set the source and target.
     NT x1 = p1.x();
     NT y1 = p1.y();
@@ -359,7 +350,7 @@ public:
     // Compute the lines: A1*x + B1*y + C1 = 0,
     //               and: A2*x + B2*y + C2 = 0,
     // where:
-    const NT _two  = 2;
+    const NT _two = 2;
 
     const NT A1 = _two*(x1 - x2);
     const NT B1 = _two*(y1 - y2);
@@ -423,8 +414,7 @@ public:
   /*! obtains the supporting line.
    * \pre The curve orientation is COLLINEAR.
    */
-  const Line_2& supporting_line() const
-  {
+  const Line_2& supporting_line() const {
     CGAL_precondition(m_orient == COLLINEAR);
     return m_line;
   }
@@ -432,8 +422,7 @@ public:
   /*! obtains the supporting circle.
    * \pre The curve orientation is not COLLINEAR.
    */
-  const Circle_2& supporting_circle() const
-  {
+  const Circle_2& supporting_circle() const {
     CGAL_precondition(m_orient != COLLINEAR);
     return m_circ;
   }
@@ -444,8 +433,7 @@ public:
   /*! obtains the source point.
    * \pre The curve is not a full circle.
    */
-  const Point_2& source() const
-  {
+  const Point_2& source() const {
     CGAL_precondition(! m_is_full);
     return (m_source);
   }
@@ -453,8 +441,7 @@ public:
   /*! obtains the target point.
    * \pre The curve is not a full circle.
    */
-  const Point_2& target() const
-  {
+  const Point_2& target() const {
     CGAL_precondition(! m_is_full);
     return (m_target);
   }
@@ -464,8 +451,7 @@ public:
    * \pre The curve is circular.
    * \return The number of points (0, 1, or 2).
    */
-  unsigned int vertical_tangency_points(Point_2* vpts) const
-  {
+  unsigned int vertical_tangency_points(Point_2* vpts) const {
     CGAL_precondition(m_orient != COLLINEAR);
     unsigned int n_vpts = 0;
 
@@ -519,8 +505,7 @@ private:
    */
   unsigned int _ccw_vertical_tangency_points(const Point_2& src,
                                              const Point_2& trg,
-                                             Point_2* vpts) const
-  {
+                                             Point_2* vpts) const {
     unsigned int n_vpts = 0;
     const NT& x0 = m_circ.center().x();
     const NT& y0 = m_circ.center().y();
@@ -547,8 +532,7 @@ private:
       if ((qs % 4) == 1) {
         // We collect the left tangency point when going from Q[1] to Q[2]:
         if (CGAL::compare(x0, trg.x()) != LARGER ||
-            CGAL::compare(y0, trg.y()) != EQUAL)
-        {
+            CGAL::compare(y0, trg.y()) != EQUAL) {
           if (m_has_radius)
             vpts[n_vpts] = Point_2(CoordNT(x0 - m_radius), y0);
           else
@@ -561,8 +545,7 @@ private:
       else if ((qs % 4) == 3) {
         // We collect the right tangency point when going from Q[3] to Q[0]:
         if (CGAL::compare(x0, trg.x()) != SMALLER ||
-            CGAL::compare(y0, trg.y()) != EQUAL)
-        {
+            CGAL::compare(y0, trg.y()) != EQUAL) {
           if (m_has_radius)
             vpts[n_vpts] = Point_2(CoordNT(x0 + m_radius), y0);
           else
@@ -581,8 +564,7 @@ private:
   /*! obtains the index of the quarter-plane containing the given point,
    * where the circle center is considered to be the origin.
    */
-  int _quart_index(const Point_2& p) const
-  {
+  int _quart_index(const Point_2& p) const {
     // The plane looks like:
     //
     //      Q[1] :  |   Q[0]:
@@ -608,8 +590,7 @@ private:
  */
 template <typename Kernel, bool Filter>
 std::ostream&
-operator<<(std::ostream& os, const _Circle_segment_2<Kernel, Filter>& c)
-{
+operator<<(std::ostream& os, const _Circle_segment_2<Kernel, Filter>& c) {
   if (c.orientation() == COLLINEAR) {
     os<< "segment: " << c.source() << " -> " << c.target();
   }
@@ -632,35 +613,33 @@ operator<<(std::ostream& os, const _Circle_segment_2<Kernel, Filter>& c)
 template <typename Kernel_, bool Filter_>
 class _X_monotone_circle_segment_2 {
 public:
-  typedef Kernel_                                          Kernel;
-  typedef _X_monotone_circle_segment_2<Kernel, Filter_>    Self;
-  typedef typename Kernel::FT                              NT;
-  typedef _One_root_point_2<NT, Filter_>                   Point_2;
-  typedef typename Kernel::Circle_2                        Circle_2;
-  typedef typename Kernel::Line_2                          Line_2;
-  typedef typename Point_2::CoordNT                        CoordNT;
+  using Kernel = Kernel_;
+  using Self = _X_monotone_circle_segment_2<Kernel, Filter_>;
+  using NT = typename Kernel::FT;
+  using Point_2 = _One_root_point_2<NT, Filter_>;
+  using Circle_2 = typename Kernel::Circle_2;
+  using Line_2 = typename Kernel::Line_2;
+  using CoordNT = typename Point_2::CoordNT;
 
   // Type definition for the intersection points mapping.
-  typedef std::pair<unsigned int, unsigned int>         Curve_id_pair;
-  typedef unsigned int                                  Multiplicity;
-  typedef std::pair<Point_2, Multiplicity>              Intersection_point;
-  typedef std::list<Intersection_point>                 Intersection_list;
+  using Curve_id_pair = std::pair<unsigned int, unsigned int>;
+  using Multiplicity = std::size_t;
+  using Intersection_point = std::pair<Point_2, Multiplicity>;
+  using Intersection_list = std::list<Intersection_point>;
 
   /*! \struct Less functor for Curve_id_pair.
    */
   struct Less_id_pair {
-    bool operator()(const Curve_id_pair& ip1, const Curve_id_pair& ip2) const
-    {
+    bool operator()(const Curve_id_pair& ip1, const Curve_id_pair& ip2) const {
       // Compare the pairs of IDs lexicographically.
       return (ip1.first < ip2.first ||
               (ip1.first == ip2.first && ip1.second < ip2.second));
     }
   };
 
-  typedef std::map<Curve_id_pair, Intersection_list, Less_id_pair>
-                                                  Intersection_map;
-  typedef typename Intersection_map::value_type   Intersection_map_entry;
-  typedef typename Intersection_map::iterator     Intersection_map_iterator;
+  using Intersection_map = std::map<Curve_id_pair, Intersection_list, Less_id_pair>;
+  using Intersection_map_entry = typename Intersection_map::value_type;
+  using Intersection_map_iterator = typename Intersection_map::iterator;
 
 protected:
   NT m_first;           // The x-coordinate of the circle center.
@@ -713,8 +692,7 @@ public:
     m_third(line.c()),
     m_source(source),
     m_target(target),
-    m_info(index << INDEX_SHIFT_BITS)
-  {
+    m_info(index << INDEX_SHIFT_BITS) {
     // Check if the segment is directed left or right:
     Comparison_result res = CGAL::compare(source.x(), target.x());
 
@@ -740,8 +718,7 @@ public:
                                const typename Kernel::Point_2& target) :
     m_source(source.x(), source.y()),
     m_target(target.x(), target.y()),
-    m_info(0)
-  {
+    m_info(0) {
     Line_2 line(source, target);
     m_first  = line.a();
     m_second = line.b();
@@ -778,8 +755,7 @@ public:
     m_third(circ.squared_radius()),
     m_source(source),
     m_target(target),
-    m_info(index << INDEX_SHIFT_BITS)
-  {
+    m_info(index << INDEX_SHIFT_BITS) {
     // Check if the segment is directed left or right:
     Comparison_result res = CGAL::compare (source.x(), target.x());
 
@@ -802,8 +778,7 @@ public:
   /*! obtains the supporting line.
    * \pre The arc is linear (a line segment).
    */
-  Line_2 supporting_line() const
-  {
+  Line_2 supporting_line() const {
     CGAL_precondition (is_linear());
     return (Line_2 (a(), b(), c()));
   }
@@ -811,8 +786,7 @@ public:
   /*! obtains the supporting circle.
    * \pre The arc is circular.
    */
-  Circle_2 supporting_circle() const
-  {
+  Circle_2 supporting_circle() const {
     CGAL_precondition (is_circular());
 
     typename Kernel::Point_2 center(x0(), y0());
@@ -843,8 +817,7 @@ public:
 
   /*! checks whether the given point is in the x-range of the arc.
    */
-  bool is_in_x_range(const Point_2& p) const
-  {
+  bool is_in_x_range(const Point_2& p) const {
     Comparison_result res = CGAL::compare (p.x(), left().x());
 
     if (res == SMALLER) return false;
@@ -858,8 +831,7 @@ public:
   { return ((m_info & IS_VERTICAL_SEGMENT_MASK) != 0); }
 
   /*! obtains the orientation of the arc. */
-  inline Orientation orientation() const
-  {
+  inline Orientation orientation() const {
     unsigned int or_ = (m_info & ORIENTATION_MASK);
     if (or_ == COUNTERCLOCKWISE_CODE) return (CGAL::COUNTERCLOCKWISE);
     else if (or_ == CLOCKWISE_CODE) return (CGAL::CLOCKWISE);
@@ -870,16 +842,14 @@ public:
 
   /*! checks the position of a given point with respect to the arc.
    */
-  Comparison_result point_position(const Point_2& p) const
-  {
+  Comparison_result point_position(const Point_2& p) const {
     if (is_linear()) return (_line_point_position(p));
     else return (_circ_point_position (p));
   }
 
   /*! compares the two arcs to the right of their intersection point.
    */
-  Comparison_result compare_to_right(const Self& cv, const Point_2& p) const
-  {
+  Comparison_result compare_to_right(const Self& cv, const Point_2& p) const {
     if (is_linear()) {
       if (cv.is_linear()) return (_lines_compare_to_right (cv, p));
       Comparison_result res = cv._circ_line_compare_to_right (*this, p);
@@ -894,8 +864,7 @@ public:
 
   /*! compares the two arcs to the left of their intersection point.
    */
-  Comparison_result compare_to_left(const Self& cv, const Point_2& p) const
-  {
+  Comparison_result compare_to_left(const Self& cv, const Point_2& p) const {
     if (is_linear()) {
       if (cv.is_linear()) return (_lines_compare_to_left (cv, p));
       Comparison_result res = cv._circ_line_compare_to_left(*this, p);
@@ -910,8 +879,7 @@ public:
 
   /*! checks whether the two arcs have the same supporting curve.
    */
-  bool has_same_supporting_curve(const Self& cv) const
-  {
+  bool has_same_supporting_curve(const Self& cv) const {
     // Check if the curve indices are the same.
     if (_index() != 0 && _index() == cv._index()) return true;
 
@@ -950,8 +918,7 @@ public:
 
   /*! checks whether the two curves are equal.
    */
-  bool equals(const Self& cv) const
-  {
+  bool equals(const Self& cv) const {
     if (! this->has_same_supporting_curve(cv)) return false;
 
     if (is_linear()) {
@@ -969,8 +936,7 @@ public:
 
   /*! splits the curve at a given point into two sub-arcs.
    */
-  void split(const Point_2& p, Self& c1, Self& c2) const
-  {
+  void split(const Point_2& p, Self& c1, Self& c2) const {
     // Copy the properties of this arc to the sub-arcs.
     c1 = *this;
     c2 = *this;
@@ -990,8 +956,7 @@ public:
    */
   template <typename OutputIterator>
   OutputIterator intersect(const Self& cv, OutputIterator oi,
-                           Intersection_map* inter_map = nullptr) const
-  {
+                           Intersection_map* inter_map = nullptr) const {
     // First check whether the two arcs have the same supporting curve.
     if (has_same_supporting_curve(cv)) {
       // Check for overlaps between the two arcs.
@@ -1064,8 +1029,7 @@ public:
     // Report only the intersection points that lie on both arcs.
     for (auto iter = inter_list.begin(); iter != inter_list.end(); ++iter) {
       if (this->_is_between_endpoints (iter->first) &&
-          cv._is_between_endpoints (iter->first))
-      {
+          cv._is_between_endpoints (iter->first)) {
         *oi++ = *iter;
       }
     }
@@ -1075,8 +1039,7 @@ public:
 
   /*! checks whether it is possible to merge our arc with the given arc.
    */
-  bool can_merge_with(const Self& cv) const
-  {
+  bool can_merge_with(const Self& cv) const {
     // In order to merge the two arcs, they should have the same supporting
     // curve.
     if (! this->has_same_supporting_curve(cv)) return false;
@@ -1089,8 +1052,7 @@ public:
   /*! merges our arc with the given arc.
    * \pre The two arcs are mergeable.
    */
-  void merge(const Self& cv)
-  {
+  void merge(const Self& cv) {
     CGAL_precondition(this->can_merge_with (cv));
 
     // Check if we should extend the arc to the left or to the right.
@@ -1109,8 +1071,7 @@ public:
   }
 
   /*! constructs an opposite arc. */
-  Self construct_opposite() const
-  {
+  Self construct_opposite() const {
     Self opp_cv;
     opp_cv.m_first = this->m_first;
     opp_cv.m_second = this->m_second;
@@ -1127,8 +1088,7 @@ public:
     return (opp_cv);
   }
 
-  Bbox_2 bbox() const
-  {
+  Bbox_2 bbox() const {
     double x_min = to_double(left().x());
     double x_max = to_double(right().x());
     double y_min = to_double(left().y());
@@ -1167,8 +1127,7 @@ protected:
 
   /*! checks if the circular arc lies on the upper half of the supporting circle.
    */
-  inline bool _is_upper() const
-  {
+  inline bool _is_upper() const {
     Orientation orient = orientation();
     bool dir_right = ((m_info & IS_DIRECTED_RIGHT_MASK) != 0);
 
@@ -1197,8 +1156,7 @@ protected:
 
   /*! checks the position of a given point with respect to a line segment.
    */
-  Comparison_result _line_point_position(const Point_2& p) const
-  {
+  Comparison_result _line_point_position(const Point_2& p) const {
     // Check if we have a vertical segment.
 
     CGAL_precondition(is_in_x_range(p));
@@ -1229,20 +1187,17 @@ protected:
 
   /*! checks the position of a given point with respect to a circular arc.
    */
-  Comparison_result _circ_point_position(const Point_2& p) const
-  {
+  Comparison_result _circ_point_position(const Point_2& p) const {
 
     Comparison_result c_res = CGAL::compare (p.y(), y0());
 
     if (_is_upper()) {
       // Check if p lies below the "equator" (while the arc lies above it):
-      if (c_res == SMALLER)
-        return (SMALLER);
+      if (c_res == SMALLER) return (SMALLER);
     }
     else {
       // Check if p lies above the "equator" (while the arc lies below it):
-      if (c_res == LARGER)
-        return (LARGER);
+      if (c_res == LARGER) return (LARGER);
     }
 
     // Check if p lies inside the supporting circle, namely we have to check
@@ -1271,8 +1226,7 @@ protected:
   /*! compares two line segments to the right of their intersection point.
    */
   Comparison_result _lines_compare_to_right(const Self& cv,
-                                            const Point_2& /* p */) const
-  {
+                                            const Point_2& /* p */) const {
     if (_index() != 0 && _index() == cv._index()) return (EQUAL);
 
     // Special treatment for vertical segments: a vertical segment is larger
@@ -1292,8 +1246,7 @@ protected:
    * their intersection point.
    */
   Comparison_result _circ_line_compare_to_right(const Self& cv,
-                                                const Point_2& p) const
-  {
+                                                const Point_2& p) const {
     // A vertical segment lies above any other circle to the right of p:
     if (cv.is_vertical()) return (SMALLER);
 
@@ -1334,8 +1287,7 @@ protected:
   /*! compares two circular arcs to the right of their intersection point.
    */
   Comparison_result _circs_compare_to_right(const Self& cv,
-                                            const Point_2& p) const
-  {
+                                            const Point_2& p) const {
     if (_index() != 0 && _index() == cv._index()) {
       // Check the case of comparing two circular arcs that originate from the
       // same supporting circle. Their comparison result is not EQUAL only if
@@ -1413,13 +1365,11 @@ protected:
     // Compare the slopes of the two tangents to the circles.
     Comparison_result  slope_res;
 
-    if (sign_slope1 == ZERO && sign_slope2 == ZERO)
-    {
+    if (sign_slope1 == ZERO && sign_slope2 == ZERO) {
       // Special case were both circles have a horizontal tangent:
       slope_res = EQUAL;
     }
-    else
-    {
+    else {
       // Actually compare the slopes.
       const bool swap_res = (sign_denom1 != sign_denom2);
       const CoordNT A = NT(cv.y0() - y0())*p.x() + (y0()*cv.x0() - cv.y0()*x0());
@@ -1466,8 +1416,7 @@ protected:
   /*! compares two line segments to the left of their intersection point.
    */
   Comparison_result _lines_compare_to_left(const Self& cv,
-                                           const Point_2& ) const
-  {
+                                           const Point_2& ) const {
     if (_index() != 0 && _index() == cv._index()) return (EQUAL);
 
     // Special treatment for vertical segments: a vertical segment is smaller
@@ -1489,8 +1438,7 @@ protected:
    * their intersection point.
    */
   Comparison_result _circ_line_compare_to_left(const Self& cv,
-                                               const Point_2& p) const
-  {
+                                               const Point_2& p) const {
     // A vertical segment lies below any other circle to the left of p:
     if (cv.is_vertical()) return (LARGER);
 
@@ -1534,8 +1482,7 @@ protected:
   /*! compares the two arcs to the left of their intersection point.
    */
   Comparison_result _circs_compare_to_left(const Self& cv,
-                                           const Point_2& p) const
-  {
+                                           const Point_2& p) const {
     if (_index() != 0 && _index() == cv._index()) {
       // Check the case of comparing two circular arcs that originate from the
       // same supporting circle. Their comparison result is not EQUAL only if
@@ -1614,8 +1561,7 @@ protected:
     // Compare the slopes of the two tangents to the circles.
     Comparison_result  slope_res;
 
-    if (sign_slope1 == ZERO && sign_slope2 == ZERO)
-    {
+    if (sign_slope1 == ZERO && sign_slope2 == ZERO) {
       // Special case were both circles have a horizontal tangent:
       slope_res = EQUAL;
     }
@@ -1668,8 +1614,7 @@ protected:
   /*! computes the intersections between two line segments.
    */
   void _lines_intersect(const Self& cv,
-                        Intersection_list& inter_list) const
-  {
+                        Intersection_list& inter_list) const {
     // The intersection of the lines:
     //   a1*x + b1*y + c1 = 0   and   a2*x + b2*y + c2 = 0 ,
     // is given by:
@@ -1695,8 +1640,7 @@ protected:
    * the supporting line of the segment cv.
    */
   void _circ_line_intersect(const Self& cv,
-                            Intersection_list& inter_list) const
-  {
+                            Intersection_list& inter_list) const {
     Point_2 p;
     unsigned int mult;
 
@@ -1818,8 +1762,7 @@ protected:
 
   /*! computes the intersections between two circles.
    */
-  void _circs_intersect(const Self& cv, Intersection_list& inter_list) const
-  {
+  void _circs_intersect(const Self& cv, Intersection_list& inter_list) const {
     Point_2 p;
     unsigned int mult;
 
@@ -1884,8 +1827,7 @@ protected:
   /*! checks if the given point lies on the arc.
    * \pre p lies on the supporting curve.
    */
-  bool _is_between_endpoints(const Point_2& p) const
-  {
+  bool _is_between_endpoints(const Point_2& p) const {
     if (is_linear()) {
       if (is_vertical()) {
         // Check if the point is in the y-range of the arc.
@@ -1908,8 +1850,7 @@ protected:
     // Check whether p lies on the upper or on the lower part of the circle.
     Comparison_result c_res = CGAL::compare(p.y(), y0());
 
-    if ((_is_upper() && c_res == SMALLER) || (! _is_upper() && c_res == LARGER))
-    {
+    if ((_is_upper() && c_res == SMALLER) || (! _is_upper() && c_res == LARGER)) {
       // The point lies on the other half of the circle:
       return false;
     }
@@ -1921,8 +1862,7 @@ protected:
   /*! checks whether the given point lies in the interior of the arc.
    * \pre p lies on the supporting curve.
    */
-  bool _is_strictly_between_endpoints(const Point_2& p) const
-  {
+  bool _is_strictly_between_endpoints(const Point_2& p) const {
     if (p.equals (m_source) || p.equals (m_target)) return false;
     return (_is_between_endpoints(p));
   }
@@ -1932,8 +1872,7 @@ protected:
    * \param overlap Output: The overlapping arc (if any).
    * \return Whether we found an overlap.
    */
-  bool _compute_overlap(const Self& cv, Self& overlap) const
-  {
+  bool _compute_overlap(const Self& cv, Self& overlap) const {
     // Check if the two arcs are identical.
     if (is_linear()) {
       // In case of line segments we can swap the source and target:
@@ -1999,10 +1938,9 @@ protected:
     return false;
   }
 
-  public:
+public:
   template <class OutputIterator>
-  void approximate(OutputIterator oi, unsigned int n) const
-  {
+  void approximate(OutputIterator oi, unsigned int n) const {
     const double x_left = CGAL::to_double(this->source().x());
     const double y_left = CGAL::to_double(this->source().y());
 
@@ -2045,8 +1983,7 @@ protected:
    * \pre Both ps and pt lies on the arc and must conform with the current
    *      direction of the arc.
    */
-  Self trim(const Point_2& ps, const Point_2& pt) const
-  {
+  Self trim(const Point_2& ps, const Point_2& pt) const {
     Self arc = *this;
 
     arc.m_source = ps;
@@ -2063,8 +2000,7 @@ protected:
 template <class Kernel, bool Filter>
 std::ostream&
 operator<<(std::ostream& os,
-           const _X_monotone_circle_segment_2<Kernel, Filter> & arc)
-{
+           const _X_monotone_circle_segment_2<Kernel, Filter>& arc) {
   if (! arc.is_linear())
     os << "(" << arc.supporting_circle() << ") ";
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_line_arc_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_line_arc_traits_2.h
@@ -43,46 +43,41 @@ namespace CGAL {
 // Traits class for CGAL::Arrangement_2 (and similar) based on a
 // CircularKernel.
 
-template < typename CircularKernel >
+template <typename CircularKernel>
 class Arr_line_arc_traits_2 {
-
   CircularKernel ck;
 
 public:
+  using Kernel = CircularKernel;
+  using Curve_2 = typename CircularKernel::Line_arc_2;
+  using X_monotone_curve_2 = typename CircularKernel::Line_arc_2;
+  using Multiplicity = std::size_t;
 
-  typedef CircularKernel Kernel;
-  typedef typename CircularKernel::Line_arc_2  Curve_2;
-  typedef typename CircularKernel::Line_arc_2  X_monotone_curve_2;
-  typedef unsigned int                         Multiplicity;
+  using Point = typename CircularKernel::Circular_arc_point_2;
+  using Point_2 = typename CircularKernel::Circular_arc_point_2;
 
-  typedef typename CircularKernel::Circular_arc_point_2      Point;
-  typedef typename CircularKernel::Circular_arc_point_2      Point_2;
+  using Has_left_category = CGAL::Tag_false;
+  using Has_merge_category = CGAL::Tag_false;
+  using Has_do_intersect_category = CGAL::Tag_false;
 
-  typedef CGAL::Tag_false                        Has_left_category;
-  typedef CGAL::Tag_false                          Has_merge_category;
-  typedef CGAL::Tag_false                        Has_do_intersect_category;
+  using Left_side_category = Arr_oblivious_side_tag;
+  using Bottom_side_category = Arr_oblivious_side_tag;
+  using Top_side_category = Arr_oblivious_side_tag;
+  using Right_side_category = Arr_oblivious_side_tag;
 
-  typedef Arr_oblivious_side_tag                 Left_side_category;
-  typedef Arr_oblivious_side_tag                 Bottom_side_category;
-  typedef Arr_oblivious_side_tag                 Top_side_category;
-  typedef Arr_oblivious_side_tag                 Right_side_category;
+  Arr_line_arc_traits_2(const CircularKernel& k = CircularKernel()) : ck(k) {}
 
-  Arr_line_arc_traits_2(const CircularKernel &k = CircularKernel())
-    : ck(k) {}
-
-  typedef typename CircularKernel::Compare_x_2          Compare_x_2;
-  typedef typename CircularKernel::Compare_xy_2         Compare_xy_2;
-  typedef typename CircularKernel::Compare_y_at_x_2     Compare_y_at_x_2;
-  typedef typename CircularKernel::Compare_y_to_right_2 Compare_y_at_x_right_2;
-  typedef typename CircularKernel::Equal_2              Equal_2;
-  // typedef typename CircularKernel::Make_x_monotone_2    Make_x_monotone_2;
-  typedef typename CircularKernel::Split_2              Split_2;
-  typedef typename CircularKernel::Construct_circular_min_vertex_2
-                                                        Construct_min_vertex_2;
-  typedef typename CircularKernel::Construct_circular_max_vertex_2
-                                                        Construct_max_vertex_2;
-  typedef typename CircularKernel::Is_vertical_2        Is_vertical_2;
-  typedef typename CircularKernel::Intersect_2          Intersect_2;
+  using Compare_x_2 = typename CircularKernel::Compare_x_2;
+  using Compare_xy_2 = typename CircularKernel::Compare_xy_2;
+  using Compare_y_at_x_2 = typename CircularKernel::Compare_y_at_x_2;
+  using Compare_y_at_x_right_2 = typename CircularKernel::Compare_y_to_right_2;
+  using Equal_2 = typename CircularKernel::Equal_2;
+  // using Make_x_monotone_2 = typename CircularKernel::Make_x_monotone_2;
+  using Split_2 = typename CircularKernel::Split_2;
+  using Construct_min_vertex_2 = typename CircularKernel::Construct_circular_min_vertex_2;
+  using Construct_max_vertex_2 = typename CircularKernel::Construct_circular_max_vertex_2;
+  using Is_vertical_2 = typename CircularKernel::Is_vertical_2;
+  using Intersect_2 = typename CircularKernel::Intersect_2;
 
   Compare_x_2 compare_x_2_object() const
   { return ck.compare_x_2_object(); }
@@ -106,7 +101,7 @@ public:
   { return ck.split_2_object(); }
 
   Intersect_2 intersect_2_object() const
-    { return ck.intersect_2_object(); }
+  { return ck.intersect_2_object(); }
 
   Construct_min_vertex_2 construct_min_vertex_2_object() const
   { return ck.construct_circular_min_vertex_2_object(); }
@@ -121,9 +116,8 @@ public:
   class Make_x_monotone_2 {
   public:
     template <typename OutputIterator>
-    OutputIterator operator()(const Curve_2& line, OutputIterator oi) const
-    {
-      typedef std::variant<Point_2, X_monotone_curve_2> Make_x_monotone_result;
+    OutputIterator operator()(const Curve_2& line, OutputIterator oi) const {
+      using Make_x_monotone_result = std::variant<Point_2, X_monotone_curve_2>;
       *oi++ = Make_x_monotone_result(line);
       return oi;
     }
@@ -137,4 +131,4 @@ public:
 
 #include <CGAL/enable_warnings.h>
 
-#endif // CGAL_CIRCULAR_KERNEL_LINE_ARC_TRAITS_H
+#endif

--- a/Arrangement_on_surface_2/include/CGAL/Arr_linear_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_linear_traits_2.h
@@ -1513,12 +1513,8 @@ public:
       auto max_vertex = m_traits.construct_max_vertex_2_object();
       const auto& src = (l2r) ? min_vertex(xcv) : max_vertex(xcv);
       const auto& trg = (l2r) ? max_vertex(xcv) : min_vertex(xcv);
-      auto xs = CGAL::to_double(src.x());
-      auto ys = CGAL::to_double(src.y());
-      auto xt = CGAL::to_double(trg.x());
-      auto yt = CGAL::to_double(trg.y());
-      *oi++ = Approximate_point_2(xs, ys);
-      *oi++ = Approximate_point_2(xt, yt);
+      *oi++ = operator()(src);
+      *oi++ = operator()(trg);
       return oi;
     }
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_linear_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_linear_traits_2.h
@@ -28,7 +28,7 @@
 
 #include <variant>
 
-#include <CGAL/Cartesian.h>
+#include <CGAL/Simple_cartesian.h>
 #include <CGAL/tags.h>
 #include <CGAL/intersections.h>
 #include <CGAL/Arr_tags.h>
@@ -49,58 +49,55 @@ class Arr_linear_traits_2 : public Kernel_ {
   friend class Arr_linear_object_2<Kernel_>;
 
 public:
-  typedef Kernel_                         Kernel;
-  typedef typename Kernel::FT             FT;
+  using Kernel = Kernel_;
+  using FT = typename Kernel::FT;
 
-  typedef typename Algebraic_structure_traits<FT>::Is_exact
-                                          Has_exact_division;
+  using Has_exact_division = typename Algebraic_structure_traits<FT>::Is_exact;
 
   // Category tags:
-  typedef Tag_true                        Has_left_category;
-  typedef Tag_true                        Has_merge_category;
-  typedef Tag_false                       Has_do_intersect_category;
+  using Has_left_category = Tag_true;
+  using Has_merge_category = Tag_true;
+  using Has_do_intersect_category = Tag_false;
 
-  typedef Arr_open_side_tag               Left_side_category;
-  typedef Arr_open_side_tag               Bottom_side_category;
-  typedef Arr_open_side_tag               Top_side_category;
-  typedef Arr_open_side_tag               Right_side_category;
+  using Left_side_category = Arr_open_side_tag;
+  using Bottom_side_category = Arr_open_side_tag;
+  using Top_side_category = Arr_open_side_tag;
+  using Right_side_category = Arr_open_side_tag;
 
-  typedef typename Kernel::Line_2         Line_2;
-  typedef typename Kernel::Ray_2          Ray_2;
-  typedef typename Kernel::Segment_2      Segment_2;
+  using Line_2 = typename Kernel::Line_2;
+  using Ray_2 = typename Kernel::Ray_2;
+  using Segment_2 = typename Kernel::Segment_2;
 
-  typedef CGAL::Segment_assertions<Arr_linear_traits_2<Kernel> >
-                                          Segment_assertions;
+  using Segment_assertions = CGAL::Segment_assertions<Arr_linear_traits_2<Kernel>>;
 
   /*! \class Representation of a linear with cached data.
    */
   class _Linear_object_cached_2 {
   public:
-    typedef typename Kernel::Line_2                Line_2;
-    typedef typename Kernel::Ray_2                 Ray_2;
-    typedef typename Kernel::Segment_2             Segment_2;
-    typedef typename Kernel::Point_2               Point_2;
+    using Line_2 = typename Kernel::Line_2;
+    using Ray_2 = typename Kernel::Ray_2;
+    using Segment_2 = typename Kernel::Segment_2;
+    using Point_2 = typename Kernel::Point_2;
 
   protected:
-    Line_2    l;                // The supporting line.
-    Point_2   ps;               // The source point (if exists).
-    Point_2   pt;               // The target point (if exists).
-    bool      has_source;       // Is the source point valid
+    Line_2 l;                   // The supporting line.
+    Point_2 ps;                 // The source point (if exists).
+    Point_2 pt;                 // The target point (if exists).
+    bool has_source;            // Is the source point valid
                                 // (false for a line).
-    bool      has_target;       // Is the target point valid
+    bool has_target;            // Is the target point valid
                                 // (false for a line and for a ray).
-    bool      is_right;         // Is the object directed to the right
+    bool is_right;              // Is the object directed to the right
                                 // (for segments and rays).
-    bool      is_vert;          // Is this a vertical object.
-    bool      is_horiz;         // Is this a horizontal object.
-    bool      has_pos_slope;    // Does the supporting line has a positive
+    bool is_vert;               // Is this a vertical object.
+    bool is_horiz;              // Is this a horizontal object.
+    bool has_pos_slope;         // Does the supporting line has a positive
                                 // slope (if all three flags is_vert, is_horiz
                                 // and has_pos_slope are false, then the line
                                 // has a negative slope).
-    bool      is_degen;         // Is the object degenerate (a single point).
+    bool is_degen;              // Is the object degenerate (a single point).
 
   public:
-
     /*! constructs default.
      */
     _Linear_object_cached_2() :
@@ -121,8 +118,7 @@ public:
       ps(source),
       pt(target),
       has_source(true),
-      has_target(true)
-    {
+      has_target(true) {
       Kernel kernel;
 
       Comparison_result res = kernel.compare_xy_2_object()(source, target);
@@ -144,8 +140,7 @@ public:
      */
     _Linear_object_cached_2(const Segment_2& seg) :
       has_source(true),
-      has_target(true)
-    {
+      has_target(true) {
       Kernel kernel;
 
       CGAL_assertion_msg(! kernel.is_degenerate_2_object()(seg),
@@ -172,8 +167,7 @@ public:
      */
     _Linear_object_cached_2(const Ray_2& ray) :
       has_source(true),
-      has_target(false)
-    {
+      has_target(false) {
       Kernel kernel;
 
       CGAL_assertion_msg(! kernel.is_degenerate_2_object()(ray),
@@ -201,8 +195,7 @@ public:
     _Linear_object_cached_2(const Line_2& ln) :
       l(ln),
       has_source(false),
-      has_target(false)
-    {
+      has_target(false) {
       Kernel kernel;
 
       CGAL_assertion_msg(! kernel.is_degenerate_2_object()(ln),
@@ -226,8 +219,7 @@ public:
      * \return `ARR_LEFT_BOUNDARY` if the left point is near the boundary;
      *         `ARR_INTERIOR` if the \f$x\f$-coordinate is finite.
      */
-    Arr_parameter_space left_infinite_in_x() const
-    {
+    Arr_parameter_space left_infinite_in_x() const {
       if (is_vert || is_degen) return (ARR_INTERIOR);
 
       return (is_right) ?
@@ -240,8 +232,7 @@ public:
      *         `ARR_INTERIOR` if the \f$y\f$-coordinate is finite.
      *         `ARR_TOP_BOUNDARY` if the left point is at \f$y = +\infty\f$;
      */
-    Arr_parameter_space left_infinite_in_y() const
-    {
+    Arr_parameter_space left_infinite_in_y() const {
       if (is_horiz || is_degen) return ARR_INTERIOR;
 
       if (is_vert) {
@@ -263,8 +254,7 @@ public:
     /*! obtains the (lexicographically) left endpoint.
      * \pre The left point is finite.
      */
-    const Point_2& left() const
-    {
+    const Point_2& left() const {
       CGAL_precondition(has_left());
       return (is_right ? ps : pt);
     }
@@ -274,8 +264,7 @@ public:
      * \pre p lies on the supporting line to the left of the right endpoint.
      */
     void set_left(const Point_2& p,
-                  bool CGAL_assertion_code(check_validity) = true)
-    {
+                  bool CGAL_assertion_code(check_validity) = true) {
       CGAL_precondition(! is_degen);
 
       CGAL_precondition_code(Kernel kernel);
@@ -296,8 +285,7 @@ public:
 
     /*! sets the (lexicographically) left endpoint as infinite.
      */
-    void set_left()
-    {
+    void set_left() {
       CGAL_precondition(! is_degen);
 
       if (is_right) has_source = false;
@@ -308,8 +296,7 @@ public:
      * \return `ARR_RIGHT_BOUNDARY` if the right point is near the boundary;
      *         `ARR_INTERIOR` if the \f$x\f$-coordinate is finite.
      */
-    Arr_parameter_space right_infinite_in_x() const
-    {
+    Arr_parameter_space right_infinite_in_x() const {
       if (is_vert || is_degen) return ARR_INTERIOR;
 
       return (is_right) ?
@@ -322,8 +309,7 @@ public:
      *         `ARR_INTERIOR` if the \f$y\f$-coordinate is finite.
      *         `ARR_TOP_BOUNDARY` if the right point is at \f$y = +\infty\f$;
      */
-    Arr_parameter_space right_infinite_in_y() const
-    {
+    Arr_parameter_space right_infinite_in_y() const {
       if (is_horiz || is_degen) return ARR_INTERIOR;
 
       if (is_vert) {
@@ -345,8 +331,7 @@ public:
     /*! obtains the (lexicographically) right endpoint.
      * \pre The right endpoint is finite.
      */
-    const Point_2& right() const
-    {
+    const Point_2& right() const {
       CGAL_precondition(has_right());
       return (is_right ? pt : ps);
     }
@@ -356,8 +341,7 @@ public:
      * \pre p lies on the supporting line to the right of the left endpoint.
      */
     void set_right(const Point_2& p,
-                   bool CGAL_assertion_code(check_validity) = true)
-    {
+                   bool CGAL_assertion_code(check_validity) = true) {
       CGAL_precondition(! is_degen);
       CGAL_precondition_code(Kernel kernel);
       CGAL_precondition
@@ -377,8 +361,7 @@ public:
 
     /*! sets the (lexicographically) right endpoint as infinite.
      */
-    void set_right()
-    {
+    void set_right() {
       CGAL_precondition(! is_degen);
 
       if (is_right) has_target = false;
@@ -387,16 +370,14 @@ public:
 
     /*! obtains the supporting line.
      */
-    const Line_2& supp_line() const
-    {
+    const Line_2& supp_line() const {
       CGAL_precondition(! is_degen);
       return (l);
     }
 
     /*! checks whether the curve is vertical.
      */
-    bool is_vertical() const
-    {
+    bool is_vertical() const {
       CGAL_precondition(! is_degen);
       return (is_vert);
     }
@@ -414,8 +395,7 @@ public:
      * \return (true) is in the \f$x\f$-range of the segment; (false) if it is
      * not.
      */
-    bool is_in_x_range(const Point_2& p) const
-    {
+    bool is_in_x_range(const Point_2& p) const {
       Kernel kernel;
       typename Kernel_::Compare_x_2 compare_x = kernel.compare_x_2_object();
       Comparison_result res1;
@@ -454,8 +434,7 @@ public:
      * \return (true) is in the \f$y\f$-range of the segment; (false) if it is
      * not.
      */
-    bool is_in_y_range(const Point_2& p) const
-    {
+    bool is_in_y_range(const Point_2& p) const {
       CGAL_precondition(is_vertical());
 
       Kernel kernel;
@@ -483,8 +462,7 @@ public:
   private:
     /*! determines if the supporting line has a positive slope.
      */
-    bool _has_positive_slope() const
-    {
+    bool _has_positive_slope() const {
       if (is_vert) return true;
       if (is_horiz) return false;
 
@@ -498,10 +476,10 @@ public:
 
 public:
   // Traits objects
-  typedef typename Kernel::Point_2              Point_2;
-  typedef Arr_linear_object_2<Kernel>           X_monotone_curve_2;
-  typedef Arr_linear_object_2<Kernel>           Curve_2;
-  typedef unsigned int                          Multiplicity;
+  using Point_2 = typename Kernel::Point_2;
+  using X_monotone_curve_2 = Arr_linear_object_2<Kernel>;
+  using Curve_2 = Arr_linear_object_2<Kernel>;
+  using Multiplicity = std::size_t;
 
 public:
   /*! constructs default.
@@ -514,7 +492,7 @@ public:
   /*! A functor that compares the \f$x\f$-coordinates of two points */
   class Compare_x_2 {
   protected:
-    typedef Arr_linear_traits_2<Kernel> Traits;
+    using Traits = Arr_linear_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -538,8 +516,7 @@ public:
      *         SMALLER if x(p1) < x(p2);
      *         EQUAL if x(p1) = x(p2).
      */
-    Comparison_result operator()(const Point_2& p1, const Point_2& p2) const
-    {
+    Comparison_result operator()(const Point_2& p1, const Point_2& p2) const {
       const Kernel& kernel = m_traits;
       return (kernel.compare_x_2_object()(p1, p2));
     }
@@ -567,7 +544,7 @@ public:
 
   class Trim_2 {
   protected:
-    typedef Arr_linear_traits_2<Kernel> Traits;
+    using Traits = Arr_linear_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -586,10 +563,8 @@ public:
   public:
     X_monotone_curve_2 operator()(const X_monotone_curve_2 xcv,
                                   const Point_2 src,
-                                  const Point_2 tgt)
-    {
-      /*
-       * "Line_segment, line, and ray" will become line segments
+                                  const Point_2 tgt) {
+      /* "Line_segment, line, and ray" will become line segments
        * when trimmed.
        */
       Equal_2 equal = Equal_2();
@@ -619,7 +594,7 @@ public:
 
   class Construct_opposite_2{
   protected:
-    typedef Arr_linear_traits_2<Kernel> Traits;
+    using Traits = Arr_linear_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -636,8 +611,7 @@ public:
     friend class Arr_linear_traits_2<Kernel>;
 
   public:
-    X_monotone_curve_2 operator()(const X_monotone_curve_2& xcv) const
-    {
+    X_monotone_curve_2 operator()(const X_monotone_curve_2& xcv) const {
       CGAL_precondition(! xcv.is_degenerate());
 
       X_monotone_curve_2 opp_xcv;
@@ -667,8 +641,7 @@ public:
      *         SMALLER if x(p1) < x(p2), or if x(p1) = x(p2) and y(p1) < y(p2);
      *         EQUAL if the two points are equal.
      */
-    Comparison_result operator()(const Point_2& p1, const Point_2& p2) const
-    {
+    Comparison_result operator()(const Point_2& p1, const Point_2& p2) const {
       Kernel kernel;
       return (kernel.compare_xy_2_object()(p1, p2));
     }
@@ -685,8 +658,7 @@ public:
      * \pre The left end of cv is a valid (bounded) point.
      * \return The left endpoint.
      */
-    const Point_2& operator()(const X_monotone_curve_2& cv) const
-    {
+    const Point_2& operator()(const X_monotone_curve_2& cv) const {
       CGAL_precondition(! cv.is_degenerate());
       CGAL_precondition(cv.has_left());
 
@@ -706,8 +678,7 @@ public:
      * \pre The right end of cv is a valid (bounded) point.
      * \return The right endpoint.
      */
-    const Point_2& operator()(const X_monotone_curve_2& cv) const
-    {
+    const Point_2& operator()(const X_monotone_curve_2& cv) const {
       CGAL_precondition(! cv.is_degenerate());
       CGAL_precondition(cv.has_right());
 
@@ -726,8 +697,7 @@ public:
      * \param cv The curve.
      * \return (true) if the curve is a vertical segment; (false) otherwise.
      */
-    bool operator()(const X_monotone_curve_2& cv) const
-    {
+    bool operator()(const X_monotone_curve_2& cv) const {
       CGAL_precondition(! cv.is_degenerate());
       return (cv.is_vertical());
     }
@@ -741,7 +711,7 @@ public:
    */
   class Compare_y_at_x_2 {
   protected:
-    typedef Arr_linear_traits_2<Kernel> Traits;
+    using Traits = Arr_linear_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -767,8 +737,7 @@ public:
      *         EQUAL if p lies on the curve.
      */
     Comparison_result operator()(const Point_2& p,
-                                 const X_monotone_curve_2& cv) const
-    {
+                                 const X_monotone_curve_2& cv) const {
       CGAL_precondition(! cv.is_degenerate());
       CGAL_precondition(cv.is_in_x_range(p));
 
@@ -809,8 +778,7 @@ public:
      */
     Comparison_result operator()(const X_monotone_curve_2& cv1,
                                  const X_monotone_curve_2& cv2,
-                                 const Point_2& CGAL_precondition_code(p)) const
-    {
+                                 const Point_2& CGAL_precondition_code(p)) const {
       CGAL_precondition(! cv1.is_degenerate());
       CGAL_precondition(! cv2.is_degenerate());
 
@@ -861,8 +829,7 @@ public:
      */
     Comparison_result operator()(const X_monotone_curve_2& cv1,
                                  const X_monotone_curve_2& cv2,
-                                 const Point_2& CGAL_precondition_code(p)) const
-    {
+                                 const Point_2& CGAL_precondition_code(p)) const {
       CGAL_precondition(! cv1.is_degenerate());
       CGAL_precondition(! cv2.is_degenerate());
 
@@ -906,8 +873,7 @@ public:
      * \return (true) if the two curves are the same; (false) otherwise.
      */
     bool operator()(const X_monotone_curve_2& cv1,
-                    const X_monotone_curve_2& cv2) const
-    {
+                    const X_monotone_curve_2& cv2) const {
       CGAL_precondition(! cv1.is_degenerate());
       CGAL_precondition(! cv2.is_degenerate());
 
@@ -918,17 +884,13 @@ public:
       if (! equal(cv1.supp_line(), cv2.supp_line()) &&
           ! equal(cv1.supp_line(),
                   kernel.construct_opposite_line_2_object()(cv2.supp_line())))
-      {
         return false;
-      }
 
       // Check that either the two left endpoints are at infinity, or they
       // are bounded and equal.
       if ((cv1.has_left() != cv2.has_left()) ||
           (cv1.has_left() && ! equal(cv1.left(), cv2.left())))
-      {
         return false;
-      }
 
       // Check that either the two right endpoints are at infinity, or they
       // are bounded and equal.
@@ -941,8 +903,7 @@ public:
      * \param p2 The second point.
      * \return (true) if the two point are the same; (false) otherwise.
      */
-    bool operator()(const Point_2& p1, const Point_2& p2) const
-    {
+    bool operator()(const Point_2& p1, const Point_2& p2) const {
       Kernel kernel;
       return (kernel.equal_2_object()(p1, p2));
     }
@@ -973,8 +934,7 @@ public:
      *                        the left at the line right end.
      */
     Arr_parameter_space operator()(const X_monotone_curve_2 & xcv,
-                                   Arr_curve_end ce) const
-    {
+                                   Arr_curve_end ce) const {
       CGAL_precondition(! xcv.is_degenerate());
       return (ce == ARR_MIN_END) ?
         xcv.left_infinite_in_x() : xcv.right_infinite_in_x();
@@ -1015,8 +975,7 @@ public:
      *                          right end.
      */
     Arr_parameter_space operator()(const X_monotone_curve_2 & xcv,
-                                   Arr_curve_end ce) const
-    {
+                                   Arr_curve_end ce) const {
       CGAL_precondition(! xcv.is_degenerate());
 
       return (ce == ARR_MIN_END) ?
@@ -1040,7 +999,7 @@ public:
    */
   class Compare_x_on_boundary_2 {
   protected:
-    typedef Arr_linear_traits_2<Kernel> Traits;
+    using Traits = Arr_linear_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -1074,8 +1033,7 @@ public:
      */
     Comparison_result operator()(const Point_2 & p,
                                  const X_monotone_curve_2 & xcv,
-                                 Arr_curve_end ) const
-    {
+                                 Arr_curve_end ) const {
       CGAL_precondition(! xcv.is_degenerate());
       CGAL_precondition(xcv.is_vertical());
 
@@ -1105,8 +1063,7 @@ public:
     Comparison_result operator()(const X_monotone_curve_2 & xcv1,
                                  Arr_curve_end /* ce1 */,
                                  const X_monotone_curve_2 & xcv2,
-                                 Arr_curve_end /* ce2 */) const
-    {
+                                 Arr_curve_end /* ce2 */) const {
       CGAL_precondition(! xcv1.is_degenerate());
       CGAL_precondition(! xcv2.is_degenerate());
       CGAL_precondition(xcv1.is_vertical());
@@ -1152,8 +1109,7 @@ public:
     Comparison_result
     operator()(const X_monotone_curve_2& CGAL_precondition_code(xcv1),
                const X_monotone_curve_2& CGAL_precondition_code(xcv2),
-               Arr_curve_end /* ce2 */) const
-    {
+               Arr_curve_end /* ce2 */) const {
       CGAL_precondition(! xcv1.is_degenerate());
       CGAL_precondition(! xcv2.is_degenerate());
       CGAL_precondition(xcv1.is_vertical());
@@ -1171,7 +1127,7 @@ public:
    */
   class Compare_y_near_boundary_2 {
   protected:
-    typedef Arr_linear_traits_2<Kernel> Traits;
+    using Traits = Arr_linear_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -1199,8 +1155,7 @@ public:
      */
     Comparison_result operator()(const X_monotone_curve_2 & xcv1,
                                  const X_monotone_curve_2 & xcv2,
-                                 Arr_curve_end ce) const
-    {
+                                 Arr_curve_end ce) const {
       // Make sure both curves are defined at \f$x = -\infty\f$ (or at
       // \f$x = +\infty\f$).
       CGAL_precondition(! xcv1.is_degenerate());
@@ -1252,11 +1207,9 @@ public:
      * \return The past-the-end iterator.
      */
     template <typename OutputIterator>
-    OutputIterator operator()(const Curve_2& cv, OutputIterator oi) const
-    {
+    OutputIterator operator()(const Curve_2& cv, OutputIterator oi) const {
       // Wrap the segment with a variant.
-      typedef std::variant<Point_2, X_monotone_curve_2>
-        Make_x_monotone_result;
+      using Make_x_monotone_result = std::variant<Point_2, X_monotone_curve_2>;
       *oi++ = Make_x_monotone_result(cv);
       return oi;
     }
@@ -1277,8 +1230,7 @@ public:
      * \pre `p` lies on `cv` but is not one of its end-points.
      */
     void operator()(const X_monotone_curve_2& cv, const Point_2& p,
-                    X_monotone_curve_2& c1, X_monotone_curve_2& c2) const
-    {
+                    X_monotone_curve_2& c1, X_monotone_curve_2& c2) const {
       CGAL_precondition(! cv.is_degenerate());
 
       // Make sure that p lies on the interior of the curve.
@@ -1306,7 +1258,7 @@ public:
 
   class Intersect_2 {
   protected:
-    typedef Arr_linear_traits_2<Kernel>        Traits;
+    using Traits = Arr_linear_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -1330,9 +1282,8 @@ public:
     template <typename OutputIterator>
     OutputIterator operator()(const X_monotone_curve_2& cv1,
                               const X_monotone_curve_2& cv2,
-                              OutputIterator oi) const
-    {
-      typedef std::pair<Point_2, Multiplicity>          Intersection_point;
+                              OutputIterator oi) const {
+      using Intersection_point = std::pair<Point_2, Multiplicity>;
 
       CGAL_precondition(! cv1.is_degenerate());
       CGAL_precondition(! cv2.is_degenerate());
@@ -1429,8 +1380,7 @@ public:
      *         by the same line and share a common endpoint; (false) otherwise.
      */
     bool operator()(const X_monotone_curve_2& cv1,
-                     const X_monotone_curve_2& cv2) const
-    {
+                     const X_monotone_curve_2& cv2) const {
       CGAL_precondition(! cv1.is_degenerate());
       CGAL_precondition(! cv2.is_degenerate());
 
@@ -1460,7 +1410,7 @@ public:
    */
   class Merge_2 {
   protected:
-    typedef Arr_linear_traits_2<Kernel> Traits;
+    using Traits = Arr_linear_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -1481,8 +1431,7 @@ public:
      */
     void operator()(const X_monotone_curve_2& cv1,
                     const X_monotone_curve_2& cv2,
-                    X_monotone_curve_2& c) const
-    {
+                    X_monotone_curve_2& c) const {
       CGAL_precondition(m_traits.are_mergeable_2_object()(cv2, cv1));
 
       CGAL_precondition(!cv1.is_degenerate());
@@ -1492,8 +1441,7 @@ public:
 
       // Check which curve extends to the right of the other.
       if (cv1.has_right() && cv2.has_left() &&
-          equal(cv1.right(), cv2.left()))
-      {
+          equal(cv1.right(), cv2.left())) {
         // cv2 extends cv1 to the right.
         c = cv1;
 
@@ -1519,9 +1467,9 @@ public:
 
   /// \name Functor definitions for the landmarks point-location strategy.
   //@{
-  typedef double                                        Approximate_number_type;
-  typedef CGAL::Cartesian<Approximate_number_type>      Approximate_kernel;
-  typedef Approximate_kernel::Point_2                   Approximate_point_2;
+  using Approximate_number_type = double;
+  using Approximate_kernel = CGAL::Simple_cartesian<Approximate_number_type>;
+  using Approximate_point_2 = Approximate_kernel::Point_2;
 
   class Approximate_2 {
   protected:
@@ -1545,8 +1493,7 @@ public:
      * \return An approximation of `p`'s \f$x\f$-coordinate (if `i` == 0), or an
      *         approximation of `p`'s \f$y\f$-coordinate (if `i` == 1).
      */
-    Approximate_number_type operator()(const Point_2& p, int i) const
-    {
+    Approximate_number_type operator()(const Point_2& p, int i) const {
       CGAL_precondition((i == 0) || (i == 1));
       return (i == 0) ? CGAL::to_double(p.x()) : CGAL::to_double(p.y());
     }
@@ -1580,8 +1527,7 @@ public:
     template <typename OutputIterator>
     OutputIterator operator()(const X_monotone_curve_2& xcv, double /* error */,
                               OutputIterator oi, const Bbox_2& bbox,
-                              bool l2r = true) const
-    {
+                              bool l2r = true) const {
       using Approx_pnt = Approximate_point_2;
       using Approx_seg = Approximate_kernel::Segment_2;
       using Approx_ray = Approximate_kernel::Ray_2;
@@ -1657,8 +1603,7 @@ public:
      * \pre p and q must not be the same.
      * \return A segment connecting `p` and `q`.
      */
-    X_monotone_curve_2 operator()(const Point_2& p, const Point_2& q) const
-    {
+    X_monotone_curve_2 operator()(const Point_2& p, const Point_2& q) const {
       Kernel kernel;
       Segment_2 seg = kernel.construct_segment_2_object()(p, q);
 
@@ -1675,7 +1620,7 @@ public:
   //@{
 
   //! Functor
-  typedef Construct_x_monotone_curve_2  Construct_curve_2;
+  using Construct_curve_2 = Construct_x_monotone_curve_2;
 
   /*! obtains a `Construct_curve_2` functor object. */
   Construct_curve_2 construct_curve_2_object() const
@@ -1688,18 +1633,16 @@ public:
  */
 template <typename Kernel_>
 class Arr_linear_object_2 :
-    public Arr_linear_traits_2<Kernel_>::_Linear_object_cached_2
-{
-  typedef typename Arr_linear_traits_2<Kernel_>::_Linear_object_cached_2
-                                                            Base;
+    public Arr_linear_traits_2<Kernel_>::_Linear_object_cached_2 {
+  using Base = typename Arr_linear_traits_2<Kernel_>::_Linear_object_cached_2;
 
 public:
-  typedef Kernel_                                           Kernel;
+  using Kernel = Kernel_;
 
-  typedef typename Kernel::Point_2                          Point_2;
-  typedef typename Kernel::Segment_2                        Segment_2;
-  typedef typename Kernel::Ray_2                            Ray_2;
-  typedef typename Kernel::Line_2                           Line_2;
+  using Point_2 = typename Kernel::Point_2;
+  using Segment_2 = typename Kernel::Segment_2;
+  using Ray_2 = typename Kernel::Ray_2;
+  using Line_2 = typename Kernel::Line_2;
 
 public:
   /*! constructs default.
@@ -1739,8 +1682,7 @@ public:
   /*! casts to a segment.
    * \pre The linear object is really a segment.
    */
-  Segment_2 segment() const
-  {
+  Segment_2 segment() const {
     CGAL_precondition(is_segment());
 
     Kernel kernel;
@@ -1756,8 +1698,7 @@ public:
   /*! casts to a ray.
    * \pre The linear object is really a ray.
    */
-  Ray_2 ray() const
-  {
+  Ray_2 ray() const {
     CGAL_precondition(is_ray());
 
     Kernel kernel;
@@ -1776,8 +1717,7 @@ public:
   /*! casts to a line.
    * \pre The linear object is really a line.
    */
-  Line_2 line() const
-  {
+  Line_2 line() const {
     CGAL_precondition(is_line());
     return (this->l);
   }
@@ -1785,8 +1725,7 @@ public:
   /*! obtains the supporting line.
    * \pre The object is not a point.
    */
-  const Line_2& supporting_line() const
-  {
+  const Line_2& supporting_line() const {
     CGAL_precondition(! this->is_degen);
     return (this->l);
   }
@@ -1794,8 +1733,7 @@ public:
   /*! obtains the source point.
    * \pre The object is a point, a segment or a ray.
    */
-  const Point_2& source() const
-  {
+  const Point_2& source() const {
     CGAL_precondition(! is_line());
 
     if (this->is_degen) return (this->ps);      // For a point.
@@ -1806,16 +1744,14 @@ public:
   /*! obtains the target point.
    * \pre The object is a point or a segment.
    */
-  const Point_2& target() const
-  {
+  const Point_2& target() const {
     CGAL_precondition(! is_line() && ! is_ray());
     return (this->pt);
   }
 
   /*! creates a bounding box for the linear object.
    */
-  Bbox_2 bbox() const
-  {
+  Bbox_2 bbox() const {
     CGAL_precondition(this->is_segment());
     Kernel kernel;
     Segment_2 seg = kernel.construct_segment_2_object()(this->ps, this->pt);
@@ -1834,8 +1770,7 @@ public:
  */
 template <typename Kernel, typename OutputStream>
 OutputStream& operator<<(OutputStream& os,
-                         const Arr_linear_object_2<Kernel>& lobj)
-{
+                         const Arr_linear_object_2<Kernel>& lobj) {
   // Print a letter identifying the object type, then the object itself.
   if (lobj.is_segment()) os << " S " << lobj.segment();
   else if (lobj.is_ray()) os << " R " << lobj.ray();
@@ -1846,8 +1781,7 @@ OutputStream& operator<<(OutputStream& os,
 /*! Importer for the segment class used by the traits-class.
  */
 template <typename Kernel, typename InputStream>
-InputStream& operator>>(InputStream& is, Arr_linear_object_2<Kernel>& lobj)
-{
+InputStream& operator>>(InputStream& is, Arr_linear_object_2<Kernel>& lobj) {
   // Read the object type.
   char c;
   do {

--- a/Arrangement_on_surface_2/include/CGAL/Arr_non_caching_segment_basic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_non_caching_segment_basic_traits_2.h
@@ -30,7 +30,7 @@
  * functors required by the concept it models.
  */
 
-#include <CGAL/Cartesian.h>
+#include <CGAL/Simple_cartesian.h>
 #include <CGAL/Algebraic_structure_traits.h>
 #include <CGAL/number_utils.h>
 #include <CGAL/tags.h>
@@ -44,34 +44,28 @@ namespace CGAL {
  * A model of the AosBasicTraits_2 concept that handles \f$x\f$-monotone
  * non-intersecting line segments.
  */
-template <class T_Kernel>
-class Arr_non_caching_segment_basic_traits_2 : public T_Kernel
-{
+template <typename T_Kernel>
+class Arr_non_caching_segment_basic_traits_2 : public T_Kernel {
 public:
-
-  typedef T_Kernel                              Kernel;
-
-  typedef typename Kernel::FT                   FT;
+  using Kernel = T_Kernel;
+  using FT = typename Kernel::FT;
 
 private:
-  typedef Algebraic_structure_traits<FT> AST;
-  typedef typename AST::Is_exact FT_is_exact;
+  using AST = Algebraic_structure_traits<FT>;
+  using FT_is_exact = typename AST::Is_exact;
+
 public:
-
-  typedef Boolean_tag<FT_is_exact::value> Has_exact_division;
-
-  typedef
-  CGAL::Segment_assertions<Arr_non_caching_segment_basic_traits_2<Kernel> >
-                                                Segment_assertions;
+  using Has_exact_division = Boolean_tag<FT_is_exact::value>;
+  using Segment_assertions = CGAL::Segment_assertions<Arr_non_caching_segment_basic_traits_2<Kernel>>;
 
   // Categories:
-  typedef Tag_true                              Has_left_category;
-  typedef Tag_false                             Has_do_intersect_category;
+  using Has_left_category = Tag_true;
+  using Has_do_intersect_category = Tag_false;
 
-  typedef Arr_oblivious_side_tag                Left_side_category;
-  typedef Arr_oblivious_side_tag                Bottom_side_category;
-  typedef Arr_oblivious_side_tag                Top_side_category;
-  typedef Arr_oblivious_side_tag                Right_side_category;
+  using Left_side_category = Arr_oblivious_side_tag;
+  using Bottom_side_category = Arr_oblivious_side_tag;
+  using Top_side_category = Arr_oblivious_side_tag;
+  using Right_side_category = Arr_oblivious_side_tag;
 
   /*! constructs default */
   Arr_non_caching_segment_basic_traits_2() {}
@@ -80,30 +74,30 @@ public:
   //@{
 
   // Traits types:
-  typedef typename Kernel::Point_2                 Point_2;
-  typedef typename Kernel::Segment_2               X_monotone_curve_2;
-  typedef unsigned int                             Multiplicity;
+  using Point_2 = typename Kernel::Point_2;
+  using X_monotone_curve_2 = typename Kernel::Segment_2;
+  using Multiplicity = std::size_t;
 
-  /*! Compare the \f$x\f$-coordinates of two points. */
-  typedef typename Kernel::Compare_x_2             Compare_x_2;
+  /*! compares the \f$x\f$-coordinates of two points. */
+  using Compare_x_2 = typename Kernel::Compare_x_2;
 
-  /*! Compare two points lexigoraphically; by \f$x\f$, then by \f$y\f$. */
-  typedef typename Kernel::Compare_xy_2            Compare_xy_2;
+  /*! compares two points lexigoraphically; by \f$x\f$, then by \f$y\f$. */
+  using Compare_xy_2 = typename Kernel::Compare_xy_2;
 
-  /*! Obtain the left endpoint of a given segment. */
-  typedef typename Kernel::Construct_min_vertex_2  Construct_min_vertex_2;
+  /*! obtains the left endpoint of a given segment. */
+  using Construct_min_vertex_2 = typename Kernel::Construct_min_vertex_2;
 
-  /*! Obtain the right endpoint of a given segment. */
-  typedef typename Kernel::Construct_max_vertex_2  Construct_max_vertex_2;
+  /*! obtains the right endpoint of a given segment. */
+  using Construct_max_vertex_2 = typename Kernel::Construct_max_vertex_2;
 
-  /*! Check whether a given segment is vertical. */
-  typedef typename Kernel::Is_vertical_2           Is_vertical_2;
+  /*! checks whether a given segment is vertical. */
+  using Is_vertical_2 = typename Kernel::Is_vertical_2;
 
-  /*! Return the location of a given point with respect to an input segment. */
-  typedef typename Kernel::Compare_y_at_x_2        Compare_y_at_x_2;
+  /*! returns the location of a given point with respect to an input segment. */
+  using Compare_y_at_x_2 = typename Kernel::Compare_y_at_x_2;
 
-  /*! Check if two segments or if two points are identical. */
-  typedef typename Kernel::Equal_2                 Equal_2;
+  /*! checks if two segments or if two points are identical. */
+  using Equal_2 = typename Kernel::Equal_2;
 
   //@}
 
@@ -127,8 +121,7 @@ public:
      */
     Comparison_result operator()(const X_monotone_curve_2& cv1,
                                  const X_monotone_curve_2& cv2,
-                                 const Point_2& CGAL_precondition_code(p)) const
-    {
+                                 const Point_2& CGAL_precondition_code(p)) const {
       Kernel kernel;
 
       // The two segments must be defined at q and also to its left.
@@ -140,13 +133,13 @@ public:
         Compare_xy_2 compare_xy = kernel.compare_xy_2_object();
         typename Kernel::Construct_vertex_2 construct_vertex =
           kernel.construct_vertex_2_object();
-        const Point_2 & source1 = construct_vertex(cv1, 0);
-        const Point_2 & target1 = construct_vertex(cv1, 1);
-        const Point_2 & left1 =
+        const Point_2& source1 = construct_vertex(cv1, 0);
+        const Point_2& target1 = construct_vertex(cv1, 1);
+        const Point_2& left1 =
           (kernel.less_xy_2_object()(source1, target1)) ? source1 : target1;
-        const Point_2 & source2 = construct_vertex(cv2, 0);
-        const Point_2 & target2 = construct_vertex(cv2, 1);
-        const Point_2 & left2 =
+        const Point_2& source2 = construct_vertex(cv2, 0);
+        const Point_2& target2 = construct_vertex(cv2, 1);
+        const Point_2& left2 =
           (kernel.less_xy_2_object()(source2, target2)) ? source2 : target2;
         );
 
@@ -181,10 +174,9 @@ public:
      *         to the right of `p`: `SMALLER`, `LARGER`, or `EQUAL`.
      */
 
-    Comparison_result operator()(const X_monotone_curve_2 & cv1,
-                                 const X_monotone_curve_2 & cv2,
-                                 const Point_2 & CGAL_precondition_code(p)) const
-    {
+    Comparison_result operator()(const X_monotone_curve_2& cv1,
+                                 const X_monotone_curve_2& cv2,
+                                 const Point_2& CGAL_precondition_code(p)) const {
       Kernel kernel;
 
       // The two segments must be defined at q and also to its right.
@@ -196,13 +188,13 @@ public:
         Compare_xy_2 compare_xy = kernel.compare_xy_2_object();
         typename Kernel::Construct_vertex_2 construct_vertex =
           kernel.construct_vertex_2_object();
-        const Point_2 & source1 = construct_vertex(cv1, 0);
-        const Point_2 & target1 = construct_vertex(cv1, 1);
-        const Point_2 & right1 =
+        const Point_2& source1 = construct_vertex(cv1, 0);
+        const Point_2& target1 = construct_vertex(cv1, 1);
+        const Point_2& right1 =
           (kernel.less_xy_2_object()(source1, target1)) ? target1 : source1;
-        const Point_2 & source2 = construct_vertex(cv2, 0);
-        const Point_2 & target2 = construct_vertex(cv2, 1);
-        const Point_2 & right2 =
+        const Point_2& source2 = construct_vertex(cv2, 0);
+        const Point_2& target2 = construct_vertex(cv2, 1);
+        const Point_2& right2 =
           (kernel.less_xy_2_object()(source2, target2)) ? target2 : source2;
         );
 
@@ -222,9 +214,9 @@ public:
 
   /// \name Functor definitions for the landmarks point-location strategy.
   //@{
-  typedef double                                        Approximate_number_type;
-  typedef CGAL::Cartesian<Approximate_number_type>      Approximate_kernel;
-  typedef Approximate_kernel::Point_2                   Approximate_point_2;
+  using Approximate_number_type = double;
+  using Approximate_kernel = CGAL::Simple_cartesian<Approximate_number_type>;
+  using Approximate_point_2 = Approximate_kernel::Point_2;
 
   class Approximate_2 {
   protected:
@@ -280,7 +272,7 @@ public:
   /*! obtains an Approximate_2 functor object. */
   Approximate_2 approximate_2_object () const { return Approximate_2(*this); }
 
-  typedef typename Kernel::Construct_segment_2    Construct_x_monotone_curve_2;
+  using Construct_x_monotone_curve_2 = typename Kernel::Construct_segment_2;
 
   /*! obtains a `Construct_x_monotone_curve_2` functor object. */
   Construct_x_monotone_curve_2 construct_x_monotone_curve_2_object () const

--- a/Arrangement_on_surface_2/include/CGAL/Arr_non_caching_segment_basic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_non_caching_segment_basic_traits_2.h
@@ -259,12 +259,8 @@ public:
       auto max_vertex = m_traits.construct_max_vertex_2_object();
       const auto& src = (l2r) ? min_vertex(xcv) : max_vertex(xcv);
       const auto& trg = (l2r) ? max_vertex(xcv) : min_vertex(xcv);
-      auto xs = CGAL::to_double(src.x());
-      auto ys = CGAL::to_double(src.y());
-      auto xt = CGAL::to_double(trg.x());
-      auto yt = CGAL::to_double(trg.y());
-      *oi++ = Approximate_point_2(xs, ys);
-      *oi++ = Approximate_point_2(xt, yt);
+      *oi++ = operator()(src);
+      *oi++ = operator()(trg);
       return oi;
     }
   };

--- a/Arrangement_on_surface_2/include/CGAL/Arr_segment_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_segment_traits_2.h
@@ -909,12 +909,8 @@ public:
       auto max_vertex = m_traits.construct_max_vertex_2_object();
       const auto& src = (l2r) ? min_vertex(xcv) : max_vertex(xcv);
       const auto& trg = (l2r) ? max_vertex(xcv) : min_vertex(xcv);
-      auto xs = CGAL::to_double(src.x());
-      auto ys = CGAL::to_double(src.y());
-      auto xt = CGAL::to_double(trg.x());
-      auto yt = CGAL::to_double(trg.y());
-      *oi++ = Approximate_point_2(xs, ys);
-      *oi++ = Approximate_point_2(xt, yt);
+      *oi++ = operator()(src);
+      *oi++ = operator()(trg);
       return oi;
     }
   };

--- a/Arrangement_on_surface_2/include/CGAL/Arr_segment_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_segment_traits_2.h
@@ -28,7 +28,7 @@
 #include <variant>
 
 #include <CGAL/Exact_predicates_exact_constructions_kernel.h>
-#include <CGAL/Cartesian.h>
+#include <CGAL/Simple_cartesian.h>
 #include <CGAL/tags.h>
 #include <CGAL/intersections.h>
 #include <CGAL/Arr_tags.h>
@@ -52,35 +52,32 @@ class Arr_segment_2;
 template <typename Kernel_ = Exact_predicates_exact_constructions_kernel>
 class Arr_segment_traits_2 : public Kernel_ {
   friend class Arr_segment_2<Kernel_>;
-
 public:
-  typedef Kernel_                         Kernel;
-  typedef typename Kernel::FT             FT;
+  using Kernel = Kernel_;
+  using FT = typename Kernel::FT;
 
-  typedef typename Algebraic_structure_traits<FT>::Is_exact
-                                          Has_exact_division;
+  using Has_exact_division = typename Algebraic_structure_traits<FT>::Is_exact;
 
   // Category tags:
-  typedef Tag_true                        Has_left_category;
-  typedef Tag_true                        Has_merge_category;
-  typedef Tag_false                       Has_do_intersect_category;
+  using Has_left_category = Tag_true;
+  using Has_merge_category = Tag_true;
+  using Has_do_intersect_category = Tag_false;
 
-  typedef Arr_oblivious_side_tag          Left_side_category;
-  typedef Arr_oblivious_side_tag          Bottom_side_category;
-  typedef Arr_oblivious_side_tag          Top_side_category;
-  typedef Arr_oblivious_side_tag          Right_side_category;
+  using Left_side_category = Arr_oblivious_side_tag;
+  using Bottom_side_category = Arr_oblivious_side_tag;
+  using Top_side_category = Arr_oblivious_side_tag;
+  using Right_side_category = Arr_oblivious_side_tag;
 
-  typedef typename Kernel::Line_2         Line_2;
-  typedef CGAL::Segment_assertions<Arr_segment_traits_2<Kernel> >
-                                          Segment_assertions;
+  using Line_2 = typename Kernel::Line_2;
+  using Segment_assertions = CGAL::Segment_assertions<Arr_segment_traits_2<Kernel>>;
 
   /*! \class Representation of a segment with cached data.
    */
   class _Segment_cached_2 {
   public:
-    typedef typename Kernel::Line_2                Line_2;
-    typedef typename Kernel::Segment_2             Segment_2;
-    typedef typename Kernel::Point_2               Point_2;
+    using Line_2 = typename Kernel::Line_2;
+    using Segment_2 = typename Kernel::Segment_2;
+    using Point_2 = typename Kernel::Point_2;
 
   protected:
     mutable Line_2 m_l;         // the line that supports the segment.
@@ -228,10 +225,10 @@ public:
 
 public:
   // Traits objects
-  typedef typename Kernel::Point_2        Point_2;
-  typedef Arr_segment_2<Kernel>           X_monotone_curve_2;
-  typedef Arr_segment_2<Kernel>           Curve_2;
-  typedef unsigned int                    Multiplicity;
+  using Point_2 = typename Kernel::Point_2;
+  using X_monotone_curve_2 = Arr_segment_2<Kernel>;
+  using Curve_2 = Arr_segment_2<Kernel>;
+  using Multiplicity = std::size_t;
 
 public:
   /*! constructs default. */
@@ -242,7 +239,7 @@ public:
 
   class Compare_x_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     //! The traits (in case it has state).
     const Traits& m_traits;
@@ -262,8 +259,7 @@ public:
      *         `SMALLER` if x(p1) < x(p2);
      *         `EQUAL` if x(p1) = x(p2).
      */
-    Comparison_result operator()(const Point_2& p1, const Point_2& p2) const
-    {
+    Comparison_result operator()(const Point_2& p1, const Point_2& p2) const {
       const Kernel& kernel = m_traits;
       return (kernel.compare_x_2_object()(p1, p2));
     }
@@ -274,7 +270,7 @@ public:
 
   class Compare_xy_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -294,8 +290,7 @@ public:
      *         SMALLER if x(p1) < x(p2), or if x(p1) = x(p2) and y(p1) < y(p2);
      *         EQUAL if the two points are equal.
      */
-    Comparison_result operator()(const Point_2& p1, const Point_2& p2) const
-    {
+    Comparison_result operator()(const Point_2& p1, const Point_2& p2) const {
       const Kernel& kernel = m_traits;
       return (kernel.compare_xy_2_object()(p1, p2));
     }
@@ -347,7 +342,7 @@ public:
 
   class Compare_y_at_x_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -369,8 +364,7 @@ public:
      *         `EQUAL` if `p` lies on the curve.
      */
     Comparison_result operator()(const Point_2& p,
-                                 const X_monotone_curve_2& cv) const
-    {
+                                 const X_monotone_curve_2& cv) const {
       CGAL_precondition(m_traits.is_in_x_range_2_object()(cv, p));
 
       const Kernel& kernel = m_traits;
@@ -396,7 +390,7 @@ public:
 
   class Compare_y_at_x_left_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -421,8 +415,7 @@ public:
      */
     Comparison_result operator()(const X_monotone_curve_2& cv1,
                                  const X_monotone_curve_2& cv2,
-                                 const Point_2& CGAL_assertion_code(p)) const
-    {
+                                 const Point_2& CGAL_assertion_code(p)) const {
       const Kernel& kernel = m_traits;
 
       // Make sure that p lies on both curves, and that both are defined to its
@@ -450,7 +443,7 @@ public:
 
   class Compare_y_at_x_right_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -475,8 +468,7 @@ public:
      */
     Comparison_result operator()(const X_monotone_curve_2& cv1,
                                  const X_monotone_curve_2& cv2,
-                                 const Point_2& CGAL_assertion_code(p)) const
-    {
+                                 const Point_2& CGAL_assertion_code(p)) const {
       const Kernel& kernel = m_traits;
 
       // Make sure that p lies on both curves, and that both are defined to its
@@ -502,7 +494,7 @@ public:
 
   class Equal_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -522,8 +514,7 @@ public:
      * \return (true) if the two curves are the same; (false) otherwise.
      */
     bool operator()(const X_monotone_curve_2& cv1,
-                    const X_monotone_curve_2& cv2) const
-    {
+                    const X_monotone_curve_2& cv2) const {
       const Kernel& kernel = m_traits;
       typename Kernel::Equal_2  equal = kernel.equal_2_object();
 
@@ -536,8 +527,7 @@ public:
      * \param p2 the second point.
      * \return (true) if the two point are the same; (false) otherwise.
      */
-    bool operator()(const Point_2& p1, const Point_2& p2) const
-    {
+    bool operator()(const Point_2& p1, const Point_2& p2) const {
       const Kernel& kernel = m_traits;
       return (kernel.equal_2_object()(p1, p2));
     }
@@ -566,11 +556,9 @@ public:
      * \return the past-the-end output iterator.
      */
     template <typename OutputIterator>
-    OutputIterator operator()(const Curve_2& cv, OutputIterator oi) const
-    {
+    OutputIterator operator()(const Curve_2& cv, OutputIterator oi) const {
       // Wrap the segment with a variant.
-      typedef std::variant<Point_2, X_monotone_curve_2>
-        Make_x_monotone_result;
+      using Make_x_monotone_result = std::variant<Point_2, X_monotone_curve_2>;
       *oi++ = Make_x_monotone_result(cv);
       return oi;
     }
@@ -582,7 +570,7 @@ public:
 
   class Split_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -595,7 +583,7 @@ public:
     friend class Arr_segment_traits_2<Kernel>;
 
   public:
-    /*! split a given \f$x\f$-monotone curve at a given point into two
+    /*! splits a given \f$x\f$-monotone curve at a given point into two
      * sub-curves.
      * \param cv the curve to split
      * \param p the split point.
@@ -604,8 +592,7 @@ public:
      * \pre `p` lies on cv but is not one of its endpoints.
      */
     void operator()(const X_monotone_curve_2& cv, const Point_2& p,
-                    X_monotone_curve_2& c1, X_monotone_curve_2& c2) const
-    {
+                    X_monotone_curve_2& c1, X_monotone_curve_2& c2) const {
       // Make sure that p lies on the interior of the curve.
       CGAL_precondition_code(const Kernel& kernel = m_traits;
                              auto compare_xy = kernel.compare_xy_2_object());
@@ -628,7 +615,7 @@ public:
 
   class Intersect_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -644,8 +631,7 @@ public:
     // this point, we already know which point is left / right for
     // both segments
     bool do_intersect(const Point_2& A1, const Point_2& A2,
-                      const Point_2& B1, const Point_2& B2) const
-    {
+                      const Point_2& B1, const Point_2& B2) const {
       const Kernel& kernel = m_traits;
       auto compare_xy = kernel.compare_xy_2_object();
       namespace interx = CGAL::Intersections::internal;
@@ -686,8 +672,7 @@ public:
     /*! determines whether the bounding boxes of two segments overlap
      */
     bool do_bboxes_overlap(const X_monotone_curve_2& cv1,
-                           const X_monotone_curve_2& cv2) const
-    {
+                           const X_monotone_curve_2& cv2) const {
       const Kernel& kernel = m_traits;
       auto construct_bbox = kernel.construct_bbox_2_object();
       auto bbox1 = construct_bbox(cv1.source()) + construct_bbox(cv1.target());
@@ -707,9 +692,8 @@ public:
     template <typename OutputIterator>
     OutputIterator operator()(const X_monotone_curve_2& cv1,
                               const X_monotone_curve_2& cv2,
-                              OutputIterator oi) const
-    {
-      typedef std::pair<Point_2, Multiplicity>          Intersection_point;
+                              OutputIterator oi) const {
+      using Intersection_point = std::pair<Point_2, Multiplicity>;
 
       // Early ending with Bbox overlapping test
       if (! do_bboxes_overlap(cv1, cv2)) return oi;
@@ -787,7 +771,7 @@ public:
 
   class Are_mergeable_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -808,8 +792,7 @@ public:
      * \pre `cv1` and `cv2` share a common endpoint.
      */
     bool operator()(const X_monotone_curve_2& cv1,
-                    const X_monotone_curve_2& cv2) const
-    {
+                    const X_monotone_curve_2& cv2) const {
       const Kernel& kernel = m_traits;
       typename Kernel::Equal_2 equal = kernel.equal_2_object();
       if (! equal(cv1.right(), cv2.left()) &&
@@ -832,7 +815,7 @@ public:
    */
   class Merge_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     /*! The traits (in case it has state) */
     const Traits& m_traits;
@@ -853,14 +836,13 @@ public:
      */
     void operator()(const X_monotone_curve_2& cv1,
                     const X_monotone_curve_2& cv2,
-                    X_monotone_curve_2& c) const
-    {
+                    X_monotone_curve_2& c) const {
       CGAL_precondition(m_traits.are_mergeable_2_object()(cv1, cv2));
 
       const Kernel& kernel = m_traits;
       auto equal = kernel.equal_2_object();
 
-      // Check which curve extends to the right of the other.
+      // checks which curve extends to the right of the other.
       if (equal(cv1.right(), cv2.left())) {
         // cv2 extends cv1 to the right.
         c = cv1;
@@ -882,9 +864,9 @@ public:
 
   /// \name Functor definitions for the landmarks point-location strategy.
   //@{
-  typedef double                                        Approximate_number_type;
-  typedef CGAL::Cartesian<Approximate_number_type>      Approximate_kernel;
-  typedef Approximate_kernel::Point_2                   Approximate_point_2;
+  using Approximate_number_type = double;
+  using Approximate_kernel = CGAL::Simple_cartesian<Approximate_number_type>;
+  using Approximate_point_2 = Approximate_kernel::Point_2;
 
   class Approximate_2 {
   protected:
@@ -943,7 +925,7 @@ public:
   //! Functor
   class Construct_x_monotone_curve_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     //! The traits (in case it has state).
     const Traits& m_traits;
@@ -956,7 +938,7 @@ public:
     friend class Arr_segment_traits_2<Kernel>;
 
   public:
-    typedef typename Kernel::Segment_2          Segment_2;
+    using Segment_2 = typename Kernel::Segment_2;
 
     /*! obtains an \f$x\f$-monotone curve connecting two given endpoints.
      * \param source the first point.
@@ -965,8 +947,7 @@ public:
      * \return a segment connecting `source` and `target`.
      */
     X_monotone_curve_2 operator()(const Point_2& source,
-                                  const Point_2& target) const
-    {
+                                  const Point_2& target) const {
       const Kernel& kernel = m_traits;
       auto line = kernel.construct_line_2_object()(source, target);
       Comparison_result res = kernel.compare_xy_2_object()(source, target);
@@ -985,8 +966,7 @@ public:
      * \pre the segment is not degenerate.
      * \return a segment that is the same as `seg`..
      */
-    X_monotone_curve_2 operator()(const Segment_2& seg) const
-    {
+    X_monotone_curve_2 operator()(const Segment_2& seg) const {
       const Kernel& kernel = m_traits;
       auto line = kernel.construct_line_2_object()(seg);
       auto vertex_ctr = kernel.construct_vertex_2_object();
@@ -1011,8 +991,7 @@ public:
      */
     X_monotone_curve_2 operator()(const Line_2& line,
                                   const Point_2& source,
-                                  const Point_2& target) const
-    {
+                                  const Point_2& target) const {
       const Kernel& kernel = m_traits;
       CGAL_precondition
         (Segment_assertions::_assert_is_point_on(source, line,
@@ -1039,7 +1018,7 @@ public:
   //@{
 
   //! Functor
-  typedef Construct_x_monotone_curve_2  Construct_curve_2;
+  using Construct_curve_2 = Construct_x_monotone_curve_2;
 
   /*! obtains a `Construct_curve_2` functor object. */
   Construct_curve_2 construct_curve_2_object() const
@@ -1051,7 +1030,7 @@ public:
 
   class Trim_2 {
    protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     /*! The traits (in case it has state). */
     const Traits& m_traits;
@@ -1074,8 +1053,7 @@ public:
   public:
     X_monotone_curve_2 operator()(const X_monotone_curve_2& xcv,
                                   const Point_2& src,
-                                  const Point_2& tgt)const
-    {
+                                  const Point_2& tgt) const {
       CGAL_precondition_code(Equal_2 equal = m_traits.equal_2_object());
       CGAL_precondition_code(Compare_y_at_x_2 compare_y_at_x =
                              m_traits.compare_y_at_x_2_object());
@@ -1119,7 +1097,7 @@ public:
 
   class Construct_opposite_2 {
   public:
-    /*! Construct an opposite \f$x\f$-monotone (with swapped source and target).
+    /*! constructs an opposite \f$x\f$-monotone (with swapped source and target).
      * \param cv the curve.
      * \return the opposite curve.
      */
@@ -1137,12 +1115,12 @@ public:
 
   class Is_in_x_range_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     //! The traits (in case it has state).
     const Traits& m_traits;
 
-    /*! Construct
+    /*! constructs
      * \param traits the traits (in case it has state)
      */
     Is_in_x_range_2(const Traits& traits) : m_traits(traits) {}
@@ -1156,8 +1134,7 @@ public:
      * \param p the point.
      * \return true if p is in the \f$x\f$-range of cv; false otherwise.
      */
-    bool operator()(const X_monotone_curve_2& cv, const Point_2& p) const
-    {
+    bool operator()(const X_monotone_curve_2& cv, const Point_2& p) const {
       const Kernel& kernel = m_traits;
       auto compare_x = kernel.compare_x_2_object();
       Comparison_result res1 = compare_x(p, cv.left());
@@ -1176,7 +1153,7 @@ public:
 
   class Is_in_y_range_2 {
   protected:
-    typedef Arr_segment_traits_2<Kernel>        Traits;
+    using Traits = Arr_segment_traits_2<Kernel>;
 
     //! The traits (in case it has state).
     const Traits& m_traits;
@@ -1195,8 +1172,7 @@ public:
      * \param p the point.
      * \return true if p is in the \f$y\f$-range of cv; false otherwise.
      */
-    bool operator()(const X_monotone_curve_2& cv, const Point_2& p) const
-    {
+    bool operator()(const X_monotone_curve_2& cv, const Point_2& p) const {
       const Kernel& kernel = m_traits;
       auto compare_y = kernel.compare_y_2_object();
       Comparison_result res1 = compare_y(p, cv.left());
@@ -1232,8 +1208,7 @@ template <typename Kernel>
 Arr_segment_traits_2<Kernel>::
 _Segment_cached_2::_Segment_cached_2(const Segment_2& seg) :
   m_is_vert(false),
-  m_is_computed(false)
-{
+  m_is_computed(false) {
   Kernel kernel;
   auto vertex_ctr = kernel.construct_vertex_2_object();
 
@@ -1255,8 +1230,7 @@ _Segment_cached_2::_Segment_cached_2(const Point_2& source,
   m_ps(source),
   m_pt(target),
   m_is_vert(false),
-  m_is_computed(false)
-{
+  m_is_computed(false) {
   Kernel kernel;
 
   Comparison_result res = kernel.compare_xy_2_object()(m_ps, m_pt);
@@ -1274,8 +1248,7 @@ _Segment_cached_2::_Segment_cached_2(const Line_2& line,
                                      const Point_2& target) :
   m_l(line),
   m_ps(source),
-  m_pt(target)
-{
+  m_pt(target) {
   Kernel kernel;
 
   CGAL_precondition
@@ -1312,8 +1285,7 @@ _Segment_cached_2(const Line_2& line,
 //! \brief assigns.
 template <typename Kernel>
 const typename Arr_segment_traits_2<Kernel>::_Segment_cached_2&
-Arr_segment_traits_2<Kernel>::_Segment_cached_2::operator=(const Segment_2& seg)
-{
+Arr_segment_traits_2<Kernel>::_Segment_cached_2::operator=(const Segment_2& seg) {
   Kernel kernel;
   auto vertex_ctr = kernel.construct_vertex_2_object();
 
@@ -1338,8 +1310,7 @@ Arr_segment_traits_2<Kernel>::_Segment_cached_2::operator=(const Segment_2& seg)
 //! \brief obtains the supporting line.
 template <typename Kernel>
 const typename Kernel::Line_2&
-Arr_segment_traits_2<Kernel>::_Segment_cached_2::line() const
-{
+Arr_segment_traits_2<Kernel>::_Segment_cached_2::line() const {
   if (!m_is_computed) {
     Kernel kernel;
     m_l = kernel.construct_line_2_object()(m_ps, m_pt);
@@ -1351,8 +1322,7 @@ Arr_segment_traits_2<Kernel>::_Segment_cached_2::line() const
 
 //! \brief determines whether the curve is vertical.
 template <typename Kernel>
-bool Arr_segment_traits_2<Kernel>::_Segment_cached_2::is_vertical() const
-{
+bool Arr_segment_traits_2<Kernel>::_Segment_cached_2::is_vertical() const {
   // Force computation of line is orientation is still unknown
   if (! m_is_computed) line();
   CGAL_precondition(!m_is_degen);
@@ -1397,8 +1367,7 @@ Arr_segment_traits_2<Kernel>::_Segment_cached_2::right() const
 
 //! \brief sets the (lexicographically) left endpoint.
 template <typename Kernel>
-void Arr_segment_traits_2<Kernel>::_Segment_cached_2::set_left(const Point_2& p)
-{
+void Arr_segment_traits_2<Kernel>::_Segment_cached_2::set_left(const Point_2& p) {
   CGAL_precondition(! m_is_degen);
   CGAL_precondition_code(Kernel kernel);
   CGAL_precondition
@@ -1411,8 +1380,7 @@ void Arr_segment_traits_2<Kernel>::_Segment_cached_2::set_left(const Point_2& p)
 
 //! \brief sets the (lexicographically) right endpoint.
 template <typename Kernel>
-void Arr_segment_traits_2<Kernel>::_Segment_cached_2::set_right(const Point_2& p)
-{
+void Arr_segment_traits_2<Kernel>::_Segment_cached_2::set_right(const Point_2& p) {
   CGAL_precondition(! m_is_degen);
   CGAL_precondition_code(Kernel kernel);
   CGAL_precondition
@@ -1428,8 +1396,7 @@ void Arr_segment_traits_2<Kernel>::_Segment_cached_2::set_right(const Point_2& p
  */
 template <typename Kernel>
 bool Arr_segment_traits_2<Kernel>::_Segment_cached_2::
-is_in_x_range(const Point_2& p) const
-{
+is_in_x_range(const Point_2& p) const {
   Kernel kernel;
   typename Kernel::Compare_x_2 compare_x = kernel.compare_x_2_object();
   const Comparison_result res1 = compare_x(p, left());
@@ -1446,8 +1413,7 @@ is_in_x_range(const Point_2& p) const
  */
 template <typename Kernel>
 bool Arr_segment_traits_2<Kernel>::_Segment_cached_2::
-is_in_y_range(const Point_2& p) const
-{
+is_in_y_range(const Point_2& p) const {
   Kernel kernel;
   typename Kernel::Compare_y_2 compare_y = kernel.compare_y_2_object();
   const Comparison_result res1 = compare_y(p, left());
@@ -1464,31 +1430,31 @@ is_in_y_range(const Point_2& p) const
  */
 template <typename Kernel_>
 class Arr_segment_2 : public Arr_segment_traits_2<Kernel_>::_Segment_cached_2 {
-  typedef Kernel_                                                  Kernel;
+  using Kernel = Kernel_;
 
-  typedef typename Arr_segment_traits_2<Kernel>::_Segment_cached_2 Base;
-  typedef typename Kernel::Segment_2                               Segment_2;
-  typedef typename Kernel::Point_2                                 Point_2;
-  typedef typename Kernel::Line_2                                  Line_2;
+  using Base = typename Arr_segment_traits_2<Kernel>::_Segment_cached_2;
+  using Segment_2 = typename Kernel::Segment_2;
+  using Point_2 = typename Kernel::Point_2;
+  using Line_2 = typename Kernel::Line_2;
 
 public:
-  /*! Construct default. */
+  /*! constructs default. */
   Arr_segment_2();
 
-  /*! Construct a segment from a "kernel" segment.
+  /*! constructs a segment from a "kernel" segment.
    * \param seg the segment.
    * \pre the segment is not degenerate.
    */
   Arr_segment_2(const Segment_2& seg);
 
-  /*! Construct a segment from two endpoints.
+  /*! constructs a segment from two endpoints.
    * \param source the source point.
    * \param target the target point.
    * \pre `source` and `target` are not equal.
    */
   Arr_segment_2(const Point_2& source, const Point_2& target);
 
-  /*! Construct a segment from a line and two endpoints.
+  /*! constructs a segment from a line and two endpoints.
    * \param line the supporting line.
    * \param source the source point.
    * \param target the target point.
@@ -1498,7 +1464,7 @@ public:
   Arr_segment_2(const Line_2& line,
                 const Point_2& source, const Point_2& target);
 
-  /*! Construct a segment from all fields.
+  /*! constructs a segment from all fields.
    * \param line the supporting line.
    * \param source the source point.
    * \param target the target point.
@@ -1510,11 +1476,11 @@ public:
                 const Point_2& source, const Point_2& target,
                 bool is_directed_right, bool is_vert, bool is_degen);
 
-  /*! Cast to a segment.
+  /*! casts to a segment.
    */
   operator Segment_2() const;
 
-  /*! Flip the segment (swap its source and target).
+  /*! flips the segment (swap its source and target).
    */
   Arr_segment_2 flip() const;
 
@@ -1558,8 +1524,7 @@ Arr_segment_2<Kernel>::Arr_segment_2(const Line_2& line,
 
 //! \brief casts to a segment.
 template <typename Kernel>
-Arr_segment_2<Kernel>::operator typename Kernel::Segment_2() const
-{
+Arr_segment_2<Kernel>::operator typename Kernel::Segment_2() const {
   Kernel kernel;
   auto seg_ctr = kernel.construct_segment_2_object();
   return seg_ctr(this->source(), this->target());
@@ -1567,8 +1532,7 @@ Arr_segment_2<Kernel>::operator typename Kernel::Segment_2() const
 
 //! \brief flips the segment (swap its source and target).
 template <typename Kernel>
-Arr_segment_2<Kernel> Arr_segment_2<Kernel>::flip() const
-{
+Arr_segment_2<Kernel> Arr_segment_2<Kernel>::flip() const {
   return Arr_segment_2(this->line(), this->target(), this->source(),
                        ! (this->is_directed_right()), this->is_vertical(),
                        this->is_degenerate());
@@ -1586,8 +1550,7 @@ Bbox_2 Arr_segment_2<Kernel>::bbox() const
 /*! Exporter for the segment class used by the traits-class.
  */
 template <typename Kernel, typename OutputStream>
-OutputStream& operator<<(OutputStream& os, const Arr_segment_2<Kernel>& seg)
-{
+OutputStream& operator<<(OutputStream& os, const Arr_segment_2<Kernel>& seg) {
   os << static_cast<typename Kernel::Segment_2>(seg);
   return (os);
 }
@@ -1595,8 +1558,7 @@ OutputStream& operator<<(OutputStream& os, const Arr_segment_2<Kernel>& seg)
 /*! Importer for the segment class used by the traits-class.
  */
 template <typename Kernel, typename InputStream>
-InputStream& operator>>(InputStream& is, Arr_segment_2<Kernel>& seg)
-{
+InputStream& operator>>(InputStream& is, Arr_segment_2<Kernel>& seg) {
   typename Kernel::Segment_2   kernel_seg;
   is >> kernel_seg;
   seg = kernel_seg;

--- a/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Curved_kernel_via_analysis_2_functors.h
+++ b/Arrangement_on_surface_2/include/CGAL/Curved_kernel_via_analysis_2/Curved_kernel_via_analysis_2_functors.h
@@ -24,6 +24,7 @@
 #include <CGAL/config.h>
 #include <CGAL/Curved_kernel_via_analysis_2/Make_x_monotone_2.h>
 #include <CGAL/iterator.h>
+
 namespace CGAL {
 
 namespace internal {
@@ -37,1862 +38,1651 @@ namespace internal {
 #endif
 #endif
 
-/*!\brief
+/*! \brief
  * Collects main functors for Curved_kernel_via_analysis_2
  */
 namespace Curved_kernel_via_analysis_2_Functors {
 
-/*!\brief
+/*! \brief
  * Base functor class for inheritance
  */
-template < class CurvedKernelViaAnalysis_2 >
+template <typename CurvedKernelViaAnalysis_2>
 class Curved_kernel_via_analysis_2_functor_base {
+public:
+  //!\name Public types
+  //!@{
+
+  //! this instance's template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
+
+  //! the point type
+  using Point_2 = typename Curved_kernel_via_analysis_2::Point_2;
+
+  //! the arc type
+  using Arc_2 = typename Curved_kernel_via_analysis_2::Arc_2;
+
+  //! type of curve kernel
+  using Curve_kernel_2 = typename Curved_kernel_via_analysis_2::Curve_kernel_2;
+
+  //! type of curve analaysis
+  using Curve_analysis_2 = typename Curve_kernel_2::Curve_analysis_2;
+
+  //! the x-coordinate type
+  using Coordinate_1 = typename Point_2::Coordinate_1;
+
+  // using Y_coordinate_1 = typename Point_2::Y_coordinate_1;
+
+  //!@}
 
 public:
-    //!\name Public types
-    //!@{
+  //!\name Constructors
+  //!@{
 
-    //! this instance's template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  /*! \brief
+   * Constructs base functor
+   *
+   * \param kernel The kernel instance
+   */
+  Curved_kernel_via_analysis_2_functor_base(Curved_kernel_via_analysis_2* kernel) :
+    _m_curved_kernel(kernel) {
+    CGAL_precondition(kernel != nullptr);
+  }
 
-     //! the point type
-    typedef typename Curved_kernel_via_analysis_2::Point_2 Point_2;
-
-    //! the arc type
-    typedef typename Curved_kernel_via_analysis_2::Arc_2 Arc_2;
-
-    //! type of curve kernel
-    typedef typename Curved_kernel_via_analysis_2::Curve_kernel_2
-    Curve_kernel_2;
-
-    //! type of curve analaysis
-    typedef typename Curve_kernel_2::Curve_analysis_2 Curve_analysis_2;
-
-    //! the x-coordinate type
-    typedef typename Point_2::Coordinate_1 Coordinate_1;
-    //typedef typename Point_2::Y_coordinate_1 Y_coordinate_1;
-
-
-    //!@}
-
-public:
-    //!\name Constructors
-    //!@{
-
-    /*!\brief
-     * Constructs base functor
-     *
-     * \param kernel The kernel instance
-     */
-    Curved_kernel_via_analysis_2_functor_base(
-            Curved_kernel_via_analysis_2 *kernel) :
-        _m_curved_kernel(kernel) {
-        CGAL_precondition(kernel != nullptr);
-    }
-
-    //!@}
+  //!@}
 
 protected:
-    //!\name Access members
-    //!@{
+  //!\name Access members
+  //!@{
 
-    /*!\brief
-     * Return pointer to curved kernel
-     * \return Pointer to stored kernel
-     */
-    Curved_kernel_via_analysis_2* _ckva() const {
-        return _m_curved_kernel;
-    }
+  /*! \brief
+   * Return pointer to curved kernel
+   * \return Pointer to stored kernel
+   */
+  Curved_kernel_via_analysis_2* _ckva() const { return _m_curved_kernel; }
 
-    //!@}
+  //!@}
 
 protected:
-    //!\name Data members
-    //!@{
+  //!\name Data members
+  //!@{
 
-    //! stores pointer to \c Curved_kernel_via_analysis_2
-    Curved_kernel_via_analysis_2 *_m_curved_kernel;
+  //! stores pointer to \c Curved_kernel_via_analysis_2
+  Curved_kernel_via_analysis_2* _m_curved_kernel;
 
-    //!@}
+  //!@}
 };
 
-#define CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES \
-    typedef typename Base::Point_2 Point_2; \
-    typedef typename Base::Arc_2 Arc_2; \
-    typedef typename Base::Curve_analysis_2 Curve_analysis_2; \
-    typedef typename Base::Coordinate_1 Coordinate_1; \
-    //typedef typename Base::Y_coordinate_1 Y_coordinate_1;
+#define CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES                  \
+  using Point_2 = typename Base::Point_2;                    \
+  using Arc_2 = typename Base::Arc_2;                        \
+  using Curve_analysis_2 = typename Base::Curve_analysis_2 ; \
+  using Coordinate_1 = typename Base::Coordinate_1;          \
+  // using Y_coordinate_1 = typename Base::Y_coordinate_1;
 
-/*!\brief
+/*! \brief
  * Functor to construct a point on a curve
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Construct_point_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Construct_point_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef Point_2 result_type;
+  //! the result type
+  using result_type = Point_2;
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Construct_point_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Construct_point_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Constructs an interior point
-     *
-     * \param x x-coordinate
-     * \param c The supporting curve
-     * \param arcno Arcnumber on curve
-     * \return The constructed point
-     */
-    Point_2 operator()(const Coordinate_1& x,
-                       const Curve_analysis_2& c,
-                       int arcno) {
-        Point_2 pt(x, c, arcno);
-        return pt;
-    }
+  /*! \brief
+   * Constructs an interior point
+   *
+   * \param x x-coordinate
+   * \param c The supporting curve
+   * \param arcno Arcnumber on curve
+   * \return The constructed point
+   */
+  Point_2 operator()(const Coordinate_1& x, const Curve_analysis_2& c, int arcno) {
+    Point_2 pt(x, c, arcno);
+    return pt;
+  }
 
-    Point_2 operator()(const Coordinate_1& x,
-                       const Arc_2& a) {
-        CGAL_precondition(a.is_in_x_range(x));
-        Point_2 pt(x, a.curve(), a.arcno(x));
-        return pt;
-    }
+  Point_2 operator()(const Coordinate_1& x, const Arc_2& a) {
+    CGAL_precondition(a.is_in_x_range(x));
+    Point_2 pt(x, a.curve(), a.arcno(x));
+    return pt;
+  }
 
-
-    template <typename T>
-    Point_2 operator() (const T& x,
-                        const T& y) {
-        Point_2 pt(x,y);
-        return pt;
-    }
-
-
+  template <typename T>
+  Point_2 operator()(const T& x, const T& y) {
+    Point_2 pt(x,y);
+    return pt;
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functor to construct point on an arc
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Construct_point_on_arc_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Construct_point_on_arc_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef Point_2 result_type;
+  //! the result type
+  using result_type = Point_2;
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Construct_point_on_arc_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Construct_point_on_arc_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Constructs point on an arc
-     *
-     * \param x x-coordinate of point
-     * \param c The supporting curve
-     * \param arcno Arcnumber on curve
-     * \param arc Can be used to query meta data
-     * \return The constructed point
-     */
-    Point_2 operator()(
-            const Coordinate_1& x,
-            const Curve_analysis_2& c, int arcno, const Arc_2& arc
-    ) {
+  /*! \brief
+   * Constructs point on an arc
+   *
+   * \param x x-coordinate of point
+   * \param c The supporting curve
+   * \param arcno Arcnumber on curve
+   * \param arc Can be used to query meta data
+   * \return The constructed point
+   */
+  Point_2 operator()(const Coordinate_1& x,
+                     const Curve_analysis_2& c, int arcno, const Arc_2& arc) {
+    // avoid compiler warning
+    (void)arc;
 
-        // avoid compiler warning
-        (void)arc;
+    //CGAL::IO::set_pretty_mode(std::cerr);
+    CERR("Construct_pt_on_arc: " << CGAL::to_double(x) << ", " << arcno <<
+         ", " << c.id() <<  "\narc = " << arc << "\n");
 
-        //CGAL::IO::set_pretty_mode(std::cerr);
-        CERR("Construct_pt_on_arc: " << CGAL::to_double(x) << ", " << arcno <<
-             ", " << c.id() <<  "\narc = " << arc << "\n");
+    //CGAL_assertion(c.id() == arc.curve().id());
+    //CGAL_assertion(arcno == arc.arcno(x));
 
-        //CGAL_assertion(c.id() == arc.curve().id());
-        //CGAL_assertion(arcno == arc.arcno(x));
+    Point_2 pt = Base::_ckva()->construct_point_2_object()(x, c, arcno);
 
-        Point_2 pt = Base::_ckva()->construct_point_2_object()(x, c, arcno);
-
-        // here we can modify the point wrt "data stored in arc",
-        // if we want to
-        return pt;
-    }
+    // here we can modify the point wrt "data stored in arc",
+    // if we want to
+    return pt;
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functor to construct an x-monotone arc
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Construct_arc_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Construct_arc_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef Arc_2 result_type;
+  //! the result type
+  using result_type = Arc_2;
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Construct_arc_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Construct_arc_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    //!\name Constructing non-vertical arcs
-    //!@{
+  //!\name Constructing non-vertical arcs
+  //!@{
 
-    /*!\brief
-     * Constructs a non-vertical arc with two interior end-points (segment).
-     *
-     * \param p first endpoint
-     * \param q second endpoint
-     * \param c The supporting curve
-     * \param arcno The arcnumber wrt \c c in the interior of the arc
-     * \param arcno_p The arcnumber wrt \c c of the arc at \c p
-     * \param arcno_q The arcnumber wrt \c c of the arc at \c q
-     * \returns The constructed segment
-     *
-     * \pre p.x() != q.x()
-     *
-     */
-    Arc_2 operator()(const Point_2& p, const Point_2& q,
-                     const Curve_analysis_2& c,
-                     int arcno, int arcno_p, int arcno_q) {
-        Arc_2 arc(p, q, c, arcno, arcno_p, arcno_q);
-        return arc;
-    }
+  /*! \brief
+   * Constructs a non-vertical arc with two interior end-points (segment).
+   *
+   * \param p first endpoint
+   * \param q second endpoint
+   * \param c The supporting curve
+   * \param arcno The arcnumber wrt \c c in the interior of the arc
+   * \param arcno_p The arcnumber wrt \c c of the arc at \c p
+   * \param arcno_q The arcnumber wrt \c c of the arc at \c q
+   * \returns The constructed segment
+   *
+   * \pre p.x() != q.x()
+   */
+  Arc_2 operator()(const Point_2& p, const Point_2& q,
+                   const Curve_analysis_2& c,
+                   int arcno, int arcno_p, int arcno_q) {
+    Arc_2 arc(p, q, c, arcno, arcno_p, arcno_q);
+    return arc;
+  }
 
-    /*!\brief
-     * Constructs a non-vertical arc with one interior end-point and whose
-     * other end approaches the left or right boundary of the parameter space
-     * (ray I)
-     *
-     * \param origin The interior end-point of the ray
-     * \param inf_end Defining whether the arc emanates from the left or right
-     *        boundary
-     * \param c The supporting curve
-     * \param arcno The arcnumber wrt \c c in the interior of the arc
-     * \param arcno_o The arcnumber wrt \c c of the arc at \c origin
-     * \return The constructed ray
-     */
-    Arc_2 operator()(const Point_2& origin, CGAL::Arr_curve_end inf_end,
-                     const Curve_analysis_2& c, int arcno, int arcno_o) {
-        Arc_2 arc(origin, inf_end, c, arcno, arcno_o);
-        return arc;
-    }
+  /*! \brief
+   * Constructs a non-vertical arc with one interior end-point and whose
+   * other end approaches the left or right boundary of the parameter space
+   * (ray I)
+   *
+   * \param origin The interior end-point of the ray
+   * \param inf_end Defining whether the arc emanates from the left or right
+   *        boundary
+   * \param c The supporting curve
+   * \param arcno The arcnumber wrt \c c in the interior of the arc
+   * \param arcno_o The arcnumber wrt \c c of the arc at \c origin
+   * \return The constructed ray
+   */
+  Arc_2 operator()(const Point_2& origin, CGAL::Arr_curve_end inf_end,
+                   const Curve_analysis_2& c, int arcno, int arcno_o) {
+    Arc_2 arc(origin, inf_end, c, arcno, arcno_o);
+    return arc;
+  }
 
-    /*!\brief
-     * Constructs a non-vertical arc with one interior end-point and whose
-     * other end approaches a vertical asymptote (ray II)
-     *
-     * \param origin The interior end-point
-     * \param asympt_x The x-coordinate of the vertical asymptote
-     * \param inf_end Arc is approaching the bottom or top boundary
-     * \param c The supporting curve
-     * \param arcno The arcnumber wrt \c c in the interior of the arc
-     * \param arcno_o The arcnumber wrt \c c of the arc at \c origin
-     * \return The constructed ray
-     *
-     * \pre origin.x() != asympt_x
-     */
-    Arc_2 operator()(const Point_2& origin, const Coordinate_1& asympt_x,
-                     CGAL::Arr_curve_end inf_end,
-                     const Curve_analysis_2& c, int arcno,
-                     int arcno_o) {
-        Arc_2 arc(origin, asympt_x, inf_end, c, arcno, arcno_o);
-        return arc;
-    }
+  /*! \brief
+   * Constructs a non-vertical arc with one interior end-point and whose
+   * other end approaches a vertical asymptote (ray II)
+   *
+   * \param origin The interior end-point
+   * \param asympt_x The x-coordinate of the vertical asymptote
+   * \param inf_end Arc is approaching the bottom or top boundary
+   * \param c The supporting curve
+   * \param arcno The arcnumber wrt \c c in the interior of the arc
+   * \param arcno_o The arcnumber wrt \c c of the arc at \c origin
+   * \return The constructed ray
+   *
+   * \pre origin.x() != asympt_x
+   */
+  Arc_2 operator()(const Point_2& origin, const Coordinate_1& asympt_x,
+                   CGAL::Arr_curve_end inf_end,
+                   const Curve_analysis_2& c, int arcno,
+                   int arcno_o) {
+    Arc_2 arc(origin, asympt_x, inf_end, c, arcno, arcno_o);
+    return arc;
+  }
 
-    /*!\brief
-     * Constructs a non-vertical arc with two non-interior ends at
-     * the left and right boundary (branch I)
-     *
-     * \param c The supporting curve
-     * \param arcno The arcnumber wrt to \c c in the interior of the arc
-     * \return The constructed branch
-     */
-    Arc_2 operator()(const Curve_analysis_2& c, int arcno) {
-        Arc_2 arc(c, arcno);
-        return arc;
-    }
+  /*! \brief
+   * Constructs a non-vertical arc with two non-interior ends at
+   * the left and right boundary (branch I)
+   *
+   * \param c The supporting curve
+   * \param arcno The arcnumber wrt to \c c in the interior of the arc
+   * \return The constructed branch
+   */
+  Arc_2 operator()(const Curve_analysis_2& c, int arcno) {
+    Arc_2 arc(c, arcno);
+    return arc;
+  }
 
-    /*!\brief
-     * Constructs a non-vertical arc with two ends approaching vertical
-     * asymptotes (branch II).
-     *
-     * \param asympt_x1 The x-coordinate of the first asymptote
-     * \param inf_end1 Arc is approaching the bottom or top boundary at
-     *                 \c asympt_x1
-     * \param asympt_x2 The x-coordinate of the second asymptote
-     * \param inf_end2 Arc is approaching the bottom or top boundary at
-     *                 \c asympt_x2
-     * \return The constructed branch
-     *
-     * \pre asympt_x1 != asympt_x2
-     */
-    Arc_2 operator()(const Coordinate_1& asympt_x1,
-                     CGAL::Arr_curve_end inf_end1,
-                     const Coordinate_1& asympt_x2,
-                     CGAL::Arr_curve_end inf_end2,
-                     const Curve_analysis_2& c, int arcno) {
-        Arc_2 arc(asympt_x1, inf_end1, asympt_x2, inf_end2, c, arcno);
-        return arc;
-    }
+  /*! \brief
+   * Constructs a non-vertical arc with two ends approaching vertical
+   * asymptotes (branch II).
+   *
+   * \param asympt_x1 The x-coordinate of the first asymptote
+   * \param inf_end1 Arc is approaching the bottom or top boundary at
+   *                 \c asympt_x1
+   * \param asympt_x2 The x-coordinate of the second asymptote
+   * \param inf_end2 Arc is approaching the bottom or top boundary at
+   *                 \c asympt_x2
+   * \return The constructed branch
+   *
+   * \pre asympt_x1 != asympt_x2
+   */
+  Arc_2 operator()(const Coordinate_1& asympt_x1,
+                   CGAL::Arr_curve_end inf_end1,
+                   const Coordinate_1& asympt_x2,
+                   CGAL::Arr_curve_end inf_end2,
+                   const Curve_analysis_2& c, int arcno) {
+    Arc_2 arc(asympt_x1, inf_end1, asympt_x2, inf_end2, c, arcno);
+    return arc;
+  }
 
-    /*!\brief
-     * Construct a non-vertical arc with one left- or right-boundary end
-     * and one end that approaches a vertical asymptote (branch III)
-     *
-     * \param inf_endx Defining whether the arc emanates from the left or right
-     *        boundary
-     * \param asympt_x The x-coordinate of the asymptote
-     * \param inf_endy Arc is approaching the bottom or top boundary at
-     *                 asympt_x
-     * \return The constructed branch
-     */
-    Arc_2 operator()(CGAL::Arr_curve_end inf_endx,
-                     const Coordinate_1& asympt_x,
-                     CGAL::Arr_curve_end inf_endy,
-                     const Curve_analysis_2& c, int arcno) {
-        Arc_2 arc(inf_endx, asympt_x, inf_endy, c, arcno);
-        return arc;
-    }
+  /*! \brief
+   * Construct a non-vertical arc with one left- or right-boundary end
+   * and one end that approaches a vertical asymptote (branch III)
+   *
+   * \param inf_endx Defining whether the arc emanates from the left or right
+   *        boundary
+   * \param asympt_x The x-coordinate of the asymptote
+   * \param inf_endy Arc is approaching the bottom or top boundary at
+   *                 asympt_x
+   * \return The constructed branch
+   */
+  Arc_2 operator()(CGAL::Arr_curve_end inf_endx,
+                   const Coordinate_1& asympt_x,
+                   CGAL::Arr_curve_end inf_endy,
+                   const Curve_analysis_2& c, int arcno) {
+    Arc_2 arc(inf_endx, asympt_x, inf_endy, c, arcno);
+    return arc;
+  }
 
-    //!@}
-    //!\name Constructing vertical arcs
-    //!@{
+  //!@}
+  //!\name Constructing vertical arcs
+  //!@{
 
-    /*!\brief
-     * Constructs a vertical arc with two interior end-points
-     * (vertical segment)
-     *
-     * \param p The first end-point
-     * \param q The second end-point
-     * \param c The supporting curve
-     * \return The constructed arc
-     *
-     * \pre p != q && p.x() == q.x()
-     * \pre c must have a vertical component at this x
-     */
-    Arc_2 operator()(const Point_2& p, const Point_2& q,
-                     const Curve_analysis_2& c) {
-        Arc_2 arc(p,q,c);
-        return arc;
-    }
+  /*! \brief
+   * Constructs a vertical arc with two interior end-points
+   * (vertical segment)
+   *
+   * \param p The first end-point
+   * \param q The second end-point
+   * \param c The supporting curve
+   * \return The constructed arc
+   *
+   * \pre p != q && p.x() == q.x()
+   * \pre c must have a vertical component at this x
+   */
+  Arc_2 operator()(const Point_2& p, const Point_2& q,
+                   const Curve_analysis_2& c) {
+    Arc_2 arc(p,q,c);
+    return arc;
+  }
 
-    /*!\brief
-     * Constructs a vertical arc with one interior end-point and
-     * one that reaches the bottom or top boundary (vertical ray)
-     *
-     * \param origin The interior end-point
-     * \param inf_end Ray emanates from bottom or top boundary
-     * \return The constructed ray
-     *
-     * \pre c must have a vertical line component at this x
-     */
-    Arc_2 operator()(const Point_2& origin, CGAL::Arr_curve_end inf_end,
-                     const Curve_analysis_2& c) {
+  /*! \brief
+   * Constructs a vertical arc with one interior end-point and
+   * one that reaches the bottom or top boundary (vertical ray)
+   *
+   * \param origin The interior end-point
+   * \param inf_end Ray emanates from bottom or top boundary
+   * \return The constructed ray
+   *
+   * \pre c must have a vertical line component at this x
+   */
+  Arc_2 operator()(const Point_2& origin, CGAL::Arr_curve_end inf_end,
+                   const Curve_analysis_2& c) {
+    Arc_2 arc(origin, inf_end, c);
+    return arc;
+  }
 
-        Arc_2 arc(origin, inf_end, c);
-        return arc;
-    }
+  /*! \brief
+   * Constructs a vertical arc that connects bottom with top boundary
+   * (vertical branch)
+   *
+   * \param x The x-coordinate of the branch
+   * \return The constructed branch
+   *
+   * \pre c must have a vertical line component at this x
+   */
+  Arc_2 operator()(const Coordinate_1& x, const Curve_analysis_2& c) {
+    Arc_2 arc(x, c);
+    return arc;
+  }
 
-    /*!\brief
-     * Constructs a vertical arc that connects bottom with top boundary
-     * (vertical branch)
-     *
-     * \param x The x-coordinate of the branch
-     * \return The constructed branch
-     *
-     * \pre c must have a vertical line component at this x
-     */
-    Arc_2 operator()(const Coordinate_1& x, const Curve_analysis_2& c) {
-        Arc_2 arc(x, c);
-        return arc;
-    }
-
-    //!@}
+  //!@}
 };
 
-/*!\brief
+/*! \brief
  * Functor that checks whether a given arc is vertical
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Is_vertical_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Is_vertical_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef bool result_type;
+  //! the result type
+  using result_type = bool;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Is_vertical_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Is_vertical_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Check whether the given x-monotone arc \c cv is a vertical segment.
-     *
-     * \param cv The curve.
-     * \return \c true if the curve is a vertical segment, \c false otherwise.
-     */
-    result_type operator()(const Arc_2& cv) const {
-        return cv.is_vertical();
-    }
+  /*! \brief
+   * Check whether the given x-monotone arc \c cv is a vertical segment.
+   *
+   * \param cv The curve.
+   * \return \c true if the curve is a vertical segment, \c false otherwise.
+   */
+  result_type operator()(const Arc_2& cv) const { return cv.is_vertical(); }
 };
 
-/*!\brief
+/*! \brief
  * Functor constructing minimum point of an arc (if interior)
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Construct_min_vertex_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Construct_min_vertex_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef Point_2 result_type;
+  //! the result type
+  using result_type = Point_2;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Construct_min_vertex_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Construct_min_vertex_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Get the minimum end-point of the arc
-     *
-     * \param cv The arc.
-     * \return The minimum end-point.
-     *
-     * \pre minimum end-point is interior
-     */
-    result_type operator()(const Arc_2& cv) const {
-
-        return cv.curve_end(CGAL::ARR_MIN_END);
-    }
+  /*! \brief
+   * Get the minimum end-point of the arc
+   *
+   * \param cv The arc.
+   * \return The minimum end-point.
+   *
+   * \pre minimum end-point is interior
+   */
+  result_type operator()(const Arc_2& cv) const
+  { return cv.curve_end(CGAL::ARR_MIN_END); }
 };
 
-/*!\brief
+/*! \brief
  * Functor constructing maximum point of an arc (if interior)
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Construct_max_vertex_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Construct_max_vertex_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef Point_2 result_type;
+  //! the result type
+  using result_type = Point_2;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Construct_max_vertex_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Construct_max_vertex_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Get the maximum end-point of the arc.
-     *
-     * \param cv The arc.
-     * \return The maximum end-point.
-     *
-     * \pre maximum end-point is interior
-     */
-    result_type operator()(const Arc_2& cv) const {
-
-        return cv.curve_end(CGAL::ARR_MAX_END);
-    }
+  /*! \brief
+   * Get the maximum end-point of the arc.
+   *
+   * \param cv The arc.
+   * \return The maximum end-point.
+   *
+   * \pre maximum end-point is interior
+   */
+  result_type operator()(const Arc_2& cv) const
+  { return cv.curve_end(CGAL::ARR_MAX_END); }
 };
 
-/*!\brief
+/*! \brief
  * Functor constructing an interior point of on an arc.
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Construct_interior_vertex_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Construct_interior_vertex_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef Point_2 result_type;
+  //! the result type
+  using result_type = Point_2;
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Construct_interior_vertex_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Construct_interior_vertex_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Get an interior point on the arc.
-     *
-     * \param arc The arc.
-     * \return A point on the interior of the arc.
-     */
+  /*! \brief
+   * Get an interior point on the arc.
+   *
+   * \param arc The arc.
+   * \return A point on the interior of the arc.
+   */
   result_type operator()(const Arc_2& arc) const {
     Point_2 p = compute_interior_vertex(arc);
     CGAL_postcondition(this->_ckva()->is_on_2_object()(p,arc));
     return p;
   }
 
+private:
+  result_type compute_interior_vertex(const Arc_2& arc) const {
+    using Curve_analysis_2 = typename Curved_kernel_via_analysis_2::Curve_2;
 
-      private:
+    using Algebraic_curve_kernel_2 = typename Curved_kernel_via_analysis_2::Curve_kernel_2;
+    using Bound = typename Algebraic_curve_kernel_2::Bound;
+    using Coordinate_1 = typename Algebraic_curve_kernel_2::Coordinate_1;
 
-    result_type compute_interior_vertex(const Arc_2& arc) const {
+    using Poly_rat_1 = CGAL::Polynomial<Bound>;
+    using Poly_rat_2 = CGAL::Polynomial<Poly_rat_1>;
 
-      typedef typename Curved_kernel_via_analysis_2::Curve_2 Curve_analysis_2;
+    using PT_rat_1 = CGAL::Polynomial_traits_d<Poly_rat_1>;
+    using PT_rat_2 = CGAL::Polynomial_traits_d<Poly_rat_2>;
 
-      typedef typename Curved_kernel_via_analysis_2::Curve_kernel_2
-                                                      Algebraic_curve_kernel_2;
-      typedef typename Algebraic_curve_kernel_2::Bound Bound;
-      typedef typename Algebraic_curve_kernel_2::Coordinate_1 Coordinate_1;
+    using FT_2 = CGAL::Fraction_traits<Poly_rat_2>;
 
-      typedef CGAL::Polynomial< Bound > Poly_rat_1;
-      typedef CGAL::Polynomial< Poly_rat_1 > Poly_rat_2;
+    if (!arc.is_vertical()) {
+      Bound x_coord = arc.boundary_in_x_range_interior();
+      int arcno = arc.arcno();
+      const Curve_analysis_2& ca = arc.curve();
 
-      typedef CGAL::Polynomial_traits_d< Poly_rat_1 > PT_rat_1;
-      typedef CGAL::Polynomial_traits_d< Poly_rat_2 > PT_rat_2;
-
-      typedef CGAL::Fraction_traits< Poly_rat_2 > FT_2;
-
-      if (!arc.is_vertical())
-      {
-        Bound x_coord = arc.boundary_in_x_range_interior();
-        int arcno = arc.arcno();
-        const Curve_analysis_2& ca = arc.curve();
-
-        Point_2 p = Curved_kernel_via_analysis_2::instance().
-          construct_point_on_arc_2_object()
-          (Coordinate_1(x_coord), ca, arcno, arc);
-        return p;
-      }
-
-      Bound y_coord = 0;
-      if (arc.is_finite(ARR_MIN_END))
-      {
-        if (arc.is_finite(ARR_MAX_END))
-        {
-          // We need torefine the interval because there is a chance that
-          // the low of the upper point is below the high of the lower point.
-          y_coord = Curved_kernel_via_analysis_2::instance().kernel().
-            bound_between_y_2_object() (arc.curve_end(ARR_MIN_END).xy(),
-                                         arc.curve_end(ARR_MAX_END).xy());
-        }
-        else
-        {
-          std::pair<Bound,Bound> approx_pair =
-            Curved_kernel_via_analysis_2::instance().kernel().
-            approximate_relative_y_2_object()
-            (arc.curve_end(ARR_MIN_END).xy(),4);
-          y_coord = approx_pair.second + Bound(1);
-
-        }
-      }
-      else
-      {
-        if (arc.is_finite(ARR_MAX_END))
-        {
-          std::pair<Bound,Bound> approx_pair =
-            Curved_kernel_via_analysis_2::instance().kernel().
-            approximate_relative_y_2_object()
-            (arc.curve_end(ARR_MAX_END).xy(),4);
-          y_coord = approx_pair.first-Bound(1);
-        }
-      }
-
-      /*! \todo Try to remove this polynomial stuff */
-      typename PT_rat_1::Construct_polynomial cp1;
-      Poly_rat_2 poly2 = typename PT_rat_2::Construct_polynomial()
-        (cp1(-y_coord), cp1(Bound(1)));
-
-      typename FT_2::Denominator_type dummy;
-      typename FT_2::Numerator_type curve_poly;
-      typename FT_2::Decompose() (poly2, curve_poly, dummy);
-
-      Curve_analysis_2 curve = Curved_kernel_via_analysis_2::instance().
-        kernel().construct_curve_2_object()(curve_poly);
-      Point_2 p =  Curved_kernel_via_analysis_2::instance().
-        construct_point_on_arc_2_object()(arc.x(), curve, 0, arc);
+      Point_2 p = Curved_kernel_via_analysis_2::instance().
+        construct_point_on_arc_2_object()
+        (Coordinate_1(x_coord), ca, arcno, arc);
       return p;
     }
+
+    Bound y_coord = 0;
+    if (arc.is_finite(ARR_MIN_END)) {
+      if (arc.is_finite(ARR_MAX_END)) {
+        // We need torefine the interval because there is a chance that
+        // the low of the upper point is below the high of the lower point.
+        y_coord = Curved_kernel_via_analysis_2::instance().kernel().
+          bound_between_y_2_object() (arc.curve_end(ARR_MIN_END).xy(),
+                                      arc.curve_end(ARR_MAX_END).xy());
+      }
+      else {
+        std::pair<Bound,Bound> approx_pair =
+          Curved_kernel_via_analysis_2::instance().kernel().
+          approximate_relative_y_2_object()
+          (arc.curve_end(ARR_MIN_END).xy(),4);
+        y_coord = approx_pair.second + Bound(1);
+      }
+    }
+    else {
+      if (arc.is_finite(ARR_MAX_END)) {
+        std::pair<Bound,Bound> approx_pair =
+          Curved_kernel_via_analysis_2::instance().kernel().
+          approximate_relative_y_2_object()
+          (arc.curve_end(ARR_MAX_END).xy(),4);
+        y_coord = approx_pair.first-Bound(1);
+      }
+    }
+
+    /*! \todo Try to remove this polynomial stuff */
+    typename PT_rat_1::Construct_polynomial cp1;
+    Poly_rat_2 poly2 = typename PT_rat_2::Construct_polynomial()
+      (cp1(-y_coord), cp1(Bound(1)));
+
+    typename FT_2::Denominator_type dummy;
+    typename FT_2::Numerator_type curve_poly;
+    typename FT_2::Decompose() (poly2, curve_poly, dummy);
+
+    Curve_analysis_2 curve = Curved_kernel_via_analysis_2::instance().
+      kernel().construct_curve_2_object()(curve_poly);
+    Point_2 p =  Curved_kernel_via_analysis_2::instance().
+      construct_point_on_arc_2_object()(arc.x(), curve, 0, arc);
+    return p;
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functor that compares x-coordinates of two interior points
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Compare_x_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Compare_x_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef CGAL::Comparison_result result_type;
+  //! the result type
+  using result_type = CGAL::Comparison_result;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Compare_x_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Compare_x_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Compare the x-coordinates of two points.
-     *
-     * \param p1 The first point.
-     * \param p2 The second point.
-     * \return CGAL::LARGER if x(p1) > x(p2);
-     *         CGAL::SMALLER if x(p1) \< x(p2);
-     *         CGAL::EQUAL if x(p1) = x(p2).
-     */
-    result_type operator()(const Point_2 &p1, const Point_2 &p2) const {
-        return Curved_kernel_via_analysis_2::instance().
-            kernel().compare_1_object()
-            (p1.x(), p2.x());
-    }
+  /*! \brief
+   * Compare the x-coordinates of two points.
+   *
+   * \param p1 The first point.
+   * \param p2 The second point.
+   * \return CGAL::LARGER if x(p1)> x(p2);
+   *         CGAL::SMALLER if x(p1) \< x(p2);
+   *         CGAL::EQUAL if x(p1) = x(p2).
+   */
+  result_type operator()(const Point_2 &p1, const Point_2 &p2) const {
+    return Curved_kernel_via_analysis_2::instance().
+      kernel().compare_1_object()(p1.x(), p2.x());
+  }
 };
 
-/*!\brief
+/*! \brief
  * Functor that compares coordinates of two interior points lexicographically
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Compare_xy_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Compare_xy_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef CGAL::Comparison_result result_type;
+  //! the result type
+  using result_type = CGAL::Comparison_result;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Compare_xy_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Compare_xy_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
+
+  /*! \brief
+   * Compares two points lexigoraphically: by x, then by y.
+   * \param p1 The first point.
+   * \param p2 The second point.
+   * \return CGAL::LARGER if x(p1)> x(p2),
+   *                      or if x(p1) = x(p2) and y(p1)> y(p2);
+   *         CGAL::SMALLER if x(p1) \< x(p2),
+   *                       or if x(p1) = x(p2) and y(p1) \< y(p2);
+   *         CGAL::EQUAL if the two points are equal.
+   */
+  result_type operator()(const Point_2& p1, const Point_2& p2,
+                         bool equal_x = false) const {
+    // TODO add CGAL_precondition(p1.location() == CGAL::ARR_INTERIOR);
+    // TODO add CGAL_precondition(p2.location() == CGAL::ARR_INTERIOR);
+
+    CERR("\ncompare_xy; p1: " << p1 << ";\n p2:" << p2 << "");
+
+    if (p1.id() == p2.id()) {
+      result_type res = CGAL::EQUAL;
+      CERR("result: " << res << "\n");
+      return res;
     }
 
-    /*!\brief
-     * Compares two points lexigoraphically: by x, then by y.
-     * \param p1 The first point.
-     * \param p2 The second point.
-     * \return CGAL::LARGER if x(p1) > x(p2),
-     *                      or if x(p1) = x(p2) and y(p1) > y(p2);
-     *         CGAL::SMALLER if x(p1) \< x(p2),
-     *                       or if x(p1) = x(p2) and y(p1) \< y(p2);
-     *         CGAL::EQUAL if the two points are equal.
-     */
-    result_type operator()(const Point_2& p1, const Point_2& p2,
-                           bool equal_x = false) const {
-        // TODO add CGAL_precondition(p1.location() == CGAL::ARR_INTERIOR);
-        // TODO add CGAL_precondition(p2.location() == CGAL::ARR_INTERIOR);
+    result_type res =
+      (Curved_kernel_via_analysis_2::instance().
+       kernel().compare_xy_2_object()
+       (p1.xy(), p2.xy(), equal_x));
 
-        CERR("\ncompare_xy; p1: " << p1
-             << ";\n p2:" << p2 << "");
+    CERR("result: " << res << "\n");
 
-        if (p1.id() == p2.id()) {
-            result_type res = CGAL::EQUAL;
-            CERR("result: " << res << "\n");
-            return res;
-        }
-
-        result_type res =
-            (Curved_kernel_via_analysis_2::instance().
-             kernel().compare_xy_2_object()
-             (p1.xy(), p2.xy(), equal_x));
-
-        CERR("result: " << res << "\n");
-
-        return res;
-    }
+    return res;
+  }
 };
 
-/*!\brief
+/*! \brief
  * Functor that computes relative vertical alignment of an interior point and
  * an arc
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Compare_y_at_x_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Compare_y_at_x_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef CGAL::Comparison_result result_type;
+  //! the result type
+  using result_type = CGAL::Comparison_result;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Compare_y_at_x_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Compare_y_at_x_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Return the relative vertical alignment of a point with an arc
-     *
-     * \param p The point
-     * \param cv The arc
-     * \return CGAL::SMALLER if y(p) \< cv(x(p)), i.e.,
-     *                       the point is below the arc;
-     *         CGAL::LARGER if y(p) > cv(x(p)), i.e.,
-     *                      the point is above the arc;
-     *         CGAL::EQUAL if p lies on the arc
-     *
-     * \pre p is in the x-range of cv.
-     *
-     */
-    result_type operator()(const Point_2& p, const Arc_2& cv) const {
+  /*! \brief
+   * Return the relative vertical alignment of a point with an arc
+   *
+   * \param p The point
+   * \param cv The arc
+   * \return CGAL::SMALLER if y(p) \< cv(x(p)), i.e.,
+   *                       the point is below the arc;
+   *         CGAL::LARGER if y(p)> cv(x(p)), i.e.,
+   *                      the point is above the arc;
+   *         CGAL::EQUAL if p lies on the arc
+   *
+   * \pre p is in the x-range of cv.
+   *
+   */
+  result_type operator()(const Point_2& p, const Arc_2& cv) const {
+    CGAL_precondition(p.is_finite());
 
-        CGAL_precondition(p.is_finite());
+    CERR("\ncompare_y_at_x; p: " << p << ";\n cv:" << cv << "\n");
 
-        CERR("\ncompare_y_at_x; p: " << p << ";\n cv:" << cv << "\n");
+    bool eq_min, eq_max;
+    CGAL_assertion_code(bool in_x_range = )
+    cv.is_in_x_range(p.x(), &eq_min, &eq_max);
+    CGAL_assertion(in_x_range);
 
-        bool eq_min, eq_max;
-        CGAL_assertion_code (
-           bool in_x_range =
-        )
-        cv.is_in_x_range(p.x(), &eq_min, &eq_max);
-        CGAL_assertion(in_x_range);
+    // TODO replace with this->compare_xy_2_object()?
+    typename Base::Curve_kernel_2::Compare_xy_2 cmp_xy(Base::_ckva()->kernel().compare_xy_2_object());
 
-        // TODO replace with this->compare_xy_2_object()?
-        typename Base::Curve_kernel_2::Compare_xy_2 cmp_xy(
-            Base::_ckva()->kernel().compare_xy_2_object());
-
-        if (cv.is_vertical()) {
-
-            if (cv.is_finite(CGAL::ARR_MIN_END)) {
-
-                // for vertical arcs we can ask for .xy() member
-                if (cmp_xy(p.xy(), cv._minpoint().xy(), true) ==
-                         CGAL::SMALLER) {
-                    CERR("cmp result: " << CGAL::SMALLER << "\n");
-                    return CGAL::SMALLER;
-                }
-            }
-
-            if (cv.is_finite(CGAL::ARR_MAX_END)) {
-                if (cmp_xy(p.xy(), cv._maxpoint().xy(), true) ==
-                    CGAL::LARGER) {
-                    CERR("cmp result: " << CGAL::LARGER << "\n");
-                    return CGAL::LARGER;
-                }
-            }
-            CERR("cmp result: " << CGAL::EQUAL << "\n");
-            return CGAL::EQUAL; // p lies on a vertical arc
+    if (cv.is_vertical()) {
+      if (cv.is_finite(CGAL::ARR_MIN_END)) {
+        // for vertical arcs we can ask for .xy() member
+        if (cmp_xy(p.xy(), cv._minpoint().xy(), true) ==
+            CGAL::SMALLER) {
+          CERR("cmp result: " << CGAL::SMALLER << "\n");
+          return CGAL::SMALLER;
         }
-        CGAL::Comparison_result res;
-        if (eq_min) {
-          if(cv._minpoint().is_finite()){
-            res = cmp_xy(p.xy(), cv._minpoint().xy(), true);
-          }else{
-            res = (cv.location(CGAL::ARR_MIN_END)==ARR_TOP_BOUNDARY)?
-              CGAL::SMALLER : CGAL::LARGER;
-          }
-        } else if (eq_max) {
-          CGAL_precondition(p.is_finite());
-          if(cv._maxpoint().is_finite()){
-            res = cmp_xy(p.xy(), cv._maxpoint().xy(), true);
-          }else{
-            res = (cv.location(CGAL::ARR_MAX_END)==ARR_TOP_BOUNDARY)?
-              CGAL::SMALLER : CGAL::LARGER;
-          }
-        } else {
-          Point_2 point_on_s =
-            Base::_ckva()->construct_point_on_arc_2_object()
-            (p.x(), cv.curve(), cv.arcno(), cv );
+      }
 
-          CGAL_precondition(p.is_finite());
-          CGAL_precondition(point_on_s.is_finite());
-            res = cmp_xy(p.xy(), point_on_s.xy(), true);
+      if (cv.is_finite(CGAL::ARR_MAX_END)) {
+        if (cmp_xy(p.xy(), cv._maxpoint().xy(), true) == CGAL::LARGER) {
+          CERR("cmp result: " << CGAL::LARGER << "\n");
+          return CGAL::LARGER;
         }
-        CERR("cmp result: " << res << "\n");
-        return res;
+      }
+      CERR("cmp result: " << CGAL::EQUAL << "\n");
+      return CGAL::EQUAL; // p lies on a vertical arc
     }
+    CGAL::Comparison_result res;
+    if (eq_min) {
+      if (cv._minpoint().is_finite()) {
+        res = cmp_xy(p.xy(), cv._minpoint().xy(), true);
+      }
+      else {
+        res = (cv.location(CGAL::ARR_MIN_END)==ARR_TOP_BOUNDARY) ?
+          CGAL::SMALLER : CGAL::LARGER;
+      }
+    }
+    else if (eq_max) {
+      CGAL_precondition(p.is_finite());
+      if (cv._maxpoint().is_finite()) {
+        res = cmp_xy(p.xy(), cv._maxpoint().xy(), true);
+      }
+      else {
+        res = (cv.location(CGAL::ARR_MAX_END)==ARR_TOP_BOUNDARY) ?
+          CGAL::SMALLER : CGAL::LARGER;
+      }
+    }
+    else {
+      Point_2 point_on_s =
+        Base::_ckva()->construct_point_on_arc_2_object()
+        (p.x(), cv.curve(), cv.arcno(), cv);
+
+      CGAL_precondition(p.is_finite());
+      CGAL_precondition(point_on_s.is_finite());
+      res = cmp_xy(p.xy(), point_on_s.xy(), true);
+    }
+    CERR("cmp result: " << res << "\n");
+    return res;
+  }
 };
 
-/*!\brief
+/*! \brief
  * Functor that computes the relative vertical alignment of two arcs left
  * of a point
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Compare_y_at_x_left_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Compare_y_at_x_left_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef CGAL::Comparison_result result_type;
+  //! the result type
+  using result_type = CGAL::Comparison_result;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Compare_y_at_x_left_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Compare_y_at_x_left_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
+
+  /*! \brief
+   * Compares the relative vertical alignment of two arcs
+   * immediately to the left of one of their intersection points.
+   *
+   * If one of the arcs is vertical (emanating downward from p), it is
+   * always considered to be below the other curve.
+   *
+   * \param cv1 The first arc
+   * \param cv2 The second arc
+   * \param p The intersection point.
+   * \return The relative vertical alignment of cv1 with respect to cv2
+   *         immediately to the left of p: CGAL::SMALLER, CGAL::LARGER or
+   CGAL::EQUAL.
+   *
+   * \pre The point p lies on both curves, and both of them must be also be
+   *      defined (lexicographically) to its left.
+   */
+  result_type operator() (const Arc_2& cv1, const Arc_2& cv2,
+                          const Point_2& p) const {
+
+    CERR("\ncompare_y_at_x_left(cv2); cv1: " << cv1 << "; cv2: " <<
+         cv2 << "; p: " << p << "\n");
+
+    // ensure that p lies on both arcs
+    CGAL_precondition(cv1.compare_y_at_x(p) == CGAL::EQUAL);
+    CGAL_precondition(cv2.compare_y_at_x(p) == CGAL::EQUAL);
+
+    // check whether both arcs indeed lie to the left of p
+    CGAL_precondition((cv1.is_vertical() &&
+                       cv1.location(CGAL::ARR_MIN_END) == CGAL::ARR_BOTTOM_BOUNDARY) ||
+                      cv1._same_arc_compare_xy(cv1._minpoint(), p) == CGAL::SMALLER);
+    CGAL_precondition((cv2.is_vertical() &&
+                       cv2.location(CGAL::ARR_MIN_END) == CGAL::ARR_BOTTOM_BOUNDARY) ||
+                      cv2._same_arc_compare_xy(cv2._minpoint(), p) == CGAL::SMALLER);
+    if (cv1.is_vertical()) {
+      // if both are vertical (they overlap), we return EQUAL
+      if (cv2.is_vertical()) return CGAL::EQUAL;
+      // a vertical arc is always smaller than the arc extending to the
+      // left
+      return CGAL::SMALLER;
+    }
+    // a vertical arc is always smaller than the arc extending to the left;
+    // due to the order, we have to return the opposite
+    if (cv2.is_vertical()) return CGAL::LARGER;
+
+    if (cv1.is_singular()) {
+      // singularity in y
+      CGAL_error_msg("Handling singularity in y is not yet implemented");
     }
 
-    /*!\brief
-     * Compares the relative vertical alignment of two arcs
-     * immediately to the left of one of their intersection points.
-     *
-     * If one of the arcs is vertical (emanating downward from p), it is
-     * always considered to be below the other curve.
-     *
-     * \param cv1 The first arc
-     * \param cv2 The second arc
-     * \param p The intersection point.
-     * \return The relative vertical alignment of cv1 with respect to cv2
-     *         immediately to the left of p: CGAL::SMALLER, CGAL::LARGER or
-               CGAL::EQUAL.
-     *
-     * \pre The point p lies on both curves, and both of them must be also be
-     *      defined (lexicographically) to its left.
-     */
-    result_type operator() (const Arc_2& cv1, const Arc_2& cv2,
-                            const Point_2& p) const {
+    // vertical line immediately to the left of p: if p lies on boundary
+    // get the vertical line over the last interval; otherwise
+    // obtain the interval w.r.t. point's x-coordinate (this also valid
+    // for discontinuity in y)
+    /*if(bndp_x == CGAL::BEFORE_SINGULARITY ||
+      bndp_x == CGAL::BEFORE_DISCONTINUITY)
+      return _compare_arc_numbers(cv2, bndp_x);
+      else*/
 
-        CERR("\ncompare_y_at_x_left(cv2); cv1: " << cv1 << "; cv2: " <<
-            cv2 << "; p: " << p << "\n");
-
-        // ensure that p lies on both arcs
-        CGAL_precondition(cv1.compare_y_at_x(p) == CGAL::EQUAL);
-        CGAL_precondition(cv2.compare_y_at_x(p) == CGAL::EQUAL);
-
-        // check whether both arcs indeed lie to the left of p
-        CGAL_precondition(
-                (cv1.is_vertical() &&
-                 cv1.location(CGAL::ARR_MIN_END) ==
-                 CGAL::ARR_BOTTOM_BOUNDARY) ||
-                cv1._same_arc_compare_xy(cv1._minpoint(), p) == CGAL::SMALLER
-        );
-        CGAL_precondition(
-                (cv2.is_vertical() &&
-                 cv2.location(CGAL::ARR_MIN_END) == CGAL::ARR_BOTTOM_BOUNDARY)
-                ||
-                cv2._same_arc_compare_xy(cv2._minpoint(), p) == CGAL::SMALLER
-        );
-        if (cv1.is_vertical()) {
-            // if both are vertical (they overlap), we return EQUAL
-            if(cv2.is_vertical()) {
-                return CGAL::EQUAL;
-            }
-            // a vertical arc is always smaller than the arc extending to the
-            // left
-            return CGAL::SMALLER;
-        }
-        // a vertical arc is always smaller than the arc extending to the left;
-        // due to the order, we have to return the opposite
-        if (cv2.is_vertical()) {
-            return CGAL::LARGER;
-        }
-
-        if (cv1.is_singular()) {// singularity in y
-            CGAL_error_msg("Handling singularity in y is not yet implemented");
-        }
-
-        // vertical line immediately to the left of p: if p lies on boundary
-        // get the vertical line over the last interval; otherwise
-        // obtain the interval w.r.t. point's x-coordinate (this also valid
-        // for discontinuity in y)
-        /*if(bndp_x == CGAL::BEFORE_SINGULARITY ||
-           bndp_x == CGAL::BEFORE_DISCONTINUITY)
-           return _compare_arc_numbers(cv2, bndp_x);
-        else*/
-
-        CGAL::Comparison_result res =
-            cv1._compare_arc_numbers(cv2,
-                                     CGAL::ARR_INTERIOR,
-                                     p.x(), CGAL::NEGATIVE);
-        CERR("result: " << res << "\n");
-        return res;
-    }
+    CGAL::Comparison_result res =
+      cv1._compare_arc_numbers(cv2,
+                               CGAL::ARR_INTERIOR,
+                               p.x(), CGAL::NEGATIVE);
+    CERR("result: " << res << "\n");
+    return res;
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functor that computes the relative vertical alignment of two arcs right
  * of a point
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Compare_y_at_x_right_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Compare_y_at_x_right_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef CGAL::Comparison_result result_type;
+  //! the result type
+  using result_type = CGAL::Comparison_result;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Compare_y_at_x_right_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Compare_y_at_x_right_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
+
+  /*! \brief
+   * Compares the relative vertical alignment of two arcs
+   * immediately to the right of one of their intersection points.
+   *
+   * If one of the arcs is vertical (emanating downward from p), it is
+   * always considered to be below the other curve.
+   *
+   * \param cv1 The first arc
+   * \param cv2 The second arc
+   * \param p The intersection point.
+   * \return The relative vertical alignment of cv1 with respect to cv2
+   *         immediately to the right of p: CGAL::SMALLER, CGAL::LARGER or
+   CGAL::EQUAL.
+   *
+   * \pre The point p lies on both curves, and both of them must be also be
+   *      defined (lexicographically) to its right.
+   */
+  result_type operator()(const Arc_2& cv1, const Arc_2& cv2,
+                         const Point_2& p) const {
+
+    CERR("\ncompare_y_at_x_right; cv1: " << cv1 << "; cv2: " <<
+         cv2 << "; p: " << p << "\n");
+
+    // ensure that p lies on both arcs and doesn't lie on the positive
+    // boundary
+    CGAL_precondition(cv1.compare_y_at_x(p) == CGAL::EQUAL);
+    CGAL_precondition(cv2.compare_y_at_x(p) == CGAL::EQUAL);
+
+    // check whether both arcs indeed lie to the left of p
+    CGAL_precondition((cv1.is_vertical() &&
+                       cv1.location(CGAL::ARR_MAX_END) == CGAL::ARR_TOP_BOUNDARY) ||
+                      cv1._same_arc_compare_xy(p, cv1._maxpoint()) == CGAL::SMALLER);
+    CGAL_precondition((cv2.is_vertical() &&
+                       cv2.location(CGAL::ARR_MAX_END) == CGAL::ARR_TOP_BOUNDARY) ||
+                      cv2._same_arc_compare_xy(p, cv2._maxpoint()) == CGAL::SMALLER);
+
+    if (cv1.is_vertical()) {
+      // if both are vertical (they overlap), we return EQUAL
+      if (cv2.is_vertical()) return CGAL::EQUAL;
+
+      // a vertical arc is always LARGER than arc extending to the
+      // right
+      return CGAL::LARGER;
+    }
+    // a vertical arc is always LARGER than arc extending to the right;
+    // due to the order, we have to return the opposite
+    if (cv2.is_vertical()) return CGAL::SMALLER;
+
+    if (cv1.is_singular()) {// singularity in y
+      CGAL_error_msg("Handling singularity in y is not yet implemented");
     }
 
-    /*!\brief
-     * Compares the relative vertical alignment of two arcs
-     * immediately to the right of one of their intersection points.
-     *
-     * If one of the arcs is vertical (emanating downward from p), it is
-     * always considered to be below the other curve.
-     *
-     * \param cv1 The first arc
-     * \param cv2 The second arc
-     * \param p The intersection point.
-     * \return The relative vertical alignment of cv1 with respect to cv2
-     *         immediately to the right of p: CGAL::SMALLER, CGAL::LARGER or
-               CGAL::EQUAL.
-     *
-     * \pre The point p lies on both curves, and both of them must be also be
-     *      defined (lexicographically) to its right.
-     */
-    result_type operator()(const Arc_2& cv1, const Arc_2& cv2,
-                           const Point_2& p) const {
-
-        CERR("\ncompare_y_at_x_right; cv1: " << cv1 << "; cv2: " <<
-            cv2 << "; p: " << p << "\n");
-
-        // ensure that p lies on both arcs and doesn't lie on the positive
-        // boundary
-        CGAL_precondition(cv1.compare_y_at_x(p) == CGAL::EQUAL);
-        CGAL_precondition(cv2.compare_y_at_x(p) == CGAL::EQUAL);
-
-        // check whether both arcs indeed lie to the left of p
-        CGAL_precondition(
-                (cv1.is_vertical() &&
-                 cv1.location(CGAL::ARR_MAX_END) == CGAL::ARR_TOP_BOUNDARY) ||
-                cv1._same_arc_compare_xy(p, cv1._maxpoint()) == CGAL::SMALLER
-        );
-        CGAL_precondition(
-                (cv2.is_vertical() &&
-                 cv2.location(CGAL::ARR_MAX_END) == CGAL::ARR_TOP_BOUNDARY) ||
-                cv2._same_arc_compare_xy(p, cv2._maxpoint()) == CGAL::SMALLER
-        );
-
-        if (cv1.is_vertical()) {
-            // if both are vertical (they overlap), we return EQUAL
-            if (cv2.is_vertical()) {
-                return CGAL::EQUAL;
-            }
-            // a vertical arc is always LARGER than arc extending to the
-            // right
-            return CGAL::LARGER;
-        }
-        // a vertical arc is always LARGER than arc extending to the right;
-        // due to the order, we have to return the opposite
-        if (cv2.is_vertical()) {
-            return CGAL::SMALLER;
-        }
-
-        if (cv1.is_singular()) {// singularity in y
-            CGAL_error_msg("Handling singularity in y is not yet \
-                implemented");
-        }
-
-        // vertical line immediately to the right of p: if p lies on boundary
-        // get the vertical line over the first interval; otherwise
-        // obtain the interval w.r.t. point's x-coordinate (this also valid
-        // for discontinuity in y)
-        /*if(bndp_x == CGAL::AFTER_SINGULARITY ||
-                bndp_x == CGAL::AFTER_DISCONTINUITY)
-           return _compare_arc_numbers(cv2, bndp_x);
-        else*/
-        CGAL::Comparison_result res =
-            cv1._compare_arc_numbers(cv2,
-                                     CGAL::ARR_INTERIOR,
-                                     p.x(),
-                                     CGAL::POSITIVE);
-        CERR("result: " << res << "\n");
-        return res;
-    }
+    // vertical line immediately to the right of p: if p lies on boundary
+    // get the vertical line over the first interval; otherwise
+    // obtain the interval w.r.t. point's x-coordinate (this also valid
+    // for discontinuity in y)
+    /*if(bndp_x == CGAL::AFTER_SINGULARITY ||
+      bndp_x == CGAL::AFTER_DISCONTINUITY)
+      return _compare_arc_numbers(cv2, bndp_x);
+      else*/
+    CGAL::Comparison_result res =
+      cv1._compare_arc_numbers(cv2,
+                               CGAL::ARR_INTERIOR,
+                               p.x(),
+                               CGAL::POSITIVE);
+    CERR("result: " << res << "\n");
+    return res;
+  }
 };
 
-/*!\brief
+/*! \brief
  * Functor that checks whether a point is in the x-range of an arc
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Is_in_x_range_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Is_in_x_range_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef bool result_type;
+  //! the result type
+  using result_type = bool;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Is_in_x_range_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Is_in_x_range_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Check whether a given point lies within the curve's x-range
-     *
-     * \param cv The arc
-     * \param p the point
-     * \return \c true if p lies in arc's x-range; \c false otherwise.
-     */
-    bool operator()(const Arc_2& cv, const Point_2& p) const {
-        return cv.is_in_x_range(p);
-    }
+  /*! \brief
+   * Check whether a given point lies within the curve's x-range
+   *
+   * \param cv The arc
+   * \param p the point
+   * \return \c true if p lies in arc's x-range; \c false otherwise.
+   */
+  bool operator()(const Arc_2& cv, const Point_2& p) const
+  { return cv.is_in_x_range(p); }
 };
 
-/*!\brief
+/*! \brief
  * Tests two objects, whether they are equal
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Equal_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Equal_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef bool result_type;
+  //! the result type
+  using result_type = bool;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Equal_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Equal_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Check if the two points are the same
-     *
-     * \param p1 The first point.
-     * \param p2 The second point.
-     * \return \c true if the two point are the same; \c false otherwise.
-     */
-    result_type operator()(const Point_2& p1, const Point_2& p2) const {
-        return (Curved_kernel_via_analysis_2::instance().
-                compare_xy_2_object()(p1, p2) ==
-                CGAL::EQUAL);
-    }
+  /*! \brief
+   * Check if the two points are the same
+   *
+   * \param p1 The first point.
+   * \param p2 The second point.
+   * \return \c true if the two point are the same; \c false otherwise.
+   */
+  result_type operator()(const Point_2& p1, const Point_2& p2) const {
+    return (Curved_kernel_via_analysis_2::instance().
+            compare_xy_2_object()(p1, p2) == CGAL::EQUAL);
+  }
 
-    /*!\brief
-     * Check if the two arcs are the same
-     *
-     * \param cv1 The first arc
-     * \param cv2 The second arc
-     * \return \c true if the two curves are the same; \c false otherwise.
-     */
-    result_type operator()(const Arc_2& cv1, const Arc_2& cv2) const {
+  /*! \brief
+   * Check if the two arcs are the same
+   *
+   * \param cv1 The first arc
+   * \param cv2 The second arc
+   * \return \c true if the two curves are the same; \c false otherwise.
+   */
+  result_type operator()(const Arc_2& cv1, const Arc_2& cv2) const {
+    if (cv1.is_identical(cv2)) return true;
 
-        if (cv1.is_identical(cv2)) {
-            return true;
-        }
-        // only one of the arcs is vertical => not equal
-        if (cv1.is_vertical() != cv2.is_vertical()) {
-            return false;
-        }
+    // only one of the arcs is vertical => not equal
+    if (cv1.is_vertical() != cv2.is_vertical()) return false;
 
-        Arc_2::simplify(cv1,cv2);
-        // distinct supporting curves implies inequality, provided the
-        // coprimality condition is satisfied
-        if (!cv1.curve().is_identical(cv2.curve())) {
-            return false;
-        }
+    Arc_2::simplify(cv1,cv2);
+    // distinct supporting curves implies inequality, provided the
+    // coprimality condition is satisfied
+    if (!cv1.curve().is_identical(cv2.curve())) return false;
 
-        // here either both or none of the arcs are vertical, check for arcnos
-        // equality
-        if (!cv1.is_vertical() && cv1.arcno() != cv2.arcno()) {
-            return false;
-        }
-        // otherwise compare respective curve ends: supporting curves and
-        // arcnos are equal => the curve ends belong to the same arc
-        return ((cv1._same_arc_compare_xy(cv1._minpoint(), cv2._minpoint()) ==
-                 CGAL::EQUAL &&
-                 cv1._same_arc_compare_xy(cv1._maxpoint(), cv2._maxpoint()) ==
-                 CGAL::EQUAL));
-    }
+    // here either both or none of the arcs are vertical, check for arcnos
+    // equality
+    if (!cv1.is_vertical() && cv1.arcno() != cv2.arcno()) return false;
 
+    // otherwise compare respective curve ends: supporting curves and
+    // arcnos are equal => the curve ends belong to the same arc
+    return ((cv1._same_arc_compare_xy(cv1._minpoint(), cv2._minpoint()) ==
+             CGAL::EQUAL &&
+             cv1._same_arc_compare_xy(cv1._maxpoint(), cv2._maxpoint()) ==
+             CGAL::EQUAL));
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functor that checks whether two arcs overlap
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Do_overlap_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Do_overlap_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef bool result_type;
+  //! the result type
+  using result_type = bool;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Do_overlap_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Do_overlap_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
+
+  /*! \brief
+   * Check whether two given arcs overlap, i.e., they have infinitely
+   * many intersection points
+   *
+   * \param cv1 The first arc
+   * \param cv2 The second arc
+   * \return \c true if the curves overlap; \c false otherwise
+   */
+  bool operator()(const Arc_2& cv1, const Arc_2& cv2) const {
+    CERR("\ndo_overlap\n");
+    if (cv1.is_identical(cv2)) return true;
+
+    Arc_2::simplify(cv1, cv2);
+    // arcs with coprime support do not overlap
+    if (!cv1.curve().is_identical(cv2.curve())) return false;
+
+    if (cv1.is_vertical() != cv2.is_vertical()) {
+      return false; // only one arc is vertical => can't overlap
     }
-
-    /*!\brief
-     * Check whether two given arcs overlap, i.e., they have infinitely
-     * many intersection points
-     *
-     * \param cv1 The first arc
-     * \param cv2 The second arc
-     * \return \c true if the curves overlap; \c false otherwise
-     */
-    bool operator()(const Arc_2& cv1, const Arc_2& cv2) const {
-
-        CERR("\ndo_overlap\n");
-        if (cv1.is_identical(cv2)) {
-            return true;
-        }
-
-        Arc_2::simplify(cv1, cv2);
-        // arcs with coprime support do not overlap
-        if (!cv1.curve().is_identical(cv2.curve())) {
-            return false;
-        }
-
-        if (cv1.is_vertical() != cv2.is_vertical()) {
-            return false; // only one arc is vertical => can't overlap
-        }
-        if (cv1.is_vertical()) { // both arcs are vertical
-            // check for x-coordinates equality
-            if (Curved_kernel_via_analysis_2::instance().
-                kernel().compare_1_object()(
-                        cv1._minpoint().x(),
-                        cv2._minpoint().x()) != CGAL::EQUAL) {
-                return false;
-            }
-            // compare y-coordinates of min curve ends
-            switch(cv1._same_arc_compare_xy(
-                           cv1._minpoint(), cv2._minpoint(), true)
-            ) {
-            case CGAL::EQUAL: // this->source == cv2->source => overlap !
-                return true;
-            case CGAL::SMALLER: // this->source < cv2->source
-                // check whether this->target > cv2->source
-                return (cv1._same_arc_compare_xy(
-                                cv1._maxpoint(), cv2._minpoint(),
-                                true) == CGAL::LARGER);
-            case CGAL::LARGER: // this->source > cv2->source
-                // check whether this->source < cv2->target
-                return (cv1._same_arc_compare_xy(
-                                cv1._minpoint(), cv2._maxpoint(),
-                                true) == CGAL::SMALLER);
-            }
-        }
-        // processing non-vertical arcs
-        if (cv1.arcno() != cv2.arcno()) {
-            return false;
-        }
-        /* At this point, we have two non-vertical arcs supported by the same
-         * curve with equal arc numbers in their interior. They do overlap if
-         * their x-ranges overlap. Compare only x-coordinates */
-        switch (cv1._same_arc_compare_xy(
-                        cv1._minpoint(), cv2._minpoint(), false, true)
-        ) {
-        case CGAL::EQUAL: // this->source == cv2->source => overlap !
-            return true;
-        case CGAL::SMALLER: // this->source < cv2->source
-            // check whether this->target > cv2->source
-            return (cv1._same_arc_compare_xy(
-                            cv1._maxpoint(), cv2._minpoint(), false,
-                            true) == CGAL::LARGER);
-        case CGAL::LARGER: // this->source > cv2->source
-            // check whether this->source < cv2->target
-            return (cv1._same_arc_compare_xy(
-                            cv1._minpoint(), cv2._maxpoint(), false,
-                            true) == CGAL::SMALLER);
-        }
-        CGAL_error_msg("bogus comparison result");
+    if (cv1.is_vertical()) { // both arcs are vertical
+      // check for x-coordinates equality
+      if (Curved_kernel_via_analysis_2::instance().
+          kernel().compare_1_object()(cv1._minpoint().x(),
+                                      cv2._minpoint().x()) != CGAL::EQUAL) {
         return false;
+      }
+      // compare y-coordinates of min curve ends
+      switch(cv1._same_arc_compare_xy(cv1._minpoint(), cv2._minpoint(), true)) {
+       case CGAL::EQUAL: // this->source == cv2->source => overlap !
+        return true;
+
+       case CGAL::SMALLER: // this->source < cv2->source
+        // check whether this->target > cv2->source
+        return (cv1._same_arc_compare_xy(cv1._maxpoint(), cv2._minpoint(), true) ==
+                CGAL::LARGER);
+
+       case CGAL::LARGER: // this->source> cv2->source
+        // check whether this->source < cv2->target
+        return (cv1._same_arc_compare_xy(cv1._minpoint(), cv2._maxpoint(), true) ==
+                CGAL::SMALLER);
+      }
     }
+    // processing non-vertical arcs
+    if (cv1.arcno() != cv2.arcno()) return false;
+
+    /* At this point, we have two non-vertical arcs supported by the same
+     * curve with equal arc numbers in their interior. They do overlap if
+     * their x-ranges overlap. Compare only x-coordinates */
+    switch (cv1._same_arc_compare_xy(cv1._minpoint(), cv2._minpoint(), false, true)) {
+     case CGAL::EQUAL: // this->source == cv2->source => overlap !
+      return true;
+     case CGAL::SMALLER: // this->source < cv2->source
+      // check whether this->target > cv2->source
+      return (cv1._same_arc_compare_xy(cv1._maxpoint(), cv2._minpoint(), false, true) ==
+              CGAL::LARGER);
+     case CGAL::LARGER: // this->source > cv2->source
+      // check whether this->source < cv2->target
+      return (cv1._same_arc_compare_xy(cv1._minpoint(), cv2._maxpoint(), false, true) ==
+              CGAL::SMALLER);
+    }
+    CGAL_error_msg("bogus comparison result");
+    return false;
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functor that computes the intersections of two arcs
  */
-template < class CurvedKernelViaAnalysis_2 >
+template <typename CurvedKernelViaAnalysis_2>
 class Intersect_2 :
-    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2>
-{
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-      Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    typedef unsigned int                              Multiplicity;
-    typedef std::pair<Point_2, Multiplicity>          Intersection_point;
-    typedef std::variant<Intersection_point, Arc_2> Intersection_result;
+  using Multiplicity = std::size_t;
+  using Intersection_point = std::pair<Point_2, Multiplicity>;
+  using Intersection_result = std::variant<Intersection_point, Arc_2>;
 
-    //! the result type
-    typedef CGAL::cpp98::iterator<std::output_iterator_tag, Intersection_result>
-      result_type;
+  //! the result type
+  using result_type = CGAL::cpp98::iterator<std::output_iterator_tag, Intersection_result>;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Intersect_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Intersect_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
+
+  // TODO add operators for non-x-monotone arcs + curves (i.e., all combis)
+
+  /*! \brief
+   * Find all intersections of the two given arcs and insert them to the
+   * output iterator.
+   *
+   * Type of output iterator is \c CGAL::Object
+   * containing either an \c Arc_2 object (overlap) or a \c
+   * std::pair< Point_2, unsigned int >, where the unsigned int denotes
+   * the multiplicity of the zero-dimensional intersection (0 if unknown)
+   *
+   * \param cv1 The first arc
+   * \param cv2 The second arc
+   * \param oi The output iterator.
+   * \return The past-the-end iterator.
+   */
+  template <typename OutputIterator>
+  OutputIterator operator()(const Arc_2& cv1, const Arc_2& cv2,
+                            OutputIterator oi) const {
+    CERR("\nintersect; cv1: " << cv1 << ";\n cv2:" << cv2 << "");
+
+    // if arcs overlap, just store their common part, otherwise compute
+    // point-wise intersections
+    std::vector<Arc_2> arcs;
+    if (cv1._trim_if_overlapped(cv2, std::back_inserter(arcs))) {
+      for (const auto& item : arcs) *oi++ = item;
+      return oi;
     }
-
-    // TODO add operators for non-x-monotone arcs + curves (i.e., all combis)
-
-    /*!\brief
-     * Find all intersections of the two given arcs and insert them to the
-     * output iterator.
-     *
-     * Type of output iterator is \c CGAL::Object
-     * containing either an \c Arc_2 object (overlap) or a \c
-     * std::pair< Point_2, unsigned int >, where the unsigned int denotes
-     * the multiplicity of the zero-dimensional intersection (0 if unknown)
-     *
-     * \param cv1 The first arc
-     * \param cv2 The second arc
-     * \param oi The output iterator.
-     * \return The past-the-end iterator.
-     */
-    template < class OutputIterator >
-    OutputIterator operator()(const Arc_2& cv1, const Arc_2& cv2,
-                              OutputIterator oi) const {
-        CERR("\nintersect; cv1: " << cv1
-             << ";\n cv2:" << cv2 << "");
-
-        // if arcs overlap, just store their common part, otherwise compute
-        // point-wise intersections
-        std::vector<Arc_2> arcs;
-        if (cv1._trim_if_overlapped(cv2, std::back_inserter(arcs))) {
-            for (const auto& item : arcs) *oi++ = item;
-            return oi;
-        }
-        // process non-ov erlapping case
-        std::vector<Intersection_point> vec;
-        Arc_2::_intersection_points(cv1, cv2, std::back_inserter(vec));
-        for (const auto& item : vec) *oi++ = item;
-        return oi;
-    }
-
+    // process non-ov erlapping case
+    std::vector<Intersection_point> vec;
+    Arc_2::_intersection_points(cv1, cv2, std::back_inserter(vec));
+    for (const auto& item : vec) *oi++ = item;
+    return oi;
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functors that trims an arc
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Trim_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Trim_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef Arc_2 result_type;
+  //! the result type
+  using result_type = Arc_2;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Trim_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Trim_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Returns a trimmed version of an arc
-     *
-     * \param cv The arc
-     * \param p the new first endpoint
-     * \param q the new second endpoint
-     * \return The trimmed arc
-     *
-     * \pre p != q
-     * \pre both points must be interior and must lie on \c cv
-     */
-    Arc_2 operator()(const Arc_2& cv, const Point_2& p, const Point_2& q) {
+  /*! \brief
+   * Returns a trimmed version of an arc
+   *
+   * \param cv The arc
+   * \param p the new first endpoint
+   * \param q the new second endpoint
+   * \return The trimmed arc
+   *
+   * \pre p != q
+   * \pre both points must be interior and must lie on \c cv
+   */
+  Arc_2 operator()(const Arc_2& cv, const Point_2& p, const Point_2& q) {
 
-        CERR("trim\n");
+    CERR("trim\n");
 
-        CGAL_precondition(p.location() == CGAL::ARR_INTERIOR);
-        CGAL_precondition(q.location() == CGAL::ARR_INTERIOR);
+    CGAL_precondition(p.location() == CGAL::ARR_INTERIOR);
+    CGAL_precondition(q.location() == CGAL::ARR_INTERIOR);
 
-        CGAL_precondition(!Base::_ckva()->equal_2_object()(p, q));
-        CGAL_precondition(cv.compare_y_at_x(p) == CGAL::EQUAL);
-        CGAL_precondition(cv.compare_y_at_x(q) == CGAL::EQUAL);
+    CGAL_precondition(!Base::_ckva()->equal_2_object()(p, q));
+    CGAL_precondition(cv.compare_y_at_x(p) == CGAL::EQUAL);
+    CGAL_precondition(cv.compare_y_at_x(q) == CGAL::EQUAL);
 
-        return cv._trim(p, q);
-    }
+    return cv._trim(p, q);
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functor that splits a arc at an interior point
  */
-template < class CurvedKernelViaAnalysis_2 >
+template <typename CurvedKernelViaAnalysis_2>
 class Split_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef void result_type;
+  //! the result type
+  using result_type = void;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Split_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Split_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Split a given arc at a given point into two sub-arcs
-     *
-     * \param cv The arc to split
-     * \param p The split point
-     * \param c1 Output: The left resulting subcurve (p is its right endpoint)
-     * \param c2 Output: The right resulting subcurve (p is its left endpoint)
-     *
-     * \pre p lies on cv but is not one of its end-points.
-     */
-    void operator()(const Arc_2& cv, const Point_2 & p,
-                    Arc_2& c1, Arc_2& c2) const {
+  /*! \brief
+   * Split a given arc at a given point into two sub-arcs
+   *
+   * \param cv The arc to split
+   * \param p The split point
+   * \param c1 Output: The left resulting subcurve (p is its right endpoint)
+   * \param c2 Output: The right resulting subcurve (p is its left endpoint)
+   *
+   * \pre p lies on cv but is not one of its end-points.
+   */
+  void operator()(const Arc_2& cv, const Point_2 & p,
+                  Arc_2& c1, Arc_2& c2) const {
 
-        CGAL_precondition(cv.compare_y_at_x(p) == CGAL::EQUAL);
-        // check that p is not an end-point of the arc
-        CGAL_precondition(cv._same_arc_compare_xy(cv._minpoint(), p) != CGAL::EQUAL);
-        CGAL_precondition(cv._same_arc_compare_xy(cv._maxpoint(), p) != CGAL::EQUAL);
+    CGAL_precondition(cv.compare_y_at_x(p) == CGAL::EQUAL);
+    // check that p is not an end-point of the arc
+    CGAL_precondition(cv._same_arc_compare_xy(cv._minpoint(), p) != CGAL::EQUAL);
+    CGAL_precondition(cv._same_arc_compare_xy(cv._maxpoint(), p) != CGAL::EQUAL);
 
-        CERR("\nsplit\n");
-        c1 = cv._replace_endpoints(
-                cv._minpoint(), p, -1, (cv.is_vertical() ? -1 : cv.arcno())
-        ).first;
-        c2 = cv._replace_endpoints(
-                p, cv._maxpoint(), (cv.is_vertical() ? -1 : cv.arcno()), -1
-        ).first;
-    }
+    CERR("\nsplit\n");
+    c1 = cv._replace_endpoints(cv._minpoint(), p, -1, (cv.is_vertical() ? -1 : cv.arcno())).first;
+    c2 = cv._replace_endpoints(p, cv._maxpoint(), (cv.is_vertical() ? -1 : cv.arcno()), -1).first;
+  }
 };
 
-/*!\brief
+/*! \brief
  * Functor that computes whether two arcs are mergeable
  */
-template < class CurvedKernelViaAnalysis_2 >
+template <typename CurvedKernelViaAnalysis_2>
 class Are_mergeable_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef bool result_type;
+  //! the result type
+  using result_type = bool;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Are_mergeable_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Are_mergeable_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
+
+  /*! \brief
+   * Check whether two given arcs are mergeable
+   *
+   * \param cv1 The first arc
+   * \param cv2 The second arc
+   * \return \c true if the two arcs are mergeable, i.e., they are supported
+   * by the same curve and share a common endpoint; \c false otherwise.
+   */
+  bool operator()(const Arc_2& cv1, const Arc_2& cv2) const {
+
+    CERR("\nare_mergeable\n");
+
+    if (cv1.do_overlap(cv2)) {// if arcs overlap they are not mergeable
+      return false;   // this also call simplify
     }
 
-    /*!\brief
-     * Check whether two given arcs are mergeable
-     *
-     * \param cv1 The first arc
-     * \param cv2 The second arc
-     * \return \c true if the two arcs are mergeable, i.e., they are supported
-     * by the same curve and share a common endpoint; \c false otherwise.
-     */
-    bool operator()(const Arc_2& cv1, const Arc_2& cv2) const {
-
-        CERR("\nare_mergeable\n");
-
-        if (cv1.do_overlap(cv2)) {// if arcs overlap they are not mergeable
-            return false;   // this also call simplify
-        }
-
-        // touch in at most one point now and supporting curves are simplified
-        // both arcs must be either vertical or not
-        if (!cv1.curve().is_identical(cv2.curve()) ||
-            cv1.is_vertical() != cv2.is_vertical()) {
-            return false;
-        }
-        // if both arcs are non-vertical => they must have equal arcnos
-        // to be mergeable
-        if (!cv1.is_vertical() && cv1.arcno() != cv2.arcno()) {
-            return false;
-        }
-        // for non-vertical arcs arc numbers are equal => can use same_arc_cmp
-        bool max_min =
-            (cv1._same_arc_compare_xy(cv1._maxpoint(), cv2._minpoint()) ==
-             CGAL::EQUAL),
-            min_max = false;
-        if (!max_min) { // both cases cannot happen simultaneously
-            min_max =
-                (cv1._same_arc_compare_xy(cv1._minpoint(), cv2._maxpoint()) ==
-                 CGAL::EQUAL);
-            if (!min_max) { // arcs have no common end-point => not mergeable
-                return false;
-            }
-        }
-        // check that the common point is not an event point
-        if (cv1.is_vertical()) { // both arcs are vertical
-            Point_2 common = (max_min ? cv1._maxpoint() : cv1._minpoint());
-            // a common end must be a finite point
-            CGAL_precondition(cv1.is_interior(common.location()));
-            // check that there are no other non-vertical branches coming
-            // through this point
-
-            Curve_analysis_2 ca_2(cv1.curve());
-            typename Curve_analysis_2::Status_line_1 cv_line =
-                ca_2.status_line_for_x(common.x());
-            CGAL_assertion(cv_line.is_event()); // ??
-
-            // we are not allowed to use number_of_incident_branches()
-            // since the common point might be supported by different curve,
-            // and therefore its arcno might be not valid for *this arc
-            for (int k = 0; k < cv_line.number_of_events(); k++) {
-                // use a temporary object for comparison predicate
-                typename Point_2::Coordinate_2 tmp(common.x(), cv1.curve(), k);
-                if (Curved_kernel_via_analysis_2::instance().
-                    kernel().compare_xy_2_object()(
-                            common.xy(), tmp) ==
-                    CGAL::EQUAL) {
-                    return false;
-                }
-            }
-        } else if (cv1.interval_id() != cv2.interval_id()) {
-            return false; // non-vertical case
-        }
-
-        return true;
+    // touch in at most one point now and supporting curves are simplified
+    // both arcs must be either vertical or not
+    if (!cv1.curve().is_identical(cv2.curve()) ||
+        cv1.is_vertical() != cv2.is_vertical()) {
+      return false;
     }
+    // if both arcs are non-vertical => they must have equal arcnos
+    // to be mergeable
+    if (! cv1.is_vertical() && cv1.arcno() != cv2.arcno()) return false;
+
+    // for non-vertical arcs arc numbers are equal => can use same_arc_cmp
+    bool max_min =
+      (cv1._same_arc_compare_xy(cv1._maxpoint(), cv2._minpoint()) ==
+       CGAL::EQUAL),
+      min_max = false;
+    if (! max_min) { // both cases cannot happen simultaneously
+      min_max =
+        (cv1._same_arc_compare_xy(cv1._minpoint(), cv2._maxpoint()) ==
+         CGAL::EQUAL);
+      if (!min_max) { // arcs have no common end-point => not mergeable
+        return false;
+      }
+    }
+    // check that the common point is not an event point
+    if (cv1.is_vertical()) { // both arcs are vertical
+      Point_2 common = (max_min ? cv1._maxpoint() : cv1._minpoint());
+      // a common end must be a finite point
+      CGAL_precondition(cv1.is_interior(common.location()));
+      // check that there are no other non-vertical branches coming
+      // through this point
+
+      Curve_analysis_2 ca_2(cv1.curve());
+      typename Curve_analysis_2::Status_line_1 cv_line =
+        ca_2.status_line_for_x(common.x());
+      CGAL_assertion(cv_line.is_event()); // ??
+
+      // we are not allowed to use number_of_incident_branches()
+      // since the common point might be supported by different curve,
+      // and therefore its arcno might be not valid for *this arc
+      for (int k = 0; k < cv_line.number_of_events(); k++) {
+        // use a temporary object for comparison predicate
+        typename Point_2::Coordinate_2 tmp(common.x(), cv1.curve(), k);
+        if (Curved_kernel_via_analysis_2::instance().
+            kernel().compare_xy_2_object()(common.xy(), tmp) ==
+            CGAL::EQUAL) {
+          return false;
+        }
+      }
+    }
+    else if (cv1.interval_id() != cv2.interval_id()) {
+      return false; // non-vertical case
+    }
+
+    return true;
+  }
 };
 
-/*!\brief
+/*! \brief
  * Functor that merges two arcs
  */
-template < class CurvedKernelViaAnalysis_2 >
+template <typename CurvedKernelViaAnalysis_2>
 class Merge_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef void result_type;
+  //! the result type
+  using result_type = void;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Merge_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Merge_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
+
+  /*! \brief
+   * Merges two given arcs into a single one
+   *
+   * \param cv1 The first arc
+   * \param cv2 The second arc
+   * \param c Output: The resulting arc
+   *
+   * \pre The two arcs are mergeable, that is they are supported by the
+   *      same curve and share a common endpoint.
+   */
+  void operator()(const Arc_2& cv1, const Arc_2& cv2, Arc_2& c) const {
+
+    CERR("merge\n");
+    CGAL_precondition(cv1.are_mergeable(cv2));
+    Arc_2::simplify(cv1, cv2);
+
+    Point_2 src, tgt;
+    int arcno_s = -1, arcno_t = -1;
+    bool replace_src; // true if cv2 < *this otherwise *this arc < cv2 arc
+    // arcs are mergeable => they have one common finite end-point
+    replace_src =
+      (cv1._same_arc_compare_xy(cv1._minpoint(), cv2._maxpoint()) ==
+       CGAL::EQUAL);
+    src = (replace_src ? cv2._minpoint() : cv1._minpoint());
+    tgt = (replace_src ? cv1._maxpoint() : cv2._maxpoint());
+
+    if (!cv1.is_vertical()) {
+      arcno_s = (replace_src ? cv2.arcno(CGAL::ARR_MIN_END) :
+                 cv1.arcno(CGAL::ARR_MIN_END));
+      arcno_t = (replace_src ? cv1.arcno(CGAL::ARR_MAX_END) :
+                 cv2.arcno(CGAL::ARR_MAX_END));
     }
+    Arc_2 arc = cv1._replace_endpoints(src, tgt, arcno_s, arcno_t).first;
+    // arc.set_boundaries_after_merge(*this, s); - no need to, since
+    // boundaries are stored in Point_2 type and will be copied implicitly
 
-    /*!\brief
-     * Merges two given arcs into a single one
-     *
-     * \param cv1 The first arc
-     * \param cv2 The second arc
-     * \param c Output: The resulting arc
-     *
-     * \pre The two arcs are mergeable, that is they are supported by the
-     *      same curve and share a common endpoint.
-     */
-    void operator()(const Arc_2& cv1, const Arc_2& cv2, Arc_2& c) const {
-
-        CERR("merge\n");
-        CGAL_precondition(cv1.are_mergeable(cv2));
-        Arc_2::simplify(cv1, cv2);
-
-        Point_2 src, tgt;
-        int arcno_s = -1, arcno_t = -1;
-        bool replace_src; // true if cv2 < *this otherwise *this arc < cv2 arc
-        // arcs are mergeable => they have one common finite end-point
-        replace_src =
-            (cv1._same_arc_compare_xy(cv1._minpoint(), cv2._maxpoint()) ==
-             CGAL::EQUAL);
-        src = (replace_src ? cv2._minpoint() : cv1._minpoint());
-        tgt = (replace_src ? cv1._maxpoint() : cv2._maxpoint());
-
-        if (!cv1.is_vertical()) {
-            arcno_s = (replace_src ? cv2.arcno(CGAL::ARR_MIN_END) :
-                       cv1.arcno(CGAL::ARR_MIN_END));
-            arcno_t = (replace_src ? cv1.arcno(CGAL::ARR_MAX_END) :
-                       cv2.arcno(CGAL::ARR_MAX_END));
-        }
-        Arc_2 arc = cv1._replace_endpoints(src, tgt, arcno_s, arcno_t).first;
-        // arc.set_boundaries_after_merge(*this, s); - no need to, since
-        // boundaries are stored in Point_2 type and will be copied implicitly
-
-        c = arc;
-    }
+    c = arc;
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functor that computes whether a point lies on a supporting curve
  */
-template < class CurvedKernelViaAnalysis_2 >
+template <typename CurvedKernelViaAnalysis_2>
 class Is_on_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef bool result_type;
+  //! the result type
+  using result_type = bool;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Is_on_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Is_on_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Checks whether \c p lies on \c c
-     *
-     * \param p The point to test
-     * \param c The curve
-     * \return \c true if the \c p lies on \c c, \c false otherwise
-     */
-    result_type operator()(const Point_2& p, const Curve_analysis_2& c) const {
-        result_type res =
-            (Curved_kernel_via_analysis_2::instance().
-             kernel().sign_at_2_object()(c, p.xy())
-             == CGAL::ZERO);
-        return res;
-    }
+  /*! \brief
+   * Checks whether \c p lies on \c c
+   *
+   * \param p The point to test
+   * \param c The curve
+   * \return \c true if the \c p lies on \c c, \c false otherwise
+   */
+  result_type operator()(const Point_2& p, const Curve_analysis_2& c) const {
+    result_type res =
+      (Curved_kernel_via_analysis_2::instance().
+       kernel().sign_at_2_object()(c, p.xy())
+       == CGAL::ZERO);
+    return res;
+  }
 
-    /*!\brief
-     * Checks whether \c p lies on \c cv
-     *
-     * \param p The point to test
-     * \param c The curve arc
-     * \return \c true if the \c p lies on \c cv, \c false otherwise
-     */
-    result_type operator()(const Point_2& p, const Arc_2& cv) const {
-      // fix by Michael Hemmer:
-      if(cv.is_in_x_range(p.x())){
-        return cv.compare_y_at_x(p) == CGAL::EQUAL;
-      }
-      return false;
+  /*! \brief
+   * Checks whether \c p lies on \c cv
+   *
+   * \param p The point to test
+   * \param c The curve arc
+   * \return \c true if the \c p lies on \c cv, \c false otherwise
+   */
+  result_type operator()(const Point_2& p, const Arc_2& cv) const {
+    // fix by Michael Hemmer:
+    if (cv.is_in_x_range(p.x())) return cv.compare_y_at_x(p) == CGAL::EQUAL;
+    return false;
 
-      // This is the old code that seems to interpret the arc as open
-      // In particular, it returns false for vertical arcs.
-      // (Michael Hemmer)
-//       bool is_left, is_right;
-//       result_type res =
-//         (cv.is_in_x_range(p.x(),&is_left,&is_right)) &&
-//         !(is_left) &&
-//         !(is_right) &&
-//         (cv.compare_y_at_x(p) == CGAL::EQUAL);
-//       return res;
-    }
-
+    // This is the old code that seems to interpret the arc as open
+    // In particular, it returns false for vertical arcs.
+    // (Michael Hemmer)
+    //       bool is_left, is_right;
+    //       result_type res =
+    //         (cv.is_in_x_range(p.x(),&is_left,&is_right)) &&
+    //         !(is_left) &&
+    //         !(is_right) &&
+    //         (cv.compare_y_at_x(p) == CGAL::EQUAL);
+    //       return res;
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functor that decomposes curve into x-monotone arcs and isolated points
  */
 template <class CurvedKernelViaAnalysis_2>
 class Make_x_monotone_2 : public
 Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
-
 public:
   //! this instance' first template parameter
-  typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
   //! the base type
-  typedef
-  Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2>
-    Base;
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
   CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
   //! the result type
-  typedef CGAL::cpp98::iterator< std::output_iterator_tag, CGAL::Object>
-    result_type;
+  using result_type = CGAL::cpp98::iterator<std::output_iterator_tag, CGAL::Object>;
 
   //! the arity of the functor
 
-  /*!\brief
+  /*! \brief
    * Standard constructor
    *
    * \param kernel The kernel
    */
-  Make_x_monotone_2(Curved_kernel_via_analysis_2* kernel) :
-    Base(kernel)
-  {}
+  Make_x_monotone_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-  /*!\brief
+  /*! \brief
    * Decomposes a given arc into list of x-monotone arcs
    * (subcurves) and insert them to the output iterator. Since \c Arc_2
    * is by definition x-monotone, an input arc is passed to the
@@ -1903,17 +1693,16 @@ public:
    * The returned objects are all wrappers Arc_2 objects
    * \return The past-the-end iterator
    */
-  template <class OutputIterator>
-  OutputIterator operator()(const Arc_2& cv, OutputIterator oi) const
-  {
-    typedef typename Curved_kernel_via_analysis_2::Point_2      Point_2;
-    typedef typename Curved_kernel_via_analysis_2::Arc_2        Arc_2;
-    typedef std::variant<Point_2, Arc_2>      Make_x_monotone_result;
+  template <typename OutputIterator>
+  OutputIterator operator()(const Arc_2& cv, OutputIterator oi) const {
+    using Point_2 = typename Curved_kernel_via_analysis_2::Point_2;
+    using Arc_2 = typename Curved_kernel_via_analysis_2::Arc_2;
+    using Make_x_monotone_result = std::variant<Point_2, Arc_2>;
     *oi++ = Make_x_monotone_result(cv);
     return oi;
   }
 
-  /*!\brief
+  /*! \brief
    * Decomposes a given curve into list of x-monotone arcs
    * (subcurves) and isolated points and insert them to the output iterator.
    *
@@ -1922,17 +1711,15 @@ public:
    * The returned objects either wrapper Arc_2 or Point_2 objects
    * \return The past-the-end iterator
    */
-  template <class OutputIterator>
-  OutputIterator operator()(const Curve_analysis_2& cv, OutputIterator oi)
-    const
-  {
-    CGAL::internal::Make_x_monotone_2< Curved_kernel_via_analysis_2 >
+  template <typename OutputIterator>
+  OutputIterator operator()(const Curve_analysis_2& cv, OutputIterator oi) const {
+    CGAL::internal::Make_x_monotone_2<Curved_kernel_via_analysis_2>
       make_x_monotone(Base::_ckva());
 
     return make_x_monotone(cv, oi);
   }
 
-  /*!\brief
+  /*! \brief
    * Splits an input object \c obj into x-monotone arcs and isolated points
    *
    * \param obj the polymorph input object: can represent \c Point_2,
@@ -1941,15 +1728,12 @@ public:
    *           encapsulates \c Point_2 or \c Arc_2
    * \return Past-the-end iterator of \c oi
    */
-  template <class OutputIterator>
-  OutputIterator operator()(CGAL::Object obj, OutputIterator oi)
-  {
-    typedef typename Curved_kernel_via_analysis_2::Point_2      Point_2;
-    typedef typename Curved_kernel_via_analysis_2::Arc_2        Arc_2;
-    typedef typename Curved_kernel_via_analysis_2::Non_x_monotone_arc_2
-      Non_x_monotone_arc_2;
-    typedef std::variant<Point_2, Arc_2>
-      Make_x_monotone_result;
+  template <typename OutputIterator>
+  OutputIterator operator()(CGAL::Object obj, OutputIterator oi) {
+    using Point_2 = typename Curved_kernel_via_analysis_2::Point_2;
+    using Arc_2 = typename Curved_kernel_via_analysis_2::Arc_2;
+    using Non_x_monotone_arc_2 = typename Curved_kernel_via_analysis_2::Non_x_monotone_arc_2;
+    using Make_x_monotone_result = std::variant<Point_2, Arc_2>;
 
     Curve_analysis_2 curve;
     Point_2 p;
@@ -1968,780 +1752,690 @@ public:
   }
 };
 
-
 // left-right
 
-/*!\brief
+/*! \brief
  * Functor computing parameter space in x for arc
  */
-template < class CurvedKernelViaAnalysis_2 >
+template <typename CurvedKernelViaAnalysis_2>
 class Parameter_space_in_x_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef CGAL::Arr_parameter_space result_type;
+  //! the result type
+  using result_type = CGAL::Arr_parameter_space;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Parameter_space_in_x_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Parameter_space_in_x_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*! Obtains the parameter space in x at the end of an arc.
-     *
-     * \param cv The arc
-     * \param ce the arc end indicator:
-     *     ARR_MIN_END - the minimal end of cv
-     *     ARR_MAX_END - the maximal end of cv
-     * \return the parameter space at the \c ce end of \c cv
-     *   ARR_LEFT_BOUNDARY  - the arc approaches the left boundary of the
-     *                        parameter space
-     *   ARR_INTERIOR       - the arc does not approach a boundary of the
-     *                        parameter space
-     *   ARR_RIGHT_BOUNDARY - the arc approaches the right boundary of the
-     *                        parameter space
-     */
-    result_type operator()(const Arc_2& cv, CGAL::Arr_curve_end ce) const {
+  /*! Obtains the parameter space in x at the end of an arc.
+   *
+   * \param cv The arc
+   * \param ce the arc end indicator:
+   *     ARR_MIN_END - the minimal end of cv
+   *     ARR_MAX_END - the maximal end of cv
+   * \return the parameter space at the \c ce end of \c cv
+   *   ARR_LEFT_BOUNDARY  - the arc approaches the left boundary of the
+   *                        parameter space
+   *   ARR_INTERIOR       - the arc does not approach a boundary of the
+   *                        parameter space
+   *   ARR_RIGHT_BOUNDARY - the arc approaches the right boundary of the
+   *                        parameter space
+   */
+  result_type operator()(const Arc_2& cv, CGAL::Arr_curve_end ce) const {
 
-        CGAL::Arr_parameter_space loc = cv.location(ce);
-        if(loc == CGAL::ARR_LEFT_BOUNDARY || loc == CGAL::ARR_RIGHT_BOUNDARY)
-            return loc;
-        return CGAL::ARR_INTERIOR;
-    }
+    CGAL::Arr_parameter_space loc = cv.location(ce);
+    if (loc == CGAL::ARR_LEFT_BOUNDARY || loc == CGAL::ARR_RIGHT_BOUNDARY) return loc;
+    return CGAL::ARR_INTERIOR;
+  }
 
-    result_type operator()(const Point_2& pt) const {
-      return pt.location();
-    }
-
+  result_type operator()(const Point_2& pt) const { return pt.location(); }
 };
 
-/*!\brief
+/*! \brief
  * Functor that compares ends of arcs near left or right boundary
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Compare_y_near_boundary_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Compare_y_near_boundary_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef CGAL::Comparison_result result_type;
+  //! the result type
+  using result_type = CGAL::Comparison_result;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Compare_y_near_boundary_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Compare_y_near_boundary_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
+
+  /*! \brief
+   * Compare the y-coordinates of 2 arcs at their ends near the left
+   * or right boundary of the parameter space
+   *
+   * \param cv1 the first arc.
+   * \param cv2 the second arc.
+   * \param ce the arc end indicator.
+   * \return CGAL::SMALLER is y(cv1,ce) < y(cv2,ce2) near left/right boundary
+   *         CGAL::EQUAL is y(cv1,ce) = y(cv2,ce2) near left/right boundary,
+   *         i.e., they overlap
+   * \return CGAL::LARGER is y(cv1,ce) > y(cv2,ce2) near left/right boundary
+   *
+   * \pre the ce ends of the arcs cv1 and cv2 lie either on the left
+   * boundary or on the right boundary of the parameter space.
+   */
+  result_type operator()(const Arc_2& cv1, const Arc_2& cv2,
+                         CGAL::Arr_curve_end ce) const {
+
+    CERR("\ncompare_y_near_boundary; cv1: " << cv1 << "; cv2: " <<
+         cv2 << "; end: " << ce << "\n");
+
+
+    CGAL::Comparison_result res = CGAL::EQUAL;
+
+    CGAL::Arr_parameter_space loc1 = cv1.location(ce);
+    CGAL_precondition(cv1.is_on_left_right(loc1));
+    CGAL_precondition(loc1 == cv2.location(ce));
+    // comparing ids is the same as calling is_identical() ??
+    if (cv1.id() == cv2.id()) {
+      CERR("result: " << res << "\n"); // EQUAL
+      return res;
     }
 
-    /*!\brief
-     * Compare the y-coordinates of 2 arcs at their ends near the left
-     * or right boundary of the parameter space
-     *
-     * \param cv1 the first arc.
-     * \param cv2 the second arc.
-     * \param ce the arc end indicator.
-     * \return CGAL::SMALLER is y(cv1,ce) < y(cv2,ce2) near left/right boundary
-     *         CGAL::EQUAL is y(cv1,ce) = y(cv2,ce2) near left/right boundary,
-     *         i.e., they overlap
-     * \return CGAL::LARGER is y(cv1,ce) > y(cv2,ce2) near left/right boundary
-     *
-     * \pre the ce ends of the arcs cv1 and cv2 lie either on the left
-     * boundary or on the right boundary of the parameter space.
-     */
-    result_type operator()(const Arc_2& cv1, const Arc_2& cv2,
-                           CGAL::Arr_curve_end ce) const {
+    // both points lie on the left-right-identification, i.e., equalx
+    // TODO this interface is NOT official
+    CGAL::Object obj1 = cv1.curve().asymptotic_value_of_arc(loc1, cv1.arcno());
+    CGAL::Object obj2 = cv2.curve().asymptotic_value_of_arc(loc1, cv2.arcno());
 
-      CERR("\ncompare_y_near_boundary; cv1: " << cv1 << "; cv2: " <<
-           cv2 << "; end: " << ce << "\n");
+    typename Point_2::Curved_kernel_via_analysis_2::Curve_kernel_2::
+      Algebraic_real_1 y1, y2;
+    CGAL::Arr_parameter_space ps1, ps2;
 
-
-      CGAL::Comparison_result res = CGAL::EQUAL;
-
-      CGAL::Arr_parameter_space loc1 = cv1.location(ce);
-      CGAL_precondition(cv1.is_on_left_right(loc1));
-      CGAL_precondition(loc1 == cv2.location(ce));
-      // comparing ids is the same as calling is_identical() ??
-      if (cv1.id() == cv2.id()) {
-        CERR("result: " << res << "\n"); // EQUAL
-        return res;
+    if (CGAL::assign(ps1, obj1)) {
+      if (CGAL::assign(ps2, obj2)) {
+        res = CGAL::EQUAL;
       }
-
-      // both points lie on the left-right-identification, i.e., equalx
-      // TODO this interface is NOT official
-      CGAL::Object obj1 =
-        cv1.curve().asymptotic_value_of_arc(loc1, cv1.arcno());
-      CGAL::Object obj2 =
-        cv2.curve().asymptotic_value_of_arc(loc1, cv2.arcno());
-
-      typename Point_2::Curved_kernel_via_analysis_2::Curve_kernel_2::
-        Algebraic_real_1 y1, y2;
-      CGAL::Arr_parameter_space ps1, ps2;
-
-      if (CGAL::assign(ps1, obj1)) {
-        if (CGAL::assign(ps2, obj2)) {
-          res = CGAL::EQUAL;
-        } else {
-          CGAL_assertion(CGAL::assign(y2, obj2));
-          res = (ps1 == CGAL::ARR_BOTTOM_BOUNDARY ?
-                 CGAL::SMALLER : CGAL::LARGER);
-        }
-      } else {
+      else {
+        CGAL_assertion(CGAL::assign(y2, obj2));
+        res = (ps1 == CGAL::ARR_BOTTOM_BOUNDARY ?
+               CGAL::SMALLER : CGAL::LARGER);
+      }
+    }
+    else {
+      CGAL_assertion_code(bool check = )
+        CGAL::assign(y1, obj1);
+      CGAL_assertion(check);
+      if (CGAL::assign(ps2, obj2)) {
+        res = (ps2 == CGAL::ARR_TOP_BOUNDARY ? CGAL::SMALLER : CGAL::LARGER);
+      }
+      else {
         CGAL_assertion_code(bool check = )
-          CGAL::assign(y1, obj1);
+          CGAL::assign(y2, obj2);
         CGAL_assertion(check);
-        if (CGAL::assign(ps2, obj2)) {
-          res = (ps2 == CGAL::ARR_TOP_BOUNDARY ?
-                 CGAL::SMALLER : CGAL::LARGER);
-        } else {
-          CGAL_assertion_code(bool check = )
-            CGAL::assign(y2, obj2);
-          CGAL_assertion(check);
 
-          // Remark: Is filtered
-          res = Base::_ckva()->kernel().compare_1_object()(y1, y2);
-        }
+        // Remark: Is filtered
+        res = Base::_ckva()->kernel().compare_1_object()(y1, y2);
       }
+    }
 
-      if (res != EQUAL) {
-        CERR("result: " << res << "\n");
-        return res;
-      }
-
-      CGAL_precondition(cv1.is_on_left_right(loc1));
-      CGAL_precondition(loc1 == cv2.location(ce));
-      // comparing ids is the same as calling is_identical() ??
-      if (cv1.id() == cv2.id()) {
-        CGAL::Comparison_result res = CGAL::EQUAL;
-        CERR("result: " << res << "\n");
-        return res;
-      }
-
-      // in this setting same handling as for +/-oo ?
-      res = cv1._compare_arc_numbers(cv2, loc1);
+    if (res != EQUAL) {
       CERR("result: " << res << "\n");
       return res;
     }
+
+    CGAL_precondition(cv1.is_on_left_right(loc1));
+    CGAL_precondition(loc1 == cv2.location(ce));
+    // comparing ids is the same as calling is_identical() ??
+    if (cv1.id() == cv2.id()) {
+      CGAL::Comparison_result res = CGAL::EQUAL;
+      CERR("result: " << res << "\n");
+      return res;
+    }
+
+    // in this setting same handling as for +/-oo ?
+    res = cv1._compare_arc_numbers(cv2, loc1);
+    CERR("result: " << res << "\n");
+    return res;
+  }
 };
 
 // bottom-top
 
-template < class CurvedKernelViaAnalysis_2 >
-class Parameter_space_in_y_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Parameter_space_in_y_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef CGAL::Arr_parameter_space result_type;
+  //! the result type
+  using result_type = CGAL::Arr_parameter_space;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Parameter_space_in_y_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Parameter_space_in_y_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*! Obtains the parameter space in y at the end of an arc.
-     *
-     * \param cv The arc
-     * \param ce the arc end indicator:
-     *     ARR_MIN_END - the minimal end of cv
-     *     ARR_MAX_END - the maximal end of cv
-     * \return the parameter space at the \c ce end of \c cv
-     *   ARR_BOTTOM_BOUNDARY- the arc approaches the bottom boundary of the
-     *                        parameter space
-     *   ARR_INTERIOR       - the arc does not approach a boundary of the
-     *                        parameter space
-     *   ARR_TOP_BOUNDARY   - the arc approaches the top boundary of the
-     *                        parameter space
-     */
-    result_type operator()(const Arc_2& cv, CGAL::Arr_curve_end ce) const {
+  /*! Obtains the parameter space in y at the end of an arc.
+   *
+   * \param cv The arc
+   * \param ce the arc end indicator:
+   *     ARR_MIN_END - the minimal end of cv
+   *     ARR_MAX_END - the maximal end of cv
+   * \return the parameter space at the \c ce end of \c cv
+   *   ARR_BOTTOM_BOUNDARY- the arc approaches the bottom boundary of the
+   *                        parameter space
+   *   ARR_INTERIOR       - the arc does not approach a boundary of the
+   *                        parameter space
+   *   ARR_TOP_BOUNDARY   - the arc approaches the top boundary of the
+   *                        parameter space
+   */
+  result_type operator()(const Arc_2& cv, CGAL::Arr_curve_end ce) const {
 
-        CGAL::Arr_parameter_space loc = cv.location(ce);
-        if(loc == CGAL::ARR_BOTTOM_BOUNDARY || loc == CGAL::ARR_TOP_BOUNDARY)
-            return loc;
-        return CGAL::ARR_INTERIOR;
-    }
+    CGAL::Arr_parameter_space loc = cv.location(ce);
+    if (loc == CGAL::ARR_BOTTOM_BOUNDARY || loc == CGAL::ARR_TOP_BOUNDARY)
+      return loc;
+    return CGAL::ARR_INTERIOR;
+  }
 
-    result_type operator()(const Point_2& pt) const {
-      return pt.location();
-    }
-
+  result_type operator()(const Point_2& pt) const { return pt.location(); }
 };
 
 
-/*!\brief
+/*! \brief
  * Functor that compares x-limits at the top or bottom boundary
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Compare_x_on_boundary_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Compare_x_on_boundary_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef CGAL::Comparison_result result_type;
+  //! the result type
+  using result_type = CGAL::Comparison_result;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    Compare_x_on_boundary_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
+  Compare_x_on_boundary_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
+
+  /*! \brief Compare the x-limit of a vertical with the x-limit of
+   * an arc end near the boundary at bottom or top boundary
+   *
+   * \param p the point direction.
+   * \param cv the arc, the endpoint of which is compared.
+   * \param ce the arc-end indicator -
+   *            ARR_MIN_END - the minimal end of cv or
+   *            ARR_MAX_END - the maximal end of cv.
+   * \return the comparison result:
+   *         SMALLER - x(p) \< x(cv, ce);
+   *         EQUAL   - x(p) = x(cv, ce);
+   *         LARGER  - x(p) > x(cv, ce).
+   *
+   * \pre p lies in the interior of the parameter space.
+   * \pre the ce end of the line cv lies on a boundary.
+   */
+  result_type operator()(const Point_2& p, const Arc_2& cv,
+                         CGAL::Arr_curve_end ce) const {
+
+    CERR("\ncompare_x_on_boundary: p: " << p << "\n cv: " <<
+         cv << "; curve_end: " << ce << "\n");
+
+    // this curve end has boundary only in y
+    CGAL_precondition(cv.is_on_bottom_top(cv.location(ce)));
+    if (cv.is_singular()) // the curve end goes to contraction => x-order
+      return CGAL::EQUAL; // doesn't matter
+
+    CGAL::Comparison_result res =
+      Curved_kernel_via_analysis_2::instance().
+      kernel().compare_1_object()(p.x(), cv.curve_end_x(ce));
+    CERR("result: " << res << "\n");
+    return res;
+  }
+
+  /*! Compare the x-limits of 2 arcs ends near the top or bottom
+   * boundary of the parameter space
+   * \param cv1 the first arc.
+   * \param ce1 the first arc end indicator -
+   *            ARR_MIN_END - the minimal end of cv1 or
+   *            ARR_MAX_END - the maximal end of cv1.
+   * \param cv2 the second arc.
+   * \param ce2 the second arc end indicator -
+   *            ARR_MIN_END - the minimal end of cv2 or
+   *            ARR_MAX_END - the maximal end of cv2.
+   * \return the second comparison result:
+   *         SMALLER - x(cv1, ce1) \< x(cv2, ce2);
+   *         EQUAL   - x(cv1, ce1) = x(cv2, ce2);
+   *         LARGER  - x(cv1, ce1) > x(cv2, ce2).
+   *
+   * \pre the ce1 end of the arc cv1 lies on a boundary.
+   * \pre the ce2 end of the arc cv2 lies on a boundary.
+   */
+  result_type operator()(const Arc_2& cv1, CGAL::Arr_curve_end ce1,
+                         const Arc_2& cv2, CGAL::Arr_curve_end ce2) const {
+
+    CERR("\ncompare_x_on_boundary: cv1: " << cv1 << "\n cv2: " <<
+         cv2 << "; end1: " << ce1 << "; end2: " << ce2 << "\n");
+    /*CGAL::Arr_boundary_type bnd1 = boundary(end1),
+      bnd2 = cv2.boundary(ce2);*/
+    CGAL_precondition_code(CGAL::Arr_parameter_space loc1 = cv1.location(ce1));
+    CGAL_precondition_code(CGAL::Arr_parameter_space loc2 = cv2.location(ce2));
+    CGAL_precondition(cv1.is_on_bottom_top(loc1));
+    CGAL_precondition(cv1.is_on_bottom_top(loc2));
+
+    if (cv1.is_singular() != cv1.is_singular()) {
+      // only one curve end lies at singularity (another at +/-oo)
+      CGAL_error_msg("SINGULARITY + INF comparison is not yet implemented");
     }
 
-    /*!\brief Compare the x-limit of a vertical with the x-limit of
-     * an arc end near the boundary at bottom or top boundary
-     *
-     * \param p the point direction.
-     * \param cv the arc, the endpoint of which is compared.
-     * \param ce the arc-end indicator -
-     *            ARR_MIN_END - the minimal end of cv or
-     *            ARR_MAX_END - the maximal end of cv.
-     * \return the comparison result:
-     *         SMALLER - x(p) \< x(cv, ce);
-     *         EQUAL   - x(p) = x(cv, ce);
-     *         LARGER  - x(p) > x(cv, ce).
-     *
-     * \pre p lies in the interior of the parameter space.
-     * \pre the ce end of the line cv lies on a boundary.
-     */
-    result_type operator()(const Point_2& p, const Arc_2& cv,
-                           CGAL::Arr_curve_end ce) const {
-
-
-        CERR("\ncompare_x_on_boundary: p: " << p << "\n cv: " <<
-             cv << "; curve_end: " << ce << "\n");
-
-        // this curve end has boundary only in y
-        CGAL_precondition(cv.is_on_bottom_top(cv.location(ce)));
-        if (cv.is_singular()) // the curve end goes to contraction => x-order
-            return CGAL::EQUAL; // doesn't matter
-
-        CGAL::Comparison_result res =
-            Curved_kernel_via_analysis_2::instance().
-            kernel().compare_1_object()(
-                    p.x(), cv.curve_end_x(ce)
-            );
-        CERR("result: " << res << "\n");
-        return res;
-    }
-
-    /*! Compare the x-limits of 2 arcs ends near the top or bottom
-     * boundary of the parameter space
-     * \param cv1 the first arc.
-     * \param ce1 the first arc end indicator -
-     *            ARR_MIN_END - the minimal end of cv1 or
-     *            ARR_MAX_END - the maximal end of cv1.
-     * \param cv2 the second arc.
-     * \param ce2 the second arc end indicator -
-     *            ARR_MIN_END - the minimal end of cv2 or
-     *            ARR_MAX_END - the maximal end of cv2.
-     * \return the second comparison result:
-     *         SMALLER - x(cv1, ce1) \< x(cv2, ce2);
-     *         EQUAL   - x(cv1, ce1) = x(cv2, ce2);
-     *         LARGER  - x(cv1, ce1) > x(cv2, ce2).
-     *
-     * \pre the ce1 end of the arc cv1 lies on a boundary.
-     * \pre the ce2 end of the arc cv2 lies on a boundary.
-     */
-    result_type operator()(const Arc_2& cv1, CGAL::Arr_curve_end ce1,
-                           const Arc_2& cv2, CGAL::Arr_curve_end ce2) const {
-
-        CERR("\ncompare_x_on_boundary: cv1: " << cv1 << "\n cv2: " <<
-            cv2 << "; end1: " << ce1 << "; end2: " << ce2 << "\n");
-        /*CGAL::Arr_boundary_type bnd1 = boundary(end1),
-            bnd2 = cv2.boundary(ce2);*/
-        CGAL_precondition_code(CGAL::Arr_parameter_space loc1 = cv1.location(ce1));
-        CGAL_precondition_code(CGAL::Arr_parameter_space loc2 = cv2.location(ce2));
-        CGAL_precondition(cv1.is_on_bottom_top(loc1));
-        CGAL_precondition(cv1.is_on_bottom_top(loc2));
-
-        if (cv1.is_singular() != cv1.is_singular()) {
-            // only one curve end lies at singularity (another at +/-oo)
-            CGAL_error_msg("SINGULARITY + INF comparison is not yet \
-                implemented");
-        }
-
-        CGAL::Comparison_result res = Curved_kernel_via_analysis_2::instance().
-          kernel().compare_1_object()(
-                                      cv1.curve_end_x(ce1),
-                                      cv2.curve_end_x(ce2)
-                                      );
-        CERR("result: " << res << "\n");
-        return res;
-    }
+    CGAL::Comparison_result res = Curved_kernel_via_analysis_2::instance().
+      kernel().compare_1_object()(cv1.curve_end_x(ce1),
+                                  cv2.curve_end_x(ce2));
+    CERR("result: " << res << "\n");
+    return res;
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functor that compares x-coordinates near the top or bottom boundary
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Compare_x_near_boundary_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Compare_x_near_boundary_2 :
+    public Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef CGAL::Comparison_result result_type;
+  //! the result type
+  using result_type = CGAL::Comparison_result;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    Compare_x_near_boundary_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
+  Compare_x_near_boundary_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
+
+  /*! Compare the x-coordinates of 2 arcs ends near the top or bottom
+   * boundary of the parameter space
+   * \param cv1 the first arc.
+   * \param cv2 the second arc.
+   * \param ce the arc end indicator -
+   *            ARR_MIN_END - the minimal end of curves or
+   *            ARR_MAX_END - the maximal end of curves.
+   * \return the second comparison result:
+   *         SMALLER - x(cv1, ce) \< x(cv2, ce);
+   *         EQUAL   - x(cv1, ce) = x(cv2, ce);
+   *         LARGER  - x(cv1, ce) > x(cv2, ce).
+   *
+   * \pre the ce1 end of the arc cv1 lies on a boundary.
+   * \pre the ce2 end of the arc cv2 lies on a boundary.
+   * \pre both curve ends are on the same boundary
+   */
+  result_type operator()(const Arc_2& cv1, const Arc_2& cv2,
+                         CGAL::Arr_curve_end ce) const {
+
+    CERR("\ncompare_x_near_boundary: cv1: " << cv1 << "\n cv2: " <<
+         cv2 << "; ce: " << ce << "\n");
+
+    CGAL::Arr_parameter_space loc1 = cv1.location(ce);
+    CGAL_precondition_code(CGAL::Arr_parameter_space loc2 =
+                           cv2.location(ce));
+    CGAL_precondition(cv1.is_on_bottom_top(loc1));
+    CGAL_precondition(cv1.is_on_bottom_top(loc2));
+    CGAL_precondition(cv1.compare_x_on_boundary(ce, cv2, ce) == CGAL::EQUAL);
+
+    CGAL_precondition(loc1 == loc2);
+
+    Coordinate_1 x0(cv1.curve_end_x(ce));
+    CGAL::Comparison_result res = cv1._compare_arc_numbers(cv2, CGAL::ARR_INTERIOR, x0,
+                                                           (ce == CGAL::ARR_MIN_END ?
+                                                            CGAL::POSITIVE : CGAL::NEGATIVE));
+    if ((ce == CGAL::ARR_MAX_END && loc1 == CGAL::ARR_TOP_BOUNDARY) ||
+        (ce == CGAL::ARR_MIN_END && loc1 == CGAL::ARR_BOTTOM_BOUNDARY)) {
+      res = opposite(res);
     }
-
-    /*! Compare the x-coordinates of 2 arcs ends near the top or bottom
-     * boundary of the parameter space
-     * \param cv1 the first arc.
-     * \param cv2 the second arc.
-     * \param ce the arc end indicator -
-     *            ARR_MIN_END - the minimal end of curves or
-     *            ARR_MAX_END - the maximal end of curves.
-     * \return the second comparison result:
-     *         SMALLER - x(cv1, ce) \< x(cv2, ce);
-     *         EQUAL   - x(cv1, ce) = x(cv2, ce);
-     *         LARGER  - x(cv1, ce) > x(cv2, ce).
-     *
-     * \pre the ce1 end of the arc cv1 lies on a boundary.
-     * \pre the ce2 end of the arc cv2 lies on a boundary.
-     * \pre both curve ends are on the same boundary
-     */
-    result_type operator()(const Arc_2& cv1, const Arc_2& cv2,
-                           CGAL::Arr_curve_end ce) const {
-
-        CERR("\ncompare_x_near_boundary: cv1: " << cv1 << "\n cv2: " <<
-            cv2 << "; ce: " << ce << "\n");
-
-        CGAL::Arr_parameter_space loc1 = cv1.location(ce);
-        CGAL_precondition_code(CGAL::Arr_parameter_space loc2 =
-                               cv2.location(ce));
-        CGAL_precondition(cv1.is_on_bottom_top(loc1));
-        CGAL_precondition(cv1.is_on_bottom_top(loc2));
-        CGAL_precondition(cv1.compare_x_on_boundary(ce, cv2, ce) == CGAL::EQUAL);
-
-        CGAL_precondition(loc1 == loc2);
-
-        Coordinate_1 x0(cv1.curve_end_x(ce));
-        CGAL::Comparison_result res = cv1._compare_arc_numbers(
-                                       cv2, CGAL::ARR_INTERIOR, x0,
-                                       (ce == CGAL::ARR_MIN_END ?
-                                        CGAL::POSITIVE : CGAL::NEGATIVE)
-                                       );
-        if ((ce == CGAL::ARR_MAX_END &&
-             loc1 == CGAL::ARR_TOP_BOUNDARY) ||
-            (ce == CGAL::ARR_MIN_END &&
-             loc1 == CGAL::ARR_BOTTOM_BOUNDARY)) {
-          res = opposite(res);
-        }
-        CERR("result: " << res << "\n");
-        return res;
-    }
+    CERR("result: " << res << "\n");
+    return res;
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functor to construct a point on a curve
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Compare_endpoints_xy_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Compare_endpoints_xy_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef CGAL::Comparison_result result_type;
+  //! the result type
+  using result_type = CGAL::Comparison_result;
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Compare_endpoints_xy_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Compare_endpoints_xy_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Compares endpoints of arc lexicographically
-     *
-     * \param arc the arc
-     * \return The order of endpoints
-     */
-    CGAL::Comparison_result operator()(const Arc_2& xcv) {
-      if (xcv.is_left_to_right()) {
-        return (CGAL::SMALLER);
-      } else {
-        return (CGAL::LARGER);
-      }
-      return CGAL::EQUAL;
-    }
+  /*! \brief
+   * Compares endpoints of arc lexicographically
+   *
+   * \param arc the arc
+   * \return The order of endpoints
+   */
+  CGAL::Comparison_result operator()(const Arc_2& xcv) {
+    if (xcv.is_left_to_right()) return (CGAL::SMALLER);
+    else return (CGAL::LARGER);
+    return CGAL::EQUAL;
+  }
 };
 
-
-/*!\brief
+/*! \brief
  * Functor to construct a point on a curve
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Construct_opposite_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Construct_opposite_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    //! the result type
-    typedef Arc_2 result_type;
+  //! the result type
+  using result_type = Arc_2;
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Construct_opposite_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Construct_opposite_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     * Construct an arc of opposite direction
-     *
-     * \param arc the arc to be reversed
-     * \return The reversed arc
-     */
-    Arc_2 operator()(const Arc_2& xcv) {
-      return xcv.flip();
-    }
+  /*! \brief
+   * Construct an arc of opposite direction
+   *
+   * \param arc the arc to be reversed
+   * \return The reversed arc
+   */
+  Arc_2 operator()(const Arc_2& xcv) { return xcv.flip(); }
 };
 
-
-
-/*!\brief
+/*! \brief
  * Functor that computes the x-extreme points of a curve
  */
-template < class CurvedKernelViaAnalysis_2 >
-class X_extreme_points_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class X_extreme_points_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    typedef typename Curve_analysis_2::Coordinate_2 Coordinate_2;
+  using Coordinate_2 = typename Curve_analysis_2::Coordinate_2;
 
-    //! the result type
-    typedef CGAL::cpp98::iterator< std::output_iterator_tag, Coordinate_2 >
-         result_type;
+  //! the result type
+  using result_type = CGAL::cpp98::iterator<std::output_iterator_tag, Coordinate_2>;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    X_extreme_points_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  X_extreme_points_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
+
+  /*! \brief
+   */
+  template <typename OutputIterator>
+  OutputIterator operator()(const Curve_analysis_2& ca,
+                            OutputIterator oi) const {
+    using Status_line_1 = typename Curve_analysis_2::Status_line_1;
+
+    int events = ca.number_of_status_lines_with_event();
+
+    for (int i = 0; i < events; i++) {
+      Status_line_1 status_line = ca.status_line_at_event(i);
+
+      int lifts = status_line.number_of_events();
+
+      for (int j = 0; j < lifts; j++) {
+        std::pair<int, int> arcs =
+          status_line.number_of_incident_branches(j);
+
+        if (arcs.first == 0 || arcs.second == 0)
+          *oi++ = status_line.algebraic_real_2(j);
+      }
     }
-
-    /*!\brief
-     */
-    template < class OutputIterator >
-    OutputIterator operator()(const Curve_analysis_2& ca,
-                              OutputIterator oi) const {
-
-        typedef typename Curve_analysis_2::Status_line_1 Status_line_1;
-
-        int events = ca.number_of_status_lines_with_event();
-
-        for ( int i = 0; i < events; i++ ) {
-
-            Status_line_1 status_line = ca.status_line_at_event(i);
-
-            int lifts = status_line.number_of_events();
-
-            for( int j = 0; j < lifts; j++ ) {
-
-                std::pair<int, int> arcs =
-                     status_line.number_of_incident_branches(j);
-
-                if (arcs.first == 0 || arcs.second == 0)
-                    *oi++ = status_line.algebraic_real_2(j);
-            }
-        }
-        return oi;
-    }
-
+    return oi;
+  }
 };
 
-/*!\brief
+/*! \brief
  * Functor that computes the y-extreme points of a curve
  */
-template < class CurvedKernelViaAnalysis_2 >
-class Y_extreme_points_2 : public
-Curved_kernel_via_analysis_2_functor_base< CurvedKernelViaAnalysis_2 > {
-
+template <typename CurvedKernelViaAnalysis_2>
+class Y_extreme_points_2 :
+    public Curved_kernel_via_analysis_2_functor_base<CurvedKernelViaAnalysis_2> {
 public:
-    //! this instance' first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
+  //! this instance' first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
 
-    //! the base type
-    typedef
-    Curved_kernel_via_analysis_2_functor_base< Curved_kernel_via_analysis_2 >
-    Base;
+  //! the base type
+  using Base = Curved_kernel_via_analysis_2_functor_base<Curved_kernel_via_analysis_2>;
 
-    CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
+  CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
-    typedef typename Curve_analysis_2::Coordinate_2 Coordinate_2;
+  using Coordinate_2 = typename Curve_analysis_2::Coordinate_2;
 
-    //! the result type
-    typedef CGAL::cpp98::iterator< std::output_iterator_tag, Coordinate_2 >
-             result_type;
+  //! the result type
+  using result_type = CGAL::cpp98::iterator<std::output_iterator_tag, Coordinate_2>;
 
-    //! the arity of the functor
+  //! the arity of the functor
 
-    /*!\brief
-     * Standard constructor
-     *
-     * \param kernel The kernel
-     */
-    Y_extreme_points_2(Curved_kernel_via_analysis_2 *kernel) :
-        Base(kernel) {
-    }
+  /*! \brief
+   * Standard constructor
+   *
+   * \param kernel The kernel
+   */
+  Y_extreme_points_2(Curved_kernel_via_analysis_2* kernel) : Base(kernel) {}
 
-    /*!\brief
-     */
-    template < class OutputIterator >
-    OutputIterator operator()(const Curve_analysis_2& ca,
-                              OutputIterator oi) const {
+  /*! \brief
+   */
+  template <typename OutputIterator>
+  OutputIterator operator()(const Curve_analysis_2& ca,
+                            OutputIterator oi) const {
+    using Status_line_1 = typename Curve_analysis_2::Status_line_1;
 
-        typedef typename Curve_analysis_2::Status_line_1 Status_line_1;
+    typename Base::Curve_kernel_2 curve_kernel = Base::_ckva()->kernel();
 
-        typename Base::Curve_kernel_2 curve_kernel = Base::_ckva()->kernel();
+    Curve_analysis_2 ca_yx = curve_kernel.swap_x_and_y_2_object() (ca);
 
-        Curve_analysis_2 ca_yx
-            = curve_kernel.swap_x_and_y_2_object() (ca);
+    std::vector<Coordinate_2> y_critical_points;
 
-        std::vector<Coordinate_2> y_critical_points;
+    Base::_ckva()->x_extreme_points_2_object()(ca_yx,
+                                               std::back_inserter(y_critical_points));
 
-        Base::_ckva()->x_extreme_points_2_object()(ca_yx,
-             std::back_inserter(y_critical_points));
+    for (typename std::vector<Coordinate_2>::iterator it = y_critical_points.begin();
+         it != y_critical_points.end();
+         it++) {
 
-        for( typename std::vector<Coordinate_2>::iterator it
-                 = y_critical_points.begin();
-             it != y_critical_points.end();
-             it++ ) {
+      Coordinate_1 curr_x = curve_kernel.get_y_2_object()( *it );
 
-            Coordinate_1 curr_x = curve_kernel.get_y_2_object()( *it );
+      Status_line_1 status_line = ca.status_line_at_exact_x(curr_x);
 
-            Status_line_1 status_line = ca.status_line_at_exact_x(curr_x);
+      int lifts = status_line.number_of_events();
 
-            int lifts = status_line.number_of_events();
+      for (int i = 0; i < lifts; i++) {
+        Coordinate_2 lift_xy = status_line.algebraic_real_2(i);
 
-            for( int i = 0; i < lifts; i++ ) {
-                Coordinate_2 lift_xy = status_line.algebraic_real_2(i);
+        bool y_coordinate_found;
 
-                bool y_coordinate_found;
+        while (true) {
+          if (curve_kernel.upper_boundary_y_2_object() (lift_xy) <
+              curve_kernel.lower_boundary_x_2_object() (*it) ) {
+            y_coordinate_found = false;
+            break;
+          }
+          if (curve_kernel.upper_boundary_y_2_object() (lift_xy)>=
+              curve_kernel.upper_boundary_x_2_object() (*it) ) {
+            y_coordinate_found = true;
+            break;
+          }
 
-                while(true) {
-
-                    if( curve_kernel.upper_boundary_y_2_object() (lift_xy) <
-                        curve_kernel.lower_boundary_x_2_object() (*it) ) {
-                        y_coordinate_found = false;
-                        break;
-                    }
-                    if( curve_kernel.upper_boundary_y_2_object() (lift_xy) >=
-                        curve_kernel.upper_boundary_x_2_object() (*it) ) {
-                        y_coordinate_found = true;
-                        break;
-                    }
-
-                    curve_kernel.refine_x_2_object() (*it);
-                }
-
-                if(y_coordinate_found) {
-                    *oi++ = Coordinate_2(curr_x, ca, i);
-                    break;
-                }
-            }
+          curve_kernel.refine_x_2_object() (*it);
         }
-        return oi;
+
+        if (y_coordinate_found) {
+          *oi++ = Coordinate_2(curr_x, ca, i);
+          break;
+        }
+      }
     }
-
+    return oi;
+  }
 };
-
 
 #undef CGAL_CKvA_2_GRAB_BASE_FUNCTOR_TYPES
 
 } // namespace Curved_kernel_via_analysis_2_Functors
 
-/*!\brief
+/*! \brief
  * Collects the main set of functors of a curved kernel
  */
-template < class CurvedKernelViaAnalysis_2, class Dummy = void>
+template <typename CurvedKernelViaAnalysis_2, typename Dummy = void>
 class Curved_kernel_via_analysis_2_functors {
-
 public:
-    //!\name Public types
-    //!@{
+  //!\name Public types
+  //!@{
 
-    //! this instance's first template parameter
-    typedef CurvedKernelViaAnalysis_2 Curved_kernel_via_analysis_2;
-    //!@}
-//     typedef Curved_kernel_via_analysis_2_functors<
-//         CurvedKernelViaAnalysis_2 > Functor_base;
+  //! this instance's first template parameter
+  using Curved_kernel_via_analysis_2 = CurvedKernelViaAnalysis_2;
+  //!@}
+  // typedef Curved_kernel_via_analysis_2_functors<CurvedKernelViaAnalysis_2> Functor_base;
 
-// declares curved kernel functors, for each functor defines a member function
-// returning an instance of this functor
+  // declares curved kernel functors, for each functor defines a member function
+  // returning an instance of this functor
 #define CGAL_CKvA_2_functor_pred(Y, Z) \
-    typedef \
-    Curved_kernel_via_analysis_2_Functors::Y< Curved_kernel_via_analysis_2 \
-        > Y; \
-    Y Z() const { return Y(&Curved_kernel_via_analysis_2::instance()); }
+  typedef Curved_kernel_via_analysis_2_Functors::Y<Curved_kernel_via_analysis_2> Y; \
+  Y Z() const { return Y(&Curved_kernel_via_analysis_2::instance()); }
 
 #define CGAL_CKvA_2_functor_cons(Y, Z) CGAL_CKvA_2_functor_pred(Y, Z)
 
-    CGAL_CKvA_2_functor_pred(Compare_x_2, compare_x_2_object);
-    CGAL_CKvA_2_functor_pred(Compare_xy_2, compare_xy_2_object);
-    CGAL_CKvA_2_functor_pred(Is_vertical_2, is_vertical_2_object);
+  CGAL_CKvA_2_functor_pred(Compare_x_2, compare_x_2_object);
+  CGAL_CKvA_2_functor_pred(Compare_xy_2, compare_xy_2_object);
+  CGAL_CKvA_2_functor_pred(Is_vertical_2, is_vertical_2_object);
 
-    CGAL_CKvA_2_functor_cons(Construct_min_vertex_2,
-                             construct_min_vertex_2_object);
-    CGAL_CKvA_2_functor_cons(Construct_max_vertex_2,
-                             construct_max_vertex_2_object);
-    CGAL_CKvA_2_functor_cons(Construct_interior_vertex_2,
-                             construct_interior_vertex_2_object);
+  CGAL_CKvA_2_functor_cons(Construct_min_vertex_2,
+                           construct_min_vertex_2_object);
+  CGAL_CKvA_2_functor_cons(Construct_max_vertex_2,
+                           construct_max_vertex_2_object);
+  CGAL_CKvA_2_functor_cons(Construct_interior_vertex_2,
+                           construct_interior_vertex_2_object);
 
-    CGAL_CKvA_2_functor_pred(Compare_y_at_x_2, compare_y_at_x_2_object);
-    CGAL_CKvA_2_functor_pred(Compare_y_at_x_left_2,
-                             compare_y_at_x_left_2_object);
-    CGAL_CKvA_2_functor_pred(Compare_y_at_x_right_2,
-                             compare_y_at_x_right_2_object);
-    CGAL_CKvA_2_functor_pred(Equal_2, equal_2_object);
-    CGAL_CKvA_2_functor_pred(Is_in_x_range_2, is_in_x_range_2_object);
-    CGAL_CKvA_2_functor_pred(Do_overlap_2, do_overlap_2_object);
-    CGAL_CKvA_2_functor_cons(Intersect_2, intersect_2_object);
-    CGAL_CKvA_2_functor_cons(Trim_2, trim_2_object);
-    CGAL_CKvA_2_functor_cons(Split_2, split_2_object);
-    CGAL_CKvA_2_functor_pred(Are_mergeable_2, are_mergeable_2_object);
-    CGAL_CKvA_2_functor_cons(Merge_2, merge_2_object);
+  CGAL_CKvA_2_functor_pred(Compare_y_at_x_2, compare_y_at_x_2_object);
+  CGAL_CKvA_2_functor_pred(Compare_y_at_x_left_2,
+                           compare_y_at_x_left_2_object);
+  CGAL_CKvA_2_functor_pred(Compare_y_at_x_right_2,
+                           compare_y_at_x_right_2_object);
+  CGAL_CKvA_2_functor_pred(Equal_2, equal_2_object);
+  CGAL_CKvA_2_functor_pred(Is_in_x_range_2, is_in_x_range_2_object);
+  CGAL_CKvA_2_functor_pred(Do_overlap_2, do_overlap_2_object);
+  CGAL_CKvA_2_functor_cons(Intersect_2, intersect_2_object);
+  CGAL_CKvA_2_functor_cons(Trim_2, trim_2_object);
+  CGAL_CKvA_2_functor_cons(Split_2, split_2_object);
+  CGAL_CKvA_2_functor_pred(Are_mergeable_2, are_mergeable_2_object);
+  CGAL_CKvA_2_functor_cons(Merge_2, merge_2_object);
 
+  CGAL_CKvA_2_functor_pred(Is_on_2, is_on_2_object);
+  CGAL_CKvA_2_functor_cons(Make_x_monotone_2, make_x_monotone_2_object);
 
-    CGAL_CKvA_2_functor_pred(Is_on_2, is_on_2_object);
-    CGAL_CKvA_2_functor_cons(Make_x_monotone_2, make_x_monotone_2_object);
+  // left-right
+  CGAL_CKvA_2_functor_pred(Parameter_space_in_x_2,
+                           parameter_space_in_x_2_object);
+  CGAL_CKvA_2_functor_pred(Compare_y_near_boundary_2,
+                           compare_y_near_boundary_2_object);
 
-    // left-right
-    CGAL_CKvA_2_functor_pred(Parameter_space_in_x_2,
-                             parameter_space_in_x_2_object);
-    CGAL_CKvA_2_functor_pred(Compare_y_near_boundary_2,
-                             compare_y_near_boundary_2_object);
+  // bottom-top
+  CGAL_CKvA_2_functor_pred(Parameter_space_in_y_2,
+                           parameter_space_in_y_2_object);
+  CGAL_CKvA_2_functor_pred(Compare_x_on_boundary_2,
+                           compare_x_on_boundary_2_object);
+  CGAL_CKvA_2_functor_pred(Compare_x_near_boundary_2,
+                           compare_x_near_boundary_2_object);
 
-    // bottom-top
-    CGAL_CKvA_2_functor_pred(Parameter_space_in_y_2,
-                             parameter_space_in_y_2_object);
-    CGAL_CKvA_2_functor_pred(Compare_x_on_boundary_2,
-                             compare_x_on_boundary_2_object);
-    CGAL_CKvA_2_functor_pred(Compare_x_near_boundary_2,
-                             compare_x_near_boundary_2_object);
+  CGAL_CKvA_2_functor_cons(X_extreme_points_2, x_extreme_points_2_object);
+  CGAL_CKvA_2_functor_cons(Y_extreme_points_2, y_extreme_points_2_object);
 
-    CGAL_CKvA_2_functor_cons(X_extreme_points_2, x_extreme_points_2_object);
-    CGAL_CKvA_2_functor_cons(Y_extreme_points_2, y_extreme_points_2_object);
+  CGAL_CKvA_2_functor_cons(Construct_point_2,
+                           construct_point_2_object);
 
-    CGAL_CKvA_2_functor_cons(Construct_point_2,
-                             construct_point_2_object);
+  CGAL_CKvA_2_functor_cons(Construct_point_on_arc_2,
+                           construct_point_on_arc_2_object);
 
-    CGAL_CKvA_2_functor_cons(Construct_point_on_arc_2,
-                             construct_point_on_arc_2_object);
+  CGAL_CKvA_2_functor_cons(Construct_arc_2,
+                           construct_arc_2_object);
 
-    CGAL_CKvA_2_functor_cons(Construct_arc_2,
-                             construct_arc_2_object);
+  CGAL_CKvA_2_functor_pred(Compare_endpoints_xy_2,
+                           compare_endpoints_xy_2_object);
 
-    CGAL_CKvA_2_functor_pred(Compare_endpoints_xy_2,
-                             compare_endpoints_xy_2_object);
-
-    CGAL_CKvA_2_functor_cons(Construct_opposite_2,
-                             construct_opposite_2_object);
+  CGAL_CKvA_2_functor_cons(Construct_opposite_2,
+                           construct_opposite_2_object);
 
 #undef CGAL_CKvA_2_functor_pred
 #undef CGAL_CKvA_2_functor_cons
@@ -2752,5 +2446,4 @@ public:
 
 } //namespace CGAL
 
-#endif // CGAL_CURVED_KERNEL_VIA_ANALYSIS_2_FUNCTORS_H
-// EOF
+#endif

--- a/Arrangement_on_surface_2/include/CGAL/draw_arrangement_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/draw_arrangement_2.h
@@ -588,7 +588,7 @@ private:
 
 #ifdef CGAL_USE_BASIC_VIEWER
 //!
-void draw_unimplemented() {
+inline void draw_unimplemented() {
   CGAL_error_msg("Geometry traits type of arrangement is required to support approximation of Point_2 and "
                  "X_monotone_curve_2. Traits on curved surfaces needs additional support for parameterization.");
 }


### PR DESCRIPTION
## Summary of Changes

This addresses issue #9084. In particular, I replaced `Cartesian` with `Simple_cartesian` in all traits.
I also defined Multiplicity to be `std::size_t` in all traits. In addition, I replaced `typedef` with `using` and properly indented and cleaned up the code in the source files I touched. I simplified the code that approximates a point of the traits classes `Arr_linear_traits_2`, `Arr_segment_traits_2`, and `Arr_non_caching_segment_basic_traits_2.h`. I did not use the [GAL::Cartesian_coverter](https://doc.cgal.org/latest/Kernel_23/classCGAL_1_1Cartesian__converter.html) (mentioned in issue #9084) because the code is now simple as it is(just one line in each traits class).

I also added a missing `inline` in draw_arrangement_2. This is unrelated to the above.

## Release Management

* Affected package(s): Arrangement_on_surface_2
* Issue(s) solved (if any): fix #9084
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: TAU

