### PR TITLE
CH3: Make convex_hull_3 deterministic (order of vertices and indices)

### DIFF
--- a/Convex_hull_3/include/CGAL/Convex_hull_face_base_2.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_face_base_2.h
@@ -18,8 +18,6 @@
 #include <CGAL/license/Convex_hull_3.h>
 
 #include <CGAL/Triangulation_ds_face_base_2.h>
-#include <CGAL/Has_timestamp.h>
-#include <CGAL/Time_stamper.h>
 
 #include <list>
 
@@ -31,7 +29,6 @@ class Convex_hull_face_base_2
   : public Fb
 {
   int _info = 0;
-  std::size_t time_stamp_ = std::size_t(-2);
 
 public:
   typedef typename Fb::Vertex_handle                   Vertex_handle;
@@ -59,7 +56,7 @@ public:
                           Vertex_handle v2,
                           Face_handle   n0,
                           Face_handle   n1,
-                          Face_handle   n2 )
+                          Face_handle   n2)
     : Fb(v0, v1, v2, n0, n1, n2), _info(0) {}
 
   const int& info() const { return _info; }
@@ -67,18 +64,6 @@ public:
 
   static int ccw(int i) {return Triangulation_cw_ccw_2::ccw(i);}
   static int  cw(int i) {return Triangulation_cw_ccw_2::cw(i);}
-
-  /// For the determinism of Compact_container iterators
-  ///@{
-  typedef Tag_true Has_timestamp;
-
-  std::size_t time_stamp() const {
-    return time_stamp_;
-  }
-  void set_time_stamp(const std::size_t& ts) {
-    time_stamp_ = ts;
-  }
-  ///@}
 };
 
 } //namespace CGAL

--- a/Convex_hull_3/include/CGAL/Convex_hull_face_base_2.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_face_base_2.h
@@ -18,6 +18,8 @@
 #include <CGAL/license/Convex_hull_3.h>
 
 #include <CGAL/Triangulation_ds_face_base_2.h>
+#include <CGAL/Has_timestamp.h>
+#include <CGAL/Time_stamper.h>
 
 #include <list>
 
@@ -29,6 +31,7 @@ class Convex_hull_face_base_2
   : public Fb
 {
   int _info = 0;
+  std::size_t time_stamp_ = std::size_t(-2);
 
 public:
   typedef typename Fb::Vertex_handle                   Vertex_handle;
@@ -64,6 +67,18 @@ public:
 
   static int ccw(int i) {return Triangulation_cw_ccw_2::ccw(i);}
   static int  cw(int i) {return Triangulation_cw_ccw_2::cw(i);}
+
+  /// For the determinism of Compact_container iterators
+  ///@{
+  typedef Tag_true Has_timestamp;
+
+  std::size_t time_stamp() const {
+    return time_stamp_;
+  }
+  void set_time_stamp(const std::size_t& ts) {
+    time_stamp_ = ts;
+  }
+  ///@}
 };
 
 } //namespace CGAL

--- a/Convex_hull_3/include/CGAL/Convex_hull_vertex_base_2.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_vertex_base_2.h
@@ -19,6 +19,8 @@
 
 #include <CGAL/Triangulation_ds_vertex_base_2.h>
 #include <CGAL/IO/io.h>
+#include <CGAL/Has_timestamp.h>
+#include <CGAL/Time_stamper.h>
 
 #include <iostream>
 
@@ -38,6 +40,7 @@ public:
 private:
   int _info = 0;
   Point _p;
+  std::size_t time_stamp_ = std::size_t(-2);
 
 public:
   template < typename TDS2 >
@@ -65,6 +68,18 @@ public:
 
   const int& info() const { return _info; }
   int&       info()       { return _info; }
+
+  /// For the determinism of Compact_container iterators
+  ///@{
+  typedef Tag_true Has_timestamp;
+
+  std::size_t time_stamp() const {
+    return time_stamp_;
+  }
+  void set_time_stamp(const std::size_t& ts) {
+    time_stamp_ = ts;
+  }
+  ///@}
 };
 
 template <typename GT, typename Vb>


### PR DESCRIPTION
## Summary of Changes

Adding timestamp to convex_hull_3 vertex

The original problem was that the convex_hull_3 when using PointRange and PolygonRange as output parameters, that the order of vertices and indices was not deterministic. The geometry itself was deterministic. However, when using non-exact Kernels, this leads to differences in volume calculations, etc. This had a large impact on approximate convex decomposition as a priority queue is used by causing non-deterministic outcome especially while using tbb.

The reason why it makes it deterministic is because during the creation of the hull some border edges are collected here:
[`find_visible_set(tds, farthest_pt, f_handle, visible_set, border, traits);`](https://github.com/CGAL/cgal/blob/main/Convex_hull_3/include/CGAL/convex_hull_3.h#L659C6-L659C80)

with `border` being [`typedef std::map<typename TDS_2::Vertex_handle, typename TDS_2::Edge> Border_edges;`](https://github.com/CGAL/cgal/blob/main/Convex_hull_3/include/CGAL/convex_hull_3.h#L643).

Then another container `edges` is filled using `border.begin()` [here](https://github.com/CGAL/cgal/blob/main/Convex_hull_3/include/CGAL/convex_hull_3.h#L678C1-L692C7).

The call to [`Vertex_handle vh = tds.star_hole(edges.begin(), edges.end(), visible_set.begin(), visible_set.end());`](https://github.com/CGAL/cgal/blob/main/Convex_hull_3/include/CGAL/convex_hull_3.h#L707) then induced that the order of faces in the TDS depends on the order of edges in `edges`. The timestamp makes that the first vertex is always the same in `border_edges`.

## Release Management

* Affected package(s): Convex_hull_3