### PR TITLE
Fix doubled word typos in various header and documentation files

### DIFF
--- a/Algebraic_foundations/examples/Algebraic_foundations/interoperable.cpp
+++ b/Algebraic_foundations/examples/Algebraic_foundations/interoperable.cpp
@@ -11,7 +11,7 @@ binary_func(const A& a , const B& b){
     // check for explicit interoperability
     static_assert(CT::Are_explicit_interoperable::value);
 
-    // CT::Cast is used to to convert both types into the coercion type
+    // CT::Cast is used to convert both types into the coercion type
     typename CT::Cast cast;
     // all operations are performed in the coercion type
     return cast(a)*cast(b);

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
@@ -1806,7 +1806,7 @@ public:
 #if CGAL_AK_ENABLE_DEPRECATED_INTERFACE
 
     /*!
-     * \brief computes the x-critical points of of a curve/a polynomial
+     * \brief computes the x-critical points of a curve/a polynomial
      *
      * An x-critical point (x,y) of \c f (or its induced curve)
      * satisfies f(x,y) = f_y(x,y) = 0,
@@ -1885,7 +1885,7 @@ public:
         x_critical_points_2_object);
 
     /*!
-     * \brief computes the y-critical points of of a curve/a polynomial
+     * \brief computes the y-critical points of  a curve/a polynomial
      *
      * An y-critical point (x,y) of \c f (or its induced curve)
      * satisfies f(x,y) = f_x(x,y) = 0,

--- a/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
+++ b/Algebraic_kernel_d/include/CGAL/Algebraic_kernel_d/Algebraic_curve_kernel_2.h
@@ -1885,7 +1885,7 @@ public:
         x_critical_points_2_object);
 
     /*!
-     * \brief computes the y-critical points of  a curve/a polynomial
+     * \brief computes the y-critical points of a curve/a polynomial
      *
      * An y-critical point (x,y) of \c f (or its induced curve)
      * satisfies f(x,y) = f_x(x,y) = 0,

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arrangement_on_surface_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arrangement_on_surface_2.h
@@ -74,7 +74,7 @@ public:
   typedef Arrangement_on_surface_2<Geometry_traits_2, Topology_traits> Self;
 
   /*! the <span class="textsc">Dcel</span> maintains the incidence
-   * relations between the cells of of the arrangement.
+   * relations between the cells of the arrangement.
    */
   typedef typename Topology_traits::Dcel                Dcel;
 

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/AosInputFormatter.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/AosInputFormatter.h
@@ -142,7 +142,7 @@ public:
    */
   void read_outer_ccbs_begin();
 
-  /*! reads a message indicating the end of of the container of outer CCBs of
+  /*! reads a message indicating the end of  the container of outer CCBs of
    * the current face.
    */
   void read_outer_ccbs_end();
@@ -152,7 +152,7 @@ public:
    */
   void read_inner_ccbs_begin();
 
-  /*! reads a message indicating the end of of the container of inner CCBs of the
+  /*! reads a message indicating the end of the container of inner CCBs of the
    * current face.
    */
   void read_inner_ccbs_end();

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/AosInputFormatter.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Concepts/AosInputFormatter.h
@@ -142,7 +142,7 @@ public:
    */
   void read_outer_ccbs_begin();
 
-  /*! reads a message indicating the end of  the container of outer CCBs of
+  /*! reads a message indicating the end of the container of outer CCBs of
    * the current face.
    */
   void read_outer_ccbs_end();

--- a/BGL/doc/BGL/BGL.txt
+++ b/BGL/doc/BGL/BGL.txt
@@ -489,7 +489,7 @@ stored in the vertex record.)
 The following example program shows a simple algorithm for calculating
 facet normals for a polyhedron using the \bgl API. A
 <a href="https://www.boost.org/libs/property_map/doc/vector_property_map.html">boost::vector_property_map</a>
-is used to to store the calculated normals instead of changing the Polyhedron items class.
+is used to store the calculated normals instead of changing the Polyhedron items class.
 
 \cgalExample{BGL_polyhedron_3/normals.cpp}
 

--- a/Bounding_volumes/doc/Bounding_volumes/Concepts/MinSphereAnnulusDTraits.h
+++ b/Bounding_volumes/doc/Bounding_volumes/Concepts/MinSphereAnnulusDTraits.h
@@ -78,7 +78,7 @@ typedef unspecified_type Construct_point_d;
 
 /*!
 exact number type used to do the exact computations in the
-underlying solver for linear programs. It has to to be a model for
+underlying solver for linear programs. It has to be a model for
 `RingNumberType`. There must be an implicit conversion from
 `RT` to `ET` available.
 */

--- a/Bounding_volumes/doc/Bounding_volumes/Concepts/MinSphereOfSpheresTraits.h
+++ b/Bounding_volumes/doc/Bounding_volumes/Concepts/MinSphereOfSpheresTraits.h
@@ -34,7 +34,7 @@ static const int D;
 /// @{
 
 /*!
-is a typedef to to some class representing a sphere.
+is a typedef  to some class representing a sphere.
 (The package will compute the minsphere of spheres of type
 `Sphere`.) The type `Sphere` must provide a copy constructor.
 */

--- a/Bounding_volumes/doc/Bounding_volumes/Concepts/MinSphereOfSpheresTraits.h
+++ b/Bounding_volumes/doc/Bounding_volumes/Concepts/MinSphereOfSpheresTraits.h
@@ -34,7 +34,7 @@ static const int D;
 /// @{
 
 /*!
-is a typedef  to some class representing a sphere.
+is a typedef to some class representing a sphere.
 (The package will compute the minsphere of spheres of type
 `Sphere`.) The type `Sphere` must provide a copy constructor.
 */

--- a/Convex_hull_2/doc/Convex_hull_2/CGAL/convex_hull_2.h
+++ b/Convex_hull_2/doc/Convex_hull_2/CGAL/convex_hull_2.h
@@ -49,7 +49,7 @@ depending on the type of iterator used to specify the input points. For
 input iterators, the algorithm used is that of Bykat \cgalCite{b-chfsp-78}, which
 has a worst-case running time of \cgalBigO{n h}, where \f$ n\f$ is the number of input
 points and \f$ h\f$ is the number of extreme points. For all other types of
-iterators, the \cgalBigO{n \log n} algorithm of of Akl and Toussaint
+iterators, the \cgalBigO{n \log n} algorithm of Akl and Toussaint
 \cgalCite{at-fcha-78} is used.
 
 

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -1297,7 +1297,7 @@ public:
 
 \cgalRefines{AdaptableFunctor}
 
-\sa `ComputePowerProduct_3` for the definition of of orthogonality for power distances.
+\sa `ComputePowerProduct_3` for the definition of orthogonality for power distances.
 
 */
 class CompareWeightedSquaredRadius_3
@@ -3121,7 +3121,7 @@ public:
 \cgalConcept
 
 \sa `CGAL::Weighted_point_3<Kernel>`
-\sa `ComputePowerProduct_3` for the definition of of orthogonality for power distances.
+\sa `ComputePowerProduct_3` for the definition of orthogonality for power distances.
 
 \cgalRefines{AdaptableFunctor}
 

--- a/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_by_reduced_convolution_2.h
+++ b/Minkowski_sum_2/include/CGAL/Minkowski_sum_2/Minkowski_sum_by_reduced_convolution_2.h
@@ -153,7 +153,7 @@ private:
     if (! is_outer_boundary_empty) get_outer_loop(arr, outer_boundary);
 
     // Check for each face whether it is a hole in the M-sum. If it is, add it
-    // to 'holes'. See chapter 3 of of Alon's master's thesis.
+    // to 'holes'. See chapter 3 of Alon's master's thesis.
     for (auto fit = arr.faces_begin(); fit != arr.faces_end(); ++fit) {
       // Check whether the face is on the M-sum's border.
 

--- a/Nef_3/doc/Nef_3/Nef_3.txt
+++ b/Nef_3/doc/Nef_3/Nef_3.txt
@@ -569,7 +569,7 @@ which is a polymorphic handle type representing any handle type, no
 matter if it is mutable or const. For further usage of the result,
 the `Object_handle` has to be casted to the concrete handle type.
 The `assign()` function performs such a cast. It returns a
-Boolean that reports the success or the failure of of the cast.
+Boolean that reports the success or the failure of the cast.
 Looking at the possible return values of the `locate` function,
 the `Object_handle` can represent a `Vertex_const_handle`, a
 `Halfedge_const_handle`, a `Halffacet_handle`, or a

--- a/Orthtree/include/CGAL/Orthtree.h
+++ b/Orthtree/include/CGAL/Orthtree.h
@@ -509,7 +509,7 @@ public:
 
     \tparam Traversal a model of `OrthtreeTraversal`
 
-    \param args Arguments to to pass to the traversal's constructor, excluding the first (always an orthtree reference)
+    \param args Arguments to pass to the traversal's constructor, excluding the first (always an orthtree reference)
 
     \return a `ForwardRange` over the node indices of the tree
    */

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/locate.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/locate.h
@@ -1108,7 +1108,7 @@ locate_in_face(const typename internal::Location_traits<TriangleMesh, NamedParam
     std::cerr << "Warning: point " << query << " is not in the input face" << std::endl;
     std::cerr << "Coordinates: " << coords[0] << " " << coords[1] << " " << coords[2] << std::endl;
 
-    // Try to to snap the coordinates, hoping the problem is just a -1e-17ish epsilon
+    // Try to snap the coordinates, hoping the problem is just a -1e-17ish epsilon
     // pushing the coordinates over the edge
     internal::snap_coordinates_to_border(coords, snap_tolerance);
   }

--- a/Polyhedron/doc/Polyhedron/CGAL/Polyhedron_incremental_builder_3.h
+++ b/Polyhedron/doc/Polyhedron/CGAL/Polyhedron_incremental_builder_3.h
@@ -42,7 +42,7 @@ halfedge data structure is ignored and all indices are relative to the
 newly added surface, or `ABSOLUTE_INDEXING`, in which all indices are
 absolute indices including an already existing polyhedral surface. The
 former mode allows to create easily independent connected components,
-while the latter mode allows to to continue the construction of an
+while the latter mode allows to continue the construction of an
 existing surface, the absolute indexing allows to address existing
 vertices when creating new facets.
 

--- a/Polytope_distance_d/doc/Polytope_distance_d/Concepts/PolytopeDistanceDTraits.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/Concepts/PolytopeDistanceDTraits.h
@@ -77,7 +77,7 @@ typedef unspecified_type Construct_point_d;
 
 /*!
 exact number type used to do the exact computations in the
-underlying solver for linear programs. It has to to be a model for
+underlying solver for linear programs. It has to be a model for
 `RingNumberType`. There must be an implicit conversion from
 `RT` to `ET` available.
 */

--- a/Spatial_searching/doc/Spatial_searching/CGAL/Manhattan_distance_iso_box_point.h
+++ b/Spatial_searching/doc/Spatial_searching/CGAL/Manhattan_distance_iso_box_point.h
@@ -67,7 +67,7 @@ distance between `b` and `p`.
 FT transformed_distance(Query_item b, Point_d p) const;
 
 /*!
-Returns the transformed value of of `d`.
+Returns the transformed value of `d`.
 */
 FT transformed_distance(FT d) const;
 

--- a/Stream_support/include/CGAL/IO/LAS.h
+++ b/Stream_support/include/CGAL/IO/LAS.h
@@ -68,7 +68,7 @@ make_las_point_reader(PointMap point_map);
    that can for example be a `std::array<unsigned short,
    4>`). In that case, the second element of the tuple should be a
    functor that constructs the value type of `PropertyMap` from N
-   objects of of type `LAS_property::Tag::type`.
+   objects of type `LAS_property::Tag::type`.
 
    The %LAS standard defines a fixed set of properties accessible
    through the following tag classes:

--- a/TDS_3/doc/TDS_3/Concepts/TriangulationDataStructure_3.h
+++ b/TDS_3/doc/TDS_3/Concepts/TriangulationDataStructure_3.h
@@ -364,7 +364,7 @@ Tests whether `(u,v)` is an edge of the triangulation data structure.
 bool is_edge(Vertex_handle u, Vertex_handle v) const;
 
 /*!
-Tests whether `(c,i)` is a facet of of the triangulation data structure.
+Tests whether `(c,i)` is a facet of  the triangulation data structure.
 Answers `false` when `dimension()` \f$ <2\f$ .
 \pre \f$ i \in\{0,1,2,3\}\f$
 */

--- a/TDS_3/doc/TDS_3/Concepts/TriangulationDataStructure_3.h
+++ b/TDS_3/doc/TDS_3/Concepts/TriangulationDataStructure_3.h
@@ -364,7 +364,7 @@ Tests whether `(u,v)` is an edge of the triangulation data structure.
 bool is_edge(Vertex_handle u, Vertex_handle v) const;
 
 /*!
-Tests whether `(c,i)` is a facet of  the triangulation data structure.
+Tests whether `(c,i)` is a facet of the triangulation data structure.
 Answers `false` when `dimension()` \f$ <2\f$ .
 \pre \f$ i \in\{0,1,2,3\}\f$
 */


### PR DESCRIPTION
Summary of Changes
Fixed common doubled word typos (e.g., "to to", "of of") in comments and documentation strings across various packages. These changes are purely cosmetic and do not affect code logic.

Release Management
Affected package(s): Algebraic_foundations, Algebraic_kernel_d, Arrangement_on_surface_2, BGL, Bounding_volumes, Convex_hull_2, Kernel_23, Minkowski_sum_2, Nef_3, Orthtree, Polygon_mesh_processing, Polyhedron, Polytope_distance_d, Spatial_searching, Stream_support, TDS_3.

Issue(s) solved (if any):

Feature/Small Feature (if any):

Link to compiled documentation:

License and copyright ownership: I agree to the transfer of the license and copyright of my contribution to the CGAL project.