### PR TITLE
Fixed the definition of the Geometry traits for drawing

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Draw_aos/Arr_coordinate_converter.h
+++ b/Arrangement_on_surface_2/include/CGAL/Draw_aos/Arr_coordinate_converter.h
@@ -71,7 +71,7 @@ private:
  */
 template <typename Kernel, int atanX, int atanY>
 class Arr_coordinate_converter<Arr_geodesic_arc_on_sphere_traits_2<Kernel, atanX, atanY>> {
-  using Geom_traits = Arr_geodesic_arc_on_sphere_traits_2<Kernel>;
+  using Geom_traits = Arr_geodesic_arc_on_sphere_traits_2<Kernel, atanX, atanY>;
   using Approx_traits = Arr_approximate_traits<Geom_traits>;
   using Approx_point = typename Approx_traits::Approx_point;
   using Approx_nt = typename Approx_traits::Approx_nt;


### PR DESCRIPTION
## Summary of Changes

This is a small fix for the drawing of arrangements induced by geodesic arcs (which I forgot to add to my recent set of small fixes).

## Release Management

* Affected package(s): Arrangement_on_surface_2/
* Issue(s) solved (if any): none
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: TAU

