### PR TITLE
Fix incorrect parameter documentation in envelope merge helper

### DIFF
--- a/Envelope_2/include/CGAL/Envelope_2/Env_divide_and_conquer_2.h
+++ b/Envelope_2/include/CGAL/Envelope_2/Env_divide_and_conquer_2.h
@@ -170,8 +170,8 @@ protected:
   /* Merge two minimization (or maximization) diagrams.
    * \param d1 The first diagram,
    *           representing the envelope of the curve set C1.
-   * \param d1 The first diagram,
-   *           representing the envelope of the curve set C1.
+   * \param d2 The second diagram,
+   *           representing the envelope of the curve set C2.
    * \param out_d Output: The merged diagram, representing the envelope of
    *                      the union of C1 and C2.
    */


### PR DESCRIPTION
## Summary of Changes

This pull request fixes a documentation typo in
`Envelope_divide_and_conquer_2.h`.

The parameter description for `_merge_envelopes` incorrectly duplicated the
documentation of `d1` for `d2`. The comment is updated so that `d2` is correctly
described as the second diagram representing the envelope of curve set `C2`.

No functional or behavioral changes are introduced.

## Release Management

- **Affected package(s):** Envelope_2
- **Issue(s) solved:** N/A
- **Feature / Small Feature:** Documentation fix
- **Link to compiled documentation:** N/A
- **License and copyright ownership:** No change
