### PR TITLE
Correcting references for METIS

### DIFF
--- a/BGL/doc/BGL/PackageDescription.txt
+++ b/BGL/doc/BGL/PackageDescription.txt
@@ -584,7 +584,7 @@ both in term of time and memory.
 \addtogroup PkgBGLPartition
 
 Methods to split a mesh into subdomains, using the library
-<a href="http://glaros.dtc.umn.edu/gkhome/metis/metis/overview">METIS</a> or a graphcut
+<a href="https://github.com/KarypisLab/METIS">METIS</a> or a graphcut
 implementation.
 */
 

--- a/BGL/include/CGAL/boost/graph/METIS/partition_dual_graph.h
+++ b/BGL/include/CGAL/boost/graph/METIS/partition_dual_graph.h
@@ -163,7 +163,7 @@ void partition_dual_graph(const TriangleMesh& tm, int nparts,
 ///     \cgalParamDefault{an array of size `METIS_NOPTIONS` with value type `idx_t`,
 ///                       initialized using the function `METIS_SetDefaultOptions()`}
 ///     \cgalParamExtra{The many options of METIS are not described here. Instead, users should refer
-///                     to the <a href="http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/manual.pdf">documentation</a>
+///                     to the <a href="https://github.com/KarypisLab/METIS/blob/master/manual/manual.pdf">documentation</a>
 ///                     of METIS directly.}
 ///   \cgalParamNEnd
 ///

--- a/BGL/include/CGAL/boost/graph/METIS/partition_graph.h
+++ b/BGL/include/CGAL/boost/graph/METIS/partition_graph.h
@@ -199,7 +199,7 @@ void partition_graph(const TriangleMesh& tm, int nparts,
 ///     \cgalParamDefault{an array of size `METIS_NOPTIONS` with value type `idx_t`,
 ///                       initialized using the function `METIS_SetDefaultOptions()`}
 ///     \cgalParamExtra{The many options of METIS are not described here. Instead, users should refer
-///                     to the <a href="http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/manual.pdf">documentation</a>
+///                     to the <a href="https://github.com/KarypisLab/METIS/blob/master/manual/manual.pdf">documentation</a>
 ///                     of METIS directly.}
 ///   \cgalParamNEnd
 ///

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -2260,7 +2260,7 @@ Release date: April 2018
     METIS functions `METIS_PartMeshNodal` and `METIS_PartMeshDual` are
     offered.
 
-    [METIS library]: http://glaros.dtc.umn.edu/gkhome/metis/metis/overview
+    [METIS library]: https://github.com/KarypisLab/METIS
 
 ## Release 4.11
 


### PR DESCRIPTION
Seen the problems with the website where METIS was hosted (see https://github.com/KarypisLab/METIS/issues/78) there is a new website, this has been implemented now.



