### PR TITLE
Restore std::array as valid triangle type

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/autorefinement.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/autorefinement.h
@@ -1578,9 +1578,9 @@ bool autorefine_triangle_soup(PointRange& soup_points,
             for (size_t ti = r.begin(); ti != r.end(); ++ti)
             {
               soup_triangles_out[offset + ti] =
-                { triangle_buffer[ti][0]->second,
+                { { triangle_buffer[ti][0]->second,
                   triangle_buffer[ti][1]->second,
-                  triangle_buffer[ti][2]->second };
+                  triangle_buffer[ti][2]->second } };
                 visitor.new_subdivision(soup_triangles_out[offset + ti], soup_triangles[tri_inter_ids_inverse[new_triangles[ti].second]]);
             }
           }
@@ -1609,9 +1609,9 @@ bool autorefine_triangle_soup(PointRange& soup_points,
     soup_triangles_out.reserve(offset + new_triangles.size());
     for (const std::pair<std::array<EK::Point_3,3>, std::size_t>& t_and_id : new_triangles)
     {
-      soup_triangles_out.push_back({ get_point_id(t_and_id.first[0]),
+      soup_triangles_out.push_back({{ get_point_id(t_and_id.first[0]),
                                      get_point_id(t_and_id.first[1]),
-                                     get_point_id(t_and_id.first[2]) });
+                                     get_point_id(t_and_id.first[2]) }});
       if constexpr(std::is_same_v<Visitor, Wrap_snap_visitor>)
         visitor.new_subdivision(soup_triangles_out[soup_triangles_out.size()-1], soup_triangles[tri_inter_ids_inverse[t_and_id.second]]);
       else

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/triangle_soup_snap_rounding.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/triangle_soup_snap_rounding.h
@@ -78,7 +78,7 @@ public:
   typedef typename Range::iterator iterator;
 
   Indexes_range() = default;
-  Indexes_range(const std::initializer_list<std::size_t>  &l): Range(l), m_id(0), modified(true){}
+//  Indexes_range(const std::initializer_list<std::size_t>  &l): Range(l), m_id(0), modified(true){}
   Indexes_range(Range &p): Range(p), modified(true){}
   Indexes_range(Range &&p): Range(std::move(p)), modified(true){}
   Indexes_range(Range &p, std::size_t id): Range(p), m_id(id),modified(false){}

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_autorefinement.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_autorefinement.cpp
@@ -1,4 +1,3 @@
-
 #include <CGAL/Polygon_mesh_processing/intersection.h>
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
 #include <CGAL/Polygon_mesh_processing/autorefinement.h>
@@ -8,6 +7,8 @@
 
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <boost/container/small_vector.hpp>
 
 #include <fstream>
 #include <sstream>
@@ -166,6 +167,15 @@ void test(const char* fname, std::size_t nb_vertices_after_autorefine, std::size
 //  CGAL::IO::write_polygon_soup("/tmp/debug.off", points, triangles);
 }
 
+template <class Triangle, class Tag>
+void test_triangle_container(Tag tag)
+{
+  std::vector<K::Point_3> points;
+  std::vector< Triangle > triangles;
+  CGAL::IO::read_polygon_soup(CGAL::data_file_path("meshes/elephant.off"), points, triangles);
+  PMP::autorefine_triangle_soup(points, triangles, CGAL::parameters::concurrency_tag(tag));
+}
+
 int main(int argc, const char** argv)
 {
   // file nb_polylines total_nb_points nb_vertices_after_autorefine all_fixed nb_vertices_after_fix triple_intersection
@@ -174,8 +184,14 @@ int main(int argc, const char** argv)
     test_coref_based(argv[1+9*i], atoi(argv[1+9*i+1]), atoi(argv[1+9*i+2]),
                      atoi(argv[1+9*i+3]), atoi(argv[1+9*i+4])==0?false:true, atoi(argv[1+9*i+5]), atoi(argv[1+9*i+6])==0?false:true);
     test(argv[1+9*i], atoi(argv[1+9*i+7]), atoi(argv[1+9*i+8]), CGAL::Sequential_tag());
+    test_triangle_container<std::vector<std::size_t> >(CGAL::Sequential_tag());
+    test_triangle_container<std::array<std::size_t,3>>(CGAL::Sequential_tag());
+    test_triangle_container<boost::container::small_vector<std::size_t, 3>>(CGAL::Sequential_tag());
 #ifdef CGAL_LINKED_WITH_TBB
     test(argv[1+9*i], atoi(argv[1+9*i+7]), atoi(argv[1+9*i+8]), CGAL::Parallel_tag());
+    test_triangle_container<std::vector<std::size_t> >(CGAL::Parallel_tag());
+    test_triangle_container<std::array<std::size_t,3>>(CGAL::Parallel_tag());
+    test_triangle_container<boost::container::small_vector<std::size_t, 3>>(CGAL::Parallel_tag());
 #endif
   }
 }


### PR DESCRIPTION
Follow up of https://github.com/CGAL/cgal/pull/8744