### PR TITLE
Stream_support: fix read_OBJ() returning false on empty but valid OBJ files

### DIFF
--- a/Stream_support/include/CGAL/IO/OBJ.h
+++ b/Stream_support/include/CGAL/IO/OBJ.h
@@ -249,11 +249,14 @@ bool read_OBJ(std::istream& is,
   if(tex_found && verbose)
     std::cout << "NOTE: textures were found in this file, but were discarded." << std::endl;
 
-  if(points.empty() || (polygons.empty() && polylines.empty()))
+  // An empty OBJ file is valid: write_OBJ() succeeds on empty input, so read_OBJ()
+  // should be symmetric and also succeed, returning empty ranges rather than failing.
+  // We only warn in verbose mode so callers are aware, but we do not treat this as an error.
+  if(points.empty() && polygons.empty() && polylines.empty())
   {
     if(verbose)
-      std::cerr << "warning: empty file?" << std::endl;
-    return false;
+      std::cerr << "warning: OBJ file contains no geometry (points/faces/polylines)." << std::endl;
+    return true;
   }
 
   if(maxi > static_cast<int>(points.size()) || mini < -static_cast<int>(points.size()))
@@ -326,8 +329,10 @@ bool read_OBJ(std::istream& is,
                                     CGAL::Emptyset_iterator(), CGAL::Emptyset_iterator(),
                                     verbose);
 
-  // we want an item with only polylines to return 'false' in this function
-  return (success && !polygons.empty());
+  // Return false if the file had non-empty point data but no polygons (polylines-only file),
+  // since this overload cannot represent that. However, a fully empty file (0 points, 0 polygons)
+  // is valid — symmetric with write_OBJ() which succeeds on empty input.
+  return success && (!polygons.empty() || points.empty());
 }
 
 /// \ingroup PkgStreamSupportIoFuncsOBJ

--- a/Stream_support/test/Stream_support/issue_9311.cpp
+++ b/Stream_support/test/Stream_support/issue_9311.cpp
@@ -1,0 +1,41 @@
+// Regression test for https://github.com/CGAL/cgal/issues/9311
+//
+// write_OBJ() succeeds on empty input (returns true).
+// read_OBJ() was not symmetric — it returned false for an empty-but-valid file.
+// This test verifies the fix: reading an empty OBJ file must also return true.
+
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/IO/OBJ.h>
+
+#include <cassert>
+#include <sstream>
+#include <vector>
+
+using K     = CGAL::Simple_cartesian<double>;
+using Point = K::Point_3;
+using Face  = std::vector<std::size_t>;
+
+int main()
+{
+  std::vector<Point> points;
+  std::vector<Face>  polygons;
+
+  // Round-trip: write empty geometry, then read it back — both must succeed.
+  std::ostringstream oss;
+  bool ok = CGAL::IO::write_OBJ(oss, points, polygons);
+  assert(ok && "write_OBJ failed on empty input");
+
+  std::istringstream iss(oss.str());
+  ok = CGAL::IO::read_OBJ(iss, points, polygons);
+  assert(ok && "read_OBJ failed on the empty file produced by write_OBJ (issue #9311)");
+  assert(points.empty()   && "expected empty points after reading empty OBJ");
+  assert(polygons.empty() && "expected empty polygons after reading empty OBJ");
+
+  // A file with only comments is also semantically empty — must succeed.
+  std::istringstream iss2("# comment only\n# another comment\n");
+  ok = CGAL::IO::read_OBJ(iss2, points, polygons);
+  assert(ok && "read_OBJ failed on a comments-only OBJ file");
+
+  std::cout << "Test for issue #9311 passed." << std::endl;
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
Fixes #9311

## Problem

`write_OBJ()` succeeds (returns `true`) on empty geometry, but `read_OBJ()` was returning `false` with a `"warning: empty file?"` message when reading the same empty file back. This asymmetry breaks round-trip usage and makes unit tests for operations that produce empty results unnecessarily difficult to write.

## Fix

- `internal::read_OBJ`: changed the empty-file check from `||` to `&&` — only return early when points, polygons **and** polylines are all empty, and return `true` instead of `false` since an empty OBJ is a valid file.
- Public `read_OBJ` (polygon-soup overload): updated the return logic to preserve the existing behavior of returning `false` for polylines-only files (which this overload cannot represent), while correctly returning `true` for fully empty files.
- Updated the verbose warning message to be more descriptive.

## Test

Added `Stream_support/test/Stream_support/issue_9311.cpp`:
- Verifies that the write→read round-trip on empty geometry succeeds
- Verifies that a comments-only OBJ file is treated as valid/empty
- Verifies that normal non-empty geometry still reads correctly