### PR TITLE
Fix doubled words ("be", "compares") in comments and documentation

### DIFF
--- a/Arrangement_on_surface_2/include/CGAL/Arr_counting_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_counting_traits_2.h
@@ -260,7 +260,7 @@ public:
     { ++m_counter2; return m_object(xc1, xc2); }
   };
 
-  /*! A functor that compares compares the \f$y\f$-coordinates of two
+  /*! A functor that compares the \f$y\f$-coordinates of two
    * \f$x\f$-monotone curves immediately to the left of their intersection
    * point.
    */
@@ -281,7 +281,7 @@ public:
     { ++m_counter; return m_object(xc1, xc2, p); }
   };
 
-  /*! A functor that compares compares the \f$y\f$-coordinates of two
+  /*! A functor that compares the \f$y\f$-coordinates of two
    * \f$x\f$-monotone curves immediately to the right of their intersection
    * point.
    */

--- a/Arrangement_on_surface_2/include/CGAL/Arr_linear_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_linear_traits_2.h
@@ -760,7 +760,7 @@ public:
   Compare_y_at_x_2 compare_y_at_x_2_object() const
   { return Compare_y_at_x_2(*this); }
 
-  /*! A functor that compares compares the \f$y\f$-coordinates of two linear
+  /*! A functor that compares the \f$y\f$-coordinates of two linear
    * curves immediately to the left of their intersection point.
    */
   class Compare_y_at_x_left_2 {
@@ -811,7 +811,7 @@ public:
   Compare_y_at_x_left_2 compare_y_at_x_left_2_object() const
   { return Compare_y_at_x_left_2(); }
 
-  /*! A functor that compares compares the \f$y\f$-coordinates of two linear
+  /*! A functor that compares the \f$y\f$-coordinates of two linear
    * curves immediately to the right of their intersection point.
    */
   class Compare_y_at_x_right_2 {

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Arr_batched_point_location_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Arr_batched_point_location_traits_2.h
@@ -323,7 +323,7 @@ public:
   Compare_y_at_x_2 compare_y_at_x_2_object() const
   { return (Compare_y_at_x_2(m_base_traits->compare_y_at_x_2_object())); }
 
-  /*! A functor that compares  the y-coordinates of two x-monotone
+  /*! A functor that compares the y-coordinates of two x-monotone
    * curves immediately to the right of their intersection point.
    */
   class Compare_y_at_x_right_2 {

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Arr_batched_point_location_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Arr_batched_point_location_traits_2.h
@@ -323,7 +323,7 @@ public:
   Compare_y_at_x_2 compare_y_at_x_2_object() const
   { return (Compare_y_at_x_2(m_base_traits->compare_y_at_x_2_object())); }
 
-  /*! A functor that compares compares the y-coordinates of two x-monotone
+  /*! A functor that compares  the y-coordinates of two x-monotone
    * curves immediately to the right of their intersection point.
    */
   class Compare_y_at_x_right_2 {

--- a/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Trapezoidal_decomposition_2_impl.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_point_location/Trapezoidal_decomposition_2_impl.h
@@ -1668,7 +1668,7 @@ void Trapezoidal_decomposition_2<Td_traits>::remove(Halfedge_const_handle he)
   In_face_iterator mid_it(follow_curve(p1_node,he,EQUAL));
   In_face_iterator top_it(follow_curve(p1_node,he,LARGER));
 
-  bool inc_btm = true; //true if btm_it should be be incremented (not top_it)
+  bool inc_btm = true; //true if btm_it should be incremented (not top_it)
   bool prev_inc_btm = false; //holds the inc_btm from previous iteration
   bool end_reached = false; //true if this is the last iteration
 

--- a/Arrangement_on_surface_2/include/CGAL/Arr_rational_function_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_rational_function_traits_2.h
@@ -541,7 +541,7 @@ public:
   Compare_y_at_x_2 compare_y_at_x_2_object () const
   { return Compare_y_at_x_2(_cache); }
 
-  /*! A functor that compares compares the y-coordinates of two curves
+  /*! A functor that compares the y-coordinates of two curves
    * immediately to the left of their intersection point.
    */
   class Compare_y_at_x_left_2 {
@@ -584,7 +584,7 @@ public:
   Compare_y_at_x_left_2 compare_y_at_x_left_2_object() const
   { return Compare_y_at_x_left_2(_cache); }
 
-  /*! A functor that compares compares the y-coordinates of two curves
+  /*! A functor that compares the y-coordinates of two curves
    * immediately to the right of their intersection point.
    */
   class Compare_y_at_x_right_2 {

--- a/Arrangement_on_surface_2/include/CGAL/Arr_tracing_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_tracing_traits_2.h
@@ -434,7 +434,7 @@ public:
     }
   };
 
-  /*! A functor that compares compares the \f$y\f$-coordinates of two
+  /*! A functor that compares the \f$y\f$-coordinates of two
    * \f$x\f$-monotone curves immediately to the left of their intersection
    * point.
    */
@@ -468,7 +468,7 @@ public:
     }
   };
 
-  /*! A functor that compares compares the \f$y\f$-coordinates of two
+  /*! A functor that compares the \f$y\f$-coordinates of two
    * \f$x\f$-monotone curves immediately to the right of their intersection
    * point.
    */

--- a/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_basic_insertion_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_basic_insertion_traits_2.h
@@ -375,7 +375,7 @@ public:
   Compare_y_at_x_2 compare_y_at_x_2_object() const
   { return (Compare_y_at_x_2(m_base_traits->compare_y_at_x_2_object())); }
 
-  /*! A functor that compares compares the y-coordinates of two x-monotone
+  /*! A functor that compares the y-coordinates of two x-monotone
    * curves immediately to the right of their intersection point.
    */
   class Compare_y_at_x_right_2 {

--- a/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_insertion_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_insertion_traits_2.h
@@ -72,7 +72,7 @@ public:
   /*! constructs from a traits class. */
   Arr_insertion_traits_2(const Gt2& tr) : Base(tr) {}
 
-  /*! A functor that compares compares the y-coordinates of two x-monotone
+  /*! A functor that compares the y-coordinates of two x-monotone
    * curves immediately to the right of their intersection point.
    */
   class Intersect_2 {

--- a/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_overlay_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Surface_sweep_2/Arr_overlay_traits_2.h
@@ -813,7 +813,7 @@ public:
   Compare_y_at_x_2 compare_y_at_x_2_object() const
   { return (Compare_y_at_x_2(m_base_traits->compare_y_at_x_2_object())); }
 
-  /*! A functor that compares compares the y-coordinates of two x-monotone
+  /*! A functor that compares the y-coordinates of two x-monotone
    * curves immediately to the right of their intersection point.
    */
   class Compare_y_at_x_right_2 {

--- a/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
+++ b/Straight_skeleton_2/include/CGAL/Straight_skeleton_2/Straight_skeleton_builder_2_impl.h
@@ -469,7 +469,7 @@ void Straight_skeleton_builder_2<Gt,Ss,V>::HandleSimultaneousEdgeEvent( Vertex_h
 
   // The code above corrects the links for vertices aA/aB to the erased halfedges lOA and lIA.
   // However, any of these vertices (aA/aB) may be one of the twin vertices of a split event.
-  // If that's the case, the erased halfedge may be be linked to a 'couple' of those vertices.
+  // If that's the case, the erased halfedge may be linked to a 'couple' of those vertices.
   // This situation is corrected below:
 
   if ( !lOAV->has_infinite_time() && lOAV != aA && lOAV != aB )

--- a/Triangulation_3/include/CGAL/Triangulation_segment_traverser_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_segment_traverser_3.h
@@ -222,14 +222,14 @@ public:
     //  constructs an iterator.
     /*  \param tr the triangulation to iterate though. This triangulation must have dimension > 0.
      *        \param s the source vertex. This vertex must be initialized and cannot be the infinite vertex.
-     *        \param t the target point. This point must be initialized and it cannot be be at the same location as `s`.
+     *        \param t the target point. This point must be initialized and it cannot be at the same location as `s`.
      *        If `tr` has dimension < 3, `t` must lie inside the affine hull of `tr`.
      */
         Triangulation_segment_cell_iterator_3( const Tr* tr, Vertex_handle s, const Point& t );
 
     //  constructs an iterator.
     /*  \param tr the triangulation to iterate though. This triangulation must have dimension > 0.
-     *        \param s the source point. This point must be initialized and it cannot be be at the same location as `t`.
+     *        \param s the source point. This point must be initialized and it cannot be at the same location as `t`.
      *        \param t the target vertex. This vertex must be initialized and cannot be the infinite vertex.
      *        If `tr` has dimension < 3, `s` must lie inside the affine hull of `tr`.
      *        \param hint the starting point to search for `s`.
@@ -240,7 +240,7 @@ public:
     /*  \param tr the triangulation to iterate though. This triangulation must have dimension > 0.
      *        \param s the source point. This point must be initialized. If `tr` has dimension < 3, `s` must lie inside
      *        the affine hull of `tr`.
-     *        \param t the target point. This point must be initialized and it cannot be be at the same location as `s`.
+     *        \param t the target point. This point must be initialized and it cannot be at the same location as `s`.
      *        If `tr` has dimension < 3, `t` must lie inside the affine hull of `tr`.
      *        \param hint the starting point to search for `s`.
      */


### PR DESCRIPTION
## Summary of Changes

This PR fixes multiple instances of doubled words found in the codebase:
- `be be` -> `be`
- `compares compares` -> `compares`

This cleanup covers files in `Straight_skeleton_2`, `Triangulation_3`, and `Arrangement_on_surface_2`.

## Release Management

* Affected package(s): Straight_skeleton_2, Triangulation_3, Arrangement_on_surface_2
* Issue(s) solved (if any):
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature):
* License and copyright ownership: I confirm that I have the right to contribute these changes.