### PR TITLE
Kernel_23: Add precondition check to Iso_rectangle_2::transform

### DIFF
--- a/Kernel_23/include/CGAL/Iso_rectangle_2.h
+++ b/Kernel_23/include/CGAL/Iso_rectangle_2.h
@@ -21,6 +21,7 @@
 #include <CGAL/Kernel/Return_base_tag.h>
 #include <CGAL/Bbox_2.h>
 #include <CGAL/Dimension.h>
+#include <CGAL/number_utils.h>
 
 namespace CGAL {
 
@@ -196,8 +197,12 @@ public:
 
   Iso_rectangle_2 transform(const Aff_transformation_2 &t) const
   {
-    // FIXME : We need a precondition like this!!!
-    // CGAL_kernel_precondition(t.is_axis_preserving());
+    // An iso-rectangle remains axis-aligned if the transformation is
+    // a diagonal matrix (scaling/translation) or anti-diagonal (90/270 degree rotation).
+    CGAL_kernel_precondition(
+        (CGAL::is_zero(t.cartesian(0,1)) && CGAL::is_zero(t.cartesian(1,0))) ||
+        (CGAL::is_zero(t.cartesian(0,0)) && CGAL::is_zero(t.cartesian(1,1)))
+    );
     return Iso_rectangle_2(t.transform(min  BOOST_PREVENT_MACRO_SUBSTITUTION ()),
                            t.transform(max  BOOST_PREVENT_MACRO_SUBSTITUTION ()));
   }


### PR DESCRIPTION
## Summary of Changes

Enforced a precondition in `Iso_rectangle_2::transform` to ensure the transformation preserves the axis-aligned property of the rectangle.

The precondition checks that the transformation matrix is either:
1.  **Diagonal** (Scaling, Reflection, Identity): `M[0][1] == 0` and `M[1][0] == 0`
2.  **Anti-Diagonal** (90°/270° Rotation): `M[0][0] == 0` and `M[1][1] == 0`

This ensures that the resulting shape remains an axis-aligned rectangle. It rejects shears and non-orthogonal rotations (e.g., 45°), while implicitly allowing all translations (as translation does not affect axis alignment).

This change resolves an existing `// FIXME` in the codebase.

## Release Management

* Affected package(s): `Kernel_23`
* Issue(s) solved (if any): Resolves internal FIXME in `Iso_rectangle_2.h`
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature):
* License and copyright ownership: I confirm that I have the right to contribute these changes under the CGAL license terms.