### PR TITLE
Homogeneous_kernel: use Fraction_traits<FT>::Decompose instead of FT member functions (#5967)

### DIFF
--- a/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
+++ b/Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h
@@ -23,6 +23,7 @@
 #include <CGAL/predicates/sign_of_determinant.h>
 #include <CGAL/Homogeneous/predicates_on_pointsH2.h>
 #include <CGAL/Homogeneous/predicates_on_pointsH3.h>
+#include <CGAL/Fraction_traits.h>
 
 namespace CGAL {
 
@@ -34,6 +35,7 @@ namespace HomogeneousKernelFunctors {
   using CartesianKernelFunctors::Are_parallel_2;
   using CartesianKernelFunctors::Are_parallel_3;
   using CartesianKernelFunctors::Compute_squared_area_3;
+  using CartesianKernelFunctors::Compare_squared_radius_2;
   using CartesianKernelFunctors::Compare_squared_radius_3;
   using CartesianKernelFunctors::Collinear_3;
   using CartesianKernelFunctors::Construct_line_3;
@@ -2598,8 +2600,9 @@ namespace HomogeneousKernelFunctors {
     Vector_2
     operator()(const Vector_2& v, const FT& f ) const
     {
-      return Vector_2( v.hx()*f.denominator(), v.hy()*f.denominator(),
-                       v.hw()*f.numerator() );
+      RT num, den;
+      typename Fraction_traits<FT>::Decompose()(f, num, den);
+      return Vector_2( v.hx()*den, v.hy()*den, v.hw()*num );
     }
 
     Vector_2
@@ -2620,8 +2623,9 @@ namespace HomogeneousKernelFunctors {
     Vector_3
     operator()(const Vector_3& v, const FT& f ) const
     {
-      return Vector_3( v.hx()*f.denominator(), v.hy()*f.denominator(),
-                       v.hz()*f.denominator(), v.hw()*f.numerator() );
+      RT num, den;
+      typename Fraction_traits<FT>::Decompose()(f, num, den);
+      return Vector_3( v.hx()*den, v.hy()*den, v.hz()*den, v.hw()*num );
     }
 
     Vector_3
@@ -3329,9 +3333,14 @@ namespace HomogeneousKernelFunctors {
                    CGAL::square(c2.center().x()) -
                    CGAL::square(c2.center().y()) + c2.squared_radius();
 
-      const RT aa = a.numerator() * b.denominator() * c.denominator();
-      const RT bb = a.denominator() * b.numerator() * c.denominator();
-      const RT cc = a.denominator() * b.denominator() * c.numerator();
+      RT num_a, den_a, num_b, den_b, num_c, den_c;
+      typename Fraction_traits<FT>::Decompose decomp;
+      decomp(a, num_a, den_a);
+      decomp(b, num_b, den_b);
+      decomp(c, num_c, den_c);
+      const RT aa = num_a * den_b * den_c;
+      const RT bb = den_a * num_b * den_c;
+      const RT cc = den_a * den_b * num_c;
 
       return Line_2(aa, bb, cc);
     }
@@ -3361,10 +3370,16 @@ namespace HomogeneousKernelFunctors {
                    CGAL::square(s2.center().y()) -
                    CGAL::square(s2.center().z()) + s2.squared_radius();
 
-      const RT aa = a.numerator() * b.denominator() * c.denominator() * d.denominator();
-      const RT bb = a.denominator() * b.numerator() * c.denominator() * d.denominator();
-      const RT cc = a.denominator() * b.denominator() * c.numerator() * d.denominator();
-      const RT dd = a.denominator() * b.denominator() * c.denominator() * d.numerator();
+      RT num_a, den_a, num_b, den_b, num_c, den_c, num_d, den_d;
+      typename Fraction_traits<FT>::Decompose decomp;
+      decomp(a, num_a, den_a);
+      decomp(b, num_b, den_b);
+      decomp(c, num_c, den_c);
+      decomp(d, num_d, den_d);
+      const RT aa = num_a * den_b * den_c * den_d;
+      const RT bb = den_a * num_b * den_c * den_d;
+      const RT cc = den_a * den_b * num_c * den_d;
+      const RT dd = den_a * den_b * den_c * num_d;
 
       return Plane_3(aa, bb, cc, dd);
     }
@@ -3387,8 +3402,9 @@ namespace HomogeneousKernelFunctors {
     Vector_2
     operator()( const Vector_2& v, const FT& c) const
     {
-      return Vector_2( v.hx()*c.numerator(), v.hy()*c.numerator(),
-                       v.hw()*c.denominator() ); }
+      RT num, den;
+      typename Fraction_traits<FT>::Decompose()(c, num, den);
+      return Vector_2( v.hx()*num, v.hy()*num, v.hw()*den ); }
   };
 
   template <typename K>
@@ -3408,8 +3424,9 @@ namespace HomogeneousKernelFunctors {
     Vector_3
     operator()( const Vector_3& v, const FT& c) const
     {
-      return Vector_3( v.hx()*c.numerator(), v.hy()*c.numerator(),
-                       v.hz()*c.numerator(), v.hw()*c.denominator() ); }
+      RT num, den;
+      typename Fraction_traits<FT>::Decompose()(c, num, den);
+      return Vector_3( v.hx()*num, v.hy()*num, v.hz()*num, v.hw()*den ); }
   };
 
   template <typename K>


### PR DESCRIPTION
**Problem:**
Several functor classes in `Homogeneous_kernel/include/CGAL/Homogeneous/function_objects.h` called `.numerator()` and `.denominator()` directly on `FT` objects:

- `Construct_divided_vector_2` / `Construct_divided_vector_3`
- `Construct_radical_line_2` / `Construct_radical_plane_3`
- `Construct_scaled_vector_2` / `Construct_scaled_vector_3`

These members only exist on `CGAL::Quotient<RT>`. They are absent on `mpq_class`, `CGAL::Exact_rational`, `Lazy_exact_nt<...>`, etc., causing compile errors when using
e.g. `Homogeneous<CGAL::Exact_integer, CGAL::Exact_rational>`.

**Fix:**
Added `#include <CGAL/Fraction_traits.h>` and replaced all 6 call sites with a single `typename Fraction_traits<FT>::Decompose()(x, num, den)` call per FT value. This:
- Works for every CGAL-supported rational field type
- Performs exactly one decomposition per value (eliminating the repeated decompositions Copilot flagged in the original)
- Uses the current recommended API (`Fraction_traits`) rather than the backward-compat  `Rational_traits`