### PR TITLE
Polytope Distance:  cleanup

### DIFF
--- a/Bounding_volumes/package_info/Bounding_volumes/dependencies
+++ b/Bounding_volumes/package_info/Bounding_volumes/dependencies
@@ -9,7 +9,6 @@ Intersections_2
 Intersections_3
 Interval_support
 Kernel_23
-Kernel_d
 Matrix_search
 Modular_arithmetic
 Number_types

--- a/Optimisation_basic/include/CGAL/Optimisation/Access_coordinates_begin_2.h
+++ b/Optimisation_basic/include/CGAL/Optimisation/Access_coordinates_begin_2.h
@@ -22,16 +22,6 @@
 
 namespace CGAL {
 
-// Class declarations
-// ==================
-template < class R_ >
-class Access_coordinates_begin_2;
-
-template < class R_ >
-class Point_2_coordinate_iterator;
-
-// Class interfaces
-// ================
 template < class R_ >
 class Point_2_coordinate_iterator {
   public:

--- a/Optimisation_basic/include/CGAL/Optimisation/Access_coordinates_begin_3.h
+++ b/Optimisation_basic/include/CGAL/Optimisation/Access_coordinates_begin_3.h
@@ -22,16 +22,6 @@
 
 namespace CGAL {
 
-// Class declarations
-// ==================
-template < class R_ >
-class Access_coordinates_begin_3;
-
-template < class R_ >
-class Point_3_coordinate_iterator;
-
-// Class interfaces
-// ================
 template < class R_ >
 class Point_3_coordinate_iterator {
   public:

--- a/Optimisation_basic/include/CGAL/Optimisation/Access_coordinates_begin_d.h
+++ b/Optimisation_basic/include/CGAL/Optimisation/Access_coordinates_begin_d.h
@@ -23,13 +23,6 @@ namespace CGAL {
 class Cartesian_tag;
 class Homogeneous_tag;
 
-// Class declaration
-// =================
-template < class R_ >
-class Access_coordinates_begin_d;
-
-// Class interface
-// ===============
 template < class R_ >
 class Access_coordinates_begin_d {
   public:

--- a/Optimisation_basic/include/CGAL/Optimisation/Access_dimension_2.h
+++ b/Optimisation_basic/include/CGAL/Optimisation/Access_dimension_2.h
@@ -21,13 +21,6 @@
 
 namespace CGAL {
 
-// Class declaration
-// =================
-template < class R_ >
-class Access_dimension_2;
-
-// Class interface
-// ===============
 template < class R_ >
 class Access_dimension_2 {
   public:
@@ -46,7 +39,7 @@ class Access_dimension_2 {
     Access_dimension_2( ) { }
 
     // operations
-    int  operator() ( const Point& p) const { return p.dimension(); }
+    int  operator() ( const Point& p) const { return 2; }
 };
 
 } //namespace CGAL

--- a/Optimisation_basic/include/CGAL/Optimisation/Access_dimension_2.h
+++ b/Optimisation_basic/include/CGAL/Optimisation/Access_dimension_2.h
@@ -39,7 +39,7 @@ class Access_dimension_2 {
     Access_dimension_2( ) { }
 
     // operations
-    int  operator() ( const Point& p) const { return 2; }
+    int  operator() ( const Point& ) const { return 2; }
 };
 
 } //namespace CGAL

--- a/Optimisation_basic/include/CGAL/Optimisation/Access_dimension_3.h
+++ b/Optimisation_basic/include/CGAL/Optimisation/Access_dimension_3.h
@@ -19,13 +19,6 @@
 
 namespace CGAL {
 
-// Class declaration
-// =================
-template < class R_ >
-class Access_dimension_3;
-
-// Class interface
-// ===============
 template < class R_ >
 class Access_dimension_3 {
   public:
@@ -44,7 +37,7 @@ class Access_dimension_3 {
     Access_dimension_3( ) { }
 
     // operations
-    int  operator() ( const Point& p) const { return p.dimension(); }
+    int  operator() ( const Point& p) const { return 3; }
 };
 
 } //namespace CGAL

--- a/Optimisation_basic/include/CGAL/Optimisation/Access_dimension_3.h
+++ b/Optimisation_basic/include/CGAL/Optimisation/Access_dimension_3.h
@@ -37,7 +37,7 @@ class Access_dimension_3 {
     Access_dimension_3( ) { }
 
     // operations
-    int  operator() ( const Point& p) const { return 3; }
+    int  operator() ( const Point& ) const { return 3; }
 };
 
 } //namespace CGAL

--- a/Optimisation_basic/include/CGAL/Optimisation/Access_dimension_d.h
+++ b/Optimisation_basic/include/CGAL/Optimisation/Access_dimension_d.h
@@ -19,13 +19,6 @@
 
 namespace CGAL {
 
-// Class declaration
-// =================
-template < class R_ >
-class Access_dimension_d;
-
-// Class interface
-// ===============
 template < class R_ >
 class Access_dimension_d {
   public:

--- a/Optimisation_basic/include/CGAL/Optimisation/Construct_point_2.h
+++ b/Optimisation_basic/include/CGAL/Optimisation/Construct_point_2.h
@@ -17,20 +17,8 @@
 #ifndef CGAL_OPTIMISATION_CONSTRUCT_POINT_2_H
 #define CGAL_OPTIMISATION_CONSTRUCT_POINT_2_H
 
-#include <CGAL/Point_2.h>
-#include <vector>
-#include <functional>
-#include <iterator>
-
 namespace CGAL {
 
-// Class declaration
-// =================
-template < class K >
-class _Construct_point_2;
-
-// Class interface
-// ===============
 template < class K_ >
 class _Construct_point_2 {
   public:

--- a/Optimisation_basic/include/CGAL/Optimisation/Construct_point_3.h
+++ b/Optimisation_basic/include/CGAL/Optimisation/Construct_point_3.h
@@ -17,20 +17,8 @@
 #ifndef CGAL_OPTIMISATION_CONSTRUCT_POINT_3_H
 #define CGAL_OPTIMISATION_CONSTRUCT_POINT_3_H
 
-#include <CGAL/Point_3.h>
-#include <vector>
-#include <functional>
-#include <iterator>
-
 namespace CGAL {
 
-// Class declaration
-// =================
-template < class K >
-class _Construct_point_3;
-
-// Class interface
-// ===============
 template < class K_ >
 class _Construct_point_3 {
   public:

--- a/Optimisation_basic/include/CGAL/Optimisation/Construct_point_d.h
+++ b/Optimisation_basic/include/CGAL/Optimisation/Construct_point_d.h
@@ -17,10 +17,6 @@
 #ifndef CGAL_OPTIMISATION_CONSTRUCT_POINT_D_H
 #define CGAL_OPTIMISATION_CONSTRUCT_POINT_D_H
 
-// includes
-#  include <CGAL/Kernel_d/Interface_classes.h>
-#  include <CGAL/Kernel_d/Point_d.h>
-
 namespace CGAL {
 
 // Class declaration

--- a/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d.h
@@ -83,7 +83,7 @@ typedef unspecified_type ET;
 
 /*!
 
-non-mutable model of the \stl concept <I>RandomAccessIterator</I>
+non-mutable model of the \stl concept `RandomAccessIterator`
 with value type `Point`. Used to access the points
 of the two polytopes.
 */
@@ -91,14 +91,14 @@ typedef unspecified_type Point_iterator;
 
 /*!
 
-non-mutable model of the \stl concept <I>RandomAccessIterator</I>
+non-mutable model of the \stl concept `RandomAccessIterator`
 with value type `Point`. Used to access the support points.
 */
 typedef unspecified_type Support_point_iterator;
 
 /*!
 
-non-mutable model of the \stl concept <I>RandomAccessIterator</I>
+non-mutable model of the \stl concept `RandomAccessIterator`
 with value type `int`. Used to access the indices of the
 support points in the provided input order (starting from 0
 in both point sets).
@@ -107,7 +107,7 @@ typedef unspecified_type Support_point_index_iterator;
 
 /*!
 
-non-mutable model of the \stl concept <I>RandomAccessIterator</I>
+non-mutable model of the \stl concept `RandomAccessIterator`
 with value type `ET`. Used to access the coordinates of
 the realizing points.
 */

--- a/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_2.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_2.h
@@ -28,9 +28,9 @@ public:
 /// @{
 
 /*!
-typedef to `K::Point_2`.
+the point type.
 */
-typedef unspecified_type Point_d;
+typedef K::Point_2 Point_d;
 
 /*!
 typedef to `K::Rep_tag`.
@@ -38,27 +38,27 @@ typedef to `K::Rep_tag`.
 typedef unspecified_type Rep_tag;
 
 /*!
-typedef to `K::RT`.
+the ring type`.
 */
-typedef unspecified_type RT;
+typedef K::RT RT;
 
 /*!
-typedef to `K::FT`.
+the field type.
 */
-typedef unspecified_type FT;
+typedef K::FT FT;
 
 /*!
-typedef to `K::Access_dimension_2`.
+functor returning `2`.
 */
 typedef unspecified_type Access_dimension_d;
 
 /*!
-typedef to `K::Access_coordinates_begin_2`.
+functor constructing the begin iterator of the homogeneous coordinates of a point.
 */
 typedef unspecified_type Access_coordinates_begin_d;
 
 /*!
-typedef to `K::Construct_point_2`.
+functor constructing a point from a coordinate range.
 */
 typedef unspecified_type Construct_point_d;
 

--- a/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_2.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_2.h
@@ -39,7 +39,7 @@ typedef to `K::Rep_tag`.
 typedef unspecified_type Rep_tag;
 
 /*!
-the ring type`.
+the ring type.
 */
 typedef K::RT RT;
 

--- a/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_2.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_2.h
@@ -10,7 +10,8 @@ optimization algorithms using the two-dimensional \cgal kernel.
 
 \tparam K must be a model for `Kernel`.
 
-\tparam ET NT must be models for `RingNumberType`. Their default is  `K::RT`.
+\tparam ET must be models for `RingNumberType`. The default is  `K::RT`.
+\tparam NT must be models for `RingNumberType`. The default is  `K::RT`.
 
 \cgalModels{PolytopeDistanceDTraits}
 

--- a/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_3.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_3.h
@@ -10,7 +10,9 @@ optimization algorithms using the three-dimensional \cgal kernel.
 
 \tparam K must be a model for `Kernel`.
 
-\tparam ET NT must be models for `RingNumberType`. Their default is  `K::RT`.
+\tparam ET must be models for `RingNumberType`. The default is  `K::RT`.
+
+\tparam NT must be models for `RingNumberType`. The default is  `K::RT`.
 
 
 \cgalModels{PolytopeDistanceDTraits}

--- a/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_3.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_3.h
@@ -29,9 +29,9 @@ public:
 /// @{
 
 /*!
-typedef to `K::Point_3`.
+the point type.
 */
-typedef unspecified_type Point_d;
+typedef K::Point_3 Point_d;
 
 /*!
 typedef to `K::Rep_tag`.
@@ -39,27 +39,27 @@ typedef to `K::Rep_tag`.
 typedef unspecified_type Rep_tag;
 
 /*!
-typedef to `K::RT`.
+the ring number type.
 */
-typedef unspecified_type RT;
+typedef K::RT RT;
 
 /*!
-typedef to `K::FT`.
+the field number type.
 */
-typedef unspecified_type FT;
+typedef K::FT FT;
 
 /*!
-typedef to `K::Access_dimension_3`.
+functor returning `3`.
 */
 typedef unspecified_type Access_dimension_d;
 
 /*!
-typedef to `K::Access_coordinates_begin_3`.
+functor constructing the begin iterator of the homogeneous coordinates of a point.
 */
 typedef unspecified_type Access_coordinates_begin_d;
 
 /*!
-typedef to `K::Construct_point_3`.
+functor constructing a point from a coordinate range.
 */
 typedef unspecified_type Construct_point_d;
 

--- a/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_d.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_d.h
@@ -29,9 +29,9 @@ public:
 /// @{
 
 /*!
-typedef to `K::Point_d`.
+the point type.
 */
-typedef unspecified_type Point_d;
+typedef K::Point_d Point_d;
 
 /*!
 typedef to `K::Rep_tag`.
@@ -39,27 +39,27 @@ typedef to `K::Rep_tag`.
 typedef unspecified_type Rep_tag;
 
 /*!
-typedef to `K::RT`.
+the ring type.
 */
-typedef unspecified_type RT;
+typedef K::RT RT;
 
 /*!
-typedef to `K::FT`.
+the field type.
 */
-typedef unspecified_type FT;
+typedef K::FT FT;
 
 /*!
-typedef to `K::Access_dimension_d`.
+functor returning the dimension of a point.
 */
 typedef unspecified_type Access_dimension_d;
 
 /*!
-typedef to `K::Access_coordinates_begin_d`.
+functor constructing the begin iterator of the homogeneous coordinates of a point.
 */
 typedef unspecified_type Access_coordinates_begin_d;
 
 /*!
-typedef to `K::Construct_point_d`.
+functor constructing a point from a coordinate range.
 */
 typedef unspecified_type Construct_point_d;
 

--- a/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_d.h
+++ b/Polytope_distance_d/doc/Polytope_distance_d/CGAL/Polytope_distance_d_traits_d.h
@@ -10,7 +10,10 @@ optimization algorithms using the \f$ d\f$-dimensional \cgal kernel.
 
 \tparam K must be a model for `Kernel`.
 
-\tparam ET NT must be models for `RingNumberType`. Their default is  `K::RT`.
+\tparam ET must be models for `RingNumberType`. The default is  `K::RT`.
+
+\tparam NT must be models for `RingNumberType`. The default is  `K::RT`.
+
 
 
 \cgalModels{PolytopeDistanceDTraits}

--- a/Polytope_distance_d/package_info/Polytope_distance_d/dependencies
+++ b/Polytope_distance_d/package_info/Polytope_distance_d/dependencies
@@ -17,7 +17,6 @@ Intersections_2
 Intersections_3
 Interval_support
 Kernel_23
-Kernel_d
 Matrix_search
 Modifier
 Modular_arithmetic


### PR DESCRIPTION
## Summary of Changes

- No need for `unspecified_type`  if in the description we write what it is. 
- Fix some wrong descriptions.
- Remove some `#include` statements

## Release Management

* Affected package(s): Polytop_distance
* License and copyright ownership:  unchanged

