### PR TITLE
Fix assertion failure in Bézier curve intersection handling

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Bezier_x_monotone_2.h
@@ -2065,15 +2065,9 @@ _intersect(const Self& cv,
     typename std::list<Point_2>::iterator  pit;
 
     for (pit = inter_pts.begin(); pit != inter_pts.end(); ++pit) {
-      // Check if the point is in the range of this curve - first using
-      // its parameter bounds, and if we fail we perform an exact check.
-      if (! self_intersect) {
-        in_range1 = _is_in_range(*pit, correct_res);
-      }
-      else {
-        in_range1 = true;
-        correct_res = true;
-      }
+      // Check if the point is in the range of this curve
+      // Note: We MUST perform this check even for self-intersections.
+      in_range1 = _is_in_range(*pit, correct_res);
 
       if (! correct_res) {
         if (! pit->is_exact()) pit->make_exact(cache);
@@ -2086,15 +2080,9 @@ _intersect(const Self& cv,
 
       if (! in_range1) continue;
 
-      // Check if the point is in the range of the other curve - first using
-      // its parameter bounds, and if we fail we perform an exact check.
-      if (! self_intersect) {
-        in_range2 = cv._is_in_range (*pit, correct_res);
-      }
-      else {
-        in_range2 = true;
-        correct_res = true;
-      }
+      // Check if the point is in the range of the other curve
+      // Note: We MUST perform this check even for self-intersections.
+      in_range2 = cv._is_in_range (*pit, correct_res);
 
       if (! correct_res) {
         if (! pit->is_exact()) pit->make_exact (cache);


### PR DESCRIPTION
## Summary of Changes

_intersect() skipped parameter-range checks for self-intersection points, incorrectly assuming that any point valid on the supporting Bézier curve was also valid for every derived x-monotone subcurve.

For looping curves, that assumption fails: a self-intersection point may lie outside the parameter range of the specific subcurve being processed. These invalid points were being passed to downstream solvers, triggering assertion failures (e.g., roots.size() == 1).

This commit forces parameter range verification via _is_in_range() for all intersection points, including those produced by self-intersections.

## Release Management

* Affected package(s): Arrangement_on_surface_2
* Issue(s) solved (if any): #9176
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

