### PR TITLE
Fix undefined behavior sanitizer casting error in Arrangement_2_iterators.h

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_2_iterators.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arrangement_2_iterators.h
@@ -290,7 +290,7 @@ public:
 
   template <typename T>
   I_Filtered_iterator (T* p) :
-    nt (pointer(p)),
+    nt (reinterpret_cast<pointer>(p)),
     iend (nt)
   {}
 
@@ -314,7 +314,7 @@ public:
   template <typename P>
   I_Filtered_iterator& operator= (const P* p)
   {
-    nt = pointer(p);
+    nt = reinterpret_cast<pointer>(p);
     iend =nt;
     return *this;
   }
@@ -455,7 +455,7 @@ public:
 
   template <typename T>
   I_Filtered_const_iterator (T* p) :
-    nt (pointer(p)),
+    nt (reinterpret_cast<pointer>(p)),
     iend (nt)
   {}
 
@@ -488,7 +488,7 @@ public:
   template <typename P>
   I_Filtered_const_iterator& operator= (const P* p)
   {
-    nt = pointer(p);
+    nt = reinterpret_cast<pointer>(p);
     iend =nt;
     return *this;
   }


### PR DESCRIPTION
_Please use the following template to help us managing pull requests._

## Summary of Changes
Fixed runtime downcast errors detected by the Undefined Behavior Sanitizer (UBSan) in Arrangement_2_iterators.h.

The code was using a functional cast pointer(p), which acts like a static_cast. This caused undefined behavior when the object at p was not fully initialized as the derived type. I replaced these with reinterpret_cast<pointer>(p) in both the constructors and assignment operators for I_Filtered_iterator and I_Filtered_const_iterator.

## Release Management
Affected package(s): Arrangement_on_surface_2
Issue(s) solved (if any): fix #9140
Feature/Small Feature (if any):
Link to compiled documentation: N/A
License and copyright ownership: I agree to transfer the copyright of my contributions to the CGAL project owner.

