### PR TITLE
Lab: Use Results to Avoid Warning

### DIFF
--- a/Lab/demo/Lab/MainWindow.cpp
+++ b/Lab/demo/Lab/MainWindow.cpp
@@ -1795,8 +1795,8 @@ bool MainWindow::loadScript(QFileInfo info)
   QString program;
   QString filename = info.absoluteFilePath();
   QFile script_file(filename);
-  script_file.open(QIODevice::ReadOnly);
-  if(!script_file.isReadable()) {
+  bool success = script_file.open(QIODevice::ReadOnly);
+  if((! success) || (!script_file.isReadable())) {
     throw std::ios_base::failure(script_file.errorString().toStdString());
   }
   program = script_file.readAll();
@@ -2747,9 +2747,9 @@ void MainWindow::exportStatistics()
   if(filename.isEmpty())
     return;
   QFile output(filename);
-  output.open(QIODevice::WriteOnly | QIODevice::Text);
+  bool success = output.open(QIODevice::WriteOnly | QIODevice::Text);
 
-  if(!output.isOpen()){
+  if((! success) || (!output.isOpen())){
     qDebug() << "- Error, unable to open" << "outputFilename" << "for output";
   }
   QTextStream outStream(&output);

--- a/Lab/demo/Lab/Plugins/Camera_position/Camera_positions_list.cpp
+++ b/Lab/demo/Lab/Plugins/Camera_position/Camera_positions_list.cpp
@@ -93,18 +93,20 @@ bool Camera_positions_list::save(QString filename) {
   if(m_model->rowCount() <1)
     return false;
   QFile file(filename);
-  file.open(QIODevice::WriteOnly);
-  QTextStream out(&file);
-  for(int i = 0; i < m_model->rowCount(); ++i)
-  {
-    QStandardItem* item = m_model->item(i);
-    out << item->data(Qt::DisplayRole).toString()
-        << "\n"
-        << item->data(Qt::UserRole).toString()
-        << "\n";
+  if(file.open(QIODevice::WriteOnly)){
+    QTextStream out(&file);
+    for(int i = 0; i < m_model->rowCount(); ++i)
+    {
+      QStandardItem* item = m_model->item(i);
+      out << item->data(Qt::DisplayRole).toString()
+          << "\n"
+          << item->data(Qt::UserRole).toString()
+          << "\n";
+    }
+    file.close();
+    return true;
   }
-  file.close();
-  return true;
+  return false;
 }
 
 void Camera_positions_list::on_saveButton_pressed()
@@ -129,19 +131,24 @@ void Camera_positions_list::on_openButton_pressed()
 
 void Camera_positions_list::load(QString filename) {
   QFile file(filename);
-  std::clog << "Loading camera positions " << qPrintable(filename) << std::endl;
-  file.open(QIODevice::ReadOnly);
-  QTextStream input(&file);
-  while(!input.atEnd()) {
-    QString text = input.readLine(1000);
-    QString coord = input.readLine(1000);
-    if(text.isNull() || coord.isNull()) return;
-    CGAL::qglviewer::Frame frame;
-    if(Three::activeViewer()->readFrame(coord, frame))
-    {
-      addItem(text,
-              Three::activeViewer()->dumpFrame(frame));
+
+  if(file.open(QIODevice::ReadOnly)){
+    std::clog << "Loading camera positions " << qPrintable(filename) << std::endl;
+
+    QTextStream input(&file);
+    while(!input.atEnd()) {
+      QString text = input.readLine(1000);
+      QString coord = input.readLine(1000);
+      if(text.isNull() || coord.isNull()) return;
+      CGAL::qglviewer::Frame frame;
+      if(Three::activeViewer()->readFrame(coord, frame))
+      {
+        addItem(text,
+                Three::activeViewer()->dumpFrame(frame));
+      }
     }
+  }else {
+    std::clog << "Loading camera positions " << qPrintable(filename) << " failed" << std::endl;
   }
 }
 


### PR DESCRIPTION
## Summary of Changes

Check that `open()` worked to avoid warnings [here](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.2-Ic-50/Lab_Demo/TestReport_cgaltest_ArchLinux-clang-CXX20-Release.gz).

## Release Management

* Affected package(s): Lab

* License and copyright ownership: unchanged

