### PR TITLE
add and check missing `inline` keywords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -999,6 +999,7 @@ cmake_install.cmake
 CMakeCache.txt
 CMakeFiles
 cmake_install.cmake
+/compile_commands.json
 
 # Editors' automatic backups
 *.bak

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -933,6 +933,9 @@ if(CGAL_BRANCH_BUILD)
   Note that this option will modify the source directory!" FALSE)
 
     message("== Setting header checking ==")
+    find_package(CGAL COMPONENTS Qt6
+                 REQUIRED NO_PACKAGE_ROOT_PATH NO_CMAKE_PATH NO_CMAKE_ENVIRONMENT_PATH
+                 HINTS "${CGAL_SOURCE_DIR}")
     find_package(GMP REQUIRED)
     find_package(Doxygen REQUIRED)
     find_package(Eigen3 REQUIRED)
@@ -1212,6 +1215,7 @@ ${CMAKE_CURRENT_SOURCE_DIR}/../${package}/include/${header}"
     foreach(header ${list_of_headers_to_test})
       file(APPEND ${CGAL_BINARY_DIR}/test_headers.cpp "#include <${header}>\n")
     endforeach() #loop on headers to include in test file
+    file(COPY_FILE ${CGAL_BINARY_DIR}/test_headers.cpp ${CGAL_BINARY_DIR}/test_headers2.cpp)
     file(APPEND ${CGAL_BINARY_DIR}/test_headers.cpp "int main(){}\n")
 
     add_custom_target(check_headers DEPENDS ${check_pkg_target_list})
@@ -1223,6 +1227,14 @@ ${CMAKE_CURRENT_SOURCE_DIR}/../${package}/include/${header}"
       POST_BUILD
       COMMAND ${CMAKE_CXX_COMPILER} ${compile_options} ${include_options} -x
               c++ -fsyntax-only ${CGAL_BINARY_DIR}/test_headers.cpp)
+
+    # New check that headers can be included in different compilation units, that can be linked
+    # together. That checks for missing `inline` keywords.
+    add_executable(check_headers_linked_twice
+                   ${CGAL_BINARY_DIR}/test_headers.cpp
+                   ${CGAL_BINARY_DIR}/test_headers2.cpp)
+    target_link_libraries(check_headers_linked_twice PRIVATE CGAL::CGAL CGAL::CGAL_Qt6 VTK::IOImage Qt6::Widgets)
+    target_compile_options(check_headers_linked_twice PRIVATE ${compile_options} ${include_options})
 
     add_custom_target(packages_dependencies DEPENDS ${packages_deps})
     message(

--- a/SMDS_3/include/CGAL/IO/File_avizo.h
+++ b/SMDS_3/include/CGAL/IO/File_avizo.h
@@ -90,7 +90,7 @@ namespace internal {
     return false;
   }
 
-  bool line_starts_with(const std::string& line, const char* cstr)
+  inline bool line_starts_with(const std::string& line, const char* cstr)
   {
     const std::size_t fnws = line.find_first_not_of(" \t");
     if (fnws != std::string::npos)
@@ -277,6 +277,7 @@ namespace internal {
     }
   }
 
+  inline
   void read_tetrahedra(std::istream& input,
                        std::vector<std::array<int, 4> >& tetrahedra,
                        const int& nb_tets,
@@ -349,6 +350,7 @@ namespace internal {
     std::string at_label;
   };
 
+  inline
   void go_to_at_label(std::istream& input,
                       std::string& line,
                       const char* at_label)// "@1"
@@ -363,6 +365,7 @@ namespace internal {
     }
   }
 
+  inline
   bool is_avizo_tetra_format(std::istream& in, const char* binary_or_ascii)
   {
     std::string format(binary_or_ascii);

--- a/Scripts/developer_scripts/cgal_check_dependencies.sh
+++ b/Scripts/developer_scripts/cgal_check_dependencies.sh
@@ -1,6 +1,7 @@
+#!/bin/bash
 #This script must be called from the CGAL root.
 set -e
-[ -n "$CGAL_DEBUG_TRAVIS" ] && set -x
+[ -n "$RUNNER_DEBUG" ] && set -x
 while test $# -gt 0
 do
     case "$1" in
@@ -22,27 +23,27 @@ done
 
 CGAL_ROOT=$PWD
 mkdir -p dep_check_build && cd dep_check_build
-for pkg_path in $CGAL_ROOT/*
+for pkg_path in "$CGAL_ROOT"/*
 do
-  pkg=$(basename $pkg_path)
-  if [ -f $pkg_path/package_info/$pkg/dependencies ]; then
-    mv $pkg_path/package_info/$pkg/dependencies $pkg_path/package_info/$pkg/dependencies.old
+  pkg=$(basename "$pkg_path")
+  if [ -f "$pkg_path/package_info/$pkg/dependencies" ]; then
+    mv "$pkg_path/package_info/$pkg/dependencies" "$pkg_path/package_info/$pkg/dependencies.old"
   else
-    if [ -d $pkg_path/package_info/$pkg ]; then
-      touch $pkg_path/package_info/$pkg/dependencies.old
+    if [ -d "$pkg_path/package_info/$pkg" ]; then
+      touch "$pkg_path/package_info/$pkg/dependencies.old"
     fi
   fi
 done
 
 cmake -DCGAL_ENABLE_CHECK_HEADERS=TRUE -DDOXYGEN_EXECUTABLE="$DOX_PATH" -DCGAL_COPY_DEPENDENCIES=TRUE -DCMAKE_CXX_FLAGS="-std=c++1y" ..
 if [ -n "$DO_CHECK_HEADERS" ]; then
-    make -j$(nproc --all) -k check_headers
+    make -j"$(nproc --all)" -k check_headers
 fi
-make -j$(nproc --all) -k packages_dependencies
+make -j"$(nproc --all)" -k packages_dependencies
 echo " Checks finished"
-for pkg_path in $CGAL_ROOT/*
+for pkg_path in "$CGAL_ROOT"/*
 do
-  pkg=$(basename $pkg_path)
+  pkg=$(basename "$pkg_path")
   if [ -f "$pkg_path/package_info/$pkg/dependencies" ]; then
     PKG_DIFF=$(grep -Fxv -f "$pkg_path/package_info/$pkg/dependencies.old" "$pkg_path/package_info/$pkg/dependencies" || true)
     if [ -n "$PKG_DIFF" ]; then
@@ -52,15 +53,16 @@ do
     if [ -n "$PKG_DIFF" ]; then
       TOTAL_RES="Differences in $pkg:\n$PKG_DIFF\nhave disappeared.\n$TOTAL_RES"
     fi
-    if [ -f $pkg_path/package_info/$pkg/dependencies.old ]; then
-      rm $pkg_path/package_info/$pkg/dependencies.old
+    if [ -f "$pkg_path/package_info/$pkg/dependencies.old" ]; then
+      rm "$pkg_path/package_info/$pkg/dependencies.old"
     fi
   fi
 done
 echo " Checks finished"
-cd $CGAL_ROOT
+cd "$CGAL_ROOT"
 rm -r dep_check_build
 if [ -n "$TOTAL_RES" ]; then
+  # shellcheck disable=SC2059
   printf "$TOTAL_RES"
   echo " You can run cmake with options CGAL_ENABLE_CHECK_HEADERS and CGAL_COPY_DEPENDENCIES ON, make the target packages_dependencies and commit the new dependencies files,"
   echo " or simply manually edit the problematic files."

--- a/Scripts/developer_scripts/cgal_check_dependencies.sh
+++ b/Scripts/developer_scripts/cgal_check_dependencies.sh
@@ -38,6 +38,7 @@ done
 cmake -DCGAL_ENABLE_CHECK_HEADERS=TRUE -DDOXYGEN_EXECUTABLE="$DOX_PATH" -DCGAL_COPY_DEPENDENCIES=TRUE -DCMAKE_CXX_FLAGS="-std=c++1y" ..
 if [ -n "$DO_CHECK_HEADERS" ]; then
     make -j"$(nproc --all)" -k check_headers
+    make -j"$(nproc --all)" -k check_headers_linked_twice
 fi
 make -j"$(nproc --all)" -k packages_dependencies
 echo " Checks finished"

--- a/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/orbifold_enums.h
+++ b/Surface_mesh_parameterization/include/CGAL/Surface_mesh_parameterization/orbifold_enums.h
@@ -60,7 +60,7 @@ enum Orbifold_type
 /// \brief Convert the orbifold type to a literal message.
 /// \param orb_type the integer value in the enum
 /// \return the string describing the orbifold type.
-const char* get_orbifold_type(int orb_type)
+inline const char* get_orbifold_type(int orb_type)
 {
   // Messages corresponding to the different orbifold types.
   static const char* type[Parallelogram+1] = {

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -272,7 +272,7 @@ struct Dihedral_angle_cosine
   }
 };
 
-Dihedral_angle_cosine cosine_of_90_degrees()
+inline Dihedral_angle_cosine cosine_of_90_degrees()
 {
   return Dihedral_angle_cosine(CGAL::ZERO, 0., 1.);
 }


### PR DESCRIPTION
## Summary of Changes

- add a CI test that verifies all CGAL headers can be included in two compilation units and then linked together without error
- add missing `inline` keywords

Before this PR, the check reported:

```
/usr/bin/ld: CMakeFiles/check_headers_linked_twice.dir/__/test_headers2.cpp.o: in function `CGAL::IO::internal::line_starts_with(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*)':
test_headers2.cpp:(.text+0xdac): multiple definition of `CGAL::IO::internal::line_starts_with(std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> > const&, char const*)'; CMakeFiles/check_headers_linked_twice.dir/__/test_headers.cpp.o:test_headers.cpp:(.text+0xdac): first defined here
/usr/bin/ld: CMakeFiles/check_headers_linked_twice.dir/__/test_headers2.cpp.o: in function `CGAL::IO::internal::read_tetrahedra(std::istream&, std::vector<std::array<int, 4ul>, std::allocator<std::array<int, 4ul> > >&, int const&, bool)':
test_headers2.cpp:(.text+0xe19): multiple definition of `CGAL::IO::internal::read_tetrahedra(std::istream&, std::vector<std::array<int, 4ul>, std::allocator<std::array<int, 4ul> > >&, int const&, bool)'; CMakeFiles/check_headers_linked_twice.dir/__/test_headers.cpp.o:test_headers.cpp:(.text+0xe19): first defined here
/usr/bin/ld: CMakeFiles/check_headers_linked_twice.dir/__/test_headers2.cpp.o: in function `CGAL::IO::internal::go_to_at_label(std::istream&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, char const*)':
test_headers2.cpp:(.text+0x1092): multiple definition of `CGAL::IO::internal::go_to_at_label(std::istream&, std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >&, char const*)'; CMakeFiles/check_headers_linked_twice.dir/__/test_headers.cpp.o:test_headers.cpp:(.text+0x1092): first defined here
/usr/bin/ld: CMakeFiles/check_headers_linked_twice.dir/__/test_headers2.cpp.o: in function `CGAL::IO::internal::is_avizo_tetra_format(std::istream&, char const*)':
test_headers2.cpp:(.text+0x110a): multiple definition of `CGAL::IO::internal::is_avizo_tetra_format(std::istream&, char const*)'; CMakeFiles/check_headers_linked_twice.dir/__/test_headers.cpp.o:test_headers.cpp:(.text+0x110a): first defined here
/usr/bin/ld: CMakeFiles/check_headers_linked_twice.dir/__/test_headers2.cpp.o: in function `CGAL::Surface_mesh_parameterization::get_orbifold_type(int)':
test_headers2.cpp:(.text+0x1329): multiple definition of `CGAL::Surface_mesh_parameterization::get_orbifold_type(int)'; CMakeFiles/check_headers_linked_twice.dir/__/test_headers.cpp.o:test_headers.cpp:(.text+0x1329): first defined here
/usr/bin/ld: CMakeFiles/check_headers_linked_twice.dir/__/test_headers2.cpp.o: in function `CGAL::Tetrahedral_remeshing::cosine_of_90_degrees()':
test_headers2.cpp:(.text+0x135f): multiple definition of `CGAL::Tetrahedral_remeshing::cosine_of_90_degrees()'; CMakeFiles/check_headers_linked_twice.dir/__/test_headers.cpp.o:test_headers.cpp:(.text+0x135f): first defined here
collect2: error: ld returned 1 exit status
```
## Release Management

* Affected package(s): CGAL
* License and copyright ownership: N/A, maintenance by GeometryFactory

