### PR TITLE
Replace raw new[] with std::vector for RAII memory management

### DIFF
--- a/Matrix_search/include/CGAL/monotone_matrix_search.h
+++ b/Matrix_search/include/CGAL/monotone_matrix_search.h
@@ -68,13 +68,13 @@ monotone_matrix_search(
 
   // table to store the reduction permutation:
   // (incl. sentinel)
-  int* reduction_table = new int[ M_new->number_of_rows() + 1];
+  std::vector<int> reduction_table(M_new->number_of_rows() + 1);
 
   if ( M_new->number_of_rows() < M_new->number_of_columns()) {
     // set sentinel:
     reduction_table[M_new->number_of_rows()] =
       M.number_of_columns() - 1;
-    _reduce_matrix( *M_new, reduction_table, compare_strictly);
+    _reduce_matrix( *M_new, reduction_table.data(), compare_strictly);
     CGAL_assertion(
       M_new->number_of_columns() == M_new->number_of_rows());
 
@@ -97,7 +97,7 @@ monotone_matrix_search(
 
   // table to store the rmax values of M_new:
   // (incl. sentinel)
-  int* t_new = new int[M_new->number_of_rows() + 1];
+  std::vector<int> t_new(M_new->number_of_rows() + 1);
   t_new[M_new->number_of_rows()] = M_new->number_of_columns();
 
   if ( M_new->number_of_rows() == 1)
@@ -105,7 +105,7 @@ monotone_matrix_search(
     // we have just one element ==> no choice
     t_new[0] = 0;
   else
-    monotone_matrix_search( *M_new, t_new);
+    monotone_matrix_search( *M_new, t_new.data());
 
 
   // and conquer
@@ -132,8 +132,6 @@ monotone_matrix_search(
   } while ( ++j < M.number_of_rows());
 
   delete M_new;
-  delete[] t_new;
-  delete[] reduction_table;
 
 } // monotone_matrix_search( M, t)
 

--- a/Subdivision_method_3/include/CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h
+++ b/Subdivision_method_3/include/CGAL/Subdivision_method_3/internal/subdivision_hosts_impl_3.h
@@ -74,8 +74,8 @@ void PQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
 
   typedef typename boost::property_traits<VertexPointMap>::value_type Point;
 
-  Point* vertex_point_buffer = new Point[num_v + num_e + num_f];
-  Point* edge_point_buffer = vertex_point_buffer + num_v;
+  std::vector<Point> vertex_point_buffer(num_v + num_e + num_f);
+  Point* edge_point_buffer = vertex_point_buffer.data() + num_v;
   Point* face_point_buffer = edge_point_buffer + num_e;
 
   int i=0;
@@ -161,7 +161,6 @@ void PQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
     put(vpm, *vitr, vertex_point_buffer[i]);
 
   CGAL_postcondition(CGAL::is_valid_polygon_mesh(p));
-  delete []vertex_point_buffer;
 }
 
 // ======================================================================
@@ -196,8 +195,8 @@ void PTQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
   // We need to reserve the memory to prevent reallocation.
   call_reserve(p,num_v + num_e, 2*2*num_e, 4*num_e/2);
 
-  Point* vertex_point_buffer = new Point[num_v + num_e];
-  Point* edge_point_buffer = vertex_point_buffer + num_v;
+  std::vector<Point> vertex_point_buffer(num_v + num_e);
+  Point* edge_point_buffer = vertex_point_buffer.data() + num_v;
 
   int i=0;
   std::unordered_map<vertex_descriptor,int> v_index;
@@ -265,7 +264,6 @@ void PTQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
     put(vpm, *vitr, vertex_point_buffer[i]);
 
   CGAL_postcondition(CGAL::is_valid_polygon_mesh(p));
-  delete []vertex_point_buffer;
 }
 
 
@@ -295,7 +293,7 @@ void DQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
       border_halfedges.push_back(halfedge(ed,p));
     }
   }
-  Point* point_buffer = new Point[num_e*2];
+  std::vector<Point> point_buffer(num_e * 2);
 
   // Build the point_buffer
   int pi = 0;
@@ -391,7 +389,6 @@ void DQQ_1step(Poly& p, VertexPointMap vpm, Mask mask) {
       Euler::remove_center_vertex(halfedge(vh,p),p);
   }
 
-  delete []point_buffer;
 }
 
 // ======================================================================
@@ -428,7 +425,7 @@ void Sqrt3_1step(Poly& p, VertexPointMap vpm, Mask mask,
         ++new_pts_size;
     }
   }
-  Point* cpt = new Point[new_pts_size];
+  std::vector<Point> cpt(new_pts_size);
 
   // size of the subdivided mesh
   call_reserve(p,num_v + new_pts_size, (num_e + 2*num_f + new_pts_size)*2, 3*num_f);
@@ -515,7 +512,6 @@ void Sqrt3_1step(Poly& p, VertexPointMap vpm, Mask mask,
   }
 
   CGAL_postcondition(CGAL::is_valid_polygon_mesh(p));
-  delete []cpt;
 }
 
 } // namespace internal


### PR DESCRIPTION
## Summary of Changes

Replaced raw pointer arrays allocated with `new[]` and released with `delete[]` by `std::vector` in `Subdivision_method_3` and `Matrix_search`.

This transition to RAII (Resource Acquisition Is Initialization) ensures automatic memory management and exception safety for temporary buffers used in:
* **Subdivision_method_3**: `PQQ_1step`, `PTQ_1step`, `DQQ_1step`, and `Sqrt3_1step` internal host implementations.
* **Matrix_search**: `monotone_matrix_search` implementation.

Logic using pointer arithmetic was preserved by utilizing `std::vector::data()`.

## Release Management

* Affected package(s): Subdivision_method_3, Matrix_search
* Issue(s) solved (if any):
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature): 
* License and copyright ownership: I confirm that I have the right to contribute these changes.