### PR TITLE
Replace deprecated random_shuffle with std::shuffle in Min_circle_2

### DIFF
--- a/Bounding_volumes/include/CGAL/Min_circle_2.h
+++ b/Bounding_volumes/include/CGAL/Min_circle_2.h
@@ -313,7 +313,7 @@ class Min_circle_2 {
 
                     // shuffle points at random
                     std::vector<Point> v( first, last);
-                    CGAL::cpp98::random_shuffle( v.begin(), v.end(), random);
+                    std::shuffle(v.begin(), v.end(), random);
                     std::copy( v.begin(), v.end(),
                                std::back_inserter( points)); }
                 else


### PR DESCRIPTION
### Summary of Changes

Replaced `CGAL::cpp98::random_shuffle` with `std::shuffle` in `CGAL/Min_circle_2.h`.
`std::random_shuffle` is deprecated in C++14 and removed in C++17. This change ensures compatibility with modern C++ standards.

### Release Management

* Affected package(s): Bounding_volumes
* Issue(s) solved (if any):
* Feature/Small Feature (if any):
* License and copyright ownership: I confirm this contribution is under the repository's license.