### PR TITLE
Mesh_3: fix use of initial_points_generator (fix #9159)

### DIFF
--- a/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
+++ b/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
@@ -948,7 +948,10 @@ power_distance_to_power_sphereC3(const FT &px, const FT &py, const FT &pz, const
                                         sx, sy, sz, sw,
                                         tx, ty, tz, FT(1));
 
-  return -ff0/(ff1 - ff0);
+  if(is_zero(ff0))
+    return FT(0);
+  else
+    return -ff0/(ff1 - ff0);
 }
 
  // I will use this to test if the radial axis of three spheres

--- a/Mesh_3/examples/Mesh_3/random_labeled_image.h
+++ b/Mesh_3/examples/Mesh_3/random_labeled_image.h
@@ -2,10 +2,9 @@
 #include <CGAL/Random.h>
 #include <algorithm>
 
-CGAL::Image_3 random_labeled_image()
+CGAL::Image_3 random_labeled_image(const int number_of_spheres = 50)
 {
   const int dim = 400;
-  const unsigned char number_of_spheres = 50;
   const int max_radius_of_spheres = 10;
   const int radius_of_big_sphere = 80;
   _image* image = _createImage(dim, dim, dim, 1,
@@ -16,7 +15,7 @@ CGAL::Image_3 random_labeled_image()
 
   std::ptrdiff_t center = dim / 2;
   CGAL::Random rand(0);
-  for(unsigned char n = number_of_spheres; n > 0 ; --n) {
+  for(auto n = number_of_spheres; n > 0 ; --n) {
     std::size_t i, j, k;
     do {
       i = rand.uniform_smallint(1 + max_radius_of_spheres,

--- a/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_labeled_image.h
@@ -189,6 +189,7 @@ struct Construct_initial_points_labeled_image
                                                      Word()));
     std::cout << "  " << seeds.size() << " components were found." << std::endl;
     std::cout << "Construct initial points..." << std::endl;
+    int nb_of_points = 0;
     for(const Seed seed : seeds)
     {
       const Point_3 seed_point = get_point(seed.i, seed.j, seed.k);
@@ -320,9 +321,11 @@ struct Construct_initial_points_labeled_image
           c3t3.set_index(v, intersect_index);
 
           *pts++ = std::make_pair(pi, intersect_index); // dimension 2 by construction, points are on surface
+          ++nb_of_points;
         }
       }
     }
+    std::cout << "  " << nb_of_points << " initial points were constructed." << std::endl;
     return pts;
   }
 };

--- a/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_labeled_image.h
@@ -105,7 +105,7 @@ struct Construct_initial_points_labeled_image
   * Constructs a functor for generating initial points in labeled images.
   * @param image the labeled image that defines the mesh domain
   * @param domain the mesh domain
-  *  @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below:
+  * @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below:
   *
   * \cgalNamedParamsBegin
   *   \cgalParamNBegin{verbose}

--- a/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_labeled_image.h
@@ -99,16 +99,32 @@ struct Construct_initial_points_labeled_image
 {
   const CGAL::Image_3& image_;
   const MeshDomain& domain_;
+  const bool verbose_;
 
   /*!
   * Constructs a functor for generating initial points in labeled images.
   * @param image the labeled image that defines the mesh domain
   * @param domain the mesh domain
+  *  @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below:
+  *
+  * \cgalNamedParamsBegin
+  *   \cgalParamNBegin{verbose}
+  *     \cgalParamDescription{if `true`, information about the connected components
+  *                           detected in the image are printed out during the
+  *                           initial points generation process.}
+  *     \cgalParamType{`bool`}
+  *     \cgalParamDefault{`false`}
+  *   \cgalParamNEnd
+  * \cgalNamedParamsEnd
   */
+
+  template <typename NamedParameters = parameters::Default_named_parameters>
   Construct_initial_points_labeled_image(const CGAL::Image_3& image,
-                                         const MeshDomain& domain)
+                                         const MeshDomain& domain,
+                                         NamedParameters np = parameters::default_values())
     : image_(image)
     , domain_(domain)
+    , verbose_(parameters::choose_parameter(parameters::get_parameter(np, internal_np::verbose), false))
   { }
 
   /*!
@@ -181,14 +197,18 @@ struct Construct_initial_points_labeled_image
 
     Seeds seeds;
     Mesh_3::internal::Get_point<Point_3> get_point(&image_);
-    std::cout << "Searching for connected components..." << std::endl;
+    if(verbose_) {
+      std::cout << "Searching for connected components..." << std::endl;
+    }
     CGAL_IMAGE_IO_CASE(image_.image(), search_for_connected_components_in_labeled_image(image_,
                                                      std::back_inserter(seeds),
                                                      CGAL::Emptyset_iterator(),
                                                      transform,
                                                      Word()));
-    std::cout << "  " << seeds.size() << " components were found." << std::endl;
-    std::cout << "Construct initial points..." << std::endl;
+    if(verbose_) {
+      std::cout << "  " << seeds.size() << " components were found." << std::endl;
+      std::cout << "Construct initial points..." << std::endl;
+    }
     int nb_of_points = 0;
     for(const Seed seed : seeds)
     {
@@ -325,7 +345,9 @@ struct Construct_initial_points_labeled_image
         }
       }
     }
-    std::cout << "  " << nb_of_points << " initial points were constructed." << std::endl;
+    if(verbose_) {
+      std::cout << "  " << nb_of_points << " initial points were constructed." << std::endl;
+    }
     return pts;
   }
 };

--- a/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_labeled_image.h
@@ -19,6 +19,7 @@
 
 #include <CGAL/iterator.h>
 #include <CGAL/point_generators_3.h>
+#include <CGAL/Named_function_parameters.h>
 
 #include <CGAL/Image_3.h>
 

--- a/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_labeled_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Construct_initial_points_labeled_image.h
@@ -135,6 +135,8 @@ struct Construct_initial_points_labeled_image
   * - a `Weighted_point_3` for the point
   * - an `int` for the minimal dimension of the subcomplexes on which the point lies
   * - a `MeshDomain::Index` for the corresponding subcomplex index
+  * @param pts output iterator to store the constructed points
+  * @param n number of points to be constructed per connected component
   */
   template <typename OutputIterator>
   OutputIterator operator()(OutputIterator pts, const int n = 20) const

--- a/STL_Extension/include/CGAL/STL_Extension/internal/mesh_option_classes.h
+++ b/STL_Extension/include/CGAL/STL_Extension/internal/mesh_option_classes.h
@@ -265,10 +265,11 @@ struct Initialization_options
       , call_( [](void* g, Point_output_function_iterator oit, const int n) {
                  using Real_generator = CGAL::cpp20::remove_cvref_t<Generator>;
                  auto* real_g = static_cast<Real_generator*>(g);
-                 if( n < 0 )
-                   return (*real_g)(oit);
-                 else
-                  return (*real_g)(oit, n);
+                 if constexpr (std::is_invocable_v<Real_generator, Point_output_function_iterator>) {
+                   if( n < 0 )
+                     return (*real_g)(oit);
+                 }
+                 return (*real_g)(oit, n);
                } )
     {
     }


### PR DESCRIPTION
## Summary of Changes

The bug was in #7798. The generator was called with its parameter `n = 0` instead of its default value.

## Todo

- [x] Add test

## Release Management

* Affected package(s): Mesh_3 
* Issue(s) solved (if any): fix #9159


