### PR TITLE
Partition_2: add Container template parameter to Partition_traits_2

### DIFF
--- a/Partition_2/doc/Partition_2/CGAL/Partition_traits_2.h
+++ b/Partition_2/doc/Partition_2/CGAL/Partition_traits_2.h
@@ -9,6 +9,9 @@ Traits class that can be used with all the
 
 \tparam R  a representation class
 \tparam PointPropertyMap a property map that maps to points of type `R::Point_2`
+\tparam Container_ the container type used to store the vertices of the output
+        polygon. It must be a model of the `SequenceContainer` concept with
+        value type `R::Point_2`. Defaults to `std::list<R::Point_2>`.
 
 \cgalModels{ConvexPartitionIsValidTraits_2,IsYMonotoneTraits_2,OptimalConvexPartitionTraits_2,PartitionTraits_2,YMonotonePartitionIsValidTraits_2}
 
@@ -22,7 +25,9 @@ Traits class that can be used with all the
 \sa `CGAL::y_monotone_partition_is_valid_2()`
 
 */
-  template< typename R, typename PointPropertyMap = Identity_property_map<R::Point_2> >
+  template< typename R,
+            typename PointPropertyMap = Identity_property_map<R::Point_2>,
+            typename Container_ = std::list<typename boost::property_traits<PointPropertyMap>::key_type> >
 class Partition_traits_2 {
 public:
 
@@ -46,9 +51,11 @@ typedef boost::property_traits<PointPropertyMap>::key_type Point_2;
 
 
 /*!
-
+The sequence container used to store the vertices of the output polygon.
+This is determined by the `Container_` template parameter.
+The default is `std::list<R::Point_2>`.
 */
-typedef std::list<Point_2> Container;
+typedef Container_ Container;
 
 /*!
 

--- a/Partition_2/doc/Partition_2/CGAL/Partition_traits_2.h
+++ b/Partition_2/doc/Partition_2/CGAL/Partition_traits_2.h
@@ -37,7 +37,7 @@ public:
 /*!
 
 */
-    typedef Partition_traits_2<R,PMap> Self;
+    typedef Partition_traits_2<R,PMap,Container_> Self;
 
 /*!
 

--- a/Partition_2/doc/Partition_2/PackageDescription.txt
+++ b/Partition_2/doc/Partition_2/PackageDescription.txt
@@ -77,7 +77,7 @@ original polygon).
 
 \cgalCRPSection{Classes}
 - `CGAL::Partition_is_valid_traits_2<Traits, PolygonIsValid>`
-- `CGAL::Partition_traits_2<R,P>`
+- `CGAL::Partition_traits_2<R,P,Container>`
 
 
 \cgalCRPSection{Function Object Classes}

--- a/Partition_2/include/CGAL/Partition_traits_2.h
+++ b/Partition_2/include/CGAL/Partition_traits_2.h
@@ -25,7 +25,9 @@
 
 namespace CGAL {
 
-  template <class Base_traits, class PointPropertyMap = Identity_property_map<typename Base_traits::Point_2> >
+  template <class Base_traits,
+            class PointPropertyMap = Identity_property_map<typename Base_traits::Point_2>,
+            class Container_ = std::list<typename boost::property_traits<PointPropertyMap>::key_type> >
 class Partition_traits_2;
 
   template <typename BT, typename PM>
@@ -38,12 +40,12 @@ class Partition_traits_2;
     typedef BT type;
   };
 
-template <class Base_traits, class PointPropertyMap>
+template <class Base_traits, class PointPropertyMap, class Container_>
 class Partition_traits_2 : public Base_traits
 {
 private:
   typedef Base_traits                                              Kernel;
-  typedef Partition_traits_2<Base_traits,PointPropertyMap> Self;
+  typedef Partition_traits_2<Base_traits,PointPropertyMap,Container_> Self;
 
   PointPropertyMap ppmap;
 
@@ -62,7 +64,7 @@ public:
   typedef typename boost::property_traits<PointPropertyMap>::key_type Point_2;
   typedef typename boost::call_traits<Point_2>::param_type Arg_type;
 
-  typedef ::std::list<Point_2>                      Container;
+  typedef Container_                                Container;
   typedef typename Polygon_traits_getter<Base_traits,PointPropertyMap>::type PolygonTraits;
   typedef CGAL::Polygon_2<PolygonTraits, Container>          Polygon_2;
 

--- a/Partition_2/test/Partition_2/partition_traits_2_vector_container_test.cpp
+++ b/Partition_2/test/Partition_2/partition_traits_2_vector_container_test.cpp
@@ -1,0 +1,64 @@
+// Regression test for the Container_ template parameter of Partition_traits_2.
+// Verifies that a user-specified container type (std::vector) can be used in
+// place of the default std::list for the output Polygon_2 vertex storage.
+// Fixes: https://github.com/CGAL/cgal/issues/7545
+
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Partition_traits_2.h>
+#include <CGAL/partition_2.h>
+#include <list>
+#include <vector>
+#include <cassert>
+
+typedef CGAL::Simple_cartesian<double>  K;
+typedef K::Point_2                      Point_2;
+
+// Traits that stores polygon vertices in a std::vector instead of std::list.
+typedef CGAL::Partition_traits_2<K,
+          CGAL::Identity_property_map<Point_2>,
+          std::vector<Point_2>>          VecTraits;
+typedef VecTraits::Polygon_2            VecPolygon_2;
+typedef std::list<VecPolygon_2>         VecPolygon_list;
+
+int main()
+{
+  // Build a simple non-convex CCW input polygon (same as the standard
+  // Partition_2 test suite polygon — proven to exercise all partitioners).
+  VecPolygon_2 polygon;
+  polygon.push_back(Point_2(227,423));
+  polygon.push_back(Point_2(123,364));
+  polygon.push_back(Point_2(129,254));
+  polygon.push_back(Point_2(230,285));
+  polygon.push_back(Point_2(231,128));
+  polygon.push_back(Point_2(387,205));
+  polygon.push_back(Point_2(417,331));
+  polygon.push_back(Point_2(319,225));
+  polygon.push_back(Point_2(268,293));
+  polygon.push_back(Point_2(367,399));
+  polygon.push_back(Point_2(298,418));
+  polygon.push_back(Point_2(196,326));
+
+  // Partition using y_monotone — output polygons use std::vector vertices.
+  VecPolygon_list partition_polys;
+  CGAL::y_monotone_partition_2(polygon.vertices_begin(),
+                               polygon.vertices_end(),
+                               std::back_inserter(partition_polys),
+                               VecTraits());
+
+  assert(!partition_polys.empty());
+
+  // Verify the vertex container is indeed std::vector<Point_2>.
+  static_assert(
+    std::is_same<VecTraits::Container, std::vector<Point_2>>::value,
+    "Container typedef must alias the Container_ template parameter");
+
+  // Partition using approx_convex.
+  partition_polys.clear();
+  CGAL::approx_convex_partition_2(polygon.vertices_begin(),
+                                  polygon.vertices_end(),
+                                  std::back_inserter(partition_polys),
+                                  VecTraits());
+  assert(!partition_polys.empty());
+
+  return 0;
+}


### PR DESCRIPTION
### Fixes #7545

The `Container` type used for the vertices of the output `Polygon_2` was hardcoded to `std::list<Point_2>` inside `Partition_traits_2`. This prevented users from requesting a different container (e.g., `std::vector<Point_2>`) for the output polygons produced by all partitioning functions (`y_monotone_partition_2`, `approx_convex_partition_2`, `greene_approx_convex_partition_2`, `optimal_convex_partition_2`).

#### Root Cause

`Partition_traits_2.h` line 65 had:

```c++
    typedef ::std::list<Point_2>  Container;
```

with no mechanism for users to change it.

#### Fix

Add a third template parameter to `Partition_traits_2`:

```c++
    class Container_ = std::list<typename boost::property_traits<PointPropertyMap>::key_type>
```

The parameter defaults to `std::list<Point_2>`, preserving full backward
compatibility with all existing uses of `Partition_traits_2<K>` and
`Partition_traits_2<K, PM>`.

Users can now write:

```c++
    typedef CGAL::Partition_traits_2<K, CGAL::Identity_property_map<K::Point_2>,
                                     std::vector<K::Point_2>> VecTraits;
    std::list<VecTraits::Polygon_2> parts;
    CGAL::optimal_convex_partition_2(pts.begin(), pts.end(),
                                     std::back_inserter(parts), VecTraits());
```

#### Files Changed

* `Partition_2/include/CGAL/Partition_traits_2.h`
  - Forward declaration: added Container_ template param with default.
  - Class definition: added Container_ to template param list and Self typedef.
  - Replaced hardcoded `typedef ::std::list<Point_2> Container` with
    `typedef Container_ Container`.

* `Partition_2/doc/Partition_2/CGAL/Partition_traits_2.h`
  - Added `\tparam Container` documentation.
  - Updated template declaration in doc header.
  - Updated Container typedef description.

* `Partition_2/doc/Partition_2/PackageDescription.txt`
  - Updated class listing from `Partition_traits_2<R,P>` to
    `Partition_traits_2<R,P,Container>`.