### PR TITLE
Workaround wrong overload pick by at least clang 21.1.6

### DIFF
--- a/Triangulation_3/test/Triangulation_3/test_regular_remove_3.cpp
+++ b/Triangulation_3/test/Triangulation_3/test_regular_remove_3.cpp
@@ -222,7 +222,7 @@ public:
 // Inserts number points in the triangulation and the multiset, using PI as the
 // point generator.
 template < class PI >
-void insert (Cls &T, point_set &points, int number)
+void insert_points (Cls &T, point_set &points, int number)
 {
     int i = 1;
     for (PI pi (number), pend; pi != pend; ++pi, ++i) {
@@ -345,28 +345,28 @@ int main(int argc, char **argv)
     std::cout << " test dimension 0" << std::endl;
     randgen.seed(seed0);
 
-    insert<point_iterator_0> (T, points, 10);
+    insert_points<point_iterator_0> (T, points, 10);
     dim_jump (T, Point (0, 0, 1), 0);
     remove (T, points, 10);
 
     std::cout << " test dimension 1" << std::endl;
     randgen.seed(seed1);
 
-    insert<point_iterator_1> (T, points, 20);
+    insert_points<point_iterator_1> (T, points, 20);
     dim_jump (T, Point (0, 0, 1), 1);
     remove (T, points, 20);
 
     std::cout << " test dimension 2" << std::endl;
     randgen.seed(seed2);
 
-    insert<point_iterator_2> (T, points, 100);
+    insert_points<point_iterator_2> (T, points, 100);
     dim_jump (T, Point (0, 0, 1), 2);
     remove (T, points, 100);
 
     std::cout << " test dimension 3" << std::endl;
     randgen.seed(seed3);
 
-    insert<point_iterator_3> (T, points, 500);
+    insert_points<point_iterator_3> (T, points, 500);
     assert(T.dimension() == 3);
     remove (T, points, 500);
 


### PR DESCRIPTION
Fixes [this error](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.0.3-I-411/Triangulation_3/TestReport_gimeno_ArchLinux-clang-CXX17-Release.gz)