### PR TITLE
typo: bissection->bisection

### DIFF
--- a/Mesh_3/test/Mesh_3/test_meshing_utilities.h
+++ b/Mesh_3/test/Mesh_3/test_meshing_utilities.h
@@ -299,7 +299,7 @@ struct Tester
                                  const Polyhedral_tag) const
   {}
 
-  // For bissection domains, check the consistency between the subdomain
+  // For bisection domains, check the consistency between the subdomain
   // indices and the surface patch indices.
   template<typename C3t3, typename MeshDomain>
   void verify_c3t3_combinatorics(const C3t3& c3t3,
@@ -353,7 +353,7 @@ struct Tester
     }
   }
 
-  // For bissection domains, do nothing.
+  // For bisection domains, do nothing.
   template<typename C3t3, typename MeshDomain>
   double compute_hausdorff_distance(const C3t3&,
                                     const MeshDomain&,

--- a/Poisson_surface_reconstruction_3/include/CGAL/Surface_mesher/Poisson_implicit_surface_oracle_3.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/Surface_mesher/Poisson_implicit_surface_oracle_3.h
@@ -335,7 +335,7 @@ namespace CGAL {
                                                          transform_functor(value_at_p2)));
 
             visitor.new_point(mid);
-            CGAL_SURFACE_MESHER_HISTOGRAM_PROFILER("Implificit_surface_oracle::Intersect_3::operator(Segment_3) bissection steps", steps)
+            CGAL_SURFACE_MESHER_HISTOGRAM_PROFILER("Implificit_surface_oracle::Intersect_3::operator(Segment_3) bisection steps", steps)
             return make_object(mid);
           }
 

--- a/Surface_mesher/include/CGAL/Surface_mesher/Implicit_surface_oracle_3.h
+++ b/Surface_mesher/include/CGAL/Surface_mesher/Implicit_surface_oracle_3.h
@@ -343,7 +343,7 @@ namespace CGAL {
                                                          value_at_p2));
 
             visitor.new_point(mid);
-            CGAL_SURFACE_MESHER_HISTOGRAM_PROFILER("Implificit_surface_oracle::Intersect_3::operator(Segment_3) bissection steps", steps)
+            CGAL_SURFACE_MESHER_HISTOGRAM_PROFILER("Implificit_surface_oracle::Intersect_3::operator(Segment_3) bisection steps", steps)
             return make_object(mid);
           }
 


### PR DESCRIPTION
## Summary of Changes

Fix typos I made lonnng ago, when I was still a master student. My bad. I was younger (and without spelling tools for code).

## Release Management

* Affected package(s): Surface_mesher, Mesh_3, and related
* License and copyright ownership: N/A
