### PR TITLE
Combinatorial map bug fix

### DIFF
--- a/Combinatorial_map/include/CGAL/Combinatorial_map_storages_with_index.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map_storages_with_index.h
@@ -144,6 +144,10 @@ namespace CGAL {
       { return idx; }
       size_type index(const_iterator cit) const
       { return cit; }
+      const Dart& operator[] (size_type i) const
+      { return mmap.mdarts[i]; }
+      Dart& operator[] (size_type i)
+      { return mmap.mdarts[i]; }
       bool is_used(size_type i) const
       { return mmap.mdarts.is_used(i); }
       bool owns(size_type i) const

--- a/Combinatorial_map/include/CGAL/Element_topo.h
+++ b/Combinatorial_map/include/CGAL/Element_topo.h
@@ -84,8 +84,9 @@ template<typename CMap, unsigned int dimcell,
          unsigned int cmapdim=CMap::dimension>
 struct Get_cell_topo
 {
-  static cell_topo run(CMap&, typename CMap::Dart_descriptor dh,
-                       typename CMap::Dart_descriptor& starting_dart)
+  static cell_topo run(const CMap&,
+                       typename CMap::Dart_const_descriptor dh,
+                       typename CMap::Dart_const_descriptor& starting_dart)
   {
     starting_dart=dh;
     return NO_TYPE;
@@ -98,8 +99,9 @@ struct Get_cell_topo
 template<typename CMap, unsigned int cmapdim>
 struct Get_cell_topo<CMap, 1, cmapdim>
 {
-  static cell_topo run(CMap&, typename CMap::Dart_descriptor it,
-                       typename CMap::Dart_descriptor& starting_dart)
+  static cell_topo run(const CMap&,
+                       typename CMap::Dart_const_descriptor it,
+                       typename CMap::Dart_const_descriptor& starting_dart)
   {
     starting_dart=it;
     return EDGE;
@@ -112,8 +114,9 @@ struct Get_cell_topo<CMap, 1, cmapdim>
 template<typename CMap, unsigned int cmapdim>
 struct Get_cell_topo<CMap, 2, cmapdim>
 {
-  static cell_topo run(CMap& cmap, typename CMap::Dart_descriptor it,
-                       typename CMap::Dart_descriptor& starting_dart)
+  static cell_topo run(const CMap& cmap,
+                       typename CMap::Dart_const_descriptor it,
+                       typename CMap::Dart_const_descriptor& starting_dart)
   {
     starting_dart=it;
 
@@ -133,8 +136,9 @@ struct Get_cell_topo<CMap, 2, cmapdim>
 template<typename CMap>
 struct Get_cell_topo<CMap, 3, 3>
 {
-  static cell_topo run(CMap& cmap, typename CMap::Dart_descriptor it,
-                       typename CMap::Dart_descriptor& starting_dart)
+  static cell_topo run(const CMap& cmap,
+                       typename CMap::Dart_const_descriptor it,
+                       typename CMap::Dart_const_descriptor& starting_dart)
   {
     starting_dart=it;
 
@@ -171,36 +175,40 @@ struct Get_cell_topo<CMap, 3, 3>
   }
 };
 
+/// get_cell_topo: two const versions
 template<unsigned int dimcell, typename CMap>
-cell_topo get_cell_topo(CMap& cmap, typename CMap::Dart_descriptor it,
-                        typename CMap::Dart_descriptor& starting_dart)
+cell_topo get_cell_topo(const CMap& cmap,
+                        typename CMap::Dart_const_descriptor it,
+                        typename CMap::Dart_const_descriptor& starting_dart)
 { return Get_cell_topo<CMap, dimcell>::run(cmap, it, starting_dart); }
 
 template<unsigned int dimcell, typename CMap>
-cell_topo get_cell_topo(CMap& cmap, typename CMap::Dart_descriptor it)
+cell_topo get_cell_topo(const CMap& cmap,
+                        typename CMap::Dart_const_descriptor it)
 {
-  typename CMap::Dart_descriptor dummy;
-  return get_cell_topo<dimcell, CMap>(cmap, it, dummy);
+  typename CMap::Dart_const_descriptor dummy;
+  return get_cell_topo<dimcell>(cmap, it, dummy);
 }
 
+/// get_cell_topo: two non-const versions
 template<unsigned int dimcell, typename CMap>
-cell_topo get_cell_topo(const CMap& cmap, typename CMap::Dart_const_descriptor it,
-    typename CMap::Dart_const_descriptor& starting_dart)
+cell_topo get_cell_topo(CMap& cmap,
+                        typename CMap::Dart_descriptor it,
+                        typename CMap::Dart_descriptor& starting_dart)
 {
-  typename CMap::Dart_descriptor it2=const_cast<CMap&>(cmap).dart_descriptor
-                                       (cmap.darts().index(it));
-  typename CMap::Dart_descriptor sd2;
-  cell_topo res=Get_cell_topo<CMap, dimcell>::run(const_cast<CMap&>(cmap),
-                                                    it2, sd2);
-  starting_dart=sd2;
+  typename CMap::Dart_const_descriptor itc=it;
+  typename CMap::Dart_const_descriptor starting_dartc;
+
+  cell_topo res=Get_cell_topo<CMap, dimcell>::run(cmap, itc, starting_dartc);
+  starting_dart=cmap.dart_descriptor(cmap.darts().index(it));
   return res;
 }
 
 template<unsigned int dimcell, typename CMap>
-cell_topo get_cell_topo(const CMap& cmap, typename CMap::Dart_const_descriptor it)
+cell_topo get_cell_topo(CMap& cmap, typename CMap::Dart_descriptor it)
 {
-  typename CMap::Dart_descriptor it2=it;
-  return Get_cell_topo<CMap, dimcell>::run(const_cast<CMap&>(cmap), it2);
+  typename CMap::Dart_const_descriptor dummy;
+  return get_cell_topo<dimcell, CMap>(cmap, it, dummy);
 }
 
 } } } // namespace CGAL::CMap::Element_topo

--- a/Linear_cell_complex/include/CGAL/CMap_linear_cell_complex_storages_with_index.h
+++ b/Linear_cell_complex/include/CGAL/CMap_linear_cell_complex_storages_with_index.h
@@ -165,6 +165,10 @@ namespace CGAL {
       { return idx; }
       size_type index(const_iterator cit) const
       { return cit; }
+      const Dart& operator[] (size_type i) const
+      { return mmap.mdarts[i]; }
+      Dart& operator[] (size_type i)
+      { return mmap.mdarts[i]; }
       bool is_used(size_type i) const
       { return mmap.mdarts.is_used(i); }
       bool owns(size_type i) const

--- a/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/test/Linear_cell_complex/CMakeLists.txt
@@ -47,3 +47,5 @@ target_compile_definitions(test_polyhedron_3_alias PRIVATE CGAL_NO_DEPRECATION_W
 
 create_single_source_cgal_program(test_plane_graph_alias.cpp ${hfiles})
 target_compile_definitions(test_plane_graph_alias PRIVATE CGAL_NO_DEPRECATION_WARNINGS)
+
+create_single_source_cgal_program(lcc_test_hook_operator.cpp)

--- a/Linear_cell_complex/test/Linear_cell_complex/lcc_test_hook_operator.cpp
+++ b/Linear_cell_complex/test/Linear_cell_complex/lcc_test_hook_operator.cpp
@@ -1,0 +1,34 @@
+#include <CGAL/Linear_cell_complex_for_combinatorial_map.h>
+
+struct Items_index: public CGAL::Linear_cell_complex_min_items
+{ using Use_index=CGAL::Tag_true; };
+
+template<typename LCC>
+bool test_lcc()
+{
+  LCC lcc;
+  typename LCC::Dart_descriptor dd;
+  for(int i=0; i<10; ++i)
+  {
+    typename LCC::Dart_descriptor cur=lcc.create_dart();
+    if(lcc.dart_descriptor(lcc.darts()[lcc.darts().index(cur)])!=cur)
+    { return false; }
+  }
+
+  return true;
+}
+
+int main()
+{
+  using LCC2=CGAL::Linear_cell_complex_for_combinatorial_map<2,2>;
+  using LCC2_INDEX=CGAL::Linear_cell_complex_for_combinatorial_map
+    <2,2,CGAL::Linear_cell_complex_traits<2>, Items_index>;
+
+  if(!test_lcc<LCC2>() || !test_lcc<LCC2_INDEX>())
+  {
+    std::cout<<"ERROR lcc_test_hook_operator."<<std::endl;
+    return EXIT_FAILURE;
+  }
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION

## Summary of Changes

Correction of two bugs in combinatorial map package:
* const correctness of Element_topo
* missing operator[] for dart storage with index

## Release Management

* Affected package(s): Combinatorial maps
