### PR TITLE
Documentation: fix in CGAL css file

### DIFF
--- a/Documentation/doc/resources/1.14.0/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.14.0/cgal_stylesheet.css
@@ -208,6 +208,14 @@ a.el {
   vertical-align: middle;
 }
 
+@media (prefers-color-scheme: dark) {
+
+  .image > img {
+    border-radius: 1ex;
+    background: white;
+  }
+}
+
 .PkgAuthors {
   font-style: italic;
 }

--- a/Documentation/doc/resources/1.14.0/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.14.0/cgal_stylesheet.css
@@ -109,11 +109,6 @@ dl {
   padding-right: 20px;
 }
 
-.tparams .paramname {
-  font-weight: bold;
-  vertical-align: top;
-}
-
 h1 {
   font-size: 180%;
 }
@@ -167,9 +162,6 @@ h2 {
   margin-right: 2px;
 }
 
-h1.groupheader {
-  font-size: 150%;
-}
 
 /* enable this to make sections more alike */
 /* h2.groupheader { */
@@ -275,9 +267,6 @@ span.footnoteContent div {
 
 /* footnote support end */
 
-dl {
-  padding: 0 0 0 0;
-}
 
 dl.section,
 dl.hasModels,


### PR DESCRIPTION
## Summary of Changes

Fixes in the file `cgal_stylesheet.css` used by the CGAL Doxygen documentation, in addition to `doxygen.css` (the later being generated by Doxygen at each run of Doxygen),

- fix the CSS for images in dark mode:
  - white background,
  - rounded corners,
- remove CSS rules that are identical to those in `doxygen.css`

## Release Management

* Affected package(s): Documentation
* License and copyright ownership: N/A


