### PR TITLE
Fix compilation error in Surface_mesh_simplification: add missing include

### DIFF
--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_garland_heckbert.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_garland_heckbert.cpp
@@ -4,6 +4,7 @@
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Edge_count_ratio_stop_predicate.h>
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_filter.h>
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_policies.h>
+#include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_plane_and_line_policies.h>
 #include <CGAL/Surface_mesh_simplification/edge_collapse.h>
 
 #include <CGAL/IO/polygon_mesh_io.h>


### PR DESCRIPTION
## Summary of Changes

This PR fixes a compilation error in `examples/Surface_mesh_simplification/edge_collapse_garland_heckbert.cpp`.

The example uses `GarlandHeckbert_plane_and_line_policies`, but the corresponding header file was not included. This caused the compiler to fail with:
`error: no template named 'GarlandHeckbert_plane_and_line_policies'`

I have added the missing `#include` to allow the example to compile correctly.

## Release Management

* Affected package(s): Surface_mesh_simplification
* Issue(s) solved (if any):
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature):
* License and copyright ownership: I confirm that I have the right to contribute these changes.