### PR TITLE
Concept-related fixes

### DIFF
--- a/AABB_tree/include/CGAL/AABB_traits_2.h
+++ b/AABB_tree/include/CGAL/AABB_traits_2.h
@@ -484,19 +484,19 @@ public:
 
 private:
   /**
-   * @brief Computes bounding box of one primitive
+   * @brief Computes the bounding box of a primitive
    * @param pr the primitive
    * @return the bounding box of the primitive \c pr
    */
   template <typename PM>
-  Bounding_box compute_bbox(const Primitive& pr, const PM&)const
+  Bounding_box compute_bbox(const Primitive& pr, const PM&) const
   {
     return get(bbm, pr.id());
   }
 
-  Bounding_box compute_bbox(const Primitive& pr, const Default&)const
+  Bounding_box compute_bbox(const Primitive& pr, const Default&) const
   {
-    return GeomTraits().construct_bbox_2_object()(internal::Primitive_helper<AT>::get_datum(pr, *this));
+    return internal::Primitive_helper<AT>::get_datum(pr,*this).bbox();
   }
 
   /// Comparison functions

--- a/Triangulation_2/doc/Triangulation_2/Concepts/TriangulationTraits_2.h
+++ b/Triangulation_2/doc/Triangulation_2/Concepts/TriangulationTraits_2.h
@@ -249,6 +249,16 @@ Construct_triangle_2 construct_triangle_2_object();
 /*!
 
 */
+Less_x_2 less_x_2_object();
+
+/*!
+
+*/
+Less_y_2 less_y_2_object();
+
+/*!
+
+*/
 Compare_x_2 compare_x_2_object();
 
 /*!


### PR DESCRIPTION
## Summary of Changes

`AABB_traits` was using `.bbox()`, and `AABB_traits_3.h` uses `.bbox()`, so not sure why `AABB_traits_2.h` was changed to use `Compute_bbox_2`?

## Release Management

* Affected package(s): `AABB_tree`, `Triangulation_3`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): - 
* License and copyright ownership: no change

