### PR TITLE
Add error handling for file input in geometry test functions

### DIFF
--- a/AABB_tree/benchmark/AABB_tree/test.cpp
+++ b/AABB_tree/benchmark/AABB_tree/test.cpp
@@ -27,6 +27,11 @@ void naive_test(int k, const std::string& fname,
                 int& nb_inter, int& nb_no_inter, int& nb_include)
 {
   std::ifstream input(fname);
+  if (!input)
+  {
+    std::cerr << "Error: Cannot open file " << fname << std::endl;
+    return;
+  }
   Surface_mesh tm, tm2;
   input >> tm;
   copy_face_graph(tm, tm2);
@@ -91,6 +96,11 @@ void test_no_collision(int k, const std::string &fname,
                        int& nb_inter, int& nb_no_inter, int& nb_include)
 {
   std::ifstream input(fname);
+  if (!input)
+  {
+    std::cerr << "Error: Cannot open file " << fname << std::endl;
+    return;
+  }
   Surface_mesh tm, tm2;
   input >> tm;
   copy_face_graph(tm, tm2);


### PR DESCRIPTION

Added proper error handling for file opening in `naive_test` and `test_no_collision`.

Previously the code used `std::ifstream input(fname)` without checking if the file was successfully opened. Now the code prints an error message and exits the function if the file cannot be opened.

This improves robustness and helps avoid undefined behavior when invalid file paths are passed.

No logic changes were made to the algorithm itself.
