### PR TITLE
improve TDS_3::is_valid

### DIFF
--- a/Constrained_triangulation_3/test/Constrained_triangulation_3/cdt_test_insert_constrained_edge_from_EDG_file.cpp
+++ b/Constrained_triangulation_3/test/Constrained_triangulation_3/cdt_test_insert_constrained_edge_from_EDG_file.cpp
@@ -49,7 +49,7 @@ int main()
     assert(cdt.is_cell(vertices[1], vertices[2], vertices[3], vertices[4], c));
 
     Delaunay::Cell_handle ch;
-    int li, lj;
+    [[maybe_unused]] int li, lj;
     assert(!cdt.is_edge(vertices[0], vertices[1], ch, li, lj));
     cdt.insert_constrained_edge(vertices[0], vertices[1]);
     cdt.insert_constrained_edge(vertices[5], vertices[1]);

--- a/STL_Extension/include/CGAL/Time_stamper.h
+++ b/STL_Extension/include/CGAL/Time_stamper.h
@@ -131,7 +131,7 @@ public:
   {
   }
 
-  static auto display_id(const T* pt, int)
+  static auto display_id(const T* pt, int = 0)
   {
     return static_cast<const void*>(pt);
   }

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -34,6 +34,7 @@
 #include <boost/iterator/function_output_iterator.hpp>
 #include <CGAL/utility.h>
 #include <CGAL/iterator.h>
+#include <CGAL/IO/io.h>
 #include <CGAL/STL_Extension/internal/Has_member_visited.h>
 
 #include <CGAL/Unique_hash_map.h>
@@ -3747,11 +3748,26 @@ bool
 Triangulation_data_structure_3<Vb,Cb,Ct>::
 is_valid(Vertex_handle v, bool verbose, int level) const
 {
-  bool result = v->is_valid(verbose,level);
-  result = result && v->cell()->has_vertex(v);
+  bool v_is_valid = v->is_valid(verbose,level);
+  bool has_vertex = v->cell()->has_vertex(v);
+  bool v_is_vertex = vertices().is_used(v);
+  bool vertex_cell_is_cell = cells().is_used(v->cell());
+  bool result = v_is_valid && has_vertex && v_is_vertex && vertex_cell_is_cell;
   if ( ! result ) {
-    if ( verbose )
-      std::cerr << "invalid vertex" << std::endl;
+    if ( verbose ) {
+      std::cerr << "invalid vertex " << IO::oformat(v) << std::endl;
+      if(! v_is_valid)
+        std::cerr << "- vertex not valid" << std::endl;
+      if(! has_vertex)
+        std::cerr << "- vertex->cell() does not have vertex" << std::endl;
+      if(! v_is_vertex)
+        std::cerr << "- not a vertex of the TDS" << std::endl;
+      if(! vertex_cell_is_cell)
+        std::cerr << "- vertex->cell() is not a cell of the TDS" << std::endl;
+      if(!has_vertex || !vertex_cell_is_cell)
+        std::cerr << "vertex->cell(): "
+                  << IO::oformat(v->cell()) << std::endl;
+    }
     CGAL_assertion(false);
   }
   return result;
@@ -3764,6 +3780,12 @@ is_valid(Cell_handle c, bool verbose, int level) const
 {
     if ( ! c->is_valid(verbose, level) )
         return false;
+    if(is_cell(c) == false) {
+        if (verbose)
+            std::cerr << "not a cell" << std::endl;
+        CGAL_assertion(false);
+        return false;
+    }
 
     switch (dimension()) {
     case -2:
@@ -3942,7 +3964,7 @@ is_valid(Cell_handle c, bool verbose, int level) const
       {
         int i;
         for(i = 0; i < 4; i++) {
-          if ( c->vertex(i) == Vertex_handle() ) {
+          if ( c->vertex(i) == Vertex_handle() || vertices().is_used(c->vertex(i)) == false ) {
             if (verbose)
                 std::cerr << "vertex " << i << " nullptr" << std::endl;
             CGAL_assertion(false);
@@ -3953,7 +3975,7 @@ is_valid(Cell_handle c, bool verbose, int level) const
 
         for(i = 0; i < 4; i++) {
           Cell_handle n = c->neighbor(i);
-          if ( n == Cell_handle() ) {
+          if ( n == Cell_handle() || cells().is_used(n) == false ) {
             if (verbose)
               std::cerr << "neighbor " << i << " nullptr" << std::endl;
             CGAL_assertion(false);

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -3780,9 +3780,9 @@ is_valid(Cell_handle c, bool verbose, int level) const
 {
     if ( ! c->is_valid(verbose, level) )
         return false;
-    if(is_cell(c) == false) {
+    if(cells().is_used(c) == false) {
         if (verbose)
-            std::cerr << "not a cell" << std::endl;
+            std::cerr << "invalid cell " << IO::oformat(c) << std::endl;
         CGAL_assertion(false);
         return false;
     }

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
@@ -277,8 +277,6 @@ public:
       {
         if (!is_well_oriented(triangulation, cit))
           return ORIENTATION_PROBLEM;
-        if (!triangulation.tds().is_valid(cit, true))
-          return C_PROBLEM;
       }
 
       // check angles
@@ -288,13 +286,6 @@ public:
         if (      curr_max_cos < max_cos_after_collapse  // angles decreased
          && acceptable_max_cos < max_cos_after_collapse) // && angles go below acceptable bound
           return ANGLE_PROBLEM;
-      }
-
-      // check validity of vertices
-      for (Vertex_handle vit : triangulation.finite_vertex_handles())
-      {
-        if (!triangulation.tds().is_valid(vit, true))
-          return V_PROBLEM;
       }
 
       //int si_nb_vh0 = nb_incident_subdomains(vh0, c3t3);


### PR DESCRIPTION
## Summary of Changes

improve `TDS_3::is_valid`:
  - for a vertex, verify that its `cell()` that is not removed from the `Compact_container`,
  - for a cell, verify that its `neighbor(i)` and `vertex(i)` are not removed,
  - and display using `CGAL::IO::oformat`.

## Release Management

* Affected package(s): TDS_3, and all 3D triangulation packages
* License and copyright ownership: no change, maintenance by GF

