### PR TITLE
Fixes issue #6446 - `approx_adv` broken and unused in `Lazy_exact_nt`

### DIFF
--- a/Number_types/include/CGAL/Lazy_exact_nt.h
+++ b/Number_types/include/CGAL/Lazy_exact_nt.h
@@ -543,9 +543,6 @@ public :
     return Interval_nt<true>(i.inf(), i.sup());
   }
 
-  Interval_nt_advanced approx_adv() const
-  { return this->ptr()->approx(); }
-
 private:
   static double & relative_precision_of_to_double_internal()
   {


### PR DESCRIPTION
## Issue #6446 - `approx_adv` broken and unused in `Lazy_exact_nt`

**Issue:** https://github.com/CGAL/cgal/issues/6446

**Problem:** `Lazy_exact_nt<ET>::approx_adv()` (lines 546-547 of `Number_types/include/CGAL/Lazy_exact_nt.h`) accessed `this->ptr()` which is a private member of the `Lazy` base class, causing a compile error under any instantiation. The function is not documented, has no tests, and has zero callers across the entire codebase.

**Fix:** Removed the `approx_adv()` method entirely. Users who need an `Interval_nt_advanced` (`Interval_nt<false>`) from a `Lazy_exact_nt` can use the existing public `approx()` method inherited from the `Lazy` base class.

**Files changed:**
- `Number_types/include/CGAL/Lazy_exact_nt.h` (-3 lines)