### PR TITLE
Mesh_3: fix a few clangd warnings

### DIFF
--- a/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
+++ b/Cartesian_kernel/include/CGAL/constructions/kernel_ftC3.h
@@ -883,7 +883,7 @@ radical_axisC3(const RT &px, const RT &py, const RT &pz, const We & /* pw */,
   c = RT(1)*determinant(dqx, dqy, drx, dry);
 }
 
-// function used in critical_squared_radiusC3
+// function used in power_distance_to_power_sphereC3
 // power ( t, tw) with respect to
 // circle orthogonal (p,pw), (q,qw), (r,rw), (s,sw)
 template < class FT>

--- a/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Slivers_exuder.h
@@ -26,34 +26,43 @@
 #include <CGAL/Mesh_3/Null_exuder_visitor.h>
 #include <CGAL/Mesh_3/Triangulation_helpers.h>
 
+#include <CGAL/assertions.h>
 #include <CGAL/Bbox_3.h>
+#include <CGAL/Compact_container.h>
 #include <CGAL/Double_map.h>
 #include <CGAL/enum.h>
 #include <CGAL/functional.h>
-#include <CGAL/STL_Extension/internal/Has_member_visited.h>
 #include <CGAL/iterator.h>
+#include <CGAL/Kernel/global_functions_3.h>
 #include <CGAL/Real_timer.h>
+#include <CGAL/STL_Extension/internal/Has_member_visited.h>
 
 #include <CGAL/boost/iterator/transform_iterator.hpp>
 
+#include <CGAL/number_type_config.h>
+#include <CGAL/tags.h>
 #include <boost/format.hpp>
 #include <boost/iterator/function_output_iterator.hpp>
 
-#include <optional>
 #include <algorithm>
-#include <iomanip> // std::setprecision
-#include <iostream> // std::cerr/cout
+#include <cstddef>
+#include <limits>
 #include <map>
-#include <set>
+#include <optional>
+#include <type_traits>
+#include <utility>
 #include <vector>
 
 #ifdef CGAL_CONCURRENT_MESH_3_PROFILING
 # define CGAL_PROFILE
 # include <CGAL/Profile_counter.h>
+# include <iostream> // std::cerr/cout
 #endif
 
 #ifdef CGAL_LINKED_WITH_TBB
+# include <CGAL/Mesh_3/Worksharing_data_structures.h>
 # include <tbb/task_group.h>
+# include <tbb/concurrent_vector.h>
 #endif
 
 
@@ -61,6 +70,9 @@
   #define CGAL_MESH_3_EXUDER_VERBOSE
 #endif
 
+#if defined(CGAL_MESH_3_EXUDER_VERBOSE) || defined(CGAL_MESH_3_DEBUG_SLIVERS_EXUDER)
+# include <iostream>
+#endif
 
 namespace CGAL {
 


### PR DESCRIPTION
## Summary of Changes

Mesh_3: fix a few clangd warnings

## Release Management

* Affected package(s): Mesh_3
