### PR TITLE
Fix 'the the' typos in documentation and comments

### DIFF
--- a/Advancing_front_surface_reconstruction/doc/Advancing_front_surface_reconstruction/Concepts/AdvancingFrontSurfaceReconstructionTraits_3.h
+++ b/Advancing_front_surface_reconstruction/doc/Advancing_front_surface_reconstruction/Concepts/AdvancingFrontSurfaceReconstructionTraits_3.h
@@ -4,7 +4,7 @@
 \cgalConcept
 
 The concept `AdvancingFrontSurfaceReconstructionTraits_3` describes the requirements
-for the the geometric traits of the class `CGAL::Delaunay_triangulation_3`
+for the geometric traits of the class `CGAL::Delaunay_triangulation_3`
 used in the class `CGAL::Advancing_front_surface_reconstruction`.
 It defines the geometric objects (points, segments...) forming the triangulation
 together with a few geometric predicates and constructions on these objects.

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
@@ -2338,7 +2338,7 @@ Instead of an explicit approach, we use an implicit bounding rectangle
 embedded in the \dcel structure. \cgalFigureRef{aos_fig-unb_dcel}
 shows the arrangement of four lines that subdivide the plane into
 eight unbounded faces and two bounded ones. Notice that in this case
-portions of the the unbounded faces now have outer boundaries (those
+portions of the unbounded faces now have outer boundaries (those
 portions inside the bounding rectangle), and the halfedges along these
 outer CCBs are drawn as arrows. The bounding rectangle is drawn
 dashed. The vertices \f$v_1,v_2,\ldots,v_8\f$, which lie on the
@@ -6294,7 +6294,7 @@ overlay faces.
 The following example shows how to compute the intersection of two
 polygons using the `overlay()` function template. It uses a
 face-extended \dcel type to instantiate the arrangement
-classes. Each face of the the \dcel is extended with a Boolean
+classes. Each face of the \dcel is extended with a Boolean
 flag. A polygon is represented as a <em>marked</em> arrangement face
 (whose flag is set). The example uses an instance of the
 `Arr_face_overlay_traits<ArrR,ArrB,ArrO,OverlayFaceData>` class

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_algebraic_segment_traits_2.h
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/CGAL/Arr_algebraic_segment_traits_2.h
@@ -209,7 +209,7 @@ public:
     /// @}
   }; /* end Arr_algebraic_segment_traits_2::Construct_x_monotone_segment_2 */
 
-  /*! A model of the the `AosTraits_2::Curve_2` concept.
+  /*! A model of the `AosTraits_2::Curve_2` concept.
    * Represents algebraic curves. Internally, the type stores
    * topological-geometric information about the particular curve.
    * In order to use internal caching, instances should only be created

--- a/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arr_compute_zone_visitor.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arrangement_2/Arr_compute_zone_visitor.h
@@ -26,7 +26,7 @@ namespace CGAL {
 
 /*! \class
  * A visitor class for Arrangement_zone_2 that outputs the zone of an
- * x-monotone curve. Specifically, it outputs handles to the the arrangement
+ * x-monotone curve. Specifically, it outputs handles to the arrangement
  * cells that the x-monotone curve intersects.
  * The class should be templated by an Arrangement_2 class, and by an
  * output iterator of a variant of types of handles to the arrangement cells

--- a/Isosurfacing_3/doc/Isosurfacing_3/Isosurfacing_3.txt
+++ b/Isosurfacing_3/doc/Isosurfacing_3/Isosurfacing_3.txt
@@ -21,7 +21,7 @@ Given a field of a scalar values, an isosurface is defined as the locus of point
 has a given constant value; in other words, it is a level set.
 This constant value is referred to as the "isovalue", and, for well-behaved fields,
 the level set forms a surface.
-In the following, we shall refer to the the field of scalar values as the value field.
+In the following, we shall refer to the field of scalar values as the value field.
 "Isosurfacing", also known as "isosurface extraction" or "contouring", is the process of constructing
 the isosurface corresponding to a given value field and isovalue.
 %Isosurfacing is often needed for volume visualization and for the simulation of physical phenomena.

--- a/Isosurfacing_3/examples/Isosurfacing_3/contouring_octree.cpp
+++ b/Isosurfacing_3/examples/Isosurfacing_3/contouring_octree.cpp
@@ -71,7 +71,7 @@ auto blobby_gradient = [](const Point& p) -> Vector
 // This refines:
 // - at the minimum till minimum depth
 // - at the maximum till maximum depth
-// - we split if the the isovalue goes through the voxel, i.e. if not all vertices of the cell
+// - we split if the isovalue goes through the voxel, i.e. if not all vertices of the cell
 //   are on the same side of the isosurface defined by a function
 // It's not a great refinement technique because the surface can enter and leave a cell
 // without involving the cell's vertex. In practice, that means a hole if at nearby adjacent

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -2554,7 +2554,7 @@ double bounded_error_Hausdorff_distance(const TriangleMesh1& tm1,
 /**
  * \ingroup PMP_distance_grp
  *
- * returns the the symmetric Hausdorff distance, that is
+ * returns the symmetric Hausdorff distance, that is
  * the maximum of `bounded_error_Hausdorff_distance(tm1, tm2, error_bound, np1, np2)`
  * and `bounded_error_Hausdorff_distance(tm2, tm1, error_bound, np2, np1)`.
  *

--- a/QP_solver/doc/QP_solver/fig_src/documentation/Degeneracies.tex
+++ b/QP_solver/doc/QP_solver/fig_src/documentation/Degeneracies.tex
@@ -672,7 +672,7 @@ equality constraints $A_{i}$, $i \in E \setminus J$.
 
 The values of nonbasic artificial variables $x_{j}$, $j \in N \cap art$ are
 increased from $-\varepsilon^{j+1}$ to zero and then $x_{j}$ is removed. This
-may render the the solution infeasible if
+may render the solution infeasible if
 \begin{equation*}
 e_{i}^{T}A_{B}^{-1}\tilde{A}_{\bullet, j} > 0
 \end{equation*} 

--- a/QP_solver/doc/QP_solver/fig_src/documentation/UpdateZ.tex
+++ b/QP_solver/doc/QP_solver/fig_src/documentation/UpdateZ.tex
@@ -481,7 +481,7 @@ and~(\ref{update:o_rep_s}) are `shrinking' and `growing' updates.
 Since the solver uses the reduced basis inverse $\check{M}_{B}^{-1}$ we can
 directly apply the update described in the last section only for
 Updates~(\ref{update:o_rep_o}) and~(\ref{update:s_rep_s}), although we could
-indirectly apply last section's update by expanding the the reduced basis
+indirectly apply last section's update by expanding the reduced basis
 matrix inverse $\check{M}_{B}^{-1}$ to $M_{B}^{-1}$, apply the update
 and shrink back to $\check{M}_{B}^{-1}$ again.
 Since we want to work with the reduced basis inverse $\check{M}_{B}^{-1}$

--- a/Shape_regularization/doc/Shape_regularization/Concepts/RegularizationType.h
+++ b/Shape_regularization/doc/Shape_regularization/Concepts/RegularizationType.h
@@ -7,7 +7,7 @@ namespace Shape_regularization {
 
 A concept that describes the set of methods used by the class
 `QP_regularization` to access various data
-required for setting up the the global regularization problem.
+required for setting up the global regularization problem.
 
 \cgalHasModelsBegin
 \cgalHasModels{Segments::Angle_regularization_2}

--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_intersection_surface_sweep_2_impl.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_intersection_surface_sweep_2_impl.h
@@ -791,7 +791,7 @@ No_intersection_surface_sweep_2<Vis>::_push_event(const Point_2& pt,
   if (events[index] == Event_queue_iterator())
   {
     // Still look for the curve end in the event queue in case two
-    // point are  the same in the vertex range
+    // points are  the same in the vertex range
     m_queueEventLess.set_parameter_space_in_x(ps_x);
     m_queueEventLess.set_parameter_space_in_y(ps_y);
     pair_res = m_queue->find_lower(pt, m_queueEventLess);
@@ -928,7 +928,7 @@ No_intersection_surface_sweep_2<Vis>::_push_event(const X_monotone_curve_2& cv,
   if (events[index] == Event_queue_iterator())
   {
     // Still look for the curve end in the event queue in case two
-    // point are the same in the vertex range
+    // points are the same in the vertex range
 
     m_queueEventLess.set_parameter_space_in_x(ps_x);
     m_queueEventLess.set_parameter_space_in_y(ps_y);

--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_intersection_surface_sweep_2_impl.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_intersection_surface_sweep_2_impl.h
@@ -791,7 +791,7 @@ No_intersection_surface_sweep_2<Vis>::_push_event(const Point_2& pt,
   if (events[index] == Event_queue_iterator())
   {
     // Still look for the curve end in the event queue in case two
-    // points are  the same in the vertex range
+    // points are the same in the vertex range
     m_queueEventLess.set_parameter_space_in_x(ps_x);
     m_queueEventLess.set_parameter_space_in_y(ps_y);
     pair_res = m_queue->find_lower(pt, m_queueEventLess);

--- a/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_intersection_surface_sweep_2_impl.h
+++ b/Surface_sweep_2/include/CGAL/Surface_sweep_2/No_intersection_surface_sweep_2_impl.h
@@ -791,7 +791,7 @@ No_intersection_surface_sweep_2<Vis>::_push_event(const Point_2& pt,
   if (events[index] == Event_queue_iterator())
   {
     // Still look for the curve end in the event queue in case two
-    // point are the the same in the vertex range
+    // point are  the same in the vertex range
     m_queueEventLess.set_parameter_space_in_x(ps_x);
     m_queueEventLess.set_parameter_space_in_y(ps_y);
     pair_res = m_queue->find_lower(pt, m_queueEventLess);
@@ -928,7 +928,7 @@ No_intersection_surface_sweep_2<Vis>::_push_event(const X_monotone_curve_2& cv,
   if (events[index] == Event_queue_iterator())
   {
     // Still look for the curve end in the event queue in case two
-    // point are the the same in the vertex range
+    // point are the same in the vertex range
 
     m_queueEventLess.set_parameter_space_in_x(ps_x);
     m_queueEventLess.set_parameter_space_in_y(ps_y);

--- a/TDS_2/include/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/Triangulation_data_structure_2.h
@@ -2302,7 +2302,7 @@ set_adjacency(Face_handle fh,
               int ih,
               std::map< Vh_pair, Edge>& edge_map)
 {
-  // set adjacency to (fh,ih) using the the map edge_map
+  // set adjacency to (fh,ih) using the map edge_map
   // or insert (fh,ih) in edge map
   Vertex_handle vhcw  =  fh->vertex(cw(ih));
   Vertex_handle vhccw =  fh->vertex(ccw(ih));


### PR DESCRIPTION
This PR fixes multiple instances of the doubled word "the" (e.g., "the the") found in various header files, documentation, and comments. 

No code logic is changed; this is purely a documentation and comment cleanup to improve readability.