### PR TITLE
Triangulation: Fix index_of_covertex doc

### DIFF
--- a/Triangulation/doc/Triangulation/CGAL/Triangulation.h
+++ b/Triangulation/doc/Triangulation/CGAL/Triangulation.h
@@ -357,7 +357,7 @@ Full_cell_handle full_cell(const Facet & f) const;
 
 /*!
 Returns the index of the vertex of the full cell
-`c=tr.full_cell(f)` which does not belong to `c`.
+`c=tr.full_cell(f)` which does not belong to `f`.
 */
 int index_of_covertex(const Facet & f) const;
 

--- a/Triangulation/doc/Triangulation/Concepts/TriangulationDataStructure.h
+++ b/Triangulation/doc/Triangulation/Concepts/TriangulationDataStructure.h
@@ -393,7 +393,7 @@ Full_cell_handle full_cell(const Facet & f) const;
 
 /*!
 Returns the index of vertex of the full cell `c=tds.full_cell(f)`
-which does not belong to `c`.
+which does not belong to `f`.
 */
 int index_of_covertex(const Facet & f) const;
 


### PR DESCRIPTION
It seems it should be the index of the cell vertex which does not belong to the facet, what do you think ?

