### PR TITLE
Polygon_repair: Mark edge and not face as processed

### DIFF
--- a/Polygon_repair/include/CGAL/Polygon_repair/internal/Triangulation_face_base_with_repair_info_2.h
+++ b/Polygon_repair/include/CGAL/Polygon_repair/internal/Triangulation_face_base_with_repair_info_2.h
@@ -15,6 +15,7 @@
 #include <CGAL/license/Polygon_repair.h>
 
 #include <CGAL/Triangulation_face_base_2.h>
+#include <bitset>
 
 namespace CGAL {
 namespace Polygon_repair {
@@ -24,6 +25,7 @@ template <typename Kernel, typename FaceBase = Triangulation_face_base_2<Kernel>
 class Triangulation_face_base_with_repair_info_2 : public FaceBase {
   int _label;
   bool _processed;
+  std::bitset<3> _edge;
 public:
   using Vertex_handle = typename FaceBase::Vertex_handle;
   using Face_handle = typename FaceBase::Face_handle;
@@ -47,6 +49,8 @@ public:
   bool& processed() { return _processed; }
   const int& label() const { return _label; }
   int& label() { return _label; }
+  bool processed(int i) const { return _edge[i]; }
+  void set_processed(int i)  { _edge[i] = true; }
 };
 
 } // namespace internal

--- a/Polygon_repair/include/CGAL/Polygon_repair/repair.h
+++ b/Polygon_repair/include/CGAL/Polygon_repair/repair.h
@@ -867,7 +867,7 @@ public:
     int current_opposite_vertex = opposite_vertex;
     do {
       CGAL_assertion(current_face->label() == face_adjacent_to_boundary->label());
-      current_face->processed() = true;
+      current_face->set_processed(current_opposite_vertex);
       Vertex_handle pivot_vertex = current_face->vertex(current_face->cw(current_opposite_vertex));
       // std::cout << "\tAdding point " << pivot_vertex->point() << std::endl;
       ring.push_back(pivot_vertex->point());
@@ -899,15 +899,11 @@ public:
     polygons.resize(number_of_polygons);
     holes.resize(number_of_polygons);
 
-    for (auto const face: t.all_face_handles()) {
-      face->processed() = false;
-    }
     for (auto const &face: t.finite_face_handles()) {
       if (face->label() < 1) continue; // exterior triangle
-      if (face->processed()) continue; // already reconstructed
       for (int opposite_vertex = 0; opposite_vertex < 3; ++opposite_vertex) {
         if (face->label() == face->neighbor(opposite_vertex)->label()) continue; // not adjacent to boundary
-
+        if(face->processed(opposite_vertex)) continue; // already reconstructed by other side of boundary
         // Reconstruct ring
         std::list<Point_2> ring;
         reconstruct_ring(ring, face, opposite_vertex);

--- a/Polygon_repair/test/Polygon_repair/CMakeLists.txt
+++ b/Polygon_repair/test/Polygon_repair/CMakeLists.txt
@@ -15,6 +15,7 @@ find_package(CGAL REQUIRED OPTIONAL_COMPONENTS Qt6)
 #  create_single_source_cgal_program("${cppfile}")
 #endforeach()
 
+create_single_source_cgal_program( "issue9325.cpp" )
 create_single_source_cgal_program( "draw_test_polygons.cpp" )
 create_single_source_cgal_program( "exact_test.cpp")
 create_single_source_cgal_program( "repair_polygon_2_test.cpp" )

--- a/Polygon_repair/test/Polygon_repair/issue9325.cpp
+++ b/Polygon_repair/test/Polygon_repair/issue9325.cpp
@@ -1,0 +1,275 @@
+#ifndef CGAL_NO_CDT_2_WARNING
+#define CGAL_NO_CDT_2_WARNING
+#endif
+
+#include <CGAL/Simple_cartesian.h>
+#include <CGAL/Exact_rational.h>
+#include <CGAL/Polygon_2.h>
+#include <CGAL/Polygon_with_holes_2.h>
+#include <CGAL/Multipolygon_with_holes_2.h>
+#include <CGAL/Polygon_repair/repair.h>
+#include <CGAL/Polygon_repair/Even_odd_rule.h>
+#include <CGAL/version.h>
+
+#include <algorithm>
+#include <initializer_list>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace {
+
+using Kernel = CGAL::Simple_cartesian<CGAL::Exact_rational>;
+using Point = Kernel::Point_2;
+using Ring = std::vector<Point>;
+using Polygon = CGAL::Polygon_2<Kernel>;
+using PolygonWithHoles = CGAL::Polygon_with_holes_2<Kernel>;
+using Multipolygon = CGAL::Multipolygon_with_holes_2<Kernel>;
+
+enum class Location {
+    Outside,
+    Inside,
+    Boundary
+};
+
+std::string qstr(const CGAL::Exact_rational& q) {
+    std::ostringstream os;
+    os << q;
+    return os.str();
+}
+
+std::string pstr(const Point& p) {
+    return "(" + qstr(p.x()) + ", " + qstr(p.y()) + ")";
+}
+
+std::string lstr(Location loc) {
+    switch (loc) {
+        case Location::Outside:
+            return "OUTSIDE";
+        case Location::Inside:
+            return "INSIDE";
+        case Location::Boundary:
+            return "BOUNDARY";
+    }
+    return "UNKNOWN";
+}
+
+Point p(long long x, long long y) {
+    return Point(CGAL::Exact_rational(x), CGAL::Exact_rational(y));
+}
+
+Point pq(long long xn, long long xd, long long yn, long long yd) {
+    CGAL::Exact_rational x = CGAL::Exact_rational(xn) / CGAL::Exact_rational(xd);
+    CGAL::Exact_rational y = CGAL::Exact_rational(yn) / CGAL::Exact_rational(yd);
+    return Point(x, y);
+}
+
+Ring ring_from_ints(std::initializer_list<std::pair<long long, long long>> pts) {
+    Ring out;
+    out.reserve(pts.size());
+    for (const auto& pt : pts) {
+        out.push_back(p(pt.first, pt.second));
+    }
+    return out;
+}
+
+bool on_segment(const Point& a, const Point& b, const Point& q) {
+    if (CGAL::orientation(a, b, q) != CGAL::COLLINEAR) {
+        return false;
+    }
+    const CGAL::Exact_rational min_x = std::min(a.x(), b.x());
+    const CGAL::Exact_rational max_x = std::max(a.x(), b.x());
+    const CGAL::Exact_rational min_y = std::min(a.y(), b.y());
+    const CGAL::Exact_rational max_y = std::max(a.y(), b.y());
+    return (min_x <= q.x() && q.x() <= max_x && min_y <= q.y() && q.y() <= max_y);
+}
+
+struct WindingResult {
+    bool boundary = false;
+    int wn = 0;
+};
+
+WindingResult winding_number_ring(const Ring& ring, const Point& q) {
+    WindingResult res;
+    if (ring.size() < 3) {
+        return res;
+    }
+
+    const size_t n = ring.size();
+    for (size_t i = 0; i < n; ++i) {
+        const Point& a = ring[i];
+        const Point& b = ring[(i + 1) % n];
+
+        if (on_segment(a, b, q)) {
+            res.boundary = true;
+            return res;
+        }
+
+        if (a.y() <= q.y()) {
+            if (b.y() > q.y() && CGAL::orientation(a, b, q) == CGAL::LEFT_TURN) {
+                ++res.wn;
+            }
+        } else {
+            if (b.y() <= q.y() && CGAL::orientation(a, b, q) == CGAL::RIGHT_TURN) {
+                --res.wn;
+            }
+        }
+    }
+    return res;
+}
+
+Location evenodd_from_input_winding(const std::vector<Ring>& rings, const Point& q) {
+    int total_wn = 0;
+    for (const auto& r : rings) {
+        WindingResult wr = winding_number_ring(r, q);
+        if (wr.boundary) {
+            return Location::Boundary;
+        }
+        total_wn += wr.wn;
+    }
+    const int parity = ((total_wn % 2) + 2) % 2;
+    return parity ? Location::Inside : Location::Outside;
+}
+
+Ring clean_ring(const Ring& ring) {
+    Ring out;
+    out.reserve(ring.size());
+    for (const Point& pt : ring) {
+        if (out.empty() || out.back() != pt) {
+            out.push_back(pt);
+        }
+    }
+    if (out.size() >= 2 && out.front() == out.back()) {
+        out.pop_back();
+    }
+    return out;
+}
+
+Multipolygon repaired_evenodd(const std::vector<Ring>& rings) {
+    Multipolygon in;
+    for (const Ring& r0 : rings) {
+        Ring r = clean_ring(r0);
+        if (r.size() < 3) {
+            continue;
+        }
+        Polygon poly(r.begin(), r.end());
+        in.add_polygon_with_holes(PolygonWithHoles(poly));
+    }
+    return CGAL::Polygon_repair::repair(in, CGAL::Polygon_repair::Even_odd_rule());
+}
+
+Location locate_in_repaired(const Multipolygon& mp, const Point& q) {
+    for (const auto& pwh : mp.polygons_with_holes()) {
+        const CGAL::Bounded_side outer = pwh.outer_boundary().bounded_side(q);
+        if (outer == CGAL::ON_BOUNDARY) {
+            return Location::Boundary;
+        }
+        if (outer == CGAL::ON_UNBOUNDED_SIDE) {
+            continue;
+        }
+
+        bool inside_hole = false;
+        for (auto hit = pwh.holes_begin(); hit != pwh.holes_end(); ++hit) {
+            const CGAL::Bounded_side hs = hit->bounded_side(q);
+            if (hs == CGAL::ON_BOUNDARY) {
+                return Location::Boundary;
+            }
+            if (hs == CGAL::ON_BOUNDED_SIDE) {
+                inside_hole = true;
+                break;
+            }
+        }
+        if (!inside_hole) {
+            return Location::Inside;
+        }
+    }
+    return Location::Outside;
+}
+
+bool print_check(const std::string& label, const std::vector<Ring>& rings, const Multipolygon& mp, const Point& q) {
+    const Location from_input = evenodd_from_input_winding(rings, q);
+    const Location from_repair = locate_in_repaired(mp, q);
+    const bool same = (from_input == from_repair);
+    std::cout << "  " << label << "  p=" << pstr(q)
+              << "  input_winding=" << lstr(from_input)
+              << "  repair=" << lstr(from_repair)
+              << "  => " << (same ? "MATCH" : "MISMATCH") << "\n";
+    return same;
+}
+
+bool run_two_square_validation() {
+    std::cout << "=== Validation: two overlapping squares (evenodd) ===\n";
+    const std::vector<Ring> rings = {
+        ring_from_ints({{0, 0}, {10, 0}, {10, 10}, {0, 10}}),
+        ring_from_ints({{5, 0}, {15, 0}, {15, 10}, {5, 10}})
+    };
+
+    const Multipolygon repaired = repaired_evenodd(rings);
+
+    bool ok = true;
+    ok &= print_check("square witness A", rings, repaired, p(2, 5));  // inside first square only
+    ok &= print_check("square witness B", rings, repaired, p(7, 5));  // in overlap, so outside under evenodd
+    std::cout << '\n';
+    return ok;
+}
+
+bool run_case45_repro() {
+    std::cout << "=== Repro: case 45 witness points ===\n";
+    std::cout << "Problem triangle reported in repaired output:\n";
+    std::cout << "  T = {(4491,1100), (4499,1135), (4100,1105)}\n";
+
+    // Exact ring bag that triggers the failure in CGAL Polygon_repair EVENODD.
+    const std::vector<Ring> rings = {
+        ring_from_ints({
+            {4505, 401}, {4522, 1145}, {4503, 1162}, {2280, 1129}, {4100, 1105},
+            {3360, 1050}, {3302, 1107}, {1026, 1126}, {1026, 235}
+        }),
+        ring_from_ints({
+            {4100, 1105}, {4499, 1135}, {4491, 1100}
+        }),
+        ring_from_ints({
+            {4491, 1100}, {4501, 1100}, {4501, 866}, {1146, 462}, {1071, 1067}, {4469, 1000}
+        }),
+        ring_from_ints({
+            {3291, 1118}, {3360, 1050}, {4512, 1136}
+        })
+    };
+
+    const Multipolygon repaired = repaired_evenodd(rings);
+
+    bool controls_ok = true;
+    controls_ok &= print_check("control OUT point", rings, repaired, p(500, 500));
+    controls_ok &= print_check("control IN point ", rings, repaired, p(4200, 800));
+
+    // Strictly interior point of the problem triangle: centroid.
+    const Point tri_centroid = pq(13090, 3, 3340, 3);
+    const bool tri_match = print_check("triangle centroid", rings, repaired, tri_centroid);
+
+    std::cout << '\n';
+    const bool reproduced = controls_ok && !tri_match;
+    std::cout << "Repro verdict: " << (reproduced ? "REPRODUCED" : "NOT REPRODUCED") << "\n";
+    return reproduced;
+}
+
+}  // namespace
+
+int main() {
+    std::cout << "CGAL_VERSION=" << CGAL_VERSION_STR << "\n";
+    std::cout << "CGAL_VERSION_NR=" << CGAL_VERSION_NR << "\n\n";
+    std::cout << "CGAL_RELEASE_DATE=" << CGAL_RELEASE_DATE << "\n\n";
+
+    const bool validation_ok = run_two_square_validation();
+    const bool repro_ok = run_case45_repro();
+
+    if (!validation_ok) {
+        std::cerr << "Validation failed: methodology check did not pass.\n";
+        return 1;
+    }
+    if(!repro_ok) {
+        std::cerr << "Mismatch as reported in Issue 9325 at triangle witness point was not observed.\n";
+        return 0;
+    }
+    return 1;
+}

--- a/Polygon_repair/test/Polygon_repair/issue9325.cpp
+++ b/Polygon_repair/test/Polygon_repair/issue9325.cpp
@@ -56,17 +56,17 @@ std::string lstr(Location loc) {
     return "UNKNOWN";
 }
 
-Point p(long long x, long long y) {
+Point p(int x, int y) {
     return Point(CGAL::Exact_rational(x), CGAL::Exact_rational(y));
 }
 
-Point pq(long long xn, long long xd, long long yn, long long yd) {
+Point pq(int xn, int xd, int yn, int yd) {
     CGAL::Exact_rational x = CGAL::Exact_rational(xn) / CGAL::Exact_rational(xd);
     CGAL::Exact_rational y = CGAL::Exact_rational(yn) / CGAL::Exact_rational(yd);
     return Point(x, y);
 }
 
-Ring ring_from_ints(std::initializer_list<std::pair<long long, long long>> pts) {
+Ring ring_from_ints(std::initializer_list<std::pair<int, int>> pts) {
     Ring out;
     out.reserve(pts.size());
     for (const auto& pt : pts) {
@@ -79,10 +79,10 @@ bool on_segment(const Point& a, const Point& b, const Point& q) {
     if (CGAL::orientation(a, b, q) != CGAL::COLLINEAR) {
         return false;
     }
-    const CGAL::Exact_rational min_x = std::min(a.x(), b.x());
-    const CGAL::Exact_rational max_x = std::max(a.x(), b.x());
-    const CGAL::Exact_rational min_y = std::min(a.y(), b.y());
-    const CGAL::Exact_rational max_y = std::max(a.y(), b.y());
+    const CGAL::Exact_rational min_x = (std::min)(a.x(), b.x());
+    const CGAL::Exact_rational max_x = (std::max)(a.x(), b.x());
+    const CGAL::Exact_rational min_y = (std::min)(a.y(), b.y());
+    const CGAL::Exact_rational max_y = (std::max)(a.y(), b.y());
     return (min_x <= q.x() && q.x() <= max_x && min_y <= q.y() && q.y() <= max_y);
 }
 


### PR DESCRIPTION
## Summary of Changes

In case all faces incident to a border were marked as _processed_ we missed holes.

## Release Management

* Affected package(s): Polygon_repair
* Issue(s) solved (if any): fix #9325
* License and copyright ownership: unchanged

