### PR TITLE
[Draft] Basic_viewer: Improve edge rendering using solid wireframe technique

### DIFF
--- a/Basic_viewer/include/CGAL/Basic_shaders.h
+++ b/Basic_viewer/include/CGAL/Basic_shaders.h
@@ -1007,8 +1007,8 @@ noperspective in vec3 GEdgeDistance;
 void main(void)
 {
 
-	float Line_Width = fEdgeSize;
-	vec4 Line_Color = vec4(0.0, 0.0, 0.0, 1.0);
+  float Line_Width = fEdgeSize;
+  vec4 Line_Color = vec4(0.0, 0.0, 0.0, 1.0);
 
   highp vec3 L = u_LightPos.xyz - vs_fP.xyz;
   highp vec3 V = -vs_fP.xyz;
@@ -1039,21 +1039,21 @@ void main(void)
   out_color = u_RenderingMode < 1 ? (diffuse + ambient) :
                       vec4(diffuse.rgb + ambient.rgb, u_RenderingMode);
 
-	float d = min( GEdgeDistance.x, GEdgeDistance.y );
-	d = min( d, GEdgeDistance.z );
-        if (u_DrawFaces){
-	float mixVal = smoothstep( Line_Width - 1, Line_Width + 1, d );
-	// Mix the surface color with the line color
-	out_color = mix( Line_Color, out_color, mixVal );
-        }
-        else{
-          if (d < Line_Width) {
-            out_color = Line_Color;
-          }
-          else {
-            discard;
-          }
-        }
+  float d = min( GEdgeDistance.x, GEdgeDistance.y );
+  d = min( d, GEdgeDistance.z );
+  if (u_DrawFaces){
+    float mixVal = smoothstep( Line_Width - 1, Line_Width + 1, d );
+    // Mix the surface color with the line color
+    out_color = mix( Line_Color, out_color, mixVal );
+  }
+  else{
+    if (d < Line_Width) {
+      out_color = Line_Color;
+    }
+    else {
+      discard;
+    }
+  }
 }
 )DELIM";
 /* const char vertex_source_clipping_plane_comp[]=R"DELIM(

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -756,7 +756,7 @@ public:
         rendering_program_face_edges.setUniformValue("u_ClipPlane", clipPlane);
         rendering_program_face_edges.setUniformValue("u_PointPlane", plane_point);
         rendering_program_face_edges.setUniformValue("u_EdgeSize", static_cast<GLfloat>(m_size_edges));
-		rendering_program_face_edges.setUniformValue("u_DrawFaces", static_cast<GLint>(m_draw_faces));
+        rendering_program_face_edges.setUniformValue("u_DrawFaces", static_cast<GLint>(m_draw_faces));
 
 
         vao[VAO_FACES].bind();


### PR DESCRIPTION
## Summary of Changes
This draft pull request addresses the issue with the rendering of basic_viewer edges. 

Previously edges were drawn as rectangles bulging out of the mesh, which can create visual bugs, especially when increasing edge sizes. 

This PR tries to solve this issue by implements a solid wireframe technique inspired by:

NVIDIA – *Solid Wireframe*  
https://developer.download.nvidia.com/SDK/10/direct3d/Source/SolidWireframe/Doc/SolidWireframe.pdf

This PR is opened early for feedback.

The following aspects are not yet addressed:
- The issues described in page 5 are not addressed yet, this can cause visual bugs when zooming into the mesh. 
- The behavior of increasing the edge sizes may be inconsistent: increasing the size of the edges in the 'draw_lcc' example takes too long due to its larger size, which is different from the other examples. 
- This approach might make the drawing of edges as cylinders unnecessary.
- Clipping support is currently not implemented yet.


## Affected package(s)

- Basic_viewer
