### PR TITLE
Advancing Front: Write in file

### DIFF
--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_class.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_class.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <fstream>
 #include <algorithm>
+#include <filesystem>
+#include <string>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Advancing_front_surface_reconstruction.h>
 
@@ -13,7 +15,11 @@ typedef K::Vector_3 Vector_3;
 
 int main(int argc, char* argv[])
 {
-  std::ifstream in((argc>1)?argv[1]:CGAL::data_file_path("points_3/half.xyz"));
+  const std::string filename = (argc > 1) ?
+    argv[1] :CGAL::data_file_path("points_3/half.xyz");
+  const std::string stem = std::filesystem::path(filename).stem().string();
+
+  std::ifstream in(filename);
   std::istream_iterator<Point_3> begin(in);
   std::istream_iterator<Point_3> end;
 
@@ -25,7 +31,9 @@ int main(int argc, char* argv[])
 
   const TDS_2& tds = reconstruction.triangulation_data_structure_2();
 
-  std::cout << "solid produced with CGAL::Advancing_front_surface_reconstruction\n";
+  std::ofstream out(stem + ".off");
+  out.precision(17);
+  out << "solid produced with CGAL::Advancing_front_surface_reconstruction\n";
   for(TDS_2::Face_iterator fit = tds.faces_begin();
       fit != tds.faces_end();
       ++fit){
@@ -40,17 +48,17 @@ int main(int argc, char* argv[])
           j++;
         }
       }
-      std::cout << "  facet normal "
-                << CGAL::unit_normal(points[0],points[1], points[2]) << "\n"
-                << "  outer loop\n"
-                << "    vertex " << points[0]  << "\n"
-                << "    vertex " << points[1]  << "\n"
-                << "    vertex " << points[2]  << "\n"
-                << "  endloop\n"
-                << "  endfacet\n";
+      out << "  facet normal "
+          << CGAL::unit_normal(points[0],points[1], points[2]) << "\n"
+          << "  outer loop\n"
+          << "    vertex " << points[0]  << "\n"
+          << "    vertex " << points[1]  << "\n"
+          << "    vertex " << points[2]  << "\n"
+          << "  endloop\n"
+          << "  endfacet\n";
     }
   }
-    std::cout << "endsolid" << std::endl;
+  out << "endsolid" << std::endl;
 
   return 0;
 }

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_fct.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_fct.cpp
@@ -1,6 +1,8 @@
 #include <iostream>
 #include <fstream>
 #include <algorithm>
+#include <filesystem>
+#include <string>
 #include <CGAL/Simple_cartesian.h>
 #include <CGAL/Advancing_front_surface_reconstruction.h>
 #include <CGAL/tuple.h>
@@ -58,7 +60,11 @@ struct Perimeter {
 
 int main(int argc, char* argv[])
 {
-  std::ifstream in((argc>1)?argv[1]:CGAL::data_file_path("points_3/half.xyz"));
+  const std::string filename = (argc > 1) ?
+    argv[1] :CGAL::data_file_path("points_3/half.xyz");
+  const std::string stem = std::filesystem::path(filename).stem().string();
+
+  std::ifstream in(filename);
   double per = (argc>2)?boost::lexical_cast<double>(argv[2]):0;
   double radius_ratio_bound = (argc>3)?boost::lexical_cast<double>(argv[3]):5.0;
 
@@ -68,6 +74,7 @@ int main(int argc, char* argv[])
   std::copy(std::istream_iterator<Point_3>(in),
             std::istream_iterator<Point_3>(),
             std::back_inserter(points));
+  std::cout << "Read " << points.size() << " points" << std::endl;
 
   Perimeter perimeter(per);
   CGAL::advancing_front_surface_reconstruction(points.begin(),
@@ -76,13 +83,15 @@ int main(int argc, char* argv[])
                                                perimeter,
                                                radius_ratio_bound);
 
-  std::cout << "OFF\n" << points.size() << " " << facets.size() << " 0\n";
+  std::ofstream out(stem + ".off");
+  out.precision(17);
+  out << "OFF\n" << points.size() << " " << facets.size() << " 0\n";
   std::copy(points.begin(),
             points.end(),
-            std::ostream_iterator<Point_3>(std::cout, "\n"));
+            std::ostream_iterator<Point_3>(out, "\n"));
   std::copy(facets.begin(),
             facets.end(),
-            std::ostream_iterator<Facet>(std::cout, "\n"));
+            std::ostream_iterator<Facet>(out, "\n"));
 
   return 0;
 }

--- a/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_surface_mesh.cpp
+++ b/Advancing_front_surface_reconstruction/examples/Advancing_front_surface_reconstruction/reconstruction_surface_mesh.cpp
@@ -2,6 +2,8 @@
 #include <fstream>
 #include <algorithm>
 #include <array>
+#include <filesystem>
+#include <string>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 #include <CGAL/Advancing_front_surface_reconstruction.h>
 #include <CGAL/Surface_mesh.h>
@@ -51,7 +53,11 @@ struct Construct{
 
 int main(int argc, char* argv[])
 {
-  std::ifstream in((argc>1)?argv[1]:CGAL::data_file_path("points_3/half.xyz"));
+  const std::string filename = (argc > 1) ?
+    argv[1] :CGAL::data_file_path("points_3/half.xyz");
+  const std::string stem = std::filesystem::path(filename).stem().string();
+
+  std::ifstream in(filename);
   std::vector<Point_3> points;
   Mesh m;
 
@@ -65,7 +71,9 @@ int main(int argc, char* argv[])
                                                points.end(),
                                                construct);
 
-  std::cout << m  << std::endl;
+  std::ofstream out(stem + ".off");
+  out.precision(17);
+  out << m  << std::endl;
 
   return 0;
 }

--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -2105,11 +2105,11 @@ namespace CGAL {
         }
       while((!_ordered_border.empty())&&(K <= K)&&(min_K != infinity())&&(K!=K_prev));
 
-#ifdef VERBOSE
+#ifdef AFSR_VERBOSE
       if ((min_K < infinity())&&(!_ordered_border.empty())) {
         std::cout << "   [ next K required = " << min_K << " ]" << std::endl;
       }
-#endif // VERBOSE
+#endif
     }
 
 
@@ -2445,7 +2445,7 @@ namespace CGAL {
               }
             while (!L_v.empty() && (L_v.size() < itmp));
           }
-#ifdef VERBOSE
+#ifdef AFSR_VERBOSE
           if(L_v.size() > 0){
             std::cout << "   " << L_v.size() << " non-regular points." << std::endl;
           }
@@ -2604,6 +2604,7 @@ namespace CGAL {
     typedef Kernel::Point_3 Point_3;
 
     CC cc=CC();
+
     Triangulation_3 dt( boost::make_transform_iterator(b, AFSR::Auto_count_cc<Point_3,CC>(cc)),
                         boost::make_transform_iterator(e, AFSR::Auto_count_cc<Point_3,CC>(cc) )  );
 
@@ -2667,7 +2668,6 @@ namespace CGAL {
     CC cc=CC();
     Triangulation_3 dt( boost::make_transform_iterator(b, AFSR::Auto_count_cc<Point_3,CC>(cc)),
                         boost::make_transform_iterator(e, AFSR::Auto_count_cc<Point_3,CC>(cc) )  );
-
     Reconstruction R(dt);
     R.run(radius_ratio_bound, beta);
     AFSR::construct_polyhedron(polyhedron, R);

--- a/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
+++ b/Advancing_front_surface_reconstruction/include/CGAL/Advancing_front_surface_reconstruction.h
@@ -2105,7 +2105,7 @@ namespace CGAL {
         }
       while((!_ordered_border.empty())&&(K <= K)&&(min_K != infinity())&&(K!=K_prev));
 
-#ifdef AFSR_VERBOSE
+#ifdef CGAL_AFSR_VERBOSE
       if ((min_K < infinity())&&(!_ordered_border.empty())) {
         std::cout << "   [ next K required = " << min_K << " ]" << std::endl;
       }
@@ -2445,7 +2445,7 @@ namespace CGAL {
               }
             while (!L_v.empty() && (L_v.size() < itmp));
           }
-#ifdef AFSR_VERBOSE
+#ifdef CGAL_AFSR_VERBOSE
           if(L_v.size() > 0){
             std::cout << "   " << L_v.size() << " non-regular points." << std::endl;
           }


### PR DESCRIPTION
## Summary of Changes

In the examples, write the resulting mesh in a file with the same stem as the input file.

## Release Management

* Affected package(s): Advancing_front_reconstruction
* License and copyright ownership:  unchanged

