### PR TITLE
[Spatial_searching] Allow K command-line argument in general_neighbor_searching example

### DIFF
--- a/Spatial_searching/examples/Spatial_searching/general_neighbor_searching.cpp
+++ b/Spatial_searching/examples/Spatial_searching/general_neighbor_searching.cpp
@@ -14,7 +14,7 @@ typedef CGAL::Manhattan_distance_iso_box_point<TreeTraits> Distance;
 typedef CGAL::K_neighbor_search<TreeTraits, Distance> Neighbor_search;
 typedef Neighbor_search::Tree Tree;
 
-int main(int argc, char* argv[]) 
+int main(int argc, char* argv[])
 {
   const int N = 1000;
   // Use command line argument if provided, otherwise default to 10


### PR DESCRIPTION
## Summary of Changes

This PR modifies the `general_neighbor_searching.cpp` example to make the number of neighbors (`K`) configurable via command-line arguments.

* **Previously:** `K` was hardcoded to `10`. To test with different values (e.g., 50 or 100), the user had to modify the source code and recompile.
* **Now:** The user can run `./general_neighbor_searching [K]`.
    * If an argument is provided (e.g., `./general_neighbor_searching 50`), the program searches for 50 neighbors.
    * If no argument is provided, it defaults to `10`, preserving the original behavior.
    * Added `#include <cstdlib>` for `std::atoi`.

## Release Management

* Affected package(s): `Spatial_searching`
* Issue(s) solved (if any):
* Feature/Small Feature (if any): Improvement to existing example
* Link to compiled documentation (obligatory for small feature): N/A (Example modification only)
* License and copyright ownership: I confirm that I have the rights to submit this contribution under the CGAL license.