### PR TITLE
Misspelled function name

### DIFF
--- a/Polygon/doc/Polygon/Concepts/MultipolygonWithHoles_2.h
+++ b/Polygon/doc/Polygon/Concepts/MultipolygonWithHoles_2.h
@@ -52,7 +52,7 @@ MultipolygonWithHoles_2(InputIterator begin, InputIterator end);
 
 /*! returns the number of polygons with holes.
  */
-Size number_of_polygons_wih_holes();
+Size number_of_polygons_with_holes();
 
 /// @}
 


### PR DESCRIPTION
Misspelled function name everywhere else `with` is used (and is also suggested in the comment).
