### PR TITLE
Add override specifier to Cartesian kernel transformation representations

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_rep_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_rep_2.h
@@ -102,7 +102,7 @@ friend class Reflection_repC2<R>;
       t21(m21), t22(m22), t23(m23)
   {}
 
-  Point_2 transform(const Point_2& p) const
+  Point_2 transform(const Point_2& p) const override
   {
     typename R::Construct_point_2 construct_point_2;
     return construct_point_2(t11 * p.x() + t12 * p.y() + t13,
@@ -110,14 +110,14 @@ friend class Reflection_repC2<R>;
   }
 
   // note that a vector is not translated
-  Vector_2 transform(const Vector_2& v) const
+  Vector_2 transform(const Vector_2& v) const override
   {
     return Vector_2(t11 * v.x() + t12 * v.y(),
                     t21 * v.x() + t22 * v.y());
   }
 
   // note that a direction is not translated
-  Direction_2 transform(const Direction_2& dir) const
+  Direction_2 transform(const Direction_2& dir) const override
   {
     return Direction_2(t11 * dir.dx() + t12 * dir.dy(),
                        t21 * dir.dx() + t22 * dir.dy());
@@ -125,20 +125,20 @@ friend class Reflection_repC2<R>;
 
   // Note that Aff_transformation is not defined yet,
   // so the following 6 functions have to be implemented later...
-  Aff_transformation_2 inverse() const;
-  Aff_transformation_2 operator*(const Aff_t_base &t) const;
-  Aff_transformation_2 compose(const Self &t) const;
-  Aff_transformation_2 compose(const Translation_repC2<R> &t) const;
-  Aff_transformation_2 compose(const Rotation_repC2<R> &t) const;
-  Aff_transformation_2 compose(const Scaling_repC2<R> &t) const;
-  Aff_transformation_2 compose(const Reflection_repC2<R> &t) const;
+  Aff_transformation_2 inverse() const override;
+  Aff_transformation_2 operator*(const Aff_t_base &t) const override;
+  Aff_transformation_2 compose(const Self &t) const override;
+  Aff_transformation_2 compose(const Translation_repC2<R> &t) const override;
+  Aff_transformation_2 compose(const Rotation_repC2<R> &t) const override;
+  Aff_transformation_2 compose(const Scaling_repC2<R> &t) const override;
+  Aff_transformation_2 compose(const Reflection_repC2<R> &t) const override;
 
-  bool is_even() const
+  bool is_even() const override
   {
     return sign_of_determinant(t11, t12, t21, t22) == POSITIVE;
   }
 
-  FT cartesian(int i, int j) const
+  FT cartesian(int i, int j) const override
   {
     switch (i)
     {
@@ -164,7 +164,7 @@ friend class Reflection_repC2<R>;
     return FT(0);
   }
 
-  std::ostream &print(std::ostream &os) const
+  std::ostream &print(std::ostream &os) const override
   {
     os <<"Aff_transformationC2(" <<t11<<" "<<t12<<" "<<t13<<std::endl;
     os <<"                     " <<t21<<" "<<t22<<" "<<t23<<")";

--- a/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_rep_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Aff_transformation_rep_3.h
@@ -105,10 +105,10 @@ public:
       t31(m31), t32(m32), t33(m33), t34(m34)
   {}
 
-  virtual ~Aff_transformation_repC3()
+  ~Aff_transformation_repC3() override
   {}
 
-  virtual Point_3 transform(const Point_3& p) const // FIXME : construction
+  Point_3 transform(const Point_3& p) const override // FIXME : construction
   {
     typename R::Construct_point_3 construct_point_3;
     return construct_point_3(t11 * p.x() + t12 * p.y() + t13 * p.z() + t14,
@@ -117,7 +117,7 @@ public:
   }
 
   // note that a vector is not translated
-  virtual Vector_3 transform(const Vector_3& v) const // FIXME : construction
+  Vector_3 transform(const Vector_3& v) const override // FIXME : construction
   {
     return Vector_3(t11 * v.x() + t12 * v.y() + t13 * v.z(),
                     t21 * v.x() + t22 * v.y() + t23 * v.z(),
@@ -125,7 +125,7 @@ public:
   }
 
   // note that a direction is not translated
-  virtual Direction_3 transform(const Direction_3& dir) const
+  Direction_3 transform(const Direction_3& dir) const override
   { // FIXME : construction
     Vector_3 v = dir.to_vector();
     return Direction_3(t11 * v.x() + t12 * v.y() + t13 * v.z(),
@@ -133,7 +133,7 @@ public:
                        t31 * v.x() + t32 * v.y() + t33 * v.z());
   }
 
-  virtual Plane_3 transform(const Plane_3& p) const
+  Plane_3 transform(const Plane_3& p) const override
   {
       if (is_even())
       return Plane_3(transform(p.point()),
@@ -147,14 +147,14 @@ public:
   // Note that Aff_transformation is not defined yet,
   // so the following 6 functions have to be implemented
   // outside class body
-  virtual Aff_transformation_3 inverse() const;
-  virtual Aff_transformation_3 transpose() const;
-  virtual Aff_transformation_3 operator*(const Transformation_base_3 &t) const;
-  virtual Aff_transformation_3 compose(const Transformation_3 &t) const;
-  virtual Aff_transformation_3 compose(const Translation_3 &t) const;
-  virtual Aff_transformation_3 compose(const Scaling_3 &t) const;
+  Aff_transformation_3 inverse() const override;
+  Aff_transformation_3 transpose() const override;
+  Aff_transformation_3 operator*(const Transformation_base_3 &t) const override;
+  Aff_transformation_3 compose(const Transformation_3 &t) const override;
+  Aff_transformation_3 compose(const Translation_3 &t) const override;
+  Aff_transformation_3 compose(const Scaling_3 &t) const override;
 
-  virtual bool is_even() const
+  bool is_even() const override
   {
     return sign_of_determinant(t11, t12, t13,
                                   t21, t22, t23,
@@ -162,7 +162,7 @@ public:
   }
 
 
-  virtual FT cartesian(int i, int j) const
+  FT cartesian(int i, int j) const override
   {
     switch (i)
     {
@@ -198,7 +198,7 @@ public:
   return FT(0);
   }
 
-  virtual std::ostream &print(std::ostream &os) const
+  std::ostream &print(std::ostream &os) const override
   {
     os <<"Aff_transformationC3("<<t11<<' '<<t12<<' '<<t13<<' '<<t14<<std::endl;
     os <<"                     "<<t21<<' '<<t22<<' '<<t23<<' '<<t24<<std::endl;

--- a/Cartesian_kernel/include/CGAL/Cartesian/Reflection_rep_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Reflection_rep_2.h
@@ -56,41 +56,41 @@ typedef typename CGAL::Line_2<R>                 Line_2;
     cosinus_ = 2*sq_cos-1;
   }
 
-  ~Reflection_repC2()
+  ~Reflection_repC2() override
   {}
 
-  Point_2      transform(const Point_2 &p) const
+  Point_2      transform(const Point_2 &p) const override
   {
     return Point_2(
           cosinus_*p.x()+sinus_*p.y()-cosinus_*t.x()-sinus_*t.y()+t.x(),
           sinus_*p.x()-cosinus_*p.y()-sinus_*t.x()+cosinus_*t.y()+t.y());
   }
 
-  Vector_2      transform(const Vector_2 &p) const
+  Vector_2      transform(const Vector_2 &p) const override
   {
     return Vector_2(
           cosinus_*p.x()+sinus_*p.y()-cosinus_*t.x()-sinus_*t.y()+t.x(),
           sinus_*p.x()-cosinus_*p.y()-sinus_*t.x()+cosinus_*t.y()+t.y());
   }
 
-  Direction_2  transform(const Direction_2 &d) const
+  Direction_2  transform(const Direction_2 &d) const override
   {
 
     return transform(d.vector()).direction();
   }
 
-  Aff_transformation_2 operator*(const Aff_t_base &t) const
+  Aff_transformation_2 operator*(const Aff_t_base &t) const override
   {
     return t.compose(*this);
   }
 
-  Aff_transformation_2 compose(const Translation &tr) const
+  Aff_transformation_2 compose(const Translation &tr) const override
   {
     return Aff_transformation_2(cosinus_, sinus_, t13()+tr.translationvector_.x(),
                                 sinus_, -cosinus_, t23()+tr.translationvector_.y());
   }
 
-  Aff_transformation_2 compose(const Scaling &s) const
+  Aff_transformation_2 compose(const Scaling &s) const override
   {
     return Aff_transformation_2(s.scalefactor_ * cosinus_,
                                 s.scalefactor_ * sinus_,
@@ -100,7 +100,7 @@ typedef typename CGAL::Line_2<R>                 Line_2;
                                 s.scalefactor_ * t23());
   }
 
-  Aff_transformation_2 compose(const Transformation &tr) const
+  Aff_transformation_2 compose(const Transformation &tr) const override
   {
     return Aff_transformation_2(
           tr.t11*cosinus_+tr.t12*sinus_,
@@ -111,7 +111,7 @@ typedef typename CGAL::Line_2<R>                 Line_2;
           tr.t21*t13()+tr.t22*t23()+tr.t23);
   }
 
-  Aff_transformation_2 compose(const Rotation &r) const
+  Aff_transformation_2 compose(const Rotation &r) const override
   {
     return Aff_transformation_2(
           r.cosinus_*cosinus_-r.sinus_*sinus_,
@@ -124,7 +124,7 @@ typedef typename CGAL::Line_2<R>                 Line_2;
           +r.cosinus_*t23());
   }
 
-  Aff_transformation_2 compose(const Reflection &r) const
+  Aff_transformation_2 compose(const Reflection &r) const override
   {
     return Aff_transformation_2(
           cosinus_*r.cosinus_+sinus_*r.sinus_,
@@ -136,23 +136,23 @@ typedef typename CGAL::Line_2<R>                 Line_2;
           r.sinus_*(t13()-r.t.x()) -r.cosinus_*(t23()-r.t.y())+r.t.y());
   }
 
-  Aff_transformation_2  inverse() const
+  Aff_transformation_2  inverse() const override
   {
     return Aff_transformation_2(cartesian(0,0), cartesian(0,1), cartesian(0,2),
                                 cartesian(1,0), cartesian(1,1), cartesian(1,2));
   }
 
-  bool is_even() const
+  bool is_even() const override
   {
     return true;
   }
 
- virtual bool is_reflection() const
+ bool is_reflection() const override
   {
     return true;
   }
 
-  FT cartesian(int i, int j) const
+  FT cartesian(int i, int j) const override
   {
     switch (i)
     {
@@ -178,7 +178,7 @@ typedef typename CGAL::Line_2<R>                 Line_2;
     return FT(0);
   }
 
-  std::ostream &print(std::ostream &os) const
+  std::ostream &print(std::ostream &os) const override
   {
     os << "Aff_transformationC2(" << sinus_ << ", " << cosinus_ <<  "; "<< t <<")";
     return os;

--- a/Cartesian_kernel/include/CGAL/Cartesian/Rotation_rep_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Rotation_rep_2.h
@@ -66,35 +66,35 @@ public:
     cosinus_ = cos_num/denom;
   }
 
-  Point_2      transform(const Point_2 &p) const
+  Point_2      transform(const Point_2 &p) const override
   {
     return Point_2(cosinus_ * p.x() - sinus_ * p.y(),
                    sinus_ * p.x() + cosinus_ * p.y());
   }
 
-  Vector_2     transform(const Vector_2 &v) const
+  Vector_2     transform(const Vector_2 &v) const override
   {
     return Vector_2(cosinus_ * v.x() - sinus_ * v.y(),
                     sinus_ * v.x() + cosinus_ * v.y());
   }
 
-  Direction_2  transform(const Direction_2 &d) const
+  Direction_2  transform(const Direction_2 &d) const override
   {
     return Direction_2(cosinus_ * d.dx() - sinus_ * d.dy(),
                        sinus_ * d.dx() + cosinus_ * d.dy());
   }
 
-  Aff_transformation_2 inverse() const
+  Aff_transformation_2 inverse() const override
   {
     return Aff_transformation_2(ROTATION, - sinus_, cosinus_, FT(1));
   }
 
-  Aff_transformation_2 operator*(const Aff_t_base &t) const
+  Aff_transformation_2 operator*(const Aff_t_base &t) const override
   {
     return t.compose(*this);
   }
 
-  Aff_transformation_2 compose(const Translation &t) const
+  Aff_transformation_2 compose(const Translation &t) const override
   {
     return Aff_transformation_2(cosinus_,
                                 -sinus_,
@@ -104,14 +104,14 @@ public:
                                 t.translationvector_.y());
   }
 
-  Aff_transformation_2 compose(const Rotation &t) const
+  Aff_transformation_2 compose(const Rotation &t) const override
   {
     return Aff_transformation_2(ROTATION,
                                 t.sinus_*cosinus_ + t.cosinus_*sinus_,
                                 t.cosinus_*cosinus_-t.sinus_*sinus_ );
   }
 
-  Aff_transformation_2 compose(const Scaling &t) const
+  Aff_transformation_2 compose(const Scaling &t) const override
   {
     return Aff_transformation_2(t.scalefactor_*cosinus_,
                                 t.scalefactor_*-sinus_,
@@ -119,7 +119,7 @@ public:
                                 t.scalefactor_*cosinus_);
   }
 
-  Aff_transformation_2 compose(const Reflection &r) const
+  Aff_transformation_2 compose(const Reflection &r) const override
   {
     return Aff_transformation_2(
           r.cosinus_*cosinus_+r.sinus_*sinus_,
@@ -130,7 +130,7 @@ public:
           , r.t23());
   }
 
-  Aff_transformation_2 compose(const Transformation &t) const
+  Aff_transformation_2 compose(const Transformation &t) const override
   {
     return Aff_transformation_2(cosinus_*t.t11 + sinus_*t.t12,
                                 -sinus_*t.t11 + cosinus_*t.t12,
@@ -140,17 +140,17 @@ public:
                                 t.t23);
   }
 
-  bool is_even() const
+  bool is_even() const override
   {
     return true;
   }
 
-  bool is_rotation() const
+  bool is_rotation() const override
   {
     return true;
   }
 
-  FT cartesian(int i, int j) const
+  FT cartesian(int i, int j) const override
   {
     switch (i)
     {
@@ -176,7 +176,7 @@ public:
     return FT(0);
   }
 
-  std::ostream &print(std::ostream &os) const
+  std::ostream &print(std::ostream &os) const override
   {
     os << "Aff_transformationC2(" << sinus_ << ", " << cosinus_ <<  ")";
     return os;

--- a/Cartesian_kernel/include/CGAL/Cartesian/Scaling_rep_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Scaling_rep_2.h
@@ -47,30 +47,30 @@ public:
     scalefactor_(scalefactor)
   {}
 
-  ~Scaling_repC2()
+  ~Scaling_repC2() override
   {}
 
-  Point_2      transform(const Point_2 &p) const
+  Point_2      transform(const Point_2 &p) const override
   {
     return Point_2(scalefactor_ * p.x(), scalefactor_ * p.y());
   }
 
-  Vector_2      transform(const Vector_2 &p) const
+  Vector_2      transform(const Vector_2 &p) const override
   {
     return Vector_2(scalefactor_ * p.x(), scalefactor_ * p.y());
   }
 
-  Direction_2  transform(const Direction_2 &d) const
+  Direction_2  transform(const Direction_2 &d) const override
   {
     return d;
   }
 
-  Aff_transformation_2 operator*(const Aff_t_base &t) const
+  Aff_transformation_2 operator*(const Aff_t_base &t) const override
   {
    return t.compose(*this);
   }
 
-  Aff_transformation_2 compose(const Translation &t) const
+  Aff_transformation_2 compose(const Translation &t) const override
   {
     FT ft0(0);
     return Aff_transformation_2(scalefactor_,
@@ -81,7 +81,7 @@ public:
                                 t.translationvector_.y());
   }
 
-  Aff_transformation_2 compose(const Rotation &t) const
+  Aff_transformation_2 compose(const Rotation &t) const override
   {
     return Aff_transformation_2(scalefactor_ * t.cosinus_,
                                 scalefactor_ * -t.sinus_,
@@ -89,18 +89,18 @@ public:
                                 scalefactor_ * t.cosinus_);
   }
 
-  Aff_transformation_2 compose(const Reflection &r) const
+  Aff_transformation_2 compose(const Reflection &r) const override
   {
     return Aff_transformation_2(scalefactor_*r.cosinus_, scalefactor_*r.sinus_,-r.cosinus_*r.t.x()-r.sinus_*r.t.y()+r.t.x(),
                                 scalefactor_*r.sinus_, -scalefactor_*r.cosinus_, -r.sinus_*r.t.x()+r.cosinus_*r.t.y()-r.t.y());
   }
 
-  Aff_transformation_2 compose(const Scaling &t) const
+  Aff_transformation_2 compose(const Scaling &t) const override
   {
     return Aff_transformation_2(SCALING, scalefactor_*t.scalefactor_);
   }
 
-  Aff_transformation_2 compose(const Transformation &t) const
+  Aff_transformation_2 compose(const Transformation &t) const override
   {
     return Aff_transformation_2(scalefactor_ * t.t11,
                                 scalefactor_ * t.t12,
@@ -110,28 +110,28 @@ public:
                                 t.t23);
   }
 
-  Aff_transformation_2  inverse() const
+  Aff_transformation_2  inverse() const override
   {
     return Aff_transformation_2(SCALING, FT(1)/scalefactor_);
   }
 
-  bool is_even() const
+  bool is_even() const override
   {
     return true;
   }
 
-  bool is_scaling() const
+  bool is_scaling() const override
   {
     return true;
   }
 
-  FT cartesian(int i, int j) const
+  FT cartesian(int i, int j) const override
   {
     if (i!=j) return FT(0);
     return (i==2) ? FT(1) : scalefactor_;
   }
 
-  std::ostream &print(std::ostream &os) const
+  std::ostream &print(std::ostream &os) const override
   {
     os << "Aff_transformationC2(" << scalefactor_ <<  ")";
     return os;

--- a/Cartesian_kernel/include/CGAL/Cartesian/Scaling_rep_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Scaling_rep_3.h
@@ -40,38 +40,38 @@ public:
 
   Scaling_repC3() {}
   Scaling_repC3(const FT &s) : scalefactor_(s) {}
-  virtual ~Scaling_repC3() {}
+  ~Scaling_repC3() override {}
 
-  virtual Point_3      transform(const Point_3 &p) const
+  Point_3      transform(const Point_3 &p) const override
   {
     return Point_3(scalefactor_ * p.x(),
                    scalefactor_ * p.y(),
                    scalefactor_ * p.z());
   }
 
-  virtual Vector_3     transform(const Vector_3 &v) const
+  Vector_3     transform(const Vector_3 &v) const override
   {
     return Vector_3(scalefactor_ * v.x(), scalefactor_ * v.y(),
                     scalefactor_ * v.z());
   }
 
-  virtual Direction_3  transform(const Direction_3 &d) const
+  Direction_3  transform(const Direction_3 &d) const override
   {
     return d;
   }
 
-  virtual Plane_3  transform(const Plane_3 &p) const
+  Plane_3  transform(const Plane_3 &p) const override
   {
     // direction ( which is (p.a(), p.b(), p.c())) does not change
     return Plane_3(p.a(),p.b(),p.c(), p.d()*scalefactor_);
   }
 
-  virtual Aff_transformation_3 operator*(const Transformation_base_3 &t) const
+  Aff_transformation_3 operator*(const Transformation_base_3 &t) const override
   {
     return t.compose(*this);
   }
 
-  virtual Aff_transformation_3 compose(const Transformation_3 &t) const
+  Aff_transformation_3 compose(const Transformation_3 &t) const override
   {
     return Aff_transformation_3(scalefactor_ * t.t11,
                                 scalefactor_ * t.t12,
@@ -89,7 +89,7 @@ public:
                                 t.t34);
   }
 
-  virtual Aff_transformation_3 compose(const Translation_3 &t) const
+  Aff_transformation_3 compose(const Translation_3 &t) const override
   {
     FT ft0(0);
     return Aff_transformation_3(scalefactor_,
@@ -108,39 +108,39 @@ public:
                                 t.translationvector_.z());
   }
 
-  virtual Aff_transformation_3 compose(const Scaling_3 &t) const
+  Aff_transformation_3 compose(const Scaling_3 &t) const override
   {
     return Aff_transformation_3(SCALING, scalefactor_*t.scalefactor_);
   }
 
-  virtual Aff_transformation_3 inverse() const
+  Aff_transformation_3 inverse() const override
   {
     return Aff_transformation_3(SCALING, FT(1)/scalefactor_);
   }
 
-  virtual Aff_transformation_3 transpose() const
+  Aff_transformation_3 transpose() const override
   {
     return Aff_transformation_3(SCALING, scalefactor_);
   }
 
-  virtual bool is_even() const
+  bool is_even() const override
   {
     return true;
   }
 
-  virtual bool is_scaling() const
+  bool is_scaling() const override
   {
     return true;
   }
 
-  virtual FT cartesian(int i, int j) const
+  FT cartesian(int i, int j) const override
   {
     if (i!=j) return FT(0);
     if (i==3) return FT(1);
     return scalefactor_;
   }
 
-  virtual std::ostream &print(std::ostream &os) const
+  std::ostream &print(std::ostream &os) const override
   {
     os << "Aff_transformationC3(" << scalefactor_ << ")";
     return os;

--- a/Cartesian_kernel/include/CGAL/Cartesian/Translation_rep_2.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Translation_rep_2.h
@@ -49,27 +49,27 @@ public:
     : translationvector_(tv)
   {}
 
-  Point_2     transform(const Point_2 &p) const
+  Point_2     transform(const Point_2 &p) const override
   {
     typename R::Construct_translated_point_2 translated_point;
     return translated_point(p, translationvector_);
   }
 
-  Vector_2    transform(const Vector_2 &v) const { return v; }
-  Direction_2 transform(const Direction_2 &d) const { return d; }
+  Vector_2    transform(const Vector_2 &v) const override { return v; }
+  Direction_2 transform(const Direction_2 &d) const override { return d; }
 
-  Aff_transformation_2 operator*(const Aff_t_base &t) const
+  Aff_transformation_2 operator*(const Aff_t_base &t) const override
   {
     return t.compose(*this);
   }
 
-  Aff_transformation_2 compose(const Translation &t) const
+  Aff_transformation_2 compose(const Translation &t) const override
   {
     return Aff_transformation_2(TRANSLATION,
                                 translationvector_ + t.translationvector_);
   }
 
-  Aff_transformation_2 compose(const Rotation &t) const
+  Aff_transformation_2 compose(const Rotation &t) const override
   {
     return Aff_transformation_2(t.cosinus_,
                                 -t.sinus_,
@@ -82,7 +82,7 @@ public:
                                 t.cosinus_*translationvector_.y());
   }
 
-  Aff_transformation_2 compose(const Scaling &t) const
+  Aff_transformation_2 compose(const Scaling &t) const override
   {
     return Aff_transformation_2(t.scalefactor_,
                                 FT(0),
@@ -93,7 +93,7 @@ public:
                                 t.scalefactor_*translationvector_.y());
   }
 
-  Aff_transformation_2 compose(const Transformation &t) const
+  Aff_transformation_2 compose(const Transformation &t) const override
   {
     return Aff_transformation_2(t.t11,
                                 t.t12,
@@ -108,7 +108,7 @@ public:
                                 + t.t23);
   }
 
-  Aff_transformation_2 compose(const Reflection &r) const
+  Aff_transformation_2 compose(const Reflection &r) const override
   {
     return Aff_transformation_2(r.cosinus_, r.sinus_,
                                 r.cosinus_*(translationvector_.x()-r.t.x())+r.sinus_*(translationvector_.y() - r.t.y()) +r.t.x(),
@@ -116,29 +116,29 @@ public:
                                 r.sinus_*(translationvector_.x()-r.t.x())-r.cosinus_*(translationvector_.y() - r.t.y())+r.t.y());
   }
 
-  Aff_transformation_2 inverse() const
+  Aff_transformation_2 inverse() const override
   {
     return Aff_transformation_2(TRANSLATION, - translationvector_);
   }
 
-  bool is_even() const
+  bool is_even() const override
   {
     return true;
   }
 
-  virtual bool is_translation() const
+  bool is_translation() const override
   {
     return true;
   }
 
-  FT cartesian(int i, int j) const
+  FT cartesian(int i, int j) const override
   {
     if (j==i) return FT(1);
     if (j==2) return translationvector_[i];
     return FT(0);
   }
 
-  std::ostream &print(std::ostream &os) const
+  std::ostream &print(std::ostream &os) const override
   {
     os << "Aff_transformationC2(VectorC2(" << translationvector_.x() << ", "
        << translationvector_.y()  <<  "))";

--- a/Cartesian_kernel/include/CGAL/Cartesian/Translation_rep_3.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/Translation_rep_3.h
@@ -40,24 +40,24 @@ public:
 
   Translation_repC3() {}
   Translation_repC3(const Vector_3 &tv) : translationvector_(tv) {}
-  virtual ~Translation_repC3() {}
+  ~Translation_repC3() override {}
 
-  virtual Point_3     transform(const Point_3 &p) const
+  Point_3     transform(const Point_3 &p) const override
   {
     return p + translationvector_;
   }
 
-  virtual Vector_3    transform(const Vector_3 &v) const
+  Vector_3    transform(const Vector_3 &v) const override
   {
     return v;
   }
 
-  virtual Direction_3 transform(const Direction_3 &d) const
+  Direction_3 transform(const Direction_3 &d) const override
   {
     return d;
   }
 
-  virtual Plane_3 transform(const Plane_3 &p) const
+  Plane_3 transform(const Plane_3 &p) const override
   {
     // direction ( which is (p.a(), p.b(), p.c())) does not change
     return Plane_3(p.a(),
@@ -66,12 +66,12 @@ public:
                    p.d()  - ( p.a()*translationvector_.x() + p.b()*translationvector_.y() + p.c()*translationvector_.z()));
   }
 
-  virtual Aff_transformation_3 operator*(const Transformation_base_3 &t) const
+  Aff_transformation_3 operator*(const Transformation_base_3 &t) const override
   {
     return t.compose(*this);
   }
 
-  virtual Aff_transformation_3 compose(const Transformation_3 &t) const
+  Aff_transformation_3 compose(const Transformation_3 &t) const override
   {
     return Aff_transformation_3(t.t11,
                                 t.t12,
@@ -95,13 +95,13 @@ public:
                                 + t.t33 * translationvector_.z() + t.t34);
   }
 
-  virtual Aff_transformation_3 compose(const Translation_3 &t) const
+  Aff_transformation_3 compose(const Translation_3 &t) const override
   {
     return Aff_transformation_3(TRANSLATION,
                                 translationvector_ + t.translationvector_);
   }
 
-  virtual Aff_transformation_3 compose(const Scaling_3 &t) const
+  Aff_transformation_3 compose(const Scaling_3 &t) const override
   {
     FT ft0(0);
     return Aff_transformation_3(t.scalefactor_,
@@ -120,34 +120,34 @@ public:
                                 t.scalefactor_ * translationvector_.z());
   }
 
-  virtual Aff_transformation_3 inverse() const
+  Aff_transformation_3 inverse() const override
   {
     return Aff_transformation_3(TRANSLATION, - translationvector_);
   }
 
-  virtual Aff_transformation_3 transpose() const
+  Aff_transformation_3 transpose() const override
   {
     return Aff_transformation_3(TRANSLATION, translationvector_);
   }
 
-  virtual bool is_even() const
+  bool is_even() const override
   {
     return true;
   }
 
-  virtual bool is_translation() const
+  bool is_translation() const override
   {
     return true;
   }
 
-  virtual FT cartesian(int i, int j) const
+  FT cartesian(int i, int j) const override
   {
     if (j==i) return FT(1);
     if (j==3) return translationvector_[i];
     return FT(0);
   }
 
-  virtual std::ostream &print(std::ostream &os) const
+  std::ostream &print(std::ostream &os) const override
   {
     os << "Aff_transformationC3(VectorC3("<< translationvector_.x() << ","
        << translationvector_.y() << ","


### PR DESCRIPTION
## Summary of Changes
It adds the `override` specifier to all overridden virtual functions and removes the redundant `virtual` keyword in the following classes:

* **3D:** `Aff_transformation_repC3`, `Translation_repC3`, `Scaling_repC3`
* **2D:** `Aff_transformation_repC2`, `Translation_repC2`, `Scaling_repC2`, `Rotation_repC2`, `Reflection_repC2`

These changes ensure adherence to **C++ Core Guideline C.128** ("Virtual functions should specify exactly one of virtual, override, or final"). This improves code safety by enforcing compile-time checks against accidental signature mismatches.

## Release Management

* **Affected package(s):** `Kernel_23`
* **Issue(s) solved (if any):**
* **Feature/Small Feature (if any):**
* **Link to compiled documentation:**
* **License and copyright ownership:**