### PR TITLE
Basic_viewer: Add dependencies between documentations

### DIFF
--- a/Basic_viewer/doc/Basic_viewer/dependencies
+++ b/Basic_viewer/doc/Basic_viewer/dependencies
@@ -4,7 +4,10 @@ Linear_cell_complex
 Nef_3
 Periodic_2_triangulation_2
 Point_set_3
+Point_set_processing_3
+Poisson_surface_reconstruction_3
 Polygon
+Polygon_mesh_processing
 Polyhedron
 Straight_skeleton_2
 Surface_mesh


### PR DESCRIPTION
## Summary of Changes

Add packages used in the examples to the dependencies so that we get links.

## Release Management

* Affected package(s): Basic_viewer
* License and copyright ownership:  unchanged

