### PR TITLE
Fix 'is is' typos in documentation and comments

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_batched_point_location.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_batched_point_location.h
@@ -39,7 +39,7 @@ namespace Ss2 = Surface_sweep_2;
  * \param points_end A past-the-end iterator for the range of query points.
  * \param oi Output: An output iterator for the query results.
  * \pre The value-type of PointsIterator is Arrangement::Point_2,
- *      and the value-type of OutputIterator is is pair<Point_2, Result>,
+ *      and the value-type of OutputIterator is pair<Point_2, Result>,
  *      where Result is std::optional<std::variant<Vertex_const_handle,
  *                                      Halfedge_const_handle,
  *                                      Face_const_handle> >.

--- a/Documentation/doc/resources/1.14.0/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.14.0/BaseDoxyfile.in
@@ -748,7 +748,7 @@ TEMPLATE_RELATIONS     = YES
 # If the INCLUDE_GRAPH, ENABLE_PREPROCESSING and SEARCH_INCLUDES tags are set to
 # YES then Doxygen will generate a graph for each documented file showing the
 # direct and indirect include dependencies of the file with other documented
-# files. Explicit enabling an include graph, when INCLUDE_GRAPH is is set to NO,
+# files. Explicit enabling an include graph, when INCLUDE_GRAPH is set to NO,
 # can be accomplished by means of the command \includegraph. Disabling an
 # include graph can be accomplished by means of the command \hideincludegraph.
 # The default value is: YES.

--- a/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_const_decorator.h
@@ -192,7 +192,7 @@ SHalfedge_around_svertex_const_circulator
 
 SFace_cycle_const_iterator sface_cycles_begin(SFace_const_handle f) const
 /*{\Mop returns an iterator for all bounding face cycles of |f|.
-The iterator is is convertible to |SVertex_const_handle|,
+The iterator is convertible to |SVertex_const_handle|,
 |SHalfloop_const_handle|, or |SHalfedge_const_handle|.}*/
 { return f->boundary_entry_objects_.begin(); }
 

--- a/Nef_S2/include/CGAL/Nef_S2/SM_decorator.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_decorator.h
@@ -231,7 +231,7 @@ Size_type number_of_sfaces() const
 
 SFace_cycle_iterator sface_cycles_begin(SFace_handle f) const
 /*{\Mop returns an iterator for all bounding face cycles of |f|.
-The iterator is is convertible to |SVertex_handle|,
+The iterator is convertible to |SVertex_handle|,
 |SHalfloop_handle|, or |SHalfedge_handle|.}*/
 { return f->boundary_entry_objects().begin(); }
 


### PR DESCRIPTION
## Summary of Changes

This PR fixes multiple instances of the doubled word "is" (e.g., "is is") found in documentation and comments. 
No code logic is changed; this is purely a cleanup to improve readability.

## Release Management

* Affected package(s): Documentation, Nef_S2, Arrangement_on_surface_2
* Issue(s) solved (if any):
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature):
* License and copyright ownership: I confirm that I have the right to contribute these changes.
