### PR TITLE
Fix compilation error in Mesh_3 example: remove invalid 'verbose' argument

### DIFF
--- a/Mesh_3/examples/Mesh_3/mesh_3D_image_with_image_initialization.cpp
+++ b/Mesh_3/examples/Mesh_3/mesh_3D_image_with_image_initialization.cpp
@@ -55,7 +55,7 @@ int main()
   // Mesh generation with a custom initialization that places points
   // on the surface of each connected component of the image.
   CGAL::Construct_initial_points_labeled_image<C3t3, Mesh_domain>
-      img_pts_generator(image, domain, CGAL::parameters::verbose(true));
+      img_pts_generator(image, domain );
 
   C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria,
                                       params::initial_points_generator(img_pts_generator));


### PR DESCRIPTION
## Summary of Changes

This PR fixes a compilation error in `examples/Mesh_3/mesh_3D_image_with_image_initialization.cpp`.

The example code was attempting to pass 3 arguments to `Construct_initial_points_labeled_image`:
`img_pts_generator(image, domain, CGAL::parameters::verbose(true));`

However, the constructor for `Construct_initial_points_labeled_image` only accepts 2 arguments (`image` and `domain`). The `verbose` parameter is not supported, causing the build to fail.

I have removed the extra argument to restore compilation.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any):
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature):
* License and copyright ownership: I confirm that I have the right to contribute these changes.