### PR TITLE
[Kernel_23] Fix duplicated word typo in FunctionObjectConcepts.h

### DIFF
--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -1297,7 +1297,7 @@ public:
 
 \cgalRefines{AdaptableFunctor}
 
-\sa `ComputePowerProduct_3` for the definition of of orthogonality for power distances.
+\sa `ComputePowerProduct_3` for the definition of orthogonality for power distances.
 
 */
 class CompareWeightedSquaredRadius_3
@@ -3121,7 +3121,7 @@ public:
 \cgalConcept
 
 \sa `CGAL::Weighted_point_3<Kernel>`
-\sa `ComputePowerProduct_3` for the definition of of orthogonality for power distances.
+\sa `ComputePowerProduct_3` for the definition of orthogonality for power distances.
 
 \cgalRefines{AdaptableFunctor}
 


### PR DESCRIPTION
## Summary of Changes

Fixed a typo in the documentation of `FunctionObjectConcepts.h` where the word "of" was duplicated in the sentence "definition of of orthogonality".

## Release Management

* Affected package(s): Kernel_23
* Issue(s) solved (if any):
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature):
* License and copyright ownership: I hold the copyright of the code/doc, and I agree to its integration in CGAL.