### PR TITLE
[Spatial_searching] Fix duplicated word typo in Manhattan_distance_iso_box_point.h

### DIFF
--- a/Spatial_searching/doc/Spatial_searching/CGAL/Manhattan_distance_iso_box_point.h
+++ b/Spatial_searching/doc/Spatial_searching/CGAL/Manhattan_distance_iso_box_point.h
@@ -67,7 +67,7 @@ distance between `b` and `p`.
 FT transformed_distance(Query_item b, Point_d p) const;
 
 /*!
-Returns the transformed value of of `d`.
+Returns the transformed value of `d`.
 */
 FT transformed_distance(FT d) const;
 


### PR DESCRIPTION
## Summary of Changes

Fixed a typo in the documentation of `Manhattan_distance_iso_box_point.h` where the word "of" was duplicated in the phrase "transformed value of of d".

## Release Management

* Affected package(s): Spatial_searching
* Issue(s) solved (if any):
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature):
* License and copyright ownership: I hold the copyright of the code/doc, and I agree to its integration in CGAL.