### PR TITLE
Examples: Fix typo 'treshold' -> 'threshold' in variable names

### DIFF
--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_linear_cell_complex.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_linear_cell_complex.cpp
@@ -41,14 +41,14 @@ int main(int argc, char** argv)
   // This is a stop predicate (defines when the algorithm terminates).
   // In this example, the simplification stops when the number of undirected edges
   // left in the surface mesh drops below the specified number (1000 by default)
-  const std::size_t edge_count_treshold = (argc > 2) ? std::stoi(argv[2]) : 1000;
-  SMS::Edge_count_stop_predicate<LCC> stop(edge_count_treshold);
+  const std::size_t edge_count_threshold = (argc > 2) ? std::stoi(argv[2]) : 1000;
+  SMS::Edge_count_stop_predicate<LCC> stop(edge_count_threshold);
 
   // This the actual call to the simplification algorithm.
   // The surface mesh and stop conditions are mandatory arguments.
   // The index maps are needed because the vertices and edges
   // of this surface mesh lack an "id()" field.
-  std::cout << "Collapsing edges of LCC: " << filename << ", aiming for " << edge_count_treshold << " final edges..." << std::endl;
+  std::cout << "Collapsing edges of LCC: " << filename << ", aiming for " << edge_count_threshold << " final edges..." << std::endl;
   int r = SMS::edge_collapse(lcc, stop,
                              CGAL::parameters::halfedge_index_map(get(CGAL::halfedge_index, lcc))
                                               .vertex_index_map(get(boost::vertex_index, lcc))

--- a/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
+++ b/Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
@@ -35,14 +35,14 @@ int main(int argc, char** argv)
   // This is a stop predicate (defines when the algorithm terminates).
   // In this example, the simplification stops when the number of undirected edges
   // left in the surface mesh drops below the specified number (1000)
-  const std::size_t edge_count_treshold = (argc > 2) ? std::stoi(argv[2]) : 1000;
-  SMS::Edge_count_stop_predicate<Surface_mesh> stop(edge_count_treshold);
+  const std::size_t edge_count_threshold = (argc > 2) ? std::stoi(argv[2]) : 1000;
+  SMS::Edge_count_stop_predicate<Surface_mesh> stop(edge_count_threshold);
 
   // This the actual call to the simplification algorithm.
   // The surface mesh and stop conditions are mandatory arguments.
   // The index maps are needed because the vertices and edges
   // of this surface mesh lack an "id()" field.
-  std::cout << "Collapsing edges of Polyhedron: " << filename << ", aiming for " << edge_count_treshold << " final edges..." << std::endl;
+  std::cout << "Collapsing edges of Polyhedron: " << filename << ", aiming for " << edge_count_threshold << " final edges..." << std::endl;
   int r = SMS::edge_collapse(surface_mesh, stop,
                              CGAL::parameters::vertex_index_map(get(CGAL::vertex_external_index, surface_mesh))
                                               .halfedge_index_map(get(CGAL::halfedge_external_index, surface_mesh)));


### PR DESCRIPTION
Fixed the typo "treshold" (missing 'h') in the variable `edge_count_treshold`.
Renamed it to `edge_count_threshold` for correctness.

Files modified:
- Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_polyhedron.cpp
- Surface_mesh_simplification/examples/Surface_mesh_simplification/edge_collapse_linear_cell_complex.cpp