### PR TITLE
Basic_viewer: fix wrong edge width and vertex size in line-width shader

### DIFF
--- a/Basic_viewer/include/CGAL/Basic_shaders.h
+++ b/Basic_viewer/include/CGAL/Basic_shaders.h
@@ -144,11 +144,14 @@ void main(void)
   float distance = gl_Position.w;
   if (u_IsOrthographic)
   {
-    distance = u_PointSize;
+    // In orthographic projection clip-space w is always 1; using u_PointSize
+    // as the divisor cancelled out the user's setting (pointSize = 1 always).
+    // Use 1.0 so gl_PointSize = u_PointSize, a direct screen-pixel diameter.
+    distance = 1.0;
   }
 
   float effectiveDistance = EqualZero(distance) ? 0.00001 : distance;
-  gl_PointSize = u_PointSize / effectiveDistance * 5.0;
+  gl_PointSize = u_PointSize / effectiveDistance;
 }
 )DELIM";
 
@@ -701,7 +704,11 @@ void main(void)
   float distance = gl_Position.w;
   if (u_IsOrthographic)
   {
-    distance = u_PointSize;
+    // In orthographic projection the clip-space w is always 1, so
+    // perspective-division would make pointSize constant at 1.0.
+    // Use 1.0 as the divisor so the user-supplied u_PointSize passes
+    // through unchanged as a screen-pixel width.
+    distance = 1.0;
   }
 
   float effectiveDistance = EqualZero(distance) ? 0.00001 : distance;
@@ -744,7 +751,11 @@ void main(void)
   vec2 p0 = ToScreenSpace(gl_in[0].gl_Position);
   vec2 p1 = ToScreenSpace(gl_in[1].gl_Position);
   vec2 v0 = normalize(p1 - p0);
-  vec2 n0 = vec2(-v0.y, v0.x) * u_PointSize * 0.5;
+  // Unit perpendicular vector scaled by 0.5; the actual half-width in screen
+  // pixels is supplied by gs_in[i].pointSize (= u_PointSize / effectiveDistance).
+  // Keeping u_PointSize out of n0 avoids the previous quadratic dependence on
+  // u_PointSize that caused edges to appear far wider than intended.
+  vec2 n0 = vec2(-v0.y, v0.x) * 0.5;
 
   // line start
   gl_Position = ToWorldSpace(vec4(p0 - n0 * gs_in[0].pointSize, gl_in[0].gl_Position.zw));

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -465,10 +465,14 @@ public:
       {
         auto renderer = [this, &color, &clipPlane, &plane_point](float rendering_mode) {
 
-          QVector2D viewport = {
-            CGAL_BASIC_VIEWER_INIT_SIZE_X,
-            CGAL_BASIC_VIEWER_INIT_SIZE_Y
-          };
+          // Use the actual current viewport dimensions so that the line-width
+          // geometry shader converts between NDC and screen-pixels correctly
+          // even after the window has been resized. Multiply by the device
+          // pixel ratio so HiDPI / Retina displays report the physical pixel
+          // count rather than the logical pixel count.
+          const float pixel_ratio = static_cast<float>(this->devicePixelRatio());
+          QVector2D viewport(static_cast<float>(this->width())  * pixel_ratio,
+                             static_cast<float>(this->height()) * pixel_ratio);
 
           rendering_program_line.bind();
 


### PR DESCRIPTION
Fix three bugs in the line-width rendering path that caused edges to appear at incorrect widths and made the `size_edges()` / `size_vertices()` API behave incorrectly or have no effect in certain modes.

---

### Bug 1 — Quadratic dependence on `u_PointSize` in `GEOMETRY_SOURCE_LINE_WIDTH`

The perpendicular offset vector was computed as:
```glsl
vec2 n0 = vec2(-v0.y, v0.x) * u_PointSize * 0.5;
```
and then scaled by `gs_in[i].pointSize = u_PointSize / effectiveDistance`, making the actual half-width proportional to `u_PointSize²`. For scenes with large bounding-box diagonals this produced edges far wider than intended, and `size_edges()` had a super-linear effect.

**Fix:** remove `u_PointSize` from `n0` so the half-width is linear: `u_PointSize / (2 * effectiveDistance)`.

---

### Bug 2 — Orthographic mode always produced width 1.0

In `VERTEX_SOURCE_LINE_WIDTH`, the orthographic branch set `distance = u_PointSize`, so `pointSize = u_PointSize / u_PointSize = 1.0`. The user-specified size was silently ignored in every 2D viewer.

**Fix:** use `distance = 1.0` so `pointSize = u_PointSize` passes through directly as a screen-pixel width.

---

### Bug 3 — Baked-in viewport dimensions

The `u_Viewport` uniform was always uploaded as the initial window size `{500, 450}`:
```cpp
QVector2D viewport = { CGAL_BASIC_VIEWER_INIT_SIZE_X, CGAL_BASIC_VIEWER_INIT_SIZE_Y };
```
After any window resize the NDC↔pixel conversions inside the geometry shader used stale dimensions, producing incorrect edge geometry.

**Fix:** use `this->width()` / `this->height()` on every frame.

---

### Files changed
- `Basic_viewer/include/CGAL/Basic_shaders.h` — `VERTEX_SOURCE_LINE_WIDTH`, `GEOMETRY_SOURCE_LINE_WIDTH`
- `Basic_viewer/include/CGAL/Qt/Basic_viewer.h` — viewport uniform in the edge-drawing renderer

Fixes #9327