### PR TITLE
Fix writing 64 bits integer into PLY files

### DIFF
--- a/Stream_support/include/CGAL/IO/PLY/PLY_writer.h
+++ b/Stream_support/include/CGAL/IO/PLY/PLY_writer.h
@@ -293,7 +293,7 @@ public:
     if(get_mode(stream) == CGAL::IO::ASCII)
     {
       stream << vec.size();
-      for(const ElementType& v : vec)
+      for(const auto& v : vec)
       {
         stream << " " << v;
       }
@@ -302,7 +302,7 @@ public:
     {
       unsigned char size = (unsigned char)(vec.size());
       stream.write(reinterpret_cast<char*>(&size), sizeof(size));
-      for(const ElementType& v : vec)
+      for(const auto& v : vec)
       {
         ElementType t = ElementType(v);
         stream.write(reinterpret_cast<char*>(&t), sizeof(t));

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -982,6 +982,10 @@ namespace IO {
 ///             of the `ofstream`, and the \link PkgStreamSupportEnumRef `IO::Mode` \endlink
 ///             of the stream must be set to `BINARY`.
 ///
+/// \attention The PLY format does not support 64 bits integer types. Therefore, if a property
+///            of type `std::int64_t` or `std::uint64_t` is found, it is converted to
+///            `std::int32_t` or `std::uint32_t` respectively while writing.
+///
 /// \tparam Point The type of the \em point property of a vertex. There is no requirement on `P`,
 ///               besides being default constructible and assignable.
 ///               In typical use cases it will be a 2D or 3D point type.

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -704,12 +704,14 @@ struct PLY_supported_data_types
                      std::int16_t, std::uint16_t,
                      std::int32_t, std::uint32_t,
                      std::int64_t, std::uint64_t,
+                     std::size_t,
                      float, double> VT_tuple; // value_type of the property map
 
   typedef std::tuple<std::int8_t, std::uint8_t,
                      std::int16_t, std::uint16_t,
                      std::int32_t, std::uint32_t,
                      std::int32_t, std::uint32_t,
+                     std::uint32_t,
                      float, double> ST_tuple; // corresponding PLY type
 
   static constexpr std::size_t data_types_n = std::tuple_size<VT_tuple>::value;
@@ -726,6 +728,7 @@ void fill_header(std::ostream& os, const Surface_mesh<Point>& sm,
                                                   "short", "ushort",
                                                   "int", "uint",
                                                   "int", "uint", // 64 --> 32
+                                                  "uint", // std::size_t
                                                   "float", "double" };
 
   typedef typename Surface_mesh<Point>::Face_index   FIndex;

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -236,7 +236,6 @@ public:
     typedef std::tuple<std::int8_t, std::uint8_t,
                        std::int16_t , std::uint16_t,
                        std::int32_t , std::uint32_t,
-                       std::int64_t, std:: uint64_t,
                        float, double> Type_tuple;
 
     for(std::size_t j = 0; j < element.number_of_properties(); ++ j)

--- a/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
@@ -72,6 +72,18 @@ int main()
     ++dvalue;
   }
 
+  std::size_t uvalue=3001;
+  auto h_uvmap = mesh.add_property_map<SMesh::Halfedge_index, std::vector<std::size_t>>("h:uv").first;
+  auto h_umap = mesh.add_property_map<SMesh::Halfedge_index, std::size_t>("h:u").first;
+  auto h_vmap = mesh.add_property_map<SMesh::Halfedge_index, std::size_t>("h:v").first;
+  for (SMesh::Halfedge_index h : halfedges(mesh))
+  {
+    h_uvmap[h]={uvalue, 2*uvalue};
+    h_umap[h]=uvalue;
+    h_vmap[h]=2*uvalue;
+    ++uvalue;
+  }
+
   out.close();
   out.open("out_ascii.ply");
   CGAL::IO::write_PLY(out, mesh);
@@ -119,6 +131,21 @@ int main()
       assert(f_umap[f]==dvalue);
       assert(f_vmap[f]==-dvalue);
       ++dvalue;
+    }
+
+    auto h_uvmap_bis = mesh_bis.property_map<SMesh::Halfedge_index, std::vector<std::uint32_t>>("h:uv").value();
+    auto h_umap_bis = mesh_bis.property_map<SMesh::Halfedge_index, std::uint32_t>("h:u").value();
+    auto h_vmap_bis = mesh_bis.property_map<SMesh::Halfedge_index, std::uint32_t>("h:v").value();
+
+    uvalue=3001;
+    for (SMesh::Halfedge_index h : halfedges(mesh_bis))
+    {
+      assert(h_uvmap_bis[h].size()==2);
+      assert(h_uvmap_bis[h][0]==uvalue);
+      assert(h_uvmap_bis[h][1]==2*uvalue);
+      assert(h_umap_bis[h]==uvalue);
+      assert(h_vmap_bis[h]==2*uvalue);
+      ++uvalue;
     }
   }
 

--- a/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
+++ b/Surface_mesh/test/Surface_mesh/sm_ply_io.cpp
@@ -97,7 +97,7 @@ int main()
   const std::array<std::string,2> fnames = {"out_ascii.ply", "out_binary.ply"};
   for (std::string fn : fnames)
   {
-    std::cout << "Reading " << fn << "\n";
+    std::cout << "Reading " << fn << std::endl;
     in.close();
     in.open(fn, std::ios::binary);
     SMesh mesh_bis;
@@ -133,8 +133,11 @@ int main()
       ++dvalue;
     }
 
+    assert((mesh_bis.property_map<SMesh::Halfedge_index, std::vector<std::uint32_t>>("h:uv").has_value()));
     auto h_uvmap_bis = mesh_bis.property_map<SMesh::Halfedge_index, std::vector<std::uint32_t>>("h:uv").value();
+    assert((mesh_bis.property_map<SMesh::Halfedge_index, std::uint32_t>("h:u").has_value()));
     auto h_umap_bis = mesh_bis.property_map<SMesh::Halfedge_index, std::uint32_t>("h:u").value();
+    assert((mesh_bis.property_map<SMesh::Halfedge_index, std::uint32_t>("h:v").has_value()));
     auto h_vmap_bis = mesh_bis.property_map<SMesh::Halfedge_index, std::uint32_t>("h:v").value();
 
     uvalue=3001;


### PR DESCRIPTION
## Summary of Changes

The PLY file format does not support 64 bits (signed/unsigned) integers.

In the overload of the writer specific to `Surface_mesh`, we try to write all property maps with value types compatible with the PLY file format (char, uchar, etc.).

We also tolerate 64 bits signed / unsigned integers, but used to cast it to int32 / uint32:

```cpp
    {
      Int64_map pmap;
      boost::tie(pmap, okay) = sm.template property_map<Simplex,boost::int64_t>(prop[i]);
      if(okay)
      {
        os << "property int " << name << std::endl;
        printers.push_back(new internal::Simple_property_printer<Simplex,Int64_map,boost::int32_t>(pmap));
        continue;
      }
    }
```

In https://github.com/CGAL/cgal/pull/6575, the code was factorized, but the conversion to 32 bits was accidentally lost (https://github.com/CGAL/cgal/commit/aa9f5215c4afa79d29cc5491d1d690cd2ed7a142). Hence, we were writing 8 bytes values (while announcing 4 bytes values) and writing a property map with value type a 64 bits integers (or a range of 64 bits integers) would make the file unreadable.

The PR re-introduces the conversions, and also removes the recursion of the function.

The bug is from CGAL 5.5, but we have recent changes to PLY I/O introducing named parameters and whatnot that make it a little tedious to backport so I will wait to see if there is a need.

## Release Management

* Affected package(s): `Surface_mesh`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

