### PR TITLE
Use O(N log N) sweep-line for polygon simplicity check

### DIFF
--- a/Surface_mesh_parameterization/package_info/Surface_mesh_parameterization/dependencies
+++ b/Surface_mesh_parameterization/package_info/Surface_mesh_parameterization/dependencies
@@ -15,6 +15,7 @@ Kernel_23
 Modular_arithmetic
 Number_types
 Polygon_mesh_processing
+Polygon
 Profiling_tools
 Property_map
 STL_Extension


### PR DESCRIPTION
## Summary of Changes

This PR replaces the inefficient implementation of `is_polygon_simple` in `MVC_post_processor_3.h` (which checked every pair of edges for intersection) with the efficient **sweep-line algorithm** provided by `CGAL::is_simple_2`.

This change improves the complexity of the simplicity check from $O(N^2)$ to $O(N \log N)$ and resolves the `@fixme` annotation previously present in the code.

## Release Management

* Affected package(s): `Surface_mesh_parameterization`
* Issue(s) solved (if any): Resolves an internal fixme
* Feature/Small Feature (if any): Optimization
* Link to compiled documentation (obligatory for small feature): 
* License and copyright ownership: I confirm that I have the right to contribute these changes.