### PR TITLE
remove 'using namespace std' from headers

### DIFF
--- a/Bounding_volumes/include/CGAL/Min_annulus_d.h
+++ b/Bounding_volumes/include/CGAL/Min_annulus_d.h
@@ -706,17 +706,15 @@ bool
 Min_annulus_d<Traits_>::
 is_valid( bool verbose, int level) const
 {
-  using namespace std;
-
   CGAL::Verbose_ostream verr( verbose);
-  verr << "CGAL::Min_annulus_d<Traits>::" << endl;
-  verr << "is_valid( true, " << level << "):" << endl;
+  verr << "CGAL::Min_annulus_d<Traits>::" << std::endl;
+  verr << "is_valid( true, " << level << "):" << std::endl;
   verr << "  |P| = " << number_of_points()
-       << ", |S| = " << number_of_support_points() << endl;
+       << ", |S| = " << number_of_support_points() << std::endl;
 
   // containment check (a)
   // ---------------------
-  verr << "  (a) containment check..." << flush;
+  verr << "  (a) containment check..." << std::flush;
 
   Point_iterator  point_it = points_begin();
   for ( ; point_it != points_end(); ++point_it) {
@@ -725,11 +723,11 @@ is_valid( bool verbose, int level) const
                                                 "annulus does not contain all points");
   }
 
-  verr << "passed." << endl;
+  verr << "passed." << std::endl;
 
   // support set check (b)
   // ---------------------
-  verr << "  (b) support set check..." << flush;
+  verr << "  (b) support set check..." << std::flush;
 
   // all inner support points on inner boundary?
   Inner_support_point_iterator  i_pt_it = inner_support_points_begin();
@@ -762,9 +760,9 @@ is_valid( bool verbose, int level) const
   }
   */
 
-  verr << "passed." << endl;
+  verr << "passed." << std::endl;
 
-  verr << "  object is valid!" << endl;
+  verr << "  object is valid!" << std::endl;
   return( true);
 }
 
@@ -774,12 +772,10 @@ std::ostream&
 operator << ( std::ostream& os,
               const Min_annulus_d<Traits_>& min_annulus)
 {
-  using namespace std;
-
   typedef  typename Min_annulus_d<Traits_>::Point  Point;
-  typedef  ostream_iterator<Point>       Os_it;
+  typedef  std::ostream_iterator<Point>       Os_it;
   typedef  typename Traits_::ET          ET;
-  typedef  ostream_iterator<ET>          Et_it;
+  typedef  std::ostream_iterator<ET>          Et_it;
 
   switch ( CGAL::IO::get_mode( os)) {
 
@@ -787,44 +783,44 @@ operator << ( std::ostream& os,
     os << "CGAL::Min_annulus_d( |P| = "
        << min_annulus.number_of_points() << ", |S| = "
        << min_annulus.number_of_inner_support_points() << '+'
-       << min_annulus.number_of_outer_support_points() << endl;
-    os << "  P = {" << endl;
+       << min_annulus.number_of_outer_support_points() << std::endl;
+    os << "  P = {" << std::endl;
     os << "    ";
-    copy( min_annulus.points_begin(), min_annulus.points_end(),
+    std::copy( min_annulus.points_begin(), min_annulus.points_end(),
           Os_it( os, ",\n    "));
-    os << "}" << endl;
-    os << "  S_i = {" << endl;
+    os << "}" << std::endl;
+    os << "  S_i = {" << std::endl;
     os << "    ";
-    copy( min_annulus.inner_support_points_begin(),
+    std::copy( min_annulus.inner_support_points_begin(),
           min_annulus.inner_support_points_end(),
           Os_it( os, ",\n    "));
-    os << "}" << endl;
-    os << "  S_o = {" << endl;
+    os << "}" << std::endl;
+    os << "  S_o = {" << std::endl;
     os << "    ";
-    copy( min_annulus.outer_support_points_begin(),
+    std::copy( min_annulus.outer_support_points_begin(),
           min_annulus.outer_support_points_end(),
           Os_it( os, ",\n    "));
-    os << "}" << endl;
+    os << "}" << std::endl;
     os << "  center = ( ";
-    copy( min_annulus.center_coordinates_begin(),
+    std::copy( min_annulus.center_coordinates_begin(),
           min_annulus.center_coordinates_end(),
           Et_it( os, " "));
-    os << ")" << endl;
+    os << ")" << std::endl;
     os << "  squared inner radius = "
        << min_annulus.squared_inner_radius_numerator() << " / "
-       << min_annulus.squared_radii_denominator() << endl;
+       << min_annulus.squared_radii_denominator() << std::endl;
     os << "  squared outer radius = "
        << min_annulus.squared_outer_radius_numerator() << " / "
-       << min_annulus.squared_radii_denominator() << endl;
+       << min_annulus.squared_radii_denominator() << std::endl;
     break;
 
   case CGAL::IO::ASCII:
-    copy( min_annulus.points_begin(), min_annulus.points_end(),
+    std::copy( min_annulus.points_begin(), min_annulus.points_end(),
           Os_it( os, "\n"));
     break;
 
   case CGAL::IO::BINARY:
-    copy( min_annulus.points_begin(), min_annulus.points_end(),
+    std::copy( min_annulus.points_begin(), min_annulus.points_end(),
           Os_it( os));
     break;
 
@@ -841,19 +837,17 @@ template < class Traits_ >
 std::istream&
 operator >> ( std::istream& is, CGAL::Min_annulus_d<Traits_>& min_annulus)
 {
-  using namespace std;
-
   switch ( CGAL::IO::get_mode( is)) {
 
   case CGAL::IO::PRETTY:
-    cerr << endl;
-    cerr << "Stream must be in ASCII or binary mode" << endl;
+    std::cerr << std::endl;
+    std::cerr << "Stream must be in ASCII or binary mode" << std::endl;
     break;
 
   case CGAL::IO::ASCII:
   case CGAL::IO::BINARY:
     typedef  typename CGAL::Min_annulus_d<Traits_>::Point  Point;
-    typedef  istream_iterator<Point>             Is_it;
+    typedef  std::istream_iterator<Point>             Is_it;
     min_annulus.set( Is_it( is), Is_it());
     break;
 

--- a/Bounding_volumes/include/CGAL/Min_circle_2.h
+++ b/Bounding_volumes/include/CGAL/Min_circle_2.h
@@ -443,17 +443,15 @@ class Min_circle_2 {
     bool
     is_valid( bool verbose = false, int level = 0) const
     {
-        using namespace std;
-
         CGAL::Verbose_ostream verr( verbose);
-        verr << endl;
-        verr << "CGAL::Min_circle_2<Traits>::" << endl;
-        verr << "is_valid( true, " << level << "):" << endl;
+        verr << std::endl;
+        verr << "CGAL::Min_circle_2<Traits>::" << std::endl;
+        verr << "is_valid( true, " << level << "):" << std::endl;
         verr << "  |P| = " << number_of_points()
-             << ", |S| = " << number_of_support_points() << endl;
+             << ", |S| = " << number_of_support_points() << std::endl;
 
         // containment check (a)
-        verr << "  a) containment check..." << flush;
+        verr << "  a) containment check..." << std::flush;
         Point_iterator point_iter;
         for ( point_iter  = points_begin();
               point_iter != points_end();
@@ -461,10 +459,10 @@ class Min_circle_2 {
             if ( has_on_unbounded_side( *point_iter))
                 return( CGAL::_optimisation_is_valid_fail( verr,
                             "circle does not contain all points"));
-        verr << "passed." << endl;
+        verr << "passed." << std::endl;
 
         // support set checks (b)+(c)
-        verr << "  b)+c) support set checks..." << flush;
+        verr << "  b)+c) support set checks..." << std::flush;
         switch( number_of_support_points()) {
 
           case 0:
@@ -548,9 +546,9 @@ class Min_circle_2 {
                         "illegal number of support points, \
                          not between 0 and 3."));
         };
-        verr << "passed." << endl;
+        verr << "passed." << std::endl;
 
-        verr << "  object is valid!" << endl;
+        verr << "  object is valid!" << std::endl;
         return( true);
     }
 

--- a/Bounding_volumes/include/CGAL/Min_circle_2/Min_circle_2_impl.h
+++ b/Bounding_volumes/include/CGAL/Min_circle_2/Min_circle_2_impl.h
@@ -28,39 +28,37 @@ std::ostream&
 operator << ( std::ostream& os,
               const Min_circle_2<Traits_>& min_circle)
 {
-    using namespace std;
-
     typedef  typename Min_circle_2<Traits_>::Point  Point;
-    typedef  ostream_iterator<Point>       Os_it;
+    typedef  std::ostream_iterator<Point>       Os_it;
 
     switch ( CGAL::IO::get_mode( os)) {
 
       case CGAL::IO::PRETTY:
-        os << endl;
+        os << std::endl;
         os << "CGAL::Min_circle_2( |P| = " << min_circle.number_of_points()
-           << ", |S| = " << min_circle.number_of_support_points() << endl;
-        os << "  P = {" << endl;
+           << ", |S| = " << min_circle.number_of_support_points() << std::endl;
+        os << "  P = {" << std::endl;
         os << "    ";
-        copy( min_circle.points_begin(), min_circle.points_end(),
+        std::copy( min_circle.points_begin(), min_circle.points_end(),
               Os_it( os, ",\n    "));
-        os << "}" << endl;
-        os << "  S = {" << endl;
+        os << "}" << std::endl;
+        os << "  S = {" << std::endl;
         os << "    ";
-        copy( min_circle.support_points_begin(),
+        std::copy( min_circle.support_points_begin(),
               min_circle.support_points_end(),
               Os_it( os, ",\n    "));
-        os << "}" << endl;
-        os << "  circle = " << min_circle.circle() << endl;
-        os << ")" << endl;
+        os << "}" << std::endl;
+        os << "  circle = " << min_circle.circle() << std::endl;
+        os << ")" << std::endl;
         break;
 
       case CGAL::IO::ASCII:
-        copy( min_circle.points_begin(), min_circle.points_end(),
+        std::copy( min_circle.points_begin(), min_circle.points_end(),
               Os_it( os, "\n"));
         break;
 
       case CGAL::IO::BINARY:
-        copy( min_circle.points_begin(), min_circle.points_end(),
+        std::copy( min_circle.points_begin(), min_circle.points_end(),
               Os_it( os));
         break;
 
@@ -76,19 +74,17 @@ template < class Traits_ >
 std::istream&
 operator >> ( std::istream& is, CGAL::Min_circle_2<Traits_>& min_circle)
 {
-    using namespace std;
-
     switch ( CGAL::IO::get_mode( is)) {
 
       case CGAL::IO::PRETTY:
-        cerr << endl;
-        cerr << "Stream must be in ASCII or binary mode" << endl;
+        std::cerr << std::endl;
+        std::cerr << "Stream must be in ASCII or binary mode" << std::endl;
         break;
 
       case CGAL::IO::ASCII:
       case CGAL::IO::BINARY:
         typedef  typename CGAL::Min_circle_2<Traits_>::Point  Point;
-        typedef  istream_iterator<Point>            Is_it;
+        typedef  std::istream_iterator<Point>            Is_it;
         min_circle.clear();
         min_circle.insert( Is_it( is), Is_it());
         break;

--- a/Bounding_volumes/include/CGAL/Min_ellipse_2.h
+++ b/Bounding_volumes/include/CGAL/Min_ellipse_2.h
@@ -524,17 +524,15 @@ class Min_ellipse_2 {
     bool
     is_valid( bool verbose = false, int level = 0) const
     {
-        using namespace std;
-
         CGAL::Verbose_ostream verr( verbose);
-        verr << endl;
-        verr << "CGAL::Min_ellipse_2<Traits>::" << endl;
-        verr << "is_valid( true, " << level << "):" << endl;
+        verr << std::endl;
+        verr << "CGAL::Min_ellipse_2<Traits>::" << std::endl;
+        verr << "is_valid( true, " << level << "):" << std::endl;
         verr << "  |P| = " << number_of_points()
-             << ", |S| = " << number_of_support_points() << endl;
+             << ", |S| = " << number_of_support_points() << std::endl;
 
         // containment check (a)
-        verr << "  a) containment check..." << flush;
+        verr << "  a) containment check..." << std::flush;
         Point_iterator point_iter;
         for ( point_iter  = points_begin();
               point_iter != points_end();
@@ -542,12 +540,12 @@ class Min_ellipse_2 {
             if ( has_on_unbounded_side( *point_iter))
                 return( CGAL::_optimisation_is_valid_fail( verr,
                             "ellipse does not contain all points"));
-        verr << "passed." << endl;
+        verr << "passed." << std::endl;
 
         // support set checks (b)+(c) (not yet implemented)
 
         // alternative support set check
-        verr << "  +) support set check..." << flush;
+        verr << "  +) support set check..." << std::flush;
         Support_point_iterator support_point_iter;
         for ( support_point_iter  = support_points_begin();
               support_point_iter != support_points_end();
@@ -556,9 +554,9 @@ class Min_ellipse_2 {
                 return( CGAL::_optimisation_is_valid_fail( verr,
                             "ellipse does not have all \
                              support points on the boundary"));
-        verr << "passed." << endl;
+        verr << "passed." << std::endl;
 
-        verr << "  object is valid!" << endl;
+        verr << "  object is valid!" << std::endl;
         return( true);
     }
 

--- a/Bounding_volumes/include/CGAL/Min_ellipse_2/Min_ellipse_2_impl.h
+++ b/Bounding_volumes/include/CGAL/Min_ellipse_2/Min_ellipse_2_impl.h
@@ -28,39 +28,37 @@ std::ostream&
 operator << ( std::ostream& os,
               const Min_ellipse_2<Traits_>& min_ellipse)
 {
-    using namespace std;
-
     typedef typename Min_ellipse_2<Traits_>::Point  Point;
-    typedef  ostream_iterator<Point>        Os_it;
+    typedef  std::ostream_iterator<Point>        Os_it;
 
     switch ( CGAL::IO::get_mode( os)) {
 
       case CGAL::IO::PRETTY:
-        os << endl;
+        os << std::endl;
         os << "CGAL::Min_ellipse_2( |P| = "<<min_ellipse.number_of_points()
-           << ", |S| = " << min_ellipse.number_of_support_points() << endl;
-        os << "  P = {" << endl;
+           << ", |S| = " << min_ellipse.number_of_support_points() << std::endl;
+        os << "  P = {" << std::endl;
         os << "    ";
-        copy( min_ellipse.points_begin(), min_ellipse.points_end(),
+        std::copy( min_ellipse.points_begin(), min_ellipse.points_end(),
               Os_it( os, ",\n    "));
-        os << "}" << endl;
-        os << "  S = {" << endl;
+        os << "}" << std::endl;
+        os << "  S = {" << std::endl;
         os << "    ";
-        copy( min_ellipse.support_points_begin(),
+        std::copy( min_ellipse.support_points_begin(),
               min_ellipse.support_points_end(),
               Os_it( os, ",\n    "));
-        os << "}" << endl;
-        os << "  ellipse = " << min_ellipse.ellipse() << endl;
-        os << ")" << endl;
+        os << "}" << std::endl;
+        os << "  ellipse = " << min_ellipse.ellipse() << std::endl;
+        os << ")" << std::endl;
         break;
 
       case CGAL::IO::ASCII:
-        copy( min_ellipse.points_begin(), min_ellipse.points_end(),
+        std::copy( min_ellipse.points_begin(), min_ellipse.points_end(),
               Os_it( os, "\n"));
         break;
 
       case CGAL::IO::BINARY:
-        copy( min_ellipse.points_begin(), min_ellipse.points_end(),
+        std::copy( min_ellipse.points_begin(), min_ellipse.points_end(),
               Os_it( os));
         break;
 
@@ -76,19 +74,17 @@ template < class Traits_ >
 std::istream&
 operator >> ( std::istream& is, CGAL::Min_ellipse_2<Traits_>& min_ellipse)
 {
-    using namespace std;
-
     switch ( CGAL::IO::get_mode( is)) {
 
       case CGAL::IO::PRETTY:
-        cerr << endl;
-        cerr << "Stream must be in ASCII or binary mode" << endl;
+        std::cerr << std::endl;
+        std::cerr << "Stream must be in ASCII or binary mode" << std::endl;
         break;
 
       case CGAL::IO::ASCII:
       case CGAL::IO::BINARY:
         typedef typename Min_ellipse_2<Traits_>::Point  Point;
-        typedef  istream_iterator<Point>       Is_it;
+        typedef  std::istream_iterator<Point>       Is_it;
         min_ellipse.clear();
         min_ellipse.insert( Is_it( is), Is_it());
         break;

--- a/Polytope_distance_d/include/CGAL/Polytope_distance_d.h
+++ b/Polytope_distance_d/include/CGAL/Polytope_distance_d.h
@@ -758,15 +758,13 @@ bool
 Polytope_distance_d<Traits_>::
 is_valid( bool verbose, int level) const
 {
-  using namespace std;
-
   CGAL::Verbose_ostream verr( verbose);
-  verr << "CGAL::Polytope_distance_d<Traits>::" << endl;
-  verr << "is_valid( true, " << level << "):" << endl;
+  verr << "CGAL::Polytope_distance_d<Traits>::" << std::endl;
+  verr << "is_valid( true, " << level << "):" << std::endl;
   verr << "  |P+Q| = " << number_of_points_p()
        <<          '+' << number_of_points_q()
        <<   ", |S| = " << number_of_support_points_p()
-       <<          '+' << number_of_support_points_q() << endl;
+       <<          '+' << number_of_support_points_q() << std::endl;
 
   if ( is_finite()) {
 
@@ -779,7 +777,7 @@ is_valid( bool verbose, int level) const
     for ( j = 0; j < d; ++j) normal[ j] = p_coords[ j] - q_coords[ j];
 
     // check correctness of computed squared distance
-    verr << "  checking squared_distance..." << flush;
+    verr << "  checking squared_distance..." << std::flush;
     ET sqr_dist_num (0);
     for ( j = 0; j < d; ++j)
       sqr_dist_num += normal[ j] * normal[ j];
@@ -793,7 +791,7 @@ is_valid( bool verbose, int level) const
 
     // check P
     // -------
-    verr << "  checking P..." << flush;
+    verr << "  checking P..." << std::flush;
 
     // check point set
     for ( i = 0; i < number_of_points_p(); ++i) {
@@ -809,11 +807,11 @@ is_valid( bool verbose, int level) const
           ( verr, "polytope P is not separated by its hyperplane");
     }
 
-    verr << "passed." << endl;
+    verr << "passed." << std::endl;
 
     // check Q
     // -------
-    verr << "  checking Q..." << flush;
+    verr << "  checking Q..." << std::flush;
 
     // check point set
     for ( i = 0; i < number_of_points_q(); ++i) {
@@ -829,10 +827,10 @@ is_valid( bool verbose, int level) const
           ( verr, "polytope Q is not separated by its hyperplane");
     }
 
-    verr << "passed." << endl;
+    verr << "passed." << std::endl;
   }
 
-  verr << "  object is valid!" << endl;
+  verr << "  object is valid!" << std::endl;
   return( true);
 }
 
@@ -842,12 +840,10 @@ std::ostream&
 operator << ( std::ostream& os,
               const Polytope_distance_d<Traits_>& poly_dist)
 {
-  using namespace std;
-
   typedef  typename Polytope_distance_d<Traits_>::Point  Point;
-  typedef  ostream_iterator<Point>       Os_it;
+  typedef  std::ostream_iterator<Point>       Os_it;
   typedef  typename Traits_::ET          ET;
-  typedef  ostream_iterator<ET>          Et_it;
+  typedef  std::ostream_iterator<ET>          Et_it;
 
   switch ( CGAL::IO::get_mode( os)) {
 
@@ -856,62 +852,62 @@ operator << ( std::ostream& os,
        << poly_dist.number_of_points_p() << '+'
        << poly_dist.number_of_points_q() << ", |S| = "
        << poly_dist.number_of_support_points_p() << '+'
-       << poly_dist.number_of_support_points_q() << endl;
-    os << "  P = {" << endl;
+       << poly_dist.number_of_support_points_q() << std::endl;
+    os << "  P = {" << std::endl;
     os << "    ";
-    copy( poly_dist.points_p_begin(), poly_dist.points_p_end(),
+    std::copy( poly_dist.points_p_begin(), poly_dist.points_p_end(),
           Os_it( os, ",\n    "));
-    os << "}" << endl;
-    os << "  Q = {" << endl;
+    os << "}" << std::endl;
+    os << "  Q = {" << std::endl;
     os << "    ";
-    copy( poly_dist.points_q_begin(), poly_dist.points_q_end(),
+    std::copy( poly_dist.points_q_begin(), poly_dist.points_q_end(),
           Os_it( os, ",\n    "));
-    os << "}" << endl;
-    os << "  S_P = {" << endl;
+    os << "}" << std::endl;
+    os << "  S_P = {" << std::endl;
     os << "    ";
-    copy( poly_dist.support_points_p_begin(),
+    std::copy( poly_dist.support_points_p_begin(),
           poly_dist.support_points_p_end(),
           Os_it( os, ",\n    "));
-    os << "}" << endl;
-    os << "  S_Q = {" << endl;
+    os << "}" << std::endl;
+    os << "  S_Q = {" << std::endl;
     os << "    ";
-    copy( poly_dist.support_points_q_begin(),
+    std::copy( poly_dist.support_points_q_begin(),
           poly_dist.support_points_q_end(),
           Os_it( os, ",\n    "));
-    os << "}" << endl;
+    os << "}" << std::endl;
     os << "  p = ( ";
-    copy( poly_dist.realizing_point_p_coordinates_begin(),
+    std::copy( poly_dist.realizing_point_p_coordinates_begin(),
           poly_dist.realizing_point_p_coordinates_end(),
           Et_it( os, " "));
-    os << ")" << endl;
+    os << ")" << std::endl;
     os << "  q = ( ";
-    copy( poly_dist.realizing_point_q_coordinates_begin(),
+    std::copy( poly_dist.realizing_point_q_coordinates_begin(),
           poly_dist.realizing_point_q_coordinates_end(),
           Et_it( os, " "));
-    os << ")" << endl;
+    os << ")" << std::endl;
     os << "  squared distance = "
        << poly_dist.squared_distance_numerator() << " / "
-       << poly_dist.squared_distance_denominator() << endl;
+       << poly_dist.squared_distance_denominator() << std::endl;
     break;
 
   case CGAL::IO::ASCII:
-    os << poly_dist.number_of_points_p() << endl;
-    copy( poly_dist.points_p_begin(),
+    os << poly_dist.number_of_points_p() << std::endl;
+    std::copy( poly_dist.points_p_begin(),
           poly_dist.points_p_end(),
           Os_it( os, "\n"));
-    os << poly_dist.number_of_points_q() << endl;
-    copy( poly_dist.points_q_begin(),
+    os << poly_dist.number_of_points_q() << std::endl;
+    std::copy( poly_dist.points_q_begin(),
           poly_dist.points_q_end(),
           Os_it( os, "\n"));
     break;
 
   case CGAL::IO::BINARY:
-    os << poly_dist.number_of_points_p() << endl;
-    copy( poly_dist.points_p_begin(),
+    os << poly_dist.number_of_points_p() << std::endl;
+    std::copy( poly_dist.points_p_begin(),
           poly_dist.points_p_end(),
           Os_it( os));
-    os << poly_dist.number_of_points_q() << endl;
-    copy( poly_dist.points_q_begin(),
+    os << poly_dist.number_of_points_q() << std::endl;
+    std::copy( poly_dist.points_q_begin(),
           poly_dist.points_q_end(),
           Os_it( os));
     break;


### PR DESCRIPTION
## Summary of Changes

This PR removes `using namespace std;` from files. It replaces implicit standard library calls with explicit `std::` prefixes (e.g., `std::copy`, `std::endl`, `std::ostream_iterator`, `std::flush`).

## Release Management

* **Affected package(s):** `Bounding_volumes`, `Polytope_distance_d`
* **Issue(s) solved (if any):**
* **Feature/Small Feature (if any):**
* **Link to compiled documentation:**
* **License and copyright ownership:**