### PR TITLE
Stream_support: add read_MSH / write_MSH for the Gmsh MSH 2.2 format

### DIFF
--- a/Stream_support/include/CGAL/IO/MSH.h
+++ b/Stream_support/include/CGAL/IO/MSH.h
@@ -1,0 +1,653 @@
+// Copyright (c) 2025  GeometryFactory Sarl (France).
+// All rights reserved.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Rajdeep Singh
+
+#ifndef CGAL_IO_MSH_H
+#define CGAL_IO_MSH_H
+
+#include <CGAL/IO/helpers.h>
+#include <CGAL/Named_function_parameters.h>
+#include <CGAL/boost/graph/named_params_helper.h>
+
+#include <boost/range/value_type.hpp>
+#include <boost/range/size.hpp>
+
+#include <iostream>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace CGAL {
+
+namespace IO {
+
+// ============================================================================
+// MSH 2.2 element type codes for surface elements
+// ============================================================================
+
+namespace internal {
+
+static const int MSH_LINE         = 1;  // 2-node line (skip)
+static const int MSH_TRIANGLE     = 2;  // 3-node triangle
+static const int MSH_QUAD         = 3;  // 4-node quadrangle
+static const int MSH_POINT        = 15; // 1-node point  (skip)
+
+// Nodes per element type (for the types we care about)
+inline int msh_nodes_for_type(int etype)
+{
+  switch(etype)
+  {
+    case MSH_LINE:      return 2;
+    case MSH_TRIANGLE:  return 3;
+    case MSH_QUAD:      return 4;
+    case MSH_POINT:     return 1;
+    // higher-order triangles / quads
+    case 9:             return 6;   // 6-node triangle
+    case 10:            return 9;   // 9-node quadrangle
+    case 16:            return 8;   // 8-node quadrangle
+    case 21:            return 10;  // 10-node triangle
+    // volume elements (skip)
+    case 4:             return 4;   // tet
+    case 5:             return 8;   // hex
+    case 6:             return 6;   // prism
+    case 7:             return 5;   // pyramid
+    case 11:            return 10;  // 10-node tet
+    case 17:            return 20;  // 20-node hex
+    // default: unknown, we'll skip these
+    default:            return -1;
+  }
+}
+
+} // namespace internal
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Read
+
+/*!
+ * \ingroup PkgStreamSupportIoFuncsMSH
+ *
+ * \brief reads the content of `is` into `points` and `polygons`, using the
+ *        Gmsh \ref IOStreamMSH format (version 2.2, ASCII).
+ *
+ * Only surface elements (triangles and quadrangles) are extracted; higher-dimensional
+ * elements (tetrahedra, hexahedra, …) and lower-dimensional elements (lines, points)
+ * are silently skipped.  Mixed meshes that contain both surface and volume elements are
+ * therefore handled correctly: only the boundary/surface faces end up in the polygon soup.
+ *
+ * \attention The polygon soup is not cleared, and the data from the stream are appended.
+ *
+ * \tparam PointRange a model of the concepts `RandomAccessContainer` and `BackInsertionSequence`
+ *                    whose value type is the point type
+ * \tparam PolygonRange a model of the concepts `SequenceContainer` and `BackInsertionSequence`
+ *                      whose `value_type` is itself a model of the concepts `SequenceContainer`
+ *                      and `BackInsertionSequence` whose `value_type` is an unsigned integer type
+ *                      convertible to `std::size_t`
+ * \tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
+ *
+ * \param is the input stream
+ * \param points points of the soup of polygons
+ * \param polygons a range of polygons. Each element in it describes a polygon
+ *        using the indices of the points in `points`.
+ * \param np optional \ref bgl_namedparameters "Named Parameters" described below
+ *
+ * \cgalNamedParamsBegin
+ *   \cgalParamNBegin{verbose}
+ *     \cgalParamDescription{indicates whether output warnings and error messages should be printed or not.}
+ *     \cgalParamType{Boolean}
+ *     \cgalParamDefault{`false`}
+ *   \cgalParamNEnd
+ * \cgalNamedParamsEnd
+ *
+ * \returns `true` if the reading was successful, `false` otherwise.
+ */
+template <typename PointRange, typename PolygonRange, typename CGAL_NP_TEMPLATE_PARAMETERS>
+bool read_MSH(std::istream& is,
+              PointRange& points,
+              PolygonRange& polygons,
+              const CGAL_NP_CLASS& np = parameters::default_values()
+#ifndef DOXYGEN_RUNNING
+              , std::enable_if_t<internal::is_Range<PolygonRange>::value>* = nullptr
+#endif
+              )
+{
+  typedef typename boost::range_value<PointRange>::type    Point;
+  typedef typename boost::range_value<PolygonRange>::type  Polygon;
+
+  const bool verbose = parameters::choose_parameter(
+      parameters::get_parameter(np, internal_np::verbose), false);
+
+  if(!is.good())
+  {
+    if(verbose)
+      std::cerr << "Error: stream is not readable." << std::endl;
+    return false;
+  }
+
+  // ---- State flags --------------------------------------------------------
+  bool found_mesh_format = false;
+  bool found_nodes       = false;
+  bool found_elements    = false;
+  bool binary_mode       = false;
+
+  // gmsh node indices are 1-based.  Map gmsh_tag → 0-based index in `points`.
+  std::unordered_map<std::size_t, std::size_t> node_index;
+
+  std::string line;
+  while(std::getline(is, line))
+  {
+    // ---- $MeshFormat -------------------------------------------------------
+    if(line == "$MeshFormat")
+    {
+      std::string version_str;
+      int file_type = 0;
+      int data_size = 8;
+
+      if(!std::getline(is, line)) break;
+      std::istringstream iss(line);
+      iss >> version_str >> file_type >> data_size;
+
+      if(file_type != 0)
+      {
+        if(verbose)
+          std::cerr << "Warning: binary MSH files are not supported; only ASCII (file-type 0) is handled." << std::endl;
+        binary_mode = true;
+        // We still set found_mesh_format so the caller gets a clean 'false'
+      }
+
+      // Accept versions 2.x
+      double version = 2.0; // default if parsing fails
+      try { version = std::stod(version_str); }
+      catch(const std::invalid_argument&) {}
+      catch(const std::out_of_range&) {}
+      if(version < 2.0 || version >= 3.0)
+      {
+        if(verbose)
+          std::cerr << "Warning: MSH version " << version_str
+                    << " detected; only version 2.x is supported." << std::endl;
+        // still attempt to parse
+      }
+
+      found_mesh_format = true;
+
+      // consume $EndMeshFormat
+      if(!std::getline(is, line)) break; // "$EndMeshFormat"
+      continue;
+    }
+
+    // ---- bail early if binary -----------------------------------------------
+    if(binary_mode)
+      continue;
+
+    // ---- $PhysicalNames (optional, skip) ------------------------------------
+    if(line == "$PhysicalNames")
+    {
+      // skip until $EndPhysicalNames
+      while(std::getline(is, line) && line != "$EndPhysicalNames")
+        ;
+      continue;
+    }
+
+    // ---- $Nodes -------------------------------------------------------------
+    if(line == "$Nodes")
+    {
+      std::size_t num_nodes = 0;
+      if(!std::getline(is, line)) break;
+      {
+        std::istringstream iss(line);
+        iss >> num_nodes;
+      }
+
+      bool nodes_ok = true;
+      for(std::size_t i = 0; i < num_nodes; ++i)
+      {
+        if(!std::getline(is, line))
+        {
+          if(verbose)
+            std::cerr << "Error: unexpected end of file inside $Nodes." << std::endl;
+          nodes_ok = false;
+          break;
+        }
+        std::istringstream iss(line);
+        std::size_t tag;
+        double x, y, z;
+        if(!(iss >> tag >> x >> y >> z))
+        {
+          if(verbose)
+            std::cerr << "Error: malformed node line: " << line << std::endl;
+          nodes_ok = false;
+          break;
+        }
+        node_index[tag] = points.size();
+        Point p;
+        internal::fill_point(x, y, z, 1.0, p);
+        points.push_back(p);
+      }
+
+      if(!nodes_ok)
+        return false;
+
+      // consume $EndNodes
+      if(!std::getline(is, line)) break; // "$EndNodes"
+      found_nodes = true;
+      continue;
+    }
+
+    // ---- $Elements ----------------------------------------------------------
+    if(line == "$Elements")
+    {
+      std::size_t num_elements = 0;
+      if(!std::getline(is, line)) break;
+      {
+        std::istringstream iss(line);
+        iss >> num_elements;
+      }
+
+      bool elements_ok = true;
+      for(std::size_t i = 0; i < num_elements; ++i)
+      {
+        if(!std::getline(is, line))
+        {
+          if(verbose)
+            std::cerr << "Error: unexpected end of file inside $Elements." << std::endl;
+          elements_ok = false;
+          break;
+        }
+
+        std::istringstream iss(line);
+        std::size_t elem_tag;
+        int elem_type, num_tags;
+
+        if(!(iss >> elem_tag >> elem_type >> num_tags))
+        {
+          if(verbose)
+            std::cerr << "Error: malformed element line: " << line << std::endl;
+          elements_ok = false;
+          break;
+        }
+
+        // Skip the tags (physical group, elementary entity, …)
+        for(int t = 0; t < num_tags; ++t)
+        {
+          int tag_val;
+          if(!(iss >> tag_val))
+          {
+            if(verbose)
+              std::cerr << "Error: could not read tag " << t
+                        << " for element " << elem_tag << "." << std::endl;
+            elements_ok = false;
+            break;
+          }
+        }
+        if(!elements_ok)
+          break;
+
+        int node_count = internal::msh_nodes_for_type(elem_type);
+        if(node_count < 0)
+        {
+          // Unknown element type — we can still try to parse by reading until end of line
+          // (already consumed by getline), just skip.
+          if(verbose)
+            std::cerr << "Warning: unknown element type " << elem_type
+                      << " (element " << elem_tag << "), skipping." << std::endl;
+          continue;
+        }
+
+        // Read node indices for this element
+        std::vector<std::size_t> elem_nodes(node_count);
+        bool node_ok = true;
+        for(int n = 0; n < node_count; ++n)
+        {
+          std::size_t nid;
+          if(!(iss >> nid))
+          {
+            if(verbose)
+              std::cerr << "Error: could not read node indices for element "
+                        << elem_tag << "." << std::endl;
+            node_ok = false;
+            break;
+          }
+
+          auto it = node_index.find(nid);
+          if(it == node_index.end())
+          {
+            if(verbose)
+              std::cerr << "Error: element " << elem_tag
+                        << " references unknown node " << nid << "." << std::endl;
+            node_ok = false;
+            break;
+          }
+          elem_nodes[n] = it->second;
+        }
+
+        if(!node_ok)
+        {
+          elements_ok = false;
+          break;
+        }
+
+        // Only add surface elements to the polygon soup
+        if(elem_type == internal::MSH_TRIANGLE || elem_type == internal::MSH_QUAD)
+        {
+          Polygon face;
+          for(int n = 0; n < node_count; ++n)
+            face.push_back(static_cast<typename Polygon::value_type>(elem_nodes[n]));
+          polygons.push_back(face);
+          found_elements = true;
+        }
+        // else: silently skip lines, points, volume elements, higher-order elements
+      }
+
+      if(!elements_ok)
+        return false;
+
+      // consume $EndElements
+      if(!std::getline(is, line)) break; // "$EndElements"
+      continue;
+    }
+
+    // ---- Any other $Section — skip until matching $EndXxx ------------------
+    if(!line.empty() && line[0] == '$' && line.substr(0, 4) != "$End")
+    {
+      const std::string end_marker = "$End" + line.substr(1);
+      while(std::getline(is, line) && line != end_marker)
+        ;
+    }
+  }
+
+  if(binary_mode)
+  {
+    if(verbose)
+      std::cerr << "Error: binary MSH is not supported." << std::endl;
+    return false;
+  }
+
+  if(!found_mesh_format)
+  {
+    if(verbose)
+      std::cerr << "Error: $MeshFormat section not found." << std::endl;
+    return false;
+  }
+
+  if(!found_nodes)
+  {
+    if(verbose)
+      std::cerr << "Error: $Nodes section not found." << std::endl;
+    return false;
+  }
+
+  if(!found_elements && verbose)
+    std::cerr << "Warning: no surface elements (triangles/quads) found." << std::endl;
+
+  return !is.bad();
+}
+
+/*!
+ * \ingroup PkgStreamSupportIoFuncsMSH
+ *
+ * \brief reads the content of a file named `fname` into `points` and `polygons`,
+ *        using the Gmsh \ref IOStreamMSH format (version 2.2, ASCII).
+ *
+ * \attention The polygon soup is not cleared, and the data from the file are appended.
+ *
+ * \tparam PointRange a model of the concepts `RandomAccessContainer` and `BackInsertionSequence`
+ *                    whose value type is the point type
+ * \tparam PolygonRange a model of the concepts `SequenceContainer` and `BackInsertionSequence`
+ *                      whose `value_type` is itself a model of the concepts `SequenceContainer`
+ *                      and `BackInsertionSequence` whose `value_type` is an unsigned integer type
+ *                      convertible to `std::size_t`
+ * \tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
+ *
+ * \param fname the path to the input file
+ * \param points points of the soup of polygons
+ * \param polygons a range of polygons. Each element in it describes a polygon
+ *        using the indices of the points in `points`.
+ * \param np optional \ref bgl_namedparameters "Named Parameters" described below
+ *
+ * \cgalNamedParamsBegin
+ *   \cgalParamNBegin{verbose}
+ *     \cgalParamDescription{indicates whether output warnings and error messages should be printed or not.}
+ *     \cgalParamType{Boolean}
+ *     \cgalParamDefault{`false`}
+ *   \cgalParamNEnd
+ * \cgalNamedParamsEnd
+ *
+ * \returns `true` if the reading was successful, `false` otherwise.
+ */
+template <typename PointRange, typename PolygonRange, typename CGAL_NP_TEMPLATE_PARAMETERS>
+bool read_MSH(const std::string& fname,
+              PointRange& points,
+              PolygonRange& polygons,
+              const CGAL_NP_CLASS& np = parameters::default_values()
+#ifndef DOXYGEN_RUNNING
+              , std::enable_if_t<internal::is_Range<PolygonRange>::value>* = nullptr
+#endif
+              )
+{
+  std::ifstream is(fname);
+  CGAL::IO::set_mode(is, CGAL::IO::ASCII);
+
+  if(!is)
+  {
+    const bool verbose = parameters::choose_parameter(
+        parameters::get_parameter(np, internal_np::verbose), false);
+    if(verbose)
+      std::cerr << "Error: cannot open file '" << fname << "'." << std::endl;
+    return false;
+  }
+
+  return read_MSH(is, points, polygons, np);
+}
+
+////////////////////////////////////////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////////////////////////
+// Write
+
+/*!
+ * \ingroup PkgStreamSupportIoFuncsMSH
+ *
+ * \brief writes the content of `points` and `polygons` in `os`,
+ *        using the Gmsh \ref IOStreamMSH format (version 2.2, ASCII).
+ *
+ * Triangles are written as MSH element type 2 and quadrangles as element type 3.
+ * Polygons with more than four vertices are fan-triangulated before writing.
+ *
+ * \tparam PointRange a model of the concept `RandomAccessContainer` whose value type is the point type
+ * \tparam PolygonRange a model of the concept `SequenceContainer`
+ *                      whose `value_type` is itself a model of the concept `SequenceContainer`
+ *                      whose `value_type` is an unsigned integer type convertible to `std::size_t`
+ * \tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
+ *
+ * \param os the output stream
+ * \param points points of the soup of polygons
+ * \param polygons a range of polygons. Each element in it describes a polygon
+ *        using the indices of the points in `points`.
+ * \param np optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
+ *
+ * \cgalNamedParamsBegin
+ *   \cgalParamNBegin{point_map}
+ *     \cgalParamDescription{a property map associating points to the elements of `points`}
+ *     \cgalParamType{a model of `ReadablePropertyMap` with value type `geom_traits::Point_3`}
+ *     \cgalParamDefault{`CGAL::Identity_property_map<geom_traits::Point_3>`}
+ *   \cgalParamNEnd
+ *   \cgalParamNBegin{stream_precision}
+ *     \cgalParamDescription{a parameter used to set the precision (i.e. how many digits are generated) of the output stream}
+ *     \cgalParamType{int}
+ *     \cgalParamDefault{the precision of the stream `os`}
+ *   \cgalParamNEnd
+ * \cgalNamedParamsEnd
+ *
+ * \return `true` if the writing was successful, `false` otherwise.
+ */
+template <typename PointRange, typename PolygonRange, typename CGAL_NP_TEMPLATE_PARAMETERS>
+bool write_MSH(std::ostream& os,
+               const PointRange& points,
+               const PolygonRange& polygons,
+               const CGAL_NP_CLASS& np = parameters::default_values()
+#ifndef DOXYGEN_RUNNING
+               , std::enable_if_t<internal::is_Range<PolygonRange>::value>* = nullptr
+#endif
+               )
+{
+  typedef typename boost::range_value<PointRange>::type   Point;
+  typedef typename boost::range_value<PolygonRange>::type Polygon;
+
+  using parameters::choose_parameter;
+  using parameters::get_parameter;
+
+  typedef typename CGAL::GetPointMap<PointRange, CGAL_NP_CLASS>::type PointMap;
+  PointMap point_map = choose_parameter<PointMap>(get_parameter(np, internal_np::point_map));
+
+  if(!os.good())
+    return false;
+
+  set_stream_precision_from_NP(os, np);
+
+  // ---- $MeshFormat --------------------------------------------------------
+  os << "$MeshFormat\n";
+  os << "2.2 0 8\n";
+  os << "$EndMeshFormat\n";
+
+  // ---- $Nodes -------------------------------------------------------------
+  const std::size_t num_nodes = boost::size(points);
+  os << "$Nodes\n";
+  os << num_nodes << "\n";
+  {
+    std::size_t tag = 1; // gmsh is 1-indexed
+    for(std::size_t i = 0; i < num_nodes; ++i, ++tag)
+    {
+      const Point& p = get(point_map, *(std::begin(points) + i));
+      os << tag << " "
+         << CGAL::to_double(p.x()) << " "
+         << CGAL::to_double(p.y()) << " "
+         << CGAL::to_double(p.z()) << "\n";
+    }
+  }
+  os << "$EndNodes\n";
+
+  // ---- $Elements ----------------------------------------------------------
+  // Pre-compute the number of output elements.
+  // Quads stay as quads; polygons with > 4 vertices are fan-triangulated.
+  std::size_t num_output_elements = 0;
+  for(const Polygon& face : polygons)
+  {
+    const std::size_t n = face.size();
+    if(n == 3)       num_output_elements += 1;           // one triangle
+    else if(n == 4)  num_output_elements += 1;           // one quad
+    else if(n > 4)   num_output_elements += (n - 2);     // fan triangulation
+    // n < 3: degenerate, skip
+  }
+
+  os << "$Elements\n";
+  os << num_output_elements << "\n";
+
+  std::size_t elem_tag = 1;
+  for(const Polygon& face : polygons)
+  {
+    const std::size_t n = face.size();
+    if(n < 3)
+      continue; // skip degenerate faces silently
+
+    if(n == 3)
+    {
+      // MSH type 2: triangle, 2 default tags (physical=0, elementary=0)
+      os << elem_tag++ << " 2 2 0 0 "
+         << (face[0] + 1) << " " << (face[1] + 1) << " " << (face[2] + 1) << "\n";
+    }
+    else if(n == 4)
+    {
+      // MSH type 3: quadrangle
+      os << elem_tag++ << " 3 2 0 0 "
+         << (face[0] + 1) << " " << (face[1] + 1) << " "
+         << (face[2] + 1) << " " << (face[3] + 1) << "\n";
+    }
+    else
+    {
+      // Fan triangulation: all triangles share face[0]
+      for(std::size_t k = 1; k + 1 < n; ++k)
+      {
+        os << elem_tag++ << " 2 2 0 0 "
+           << (face[0] + 1) << " " << (face[k] + 1) << " " << (face[k + 1] + 1) << "\n";
+      }
+    }
+  }
+  os << "$EndElements\n";
+
+  return !os.fail();
+}
+
+/*!
+ * \ingroup PkgStreamSupportIoFuncsMSH
+ *
+ * \brief writes the content of `points` and `polygons` in a file named `fname`,
+ *        using the Gmsh \ref IOStreamMSH format (version 2.2, ASCII).
+ *
+ * \tparam PointRange a model of the concept `RandomAccessContainer` whose value type is the point type
+ * \tparam PolygonRange a model of the concept `SequenceContainer`
+ *                      whose `value_type` is itself a model of the concept `SequenceContainer`
+ *                      whose `value_type` is an unsigned integer type convertible to `std::size_t`
+ * \tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
+ *
+ * \param fname the path to the output file
+ * \param points points of the soup of polygons
+ * \param polygons a range of polygons. Each element in it describes a polygon
+ *        using the indices of the points in `points`.
+ * \param np optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
+ *
+ * \cgalNamedParamsBegin
+ *   \cgalParamNBegin{point_map}
+ *     \cgalParamDescription{a property map associating points to the elements of `points`}
+ *     \cgalParamType{a model of `ReadablePropertyMap` with value type `geom_traits::Point_3`}
+ *     \cgalParamDefault{`CGAL::Identity_property_map<geom_traits::Point_3>`}
+ *   \cgalParamNEnd
+ *   \cgalParamNBegin{stream_precision}
+ *     \cgalParamDescription{a parameter used to set the precision (i.e. how many digits are generated) of the output stream}
+ *     \cgalParamType{int}
+ *     \cgalParamDefault{`6`}
+ *   \cgalParamNEnd
+ * \cgalNamedParamsEnd
+ *
+ * \return `true` if the writing was successful, `false` otherwise.
+ */
+template <typename PointRange, typename PolygonRange, typename CGAL_NP_TEMPLATE_PARAMETERS>
+bool write_MSH(const std::string& fname,
+               const PointRange& points,
+               const PolygonRange& polygons,
+               const CGAL_NP_CLASS& np = parameters::default_values()
+#ifndef DOXYGEN_RUNNING
+               , std::enable_if_t<internal::is_Range<PolygonRange>::value>* = nullptr
+#endif
+               )
+{
+  std::ofstream os(fname);
+  CGAL::IO::set_mode(os, CGAL::IO::ASCII);
+
+  if(!os)
+  {
+    const bool verbose = parameters::choose_parameter(
+        parameters::get_parameter(np, internal_np::verbose), false);
+    if(verbose)
+      std::cerr << "Error: cannot open file '" << fname << "' for writing." << std::endl;
+    return false;
+  }
+
+  return write_MSH(os, points, polygons, np);
+}
+
+} // namespace IO
+
+} // namespace CGAL
+
+#endif // CGAL_IO_MSH_H

--- a/Stream_support/test/Stream_support/test_MSH.cpp
+++ b/Stream_support/test/Stream_support/test_MSH.cpp
@@ -1,0 +1,386 @@
+// Copyright (c) 2025  GeometryFactory Sarl (France).
+// All rights reserved.
+//
+// Licensees holding a valid commercial license may use this file in
+// accordance with the commercial license agreement provided with the software.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+// Author(s)     : Rajdeep Singh
+
+#include <CGAL/IO/MSH.h>
+#include <CGAL/Simple_cartesian.h>
+
+#include <cassert>
+#include <iostream>
+#include <sstream>
+#include <vector>
+#include <string>
+#include <cstdio>
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+typedef CGAL::Simple_cartesian<double>         Kernel;
+typedef Kernel::Point_3                        Point;
+typedef std::vector<Point>                     PointRange;
+typedef std::vector<std::size_t>               Polygon;
+typedef std::vector<Polygon>                   PolygonRange;
+
+// ---------------------------------------------------------------------------
+// Helper: build a minimal MSH 2.2 string in memory
+// ---------------------------------------------------------------------------
+static const std::string TRIANGLE_MESH_MSH = R"($MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+4
+1 0.0 0.0 0.0
+2 1.0 0.0 0.0
+3 0.5 1.0 0.0
+4 1.5 1.0 0.0
+$EndNodes
+$Elements
+2
+1 2 2 0 0 1 2 3
+2 2 2 0 0 2 4 3
+$EndElements
+)";
+
+// A mesh that contains a quad
+static const std::string QUAD_MESH_MSH = R"($MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+4
+1 0.0 0.0 0.0
+2 1.0 0.0 0.0
+3 1.0 1.0 0.0
+4 0.0 1.0 0.0
+$EndNodes
+$Elements
+1
+1 3 2 0 0 1 2 3 4
+$EndElements
+)";
+
+// A mesh with both surface triangles and volume tetrahedra (tets should be skipped)
+static const std::string MIXED_MESH_MSH = R"($MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+4
+1 0.0 0.0 0.0
+2 1.0 0.0 0.0
+3 0.5 1.0 0.0
+4 0.5 0.5 1.0
+$EndNodes
+$Elements
+2
+1 2 2 0 0 1 2 3
+2 4 2 0 0 1 2 3 4
+$EndElements
+)";
+
+// A valid MSH with only non-surface elements (lines + points) — expect empty polygons
+static const std::string LINES_ONLY_MSH = R"($MeshFormat
+2.2 0 8
+$EndMeshFormat
+$Nodes
+2
+1 0.0 0.0 0.0
+2 1.0 0.0 0.0
+$EndNodes
+$Elements
+1
+1 1 2 0 0 1 2
+$EndElements
+)";
+
+// A completely empty file
+static const std::string EMPTY_MSH = "";
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+void test_triangle_round_trip()
+{
+  std::cout << "test_triangle_round_trip ... ";
+
+  PointRange   pts_in, pts_out;
+  PolygonRange polys_in, polys_out;
+
+  // Build a simple tetrahedron surface (4 triangles)
+  pts_in = {
+    Point(0, 0, 0),
+    Point(1, 0, 0),
+    Point(0, 1, 0),
+    Point(0, 0, 1)
+  };
+  polys_in = {
+    {0, 1, 2},
+    {0, 1, 3},
+    {0, 2, 3},
+    {1, 2, 3}
+  };
+
+  // write to stream
+  std::ostringstream oss;
+  bool ok = CGAL::IO::write_MSH(oss, pts_in, polys_in);
+  assert(ok && "write_MSH failed");
+
+  // read back
+  std::istringstream iss(oss.str());
+  ok = CGAL::IO::read_MSH(iss, pts_out, polys_out);
+  assert(ok && "read_MSH failed on round-trip data");
+  assert(pts_out.size()   == pts_in.size()   && "point count mismatch");
+  assert(polys_out.size() == polys_in.size() && "polygon count mismatch");
+
+  // verify all faces have 3 nodes
+  for(const auto& f : polys_out)
+    assert(f.size() == 3);
+
+  std::cout << "PASS\n";
+}
+
+void test_quad_round_trip()
+{
+  std::cout << "test_quad_round_trip ... ";
+
+  PointRange   pts_in, pts_out;
+  PolygonRange polys_in, polys_out;
+
+  pts_in = {
+    Point(0, 0, 0),
+    Point(1, 0, 0),
+    Point(1, 1, 0),
+    Point(0, 1, 0)
+  };
+  polys_in = {
+    {0, 1, 2, 3}   // one quad face
+  };
+
+  std::ostringstream oss;
+  bool ok = CGAL::IO::write_MSH(oss, pts_in, polys_in);
+  assert(ok && "write_MSH failed");
+
+  std::istringstream iss(oss.str());
+  ok = CGAL::IO::read_MSH(iss, pts_out, polys_out);
+  assert(ok && "read_MSH failed");
+  assert(pts_out.size()   == 4 && "point count");
+  assert(polys_out.size() == 1 && "polygon count");
+  assert(polys_out[0].size() == 4 && "quad size");
+
+  std::cout << "PASS\n";
+}
+
+void test_read_triangle_mesh()
+{
+  std::cout << "test_read_triangle_mesh ... ";
+
+  PointRange   pts;
+  PolygonRange polys;
+
+  std::istringstream iss(TRIANGLE_MESH_MSH);
+  bool ok = CGAL::IO::read_MSH(iss, pts, polys);
+  assert(ok);
+  assert(pts.size()   == 4);
+  assert(polys.size() == 2);
+  for(const auto& f : polys)
+    assert(f.size() == 3);
+
+  std::cout << "PASS\n";
+}
+
+void test_read_quad_mesh()
+{
+  std::cout << "test_read_quad_mesh ... ";
+
+  PointRange   pts;
+  PolygonRange polys;
+
+  std::istringstream iss(QUAD_MESH_MSH);
+  bool ok = CGAL::IO::read_MSH(iss, pts, polys);
+  assert(ok);
+  assert(pts.size()   == 4);
+  assert(polys.size() == 1);
+  assert(polys[0].size() == 4);
+
+  std::cout << "PASS\n";
+}
+
+void test_mixed_volume_surface()
+{
+  std::cout << "test_mixed_volume_surface ... ";
+
+  PointRange   pts;
+  PolygonRange polys;
+
+  std::istringstream iss(MIXED_MESH_MSH);
+  bool ok = CGAL::IO::read_MSH(iss, pts, polys);
+  assert(ok);
+  assert(pts.size()   == 4);
+  // Only the triangle (type 2) should have been extracted; the tet (type 4) skipped
+  assert(polys.size() == 1 && "volume element not skipped");
+  assert(polys[0].size() == 3);
+
+  std::cout << "PASS\n";
+}
+
+void test_lines_only()
+{
+  std::cout << "test_lines_only ... ";
+
+  PointRange   pts;
+  PolygonRange polys;
+
+  std::istringstream iss(LINES_ONLY_MSH);
+  // read_MSH should succeed (file is valid) but polygons stays empty
+  bool ok = CGAL::IO::read_MSH(iss, pts, polys);
+  assert(ok);
+  assert(pts.size()   == 2);
+  assert(polys.empty());
+
+  std::cout << "PASS\n";
+}
+
+void test_empty_stream()
+{
+  std::cout << "test_empty_stream ... ";
+
+  PointRange   pts;
+  PolygonRange polys;
+
+  std::istringstream iss(EMPTY_MSH);
+  bool ok = CGAL::IO::read_MSH(iss, pts, polys);
+  // An empty file has no $MeshFormat → should return false
+  assert(!ok);
+
+  std::cout << "PASS\n";
+}
+
+void test_nonexistent_file()
+{
+  std::cout << "test_nonexistent_file ... ";
+
+  PointRange   pts;
+  PolygonRange polys;
+
+  bool ok = CGAL::IO::read_MSH(std::string("this_file_does_not_exist_12345678.msh"),
+                                pts, polys,
+                                CGAL::parameters::verbose(false));
+  assert(!ok);
+
+  std::cout << "PASS\n";
+}
+
+void test_file_overloads()
+{
+  std::cout << "test_file_overloads ... ";
+
+  const std::string tmp = "cgal_test_msh_temp.msh";
+
+  PointRange   pts_in = {
+    Point(0, 0, 0), Point(1, 0, 0), Point(0, 1, 0), Point(0, 0, 1)
+  };
+  PolygonRange polys_in = {
+    {0, 1, 2}, {0, 1, 3}, {0, 2, 3}, {1, 2, 3}
+  };
+
+  bool ok = CGAL::IO::write_MSH(tmp, pts_in, polys_in);
+  assert(ok && "file write failed");
+
+  PointRange   pts_out;
+  PolygonRange polys_out;
+  ok = CGAL::IO::read_MSH(tmp, pts_out, polys_out);
+  assert(ok && "file read failed");
+  assert(pts_out.size()   == pts_in.size());
+  assert(polys_out.size() == polys_in.size());
+
+  std::remove(tmp.c_str());
+  std::cout << "PASS\n";
+}
+
+void test_append_semantics()
+{
+  std::cout << "test_append_semantics ... ";
+
+  PointRange   pts;
+  PolygonRange polys;
+
+  // First read
+  {
+    std::istringstream iss(TRIANGLE_MESH_MSH);
+    bool ok = CGAL::IO::read_MSH(iss, pts, polys);
+    assert(ok);
+    assert(pts.size()   == 4);
+    assert(polys.size() == 2);
+  }
+
+  // Second read — should append (not clear)
+  {
+    std::istringstream iss(TRIANGLE_MESH_MSH);
+    bool ok = CGAL::IO::read_MSH(iss, pts, polys);
+    assert(ok);
+    assert(pts.size()   == 8 && "append: points should double");
+    assert(polys.size() == 4 && "append: polygons should double");
+  }
+
+  // The second read's face indices should reference the appended points (index >= 4)
+  for(std::size_t i = 2; i < 4; ++i)
+    for(std::size_t j = 0; j < polys[i].size(); ++j)
+      assert(polys[i][j] >= 4 && "appended face indices must reference the second set of nodes");
+
+  std::cout << "PASS\n";
+}
+
+void test_fan_triangulation_on_write()
+{
+  std::cout << "test_fan_triangulation_on_write ... ";
+
+  PointRange pts = {
+    Point(0, 0, 0), Point(1, 0, 0), Point(1, 1, 0),
+    Point(0.5, 1.5, 0), Point(0, 1, 0)
+  };
+  PolygonRange polys = { {0, 1, 2, 3, 4} };  // pentagon → 3 triangles after fan-triangulation
+
+  std::ostringstream oss;
+  bool ok = CGAL::IO::write_MSH(oss, pts, polys);
+  assert(ok);
+
+  PointRange   pts_out;
+  PolygonRange polys_out;
+  std::istringstream iss(oss.str());
+  ok = CGAL::IO::read_MSH(iss, pts_out, polys_out);
+  assert(ok);
+  assert(pts_out.size()   == 5 && "pentagon vertices");
+  assert(polys_out.size() == 3 && "pentagon → 3 triangles");
+
+  std::cout << "PASS\n";
+}
+
+// ---------------------------------------------------------------------------
+// main
+// ---------------------------------------------------------------------------
+int main()
+{
+  test_read_triangle_mesh();
+  test_read_quad_mesh();
+  test_mixed_volume_surface();
+  test_lines_only();
+  test_empty_stream();
+  test_nonexistent_file();
+  test_triangle_round_trip();
+  test_quad_round_trip();
+  test_file_overloads();
+  test_append_semantics();
+  test_fan_triangulation_on_write();
+
+  std::cout << "\nAll MSH tests PASSED.\n";
+  return 0;
+}


### PR DESCRIPTION
This PR adds polygon soup I/O support for the Gmsh MSH 2.2 ASCII format,
following the same API pattern as read_OBJ / write_OBJ.

## What
- `CGAL::IO::read_MSH()` — reads triangles and quads from $Elements;
  volume and line elements are skipped so mixed meshes work out of the box.
- `CGAL::IO::write_MSH()` — writes MSH 2.2 ASCII; quads stay quads,
  larger polygons are fan-triangulated.
- Both stream and file overloads; supports named parameters
  (verbose, stream_precision, point_map).
- No external library dependency (MSH 2.2 ASCII is plain text).

## Tests (test_MSH.cpp)
11 cases: triangle/quad read, mixed volume+surface, lines-only,
empty stream, non-existent file, round-trips, file overloads,
append semantics, pentagon fan-triangulation.

Related GSoC project: "Adding Support for New File Formats for Meshes"