### PR TITLE
typo CGAL_NO_DEPREACTED_CODE

### DIFF
--- a/Classification/examples/Classification/example_classification.cpp
+++ b/Classification/examples/Classification/example_classification.cpp
@@ -214,10 +214,10 @@ int main (int argc, char** argv)
   CGAL::IO::write_PLY_with_properties
     (f, CGAL::make_range (boost::counting_iterator<std::size_t>(0),
                           boost::counting_iterator<std::size_t>(pts.size())),
-     CGAL::make_ply_point_writer (CGAL::make_property_map(pts)),
-     std::make_pair(CGAL::make_property_map(red), CGAL::PLY_property<unsigned char>("red")),
-     std::make_pair(CGAL::make_property_map(green), CGAL::PLY_property<unsigned char>("green")),
-     std::make_pair(CGAL::make_property_map(blue), CGAL::PLY_property<unsigned char>("blue")));
+     CGAL::IO::make_ply_point_writer (CGAL::make_property_map(pts)),
+     std::make_pair(CGAL::make_property_map(red), CGAL::IO::PLY_property<unsigned char>("red")),
+     std::make_pair(CGAL::make_property_map(green), CGAL::IO::PLY_property<unsigned char>("green")),
+     std::make_pair(CGAL::make_property_map(blue), CGAL::IO::PLY_property<unsigned char>("blue")));
 
 
   std::cerr << "All done" << std::endl;

--- a/Point_set_processing_3/examples/Point_set_processing_3/read_ply_points_with_colors_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/read_ply_points_with_colors_example.cpp
@@ -29,8 +29,8 @@ int main(int argc, char*argv[])
   std::vector<PNCI> points; // store points
   std::ifstream in(fname);
   if(!CGAL::IO::read_PLY_with_properties(in, std::back_inserter(points),
-                                         CGAL::make_ply_point_reader(Point_map()),
-                                         std::make_pair(Intensity_map(), CGAL::PLY_property<int>("intensity")),
+                                         CGAL::IO::make_ply_point_reader(Point_map()),
+                                         std::make_pair(Intensity_map(), CGAL::IO::PLY_property<int>("intensity")),
                                          std::make_tuple(Color_map(),
                                                          CGAL::Construct_array(),
                                                          CGAL::IO::PLY_property<unsigned char>("red"),

--- a/Point_set_processing_3/examples/Point_set_processing_3/write_ply_points_example.cpp
+++ b/Point_set_processing_3/examples/Point_set_processing_3/write_ply_points_example.cpp
@@ -57,7 +57,7 @@ int main(int, char**)
   CGAL::IO::set_binary_mode(f); // The PLY file will be written in the binary format
 
   CGAL::IO::write_PLY_with_properties(f, points,
-                                      CGAL::make_ply_point_writer (Point_map()),
+                                      CGAL::IO::make_ply_point_writer (Point_map()),
                                       std::make_tuple(Color_map(),
                                                       CGAL::IO::PLY_property<unsigned char>("red"),
                                                       CGAL::IO::PLY_property<unsigned char>("green"),

--- a/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_model_complexity_control.cpp
+++ b/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_model_complexity_control.cpp
@@ -52,9 +52,9 @@ int main(int argc, char* argv[])
 
   if (!CGAL::IO::read_PLY_with_properties(input_stream,
                                           std::back_inserter(points),
-                                          CGAL::make_ply_point_reader(Point_map()),
-                                          CGAL::make_ply_normal_reader(Normal_map()),
-                                          std::make_pair(Plane_index_map(), CGAL::PLY_property<int>("segment_index"))))
+                                          CGAL::IO::make_ply_point_reader(Point_map()),
+                                          CGAL::IO::make_ply_normal_reader(Normal_map()),
+                                          std::make_pair(Plane_index_map(), CGAL::IO::PLY_property<int>("segment_index"))))
   {
     std::cerr << "Error: cannot read file " << input_file << std::endl;
     return EXIT_FAILURE;

--- a/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_user_provided_planes.cpp
+++ b/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_user_provided_planes.cpp
@@ -1,4 +1,3 @@
-#define CGAL_NO_DEPRECATED_CODE
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/IO/read_points.h>
 #include <CGAL/property_map.h>

--- a/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_user_provided_planes.cpp
+++ b/Polygonal_surface_reconstruction/examples/Polygonal_surface_reconstruction/polyfit_example_user_provided_planes.cpp
@@ -1,3 +1,4 @@
+#define CGAL_NO_DEPRECATED_CODE
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/IO/read_points.h>
 #include <CGAL/property_map.h>
@@ -52,9 +53,9 @@ int main(int argc, char* argv[])
 
   if (!CGAL::IO::read_PLY_with_properties(input_stream,
                                           std::back_inserter(points),
-                                          CGAL::make_ply_point_reader(Point_map()),
-                                          CGAL::make_ply_normal_reader(Normal_map()),
-                                          std::make_pair(Plane_index_map(), CGAL::PLY_property<int>("segment_index"))))
+                                          CGAL::IO::make_ply_point_reader(Point_map()),
+                                          CGAL::IO::make_ply_normal_reader(Normal_map()),
+                                          std::make_pair(Plane_index_map(), CGAL::IO::PLY_property<int>("segment_index"))))
   {
     std::cerr << "Error: cannot read file " << input_file << std::endl;
     return EXIT_FAILURE;

--- a/Polygonal_surface_reconstruction/test/Polygonal_surface_reconstruction/polygonal_surface_reconstruction_test_framework.h
+++ b/Polygonal_surface_reconstruction/test/Polygonal_surface_reconstruction/polygonal_surface_reconstruction_test_framework.h
@@ -98,9 +98,9 @@ int reconstruct(const std::string& input_file, bool force_extract_planes)
         if (!CGAL::IO::read_PLY_with_properties(
                     input_stream,
                     std::back_inserter(points),
-                    CGAL::make_ply_point_reader(Point_map()),
-                    CGAL::make_ply_normal_reader(Normal_map()),
-                    std::make_pair(Plane_index_map(), CGAL::PLY_property<int>("segment_index"))))
+                    CGAL::IO::make_ply_point_reader(Point_map()),
+                    CGAL::IO::make_ply_normal_reader(Normal_map()),
+                    std::make_pair(Plane_index_map(), CGAL::IO::PLY_property<int>("segment_index"))))
         {
           std::cerr << " Error: cannot read file " << input_file << std::endl;
           return EXIT_FAILURE;

--- a/Shape_detection/examples/Shape_detection/include/utils.h
+++ b/Shape_detection/examples/Shape_detection/include/utils.h
@@ -77,7 +77,7 @@ void save_point_regions_2(
   CGAL::IO::set_ascii_mode(out);
   CGAL::IO::write_PLY_with_properties(
     out, pwc,
-    CGAL::make_ply_point_writer(PLY_Point_map()),
+    CGAL::IO::make_ply_point_writer(PLY_Point_map()),
     std::make_tuple(
       PLY_Color_map(),
       CGAL::IO::PLY_property<unsigned char>("red"),
@@ -122,7 +122,7 @@ void save_point_regions_3(
   CGAL::IO::set_ascii_mode(out);
   CGAL::IO::write_PLY_with_properties(
     out, pwc,
-    CGAL::make_ply_point_writer(PLY_Point_map()),
+    CGAL::IO::make_ply_point_writer(PLY_Point_map()),
       std::make_tuple(
         PLY_Color_map(),
         CGAL::IO::PLY_property<unsigned char>("red"),
@@ -170,7 +170,7 @@ void save_segment_regions_2(
   CGAL::IO::set_ascii_mode(out);
   CGAL::IO::write_PLY_with_properties(
     out, pwc,
-    CGAL::make_ply_point_writer(PLY_Point_map()),
+    CGAL::IO::make_ply_point_writer(PLY_Point_map()),
       std::make_tuple(
         PLY_Color_map(),
         CGAL::IO::PLY_property<unsigned char>("red"),
@@ -216,7 +216,7 @@ void save_segment_regions_3(
   CGAL::IO::set_ascii_mode(out);
   CGAL::IO::write_PLY_with_properties(
     out, pwc,
-    CGAL::make_ply_point_writer(PLY_Point_map()),
+    CGAL::IO::make_ply_point_writer(PLY_Point_map()),
       std::make_tuple(
         PLY_Color_map(),
         CGAL::IO::PLY_property<unsigned char>("red"),

--- a/Shape_detection/examples/Shape_detection/include/utils.h
+++ b/Shape_detection/examples/Shape_detection/include/utils.h
@@ -80,9 +80,9 @@ void save_point_regions_2(
     CGAL::make_ply_point_writer(PLY_Point_map()),
     std::make_tuple(
       PLY_Color_map(),
-      CGAL::PLY_property<unsigned char>("red"),
-      CGAL::PLY_property<unsigned char>("green"),
-      CGAL::PLY_property<unsigned char>("blue")));
+      CGAL::IO::PLY_property<unsigned char>("red"),
+      CGAL::IO::PLY_property<unsigned char>("green"),
+      CGAL::IO::PLY_property<unsigned char>("blue")));
   out.close();
 }
 
@@ -125,9 +125,9 @@ void save_point_regions_3(
     CGAL::make_ply_point_writer(PLY_Point_map()),
       std::make_tuple(
         PLY_Color_map(),
-        CGAL::PLY_property<unsigned char>("red"),
-        CGAL::PLY_property<unsigned char>("green"),
-        CGAL::PLY_property<unsigned char>("blue")));
+        CGAL::IO::PLY_property<unsigned char>("red"),
+        CGAL::IO::PLY_property<unsigned char>("green"),
+        CGAL::IO::PLY_property<unsigned char>("blue")));
   out.close();
 }
 
@@ -173,9 +173,9 @@ void save_segment_regions_2(
     CGAL::make_ply_point_writer(PLY_Point_map()),
       std::make_tuple(
         PLY_Color_map(),
-        CGAL::PLY_property<unsigned char>("red"),
-        CGAL::PLY_property<unsigned char>("green"),
-        CGAL::PLY_property<unsigned char>("blue")));
+        CGAL::IO::PLY_property<unsigned char>("red"),
+        CGAL::IO::PLY_property<unsigned char>("green"),
+        CGAL::IO::PLY_property<unsigned char>("blue")));
   out.close();
 }
 
@@ -219,9 +219,9 @@ void save_segment_regions_3(
     CGAL::make_ply_point_writer(PLY_Point_map()),
       std::make_tuple(
         PLY_Color_map(),
-        CGAL::PLY_property<unsigned char>("red"),
-        CGAL::PLY_property<unsigned char>("green"),
-        CGAL::PLY_property<unsigned char>("blue")));
+        CGAL::IO::PLY_property<unsigned char>("red"),
+        CGAL::IO::PLY_property<unsigned char>("green"),
+        CGAL::IO::PLY_property<unsigned char>("blue")));
   out.close();
 }
 

--- a/Stream_support/include/CGAL/IO/PLY/PLY_reader.h
+++ b/Stream_support/include/CGAL/IO/PLY/PLY_reader.h
@@ -783,7 +783,7 @@ bool read_PLY_faces(std::istream& in,
 } // namespace PLY
 } // namespace internal
 
-#ifndef CGAL_NO_DEPREACTED_CODE
+#ifndef CGAL_NO_DEPRECATED_CODE
 using IO::PLY_property;
 using IO::make_ply_normal_reader;
 using IO::make_ply_normal_writer;

--- a/Stream_support/test/Stream_support/issue8155.cpp
+++ b/Stream_support/test/Stream_support/issue8155.cpp
@@ -35,8 +35,8 @@ int main()
   pv_pairs.clear();
   std::ifstream file("data/simple_ascii.ply");
   CGAL::IO::read_PLY_with_properties<PointVectorPair>(file, boost::function_output_iterator(lambda),
-    CGAL::make_ply_point_reader(Point_map()),
-    CGAL::make_ply_normal_reader(Normal_map()));
+    CGAL::IO::make_ply_point_reader(Point_map()),
+    CGAL::IO::make_ply_normal_reader(Normal_map()));
 
   assert(pv_pairs[0].first == Point_3(1, 1, 1));
   assert(pv_pairs[1].first == Point_3(3, 3, 3));


### PR DESCRIPTION
The preprocessor directive is misspelled and will normally not be used, corrected.

Note: I cannot compile CGAL so I don't know whether the code inside the `#if` construct is correct (i.e. when `CGAL_NO_DEPRECATED_CODE` is set and not set).

