### PR TITLE
Mesh_3 - fix protecting balls placement

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Protect_edges_sizing_field.h
@@ -54,7 +54,6 @@
 #  include <boost/math/special_functions/next.hpp> // for float_prior
 #endif
 #include <optional>
-#include <boost/tuple/tuple.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/unordered_set.hpp>
 
@@ -1050,7 +1049,7 @@ insert_balls_on_edges()
           // if 'p' is not a corner, find out a second point 'q' on the
           // curve, "far" from 'p', and limit the radius of the ball of 'p'
           // with the third of the distance from 'p' to 'q'.
-          FT p_size = query_size(p, 1, p_index);
+          FT p_size = query_size(p, 1, curve_index);
 
           FT curve_length = domain_.curve_length(curve_index);
 
@@ -1063,7 +1062,7 @@ insert_balls_on_edges()
           vp = smart_insert_point(p,
                                   CGAL::square(p_size),
                                   1 /*dim*/,
-                                  p_index,
+                                  curve_index,
                                   Vertex_handle(),
                                   CGAL::Emptyset_iterator()).first;
         }
@@ -1106,6 +1105,7 @@ get_vertex_corner_from_point(const Bare_point& p, const Index&) const
   c3t3_.triangulation().is_vertex(cwp(p), v);
 
   CGAL_assertion( q_found );
+  CGAL_assertion(v->in_dimension() == 0);
   return v;
 }
 
@@ -2189,6 +2189,9 @@ repopulate_edges_around_corner(const Vertex_handle& v, ErasedVeOutIt out)
   {
     const Vertex_handle& next = vit->first;
     const Curve_index& curve_index = vit->second;
+
+    CGAL_assertion_code(const Curve_index cid = c3t3_.curve_index(v, next));
+    CGAL_assertion(cid == curve_index);
 
     // if `v` is incident to a cycle, it might be that the full cycle,
     // including the edge `[next, v]`, has already been processed by


### PR DESCRIPTION
## Summary of Changes

Here, `p` corresponds to a point on a feature, with dimension 1.
We must use `curve_index` and not `p_index`, which may be a corner index for `p` corresponding to a vertex with `in_dimension=0`.

The risk is to compare a `Corner_index` and a `Curve_index` which have the same types (`int` by default) and same values though they correspond to corner of index `i` and curve of index `i`

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix ?
* License and copyright ownership: unchanged

