### PR TITLE
Introduce strictly_inside parameter for PMP::kernel_point()

### DIFF
--- a/Lab/demo/Lab/Plugins/PMP/Kernel_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/PMP/Kernel_plugin.cpp
@@ -68,7 +68,7 @@ void CGAL_Lab_mesh_kernel_plugin::on_actionKernel_triggered()
     SMesh* sMesh = sm_item->polyhedron();
     SMesh* kernel = new SMesh;
 
-    CGAL::Polygon_mesh_processing::kernel(*sMesh, *kernel);
+    CGAL::Polygon_mesh_processing::kernel(*sMesh, *kernel, CGAL::parameters::allow_open_input(true));
 
     if(is_empty(*kernel)){
       QApplication::restoreOverrideCursor();

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
@@ -448,11 +448,12 @@ remove_bounded_region_and_fill(PolygonMesh& pm,
     }
   }
 
-  // Case where the output is degenerated to a segment
+  // Case where the output is degenerated to a segment or a vertex
   if(vertices(pm).size() < 3){
-    if(faces(pm).size())
+    if(!faces(pm).empty())
       remove_face(*faces(pm).begin(), pm);
-    for(edge_descriptor e: edges(pm))
+    std::vector<edge_descriptor> edges_to_remove(edges(pm).begin(), edges(pm).end());
+    for(edge_descriptor e: edges_to_remove)
       remove_edge(e, pm);
     for(vertex_descriptor v: vertices(pm))
       set_halfedge(v, BGT::null_halfedge(), pm);
@@ -621,13 +622,19 @@ clip_convex(PolygonMesh& pm,
   if(boundaries.empty()){ // No edges in the plane after refine, it means there are only a vertex
     vertex_descriptor v0 = target(he, pm);
     CGAL_assertion(oriented_side(plane, get(vpm, v0)) == ON_ORIENTED_BOUNDARY);
-    for(face_descriptor f: faces(pm))
+    std::vector<face_descriptor> faces_to_remove(faces(pm).begin(), faces(pm).end());
+    for(face_descriptor f: faces_to_remove)
       remove_face(f, pm);
-    for(edge_descriptor e: edges(pm))
+    std::vector<edge_descriptor> edges_to_remove(edges(pm).begin(), edges(pm).end());
+    for(edge_descriptor e: edges_to_remove)
       remove_edge(e, pm);
+    std::vector<vertex_descriptor> vertices_to_remove;
+    vertices_to_remove.reserve(vertices(pm).size()-1);
     for(vertex_descriptor v: vertices(pm))
       if(v!=v0)
-        remove_vertex(v, pm);
+        vertices_to_remove.push_back(v);
+    for(vertex_descriptor v: vertices_to_remove)
+      remove_vertex(v, pm);
     set_halfedge(v0, BGT::null_halfedge(), pm);
     return v0;
   }

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
@@ -619,9 +619,8 @@ clip_convex(PolygonMesh& pm,
     return parameters::choose_parameter(parameters::get_parameter(np, internal_np::starting_vertex_descriptor), *vertices(pm).begin());
   const auto &boundaries =refine_convex_with_plane(pm, plane, he, np);
   if(boundaries.empty()){ // No edges in the plane after refine, it means there are only a vertex
-    Point_3 p = get(vpm, target(he, pm));
     vertex_descriptor v0 = target(he, pm);
-    CGAL_assertion(oriented_side(plane, p) == ON_ORIENTED_BOUNDARY);
+    CGAL_assertion(oriented_side(plane, get(vpm, v0)) == ON_ORIENTED_BOUNDARY);
     for(face_descriptor f: faces(pm))
       remove_face(f, pm);
     for(edge_descriptor e: edges(pm))

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
@@ -121,7 +121,7 @@ find_crossing_edge(PolygonMesh& pm,
       }
     }
 
-    // Nothing on negative side
+    // Nothing on positive side
     if(no_positive_side){
       if constexpr(!parameters::is_default_parameter<NamedParameters, internal_np::face_to_face_map_t>::value){
         // Search a coplanar face
@@ -282,8 +282,6 @@ refine_convex_with_plane(PolygonMesh& pm,
   } while(target(h, pm)!=v_start || (boundaries.empty() && h!=h_start));
 
   CGAL_assertion(is_valid_polygon_mesh(pm));
-  CGAL_assertion(!boundaries.empty());
-
   return boundaries;
 }
 
@@ -469,6 +467,7 @@ clip_convex(PolygonMesh& pm,
 
   // graph typedefs
   using BGT = boost::graph_traits<PolygonMesh>;
+  using face_descriptor = typename BGT::face_descriptor;
   using halfedge_descriptor = typename BGT::halfedge_descriptor;
   using edge_descriptor = typename BGT::edge_descriptor;
   using vertex_descriptor = typename BGT::vertex_descriptor;
@@ -611,6 +610,20 @@ clip_convex(PolygonMesh& pm,
   if(he == boost::graph_traits<PolygonMesh>::null_halfedge())
     return parameters::choose_parameter(parameters::get_parameter(np, internal_np::starting_vertex_descriptor), *vertices(pm).begin());
   const auto &boundaries =refine_convex_with_plane(pm, plane, he, np);
+  if(boundaries.empty()){ // No edges in the plane after refine, it means there are only a vertex
+    Point_3 p = get(vpm, target(he, pm));
+    vertex_descriptor v0 = target(he, pm);
+    CGAL_assertion(oriented_side(plane, p) == ON_ORIENTED_BOUNDARY);
+    for(face_descriptor f: faces(pm))
+      remove_face(f, pm);
+    for(edge_descriptor e: edges(pm))
+      remove_edge(e, pm);
+    for(vertex_descriptor v: vertices(pm))
+      if(v!=v0)
+        remove_vertex(v, pm);
+    set_halfedge(v0, BGT::null_halfedge(), pm);
+    return v0;
+  }
   return remove_bounded_region_and_fill(pm, boundaries, source(he, pm), np, plane_fd);
 }
 

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
@@ -80,7 +80,6 @@ find_crossing_edge(PolygonMesh& pm,
       bool is_local_max=true;
       for(auto v: vertices_around_target(src ,pm)){
         sp_trg = sq(plane, get(vpm, v));
-        CGAL_assertion(sq(plane, get(vpm, v)) == sp_trg);
         // Check if v in the direction to the plane
         if(compare(sp_src, sp_trg)==direction_to_zero){
           if(sign(sp_trg)!=direction_to_zero){
@@ -445,7 +444,8 @@ remove_bounded_region_and_fill(PolygonMesh& pm,
 
   // Case where the output is degenerated to a segment
   if(vertices(pm).size() < 3){
-    remove_face(*faces(pm).begin(), pm);
+    if(faces(pm).size())
+      remove_face(*faces(pm).begin(), pm);
     for(edge_descriptor e: edges(pm))
       remove_edge(e, pm);
     for(vertex_descriptor v: vertices(pm))
@@ -530,7 +530,7 @@ clip_convex(PolygonMesh& pm,
         remove_vertex(v1, pm); // Degenerate to a point
       }
     }
-    return v0;
+    return *vertices(pm).begin();
 
   } else if(faces(pm).size()==1){
     // Dimension == 2

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
@@ -57,12 +57,20 @@ find_crossing_edge(PolygonMesh& pm,
   GT traits = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
 
   using FT = typename GT::FT;
+  using Plane_3 = typename GT::Plane_3;
+  using Point_3 = typename GT::Point_3;
 
   auto vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                               get_property_map(vertex_point, pm));
 
   auto oriented_side = traits.oriented_side_3_object();
-  auto sq = traits.compute_squared_distance_3_object();
+  auto normal = traits.construct_orthogonal_vector_3_object();
+  auto vector = traits.construct_vector_3_object();
+  auto point_on = traits.construct_point_on_3_object();
+  auto dot = traits.compute_scalar_product_3_object();
+  auto sq = [&](const Plane_3& pl, const Point_3& p){
+    return dot(vector(point_on(pl), p), normal(pl));
+  };
 
   // ____________________ Find a crossing edge _____________________
 

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/kernel.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/kernel.h
@@ -219,10 +219,10 @@ kernel(const FaceRange& face_range,
   }
 
   if(used_to_find_a_point){
-    bool require_strictly_inside = choose_parameter(get_parameter(np, internal_np::require_strictly_inside), true);
+    bool strictly_inside = choose_parameter(get_parameter(np, internal_np::strictly_inside), true);
 
     // If we don't want a point on the surface and the kernel is degenerated, do nothing
-    if(require_strictly_inside && ((vertices(kernel).size()<3) || (faces(kernel).size()==1))){
+    if(strictly_inside && ((vertices(kernel).size()<3) || (faces(kernel).size()==1))){
       clear(kernel);
       return;
     }
@@ -460,7 +460,7 @@ bool has_empty_kernel(const PolygonMesh& pm,
   * In addition to the parameters available in `CGAL::Polygon_mesh_processing::kernel()`, the following parameter is also available:
   *
   * \cgalNamedParamsBegin
-  *   \cgalParamNBegin{require_strictly_inside}
+  *   \cgalParamNBegin{strictly_inside}
   *     \cgalParamDescription{If set to `true`, the returned point is required to lie strictly inside
   *         the mesh and not on its boundary. If the kernel is degenerate, this requirement
   *         cannot be satisfied and no point is returned.}

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/kernel.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/kernel.h
@@ -219,6 +219,14 @@ kernel(const FaceRange& face_range,
   }
 
   if(used_to_find_a_point){
+    bool require_strictly_inside = choose_parameter(get_parameter(np, internal_np::require_strictly_inside), true);
+
+    // If we don't want a point on the surface and the kernel is degenerated, do nothing
+    if(require_strictly_inside && ((vertices(kernel).size()<3) || (faces(kernel).size()==1))){
+      clear(kernel);
+      return;
+    }
+
     // Get the centroid
     EPoint_3 centroid(ORIGIN);
     for(auto v: vertices(kernel))
@@ -427,16 +435,13 @@ bool has_empty_kernel(const FaceRange& face_range,
   *
   * \brief indicates whether the kernel of the given polygon mesh is empty.
   *
-  * The kernel is defined as the convex polyhedron that is the intersection
-  * of all the halfspaces on the negative side of the oriented planes defined by a range of faces
-  * of the input mesh.
-  *
-  * See `CGAL::Polygon_mesh_processing::kernel()` for a comprehensive description of the parameters.
+  * This is a convenience overload that calls the overload above
+  * on all faces of the mesh.
   */
 template <typename PolygonMesh,
           typename CGAL_NP_TEMPLATE_PARAMETERS>
 bool has_empty_kernel(const PolygonMesh& pm,
-                     const CGAL_NP_CLASS& np = parameters::default_values())
+                      const CGAL_NP_CLASS& np = parameters::default_values())
 {
   return has_empty_kernel(faces(pm), pm, np);
 }
@@ -451,6 +456,18 @@ bool has_empty_kernel(const PolygonMesh& pm,
   * of the input mesh.
   *
   * See `CGAL::Polygon_mesh_processing::kernel()` for a comprehensive description of the parameters.
+  *
+  * In addition to the parameters available in `CGAL::Polygon_mesh_processing::kernel()`, the following parameters are also available:
+  *
+  * \cgalNamedParamsBegin
+  *   \cgalParamNBegin{require_strictly_inside}
+  *     \cgalParamDescription{If set to `true`, the returned point is required to lie strictly inside
+  *         the mesh and not on its boundary. If the kernel is degenerate, this requirement
+  *         cannot be satisfied and no point is returned.}
+  *     \cgalParamType{Boolean}
+  *     \cgalParamDefault{`false`}
+  *   \cgalParamNEnd
+  * \cgalNamedParamsEnd
   *
   * \return `std::nullopt` if and only if the kernel is empty.
   */
@@ -482,13 +499,8 @@ kernel_point(const FaceRange& face_range,
   *
   * \brief returns a point inside the kernel of the given polygon mesh.
   *
-  * The kernel is defined as the convex polyhedron that is the intersection
-  * of all the halfspaces on the negative side of the oriented planes defined by a range of faces
-  * of the input mesh.
-  *
-  * See `CGAL::Polygon_mesh_processing::kernel()` for a comprehensive description of the parameters.
-  *
-  * \return `std::nullopt` if and only if the kernel is empty.
+  * This is a convenience overload that calls the overload above
+  * on all faces of the mesh.
   */
 template <typename PolygonMesh,
           typename CGAL_NP_TEMPLATE_PARAMETERS>

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/kernel.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/kernel.h
@@ -457,7 +457,7 @@ bool has_empty_kernel(const PolygonMesh& pm,
   *
   * See `CGAL::Polygon_mesh_processing::kernel()` for a comprehensive description of the parameters.
   *
-  * In addition to the parameters available in `CGAL::Polygon_mesh_processing::kernel()`, the following parameter is also available:
+  * In addition to the parameters available in `CGAL::Polygon_mesh_processing::kernel()`, the following named parameter is also available:
   *
   * \cgalNamedParamsBegin
   *   \cgalParamNBegin{strictly_inside}

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/kernel.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/kernel.h
@@ -457,7 +457,7 @@ bool has_empty_kernel(const PolygonMesh& pm,
   *
   * See `CGAL::Polygon_mesh_processing::kernel()` for a comprehensive description of the parameters.
   *
-  * In addition to the parameters available in `CGAL::Polygon_mesh_processing::kernel()`, the following parameters are also available:
+  * In addition to the parameters available in `CGAL::Polygon_mesh_processing::kernel()`, the following parameter is also available:
   *
   * \cgalNamedParamsBegin
   *   \cgalParamNBegin{require_strictly_inside}

--- a/PMP_Boolean_operations/test/PMP_Boolean_operations/test_mesh_kernel.cpp
+++ b/PMP_Boolean_operations/test/PMP_Boolean_operations/test_mesh_kernel.cpp
@@ -52,7 +52,7 @@ void test_clip_convex_on_mesh(const Mesh &m, const Plane_3 &pl, std::size_t expe
 template<class Mesh>
 void test_kernel_on_mesh(const Mesh &input, std::size_t expected_nb_vertices, std::size_t expected_nb_edges, std::size_t expected_nb_faces, double expected_volume = 0){
   assert(PMP::has_empty_kernel(input, CGAL::parameters::allow_open_input(true)) == (expected_nb_vertices == 0));
-  assert((PMP::kernel_point(input, CGAL::parameters::allow_open_input(true).require_strictly_inside(false)) != std::nullopt) == (expected_nb_vertices != 0));
+  assert((PMP::kernel_point(input, CGAL::parameters::allow_open_input(true).strictly_inside(false)) != std::nullopt) == (expected_nb_vertices != 0));
 
   Mesh kernel;
   PMP::kernel(input, kernel, CGAL::parameters::allow_open_input(true));

--- a/PMP_Boolean_operations/test/PMP_Boolean_operations/test_mesh_kernel.cpp
+++ b/PMP_Boolean_operations/test/PMP_Boolean_operations/test_mesh_kernel.cpp
@@ -26,6 +26,29 @@ rotation(double a, double b, double c)
   return aff;
 }
 
+
+std::size_t i=0;
+template<class Mesh, class Plane_3>
+void test_clip_convex_on_mesh(const Mesh &m, const Plane_3 &pl, std::size_t expected_nb_vertices, std::size_t expected_nb_edges, std::size_t expected_nb_faces){
+  using K =typename CGAL::Kernel_traits<typename Plane_3::value_type>::Kernel;
+  using Pl = typename K::Plane_3;
+  using Pl_3P = typename PMP::internal::Three_point_cut_plane_traits<K>::Plane_3;
+
+  auto m_copy = m;
+  PMP::internal::clip_convex(m_copy, Pl_3P(pl[0], pl[1], pl[2]), CGAL::parameters::geom_traits(PMP::internal::Three_point_cut_plane_traits<K>()));
+
+  assert(vertices(m_copy).size() == expected_nb_vertices);
+  assert(edges(m_copy).size()    == expected_nb_edges);
+  assert(faces(m_copy).size()    == expected_nb_faces);
+
+  m_copy = m;
+  PMP::internal::clip_convex(m_copy, Pl(pl[0], pl[1], pl[2]));
+
+  assert(vertices(m_copy).size() == expected_nb_vertices);
+  assert(edges(m_copy).size()    == expected_nb_edges);
+  assert(faces(m_copy).size()    == expected_nb_faces);
+}
+
 template<class Mesh>
 void test_kernel_on_mesh(const Mesh &input, std::size_t expected_nb_vertices, std::size_t expected_nb_edges, std::size_t expected_nb_faces, double expected_volume = 0){
   assert(PMP::has_empty_kernel(input, CGAL::parameters::allow_open_input(true)) == (expected_nb_vertices == 0));
@@ -79,6 +102,11 @@ void test_kernel_on_mesh(const Mesh &input, std::size_t expected_nb_vertices, st
 template<class Mesh, class K>
 void tests(){
   using P = typename K::Point_3;
+  using Pl = std::array<P, 3>;
+  auto opposite = [](const Pl &a){
+    return Pl({a[0], a[2], a[1]});
+  };
+
   Mesh m;
 
 #ifdef TEST_MESH_KERNEL_VERBOSE
@@ -197,6 +225,55 @@ void tests(){
   make_hexahedron(P(0,0,0).bbox()+P(-2,-2,-2).bbox(), m);
   test_kernel_on_mesh(m, 0, 0, 0, 0);
   clear(m);
+
+  make_hexahedron(P(0,0,0).bbox()+P(1,1,1).bbox(), m);
+  Pl pl;
+#ifdef TEST_MESH_KERNEL_VERBOSE
+  std::cout << "Test clip general" << std::endl;
+#endif
+  pl = {P(1,1,0.5),P(1,0,0.5),P(0,1,0.5)};
+  test_clip_convex_on_mesh(m, pl, 8, 12, 6);
+
+#ifdef TEST_MESH_KERNEL_VERBOSE
+  std::cout << "Test clip one vertex on" << std::endl;
+#endif
+  pl = {P(1,1,1),P(1,0,0.8),P(0,1,0.8)};
+  test_clip_convex_on_mesh(m, pl, 7, 11, 6);
+  test_clip_convex_on_mesh(m, opposite(pl), 8, 12, 6);
+
+#ifdef TEST_MESH_KERNEL_VERBOSE
+  std::cout << "Test clip two vertices on" << std::endl;
+#endif
+  pl = {P(1,1,1),P(0,0,1),P(0,1,0.8)};
+  test_clip_convex_on_mesh(m, pl, 4, 6, 4);
+  test_clip_convex_on_mesh(m, opposite(pl), 8, 13, 7);
+
+#ifdef TEST_MESH_KERNEL_VERBOSE
+  std::cout << "Test clip three vertices on" << std::endl;
+#endif
+  pl = {P(1,1,1),P(0,0,1),P(0,1,0)};
+  test_clip_convex_on_mesh(m, pl, 4, 6, 4);
+  test_clip_convex_on_mesh(m, opposite(pl), 7, 12, 7);
+
+#ifdef TEST_MESH_KERNEL_VERBOSE
+  std::cout << "Test clip full outside except one edge" << std::endl;
+#endif
+  pl = {P(1,1,1),P(1,1,0),P(2,0,0)};
+  test_clip_convex_on_mesh(m, pl, 2, 0, 0);
+#ifdef TEST_MESH_KERNEL_VERBOSE
+  std::cout << "Test clip full inside except one edge" << std::endl;
+#endif
+  test_clip_convex_on_mesh(m, opposite(pl), 8, 12, 6);
+
+#ifdef TEST_MESH_KERNEL_VERBOSE
+  std::cout << "Test clip full outside except one vertex" << std::endl;
+#endif
+  pl = {P(1,1,1),P(0,3,0),P(3,0,0)};
+  test_clip_convex_on_mesh(m, pl, 1, 0, 0);
+#ifdef TEST_MESH_KERNEL_VERBOSE
+  std::cout << "Test clip full inside except one vertex" << std::endl;
+#endif
+  test_clip_convex_on_mesh(m, opposite(pl), 8, 12, 6);
 }
 
 int main(/*int argc, char** argv*/)

--- a/PMP_Boolean_operations/test/PMP_Boolean_operations/test_mesh_kernel.cpp
+++ b/PMP_Boolean_operations/test/PMP_Boolean_operations/test_mesh_kernel.cpp
@@ -29,7 +29,7 @@ rotation(double a, double b, double c)
 template<class Mesh>
 void test_kernel_on_mesh(const Mesh &input, std::size_t expected_nb_vertices, std::size_t expected_nb_edges, std::size_t expected_nb_faces, double expected_volume = 0){
   assert(PMP::has_empty_kernel(input, CGAL::parameters::allow_open_input(true)) == (expected_nb_vertices == 0));
-  assert((PMP::kernel_point(input, CGAL::parameters::allow_open_input(true)) != std::nullopt) == (expected_nb_vertices != 0));
+  assert((PMP::kernel_point(input, CGAL::parameters::allow_open_input(true).require_strictly_inside(false)) != std::nullopt) == (expected_nb_vertices != 0));
 
   Mesh kernel;
   PMP::kernel(input, kernel, CGAL::parameters::allow_open_input(true));

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Three_point_cut_plane_traits.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Three_point_cut_plane_traits.h
@@ -66,33 +66,23 @@ struct Three_point_cut_plane_traits
     }
   };
 
-  struct Compute_squared_distance_3
-  {
-    using Compute_scalar_product_3 = typename Kernel::Compute_scalar_product_3;
-    FT operator()(const Plane_3& plane, const Point_3& p)
+  struct Construct_point_on_3{
+    Point_3 operator()(const Plane_3& plane)
     {
-      // Not normalized
-      typename Kernel::Plane_3 pl(plane[0], plane[1], plane[2]);
-      return Compute_scalar_product_3()(Vector_3(ORIGIN, p), pl.orthogonal_vector())+pl.d();
+      return plane[0];
     }
   };
 
-  Oriented_side_3 oriented_side_3_object() const
-  {
-    return Oriented_side_3();
-  }
+  Oriented_side_3 oriented_side_3_object() const { return Oriented_side_3(); }
+  Construct_plane_line_intersection_point_3 construct_plane_line_intersection_point_3_object() const { return Construct_plane_line_intersection_point_3(); }
+  Construct_orthogonal_vector_3 construct_orthogonal_vector_3_object() const { return Construct_orthogonal_vector_3(); }
+  Construct_point_on_3 construct_point_on_3_object() const { return Construct_point_on_3(); }
 
-  Construct_plane_line_intersection_point_3 construct_plane_line_intersection_point_3_object() const
-  {
-    return Construct_plane_line_intersection_point_3();
-  }
+  using Compute_scalar_product_3 = typename Kernel::Compute_scalar_product_3;
+  using Construct_vector_3 = typename Kernel::Construct_vector_3;
 
-  Construct_orthogonal_vector_3 construct_orthogonal_vector_3_object() const
-  {
-    return Construct_orthogonal_vector_3();
-  }
-
-  Compute_squared_distance_3 compute_squared_distance_3_object() const { return Compute_squared_distance_3(); }
+  Compute_scalar_product_3 compute_scalar_product_3_object(){ return Kernel().compute_scalar_product_3_object(); }
+  Construct_vector_3 construct_vector_3_object(){ return Kernel().construct_vector_3_object(); }
 
 #ifndef CGAL_PLANE_CLIP_DO_NOT_USE_BOX_INTERSECTION_D
 // for does self-intersect

--- a/STL_Extension/include/CGAL/STL_Extension/internal/parameters_interface.h
+++ b/STL_Extension/include/CGAL/STL_Extension/internal/parameters_interface.h
@@ -184,6 +184,7 @@ CGAL_add_named_parameter(shuffle_planes_t, shuffle_planes, shuffle_planes)
 CGAL_add_named_parameter(use_convex_specialization_t, use_convex_specialization, use_convex_specialization)
 CGAL_add_named_parameter(faces_range_t, faces_range, faces_range)
 CGAL_add_named_parameter(allow_open_input_t, allow_open_input, allow_open_input)
+CGAL_add_named_parameter(require_strictly_inside_t, require_strictly_inside, require_strictly_inside)
 
 // List of named parameters that we use in the package 'Surface Mesh Simplification'
 CGAL_add_named_parameter(get_cost_policy_t, get_cost_policy, get_cost)

--- a/STL_Extension/include/CGAL/STL_Extension/internal/parameters_interface.h
+++ b/STL_Extension/include/CGAL/STL_Extension/internal/parameters_interface.h
@@ -184,7 +184,7 @@ CGAL_add_named_parameter(shuffle_planes_t, shuffle_planes, shuffle_planes)
 CGAL_add_named_parameter(use_convex_specialization_t, use_convex_specialization, use_convex_specialization)
 CGAL_add_named_parameter(faces_range_t, faces_range, faces_range)
 CGAL_add_named_parameter(allow_open_input_t, allow_open_input, allow_open_input)
-CGAL_add_named_parameter(require_strictly_inside_t, require_strictly_inside, require_strictly_inside)
+CGAL_add_named_parameter(strictly_inside_t, strictly_inside, strictly_inside)
 
 // List of named parameters that we use in the package 'Surface Mesh Simplification'
 CGAL_add_named_parameter(get_cost_policy_t, get_cost_policy, get_cost)


### PR DESCRIPTION
## Summary of Changes

Add a parameter "require_strictly_inside" to the function "PMP::kernel_point()".
If the parameter is `true` and the kernel of the input mesh is degenerated, the function returns nothing instead of a point on the boundary of the kernel.

## Release Management

* Affected package(s): PMP
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): [here](https://cgalwiki.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Add_require_strictly_inside_parameter_for_PMP::kernel_point()) pre-approved -- Sloriot 2026-03-26 
* Link to compiled documentation (obligatory for small feature) [here](https://cgal.github.io/9339/v0/PMP_Boolean_operations/group__PMP__kernel__grp.html#gaea657a1fbac5d35c3d51735c3ec2fede)
* License and copyright ownership: no change

