### PR TITLE
Nef_S2: Add missing #include

### DIFF
--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_circle.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_circle.h
@@ -17,6 +17,7 @@
 
 
 #include <CGAL/basic.h>
+#include <CGAL/Nef_2/debug.h>
 #include <CGAL/Nef_S2/Sphere_point.h>
 
 namespace CGAL {

--- a/Nef_S2/include/CGAL/Nef_S2/Sphere_point.h
+++ b/Nef_S2/include/CGAL/Nef_S2/Sphere_point.h
@@ -15,7 +15,6 @@
 
 #include <CGAL/license/Nef_S2.h>
 
-
 #include <CGAL/basic.h>
 #include <CGAL/Origin.h>
 


### PR DESCRIPTION
## Summary of Changes

Add the `#include`  which contains a debug macro.    

## Release Management

* Affected package(s):  Nef_S2
* Issue(s) solved (if any): fix #9307.
* License and copyright ownership:  unchanged

