### PR TITLE
Fix doubled word typos in documentation and comments

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_batched_point_location.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_batched_point_location.h
@@ -39,7 +39,7 @@ namespace Ss2 = Surface_sweep_2;
  * \param points_end A past-the-end iterator for the range of query points.
  * \param oi Output: An output iterator for the query results.
  * \pre The value-type of PointsIterator is Arrangement::Point_2,
- *      and the value-type of OutputIterator is is pair<Point_2, Result>,
+ *      and the value-type of OutputIterator is pair<Point_2, Result>,
  *      where Result is std::optional<std::variant<Vertex_const_handle,
  *                                      Halfedge_const_handle,
  *                                      Face_const_handle> >.

--- a/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arr_compute_zone_visitor.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arr_compute_zone_visitor.h
@@ -26,7 +26,7 @@ namespace CGAL {
 
 /*! \class
  * A visitor class for Arrangement_zone_2 that outputs the zone of an
- * x-monotone curve. Specifically, it outputs handles to the the arrangement
+ * x-monotone curve. Specifically, it outputs handles to the arrangement
  * cells that the x-monotone curve intersects.
  * The class should be templated by an Arrangement_2 class, and by an
  * output iterator of a variant of types of handles to the arrangement cells

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -2554,7 +2554,7 @@ double bounded_error_Hausdorff_distance(const TriangleMesh1& tm1,
 /**
  * \ingroup PMP_distance_grp
  *
- * returns the the symmetric Hausdorff distance, that is
+ * returns the symmetric Hausdorff distance, that is
  * the maximum of `bounded_error_Hausdorff_distance(tm1, tm2, error_bound, np1, np2)`
  * and `bounded_error_Hausdorff_distance(tm2, tm1, error_bound, np2, np1)`.
  *

--- a/TDS_2/include/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/Triangulation_data_structure_2.h
@@ -2302,7 +2302,7 @@ set_adjacency(Face_handle fh,
               int ih,
               std::map< Vh_pair, Edge>& edge_map)
 {
-  // set adjacency to (fh,ih) using the the map edge_map
+  // set adjacency to (fh,ih) using the map edge_map
   // or insert (fh,ih) in edge map
   Vertex_handle vhcw  =  fh->vertex(cw(ih));
   Vertex_handle vhccw =  fh->vertex(ccw(ih));


### PR DESCRIPTION
Fixed doubled words (e.g., "the the", "is is") in documentation and comments.

Files modified:
- Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
- TDS_2/include/CGAL/Triangulation_data_structure_2.h
- Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arr_compute_zone_visitor.h
- Arrangement_on_surface_2/include/CGAL/Arr_batched_point_location.h

I confirm this contribution is under the repository's license.