### PR TITLE
PMP: Tests CMakelists.txt bugfix

### DIFF
--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/CMakeLists.txt
@@ -137,7 +137,7 @@ else()
   message(STATUS "NOTICE: Tests are not using Ceres.")
 endif()
 
-if(CGAL_ENABLE_TESTING)
+if(CGAL_ENABLE_TESTING AND TARGET CGAL::Eigen3_support)
   set_tests_properties(
     "execution   of  triangulate_hole_Polyhedron_3_no_delaunay_test"
     "execution   of  triangulate_hole_Polyhedron_3_test"


### PR DESCRIPTION
## Summary of Changes

Tests for triangulate_hole_Polyhedron_3_no_delaunay_test and triangulate_hole_Polyhedron_3_test were also added in absence of Eigen3 causing the testsuite to abort

## Release Management

* Affected package(s): PMP

