### PR TITLE
doc: restore consistent styling for Doxygen 1.16.1

### DIFF
--- a/Documentation/doc/CMakeLists.txt
+++ b/Documentation/doc/CMakeLists.txt
@@ -285,7 +285,7 @@ list(GET DOXYGEN_VERSION 0 DOXYGEN_VERSION)
 message(VERBOSE "Doxygen version ${DOXYGEN_VERSION}: ${DOXYGEN_EXECUTABLE}")
 
 # The Doxygen version is search in that sorted list (to find the index for which the version is less or equal)
-set(CGAL_DOXYGEN_RESOURCES_VERSIONS 1.8.13 1.9.6 1.14.0)
+set(CGAL_DOXYGEN_RESOURCES_VERSIONS 1.8.13 1.9.6 1.14.0 1.16.1)
 list(SORT CGAL_DOXYGEN_RESOURCES_VERSIONS COMPARE NATURAL)
 
 # The GLOB is here to check that the list in CGAL_DOXYGEN_RESOURCES_VERSIONS is correct.

--- a/Documentation/doc/resources/1.16.1/BaseDoxyfile.in
+++ b/Documentation/doc/resources/1.16.1/BaseDoxyfile.in
@@ -1,0 +1,838 @@
+# Doxyfile 1.16.1
+
+# This file describes the settings to be used by the documentation system
+# Doxygen (www.doxygen.org) for a project.
+#
+# Only the settings that are not the default ones are kept in this file
+
+#---------------------------------------------------------------------------
+# Project related configuration options
+#---------------------------------------------------------------------------
+
+# The PROJECT_NAME tag is a single word (or a sequence of words surrounded by
+# double-quotes, unless you are using Doxywizard) that should identify the
+# project for which the documentation is generated. This name is used in the
+# title of most generated pages and in a few other places.
+# The default value is: My Project.
+
+PROJECT_NAME           =
+
+# This tag implements a quasi-intelligent brief description abbreviator that is
+# used to form the text in various listings. Each string in this list, if found
+# as the leading text of the brief description, will be stripped from the text
+# and the result, after processing the whole list, is used as the annotated
+# text. Otherwise, the brief description is used as-is. If left blank, the
+# following values are used ($name is automatically replaced with the name of
+# the entity):The $name class, The $name widget, The $name file, is, provides,
+# specifies, contains, represents, a, an and the.
+
+ABBREVIATE_BRIEF       =
+
+# If the JAVADOC_AUTOBRIEF tag is set to YES then doxygen will interpret the
+# first line (until the first dot) of a Javadoc-style comment as the brief
+# description. If set to NO, the Javadoc-style will behave just like regular Qt-
+# style comments (thus requiring an explicit @brief command for a brief
+# description.)
+# The default value is: NO.
+
+JAVADOC_AUTOBRIEF      = YES
+
+# If the QT_AUTOBRIEF tag is set to YES then doxygen will interpret the first
+# line (until the first dot) of a Qt-style comment as the brief description. If
+# set to NO, the Qt-style will behave just like regular Qt-style comments (thus
+# requiring an explicit \brief command for a brief description.)
+# The default value is: NO.
+
+QT_AUTOBRIEF           = YES
+
+# If the INHERIT_DOCS tag is set to YES then an undocumented member inherits the
+# documentation from any documented member that it re-implements.
+# The default value is: YES.
+
+INHERIT_DOCS           = NO
+
+# This tag can be used to specify a number of aliases that act as commands in
+# the documentation. An alias has the form:
+# name=value
+# For example adding
+# "sideeffect=@par Side Effects:^^"
+# will allow you to put the command \sideeffect (or @sideeffect) in the
+# documentation, which will result in a user-defined paragraph with heading
+# "Side Effects:". Note that you cannot put \n's in the value part of an alias
+# to insert newlines (in the resulting output). You can put ^^ in the value part
+# of an alias to insert a newline as if a physical newline was in the original
+# file. When you need a literal { or } or , in the value part of an alias you
+# have to escape them by means of a backslash (\), this can lead to conflicts
+# with the commands \{ and \} for these it is advised to use the version @{ and
+# @} or use a double escape (\\{ and \\})
+
+ALIASES                = "cgal=%CGAL" \
+                         "protocgal=C++gal" \
+                         "plageo=Plageo" \
+                         "stl=STL" \
+                         "gmp=GMP" \
+                         "gmpxx=GMPXX" \
+                         "iso=ISO" \
+                         "lisp=Lisp" \
+                         "ieee=IEEE" \
+                         "ascii=ASCII" \
+                         "exacus=Exacus" \
+                         "mpir=MPIR" \
+                         "mpfr=MPFR" \
+                         "leda=LEDA" \
+                         "gcc=GCC" \
+                         "dcel=DCEL" \
+                         "bgl=BGL" \
+                         "boost=Boost" \
+                         "gnu=GNU" \
+                         "ms=MS" \
+                         "qt=Qt" \
+                         "qt6=Qt6" \
+                         "eigen=Eigen" \
+                         "opengr=OpenGR" \
+                         "libpointmatcher=libpointmatcher" \
+                         "core=Core" \
+                         "mpfi=MPFI" \
+                         "ntl=NTL" \
+                         "pdb=PDB" \
+                         "esbtl=ESBTL" \
+                         "tbb=TBB" \
+                         "laslib=LASlib" \
+                         "opencv=OpenCV" \
+                         "tensorflow=TensorFlow" \
+                         "metis=METIS" \
+                         "suitesparse=SuiteSparse" \
+                         "zlib=zlib" \
+                         "ceres=Ceres" \
+                         "glpk=GLPK" \
+                         "scip=SCIP" \
+                         "osqp=OSQP" \
+                         "rs=RS" \
+                         "rs3=RS3" \
+                         "unix=Unix" \
+                         "api=API" \
+                         "vtk=VTK" \
+                         "visualstudio=Visual Studio" \
+                         "taucs=TAUCS" \
+                         "lapack=LAPACK" \
+                         "blas=BLAS" \
+                         "cpp=C++" \
+                         "cpp11=C++11" \
+                         "CC=C++" \
+                         "cgalExample{1}=<br><b>File</b> \ref \1 \include \1" \
+                         "cgalFigureAnchor{1}=\anchor fig__\1" \
+                         "cgalFigureRef{1}=\ref fig__\1" \
+                         "cgalFigureBegin{2}=\anchor fig__\1 ^^ \image html \2 ^^ \image latex \2 \"\" width=15cm ^^ \htmlonly[block] <div class=\"cgal_figure_caption\"> \endhtmlonly ^^ \ref fig__\1" \
+                         "cgalFigureBegin{3}=\anchor fig__\1 ^^  <CENTER> <TABLE border=0> <TR> <TD> \image html \2 ^^ \image latex \2 \"\" width=7.5cm ^^ </TD> <TD> \image html \3 ^^ \image latex \3 \"\" width=7.5cm ^^ </TD> </TR> </TABLE> </CENTER> \htmlonly[block] <div class=\"cgal_figure_caption\"> \endhtmlonly ^^ \ref fig__\1" \
+                         "cgalFigureBegin{4}=\anchor fig__\1 ^^  <CENTER> <TABLE border=0> <TR> <TD> \image html \2 ^^ \image latex \2 \"\" width=5cm ^^ </TD> <TD> \image html \3 ^^ \image latex \3 \"\" width=5cm ^^ </TD> <TD> \image html \4 ^^ \image latex \4 \"\" width=5cm ^^ </TD> </TR> </TABLE> </CENTER> \htmlonly[block] <div class=\"cgal_figure_caption\"> \endhtmlonly ^^ \ref fig__\1" \
+                         "cgalFigureBegin{5}=\anchor fig__\1 ^^  <CENTER> <TABLE border=0> <TR> <TD> \image html \2 ^^ \image latex \2 \"\" width=3.75cm ^^ </TD> <TD> \image html \3 ^^ \image latex \3 \"\" width=3.75cm ^^ </TD> <TD> \image html \4 ^^ \image latex \4 \"\" width=3.75cm ^^ </TD> <TD> \image html \5 ^^ \image latex \5 \"\" width=3.75cm ^^ </TD> </TR> </TABLE> </CENTER> \htmlonly[block] <div class=\"cgal_figure_caption\"> \endhtmlonly ^^ \ref fig__\1" \
+                         "cgalFigureBegin{6}=\anchor fig__\1 ^^  <CENTER> <TABLE border=0> <TR> <TD> \image html \2 ^^ \image latex \2 \"\" width=3cm ^^ </TD> <TD> \image html \3 ^^ \image latex \3 \"\" width=3cm ^^ </TD> <TD> \image html \4 ^^ \image latex \4 \"\" width=3cm ^^ </TD> <TD> \image html \5 ^^ \image latex \5 \"\" width=3cm ^^ </TD> <TD> \image html \6 ^^ \image latex \6 \"\" width=3cm ^^ </TD> </TR> </TABLE> </CENTER> \htmlonly[block] <div class=\"cgal_figure_caption\"> \endhtmlonly ^^ \ref fig__\1" \
+                         "cgalFigureBegin{7}=\anchor fig__\1 ^^  <CENTER> <TABLE border=0> <TR> <TD> \image html \2 ^^ \image latex \2 \"\" width=2.5cm ^^ </TD> <TD> \image html \3 ^^ \image latex \3 \"\" width=2.5cm ^^ </TD> <TD> \image html \4 ^^ \image latex \4 \"\" width=2.5cm ^^ </TD> <TD> \image html \5 ^^ \image latex \5 \"\" width=2.5cm ^^ </TD> <TD> \image html \6 ^^ \image latex \6 \"\" width=2.5cm ^^ </TD> <TD> \image html \7 ^^ \image latex \7 \"\" width=2.5cm ^^ </TD> </TR> </TABLE> </CENTER> \htmlonly[block] <div class=\"cgal_figure_caption\"> \endhtmlonly ^^ \ref fig__\1" \
+                         "cgalFigureBegin{8}=\anchor fig__\1 ^^  <CENTER> <TABLE border=0> <TR> <TD> \image html \2 ^^ \image latex \2 \"\" width=2.1cm ^^ </TD> <TD> \image html \3 ^^ \image latex \3 \"\" width=2.1cm ^^ </TD> <TD> \image html \4 ^^ \image latex \4 \"\" width=2.1cm ^^ </TD> <TD> \image html \5 ^^ \image latex \5 \"\" width=2.1cm ^^ </TD> <TD> \image html \6 ^^ \image latex \6 \"\" width=2.1cm ^^ </TD> <TD> \image html \7 ^^ \image latex \7 \"\" width=2.1cm ^^ </TD> <TD> \image html \8 ^^ \image latex \8 \"\" width=2.1cm ^^ </TD> </TR> </TABLE> </CENTER> \htmlonly[block] <div class=\"cgal_figure_caption\"> \endhtmlonly ^^ \ref fig__\1" \
+                         "cgalFigureBegin{9}=\anchor fig__\1 ^^  <CENTER> <TABLE border=0> <TR> <TD> \image html \2 ^^ \image latex \2 \"\" width=1.9cm ^^ </TD> <TD> \image html \3 ^^ \image latex \3 \"\" width=1.9cm ^^ </TD> <TD> \image html \4 ^^ \image latex \4 \"\" width=1.9cm ^^ </TD> <TD> \image html \5 ^^ \image latex \5 \"\" width=1.9cm ^^ </TD> <TD> \image html \6 ^^ \image latex \6 \"\" width=1.9cm ^^ </TD> <TD> \image html \7 ^^ \image latex \7 \"\" width=1.9cm ^^ </TD> <TD> \image html \8 ^^ \image latex \8 \"\" width=1.9cm ^^ </TD> <TD> \image html \9 ^^ \image latex \9 \"\" width=1.9cm ^^ </TD> </TR> </TABLE> </CENTER> \htmlonly[block] <div class=\"cgal_figure_caption\"> \endhtmlonly ^^ \ref fig__\1" \
+                         "cgalFigureBegin{10}=\anchor fig__\1 ^^ <CENTER> <TABLE border=0> <TR> <TD> \image html \2 ^^ \image latex \2 \"\" width=1.6cm ^^ </TD> <TD> \image html \3 ^^ \image latex \3 \"\" width=1.6cm ^^ </TD> <TD> \image html \4 ^^ \image latex \4 \"\" width=1.6cm ^^ </TD> <TD> \image html \5 ^^ \image latex \5 \"\" width=1.6cm ^^ </TD> <TD> \image html \6 ^^ \image latex \6 \"\" width=1.6cm ^^ </TD> <TD> \image html \7 ^^ \image latex \7 \"\" width=1.6cm ^^ </TD> <TD> \image html \8 ^^ \image latex \8 \"\" width=1.6cm ^^ </TD> <TD> \image html \9 ^^ \image latex \9 \"\" width=1.6cm ^^ </TD> <TD> \image html \10 ^^ \image latex \10 \"\" width=1.6cm ^^ </TD> </TR> </TABLE> </CENTER> \htmlonly[block] <div class=\"cgal_figure_caption\"> \endhtmlonly ^^ \ref fig__\1" \
+                         "cgalFigureEnd=\htmlonly[block] </div> \endhtmlonly <br>" \
+                         "cgalFigureCaptionBegin{1}=\htmlonly[block] <div class=\"cgal_figure_caption\"> \endhtmlonly \ref fig__\1" \
+                         "cgalFigureCaptionEnd=\htmlonly[block] </div> \endhtmlonly <br>" \
+                         "cgalConcept=\details <div id=\"CGALConcept\"></div>^^ \brief" \
+                         "cgalConceptNamespace=\details <div id=\"CGALConceptNS\"></div>^^ \brief" \
+                         "cgalRefines=Refines" \
+                         "cgalRefines{1}=<dl><dt>@cgalRefines</dt><dd>@c \1</dd></dl>" \
+                         "cgalRefines{2}=<dl><dt>@cgalRefines</dt><dd>@c \1</dd><dt></dt><dd>@c \2</dd></dl>" \
+                         "cgalRefines{3}=<dl><dt>@cgalRefines</dt><dd>@c \1</dd><dt></dt><dd>@c \2</dd><dt></dt><dd>@c \3</dd></dl>" \
+                         "cgalRefines{4}=<dl><dt>@cgalRefines</dt><dd>@c \1</dd><dt></dt><dd>@c \2</dd><dt></dt><dd>@c \3</dd><dt></dt><dd>@c \4</dd></dl>" \
+                         "cgalRefines{5}=<dl><dt>@cgalRefines</dt><dd>@c \1</dd><dt></dt><dd>@c \2</dd><dt></dt><dd>@c \3</dd><dt></dt><dd>@c \4</dd><dt></dt><dd>@c \5</dd></dl>" \
+                         "cgalRefinesBare{1}=<dl><dt>@cgalRefines</dt><dd>\1</dd></dl>" \
+                         "cgalRefinesBare{2}=<dl><dt>@cgalRefines</dt><dd>@c \1</dd><dt></dt><dd>\2</dd></dl>" \
+                         "cgalModelsHeader=Is model of" \
+                         "cgalModels{1}=<dl><dt>@cgalModelsHeader</dt><dd>@c \1</dd></dl>" \
+                         "cgalModels{2}=<dl><dt>@cgalModelsHeader</dt><dd>@c \1</dd><dt></dt><dd>@c \2</dd></dl>" \
+                         "cgalModels{3}=<dl><dt>@cgalModelsHeader</dt><dd>@c \1</dd><dt></dt><dd>@c \2</dd><dt></dt><dd>@c \3</dd></dl>" \
+                         "cgalModels{4}=<dl><dt>@cgalModelsHeader</dt><dd>@c \1</dd><dt></dt><dd>@c \2</dd><dt></dt><dd>@c \3</dd><dt></dt><dd>@c \4</dd></dl>" \
+                         "cgalModels{5}=<dl><dt>@cgalModelsHeader</dt><dd>@c \1</dd><dt></dt><dd>@c \2</dd><dt></dt><dd>@c \3</dd><dt></dt><dd>@c \4</dd><dt></dt><dd>@c \5</dd></dl>" \
+                         "cgalModels{6}=<dl><dt>@cgalModelsHeader</dt><dd>@c \1</dd><dt></dt><dd>@c \2</dd><dt></dt><dd>@c \3</dd><dt></dt><dd>@c \4</dd><dt></dt><dd>@c \5</dd><dt></dt><dd>@c \6</dd></dl>" \
+                         "cgalModelsBareBegin=<dl><dt>@cgalModelsHeader</dt><dd></dd>" \
+                         "cgalModelsBareEnd=</dl>" \
+                         "cgalModelsBare{1}=<dt></dt><dd>\1</dd>" \
+                         "cgalGeneralizes=\xrefitem generalizes \"Generalizes\" \"Generalization Relationships\"" \
+                         "cgalHasModelsHeader=Has models" \
+                         "cgalHasModelsBegin=<dl><dt>@cgalHasModelsHeader</dt><dd></dd>" \
+                         "cgalHasModels{1}=<dt></dt><dd>`\1`</dd>" \
+                         "cgalHasModelsBare{1}=<dt></dt><dd>\1</dd>" \
+                         "cgalHasModelsEnd=</dl>" \
+                         "cgalDebugBegin=\htmlonly[block] <div class=\"CGALDebug\"> <div>Debugging Support</div> \endhtmlonly ^^" \
+                         "cgalDebugEnd=\htmlonly[block] </div> \endhtmlonly" \
+                         "cgalDebugFunction=This is a function for debugging purpose." \
+                         "cgalAdvancedBegin=^^ \htmlonly[block] <div class=\"CGALAdvanced\"> <div>Advanced</div> \endhtmlonly ^^" \
+                         "cgalAdvancedEnd=\noop ^^ \htmlonly[block] </div> \endhtmlonly" \
+                         "cgalAdvancedFunction=This is an advanced function." \
+                         "cgalAdvancedClass=This is an advanced class." \
+                         "cgalAdvancedType=This is an advanced type." \
+                         "cgalAdvancedConcept=This is an advanced concept." \
+                         "cgalRequiresCPP11=\warning This function requires a C++11 compiler." \
+                         "cgalPkgPicture{1}=<div class=\"PkgImage\"> ^^ \image html \1 ^^</div>" \
+                         "cgalPkgSummaryBegin=<div class=\"PkgSummary\">" \
+                         "cgalPkgSummaryEnd=</div>" \
+                         "cgalPkgShortInfoBegin=<div class=\"PkgShortInfo\">" \
+                         "cgalPkgShortInfoEnd=</div>" \
+                         "cgalPkgAuthor{1}=<div class=\"PkgAuthors\">\1</div>" \
+                         "cgalPkgAuthors{1}=\cgalPkgAuthor{\1}" \
+                         "cgalPkgDesc{1}=<div class=\"PkgDescription\">\1</div>" \
+                         "cgalPkgSince{1}=<B>Introduced in:</B> \cgal \1<BR>" \
+                         "cgalPkgDependsOn{1}=<B>Depends on:</B> \1 <BR>" \
+                         "cgalPkgLicense{1}=<B>License:</B> \1 <BR>" \
+                         "cgalPkgDemo{2}=<B>Windows Demo:</B> <a href=\"https://www.cgal.org/demo/${CGAL_CREATED_VERSION_NUM}/\2\">\1</a><BR>" \
+                         "cgalPkgDemo{4}=<B>Windows Demos:</B> <a href=\"https://www.cgal.org/demo/${CGAL_CREATED_VERSION_NUM}/\2\">\1</a>, <a href=\"https://www.cgal.org/demo/${CGAL_CREATED_VERSION_NUM}/\4\">\3</a><BR>" \
+                         "cgalPkgDemo{6}=<B>Windows Demos:</B> <a href=\"https://www.cgal.org/demo/${CGAL_CREATED_VERSION_NUM}/\2\">\1</a>, <a href=\"https://www.cgal.org/demo/${CGAL_CREATED_VERSION_NUM}/\4\">\3</a>, <a href=\"https://www.cgal.org/demo/${CGAL_CREATED_VERSION_NUM}/\6\">\5</a><BR>" \
+                         "cgalPkgDescriptionEnd=" \
+                         "cgalModifBegin=\htmlonly <div class=\"CGALModification\"> \endhtmlonly \xrefitem Modification \"Modifications\" \"MODIFICATIONS\"" \
+                         "cgalModifEnd=\htmlonly </div> \endhtmlonly \latexonly END MODIFICATIONS \endlatexonly" \
+                         "cgalPkgBib{1}=<B>BibTeX:</B> <a href=\"../Manual/how_to_cite_cgal.html#\1-${CGAL_RELEASE_YEAR_ID}\">\1-${CGAL_RELEASE_YEAR_ID}</a><BR>" \
+                         "cgalFootnote{1}=<span class=\"footnote\">\1</span>" \
+                         "cgalFootnoteCode{1}=<tt style='display:inline'>\1</tt>" \
+                         "cgalAutoToc=\htmlonly[block] <div id=\"autotoc\" class=\"toc\"></div> \endhtmlonly" \
+                         "cgalTagTrue=\link CGAL::Tag_true `CGAL::Tag_true`\endlink" \
+                         "cgalTagFalse=\link CGAL::Tag_false `CGAL::Tag_false`\endlink" \
+                         "cgalHeading{1}= <B>\1</B><BR>" \
+                         "cgalClassifedRefPages=\htmlonly[block] <h2 class=\"groupheader\">Classified Reference Pages</h2> \endhtmlonly" \
+                         "cgalCRPSection{1}=<h2>\1</h2>" \
+                         "cgalCRPSubsection{1}=<h3>\1</h3>" \
+                         "cgalCite{1}=<!-- -->\cite \1" \
+                         "cgalPackageSection{2}=\htmlonly[block] <div class=\"package_section\">\endhtmlonly \section \1 \2 ^^ \htmlonly[block] </div>\endhtmlonly" \
+                         "cgalNamedParamsBegin=<dl class=\"params\"><dt>Optional Named Parameters</dt><dd> <table class=\"params\">" \
+                         "cgalNamedParamsBegin{1}=<dl class=\"params\"><dt>\1</dt><dd> <table class=\"params\">" \
+                         "cgalNamedParamsEnd=</table> </dd> </dl>" \
+                         "cgalParamNBegin{1}=<tr><td class> \htmlonly[block] <button class=\"collapsible\">\endhtmlonly <b>\1</b> \htmlonly[block]</button> <div class=\"content\">\endhtmlonly<ul>" \
+                         "cgalParamDescription{1}=<li>\1</li>" \
+                         "cgalParamType{1}=<li><b>Type: </b>\1</li>" \
+                         "cgalParamDefault{1}=<li><b>%Default: </b>\1</li>" \
+                         "cgalParamExtra{1}=<li><b>Extra: </b>\1</li>" \
+                         "cgalParamNEnd=</ul> \htmlonly[block] </div> \endhtmlonly </td><td></td></tr>" \
+                         "cgalParamSectionBegin{1}=\cgalParamNBegin{\1}" \
+                         "cgalParamSectionEnd=\cgalParamNEnd" \
+                         "cgalParamPrecondition{1}=<li><b>Precondition: </b>\1</li>" \
+                         "cgalBigO{1}=\f$O(\1)\f$" \
+                         "cgalBigOLarge{1}=\f$O\left(\1\right)\f$" \
+                         "cgalInclude{1}=`#include<\1>`" \
+                         "cgalEpicExact=<dl class=\"section note\"><dt>Exactness</dt><dd>This construction is trivial and therefore always exact in `Exact_predicates_inexact_constructions_kernel`.</dd></dl>"
+
+# Doxygen selects the parser to use depending on the extension of the files it
+# parses. With this tag you can assign which parser to use for a given
+# extension. Doxygen has a built-in mapping, but you can override or extend it
+# using this tag. The format is ext=language, where ext is a file extension, and
+# language is one of the parsers supported by Doxygen: IDL, Java, JavaScript,
+# Csharp (C#), C, C++, Lex, D, PHP, md (Markdown), Objective-C, Python, Slice,
+# VHDL, Fortran (fixed format Fortran: FortranFixed, free formatted Fortran:
+# FortranFree, unknown formatted Fortran: Fortran. In the later case the parser
+# tries to guess whether the code is fixed or free formatted code, this is the
+# default for Fortran type files). For instance to make Doxygen treat .inc files
+# as Fortran files (default is PHP), and .f files as C (default is Fortran),
+# use: inc=Fortran f=C.
+#
+# Note: For files without extension you can use no_extension as a placeholder.
+#
+# Note that for custom extensions you also need to set FILE_PATTERNS otherwise
+# the files are not read by Doxygen. When specifying no_extension you should add
+# * to the FILE_PATTERNS.
+#
+# Note see also the list of default file extension mappings.
+
+EXTENSION_MAPPING      = txt=C++
+
+# When the TOC_INCLUDE_HEADINGS tag is set to a non-zero value, all headings up
+# to that level are automatically included in the table of contents, even if
+# they do not have an id attribute.
+# Note: This feature currently applies only to Markdown headings.
+# Minimum value: 0, maximum value: 99, default value: 6.
+# This tag requires that the tag MARKDOWN_SUPPORT is set to YES.
+
+TOC_INCLUDE_HEADINGS   = 0
+
+# If you use STL classes (i.e. std::string, std::vector, etc.) but do not want
+# to include (a tag file for) the STL sources as input, then you should set this
+# tag to YES in order to let Doxygen match functions declarations and
+# definitions whose arguments contain STL classes (e.g. func(std::string);
+# versus func(std::string) {}). This also makes the inheritance and
+# collaboration diagrams that involve STL classes more complete and accurate.
+# The default value is: NO.
+
+BUILTIN_STL_SUPPORT    = YES
+
+# For Microsoft's IDL there are propget and propput attributes to indicate
+# getter and setter methods for a property. Setting this option to YES will make
+# Doxygen to replace the get and set methods by a property in the documentation.
+# This will only work if the methods are indeed getting or setting a simple
+# type. If this is not the case, or you want to show the methods anyway, you
+# should set this option to NO.
+# The default value is: YES.
+
+IDL_PROPERTY_SUPPORT   = NO
+
+# Set the SUBGROUPING tag to YES to allow class member groups of the same type
+# (for instance a group of public functions) to be put as a subgroup of that
+# type (e.g. under the Public Functions section). Set it to NO to prevent
+# subgrouping. Alternatively, this can be done per class using the
+# \nosubgrouping command.
+# The default value is: YES.
+
+SUBGROUPING            = NO
+
+#---------------------------------------------------------------------------
+# Build related configuration options
+#---------------------------------------------------------------------------
+
+# If the EXTRACT_ALL tag is set to YES, Doxygen will assume all entities in
+# documentation are documented, even if no documentation was available. Private
+# class members and static file members will be hidden unless the
+# EXTRACT_PRIVATE respectively EXTRACT_STATIC tags are set to YES.
+# Note: This will also disable the warnings about undocumented members that are
+# normally produced when WARNINGS is set to YES.
+# The default value is: NO.
+
+EXTRACT_ALL            = YES
+
+# If the EXTRACT_STATIC tag is set to YES, all static members of a file will be
+# included in the documentation.
+# The default value is: NO.
+
+EXTRACT_STATIC         = YES
+
+# If the SHOW_GROUPED_MEMB_INC tag is set to YES then Doxygen will add for each
+# grouped member an include statement to the documentation, telling the reader
+# which file to include in order to use the member.
+# The default value is: NO.
+
+SHOW_GROUPED_MEMB_INC  = YES
+
+# If the INLINE_INFO tag is set to YES then a tag [inline] is inserted in the
+# documentation for inline members.
+# The default value is: YES.
+
+INLINE_INFO            = NO
+
+# If the SORT_BY_SCOPE_NAME tag is set to YES, the class list will be sorted by
+# fully-qualified names, including namespaces. If set to NO, the class list will
+# be sorted only by class name, not including the namespace part.
+# Note: This option is not very useful if HIDE_SCOPE_NAMES is set to YES.
+# Note: This option applies only to the class list, not to the alphabetical
+# list.
+# The default value is: NO.
+
+SORT_BY_SCOPE_NAME     = YES
+
+# Set the SHOW_USED_FILES tag to NO to disable the list of files generated at
+# the bottom of the documentation of classes and structs. If set to YES, the
+# list will mention the files that were used to generate the documentation.
+# The default value is: YES.
+
+SHOW_USED_FILES        = NO
+
+# Set the SHOW_FILES tag to NO to disable the generation of the Files page. This
+# will remove the Files entry from the Quick Index and from the Folder Tree View
+# (if specified).
+# The default value is: YES.
+
+SHOW_FILES             = NO
+
+# The LAYOUT_FILE tag can be used to specify a layout file which will be parsed
+# by Doxygen. The layout file controls the global structure of the generated
+# output files in an output format independent way. To create the layout file
+# that represents Doxygen's defaults, run Doxygen with the -l option. You can
+# optionally specify a file name after the option, if omitted DoxygenLayout.xml
+# will be used as the name of the layout file. See also section "Changing the
+# layout of pages" for information.
+#
+# Note that if you run Doxygen from a directory containing a file called
+# DoxygenLayout.xml, Doxygen will parse it automatically even if the LAYOUT_FILE
+# tag is left empty.
+
+LAYOUT_FILE            = ${CGAL_DOC_RESOURCE_DIR}/DoxygenLayoutPackage.xml
+
+# The CITE_BIB_FILES tag can be used to specify one or more bib files containing
+# the reference definitions. This must be a list of .bib files. The .bib
+# extension is automatically appended if omitted. This requires the bibtex tool
+# to be installed. See also https://en.wikipedia.org/wiki/BibTeX for more info.
+# For LaTeX the style of the bibliography can be controlled using
+# LATEX_BIB_STYLE. To use this feature you need bibtex and perl available in the
+# search path. See also \cite for info how to create references.
+
+CITE_BIB_FILES         = ${CGAL_DOC_BIBLIO_DIR}/cgal_manual.bib \
+                         ${CGAL_DOC_BIBLIO_DIR}/geom.bib
+
+#---------------------------------------------------------------------------
+# Configuration options related to warning and progress messages
+#---------------------------------------------------------------------------
+
+# The QUIET tag can be used to turn on/off the messages that are generated to
+# standard output by Doxygen. If QUIET is set to YES this implies that the
+# messages are off.
+# The default value is: NO.
+
+QUIET                  = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to the input files
+#---------------------------------------------------------------------------
+
+# If the value of the INPUT tag contains directories, you can use the
+# FILE_PATTERNS tag to specify one or more wildcard patterns (like *.cpp and
+# *.h) to filter out the source-files in the directories.
+#
+# Note that for custom extensions or not directly supported extensions you also
+# need to set EXTENSION_MAPPING for the extension otherwise the files are not
+# read by Doxygen.
+#
+# Note the list of default checked file patterns might differ from the list of
+# default file extension mappings.
+#
+# If left blank the following patterns are tested:*.c, *.cc, *.cxx, *.cpp,
+# *.c++, *.java, *.ii, *.ixx, *.ipp, *.i++, *.inl, *.idl, *.ddl, *.odl, *.h,
+# *.hh, *.hxx, *.hpp, *.h++, *.l, *.cs, *.d, *.php, *.php4, *.php5, *.phtml,
+# *.inc, *.m, *.markdown, *.md, *.mm, *.dox (to be provided as doxygen C
+# comment), *.py, *.pyw, *.f90, *.f95, *.f03, *.f08, *.f18, *.f, *.for, *.vhd,
+# *.vhdl, *.ucf, *.qsf and *.ice.
+
+FILE_PATTERNS          = *.cpp \
+                         *.txt \
+                         *.md \
+                         *.h \
+                         *.hpp
+
+# The RECURSIVE tag can be used to specify whether or not subdirectories should
+# be searched for input files as well.
+# The default value is: NO.
+
+RECURSIVE              = YES
+
+# The EXCLUDE_SYMBOLS tag can be used to specify one or more symbol names
+# (namespaces, classes, functions, etc.) that should be excluded from the
+# output. The symbol name can be a fully qualified name, a word, or if the
+# wildcard * is used, a substring. Examples: ANamespace, AClass,
+# ANamespace::AClass, ANamespace::*Test
+
+EXCLUDE_SYMBOLS        = Tr \
+                         Vb \
+                         Cb \
+                         Fb \
+                         K \
+                         Traits \
+                         internal
+
+# If the value of the EXAMPLE_PATH tag contains directories, you can use the
+# EXAMPLE_PATTERNS tag to specify one or more wildcard pattern (like *.cpp and
+# *.h) to filter out the source-files in the directories. If left blank all
+# files are included.
+
+EXAMPLE_PATTERNS       = *.cpp \
+                         *.h
+
+# If the EXAMPLE_RECURSIVE tag is set to YES then subdirectories will be
+# searched for input files to be used with the \include or \dontinclude commands
+# irrespective of the value of the RECURSIVE tag.
+# The default value is: NO.
+
+EXAMPLE_RECURSIVE      = YES
+
+#---------------------------------------------------------------------------
+# Configuration options related to source browsing
+#---------------------------------------------------------------------------
+
+# If the VERBATIM_HEADERS tag is set the YES then Doxygen will generate a
+# verbatim copy of the header file for each class for which an include is
+# specified. Set to NO to disable this.
+# See also: Section \class.
+# The default value is: YES.
+
+VERBATIM_HEADERS       = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the alphabetical class index
+#---------------------------------------------------------------------------
+
+# If the ALPHABETICAL_INDEX tag is set to YES, an alphabetical index of all
+# compounds will be generated. Enable this if the project contains a lot of
+# classes, structs, unions or interfaces.
+# The default value is: YES.
+
+ALPHABETICAL_INDEX     = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the HTML output
+#---------------------------------------------------------------------------
+
+#
+# To get valid HTML the header file that includes any scripts and style sheets
+# that Doxygen needs, which is dependent on the configuration options used (e.g.
+# the setting GENERATE_TREEVIEW). It is highly recommended to start with a
+# default header using
+# doxygen -w html new_header.html new_footer.html new_stylesheet.css
+# YourConfigFile
+# and then modify the file new_header.html. See also section "Doxygen usage"
+# for information on how to generate the default header that Doxygen normally
+# uses.
+# Note: The header is subject to change so you typically have to regenerate the
+# default header when upgrading to a newer version of Doxygen. For a description
+# of the possible markers and block names see the documentation.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_HEADER            = ${CGAL_DOC_HEADER_PACKAGE}
+
+# The HTML_FOOTER tag can be used to specify a user-defined HTML footer for each
+# generated HTML page. If the tag is left blank Doxygen will generate a standard
+# footer. See HTML_HEADER for more information on how to generate a default
+# footer and what special commands can be used inside the footer. See also
+# section "Doxygen usage" for information on how to generate the default footer
+# that Doxygen normally uses.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_FOOTER            = ${CGAL_DOC_RESOURCE_DIR}/footer.html
+
+# Doxygen stores a couple of settings persistently in the browser (via e.g.
+# cookies). By default these settings apply to all HTML pages generated by
+# Doxygen across all projects. The HTML_PROJECT_COOKIE tag can be used to store
+# the settings under a project specific key, such that the user preferences will
+# be stored separately.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_PROJECT_COOKIE    = CGAL
+
+# If you want full control over the layout of the generated HTML pages it might
+# be necessary to disable the index and replace it with your own. The
+# DISABLE_INDEX tag can be used to turn on/off the condensed index (tabs) at top
+# of each HTML page. A value of NO enables the index and the value YES disables
+# it. Since the tabs in the index contain the same information as the navigation
+# tree, you can set this option to YES if you also set GENERATE_TREEVIEW to YES.
+# The default value is: NO.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+DISABLE_INDEX          = YES
+
+# When GENERATE_TREEVIEW is set to YES, the PAGE_OUTLINE_PANEL option determines
+# if an additional navigation panel is shown at the right hand side of the
+# screen, displaying an outline of the contents of the main page, similar to
+# e.g. https://developer.android.com/reference If GENERATE_TREEVIEW is set to
+# NO, this option has no effect.
+# The default value is: YES.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+PAGE_OUTLINE_PANEL     = NO
+
+# If the HTML_FORMULA_FORMAT option is set to svg, Doxygen will use the pdf2svg
+# tool (see https://github.com/dawbarton/pdf2svg) or inkscape (see
+# https://inkscape.org) to generate formulas as SVG images instead of PNGs for
+# the HTML output. These images will generally look nicer at scaled resolutions.
+# Possible values are: png (the default) and svg (looks nicer but requires the
+# pdf2svg or inkscape tool).
+# The default value is: png.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+HTML_FORMULA_FORMAT    = svg
+
+# Enable the USE_MATHJAX option to render LaTeX formulas using MathJax (see
+# https://www.mathjax.org) which uses client side JavaScript for the rendering
+# instead of using pre-rendered bitmaps. Use this if you do not have LaTeX
+# installed or if you want to formulas look prettier in the HTML output. When
+# enabled you may also need to install MathJax separately and configure the path
+# to it using the MATHJAX_RELPATH option.
+# The default value is: NO.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+USE_MATHJAX            = YES
+
+# When MathJax is enabled you need to specify the location relative to the HTML
+# output directory using the MATHJAX_RELPATH option. The destination directory
+# should contain the MathJax.js script. For instance, if the mathjax directory
+# is located at the same level as the HTML output directory, then
+# MATHJAX_RELPATH should be ../mathjax. The default value points to the MathJax
+# Content Delivery Network so you can quickly see the result without installing
+# MathJax. However, it is strongly recommended to install a local copy of
+# MathJax from https://www.mathjax.org before deployment. The default value is:
+# - in case of MathJax version 2: https://cdn.jsdelivr.net/npm/mathjax@2
+# - in case of MathJax version 3: https://cdn.jsdelivr.net/npm/mathjax@3
+# This tag requires that the tag USE_MATHJAX is set to YES.
+
+${CGAL_DOC_MATHJAX_LOCATION_FULL_OPTION_LINE}
+
+# The MATHJAX_EXTENSIONS tag can be used to specify one or more MathJax
+# extension names that should be enabled during MathJax rendering. For example
+# for MathJax version 2 (see
+# https://docs.mathjax.org/en/v2.7-latest/tex.html#tex-and-latex-extensions):
+# MATHJAX_EXTENSIONS = TeX/AMSmath TeX/AMSsymbols
+# For example for MathJax version 3 (see
+# http://docs.mathjax.org/en/latest/input/tex/extensions/index.html):
+# MATHJAX_EXTENSIONS = ams
+# This tag requires that the tag USE_MATHJAX is set to YES.
+
+MATHJAX_EXTENSIONS     = TeX/AMSmath \
+                         TeX/AMSsymbols
+
+# The MATHJAX_CODEFILE tag can be used to specify a file with JavaScript pieces
+# of code that will be used on startup of the MathJax code. See the MathJax site
+# (see:
+# http://docs.mathjax.org/en/v2.7-latest/output.html) for more details. For an
+# example see the documentation.
+# This tag requires that the tag USE_MATHJAX is set to YES.
+
+MATHJAX_CODEFILE       = ${CGAL_DOC_RESOURCE_DIR}/CGAL_mathjax.js
+
+# When the SEARCHENGINE tag is enabled Doxygen will generate a search box for
+# the HTML output. The underlying search engine uses JavaScript and DHTML and
+# should work on any modern browser. Note that when using HTML help
+# (GENERATE_HTMLHELP), Qt help (GENERATE_QHP), or docsets (GENERATE_DOCSET)
+# there is already a search function so this one should typically be disabled.
+# For large projects the JavaScript based search engine can be slow, then
+# enabling SERVER_BASED_SEARCH may provide a better solution. It is possible to
+# search using the keyboard; to jump to the search box use <access key> + S
+# (what the <access key> is depends on the OS and browser, but it is typically
+# <CTRL>, <ALT>/<option>, or both). Inside the search box use the <cursor down
+# key> to jump into the search results window, the results can be navigated
+# using the <cursor keys>. Press <Enter> to select an item or <escape> to cancel
+# the search. The filter options can be selected when the cursor is inside the
+# search box by pressing <Shift>+<cursor down>. Also here use the <cursor keys>
+# to select a filter and <Enter> or <escape> to activate or cancel the filter
+# option.
+# The default value is: YES.
+# This tag requires that the tag GENERATE_HTML is set to YES.
+
+SEARCHENGINE           = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the LaTeX output
+#---------------------------------------------------------------------------
+
+# If the GENERATE_LATEX tag is set to YES, Doxygen will generate LaTeX output.
+# The default value is: YES.
+
+GENERATE_LATEX         = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the RTF output
+#---------------------------------------------------------------------------
+
+#---------------------------------------------------------------------------
+# Configuration options related to the man page output
+#---------------------------------------------------------------------------
+
+#---------------------------------------------------------------------------
+# Configuration options related to the XML output
+#---------------------------------------------------------------------------
+
+# If the XML_PROGRAMLISTING tag is set to YES, Doxygen will dump the program
+# listings (including syntax highlighting and cross-referencing information) to
+# the XML output. Note that enabling this will significantly increase the size
+# of the XML output.
+# The default value is: YES.
+# This tag requires that the tag GENERATE_XML is set to YES.
+
+XML_PROGRAMLISTING     = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to the preprocessor
+#---------------------------------------------------------------------------
+
+# If the MACRO_EXPANSION tag is set to YES, Doxygen will expand all macro names
+# in the source code. If set to NO, only conditional compilation will be
+# performed. Macro expansion can be done in a controlled way by setting
+# EXPAND_ONLY_PREDEF to YES.
+# The default value is: NO.
+# This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
+
+MACRO_EXPANSION        = YES
+
+# If the EXPAND_ONLY_PREDEF and MACRO_EXPANSION tags are both set to YES then
+# the macro expansion is limited to the macros specified with the PREDEFINED and
+# EXPAND_AS_DEFINED tags.
+# The default value is: NO.
+# This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
+
+EXPAND_ONLY_PREDEF     = YES
+
+# The PREDEFINED tag can be used to specify one or more macro names that are
+# defined before the preprocessor is started (similar to the -D option of e.g.
+# gcc). The argument of the tag is a list of macros of the form: name or
+# name=definition (no spaces). If the definition and the "=" are omitted, "=1"
+# is assumed. To prevent a macro definition from being undefined via #undef or
+# recursively expanded use the := operator instead of the = operator.
+# This tag requires that the tag ENABLE_PREPROCESSING is set to YES.
+
+PREDEFINED             = DOXYGEN_RUNNING \
+                         "CGAL_NP_TEMPLATE_PARAMETERS=NamedParameters = CGAL::parameters::Default_named_parameters" \
+                         "CGAL_NP_CLASS=NamedParameters" \
+                         "CGAL_NP_TEMPLATE_PARAMETERS_1=NamedParameters1 = CGAL::parameters::Default_named_parameter" \
+                         "CGAL_NP_CLASS_1=NamedParameters1" \
+                         "CGAL_NP_TEMPLATE_PARAMETERS_2=NamedParameters2 = CGAL::parameters::Default_named_parameter" \
+                         "CGAL_NP_CLASS_2=NamedParameters2" \
+                         CGAL_DEPRECATED  \
+                         CGAL_DEPRECATED_MSG(name)=
+
+
+#---------------------------------------------------------------------------
+# Configuration options related to external references
+#---------------------------------------------------------------------------
+
+# If the EXTERNAL_GROUPS tag is set to YES, all external groups will be listed
+# in the topic index. If set to NO, only the current project's groups will be
+# listed.
+# The default value is: YES.
+
+EXTERNAL_GROUPS        = NO
+
+# If the EXTERNAL_PAGES tag is set to YES, all external pages will be listed in
+# the related pages index. If set to NO, only the current project's pages will
+# be listed.
+# The default value is: YES.
+
+EXTERNAL_PAGES         = NO
+
+#---------------------------------------------------------------------------
+# Configuration options related to diagram generator tools
+#---------------------------------------------------------------------------
+
+# If you set the HAVE_DOT tag to YES then Doxygen will assume the dot tool is
+# available from the path. This tool is part of Graphviz (see:
+# https://www.graphviz.org/), a graph visualization toolkit from AT&T and Lucent
+# Bell Labs. The other options in this section have no effect if this option is
+# set to NO
+# The default value is: NO.
+
+HAVE_DOT               = YES
+
+# If the CLASS_GRAPH tag is set to YES or GRAPH or BUILTIN then Doxygen will
+# generate a graph for each documented class showing the direct and indirect
+# inheritance relations. In case the CLASS_GRAPH tag is set to YES or GRAPH and
+# HAVE_DOT is enabled as well, then dot will be used to draw the graph. In case
+# the CLASS_GRAPH tag is set to YES and HAVE_DOT is disabled or if the
+# CLASS_GRAPH tag is set to BUILTIN, then the built-in generator will be used.
+# If the CLASS_GRAPH tag is set to TEXT the direct and indirect inheritance
+# relations will be shown as texts / links. Explicit enabling an inheritance
+# graph or choosing a different representation for an inheritance graph of a
+# specific class, can be accomplished by means of the command \inheritancegraph.
+# Disabling an inheritance graph can be accomplished by means of the command
+# \hideinheritancegraph.
+# Possible values are: NO, YES, TEXT, GRAPH and BUILTIN.
+# The default value is: YES.
+
+CLASS_GRAPH            = TEXT
+
+# If the COLLABORATION_GRAPH tag is set to YES then Doxygen will generate a
+# graph for each documented class showing the direct and indirect implementation
+# dependencies (inheritance, containment, and class references variables) of the
+# class with other documented classes. Explicit enabling a collaboration graph,
+# when COLLABORATION_GRAPH is set to NO, can be accomplished by means of the
+# command \collaborationgraph. Disabling a collaboration graph can be
+# accomplished by means of the command \hidecollaborationgraph.
+# The default value is: YES.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+COLLABORATION_GRAPH    = NO
+
+# If the GROUP_GRAPHS tag is set to YES then Doxygen will generate a graph for
+# groups, showing the direct groups dependencies. Explicit enabling a group
+# dependency graph, when GROUP_GRAPHS is set to NO, can be accomplished by means
+# of the command \groupgraph. Disabling a directory graph can be accomplished by
+# means of the command \hidegroupgraph. See also the chapter Grouping in the
+# manual.
+# The default value is: YES.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+GROUP_GRAPHS           = NO
+
+# If the TEMPLATE_RELATIONS tag is set to YES then the inheritance and
+# collaboration graphs will show the relations between templates and their
+# instances.
+# The default value is: NO.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+TEMPLATE_RELATIONS     = YES
+
+# If the INCLUDE_GRAPH, ENABLE_PREPROCESSING and SEARCH_INCLUDES tags are set to
+# YES then Doxygen will generate a graph for each documented file showing the
+# direct and indirect include dependencies of the file with other documented
+# files. Explicit enabling an include graph, when INCLUDE_GRAPH is set to NO,
+# can be accomplished by means of the command \includegraph. Disabling an
+# include graph can be accomplished by means of the command \hideincludegraph.
+# The default value is: YES.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+INCLUDE_GRAPH          = NO
+
+# If the INCLUDED_BY_GRAPH, ENABLE_PREPROCESSING and SEARCH_INCLUDES tags are
+# set to YES then Doxygen will generate a graph for each documented file showing
+# the direct and indirect include dependencies of the file with other documented
+# files. Explicit enabling an included by graph, when INCLUDED_BY_GRAPH is set
+# to NO, can be accomplished by means of the command \includedbygraph. Disabling
+# an included by graph can be accomplished by means of the command
+# \hideincludedbygraph.
+# The default value is: YES.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+INCLUDED_BY_GRAPH      = NO
+
+# If the GRAPHICAL_HIERARCHY tag is set to YES then Doxygen will graphical
+# hierarchy of all classes instead of a textual one.
+# The default value is: YES.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+GRAPHICAL_HIERARCHY    = NO
+
+# If the DIRECTORY_GRAPH tag is set to YES then Doxygen will show the
+# dependencies a directory has on other directories in a graphical way. The
+# dependency relations are determined by the #include relations between the
+# files in the directories. Explicit enabling a directory graph, when
+# DIRECTORY_GRAPH is set to NO, can be accomplished by means of the command
+# \directorygraph. Disabling a directory graph can be accomplished by means of
+# the command \hidedirectorygraph.
+# The default value is: YES.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+DIRECTORY_GRAPH        = NO
+
+# The DOT_IMAGE_FORMAT tag can be used to set the image format of the images
+# generated by dot. For an explanation of the image formats see the section
+# output formats in the documentation of the dot tool (Graphviz (see:
+# https://www.graphviz.org/)).
+#
+# Note the formats svg:cairo and svg:cairo:cairo cannot be used in combination
+# with INTERACTIVE_SVG (the INTERACTIVE_SVG will be set to NO).
+# Possible values are: png, jpg, gif, svg, png:gd, png:gd:gd, png:cairo,
+# png:cairo:gd, png:cairo:cairo, png:cairo:gdiplus, png:gdiplus,
+# png:gdiplus:gdiplus, svg:cairo, svg:cairo:cairo, svg:svg, svg:svg:core,
+# gif:cairo, gif:cairo:gd, gif:cairo:gdiplus, gif:gdiplus, gif:gdiplus:gdiplus,
+# gif:gd, gif:gd:gd, jpg:cairo, jpg:cairo:gd, jpg:cairo:gdiplus, jpg:gd,
+# jpg:gd:gd, jpg:gdiplus and jpg:gdiplus:gdiplus.
+# The default value is: png.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+DOT_IMAGE_FORMAT       = svg
+
+# If DOT_IMAGE_FORMAT is set to svg, then this option can be set to YES to
+# enable generation of interactive SVG images that allow zooming and panning.
+#
+# Note that this requires a modern browser other than Internet Explorer. Tested
+# and working are Firefox, Chrome, Safari, and Opera.
+#
+# Note This option will be automatically disabled when DOT_IMAGE_FORMAT is set
+# to svg:cairo or svg:cairo:cairo.
+# The default value is: NO.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+INTERACTIVE_SVG        = YES
+
+# If the GENERATE_LEGEND tag is set to YES Doxygen will generate a legend page
+# explaining the meaning of the various boxes and arrows in the dot generated
+# graphs.
+# Note: This tag requires that UML_LOOK isn't set, i.e. the Doxygen internal
+# graphical representation for inheritance and collaboration diagrams is used.
+# The default value is: YES.
+# This tag requires that the tag HAVE_DOT is set to YES.
+
+GENERATE_LEGEND        = NO
+
+# Flag available on in https://github.com/CGAL/doxygen/tree/release_1_9_6_patched
+# When the EXTRACT_ALL tag is set to YES and a member or class has no
+# documentation, no detailed section will be produced if the
+# NO_ADDITIONAL_DETAILS tag is set to YES. This tag has no effect if
+# the EXTRACT_ALL tag is set to NO.
+# The default value is: NO.
+${CGAL_OPT_NO_ADDITIONAL_DETAILS}
+

--- a/Documentation/doc/resources/1.16.1/CGAL_mathjax.js
+++ b/Documentation/doc/resources/1.16.1/CGAL_mathjax.js
@@ -1,0 +1,45 @@
+//<![CDATA[
+MathJax.Hub.Config(
+{
+  TeX: {
+      Macros: {
+          qprel: [ "{\\gtreqless}", 0],
+          qpx: [ "{\\mathbf{x}}", 0],
+          qpl: [ "{\\mathbf{l}}", 0],
+          qpu: [ "{\\mathbf{u}}", 0],
+          qpc: [ "{\\mathbf{c}}", 0],
+          qpb: [ "{\\mathbf{b}}", 0],
+          qpy: [ "{\\mathbf{y}}", 0],
+          qpw: [ "{\\mathbf{w}}", 0],
+          qplambda: [ "{\\mathbf{\\lambda}}", 0],
+          ssWpoint: [ "{\\bf #1}", 1],
+          ssWeight: [ "{w_{#1}}", 1],
+          dabs: [ "{\\parallel\\! #1 \\!\\parallel}", 1],
+          E: [ "{\\mathrm{E}}", 0],
+          A: [ "{\\mathrm{A}}", 0],
+          R: [ "{\\mathrm{R}}", 0],
+          N: [ "{\\mathrm{N}}", 0],
+          Q: [ "{\\mathrm{Q}}", 0],
+          Z: [ "{\\mathrm{Z}}", 0],
+          ccSum: [ "{\\sum_{#1}^{#2}{#3}}", 3],
+          ccProd: [ "{\\prod_{#1}^{#2}{#3}}", 3],
+          pyr: [ "{\\operatorname{Pyr}}", 0],
+          aff: [ "{\\operatorname{aff}}", 0],
+          Ac: [ "{\\cal A}", 0],
+          Sc: [ "{\\cal S}", 0],
+      },
+      equationNumbers: { autoNumber: "AMS" }
+  }
+}
+);
+MathJax.Hub.Register.StartupHook("TeX Jax Ready",function () {
+  var PARSE = MathJax.InputJax.TeX.Parse,
+      TEXT = PARSE.prototype.InternalText;
+  PARSE.Augment({
+    InternalText: function (text,def) {
+      text = text.replace(/\\/g,"");
+      return TEXT.call(this,text,def);
+    }
+  });
+});
+//]]>

--- a/Documentation/doc/resources/1.16.1/DoxygenLayout.xml
+++ b/Documentation/doc/resources/1.16.1/DoxygenLayout.xml
@@ -1,0 +1,177 @@
+<doxygenlayout version="1.0">
+  <!-- Navigation index tabs for HTML output -->
+  <navindex>
+    <tab type="mainpage" visible="yes" title=""/>
+    <tab type="topics" visible="yes" title="" intro=""/>
+    <tab type="pages" visible="yes" title="" intro=""/>
+    <tab type="classlist" visible="no" title="Class and Concept List" intro="Here is the list of all concepts and classes of the CGAL Library. Classes are inside the namespace CGAL. Concepts are in the global namespace."/>
+    <tab type="examples" visible="no" title="" intro=""/>  
+    <!-- <tab type="user" url="@ref how_to_cite_cgal" title="Acknowledging CGAL"/> -->
+  </navindex>
+
+  <!-- Layout definition for a class page -->
+  <class>
+    <briefdescription visible="no"/>
+    <detaileddescription title=" "/>
+    <includes visible="$SHOW_INCLUDE_FILES"/>
+    <inheritancegraph visible="$CLASS_GRAPH"/>
+    <collaborationgraph visible="$COLLABORATION_GRAPH"/>
+    <allmemberslink visible="yes"/>
+    <memberdecl>
+      <nestedclasses visible="yes" title=""/>
+      <publictypes title=""/>
+      <publicslots title=""/>
+      <signals title=""/>
+      <publicmethods title=""/>
+      <publicstaticmethods title=""/>
+      <publicattributes title=""/>
+      <publicstaticattributes title=""/>
+      <protectedtypes title=""/>
+      <protectedslots title=""/>
+      <protectedmethods title=""/>
+      <protectedstaticmethods title=""/>
+      <protectedattributes title=""/>
+      <protectedstaticattributes title=""/>
+      <packagetypes title=""/>
+      <packagemethods title=""/>
+      <packagestaticmethods title=""/>
+      <packageattributes title=""/>
+      <packagestaticattributes title=""/>
+      <properties title=""/>
+      <events title=""/>
+      <privatetypes title=""/>
+      <privateslots title=""/>
+      <privatemethods title=""/>
+      <privatestaticmethods title=""/>
+      <privateattributes title=""/>
+      <privatestaticattributes title=""/>
+      <friends title=""/>
+      <related title="" subtitle=""/>
+      <membergroups visible="yes"/>
+    </memberdecl>
+
+    <memberdef>
+      <inlineclasses title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <constructors title=""/>
+      <functions title=""/>
+      <related title=""/>
+      <variables title=""/>
+      <properties title=""/>
+      <events title=""/>
+    </memberdef>
+    <usedfiles visible="$SHOW_USED_FILES"/>
+    <authorsection visible="yes"/>
+  </class>
+
+  <!-- Layout definition for a namespace page -->
+  <namespace>
+    <briefdescription visible="yes"/>
+    <memberdecl>
+      <nestednamespaces visible="yes" title=""/>
+      <classes visible="yes" title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <functions title=""/>
+      <variables title=""/>
+      <membergroups visible="yes"/>
+    </memberdecl>
+    <detaileddescription title=""/>
+    <memberdef>
+      <inlineclasses title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <functions title=""/>
+      <variables title=""/>
+    </memberdef>
+    <authorsection visible="yes"/>
+  </namespace>
+
+  <!-- Layout definition for a file page -->
+  <file>
+    <briefdescription visible="yes"/>
+    <includes visible="$SHOW_INCLUDE_FILES"/>
+    <includegraph visible="$INCLUDE_GRAPH"/>
+    <includedbygraph visible="$INCLUDED_BY_GRAPH"/>
+    <sourcelink visible="yes"/>
+    <memberdecl>
+      <classes visible="yes" title=""/>
+      <namespaces visible="yes" title=""/>
+      <defines title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <functions title=""/>
+      <variables title=""/>
+      <membergroups visible="yes"/>
+    </memberdecl>
+    <detaileddescription title=""/>
+    <memberdef>
+      <inlineclasses title=""/>
+      <defines title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <functions title=""/>
+      <variables title=""/>
+    </memberdef>
+    <authorsection/>
+  </file>
+
+  <!-- Layout definition for a group page -->
+  <group>
+    <detaileddescription title=" "/>
+    <authorsection visible="yes"/>
+    <groupgraph visible="$GROUP_GRAPHS"/>
+    <memberdef>
+      <pagedocs/>
+    </memberdef>
+    <memberdecl>
+      <nestedgroups visible="yes" title=""/>
+      <dirs visible="yes" title=""/>
+      <files visible="yes" title=""/>
+      <namespaces visible="yes" title=""/>
+      <classes visible="yes" title=""/>
+      <defines title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <enumvalues title=""/>
+      <functions title=""/>
+      <variables title=""/>
+      <signals title=""/>
+      <publicslots title=""/>
+      <protectedslots title=""/>
+      <privateslots title=""/>
+      <events title=""/>
+      <properties title=""/>
+      <friends title=""/>
+      <membergroups visible="yes"/>
+    </memberdecl>
+    <memberdef>
+      <inlineclasses title=""/>
+      <defines title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <enumvalues title=""/>
+      <functions title=""/>
+      <variables title=""/>
+      <signals title=""/>
+      <publicslots title=""/>
+      <protectedslots title=""/>
+      <privateslots title=""/>
+      <events title=""/>
+      <properties title=""/>
+      <friends title=""/>
+    </memberdef>
+  </group>
+
+  <!-- Layout definition for a directory page -->
+  <directory>
+    <briefdescription visible="yes"/>
+    <directorygraph visible="yes"/>
+    <memberdecl>
+      <dirs visible="yes"/>
+      <files visible="yes"/>
+    </memberdecl>
+    <detaileddescription title=""/>
+  </directory>
+</doxygenlayout>

--- a/Documentation/doc/resources/1.16.1/DoxygenLayoutPackage.xml
+++ b/Documentation/doc/resources/1.16.1/DoxygenLayoutPackage.xml
@@ -1,0 +1,178 @@
+<doxygenlayout version="1.0">
+  <!-- Navigation index tabs for HTML output -->
+  <navindex>
+    <tab type="mainpage" visible="yes" title=""/>
+    <tab type="topics" visible="yes" title="Reference Manual" intro=""/>
+    <tab type="pages" visible="yes" title="Pages" intro=""/>
+    <tab type="classlist" visible="yes" title="Class and Concept List" intro="Here is the list of all concepts and classes of this package. Classes are inside the namespace CGAL. Concepts are in the global namespace."/>
+    <tab type="filelist" visible="yes" title="" intro=""/>
+    <tab type="examples" visible="yes" title="" intro=""/>  
+  </navindex>
+
+  <!-- Layout definition for a class page -->
+  <class>
+    <briefdescription visible="no"/>
+    <includes visible="$SHOW_INCLUDE_FILES"/>
+    <inheritancegraph visible="$CLASS_GRAPH"/>
+    <detaileddescription title="Definition"/>
+    <collaborationgraph visible="$COLLABORATION_GRAPH"/>
+    <allmemberslink visible="yes"/>
+    <memberdecl>
+      <nestedclasses visible="yes" title=""/>
+      <!-- Disable the naming of the public types group -->
+      <publictypes title=""/>
+      <publicslots title=""/>
+      <signals title=""/>
+      <publicmethods title=""/>
+      <publicstaticmethods title=""/>
+      <publicattributes title=""/>
+      <publicstaticattributes title=""/>
+      <protectedtypes title=""/>
+      <protectedslots title=""/>
+      <protectedmethods title=""/>
+      <protectedstaticmethods title=""/>
+      <protectedattributes title=""/>
+      <protectedstaticattributes title=""/>
+      <packagetypes title=""/>
+      <packagemethods title=""/>
+      <packagestaticmethods title=""/>
+      <packageattributes title=""/>
+      <packagestaticattributes title=""/>
+      <properties title=""/>
+      <events title=""/>
+      <privatetypes title=""/>
+      <privateslots title=""/>
+      <privatemethods title=""/>
+      <privatestaticmethods title=""/>
+      <privateattributes title=""/>
+      <privatestaticattributes title=""/>
+      <friends title=""/>
+      <related title="" subtitle=""/>
+      <membergroups visible="yes"/>
+    </memberdecl>
+
+    <memberdef>
+      <inlineclasses title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <constructors title=""/>
+      <functions title=""/>
+      <related title=""/>
+      <variables title=""/>
+      <properties title=""/>
+      <events title=""/>
+    </memberdef>
+    <usedfiles visible="$SHOW_USED_FILES"/>
+    <authorsection visible="yes"/>
+  </class>
+
+  <!-- Layout definition for a namespace page -->
+  <namespace>
+    <briefdescription visible="yes"/>
+    <memberdecl>
+      <nestednamespaces visible="yes" title=""/>
+      <classes visible="yes" title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <functions title=""/>
+      <variables title=""/>
+      <membergroups visible="yes"/>
+    </memberdecl>
+    <detaileddescription title="Definition"/>
+    <memberdef>
+      <inlineclasses title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <functions title=""/>
+      <variables title=""/>
+    </memberdef>
+    <authorsection visible="yes"/>
+  </namespace>
+
+  <!-- Layout definition for a file page -->
+  <file>
+    <briefdescription visible="yes"/>
+    <includes visible="$SHOW_INCLUDE_FILES"/>
+    <includegraph visible="$INCLUDE_GRAPH"/>
+    <includedbygraph visible="$INCLUDED_BY_GRAPH"/>
+    <sourcelink visible="yes"/>
+    <memberdecl>
+      <classes visible="yes" title=""/>
+      <namespaces visible="yes" title=""/>
+      <defines title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <functions title=""/>
+      <variables title=""/>
+      <membergroups visible="yes"/>
+    </memberdecl>
+    <detaileddescription title=""/>
+    <memberdef>
+      <inlineclasses title=""/>
+      <defines title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <functions title=""/>
+      <variables title=""/>
+    </memberdef>
+    <authorsection/>
+  </file>
+
+  <!-- Layout definition for a group page -->
+  <group>
+    <detaileddescription title=" "/>
+    <authorsection visible="yes"/>
+    <groupgraph visible="$GROUP_GRAPHS"/>
+    <memberdef>
+      <pagedocs/>
+    </memberdef>
+    <memberdecl>
+      <nestedgroups visible="yes" title=""/>
+      <dirs visible="yes" title=""/>
+      <files visible="yes" title=""/>
+      <namespaces visible="yes" title=""/>
+      <classes visible="yes" title=""/>
+      <defines title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <enumvalues title=""/>
+      <functions title=""/>
+      <variables title=""/>
+      <signals title=""/>
+      <publicslots title=""/>
+      <protectedslots title=""/>
+      <privateslots title=""/>
+      <events title=""/>
+      <properties title=""/>
+      <friends title=""/>
+      <membergroups visible="yes"/>
+    </memberdecl>
+    <memberdef>
+      <inlineclasses title=""/>
+      <defines title=""/>
+      <typedefs title=""/>
+      <enums title=""/>
+      <enumvalues title=""/>
+      <functions title=""/>
+      <variables title=""/>
+      <signals title=""/>
+      <publicslots title=""/>
+      <protectedslots title=""/>
+      <privateslots title=""/>
+      <events title=""/>
+      <properties title=""/>
+      <friends title=""/>
+    </memberdef>
+  </group>
+
+  <!-- Layout definition for a directory page -->
+  <directory>
+    <briefdescription visible="yes"/>
+    <directorygraph visible="yes"/>
+    <memberdecl>
+      <dirs visible="yes"/>
+      <files visible="yes"/>
+    </memberdecl>
+    <detaileddescription title=""/>
+  </directory>
+</doxygenlayout>

--- a/Documentation/doc/resources/1.16.1/cgal_stylesheet.css
+++ b/Documentation/doc/resources/1.16.1/cgal_stylesheet.css
@@ -1,0 +1,575 @@
+/* Color and background rules */
+
+:root {
+  color-scheme: light dark;
+  /* Light defaults */
+  --back-nav-bg: #FAF9FB;
+  --cgaladvanced-bg: #eeb;
+  --cgaladvanced-border: #9e9e7d;
+  --cgaladvanced-shadow: #ccc;
+  --cgaldebug-bg: #c8a8d0;
+  --cgaldebug-border: #846f8a;
+  --cgaldebug-shadow: #777;
+  --cgalmodification-bg: #f85858;
+  --cgalmodification-border: #000000;
+  --cgalmodification-shadow: #777;
+  --collapsible-after-color: #7A93C5;
+  --collapsible-bg: #fff;
+  --collapsible-color: #602020;
+  --content-bg: #fff;
+  --content-color: #000;
+  --deprecated-bg: #d8c0a0;
+  --deprecated-border: #94836e;
+  --deprecated-shadow: #aaa;
+  --iotable-border-color: #2D4068;
+  --iotable-th-bg: #374F7F;
+  --iotable-th-color: #FFFFFF;
+  --iotable-th-link-color: #FFFFFF;
+  --modification-bg: #f85858;
+  --package-section-h1-bg: #EEEDF2;
+  --titlearea-bg: #FFFFFF;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --back-nav-bg: #1A1A1A;
+    --cgaladvanced-bg: #4f4f19;
+    --cgaladvanced-border: #9e9e7d;
+    --cgaladvanced-shadow: #ccc;
+    --cgaldebug-bg: #45244d;
+    --cgaldebug-border: #846f8a;
+    --cgaldebug-shadow: #777;
+    --cgalmodification-bg: #601616;
+    --cgalmodification-border: #000000;
+    --cgalmodification-shadow: #777;
+    --collapsible-after-color: #7A93C5;
+    --collapsible-bg: #000;
+    --collapsible-color: #B0B0B0;
+    --content-bg: #000;
+    --content-color: #fff;
+    --deprecated-bg: #684618;
+    --deprecated-border: #94836e;
+    --deprecated-shadow: #aaa;
+    --iotable-border-color: #5A6B9A;
+    --iotable-th-bg: #223055;
+    --iotable-th-color: #FFFFFF;
+    --iotable-th-link-color: #FFFFFF;
+    --modification-bg: #601616;
+    --package-section-h1-bg: #1A1A1A;
+    --titlearea-bg: #1A1A1A;
+    --warning-bg: #4f1919;
+    --warning-border: #9e7d7d;
+    --note-bg: #19324f;
+    --note-border: #7d8e9e;
+  }
+}
+
+:root {
+  --warning-bg: #fdf1f1;
+  --warning-border: #f85858;
+  --note-bg: #f1f5fd;
+  --note-border: #7A93C5;
+}
+
+#titlearea {
+  background: var(--titlearea-bg);
+}
+
+.package_section h1 {
+  padding: 1ex 0 1ex 0;
+  background-color: var(--package-section-h1-bg);
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+body,
+table,
+div,
+p,
+dl {
+  font: Lucida Grande, sans-serif;
+}
+
+.textsc {
+  font-variant: small-caps;
+}
+
+#projectnumber {
+  display: none;
+}
+
+#back-nav {
+  background-color: var(--back-nav-bg);
+  border-bottom: 1px solid;
+  padding: 0.5em;
+}
+
+#back-nav h2 {
+  display: inline;
+}
+
+#back-nav ul {
+  display: inline;
+  padding: 0;
+  margin: 0;
+}
+
+#back-nav li {
+  display: inline;
+  list-style-type: none;
+  padding-right: 20px;
+}
+
+h1 {
+  font-size: 180%;
+}
+
+h2 {
+  font-size: 120%;
+}
+
+.icon-namespace {
+  font-family: Arial, Helvetica;
+  font-weight: bold;
+  font-size: 12px;
+  height: 22px;
+  width: 16px;
+  display: inline-block;
+  background-color: #FF0000;
+  color: white;
+  text-align: center;
+  border-radius: 4px;
+  margin-left: 2px;
+  margin-right: 2px;
+}
+
+.icon-class {
+  font-family: Arial, Helvetica;
+  font-weight: bold;
+  font-size: 12px;
+  height: 22px;
+  width: 16px;
+  display: inline-block;
+  background-color: #0000FF;
+  color: white;
+  text-align: center;
+  border-radius: 4px;
+  margin-left: 2px;
+  margin-right: 2px;
+}
+
+.icon-concept {
+  font-family: Arial, Helvetica;
+  font-weight: bold;
+  font-size: 12px;
+  height: 22px;
+  width: 16px;
+  display: inline-block;
+  background-color: #67489A;
+  color: white;
+  text-align: center;
+  border-radius: 4px;
+  margin-left: 2px;
+  margin-right: 2px;
+}
+
+
+/* enable this to make sections more alike */
+/* h2.groupheader { */
+/*     border-bottom: none; */
+/*     color: black; */
+/*     font-size: 100%; */
+/*     font-weight: bold; */
+/*     margin-top: 1.75em; */
+/*     padding-bottom: 0; */
+/*     padding-top: 0; */
+/*     width: 100%; */
+/* } */
+
+a.el {
+  font-weight: normal;
+}
+
+.memproto a {
+  font-weight: bold;
+}
+
+.PkgSummary {
+  width: 60%;
+}
+
+.PkgShortInfo {
+  width: 20%;
+}
+
+.PkgSummary,
+.PkgShortInfo,
+.PkgImage,
+.PkgImage .image {
+  display: inline-block;
+  padding: 5px;
+  vertical-align: middle;
+}
+
+@media (prefers-color-scheme: dark) {
+
+  .image>img {
+    border-radius: 1ex;
+    background: white;
+  }
+}
+
+.PkgAuthors {
+  font-style: italic;
+}
+
+.PkgDescription {
+  padding-top: 5px;
+  padding-bottom: 5px;
+  text-align: justify;
+}
+
+/* footnote support */
+
+blockquote sup {
+  position: absolute;
+  right: 3px;
+  top: 3px;
+}
+
+.footnote ol li:hover {
+  text-decoration: underline;
+}
+
+a.footnoteBackref,
+a.footnoteLink {
+  text-decoration: none;
+}
+
+ol.footnotesList {
+  margin: 0;
+  font-size: 0.8em;
+  padding-top: 5px;
+}
+
+ol.footnotesList>li {
+  text-indent: -1.5em;
+  padding-left: 1.5em;
+  vertical-align: top;
+}
+
+.footnoteBackReferenceGroup {
+  padding-right: 0.5em;
+}
+
+.footnoteBackref {
+  padding-right: 0.25em;
+}
+
+span.footnoteContent>p:first-child,
+span.footnoteContent>div:first-child {
+  display: inline;
+}
+
+span.footnoteContent p,
+span.footnoteContent div {
+  text-indent: 0em;
+}
+
+/* footnote support end */
+
+
+dl.section,
+dl.hasModels,
+dl.debugs,
+dl.models,
+dl.refines,
+dl.requires {
+  margin-left: 0px;
+  padding-left: 0px;
+}
+
+dl.section dt a,
+dl.hasModels dt a,
+dl.debugs dt a,
+dl.models dt a,
+dl.refines dt a,
+dl.advanced dt a,
+dl.requires dt a,
+dl.todo dt a,
+dl.bug dt a,
+dl.test dt a {
+  font-weight: bold;
+  color: black;
+}
+
+div.toc {
+  width: auto;
+}
+
+.ui-resizable-e {
+  background-repeat: repeat-y;
+}
+
+div.cgal_figure_caption {
+  text-align: center;
+}
+
+div.cgal_video_caption {
+  text-align: center;
+}
+
+div.groupText {
+  font-style: none;
+}
+
+#projectname {
+  font: 200% Tahoma, Arial, sans-serif;
+}
+
+#MSearchResultsWindow {
+  z-index: 2;
+}
+
+dl.note,
+dl.warning,
+dl.attention,
+dl.important,
+dl.caution,
+dl.pre,
+dl.post,
+dl.invariant,
+dl.deprecated,
+dl.todo,
+dl.test,
+dl.bug {
+  margin-left: 0px;
+  padding-left: 10px;
+  padding-top: 5px;
+  padding-bottom: 5px;
+  border-left: 4px solid;
+  border-radius: 0 4px 4px 0;
+}
+
+dl.warning,
+dl.attention,
+dl.caution {
+  background-color: var(--warning-bg);
+  border-color: var(--warning-border);
+}
+
+dl.note,
+dl.important,
+dl.info {
+  background-color: var(--note-bg);
+  border-color: var(--note-border);
+}
+
+dl.note .fragment,
+dl.warning .fragment,
+dl.attention .fragment,
+dl.important .fragment,
+dl.caution .fragment {
+  background-color: transparent;
+  border: none;
+  box-shadow: none;
+}
+
+dl.deprecated {
+  background: var(--deprecated-bg);
+  border: 1px solid var(--deprecated-border);
+  border-left: 4px solid var(--deprecated-border);
+  box-shadow: 0.5ex 0.5ex var(--deprecated-shadow);
+}
+
+div.CGALAdvanced {
+  background: var(--cgaladvanced-bg);
+  border: 1px solid var(--cgaladvanced-border);
+  box-shadow: 0.5ex 0.5ex var(--cgaladvanced-shadow);
+}
+
+div.CGALDebug {
+  background: var(--cgaldebug-bg);
+  border: 1px solid var(--cgaldebug-border);
+  box-shadow: 0.5ex 0.5ex var(--cgaldebug-shadow);
+}
+
+dl.deprecated {
+  background: var(--deprecated-bg);
+  border: 1px solid var(--deprecated-border);
+  box-shadow: 0.5ex 0.5ex var(--deprecated-shadow);
+}
+
+div.CGALAdvanced,
+div.CGALDebug,
+dl.deprecated {
+  border-radius: 1ex;
+  padding-top: 0.5ex;
+  padding-bottom: 0.25ex;
+  padding-left: 1ex;
+  padding-right: 1ex;
+  margin-bottom: 1ex;
+}
+
+div.CGALModification {
+  background: var(--cgalmodification-bg);
+  border: 1px solid var(--cgalmodification-border);
+  box-shadow: 0.5ex 0.5ex var(--cgalmodification-shadow);
+  border-radius: 1ex;
+  padding-top: 0.5ex;
+  padding-bottom: 0.25ex;
+  padding-left: 1ex;
+  padding-right: 1ex;
+  margin-bottom: 1ex;
+}
+
+.Modification {
+  background: var(--modification-bg);
+  border: 0px;
+  padding-top: 0ex;
+  padding-bottom: 0ex;
+  padding-left: 0ex;
+  padding-right: 0ex;
+  margin-bottom: 0ex;
+}
+
+/* The first div in CGALAdvanced sections is the "Advanced" header */
+div.CGALAdvanced>div,
+div.CGALDebug>div,
+dl.deprecated>dt>b>a {
+  font-style: italic;
+  font-weight: bold;
+}
+
+/* Everything else is noise and should stay in the normal font */
+div.CGALAdvanced>div~div,
+div.CGALDebug>div~div,
+dl.deprecated>dt~dt {
+  font-style: normal;
+  font-weight: normal;
+}
+
+/* More indentation for the text body */
+div.CGALAdvanced>p,
+div.CGALDebug>p,
+dl.deprecated>dd {
+  margin-left: 0;
+  margin-top: 1ex;
+  margin-bottom: 1ex;
+  padding-left: 1em;
+  padding-right: 1em;
+}
+
+div.fragment,
+code,
+tt,
+span.tt,
+.paramname {
+  background-color: transparent !important;
+}
+
+/* Make summary smaller to avoid wrapping of classes and concepts */
+div.summary {
+  width: auto;
+}
+
+.collapsible {
+  background-color: var(--collapsible-bg);
+  color: var(--collapsible-color);
+  cursor: pointer;
+  padding: 3px;
+  width: 100%;
+  border: none;
+  text-align: left;
+  outline: none;
+  font: 14px Roboto, sans-serif;
+  user-select: auto;
+}
+
+.active,
+.collapsible:hover {
+  background-color: var(--collapsible-bg);
+}
+
+.collapsible:after {
+  color: var(--collapsible-after-color);
+  content: '\25B6';
+  font-weight: bold;
+  float: left;
+  margin-left: -20px;
+  margin-right: 5px;
+}
+
+.active:after {
+  content: "\25BC";
+}
+
+.content {
+  color: var(--content-color);
+  background-color: var(--content-bg);
+  padding: 0 18px;
+  max-height: 0;
+  overflow: hidden;
+  transition: max-height 0.2s ease-out;
+}
+
+@media print {
+  .collapsible:after {
+    content: '';
+  }
+
+  .content {
+    max-height: unset;
+  }
+}
+
+table.iotable caption {
+  caption-side: top;
+}
+
+table.iotable {
+  border-collapse: collapse;
+  margin-top: 4px;
+  margin-bottom: 4px;
+}
+
+table.iotable td,
+table.iotable th {
+  border: 1px solid var(--iotable-border-color, #2D4068);
+  padding: 3px 7px 2px;
+}
+
+table.iotable th {
+  background-color: var(--iotable-th-bg, #374F7F);
+  color: var(--iotable-th-color, #FFFFFF);
+  font-size: 110%;
+  padding-bottom: 4px;
+  padding-top: 5px;
+}
+
+table.iotable th a,
+table.iotable th a:visited {
+  font-weight: bold;
+  color: var(--iotable-th-link-color, #FFFFFF);
+  text-decoration: underline;
+}
+
+th.associated-type {
+  box-sizing: border-box;
+  width: 780px;
+}
+
+th.description {
+  box-sizing: border-box;
+  width: 600px;
+}
+
+th.return-type {
+  box-sizing: border-box;
+  width: 450px;
+}
+
+th.valid-expression {
+  box-sizing: border-box;
+  width: 330px;
+}

--- a/Documentation/doc/resources/1.16.1/footer.html
+++ b/Documentation/doc/resources/1.16.1/footer.html
@@ -1,0 +1,21 @@
+<!-- HTML footer for doxygen 1.14.0-->
+<!-- start footer part -->
+<!-- The footer div is not part of the default but we require it to
+move the footer to the bottom of the page. -->
+<div id="footer">
+<!--BEGIN GENERATE_TREEVIEW-->
+<div id="nav-path" class="navpath"><!-- id is needed for treeview function! -->
+  <ul>
+    $navpath
+    <li class="footer">$generatedby <a href="https://www.doxygen.org/index.html"><img class="footer" src="$relpath^doxygen.svg" width="104" height="31" alt="doxygen"/></a> $doxygenversion </li>
+  </ul>
+</div>
+<!--END GENERATE_TREEVIEW-->
+<!--BEGIN !GENERATE_TREEVIEW-->
+<hr class="footer"/><address class="footer"><small>
+$generatedby&#160;<a href="https://www.doxygen.org/index.html"><img class="footer" src="$relpath^doxygen.svg" width="104" height="31" alt="doxygen"/></a> $doxygenversion
+</small></address>
+<!--END !GENERATE_TREEVIEW-->
+</div>
+</body>
+</html>

--- a/Documentation/doc/resources/1.16.1/hacks.js
+++ b/Documentation/doc/resources/1.16.1/hacks.js
@@ -1,0 +1,128 @@
+function generate_autotoc() {
+    var toc = $("#autotoc").append('<ul></ul>');
+    if(toc.length > 0) { // an autotoc has been requested
+        toc = toc.find('ul');
+        var indices = new Array();
+        indices[0] = 0;
+        indices[1] = 0;
+        indices[2] = 0;
+
+        $("h1, h2, h3").each(function(i) {
+            var current = $(this);
+            var levelTag = current[0].tagName.charAt(1);
+            var cur_id = current.attr("id");
+
+            indices[levelTag-1]+=1;  
+            var prefix=indices[0];
+            if (levelTag >1) prefix+="."+indices[1];
+            if (levelTag >2) prefix+="."+indices[2];
+            current.html(prefix + "   " + current.html());
+            for(var l = levelTag; l < 3; ++l){
+                indices[l] = 0;
+            }
+
+            if(cur_id == undefined) {
+                current.attr('id', 'title' + i);
+                current.addClass('anchor');
+                toc.append("<li class='level" + levelTag + "'><a id='link" + i + "' href='#title" +
+                           i + "' title='" + current.prop("tagName") + "'>" + current.text() + "</a></li>");
+            } else {
+                toc.append("<li class='level" + levelTag + "'><a id='" + cur_id + "' href='#title" +
+                           i + "' title='" + current.prop("tagName") + "'>" + current.text() + "</a></li>");
+            }
+
+        });
+    }
+}
+
+// throw a stick at the topics array and hijack gotoNode
+// for our own evil purposes
+$(document).ready(function() {
+    if (typeof topics !== 'undefined') {
+        // topics has been loaded, that means we are inside the
+        // documentation of a package
+        NAVTREE[0][2][1][1] = topics[0][1];
+        NAVTREE[0][2][1][2] = topics[0][2];
+        // override gotoNode from navtree.js
+        gotoNode = function (o,subIndex,root,hash,relpath) {
+            var nti = navTreeSubIndices[subIndex][root+hash];
+            if (!nti)
+            {
+              nti = navTreeSubIndices[subIndex][root];
+            }
+            if(nti && (nti[0] === 1 && nti[0])) {
+                nti.splice(1, 1);
+            }
+            o.breadcrumbs = $.extend(true, [], nti ? nti : navTreeSubIndices[subIndex][root]);
+            if (!o.breadcrumbs && root!=NAVTREE[0][1]) { // fallback: show index
+                navTo(o,NAVTREE[0][1],"",relpath);
+                $('.item').removeClass('selected');
+                $('.item').removeAttr('id');
+            }
+            if (o.breadcrumbs) {
+                o.breadcrumbs.unshift(0); // add 0 for root node
+                showNode(o, o.node, 0, hash);
+            }
+        }
+    }
+    // set-up footnote generation
+    $("#doc-content").append('<ol id="autoFootnotes0" class="footnotesList"></ol>');
+    $("body").footnotes();
+    generate_autotoc();
+});
+
+
+/* 
+ * A jQuery plugin by Brian Holt that will search the selected blocks for 
+ * specially-defined footnote elements.	 If found, these elements will be 
+ * moved to a footnotes section and links to and from the footnotes will 
+ * be created.
+ *
+ * See http://www.planetholt.com/articles/jQuery-Footnotes	
+ * for full documentation.
+ *
+ * By default, footnotes will be found in SPANs with the footnote class,
+ * and in BLOCKQUOTEs with a TITLE attribute.
+ *
+ * Thanks to CSSNewbies.com for the general idea, which I have enhanced 
+ * and implemented with as a jQuery plugin.
+ * 
+ * Copyright 2008-2009 Brian Holt.	
+ * Licensed under the LGPL license. See 
+ * http://www.gnu.org/licenses/lgpl-3.0-standalone.html
+ * 
+ * Version 1.2.2
+ */
+(function(c){c.fn.footnotes=function(d){var e=c.extend({},c.fn.footnotes.defaults,d);return this.each(function(f){b("INFO: Building footnotes for "+(f+1)+"...",e.debugMode);c(e.footnotes,this).addClass(e.autoFootnoteClass);var h=(""===e.contentBlock)?c(this):c(e.contentBlock,this),g=e.orderedList?"<ol/>":"<ul/>";c("."+e.autoFootnoteClass).each(function(l){var t=-1,n=f+"-"+l,q=c(this),j,r,s,u,p,m,o,k;if(e.singleFootnoteDestination){j=c("#"+e.destination);if(0===j.length){b("INFO: No #autoFootnotes found; adding our own",e.debugMode);j=c(g).attr("id",e.destination).addClass("footnotesList").appendTo(h)}}else{j=c("#"+e.destination+f);if(0===j.length){b("INFO: No #autoFootnotes"+f+" found; adding our own for "+(f+1),e.debugMode);j=c(g).attr("id",e.destination+f).addClass("footnotesList").appendTo(h)}}q.removeClass(e.autoFootnoteClass);r=e.fnExtractFootnote(this);t=-1;n=f+"-"+l;j.find("li > .footnoteContent").each(function(i){var v=c(this);if(v.html()===r){t=i;s=c(v.parents("li").get(0));return false}});if(-1===t){u=c("<a/>").attr("href","#cite-text-"+n).attr("name","cite-ref-"+n).attr("id","cite-ref-"+n).attr("dir","ltr").attr("title",r).text("["+(j.find("li").length+1)+"]").addClass("footnoteLink");if(q.is(e.prependTags)){c("<sup/>").prependTo(this).append(u)}else{c("<sup/>").appendTo(this).append(u)}p=c("<li/>").attr("id","cite-text-"+n);m=c("<span/>").addClass("footnoteBackReferenceGroup").appendTo(p);c("<span/>").addClass("footnoteContent").html(r).appendTo(p);u=c("<a/>").text("^").attr("href","#cite-ref-"+n).addClass("footnoteBackref").prependTo(m);j.append(p)}else{n=f+"-"+t;m=c(c("li > .footnoteBackReferenceGroup",j).get(t));o=m.find(".footnoteBackref");k=o.length;if(0===o.length){b("ERROR: $backRefs.length == 0, which should have prevented this code path",e.debugMode)}else{if(1===o.length){c("<sup/>").text("^ ").addClass("footnoteBackref").prependTo(m);o.html("<sup>a</sup>");++k}u=c("<a/>").attr("href","#"+s.attr("id")).attr("name","cite-ref-"+n+"-"+o.length).attr("id","cite-ref-"+n+"-"+o.length).attr("title",r).text("["+(t+1)+"]").addClass("footnoteLink");if(q.is(e.prependTags)){c("<sup/>").prependTo(this).append(u)}else{c("<sup/>").appendTo(this).append(u)}u=c("<a/>").attr("href","#cite-ref-"+n+"-"+o.length).addClass("footnoteBackref");if(k>=26){b("WARN: multiple letter functionality is probably broken when more than 26 footnotes exist",e.debugMode)}u.prepend(String.fromCharCode((k)+96));c("<sup/>").appendTo(m).append(u)}}});b("INFO: Done building footnotes for "+(f+1),e.debugMode)})};c.fn.footnotes.version=function(){return"1.2.2"};c.fn.footnotes.defaults={footnotes:"blockquote[title],span.footnote,blockquote[cite]",prependTags:"blockquote",singleFootnoteDestination:false,destination:"autoFootnotes",contentBlock:".content",autoFootnoteClass:"autoFootnote",fnExtractFootnote:a,orderedList:true,debugMode:true};function b(e,d){if(d){if(window.console&&window.console.log){window.console.log(e)}}}function a(i){var j=c(i),e,f,h,g,d;if(j.is("span.footnote")){e=c(i).html();f=/^(?:(?:&nbsp;)|\s)*\(([\S\s]+)\)(?:(?:&nbsp;)|\s)*$/;h=e.match(f);if(h&&2===h.length){e=h[1]}j.empty()}else{if(j.is("blockquote[title]")){g=j.attr("cite");e=j.attr("title");if(""!==g){d=c("<a/>").attr("href",g);if(0===c(e).length){e=d.text(e)}else{e=d.text(g).wrap("<span/>").parent().append(": "+e);j.attr("title","")}}}else{if(j.is("blockquote[cite]")){g=j.attr("cite");e=c("<a/>").attr("href",g).text(g)}}}return e}})(jQuery);
+(function(){
+    if(window.location.href.includes("doc.cgal.org")){ 
+      var url='https://doc.cgal.org/latest/Manual/menu_version.js';
+      var script = document.createElement("script"); // Make a script DOM node
+      script.src = url; // Set its src to the provided URL
+      document.head.appendChild(script);
+    }
+    else
+    {
+      var url='../Manual/menu_version.js';
+      var script = document.createElement("script"); // Make a script DOM node
+      script.src = url; // Set its src to the provided URL
+      document.head.appendChild(script);
+    }
+})();
+
+$(document).ready(function() {
+    var coll = document.getElementsByClassName("collapsible");
+    var i;
+
+    for (i = 0; i < coll.length; i++) {
+        coll[i].addEventListener("click", function() {
+            this.classList.toggle("active");
+            var content = this.nextElementSibling;
+            if (content.style.maxHeight){
+              content.style.maxHeight = null;
+            } else {
+              content.style.maxHeight = content.scrollHeight + "px";
+            }
+        });
+    }
+});

--- a/Documentation/doc/resources/1.16.1/header.html
+++ b/Documentation/doc/resources/1.16.1/header.html
@@ -1,0 +1,84 @@
+<!-- HTML header for doxygen 1.14.0-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$langISO">
+<head>
+<link rel="icon" type="image/png" href="$relpath$../Manual/g-196x196-doc.png"/>
+<meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=11"/>
+<meta name="generator" content="Doxygen $doxygenversion"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
+<!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
+<!-- <link href="$relpath^../Manual/tabs.css" rel="stylesheet" type="text/css"/> -->
+<!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN FULL_SIDEBAR-->
+<script type="text/javascript">var page_layout=1;</script>
+  <!--END FULL_SIDEBAR-->
+<!--END DISABLE_INDEX-->
+<script type="text/javascript" src="$relpath^../Manual/jquery.js"></script>
+<script type="text/javascript" src="$relpath^../Manual/dynsections.js"></script>
+<!--BEGIN COPY_CLIPBOARD-->
+<script type="text/javascript" src="$relpath^clipboard.js"></script>
+<!--END COPY_CLIPBOARD-->
+<script src="$relpath$../Manual/hacks.js" type="text/javascript"></script>
+$treeview
+$search
+$mathjax
+$darkmode
+<link href="$relpath^$stylesheet" rel="stylesheet" type="text/css" />
+<link href="$relpath$../Manual/cgal_stylesheet.css" rel="stylesheet" type="text/css" />
+$extrastylesheet
+</head>
+<body>
+<!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN FULL_SIDEBAR-->
+<div id="side-nav" class="ui-resizable side-nav-resizable"><!-- do not remove this div, it is closed by doxygen! -->
+  <!--END FULL_SIDEBAR-->
+<!--END DISABLE_INDEX-->
+<div id="top"><!-- do not remove this div, it is closed by doxygen! -->
+<div id="back-nav">
+  <ul>
+    <li><a href="https://www.cgal.org/">cgal.org</a></li>
+    <li><a href="../Manual/index.html">Top</a></li>
+    <li><a href="../Manual/general_intro.html">Getting Started</a></li>
+    <li><a href="../Manual/tutorials.html">Tutorials</a></li>
+    <li><a href="../Manual/packages.html">Package Overview</a></li>
+    <li><a href="../Manual/how_to_cite_cgal.html">Acknowledging CGAL</a></li>
+  </ul>
+  $searchbox
+</div>
+
+<!--BEGIN TITLEAREA-->
+<div id="titlearea">
+<table cellspacing="0" cellpadding="0">
+ <tbody>
+ <tr id="projectrow">
+  <!--BEGIN PROJECT_LOGO-->
+  <td id="projectlogo"><img alt="Logo" src="$relpath^$projectlogo"/></td>
+  <!--END PROJECT_LOGO-->
+  <!--BEGIN PROJECT_NAME-->
+  <td id="projectalign">
+   <div id="projectname">$projectname<!--BEGIN PROJECT_NUMBER--><span id="projectnumber">&#160;$projectnumber</span><!--END PROJECT_NUMBER-->
+   </div>
+   <!--BEGIN PROJECT_BRIEF--><div id="projectbrief">$projectbrief</div><!--END PROJECT_BRIEF-->
+  </td>
+  <!--END PROJECT_NAME-->
+  <!--BEGIN !PROJECT_NAME-->
+   <!--BEGIN PROJECT_BRIEF-->
+    <div id="projectbrief">$projectbrief</div>
+    </td>
+   <!--END PROJECT_BRIEF-->
+  <!--END !PROJECT_NAME-->
+  <!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN SEARCHENGINE-->
+  <!-- We disable the search box because we have added it in the
+  back-nav for stylistic reasons. -->
+  <!-- <td>$searchbox</td> -->
+  <!--END SEARCHENGINE-->
+  <!--END DISABLE_INDEX-->
+ </tr>
+ </tbody>
+</table>
+</div>
+<!--END TITLEAREA-->
+<!-- end header part -->

--- a/Documentation/doc/resources/1.16.1/header_package.html
+++ b/Documentation/doc/resources/1.16.1/header_package.html
@@ -1,0 +1,147 @@
+<!-- HTML header for doxygen 1.14.0-->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "https://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" lang="$langISO">
+<head>
+<link rel="icon" type="image/png" href="$relpath$../Manual/g-196x196-doc.png"/>
+<meta http-equiv="Content-Type" content="text/xhtml;charset=UTF-8"/>
+<meta http-equiv="X-UA-Compatible" content="IE=11"/>
+<meta name="generator" content="Doxygen $doxygenversion"/>
+<meta name="viewport" content="width=device-width, initial-scale=1"/>
+<!--BEGIN PROJECT_NAME--><title>$projectname: $title</title><!--END PROJECT_NAME-->
+<!--BEGIN !PROJECT_NAME--><title>$title</title><!--END !PROJECT_NAME-->
+<!-- <link href="$relpath^../Manual/tabs.css" rel="stylesheet" type="text/css"/> -->
+<!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN FULL_SIDEBAR-->
+<script type="text/javascript">var page_layout=1;</script>
+  <!--END FULL_SIDEBAR-->
+<!--END DISABLE_INDEX-->
+<script type="text/javascript" src="$relpath^../Manual/jquery.js"></script>
+<script type="text/javascript" src="$relpath^../Manual/dynsections.js"></script>
+<!--BEGIN COPY_CLIPBOARD-->
+<script type="text/javascript" src="$relpath^clipboard.js"></script>
+<!--END COPY_CLIPBOARD-->
+<script src="$relpath^../Manual/hacks.js" type="text/javascript"></script>
+<!-- Manually include treeview and search to avoid bloat and to fix
+     paths to the directory Manual . -->
+<!-- $.treeview -->
+<!-- $.search -->
+<link href="navtree.css" rel="stylesheet" type="text/css"/>
+<script src="$relpath^../Manual/cookie.js" type="text/javascript"></script>
+<script type="text/javascript" src="$relpath^../Manual/resize.js"></script>
+<script type="text/javascript" src="navtreedata.js"></script>
+<script type="text/javascript" src="navtree.js"></script>
+<script type="text/javascript">
+  $(document).ready(initResizable);
+</script>
+<link href="$relpath^../Manual/search/search.css" rel="stylesheet" type="text/css"/>
+<script type="text/javascript" src="$relpath^../Manual/search/searchdata.js"></script>
+<script type="text/javascript" src="$relpath^../Manual/search/search.js"></script>
+<script type="text/javascript">
+  $(document).ready(function() { init_search(); });
+</script>
+<link href="$relpath^../Manual/search/search.css" rel="stylesheet" type="text/css"/>
+<script type="text/javascript" src="../Manual/search/search.js"></script>
+<!-- Manually done below. -->
+<link href="$relpath^../Manual/$stylesheet" rel="stylesheet" type="text/css" />
+<link href="$relpath$../Manual/cgal_stylesheet.css" rel="stylesheet" type="text/css" />
+$mathjax
+$darkmode
+<script src="$relpath^topics.js" type="text/javascript"></script>
+$extrastylesheet
+</head>
+<body>
+<!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN FULL_SIDEBAR-->
+<div id="side-nav" class="ui-resizable side-nav-resizable"><!-- do not remove this div, it is closed by doxygen! -->
+  <!--END FULL_SIDEBAR-->
+<!--END DISABLE_INDEX-->
+<div id="top"><!-- do not remove this div, it is closed by doxygen! -->
+<div id="back-nav">
+  <ul>
+    <li><a href="https://www.cgal.org/">cgal.org</a></li>
+    <li><a href="../Manual/index.html">Top</a></li>
+    <li><a href="../Manual/general_intro.html">Getting Started</a></li>
+    <li><a href="../Manual/tutorials.html">Tutorials</a></li>
+    <li><a href="../Manual/packages.html">Package Overview</a></li>
+    <li><a href="../Manual/how_to_cite_cgal.html">Acknowledging CGAL</a></li>
+  </ul>
+  <!-- In a package SEARCHENGINE = false, so we cannot use $searchbox
+       insertion. That's why we have to do it manually here. Notice
+       that we also take pngs from the Manual. -->
+  <div id="MSearchBox" class="MSearchBoxInactive">
+      <span class="left">
+         <span id="MSearchSelect"
+               onmouseover="return searchBox.OnSearchSelectShow()"
+               onmouseout="return searchBox.OnSearchSelectHide()">&#160;
+        </span>
+        <input type="text" id="MSearchField" value="" placeholder="Search" accesskey="S"
+               onfocus="searchBox.OnSearchFieldFocus(true)"
+               onblur="searchBox.OnSearchFieldFocus(false)"
+               onkeyup="searchBox.OnSearchFieldChange(event)"/>
+      </span>
+      <span class="right">
+            <a id="MSearchClose" href="javascript:searchBox.CloseResultsWindow()"><img id="MSearchCloseImg" border="0" src="$relpath^../Manual/search/close.svg" alt=""/></a>
+      </span>
+  </div>
+
+</div>
+<!--BEGIN TITLEAREA-->
+<div id="titlearea">
+<table cellspacing="0" cellpadding="0">
+ <tbody>
+ <tr id="projectrow">
+  <!--BEGIN PROJECT_LOGO-->
+  <td id="projectlogo"><img alt="Logo" src="$relpath^$projectlogo"/></td>
+  <!--END PROJECT_LOGO-->
+  <!--BEGIN PROJECT_NAME-->
+  <td id="projectalign">
+   <div id="projectname">$projectname<!--BEGIN PROJECT_NUMBER--><span id="projectnumber">&#160;$projectnumber</span><!--END PROJECT_NUMBER-->
+   </div>
+   <!--BEGIN PROJECT_BRIEF--><div id="projectbrief">$projectbrief</div><!--END PROJECT_BRIEF-->
+  </td>
+  <!--END PROJECT_NAME-->
+  <!--BEGIN !PROJECT_NAME-->
+   <!--BEGIN PROJECT_BRIEF-->
+    <div id="projectbrief">$projectbrief</div>
+    </td>
+   <!--END PROJECT_BRIEF-->
+  <!--END !PROJECT_NAME-->
+  <!--BEGIN DISABLE_INDEX-->
+  <!--BEGIN SEARCHENGINE-->
+  <!-- We disable the search box because we have added it in the
+  back-nav for stylistic reasons. -->
+  <!-- <td>$.searchbox</td> -->
+  <!--END SEARCHENGINE-->
+  <!--END DISABLE_INDEX-->
+ </tr>
+ </tbody>
+</table>
+</div>
+<!-- Code below is usually inserted by doxygen when SEARCHENGINE =
+     true. Notice that the path to the search directory is adjusted to
+     the top-level.-->
+<script type="text/javascript">
+var searchBox = new SearchBox("searchBox", "../Manual/search/",'.html');
+</script>
+<!-- window showing the filter options -->
+<div id="MSearchSelectWindow"
+     onmouseover="return searchBox.OnSearchSelectShow()"
+     onmouseout="return searchBox.OnSearchSelectHide()"
+     onkeydown="return searchBox.OnSearchSelectKey(event)">
+</div>
+<!-- iframe showing the search results (closed by default) -->
+<div id="MSearchResultsWindow">
+<div id="MSearchResults">
+<div class="SRPage">
+<div id="SRIndex">
+<div id="SRResults"></div>
+<div class="SRStatus" id="Loading">Loading...</div>
+<div class="SRStatus" id="Searching">Searching...</div>
+<div class="SRStatus" id="NoMatches">No Matches</div>
+</div>
+</div>
+</div>
+</div>
+
+<!--END TITLEAREA-->
+<!-- end header part -->

--- a/Documentation/doc/resources/1.16.1/menu_version.js
+++ b/Documentation/doc/resources/1.16.1/menu_version.js
@@ -1,0 +1,110 @@
+(function() {
+  'use strict';
+
+  var url_re =  /(cgal\.geometryfactory\.com\/CGAL\/doc\/|doc\.cgal\.org\/)(main|latest|(\d\.\d+|\d\.\d+\.\d+)(-beta\d)?)\//;
+  var url_local =  /.*\/doc_output\//;
+  var current_version_local = 'main'
+  var all_versions = [
+    'main',
+    '6.1',
+    '6.0.2',
+    'latest',
+    '5.6.3',
+    '5.5.5',
+    '5.4.5',
+    '5.3.2',
+    '5.2.4',
+    '5.1.5',
+    '5.0.4',
+    '4.14.3',
+    '4.13.2',
+    '4.12.2',
+    '4.11.3',
+    '4.10.2',
+    '4.9.1',
+    '4.8.2',
+    '4.7',
+    '4.6.3',
+    '4.5.2',
+    '4.4',
+    '4.3'
+];
+
+  function build_select(current_version) {
+    if( current_version == 'main') {
+      let top_elt = document.getElementById("top");
+
+      let first_element = top_elt.childNodes[0];
+      let new_div = document.createElement("p");
+      new_div.innerHTML = '⚠️ This documentation corresponds to the <a style="font-family: monospace;" href="https://github.com/CGAL/cgal/tree/main">main</a> development branch of CGAL. It might diverge from the official releases.';
+      new_div.style.cssText = "background-color: #ff9800; margin: 1ex auto 1ex 1em; padding: 1ex; border-radius: 1ex; display: inline-block;"
+      let OK = top_elt.insertBefore(new_div, first_element);
+    }
+    var buf = ['<select>'];
+    $.each(all_versions, function(id) {
+      var version = all_versions[id];
+      buf.push('<option value="' + version + '"');
+      if (version == current_version) {
+        buf.push(' selected="selected">' + version);
+      } else {
+        buf.push('>' + version);
+      }
+      buf.push('</option>');
+    });
+    if ( !all_versions.includes(current_version)) {
+       buf.push('<option value="' + current_version + '"');
+       buf.push(' selected="selected">' + current_version);
+       buf.push('</option>');
+    }
+    buf.push('</select>');
+    return buf.join('');
+  }
+
+  function patch_url(url, new_version) {
+    if(url.includes("doc.cgal.org")||url.includes("cgal.geometryfactory.com")){
+      return url.replace(url_re, 'doc.cgal.org/' + new_version + '/');
+    }
+    else{
+      return url.replace(url_local, 'https://doc.cgal.org/' + new_version + '/');
+    }
+  }
+
+  function on_switch() {
+    var selected = $(this).children('option:selected').attr('value');
+    var url = window.location.href,
+        new_url = patch_url(url, selected);
+    if (new_url != url) {
+      window.location.href = new_url;
+    }
+  }
+
+  $(document).ready(function() {
+      var motherNode=$("#back-nav ul")[0];
+      var node = document.createElement("LI");
+      var spanNode = document.createElement("SPAN");
+      var titleNode =document.createTextNode("CGAL Version: ");
+      var textNode = document.createTextNode("x.y");
+      spanNode.setAttribute("class", "version_menu");
+      spanNode.appendChild(textNode);
+      node.appendChild(titleNode);
+      node.appendChild(spanNode);
+      motherNode.insertBefore(node, motherNode.firstChild);
+      $("#back-nav").css("padding-top", "0").css("padding-bottom", "0");
+      var match = url_re.exec(window.location.href);
+      if (match) {
+        var version = match[2];
+        var select = build_select(version);
+        spanNode.innerHTML=select;
+        $('.version_menu select').bind('change', on_switch);
+      }
+      else {
+        match = url_local.exec(window.location.href);
+        if (match) {
+          var version = current_version_local;
+          var select = build_select(version);
+          spanNode.innerHTML=select;
+          $('.version_menu select').bind('change', on_switch);
+        }
+     }
+  });
+})();

--- a/Documentation/doc/resources/1.16.1/test.html
+++ b/Documentation/doc/resources/1.16.1/test.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>CGAL CSS Test Page</title>
+  <link rel="stylesheet" href="cgal_stylesheet.css">
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+    }
+  </style>
+</head>
+<body>
+
+<div id="back-nav">Back Navigation</div>
+
+<div id="titlearea">Title Area</div>
+
+<div class="PkgImage">
+  <div class="image">
+    <img alt="" src="../../Documentation/fig/pkg-small.png">
+  </div>
+</div>
+
+<div class="package_section">
+  <h1 class=""><a class="anchor" id="PartPolyhedra"></a>
+    Cell Complexes and Polyhedra</h1>
+</div>
+
+<div class="CGALAdvanced">CGAL Advanced</div>
+<div class="CGALDebug">CGAL Debug</div>
+<dl class="deprecated">Deprecated</dl>
+<div class="CGALModification">CGAL Modification</div>
+<div class="Modification">Modification</div>
+
+<button class="collapsible">Collapsible</button>
+<div class="content">
+  Content inside collapsible.
+</div>
+
+<script>
+  var coll = document.getElementsByClassName("collapsible");
+  var i;
+
+  for (i = 0; i < coll.length; i++) {
+    coll[i].addEventListener("click", function() {
+      this.classList.toggle("active");
+      var content = this.nextElementSibling;
+      if (content.style.maxHeight){
+        content.style.maxHeight = null;
+      } else {
+        content.style.maxHeight = content.scrollHeight + "px";
+      }
+    });
+  }
+</script>
+
+</body>
+</html>


### PR DESCRIPTION
This PR addresses visual discrepancies introduced by Doxygen 1.16.1 in the CGAL documentation builds (see #9316). Newer Doxygen versions changed the default layout for commands like `\warning` and `\note`, resulting in oversized left bars and background color clashes, especially when code blocks were nested inside these elements.

#### Changes
- **Resources**: Added a new resource directory `Documentation/doc/resources/1.16.1` (initially branched from 1.14.0) to hold version-specific overrides.
- **CMake**: Updated `Documentation/doc/CMakeLists.txt` to recognize and use resources for Doxygen 1.16.1.
- **Styling Fixes**: 
    - Restored 4px left bars and consistent background colors for `\warning`, `\note`, `\attention`, `\important`, and `\caution`.
    - Set backgrounds of code blocks (`div.fragment`) and inline code to `transparent` when nested inside these boxes to prevent color clashes.
    - Unified styling for custom CGAL blocks (`\cgalAdvancedBegin`, `\cgalDebugBegin`) to maintain theme consistency.

Fixes #9316