### PR TITLE
Fix typo in Algebraic_structure_traits.h: Fiel_tag -> Field_tag

### DIFF
--- a/Number_types/include/CGAL/Sqrt_extension/Algebraic_structure_traits.h
+++ b/Number_types/include/CGAL/Sqrt_extension/Algebraic_structure_traits.h
@@ -178,7 +178,7 @@ template< class Type >
 class Sqrt_extension_algebraic_structure_traits_base< Type,
                                                 CGAL::Field_with_kth_root_tag >
   : public Sqrt_extension_algebraic_structure_traits_base< Type,
-                                      // TODO: Why not Fiel_tag?
+                                      // TODO: Why not Field_tag?
                                       CGAL::Field_with_sqrt_tag > {
   // Nothing new
 };
@@ -187,7 +187,7 @@ template< class Type >
 class Sqrt_extension_algebraic_structure_traits_base< Type,
                                                 CGAL::Field_with_root_of_tag >
   : public Sqrt_extension_algebraic_structure_traits_base< Type,
-                                      // TODO: Why not Fiel_tag?
+                                      // TODO: Why not Field_tag?
                                       CGAL::Field_with_sqrt_tag > {
   // Nothing new
 };


### PR DESCRIPTION
## Summary of Changes

Fixed a typo in `Algebraic_structure_traits.h` where `Field_tag` was misspelled as `Fiel_tag` in the comments.

## Release Management

* Affected package(s): Number_types
* Issue(s) solved (if any):
* Feature/Small Feature (if any):
* License and copyright ownership: I confirm this contribution is under the repository's license.
