### PR TITLE
config: do not use [[assume]] for CGAL_ASSUME on GCC

### DIFF
--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -359,17 +359,33 @@ using std::max;
 #endif
 
 // Macro CGAL_ASSUME and CGAL_UNREACHABLE
-#ifdef CGAL_CXX23
+//
+// CGAL_ASSUME(EX) tells the compiler that EX is true, as an optimisation hint.
+//   - [[assume(EX)]] (C++23): does not evaluate EX, but on GCC it enables
+//     fewer optimizations than __builtin_unreachable() and is often ignored.
+//   - __builtin_assume(EX) (Clang/ICC): does not evaluate EX, zero-cost hint.
+//   - if(!(EX)){__builtin_unreachable();} (GCC): evaluates EX, but enables
+//     stronger optimizations on GCC.
+//   - __assume(EX) (MSVC): does not evaluate EX.
+//
+// GCC is excluded from the C++23 [[assume]] path because __builtin_unreachable()
+// provides strictly stronger optimizations there.
+#if defined(CGAL_CXX23) && !(defined(__GNUC__) && !defined(__clang__))
+// C++23: [[assume(EX)]] does not evaluate EX.
+// Not used on GCC where __builtin_unreachable() is more effective.
 #  define CGAL_ASSUME(EX) [[ assume(EX) ]]
 #  define CGAL_UNREACHABLE() std::unreachable()
+#elif __has_builtin(__builtin_assume)
+// Clang/ICC: __builtin_assume(EX) does not evaluate EX, zero-cost hint.
+#  define CGAL_ASSUME(EX) __builtin_assume(EX)
+#  define CGAL_UNREACHABLE() __builtin_unreachable()
 #elif __has_builtin(__builtin_unreachable) || (CGAL_GCC_VERSION > 0 && !__STRICT_ANSI__)
-// Call a builtin of the compiler to pass a hint to the compiler
-// From g++ 4.5, there exists a __builtin_unreachable()
-// Also in LLVM/clang
+// GCC: __builtin_unreachable() enables stronger optimizations than [[assume]].
+// Note: this form evaluates EX at runtime.
 #  define CGAL_ASSUME(EX) if(!(EX)) { __builtin_unreachable(); }
 #  define CGAL_UNREACHABLE() __builtin_unreachable()
 #elif defined(_MSC_VER)
-// MSVC has __assume
+// MSVC: __assume(EX) does not evaluate EX.
 #  define CGAL_ASSUME(EX) __assume(EX)
 #  define CGAL_UNREACHABLE() __assume(0)
 #endif

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -359,7 +359,10 @@ using std::max;
 #endif
 
 // Macro CGAL_ASSUME and CGAL_UNREACHABLE
-#ifdef CGAL_CXX23
+// GCC is excluded from the C++23 [[assume]] path: there [[assume(EX)]] does not
+// evaluate EX, which enables a much more restricted set of optimizations than
+// __builtin_unreachable() and is often simply ignored.
+#if defined(CGAL_CXX23) && !(defined(__GNUC__) && !defined(__clang__))
 #  define CGAL_ASSUME(EX) [[ assume(EX) ]]
 #  define CGAL_UNREACHABLE() std::unreachable()
 #elif __has_builtin(__builtin_unreachable) || (CGAL_GCC_VERSION > 0 && !__STRICT_ANSI__)


### PR DESCRIPTION
`CGAL_ASSUME(EX)` expands to `[[assume(EX)]]` in C++23 mode. As @mglisse pointed out in the review, on GCC that is not an improvement over `if(!(EX)){__builtin_unreachable();}`: `[[assume]]` is guaranteed not to evaluate `EX`, and to keep that guarantee GCC enables a much more restricted set of optimizations and often simply ignores the assumption, whereas `__builtin_unreachable()` enables the stronger ones.

This PR therefore excludes GCC from the C++23 `[[assume]]` path, so GCC keeps `if(!(EX)){__builtin_unreachable();}` in every standard mode. Clang and MSVC are unaffected.

### What changed since the first version

The first version of this PR also added a `__builtin_assume(EX)` branch for Clang and ICC, to make `CGAL_ASSUME` a genuinely non-evaluating hint (issue #7334). That has been dropped. `__builtin_assume` does not evaluate its argument, and several of CGAL's 39 `CGAL_assume()` call sites pass function calls, for example:

```cpp
CGAL_assume(info_has_been_set());
CGAL_assume(!this->debug().validity() || this->is_valid(true));
CGAL_assume(f != e);
```

A non-evaluating assumption silently discards those calls and makes Clang emit `-Wassume`, which is the testsuite failure reported by @afabri and @sloriot. Making `CGAL_ASSUME` non-evaluating would first need the audit of all uses that @mglisse described, and possibly a separate `CGAL_ASSUME_STRONG`, so it is left out here.

### Verification

Comparing the macro expansion with g++ on main and on this branch:

| standard | main | this branch |
|---|---|---|
| C++17 | `if(!(x>0)){__builtin_unreachable();}` | identical |
| C++23 | `[[ assume(x > 0) ]]` | `if(!(x>0)){__builtin_unreachable();}` |

C++17, which is what the testsuite builds, is unchanged from main, and C++23 on GCC
gets the stronger form. The `NewKernel_d` site from the report
(`Vector/array.h:63`, reached through `Epick_d`) compiles with no warnings.

### Release Management

Affected package(s): Installation (`CGAL/config.h`)
Issue(s) solved (if any): none. This no longer implements #7334, see above.
Feature/Small Feature (if any): none
License and copyright ownership: already covered by existing headers