### PR TITLE
Docs: Fix repeated 'the' typos in comments and documentation

### DIFF
--- a/Isosurfacing_3/examples/Isosurfacing_3/contouring_octree.cpp
+++ b/Isosurfacing_3/examples/Isosurfacing_3/contouring_octree.cpp
@@ -71,7 +71,7 @@ auto blobby_gradient = [](const Point& p) -> Vector
 // This refines:
 // - at the minimum till minimum depth
 // - at the maximum till maximum depth
-// - we split if the the isovalue goes through the voxel, i.e. if not all vertices of the cell
+// - we split if the isovalue goes through the voxel, i.e. if not all vertices of the cell
 //   are on the same side of the isosurface defined by a function
 // It's not a great refinement technique because the surface can enter and leave a cell
 // without involving the cell's vertex. In practice, that means a hole if at nearby adjacent

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -2554,7 +2554,7 @@ double bounded_error_Hausdorff_distance(const TriangleMesh1& tm1,
 /**
  * \ingroup PMP_distance_grp
  *
- * returns the the symmetric Hausdorff distance, that is
+ * returns the symmetric Hausdorff distance, that is
  * the maximum of `bounded_error_Hausdorff_distance(tm1, tm2, error_bound, np1, np2)`
  * and `bounded_error_Hausdorff_distance(tm2, tm1, error_bound, np2, np1)`.
  *

--- a/Shape_regularization/doc/Shape_regularization/Concepts/RegularizationType.h
+++ b/Shape_regularization/doc/Shape_regularization/Concepts/RegularizationType.h
@@ -7,7 +7,7 @@ namespace Shape_regularization {
 
 A concept that describes the set of methods used by the class
 `QP_regularization` to access various data
-required for setting up the the global regularization problem.
+required for setting up the global regularization problem.
 
 \cgalHasModelsBegin
 \cgalHasModels{Segments::Angle_regularization_2}

--- a/TDS_2/include/CGAL/Triangulation_data_structure_2.h
+++ b/TDS_2/include/CGAL/Triangulation_data_structure_2.h
@@ -2302,7 +2302,7 @@ set_adjacency(Face_handle fh,
               int ih,
               std::map< Vh_pair, Edge>& edge_map)
 {
-  // set adjacency to (fh,ih) using the the map edge_map
+  // set adjacency to (fh,ih) using the map edge_map
   // or insert (fh,ih) in edge map
   Vertex_handle vhcw  =  fh->vertex(cw(ih));
   Vertex_handle vhccw =  fh->vertex(ccw(ih));


### PR DESCRIPTION
Found and fixed multiple instances of the typo "the the" (repeated words) in documentation and code comments.

Files modified:
- TDS_2/include/CGAL/Triangulation_data_structure_2.h
- Shape_regularization/doc/Shape_regularization/Concepts/RegularizationType.h
- Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
- Isosurfacing_3/examples/Isosurfacing_3/contouring_octree.cpp