### PR TITLE
Documentation Half-space -> Halfspace etc 

### DIFF
--- a/Apollonius_graph_2/doc/Apollonius_graph_2/Concepts/ApolloniusGraphTraits_2.h
+++ b/Apollonius_graph_2/doc/Apollonius_graph_2/Concepts/ApolloniusGraphTraits_2.h
@@ -179,9 +179,9 @@ Must provide `Oriented_side operator()(Site_2 s1,
 Site_2 s2, Point_2 p)`, which returns
 the oriented side of the bisector of `s1` and `s2` that
 contains `p`. Returns `ON_POSITIVE_SIDE` if `p` lies in
-the half-space of `s1` (i.e., `p` is closer to `s1` than
+the halfspace of `s1` (i.e., `p` is closer to `s1` than
 `s2`); returns `ON_NEGATIVE_SIDE` if `p` lies in the
-half-space of `s2`; returns `ON_ORIENTED_BOUNDARY` if `p`
+halfspace of `s2`; returns `ON_ORIENTED_BOUNDARY` if `p`
 lies on the bisector of `s1` and `s2`.
 */
 typedef unspecified_type Oriented_side_of_bisector_2;

--- a/Arrangement_on_surface_2/demo/Arrangement_on_surface_2_earth/Aos.cpp
+++ b/Arrangement_on_surface_2/demo/Arrangement_on_surface_2_earth/Aos.cpp
@@ -907,7 +907,7 @@ void Aos::save_arr(Kml::Placemarks& placemarks, const std::string& file_name) {
 
     js_faces.push_back(std::move(js_face));
   }
-  std::cout << "total num half-edges = " << total_num_half_edges << std::endl;
+  std::cout << "total num halfedges = " << total_num_half_edges << std::endl;
 
   // save the arrangement
   std::ofstream ofile(file_name);

--- a/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
+++ b/Arrangement_on_surface_2/doc/Arrangement_on_surface_2/Arrangement_on_surface_2.txt
@@ -2850,7 +2850,7 @@ right sides) are <em>identified</em> if
 \f$x \in X \f$. The curve \f$x \mapsto \phi_S(x,y_{\rm min})\f$ is
 called an <em>identification curve</em>.
 
-Rectangles, strips, quadrants, half-planes, and planes can be modeled
+Rectangles, strips, quadrants, halfplanes, and planes can be modeled
 with \f$\phi_S\f$ being the identity mapping. For example,
 \f$\Phi_S(x, y) = (x, y, 0)\f$ with \f$X = Y =(-\infty, +\infty)\f$
 parameterizes a plane. Surfaces such as paraboloids can be

--- a/Arrangement_on_surface_2/include/CGAL/Arr_conic_traits_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_conic_traits_2.h
@@ -3329,7 +3329,7 @@ public:
     //  cos(phi)*x + sin(phi)*y - (cos(phi)*x0 + sin(phi)*y0) = 0
     //
     // We store the equation of this line in the extra data structure and also
-    // the sign (side of half-plane) our arc occupies with respect to the line.
+    // the sign (side of halfplane) our arc occupies with respect to the line.
     // We use it to make sure that the two endpoints are located on the same
     // branch of the hyperbola.
     auto a = cos_phi;

--- a/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Conic_arc_2.h
+++ b/Arrangement_on_surface_2/include/CGAL/Arr_geometry_traits/Conic_arc_2.h
@@ -1173,7 +1173,7 @@ protected:
     //  cos(phi)*x + sin(phi)*y - (cos(phi)*x0 + sin(phi)*y0) = 0
     //
     // We store the equation of this line in the extra data structure and also
-    // the sign (side of half-plane) our arc occupies with respect to the line.
+    // the sign (side of halfplane) our arc occupies with respect to the line.
     m_extra_data = new Extra_data;
 
     m_extra_data->a = cos_phi;

--- a/Boolean_set_operations_2/include/CGAL/Boolean_set_operations_2/Gps_bfs_base_visitor.h
+++ b/Boolean_set_operations_2/include/CGAL/Boolean_set_operations_2/Gps_bfs_base_visitor.h
@@ -54,10 +54,10 @@ public:
   //! discovered_face
   /*! discovered_face is called by Gps_bfs_scanner when it reveals a new face
    * during a BFS scan. In the BFS traversal we are going from old_face to
-   * new_face through the half-edge he.
+   * new_face through the halfedge he.
    * \param old_face The face that was already revealed
    * \param new_face The face that we have just now revealed
-   * \param he The half-edge that is used to traverse between them.
+   * \param he The halfedge that is used to traverse between them.
    */
   void discovered_face(Face_iterator old_face,
                        Face_iterator new_face,

--- a/Boolean_set_operations_2/include/CGAL/Boolean_set_operations_2/Gps_bfs_xor_visitor.h
+++ b/Boolean_set_operations_2/include/CGAL/Boolean_set_operations_2/Gps_bfs_xor_visitor.h
@@ -51,7 +51,7 @@ public:
 
   //! after_scan postprocessing after bfs scan.
   /*! The function fixes some of the curves, to be in the same direction as the
-   * half-edges.
+   * halfedges.
    *
    * \param arr The given arrangement.
    */

--- a/Combinatorial_map/include/CGAL/Combinatorial_map.h
+++ b/Combinatorial_map/include/CGAL/Combinatorial_map.h
@@ -3711,7 +3711,7 @@ namespace CGAL {
     { this->automatic_attributes_management = newval; }
 
     /** Creates a halfedge.
-     * @return a dart of the new half-edge.
+     * @return a dart of the new halfedge.
      */
     Dart_descriptor make_half_edge()
     { return create_dart(); }

--- a/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/dual/halfspace_intersection_3.h
@@ -258,7 +258,7 @@ namespace CGAL
         CGAL_assertion_code(for(PlaneIterator pit=begin;pit!=end;++pit))
           CGAL_assertion(pit->has_on_negative_side(*origin));
 
-        // compute the intersection of the half-space using the dual formulation
+        // compute the intersection of the halfspace using the dual formulation
         Hull_traits_dual_3 dual_traits(*origin);
         Polyhedron_dual_3 dual_convex_hull;
         CGAL::convex_hull_3(begin, end, dual_convex_hull, dual_traits);

--- a/Envelope_3/doc/Envelope_3/CGAL/Env_plane_traits_3.h
+++ b/Envelope_3/doc/Envelope_3/CGAL/Env_plane_traits_3.h
@@ -22,14 +22,14 @@ namespace CGAL {
  * by `Arr_linear_traits_2<Kernel>`.
  *
  * Note that an entire plane has no boundaries, and the projection of a
- * half-plane is an (unbounded) line. Naturally, rays and segments may occur as
+ * halfplane is an (unbounded) line. Naturally, rays and segments may occur as
  * a result of overlaying projections of several half planes. Indeed,
  * `Env_plane_traits_3` inherits from the traits class that substitutes
  * `ArrLinearTraits`, and extends it by adding operations on planes and half
  * planes.  The nested `Xy_monotone_surface_3` and `Surface_3` types refer to
  * the same type. They are constructible from a `Kernel::Plane_3` in case of an
  * entire plane, or from `Kernel::Plane_3` and `Kernel::Line_2` in case of a
- * half-plane. The line orientation determines which half is considered.
+ * halfplane. The line orientation determines which half is considered.
  *
  * \cgalModels{EnvelopeTraits_3}
  */

--- a/Envelope_3/include/CGAL/Env_plane_traits_3.h
+++ b/Envelope_3/include/CGAL/Env_plane_traits_3.h
@@ -375,7 +375,7 @@ public:
         return o;
       }
 
-      // s is half-plane
+      // s is halfplane
       const Kernel& kernel = m_traits;
       const Point_2& p1 = kernel.construct_point_on_2_object()(s.line(), 0);
       const Point_2& p2 = kernel.construct_point_on_2_object()(s.line(), 1);

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -8192,7 +8192,7 @@ public:
 
   /*!
     returns true iff `p` lies on the negative side of `l`
-    (`l` is considered a half-space).
+    (`l` is considered a halfspace).
   */
   bool operator()(const Kernel::Line_2&l,
                   const Kernel::Point_2&p);
@@ -8227,7 +8227,7 @@ public:
 
   /*!
     returns true iff `p` lies on the negative side of `h`
-    (`h` is considered a half-space).
+    (`h` is considered a halfspace).
   */
   bool operator()(const Kernel::Plane_3&h,
                   const Kernel::Point_3&p);
@@ -8274,7 +8274,7 @@ public:
 
   /*!
     returns true iff `p` lies on the positive side of `l`
-    (`l` is considered a half-space).
+    (`l` is considered a halfspace).
   */
   bool operator()(const Kernel::Line_2&l,
                   const Kernel::Point_2&p);
@@ -8309,7 +8309,7 @@ public:
 
   /*!
     returns true iff `p` lies on the positive side of `h`
-    (`h` is considered a half-space).
+    (`h` is considered a halfspace).
   */
   bool operator()(const Kernel::Plane_3&h,
                   const Kernel::Point_3&p);

--- a/Kernel_23/doc/Kernel_23/Concepts/GeomObjects.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/GeomObjects.h
@@ -313,7 +313,7 @@ public:
   \ingroup PkgKernel23ConceptsGeomObject
   \cgalConcept
 
-  A type representing planes (and half-spaces) in three dimensions.
+  A type representing planes (and halfspaces) in three dimensions.
 
   \cgalRefines{CopyConstructible,Assignable,DefaultConstructible}
 

--- a/Kernel_23/doc/Kernel_23/Kernel_23.txt
+++ b/Kernel_23/doc/Kernel_23/Kernel_23.txt
@@ -388,7 +388,7 @@ three points, or a point and a line, ray, or segment.
 space \f$ \E^3\f$ and the embedding of \f$ \E^2\f$ in that space.
 Just like lines, planes are oriented and partition space into a positive side
 and a negative side.
-In \cgal, there are no special classes for half-spaces. Half-spaces in 2D and
+In \cgal, there are no special classes for halfspaces. Halfspaces in 2D and
 3D are supposed to be represented by oriented lines and planes, respectively.
 
 Concerning polygons and polyhedra, the kernel provides triangles,
@@ -405,7 +405,7 @@ separate the plane into two regions, one bounded and one unbounded.
 Geometric objects in \cgal have member functions that test the
 position of a point relative to the object. Full dimensional objects
 and their boundaries are represented by the same type,
-e.g. half-spaces and hyperplanes are not distinguished, neither are balls and
+e.g. halfspaces and hyperplanes are not distinguished, neither are balls and
 spheres and discs and circles. Such objects split the ambient space into two
 full-dimensional parts, a bounded part and an unbounded part
 (e.g. circles), or two unbounded parts (e.g. hyperplanes). By default these

--- a/Linear_cell_complex/benchmark/Linear_cell_complex_3/openvolumemesh_performance.h
+++ b/Linear_cell_complex/benchmark/Linear_cell_complex_3/openvolumemesh_performance.h
@@ -399,13 +399,13 @@ private:
       // Center vertex
       VertexHandle vhc = mesh.add_vertex(c);
 
-      // Get first half-face
+      // Get first halfface
       HalfFaceHandle curHF = *mesh.cell(*c_it).halffaces().begin();
 
       HalfFaceHandle ohf0, ohf1, ohf2, ohf3;
       ohf0 = curHF;
 
-      // Get first half-edge
+      // Get first halfedge
       HalfEdgeHandle curHE = *mesh.halfface(curHF).halfedges().begin();
 
       VertexHandle vh0 = mesh.halfedge(curHE).from_vertex();
@@ -546,13 +546,13 @@ private:
       // Center vertex
       VertexHandle vhc = mesh.add_vertex(c);
 
-      // Get first half-face
+      // Get first halfface
       HalfFaceHandle curHF = *mesh.cell(*c_it).halffaces().begin();
 
       HalfFaceHandle ohf0, ohf1, ohf2, ohf3;
       ohf0 = curHF;
 
-      // Get first half-edge
+      // Get first halfedge
       HalfEdgeHandle curHE = *mesh.halfface(curHF).halfedges().begin();
 
       VertexHandle vh0 = mesh.halfedge(curHE).from_vertex();

--- a/Mesh_2/include/CGAL/Mesh_2/Lipschitz_sizing_field_2.h
+++ b/Mesh_2/include/CGAL/Mesh_2/Lipschitz_sizing_field_2.h
@@ -221,7 +221,7 @@ protected:
           }
         poles.push_back(*maxp);
 
-        // find the farthest voronoi vertex from this point in the other half-plane
+        // find the farthest voronoi vertex from this point in the other halfplane
         typename std::list<Point>::iterator maxp2 = vv.begin();
         for (typename std::list<Point>::iterator pi = vv.begin(); pi != vv.end(); pi++)
           {

--- a/Nef_2/include/CGAL/Nef_polyhedron_2.h
+++ b/Nef_2/include/CGAL/Nef_polyhedron_2.h
@@ -112,7 +112,7 @@ public:
 /*{\Mdefinition
 An instance of data type |\Mname| is a subset of the plane that is
 the result of forming complements and intersections starting from a
-finite set |H| of half-spaces. |\Mtype| is closed under all binary set
+finite set |H| of halfspaces. |\Mtype| is closed under all binary set
 operations |intersection|, |union|, |difference|, |complement| and
 under the topological operations |boundary|, |closure|, and
 |interior|.
@@ -139,7 +139,7 @@ static  T EK; // static extended kernel
   typedef typename T::Segment_2 Extended_segment;
 
   typedef typename T::Standard_line_2 Line;
-  /*{\Mtypemember the oriented lines modeling half-planes}*/
+  /*{\Mtypemember the oriented lines modeling halfplanes}*/
   typedef typename T::Standard_point_2 Point;
   /*{\Mtypemember the affine points of the plane.}*/
   typedef typename T::Standard_direction_2 Direction;
@@ -351,7 +351,7 @@ public:
 
 
   Nef_polyhedron_2(const Line& l, Boundary line = INCLUDED) : Base(Nef_rep())
-  /*{\Mcreate creates a Nef polyhedron |\Mvar| containing the half-plane
+  /*{\Mcreate creates a Nef polyhedron |\Mvar| containing the halfplane
   left of |l| including |l| if |line==INCLUDED|, excluding |l| if
   |line==EXCLUDED|.}*/
   {   CGAL_NEF_TRACEN("Nconstruction from line "<<l);
@@ -853,7 +853,7 @@ public:
 
   /*{\Mtext \headerline{Exploration - Point location - Ray shooting}
   As Nef polyhedra are the result of forming complements
-  and intersections starting from a set |H| of half-spaces that are
+  and intersections starting from a set |H| of halfspaces that are
   defined by oriented lines in the plane, they can be represented by
   an attributed plane map $M = (V,E,F)$. For topological queries
   within |M| the following types and operations allow exploration

--- a/Nef_S2/doc/Nef_S2/CGAL/Nef_polyhedron_S2.h
+++ b/Nef_S2/doc/Nef_S2/CGAL/Nef_polyhedron_S2.h
@@ -38,7 +38,7 @@ template parameters.
 
 As Nef
 polyhedra are the result of forming complements and intersections
-starting from a set `H` of half-spaces that are defined by
+starting from a set `H` of halfspaces that are defined by
 oriented lines in the plane, they can be represented by an attributed
 plane map \f$ M = (V,E,F)\f$. For topological queries within `M` the
 following types and operations allow exploration access to this
@@ -46,7 +46,7 @@ structure.
 
 \cgalHeading{Input and Output}
 
-A Nef polyhedron `N` can be visualized in an open GL window. The
+A Nef polyhedron `N` can be visualized in an OpenGL window. The
 output operator is defined in the file
 `CGAL/IO/Nef_polyhedron_2_Window-stream.h`.
 

--- a/Nef_S2/include/CGAL/Nef_polyhedron_S2.h
+++ b/Nef_S2/include/CGAL/Nef_polyhedron_S2.h
@@ -87,7 +87,7 @@ public:
 
 /*{\Mdefinition An instance of data type |\Mname| is a subset of $S_2$
 that is the result of forming complements and intersections starting
-from a finite set |H| of half-spaces. |\Mtype| is closed under all
+from a finite set |H| of halfspaces. |\Mtype| is closed under all
 binary set operations |intersection|, |union|, |difference|,
 |complement| and under the topological operations |boundary|,
 |closure|, and |interior|.
@@ -122,7 +122,7 @@ public:
   /*{\Mtypemember segments in the sphere surface.}*/
 
   typedef typename Sphere_kernel::Sphere_circle  Sphere_circle;
-  /*{\Mtypemember oriented great circles modeling spherical half-spaces}*/
+  /*{\Mtypemember oriented great circles modeling spherical halfspaces}*/
 
   typedef typename Sphere_kernel::Sphere_direction Sphere_direction;
 
@@ -546,7 +546,7 @@ public:
 
   /*{\Mtext \headerline{Exploration - Point location - Ray shooting}
   As Nef polyhedra are the result of forming complements
-  and intersections starting from a set |H| of half-spaces that are
+  and intersections starting from a set |H| of halfspaces that are
   defined by oriented lines in the plane, they can be represented by
   an attributed plane map $M = (V,E,F)$. For topological queries
   within |M| the following types and operations allow exploration

--- a/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
+++ b/Optimal_transportation_reconstruction_2/include/CGAL/Optimal_transportation_reconstruction_2.h
@@ -258,8 +258,8 @@ public:
 
 
   /*!
-        The use_flip parameter determines whether the edge flipping procedure
-        is used for the half-edge collapse.
+        The `use_flip` parameter determines whether the edge flipping procedure
+        is used for the halfedge collapse.
    */
   void set_use_flip(const bool use_flip) {
     m_use_flip = use_flip;
@@ -340,7 +340,7 @@ public:
     m_ignore = 0;
   }
 
-  //Function if one wants to create a Optimal_transportation_reconstruction_2
+  //Function if one wants to create an Optimal_transportation_reconstruction_2
   //without yet specifying the input in the constructor.
   template <class InputIterator>
   void initialize(
@@ -1598,7 +1598,9 @@ public:
 
 
   /*!
-    Since noise and missing data may prevent the reconstructed shape to have sharp corners well located, the algorithm offers the possibility to automatically relocate points after each edge collapse. The new location of the points is chosen such that the fitting of the output segments to the input points is improved.
+    Since noise and missing data may prevent the reconstructed shape to have sharp corners well located,
+    the algorithm offers the possibility to automatically relocate points after each edge collapse.
+    The new location of the points is chosen such that the fitting of the output segments to the input points is improved.
    */
   void relocate_all_points() {
     CGAL::Real_timer timer;

--- a/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Voronoi_covariance_3/voronoi_covariance_3.h
+++ b/Point_set_processing_3/include/CGAL/Point_set_processing_3/internal/Voronoi_covariance_3/voronoi_covariance_3.h
@@ -144,7 +144,7 @@ namespace CGAL {
                     std::list<Vertex_handle> vertices;
                     dt.incident_vertices(v,std::back_inserter(vertices));
 
-                    // construct intersection of half-planes using the convex hull function
+                    // construct intersection of halfplanes using the convex hull function
                     std::list<Plane> planes;
                     for(typename std::list<Vertex_handle>::iterator it = vertices.begin();
                         it != vertices.end(); ++it)
@@ -155,7 +155,7 @@ namespace CGAL {
                         planes.push_back (Plane(CGAL::ORIGIN+p, p));
                     }
 
-                    // add half-planes defining the sphere discretization
+                    // add halfplanes defining the sphere discretization
                     sphere(std::back_inserter(planes));
 
                     Polyhedron P;

--- a/Ridges_3/doc/Ridges_3/Ridges_3.txt
+++ b/Ridges_3/doc/Ridges_3/Ridges_3.txt
@@ -370,7 +370,7 @@ The ridge lines are stored in
 `Ridge_line` objects and output through an iterator.
 Each ridge line is represented as a list of halfedges of the mesh it
 crosses with a scalar defining the barycentric coordinate of the
-crossing point with respect to the half-edge endpoints. Each ridge
+crossing point with respect to the halfedge endpoints. Each ridge
 line comes with its type `Ridge_type`, its strength and sharpness.
 
 If one chooses to use only third order quantities, the quantities
@@ -390,7 +390,7 @@ has a parameter to define the size of the neighborhood of the umbilic.
 Umbilics are stored in `Umbilic` objects, they come with their
 type : \ref ELLIPTIC_UMBILIC, \ref HYPERBOLIC_UMBILIC or
 \ref NON_GENERIC_UMBILIC; the vertex of the mesh they are associated
-to and the list of half-edges representing the contour of the
+to and the list of halfedges representing the contour of the
 neighborhood.
 
 

--- a/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphTraits_2.h
+++ b/Segment_Delaunay_graph_2/doc/Segment_Delaunay_graph_2/Concepts/SegmentDelaunayGraphTraits_2.h
@@ -192,9 +192,9 @@ A predicate object type.
 Must provide `Oriented_side operator()(Site_2 s1, Site_2 s2, Point_2 p)`, which returns
 the oriented side of the bisector of `s1` and `s2` that
 contains `p`. Returns `ON_POSITIVE_SIDE` if `p` lies in
-the half-space of `s1` (i.e., `p` is closer to `s1` than
+the halfspace of `s1` (i.e., `p` is closer to `s1` than
 `s2`); returns `ON_NEGATIVE_SIDE` if `p` lies in the
-half-space of `s2`; returns `ON_ORIENTED_BOUNDARY` if `p`
+halfspace of `s2`; returns `ON_ORIENTED_BOUNDARY` if `p`
 lies on the bisector of `s1` and `s2`.
 */
 typedef unspecified_type Oriented_side_of_bisector_2;

--- a/Spatial_sorting/doc/Spatial_sorting/Spatial_sorting.txt
+++ b/Spatial_sorting/doc/Spatial_sorting/Spatial_sorting.txt
@@ -98,9 +98,16 @@ The points to be sorted are supposed to be close to the sphere.
 
 Actually, we approximate a space filling curve on
 the unit sphere by a space filling curve on a cube (with facets at \f$x, y, z = \pm 1/\sqrt{3}\f$).
-Roughly speaking, we split the original set of points in six subsets corresponding to the six facets of the cube. The subset corresponding to a facet \f$f\f$ is the set of points that lie in the half-space defined by the supporting plane of \f$f\f$ that does not contain the origin. And then we basically use the 2D Hilbert sort with its corresponding policy, as explained above for the projection of the points in each subset on its corresponding facet of the cube. The axes orientation on each facet is chosen so that the space filling curve covers the whole cube without any jump; see \cgalFigureRef{Spatial_sorting_fig_Faces_orientations}.
-A point can lie in more than one such half-plane, so, we give a priority for each facet of the cube. The priority order is:
-first, the facet of the cube at \f$x = 1/\sqrt{3}\f$; second, the facet of the cube at \f$y = 1/\sqrt{3}\f$; third, the facet of the cube at \f$ x = -1/\sqrt{3}\f$; fourth, the facet of the cube at \f$ z = 1/\sqrt{3}\f$; fifth, the facet of the cube at \f$ y = -1/\sqrt{3}\f$; and, sixth, the facet of the cube at \f$ z = -1/\sqrt{3}\f$.
+Roughly speaking, we split the original set of points in six subsets corresponding to the six facets of the cube.
+The subset corresponding to a facet \f$f\f$ is the set of points that lie in the halfspace defined by the supporting plane
+of \f$f\f$ that does not contain the origin. And then we basically use the 2D Hilbert sort with its corresponding policy,
+as explained above for the projection of the points in each subset on its corresponding facet of the cube.
+The axes orientation on each facet is chosen so that the space filling curve covers the whole cube without any jump;
+see \cgalFigureRef{Spatial_sorting_fig_Faces_orientations}.
+A point can lie in more than one such halfplane, so, we give a priority for each facet of the cube. The priority order is:
+first, the facet of the cube at \f$x = 1/\sqrt{3}\f$; second, the facet of the cube at \f$y = 1/\sqrt{3}\f$; third,
+the facet of the cube at \f$ x = -1/\sqrt{3}\f$; fourth, the facet of the cube at \f$ z = 1/\sqrt{3}\f$; fifth,
+the facet of the cube at \f$ y = -1/\sqrt{3}\f$; and, sixth, the facet of the cube at \f$ z = -1/\sqrt{3}\f$.
 
 If points are not close to the sphere, they are still sorted the same way, however there is no guarantee that such an order is good anymore.
 

--- a/Triangulation/doc/Triangulation/CGAL/Triangulation.h
+++ b/Triangulation/doc/Triangulation/CGAL/Triangulation.h
@@ -611,7 +611,7 @@ c);
 
 /*!
 Inserts point `p` in the triangulation.
-\pre `p` must lie outside the convex hull of `tr`. The half-space
+\pre `p` must lie outside the convex hull of `tr`. The halfspace
 defined by the infinite full cell `c` must contain `p`.
 */
 Vertex_handle insert_outside_convex_hull(const Point &,

--- a/Triangulation/doc/Triangulation/Triangulation.txt
+++ b/Triangulation/doc/Triangulation/Triangulation.txt
@@ -401,7 +401,7 @@ unique triangulation even in these cases.
 When a new point `p` is inserted into a Delaunay triangulation, the
 full cells whose circumscribing ball contains `p` are said to
 <I>be in conflict</I> with point `p`. Note that the circumscribing ball
-of an infinite full cell is the empty half-space bounded by the affine hull
+of an infinite full cell is the empty halfspace bounded by the affine hull
 of the finite facet of this cell. The set of full cells that are in
 conflict with `p` form the <I>conflict zone</I>. The full cells
 in the conflict zone are removed, leaving a hole that contains `p`. That

--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -1533,7 +1533,7 @@ side_of_circle(Cell_handle c, int i, const Point& p, bool perturb) const
   // in dimension 2, for an infinite facet
   // in this case, returns ON_BOUNDARY if the point lies on the
   // finite edge (endpoints included)
-  // ON_BOUNDED_SIDE for a point in the open half-plane
+  // ON_BOUNDED_SIDE for a point in the open halfplane
   // ON_UNBOUNDED_SIDE elsewhere
 
   CGAL_precondition(dimension() >= 2);


### PR DESCRIPTION
## Summary of Changes

Cleanup of the documentation.     We had half-space, half-plane, half-edge.     
I did not change half-circle and half-sphere though. Shall I @MaelRL ?

## Release Management

* Affected package(s): several
* License and copyright ownership:  unchanged

