### PR TITLE
Added dimension-aware vertex iterators to prevent segfaults in lower-dimensional triangulations

### DIFF
--- a/Triangulation/doc/Triangulation/Concepts/TriangulationDataStructure.h
+++ b/Triangulation/doc/Triangulation/Concepts/TriangulationDataStructure.h
@@ -825,7 +825,10 @@ int maximal_dimension() const;
 
 /*!
 Returns an iterator to the first `Vertex_handle` stored in the
-full cell.
+full cell. If the current dimension of the triangulation is smaller than the maximal
+dimension, only the first `current_dimension()+1` vertices of a full cell
+are geometrically valid. Iterating up to `vertices_end()` may therefore
+access vertices that do not belong to the geometric simplex.
 */
 Vertex_handle_iterator vertices_begin() const;
 

--- a/Triangulation/include/CGAL/Triangulation_ds_full_cell.h
+++ b/Triangulation/include/CGAL/Triangulation_ds_full_cell.h
@@ -102,13 +102,13 @@ public:
 
     // These overloads allow callers that know the current geometric dimension
     // to iterate only over valid vertices (0..cur_dim).
-    Vertex_handle_const_iterator vertices_begin(const int cur_dim) const /* Concept */
+    Vertex_handle_const_iterator vertices_begin(const int cur_dim) const
     {
         CGAL_USE(cur_dim);
         return vertices().begin();
     }
 
-    Vertex_handle_const_iterator vertices_end(const int cur_dim) const /* Concept */
+    Vertex_handle_const_iterator vertices_end(const int cur_dim) const
     {
         CGAL_precondition(0 <= cur_dim && cur_dim <= maximal_dimension());
         return vertices().begin() + (cur_dim + 1);


### PR DESCRIPTION
## Summary of Changes

Added two overloads to the Triangulation_ds_full_cell class. These overloads allow iteration over only the valid vertices of a full cell. This prevents segmentation faults when the triangulation’s current dimension is lower than the maximal dimension, as suggested by @mglisse.
I audited other files under Triangulation and didn’t find any code that assumes fixed-maximal-dimension iteration. The new overloads don’t conflict with any existing logic.

## Release Management

* Affected package(s): Triangulation
* Issue(s) solved (if any): fix #8967
* Feature/Small Feature (if any): n/a
* License and copyright ownership: unchanged

