### PR TITLE
Number_types: Document boost::multiprecision number types

### DIFF
--- a/Number_types/doc/Number_types/CGAL/boost_mp.h
+++ b/Number_types/doc/Number_types/CGAL/boost_mp.h
@@ -1,0 +1,40 @@
+
+
+
+/*!
+\ingroup nt_gmp
+
+The class `mpq_class` is an exact multiprecision rational number type,
+provided by \gmp.
+CGAL provides the necessary functions to make it compliant to the number type
+concept.
+
+\cgalModels{Field,RealEmbeddable,Fraction}
+
+See the \gmp documentation for additional details.
+
+*/
+
+class mpq_class {
+}; /* end mpq_class */
+
+
+
+
+/*!
+\ingroup nt_gmp
+
+The class `mpz_class` is an exact multiprecision integer number type,
+provided by \gmp.
+CGAL provides the necessary functions to make it compliant to the number type
+concept.
+
+\cgalModels{EuclideanRing,RealEmbeddable}
+
+See the \gmp documentation for additional details.
+
+*/
+
+class mpz_class {
+}; /* end mpz_class */
+

--- a/Number_types/doc/Number_types/CGAL/boost_mp.h
+++ b/Number_types/doc/Number_types/CGAL/boost_mp.h
@@ -6,7 +6,7 @@ namespace boost { namespace multiprecision {
 
 The class `cpp_rational` is an exact multiprecision rational number type,
 provided by \boost.
-CGAL provides the necessary functions to make it compliant to the number type
+This header provides the necessary functions to make it compliant to the number type
 concept.
 
 \cgalModels{Field,RealEmbeddable,Fraction}
@@ -20,6 +20,23 @@ class cpp_rational {
 };
 
 
+/*!
+\ingroup nt_boost
+
+The class `gmp_rational` is an exact multiprecision rational number type,
+provided by \boost.
+This header provides the necessary functions to make it compliant to the number type
+concept.
+
+\cgalModels{Field,RealEmbeddable,Fraction}
+
+See the \boost documentation for additional details on
+<a href="https://www.boost.org/doc/libs/latest/libs/multiprecision/doc/html/boost_multiprecision/tut/rational.html">Boost Multiprecision Rational Types</a>
+
+*/
+
+class gmp_rational {
+};
 
 
 /*!
@@ -27,7 +44,7 @@ class cpp_rational {
 
 The class `cpp_int` is an exact multiprecision integer number type,
 provided by \boost.
-CGAL provides the necessary functions to make it compliant to the number type
+This header provides the necessary functions to make it compliant to the number type
 concept.
 
 \cgalModels{EuclideanRing,RealEmbeddable}
@@ -38,6 +55,24 @@ See the \boost documentation for additional details on
 */
 
 class cpp_int {
+};
+
+/*!
+\ingroup nt_boost
+
+The class `gmp_int` is an exact multiprecision integer number type,
+provided by \boost.
+This header provides the necessary functions to make it compliant to the number type
+concept.
+
+\cgalModels{EuclideanRing,RealEmbeddable}
+
+See the \boost documentation for additional details on
+<a href="https://www.boost.org/doc/libs/latest/libs/multiprecision/doc/html/boost_multiprecision/tut/ints.html">Boost Multiprecision Integer Types</a>
+
+*/
+
+class gmp_int {
 };
 
 }} //namespace boost::multiprecision

--- a/Number_types/doc/Number_types/CGAL/boost_mp.h
+++ b/Number_types/doc/Number_types/CGAL/boost_mp.h
@@ -1,40 +1,43 @@
 
-
+namespace boost { namespace multiprecision {
 
 /*!
-\ingroup nt_gmp
+\ingroup nt_boost
 
-The class `mpq_class` is an exact multiprecision rational number type,
-provided by \gmp.
+The class `cpp_rational` is an exact multiprecision rational number type,
+provided by \boost.
 CGAL provides the necessary functions to make it compliant to the number type
 concept.
 
 \cgalModels{Field,RealEmbeddable,Fraction}
 
-See the \gmp documentation for additional details.
+See the \boost documentation for additional details on
+<a href="https://www.boost.org/doc/libs/latest/libs/multiprecision/doc/html/boost_multiprecision/tut/rational.html">Boost Multiprecision Rational Types</a>
 
 */
 
-class mpq_class {
-}; /* end mpq_class */
+class cpp_rational {
+};
 
 
 
 
 /*!
-\ingroup nt_gmp
+\ingroup nt_boost
 
-The class `mpz_class` is an exact multiprecision integer number type,
-provided by \gmp.
+The class `cpp_int` is an exact multiprecision integer number type,
+provided by \boost.
 CGAL provides the necessary functions to make it compliant to the number type
 concept.
 
 \cgalModels{EuclideanRing,RealEmbeddable}
 
-See the \gmp documentation for additional details.
+See the \boost documentation for additional details on
+<a href="https://www.boost.org/doc/libs/latest/libs/multiprecision/doc/html/boost_multiprecision/tut/ints.html">Boost Multiprecision Integer Types</a>
 
 */
 
-class mpz_class {
-}; /* end mpz_class */
+class cpp_int {
+};
 
+}} //namespace boost::multiprecision

--- a/Number_types/doc/Number_types/CGAL/gmpxx.h
+++ b/Number_types/doc/Number_types/CGAL/gmpxx.h
@@ -6,7 +6,7 @@
 
 The class `mpq_class` is an exact multiprecision rational number type,
 provided by \gmp.
-CGAL provides the necessary functions to make it compliant to the number type
+This header provides the necessary functions to make it compliant to the number type
 concept.
 
 \cgalModels{Field,RealEmbeddable,Fraction}
@@ -26,7 +26,7 @@ class mpq_class {
 
 The class `mpz_class` is an exact multiprecision integer number type,
 provided by \gmp.
-CGAL provides the necessary functions to make it compliant to the number type
+This header provides the necessary functions to make it compliant to the number type
 concept.
 
 \cgalModels{EuclideanRing,RealEmbeddable}


### PR DESCRIPTION
## Summary of Changes

Add documentation of `boost::multiprecision::cpp_int`  and other types.

## Release Management

* Affected package(s): Number_types
* Issue(s) solved (if any): fix #9163
* Documentation: [link](https://cgal.github.io/9164/v0/Number_types/group__nt__boost.html)
* License and copyright ownership: unchanged

