### PR TITLE
Replace deprecated random_shuffle with std::shuffle in Min_ellipse_2.h

### DIFF
--- a/Bounding_volumes/include/CGAL/Min_ellipse_2.h
+++ b/Bounding_volumes/include/CGAL/Min_ellipse_2.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include <algorithm>
 #include <iostream>
+#include<random>
 
 namespace CGAL {
 
@@ -339,7 +340,8 @@ class Min_ellipse_2 {
 
                     // shuffle points at random
                     std::vector<Point> v( first, last);
-                    CGAL::cpp98::random_shuffle( v.begin(), v.end(), random);
+                    std::default_random_engine rng(random.get_seed());
+                    std::shuffle( v.begin(), v.end(), rng);
                     std::copy( v.begin(), v.end(),
                                std::back_inserter( points)); }
                 else


### PR DESCRIPTION
## Summary of Changes

Replaced the deprecated `CGAL::cpp98::random_shuffle` with the modern C++11 `std::shuffle` in `Bounding_volumes/include/CGAL/Min_ellipse_2.h`.

To enable this change, I:
- Added `#include <random>`.
- Initialized a `std::default_random_engine` using the seed from the existing `CGAL::Random` object to ensure the `std::shuffle` function works correctly with the existing random number generator logic.
- Verified the fix by building and running the `test_Min_ellipse_2` test executable.

## Release Management

* Affected package(s): Bounding_volumes
* Issue(s) solved (if any):
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature):
* License and copyright ownership: I confirm that I have the right to contribute this code.