### PR TITLE
Fix viewer edge and vertex scaling based on fixed small number and vi…

### DIFF
--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -1479,21 +1479,27 @@ protected:
   {
     if(!m_scene.empty())
     {
-      auto& bbox=m_scene.bounding_box();
-      double d=is_two_dimensional()
-              ?2.5
-              : CGAL::sqrt(CGAL::squared_distance
-                           (Local_point(bbox.xmin(), bbox.ymin(), bbox.zmin()),
-                            Local_point(bbox.xmax(), bbox.ymax(), bbox.zmax())));
-      // std::cout<<"Length of the diagonal: "<<d<<std::endl;
-      // std::cout<<"width: "<< this->width() <<std::endl;
-      // std::cout<<"height: "<< this->height() <<std::endl;
-
+      CGAL::Bbox_3 bbox = m_scene.bbox();
+      double bbox_diagonal = CGAL::sqrt(
+        CGAL::squared_distance(
+         Local_point(bbox.xmin(),bbox.ymin(),bbox.zmin()),
+         Local_point(bbox.xmax(),bbox.ymax(),bbox.zmax())
+        )
+      );
+      int viewport_size = std::min(this->width(),this->height());
+      double d=(bbox_diagonal/viewport_size)*2.5;
       m_size_vertices=1.5*d;
       m_size_edges=d;
-      m_size_rays=m_size_edges;
-      m_size_lines=m_size_edges;
-      m_size_normals=d/3;
+      m_size_rays=d;
+      m_size_lines=d;
+      m_size_normals=d/3.0;
+      m_height_factor_normals=0.02;
+    } else {
+      m_size_vertices=1.0;
+      m_size_edges=1.0;
+      m_size_rays=1.0;
+      m_size_lines=1.0;
+      m_size_normals=0.5;
       m_height_factor_normals=0.02;
     }
   }


### PR DESCRIPTION
## Summary of Changes

Fixes vertex and edge scaling in Basic_viewer for both 2D and 3D scenes. Previously, the size was based on the bounding box diagonal, resulting in overly large edges and vertices.

Changes:

- Calculates size based on pixel-to-world-space ratio (bbox_diagonal / viewport_size).

- Scales result by factor of 2.5 to maintain ~2.5 pixel visual width

- Provides reasonable default sizes when the scene is empty.

- Ensures consistent behavior across 2D and 3D views

## Release Management

- Affected package(s): Basic_viewer (Qt package)

- Issue(s) solved (if any): #9327

- Feature/Small Feature (if any): 

- Link to compiled documentation: 

- License and copyright ownership: Unchanged

