### PR TITLE
Surface_mesh: remove obsolete g++4.4 workaround from SM_Halfedge_index

### DIFF
--- a/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/Surface_mesh.h
@@ -162,15 +162,6 @@ namespace CGAL {
     {
     public:
 
-        // Workaround for a bug in g++4.4 in ADL for function next:
-        // we provide the types needed for std::iterator_traits<Surface_mesh::halfedge_index>,
-        // although this descriptor is not an iterator.
-        typedef void iterator_category;
-        typedef void value_type;
-        typedef void difference_type;
-        typedef void pointer;
-        typedef void reference;
-
         SM_Halfedge_index() : SM_Index<SM_Halfedge_index>((std::numeric_limits<size_type>::max)()) {}
 
         explicit SM_Halfedge_index(size_type _idx) : SM_Index<SM_Halfedge_index>(_idx) {}


### PR DESCRIPTION
Fixes #9319

#### Problem
`pybind11::detail::is_move_constructible<CGAL::SM_Halfedge_index>` evaluates to `false` while `std::move_constructible<CGAL::SM_Halfedge_index>` correctly evaluates to `true`. This inconsistency prevents pybind11-based Python bindings from properly wrapping types that hold or use `SM_Halfedge_index`.

#### Root Cause
`SM_Halfedge_index` contained five `typedef void` members (`iterator_category`, `value_type`, `difference_type`, `pointer`, `reference`) added as a workaround for a g++ 4.4 ADL bug for `std::next`. pybind11 inspects `value_type` via legacy iterator_traits and, finding `void`, concludes the type is not a proper value type and marks it as not move-constructible.

#### Fix
CGAL 6.0 raised the minimum GCC requirement to 11.4, making the g++ 4.4 workaround unnecessary. Remove the five `typedef void` members and their explanatory comment. No code in the CGAL codebase references these typedefs.