### PR TITLE
CGAL_SetupBoost - remove `cmake_policy`

### DIFF
--- a/Installation/cmake/modules/CGAL_SetupBoost.cmake
+++ b/Installation/cmake/modules/CGAL_SetupBoost.cmake
@@ -13,7 +13,6 @@
 include_guard(GLOBAL)
 include(${CMAKE_CURRENT_LIST_DIR}/CGAL_TweakFindBoost.cmake)
 
-cmake_policy(VERSION 3.12...3.30)
 find_package( Boost 1.74 REQUIRED )
 
 if(Boost_FOUND AND Boost_VERSION VERSION_LESS 1.74)


### PR DESCRIPTION
As it's superseded by e5001d1 which sets in `CGAL_SetupCGALDependencies.cmake` 

```cmake
cmake_minimum_required(VERSION 3.12...3.31)
```

which implies

```cmake
cmake_policy(VERSION 3.12...3.31)
```

which propagated to `SetupBoost` automatically.
