### PR TITLE
Cleanup CMake and Documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,8 @@
 # Top level CMakeLists.txt for CGAL-branchbuild
 
 # Minimal version of CMake:
-cmake_minimum_required(VERSION 3.12...3.31)
+cmake_minimum_required(VERSION 3.15...3.31) # CMake>=3.15 for message(VERBOSE...)
 
-message("== CMake setup ==")
 project(CGAL CXX C)
 export(PACKAGE CGAL)
 
@@ -44,8 +43,6 @@ option(
   "Switch on to start (naive) detection of duplicate source- and headerfiles in packages"
   OFF)
 
-message("== CMake setup (DONE) ==\n")
-
 # Enable testing with CGAL_ENABLE_TESTING. Before CGAL-6.0, users would enable
 # the tests by specifying BUILD_TESTING. For compatibility, If BUILD_TESTING is
 # set, that is the default value for CGAL_ENABLE_TESTING. Otherwise, the default
@@ -59,36 +56,6 @@ endif()
 if(CGAL_ENABLE_TESTING)
   enable_testing()
 endif()
-
-#setup prefix path
-file(GLOB BOOST_DIRS "C:/Program Files/boost/*")
-if(NOT BOOST_DIRS)
-  file(GLOB BOOST_DIRS "C:/Program Files/boost*")
-endif()
-if(NOT BOOST_DIRS)
-  file(GLOB BOOST_DIRS "C:/Program Files (x86)/boost/*")
-endif()
-if(NOT BOOST_DIRS)
-  file(GLOB BOOST_DIRS "C:/Program Files (x86)/boost*")
-endif()
-if(NOT BOOST_DIRS)
-  file(GLOB BOOST_DIRS "C:/local/boost*")
-endif()
-if(BOOST_DIRS)
-  list(GET BOOST_DIRS 0 boost_dir)
-  list(APPEND CMAKE_PREFIX_PATH "${boost_dir}")
-endif()#BOOST_DIRS
-
-file(GLOB QT_DIRS "C:/Qt/5")
-if(QT_DIRS)
-  list(GET QT_DIRS 0 qt_dir)
-  file(GLOB COMPS "${qt_dir}/msvc*")
-  if(COMPS)
-    list(GET COMPS 0 COMP)
-    list(APPEND CMAKE_PREFIX_PATH "${COMP}")
-  endif()#COMPS
-endif()#QT_DIRS
-
 
 # and finally start actual build
 add_subdirectory(Installation)

--- a/Cone_spanners_2/include/CGAL/Compute_cone_boundaries_2.h
+++ b/Cone_spanners_2/include/CGAL/Compute_cone_boundaries_2.h
@@ -26,7 +26,7 @@
 #include <cstdlib>
 #include <vector>
 #include <utility>
-#include <CGAL/config.h>      // included compiler_config.h, defining CGAL_USE_CORE, etc.
+#include <CGAL/config.h>
 #include <CGAL/Polynomial.h>
 #include <CGAL/number_type_config.h>    // CGAL_PI is defined there
 #include <CGAL/enum.h>

--- a/Documentation/doc/Documentation/Developer_manual/Chapter_portability.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_portability.txt
@@ -194,116 +194,9 @@ Linux
 
 \section secproblems_and_workarounds Known problems and workarounds
 
-For (good) reasons that will not be discussed here, it was decided to
-use \cpp for the development of \cgal. An international standard for
-\cpp has been sanctioned in 1998 \cgalCite{cgal:ansi-is14882-98} and the
-level of compliance varies widely between different
-compilers, let alone bugs.
-
-\subsection secworkaround_flags Workaround flags
-
-In order to provide a uniform development environment for \cgal that
-looks more standard compliant than what the compilers provide, a number
-of workaround flags and macros have been created.  Some of the
-workaround macros are set in `<CGAL/config.h>`.
-
-using the macros
-listed in Section  \ref secwhich_compiler  to identify the compiler.
-But most of them are set in the platform-specific configuration files
-
-<CENTER>
-<TT><CGAL/config/</TT><I>os-compiler</I><TT>/CGAL/compiler_config.h></TT>
-
-</CENTER>
-where <I>os-compiler</I> refers to a string describing your
-operating system and compiler that is defined as follows.
-
-<CENTER>
-  <I>`<arch>_<os>-<os-version>_<comp>-<comp-version>`</I>
-
-</CENTER>
-
-<DL>
-<DT><B>`<arch>`</B><DD> is the system architecture as defined by <TT>uname -p</TT> or <TT>uname -m</TT>,
-<DT><B>`<os>`</B><DD> is the operating system as defined by <TT>uname
-    -s</TT>,
-<DT><B>`<os-version>`</B><DD> is the operating system version as defined by
-  <TT>uname -r</TT>,
-<DT><B>`<comp>`</B><DD> is the basename of the compiler executable (if it
-  contains spaces, these are replaced by "-"), and
-<DT><B>`<comp-version>`</B><DD> is the compiler's version number (which
-  unfortunately can not be derived in a uniform manner, since it is
-  quite compiler specific).
-</DL>
-
-Examples are <TT>mips_IRIX64-6.5_CC-n32-7.30</TT> or <TT>sparc_SunOS-5.6_g++-2.95</TT>.
-For more information, see the \cgal \link usage usage guide \endlink.
-
-This platform-specific configuration file is created during
-
-installation by the script <TT>install_cgal</TT>. The flags listed below
-are set according to the results of test programs that are compiled and run.
-These test programs reside in the directory
-<CENTER>
-<TT>$(CGAL_ROOT)/config/testfiles</TT>
-
-</CENTER>
-where <TT>$(CGAL_ROOT)</TT> represents the installation directory for the library.
-The names of all testfiles, which correspond to the names of the flags,
-
-start with <TT>CGAL_CFG_</TT> followed by
-<UL>
-<LI><I>either</I> a description of a bug ending with
-  <TT>_BUG</TT>
-<LI><I>or</I> a description of a feature starting with
-  <TT>NO_</TT>.
-</UL>
-For any of these files a corresponding flag is set in the
-platform-specific configuration file, iff either compilation or execution
-fails. The reasoning behind this sort of negative scheme is that on
-standard-compliant platforms there should be no flags at all.
-
-Currently (CGAL-3.4-I-181), we have the following configuration
-test files (and flags). The short descriptions that are given in the files are
-included here. In some cases, it is probably necessary to have a look at the
-actual files to understand what the flag is for. This list is just to
-give an overview.
-Be sure to have a look at <TT>Installation/config/testfiles/</TT> to have an
-up-to-date version of this list.
-
-<DL>
-<DT><B><TT>CGAL_CFG_LONGNAME_BUG</TT></B><DD>
-
-   This flag is set if a compiler (or assembler or linker) has problems
- with long symbol names.
-
-<DT><B><TT>CGAL_CFG_NET2003_MATCHING_BUG</TT></B><DD>
-
-   This flag is set, if the compiler does not match a member definition
- to an existing declaration. This bug shows up on VC 7.1 Beta
- (`cl1310`).
-
-<DT><B><TT>CGAL_CFG_NO_LIMITS</TT></B><DD>
-
-   This flag is set if a compiler does not know the limits.
-
-<DT><B><TT>CGAL_CFG_NO_LONG_LONG</TT></B><DD>
-
-   The `long long` built-in integral type is not part of the
-  \iso C++ standard, but many compilers support it
-  nevertheless, since it is part of the \iso C standard. This
-  flag is set if it is supported.
-
-<DT><B><TT>CGAL_CFG_NO_TMPL_IN_TMPL_PARAM</TT></B><DD>
-
-  Nested templates in template parameter, such as `template <
-  template <class T> class A>` are not supported by any compiler.
-  This flag is set if they are not supported.
-</DL>
-
 \subsection secworkaround_macros Macros connected to workarounds/compilers
 
-Some macros are defined according to certain workaround flags. This is
+Some macros are defined according to the detected compiler. This is
 done to avoid some `ifdef`s in our actual code.
 
 <DL>
@@ -380,15 +273,5 @@ enclosed by
 \endcode
 This may not be true anymore for recent VC++ versions.
 </DL>
-
-\section secportability_req_and_rec Requirements and recommendations
-
-Recommendations:
-<UL>
-<LI>Workarounds for a compiler bug or a missing feature should not
-      be treated on a per-compiler basis. When you detect a deficiency,
-      you should rather write a short test program that triggers the setting
-      of a flag for this deficiency during configuration.
-</UL>
 
 */

--- a/Documentation/doc/Documentation/Developer_manual/Chapter_portability.txt
+++ b/Documentation/doc/Documentation/Developer_manual/Chapter_portability.txt
@@ -11,7 +11,6 @@ configuration of \cgal that allow you to answer such questions as:
 <UL>
 <LI>Is \em LEDA / \gmp there? (Section  \ref secleda_gmp_support)
 <LI>Which compiler is this? (Section  \ref secwhich_compiler )
-<LI>Does the compiler support feature X? (Section  \ref secworkaround_flags )
 </UL>
 
 Also addressed here are issues related to writing code for
@@ -24,10 +23,6 @@ assume. Especially you may assume that the compiler
 <LI>supports member templates
 <LI>support for <TT>std::iterator_traits</TT>.
 </UL>
-Still, there are many bugs (sometimes known as "features") left in the
-compilers.  Have a look at the list of (non-obsolete) workarounds in
-Section  \ref secworkaround_flags  to get an idea of which "features" are
-still present.
 
 \section secleda_gmp_support Checking for LEDA or GMP support
 

--- a/Documentation/doc/Documentation/advanced/Configuration_variables.txt
+++ b/Documentation/doc/Documentation/advanced/Configuration_variables.txt
@@ -367,28 +367,4 @@ If GLPK is not automatically found, the following variables must be set:
 | `GLPK_INCLUDE_DIR` | Directory containing the file `glpk.h` | CMake |
 | `GLPK_LIBRARIES` | Full pathname of the compiled GLPK library | CMake |
 
-\section installation_compiler_workarounds Compiler Workarounds
-
-A number of boolean flags are used to workaround compiler bugs and
-limitations. They all start with the prefix `CGAL_CFG`. These
-flags are used to work around compiler bugs and limitations.
-
-For each installation a file <TT><CGAL/compiler_config.h></TT>
-is defined, with the correct
-settings of all flags. This file is generated automatically by CMake,
-and it is located in the `include` directory of where you run
-CMake. For an in-source configuration this means
-`CGAL-\cgalReleaseNumber``/include`.
-
-The test programs used to generate the `compiler_config.h`
-file can be found in `config/testfiles`.
-Both
-`compiler_config.h` and the test programs contain a short
-description of the problem. In case of trouble with one of the
-`CGAL_CFG` flags, it is a good idea to take a look at it.
-
-The file `CGAL/compiler_config.h` is included from
-`<CGAL/config.h>`.
-which is included by all \cgal header files.
-
 */

--- a/Documentation/doc/Documentation/advanced/Installation.txt
+++ b/Documentation/doc/Documentation/advanced/Installation.txt
@@ -152,11 +152,6 @@ For example:
     cd CGAL-\cgalReleaseNumber/build
     cmake ..
 
-The configuration process not only determines the location of the required dependencies, it also dynamically generates a
-`compiler_config.h` file, which encodes the properties of your system and a special file named
-`CGALConfig.cmake`, which is used to build programs using \cgal. The
-purpose of this file is explained below.
-
 \cgalAdvancedBegin
 CMake keeps the variables that a user can manipulate in a
 so-called <I>CMake cache</I>, a simple text file named

--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -4,7 +4,7 @@
 # ${CGAL_SOURCE_DIR} and to the root binary directory of the project as
 # ${CGAL_BINARY_DIR} or ${CGAL_BINARY_DIR}.
 if(NOT PROJECT_NAME)
-  cmake_minimum_required(VERSION 3.12...3.31)
+  cmake_minimum_required(VERSION 3.15...3.31) # CMake>=3.15 message(VERBOSE...)
   project(CGAL CXX C)
 endif()
 
@@ -51,7 +51,7 @@ if(CGAL_BRANCH_BUILD)
     NO_DEFAULT_PATH NO_CMAKE_ENVIRONMENT_PATH)
 
   if(DEFINED CGAL_WRONG_PACKAGES)
-    message(STATUS "Removed not-a-package: ${CGAL_WRONG_PACKAGES}")
+    message(VERBOSE "Removed not-a-package: ${CGAL_WRONG_PACKAGES}")
     list(REMOVE_ITEM CGAL_CONFIGURED_PACKAGES ${CGAL_WRONG_PACKAGES})
   endif()
 
@@ -74,11 +74,11 @@ if(CGAL_BRANCH_BUILD)
       "${CGAL_SOURCE_DIR}/GraphicsView"
       CACHE INTERNAL "Directory containing the GraphicsView package")
   file(GLOB INCLUDE_CGAL_QT_DIRECTORIES "${CGAL_SOURCE_DIR}/*/include/CGAL/Qt")
-  message(STATUS "Include CGAL/Qt directories: ${INCLUDE_CGAL_QT_DIRECTORIES}")
+  message(VERBOSE "Include CGAL/Qt directories: ${INCLUDE_CGAL_QT_DIRECTORIES}")
 
-  message(STATUS "Installation package directory: ${CGAL_INSTALLATION_PACKAGE_DIR}")
-  message(STATUS "Maintenance package directory: ${CGAL_MAINTENANCE_PACKAGE_DIR}")
-  message(STATUS "Core package directory: ${CGAL_CORE_PACKAGE_DIR}")
+  message(VERBOSE "Installation package directory: ${CGAL_INSTALLATION_PACKAGE_DIR}")
+  message(VERBOSE "Maintenance package directory: ${CGAL_MAINTENANCE_PACKAGE_DIR}")
+  message(VERBOSE "Core package directory: ${CGAL_CORE_PACKAGE_DIR}")
 
 else(CGAL_BRANCH_BUILD)
 
@@ -134,8 +134,7 @@ if(IS_DIRECTORY "${CGAL_SOURCE_DIR}/Documentation")
       PARENT_SCOPE)
 endif()
 
-message(STATUS "Packagenames: ${CGAL_CONFIGURED_PACKAGES_NAMES}")
-message("== Setting paths (DONE) ==\n")
+message(VERBOSE "Packagenames: ${CGAL_CONFIGURED_PACKAGES_NAMES}")
 
 message("== Generate version files ==")
 
@@ -194,11 +193,11 @@ if(CGAL_BRANCH_BUILD)
   set(CGAL_CREATED_VERSION_NR
       "1${CGAL_TMP_MAJOR}${CGAL_TMP_MINOR}${CGAL_BUGFIX_VERSION}${CGAL_TMP_BUILD}"
   )
-  message(STATUS "CGAL_VERSION_NR is ${CGAL_CREATED_VERSION_NR}")
+  message(VERBOSE "CGAL_VERSION_NR is ${CGAL_CREATED_VERSION_NR}")
 
-  message(STATUS "CGAL_GIT_HASH is ${CGAL_GIT_HASH}")
+  message(VERBOSE "CGAL_GIT_HASH is ${CGAL_GIT_HASH}")
   message(
-    STATUS "CGAL_CREATED_SVN_REVISION is ${CGAL_CREATED_SVN_REVISION} (dummy)")
+    VERBOSE "CGAL_CREATED_SVN_REVISION is ${CGAL_CREATED_SVN_REVISION} (dummy)")
 
   file(REMOVE ${CGAL_BINARY_DIR}/include/CGAL/version.h)
   string(TIMESTAMP CGAL_CREATED_RELEASE_DATE "%Y%m%d")
@@ -345,11 +344,11 @@ endif()
 #
 #--------------------------------------------------------------------------------------------------
 
-message(STATUS "CGAL_MAJOR_VERSION=${CGAL_MAJOR_VERSION}")
-message(STATUS "CGAL_MINOR_VERSION=${CGAL_MINOR_VERSION}")
-message(STATUS "CGAL_BUGFIX_VERSION=${CGAL_BUGFIX_VERSION}")
+message(VERBOSE "CGAL_MAJOR_VERSION=${CGAL_MAJOR_VERSION}")
+message(VERBOSE "CGAL_MINOR_VERSION=${CGAL_MINOR_VERSION}")
+message(VERBOSE "CGAL_BUGFIX_VERSION=${CGAL_BUGFIX_VERSION}")
 if(CGAL_BUILD_VERSION LESS 1000)
-  message(STATUS "CGAL_BUILD_VERSION=${CGAL_BUILD_VERSION}")
+  message(VERBOSE "CGAL_BUILD_VERSION=${CGAL_BUILD_VERSION}")
 endif()
 
 set(CGAL_VERSION_DIR CGAL-${CGAL_VERSION})
@@ -496,18 +495,13 @@ message("== Generate version files (DONE) ==\n")
 #--------------------------------------------------------------------------------------------------
 
 if(CGAL_DEV_MODE OR RUNNING_CGAL_AUTO_TEST OR CGAL_TEST_SUITE)
-  message("== Set up flags ==")
-
   # Ugly hack to be compatible with current CGAL testsuite process (as of
   # Nov. 2017). -- Laurent Rineau
   include(CGAL_SetupFlags)
 
-  message("== Set up flags (DONE) ==\n")
 else()
   include(CGAL_display_flags)
 endif()
-
-message("== Detect external libraries ==")
 
 # set some to have special prefix
 macro(set_special_prefix library prefix)
@@ -577,14 +571,6 @@ cache_set(CGAL_3RD_PARTY_LIBRARIES_DIRS "")
 # this; e.g. in MPFI/RS in Algebraic_kernel_d. For these cases CGAL
 # and the example/test must be configured with MPFI (just one is not sufficient)
 
-message("== Detect external libraries (DONE) ==\n")
-
-#--------------------------------------------------------------------------------------------------
-#
-#                                    -= Generation of compiler_config.h =-
-#
-#--------------------------------------------------------------------------------------------------
-
 #--------------------------------------------------------------------------------------------------
 #
 #                                    -= Installation Setup =-
@@ -645,8 +631,6 @@ set(CGAL_INSTALL_MAN_DIR
 #
 #--------------------------------------------------------------------------------------------------
 
-message("== Generating build files ==")
-
 set(CGAL_INCLUDE_DIRS ${CGAL_BINARY_DIR}/include)
 
 foreach(package ${CGAL_CONFIGURED_PACKAGES})
@@ -676,13 +660,11 @@ get_property(CGAL_Core_FOUND GLOBAL PROPERTY CGAL_Core_FOUND)
 get_property(CGAL_ImageIO_FOUND GLOBAL PROPERTY CGAL_ImageIO_FOUND)
 get_property(CGAL_Qt6_FOUND GLOBAL PROPERTY CGAL_Qt6_FOUND)
 
-#
-# Repeat some problems
-#
-message("== Generating build files (DONE) ==\n")
+if(CGAL_BRANCH_BUILD AND (CGAL_REPORT_DUPLICATE_FILES OR CGAL_DUPLICATE_HEADER_FILES))
 
-if(CGAL_BRANCH_BUILD AND CGAL_REPORT_DUPLICATE_FILES)
-
+  #
+  # Repeat some problems
+  #
   message(STATUS "Problems: ")
 
   if(CGAL_DUPLICATE_HEADER_FILES)
@@ -865,8 +847,6 @@ if(NOT RUNNING_CGAL_AUTO_TEST)
   endif()
   CGAL_add_subdirectories(benchmark benchmarks OFF)
 endif()
-
-message("== Setting paths ==")
 
 #--------------------------------------------------------------------------------------------------
 #


### PR DESCRIPTION
## Summary of Changes

- pass a few CMake message from `STATUS` to `VERBOSE`, so that they are no longer displayed by default
- remove a few lines of deprecated CMake code
- remove mentions of `CGAL/compiler_config.h` and workaround macros in the CGAL documentation

## Release Management

* Affected package(s): CGAL
* License and copyright ownership: no change

