### PR TITLE
Replace deprecated random_shuffle with std::shuffle in Polygon_mesh_processing

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -50,6 +50,7 @@
 #include <type_traits>
 #include <typeinfo>
 #include <vector>
+#include <random>
 
 namespace CGAL {
 namespace Polygon_mesh_processing {
@@ -430,8 +431,8 @@ self_intersections_impl(const FaceRange& face_range,
   {
     // We are going to split the range into a number of smaller ranges. To handle
     // smaller trees of roughly the same size, we first apply a random shuffle to the range
-    CGAL::Random rng(seed);
-    CGAL::cpp98::random_shuffle(box_ptr.begin(), box_ptr.end(), rng);
+    std::default_random_engine rng(seed);
+    std::shuffle(box_ptr.begin(), box_ptr.end(), rng);
 
     // Write in a concurrent vector all pairs that intersect
     typedef tbb::concurrent_vector<std::pair<face_descriptor, face_descriptor> >         Face_pairs;


### PR DESCRIPTION
## Summary of Changes

Replaced `CGAL::cpp98::random_shuffle` with `std::shuffle` in `Polygon_mesh_processing/self_intersections.h`.
`std::random_shuffle` is deprecated in C++14 and removed in C++17.
Also replaced the incompatible `CGAL::Random` generator with `std::default_random_engine` to support `std::shuffle`.

## Release Management

* Affected package(s): Polygon_mesh_processing
* Issue(s) solved (if any):
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature):
* License and copyright ownership: I confirm this contribution is under the repository's license.
