### PR TITLE
Tetrahedral remeshing for slivers only

### DIFF
--- a/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/mesh_and_remesh_polyhedral_domain_with_features.cpp
+++ b/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/mesh_and_remesh_polyhedral_domain_with_features.cpp
@@ -1,3 +1,8 @@
+#define CGAL_TETRAHEDRAL_REMESHING_DEBUG
+#define CGAL_TETRAHEDRAL_REMESHING_VERBOSE
+#define CGAL_TETRAHEDRAL_REMESHING_VERBOSE_PROGRESS
+#define CGAL_DUMP_REMESHING_STEPS
+
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Mesh_triangulation_3.h>
@@ -95,7 +100,7 @@ int main(int argc, char* argv[])
   CGAL::tetrahedral_isotropic_remeshing(tr, size,
     number_of_iterations(nb_iter)
     .edge_is_constrained_map(constraints_pmap)
-    .cell_is_selected_map(CGAL::sliver_selection_property_map(tr, 4. /*min dihedral angle*/)));
+    .cell_is_selected_map(CGAL::sliver_selection_property_map(tr, 3. /*min dihedral angle*/)));
 
   std::ofstream out("out_remeshed.mesh");
   CGAL::IO::write_MEDIT(out, tr);

--- a/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/mesh_and_remesh_polyhedral_domain_with_features.cpp
+++ b/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/mesh_and_remesh_polyhedral_domain_with_features.cpp
@@ -5,10 +5,11 @@
 #include <CGAL/Mesh_criteria_3.h>
 
 #include <CGAL/Surface_mesh.h>
+#include <CGAL/make_mesh_3.h>
 #include <CGAL/Polyhedral_mesh_domain_with_features_3.h>
 
-#include <CGAL/make_mesh_3.h>
 #include <CGAL/tetrahedral_remeshing.h>
+#include <CGAL/sliver_selection_property_map.h>
 
 #include <CGAL/property_map.h>
 #include <CGAL/IO/File_medit.h>
@@ -93,7 +94,8 @@ int main(int argc, char* argv[])
   // Remeshing
   CGAL::tetrahedral_isotropic_remeshing(tr, size,
     number_of_iterations(nb_iter)
-    .edge_is_constrained_map(constraints_pmap));
+    .edge_is_constrained_map(constraints_pmap)
+    .cell_is_selected_map(CGAL::sliver_selection_property_map(tr, 4. /*min dihedral angle*/)));
 
   std::ofstream out("out_remeshed.mesh");
   CGAL::IO::write_MEDIT(out, tr);

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -297,7 +297,20 @@ public:
 #ifdef CGAL_DUMP_REMESHING_STEPS
     CGAL::Tetrahedral_remeshing::debug::dump_c3t3(m_c3t3, "99-postprocess");
 #endif
+#ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
+    mindh = 180.;
+    for (Cell_handle cit : tr().finite_cell_handles())
+    {
+      if (m_c3t3.is_in_complex(cit))
+      {
+        const double dh = min_dihedral_angle(tr(), cit);
+        mindh = (std::min)(dh, mindh);
+      }
+    }
+    std::cout << "Peeling done (removed " << nb_peeled << " slivers, "
+      << "min dihedral angle = " << mindh << ")." << std::endl;
 
+#endif
     return nb_peeled;
   }
 

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -298,7 +298,7 @@ public:
     CGAL::Tetrahedral_remeshing::debug::dump_c3t3(m_c3t3, "99-postprocess");
 #endif
 #ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
-    mindh = 180.;
+    double mindh = 180.;
     for (Cell_handle cit : tr().finite_cell_handles())
     {
       if (m_c3t3.is_in_complex(cit))

--- a/Tetrahedral_remeshing/include/CGAL/sliver_selection_property_map.h
+++ b/Tetrahedral_remeshing/include/CGAL/sliver_selection_property_map.h
@@ -1,0 +1,122 @@
+// Copyright (c) 2022 GeometryFactory (France)
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+//
+//
+// Author(s)     : Jane Tournois
+
+#ifndef TETRAHEDRAL_REMESHING_CELL_SELECTOR_H
+#define TETRAHEDRAL_REMESHING_CELL_SELECTOR_H
+
+#include <CGAL/license/Tetrahedral_remeshing.h>
+
+#include <CGAL/Mesh_3/min_dihedral_angle.h> //todo : remove dependency on Mesh_3
+
+#include <CGAL/property_map.h>
+
+#include <unordered_set>
+
+namespace CGAL
+{
+/*!
+* \ingroup PkgTetrahedralRemeshingRef
+*
+*
+* \sa `CGAL::tetrahedral_isotropic_remeshing()`
+* 
+* \todo use sliver_value() from Mesh_cell_base_3.h when available
+*/
+template<typename Triangulation>
+class Sliver_selection_property_map
+{
+  using Tr = Triangulation;
+  using Cell_handle = typename Tr::Cell_handle;
+  using FT = typename Tr::Geom_traits::FT;
+  using Subdomain_index
+    = typename Tr::Triangulation_data_structure::Cell::Subdomain_index;
+
+  const Tr& m_tr;
+  std::unordered_set<Cell_handle> m_slivers;
+
+public:
+  using key_type    = Cell_handle;
+  using value_type  = bool;
+  using reference   = bool;
+  using category    = boost::read_write_property_map_tag;
+
+  Sliver_selection_property_map(const Tr& tr, const FT& sliver_bound)
+    : m_tr(tr)
+    , m_slivers()
+  {
+    collect_slivers(sliver_bound);
+  }
+
+  friend value_type get(const Sliver_selection_property_map& map,
+                        const key_type& c)
+  {
+    return map.m_slivers.find(c) != map.m_slivers.end();
+  }
+  friend void put(Sliver_selection_property_map& map,
+                  const key_type& c,
+                  const value_type b)
+  {
+    if (b)               map.m_slivers.insert(c);
+    else if (get(map, c)) map.m_slivers.erase(c);
+  }
+
+private:
+  template<typename CellsSet>
+  void insert_neighbors(Cell_handle c, CellsSet& cells)
+  {
+    for (int i = 0; i < 4; ++i)
+    {
+      Cell_handle ni = c->neighbor(i);
+      if (Subdomain_index() != ni->subdomain_index())
+        cells.insert(ni);
+    }
+  }
+
+  void collect_slivers(const FT& sliver_bound)
+  {
+    using CGAL::Mesh_3::minimum_dihedral_angle;
+    auto cp = m_tr.geom_traits().construct_point_3_object();
+
+    for (Cell_handle c : m_tr.finite_cell_handles())
+    {
+      FT a = minimum_dihedral_angle(cp(c->vertex(0)->point()),
+                                    cp(c->vertex(1)->point()),
+                                    cp(c->vertex(2)->point()),
+                                    cp(c->vertex(3)->point()),
+                                    m_tr.geom_traits());
+      if (a < sliver_bound)
+        m_slivers.insert(c);
+    }
+
+    std::unordered_set<Cell_handle> neighbors;
+    for (Cell_handle c : m_slivers)
+      insert_neighbors(c, neighbors);
+    //todo : we probably need to enlarge the selected region
+  }
+
+
+};//end class Sliver_selection_property_map
+
+/**
+*/
+template<typename Tr>
+Sliver_selection_property_map<Tr>
+sliver_selection_property_map(const Tr& tr,
+                              const typename Tr::Geom_traits::FT& angle)
+{
+  return Sliver_selection_property_map<Tr>(tr, angle);
+}
+
+
+}//end namespace CGAL
+
+#endif //TETRAHEDRAL_REMESHING_CELL_SELECTOR_H

--- a/Tetrahedral_remeshing/include/CGAL/sliver_selection_property_map.h
+++ b/Tetrahedral_remeshing/include/CGAL/sliver_selection_property_map.h
@@ -28,7 +28,7 @@ namespace CGAL
 *
 *
 * \sa `CGAL::tetrahedral_isotropic_remeshing()`
-* 
+*
 * \todo use sliver_value() from Mesh_cell_base_3.h when available
 */
 template<typename Triangulation>


### PR DESCRIPTION
## Summary of Changes

Add a `cell_selector` to remesh slivers only


## Release Management

* Affected package(s):
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

