### PR TITLE
Clean up CH3::do_intersect

### DIFF
--- a/Convex_hull_3/include/CGAL/Convex_hull_3/do_intersect.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/do_intersect.h
@@ -65,37 +65,39 @@ struct SphericalPolygonElement {
 };
 
 template <class Vector_3>
-struct SphericalPolygon : public std::vector<SphericalPolygonElement<Vector_3>> {
-
-  typedef std::vector<SphericalPolygonElement<Vector_3>> Base;
-  typedef typename Base::iterator iterator;
-  typedef typename Base::const_iterator const_iterator;
+struct SphericalPolygon
+{
+  using Storage = std::vector<SphericalPolygonElement<Vector_3>>;
+  using iterator = typename Storage::iterator;
+  using const_iterator = typename Storage::const_iterator;
   typedef typename Kernel_traits<Vector_3>::Kernel Kernel;
   typedef typename Kernel::FT NT;
 
+  Storage storage;
+
   SphericalPolygon() {
-    this->reserve(16);
+    storage.reserve(16);
   }
 
   Vector_3 averageDirection() const {
     // PRECONDITION : all vertices (that are unit vectors on the sphere) are normalized.
-    switch( this->size() ) {
+    switch( storage.size() ) {
       case 0 : return Vector_3(1,0,0); break; // An arbitrary one
-      case 1 : return this->begin()->north_; break;
+      case 1 : return storage.begin()->north_; break;
       case 2 :{   // The two vertices are opposite so we do not take their mean
                   // We want a direction with negative dot with bith north_
                   // We take the two perpendicular vector of resp north_0, and north_1 that lies on the same circle on them
                   // And we take a barycenter of them
-                  Vector_3 perp1= LInf_normalize(cross_product((*this)[0].north_, (*this)[0].vertex_));
-                  Vector_3 perp2= LInf_normalize(cross_product((*this)[1].north_, (*this)[1].vertex_));
-                  CGAL_assertion(is_positive((perp1+perp2) * (*this)[0].north_));
-                  CGAL_assertion(is_positive((perp1+perp2) * (*this)[1].north_));
+                  Vector_3 perp1= LInf_normalize(cross_product(storage[0].north_, storage[0].vertex_));
+                  Vector_3 perp2= LInf_normalize(cross_product(storage[1].north_, storage[1].vertex_));
+                  CGAL_assertion(is_positive((perp1+perp2) * storage[0].north_));
+                  CGAL_assertion(is_positive((perp1+perp2) * storage[1].north_));
                   return (perp1 + perp2);
-                  // return (*this)[0].north_ + (*this)[1].north_; //Old, need that both north_ was L2 normalized
+                  // return storage[0].north_ + storage[1].north_; //Old, need that both north_ was L2 normalized
                } break;
       default : {
                   Vector_3 avg(NULL_VECTOR);
-                  for( const SphericalPolygonElement<Vector_3> & v : *this )
+                  for( const SphericalPolygonElement<Vector_3> & v : storage)
                     avg += v.vertex_;
                   return avg;
                 } break;
@@ -103,43 +105,43 @@ struct SphericalPolygon : public std::vector<SphericalPolygonElement<Vector_3>> 
   }
 
   void clip(const Vector_3& clipNorth, SphericalPolygon<Vector_3> &result) const {
-    const int n = this->size();
-    result.clear();
+    const int n = storage.size();
+    result.storage.clear();
     switch( n ) {
       case 0 : {
-                  result.emplace_back(clipNorth);
+                  result.storage.emplace_back(clipNorth);
                   break;
                }
       case 1 : {
-                 result = (*this);
+                 result = *this;
                 //  NT dot = this->begin()->north_ * clipNorth;
-                 Vector_3 v(LInf_normalize(cross_product(clipNorth, this->begin()->north_)));
+                 Vector_3 v(LInf_normalize(cross_product(clipNorth, storage[0].north_)));
                  if(v==NULL_VECTOR /* && is_negative(dot) */){
-                  CGAL_assertion(is_negative(clipNorth * this->begin()->north_)); //Could not be two equal hemispheres
+                  CGAL_assertion(is_negative(clipNorth * storage[0].north_)); //Could not be two equal hemispheres
                    // intersection of two opposite hemispheres ==> empty
-                   result.clear();
+                   result.storage.clear();
                    break;
                  }
 
-                 result.begin()->vertex_ = v;
-                 result.emplace_back(-v, clipNorth);
+                 result.storage.begin()->vertex_ = v;
+                 result.storage.emplace_back(-v, clipNorth);
                  break;
                }
       case 2 : {
-                 result = (*this);
-                 iterator next = result.begin();
+                 result = *this;
+                 iterator next = result.storage.begin();
                  iterator cur = next++;
-                 NT vDot = this->begin()->vertex_ * clipNorth;
+                 NT vDot = storage.begin()->vertex_ * clipNorth;
                  if( is_positive(vDot) ) {
                    // we'll get a triangle
                    next->vertex_ = LInf_normalize(cross_product(clipNorth, next->north_));
                    Vector_3 v( LInf_normalize(cross_product(cur->north_, clipNorth)));
-                   result.emplace(next, v, clipNorth);
+                   result.storage.emplace(next, v, clipNorth);
                  } else if( is_negative(vDot) ) {
                    // we'll get a triangle
                    cur->vertex_ =  LInf_normalize(cross_product(clipNorth, cur->north_));
                    Vector_3 v( LInf_normalize(cross_product(next->north_, clipNorth)));
-                   result.emplace_back(v, clipNorth);
+                   result.storage.emplace_back(v, clipNorth);
                  } else {
                    // we keep a moon crescent
                    NT curTest(clipNorth *  cross_product(cur->north_, cur->vertex_));
@@ -157,7 +159,7 @@ struct SphericalPolygon : public std::vector<SphericalPolygonElement<Vector_3>> 
                        cur->vertex_ = -next->vertex_;
                      } else {
                        //killed the crescent
-                       result.clear();
+                       result.storage.clear();
                      }
                    }
                  }
@@ -165,40 +167,56 @@ struct SphericalPolygon : public std::vector<SphericalPolygonElement<Vector_3>> 
                }
       default : { // n >= 3
                   int nbKept(0);
-                  const_iterator cur = this->begin();
+                  const_iterator cur = storage.begin();
                   NT nextDot, curDot = clipNorth * cur->vertex_;
-                  while( cur != this->end() ) {
-                    if( cur+1 == this->end() )
-                      nextDot = clipNorth * this->begin()->vertex_;
+                  while( cur != storage.end() ) {
+                    if( cur+1 == storage.end() )
+                      nextDot = clipNorth * storage.begin()->vertex_;
                     else
                       nextDot = clipNorth * (cur+1)->vertex_;
                     if( is_positive(curDot) ) { // cur is "IN"
                       ++nbKept;
-                      result.push_back(*cur);
+                      result.storage.push_back(*cur);
                       if( is_negative(nextDot) ) { // next is "OUT"
-                        result.emplace_back( LInf_normalize(cross_product(cur->north_, clipNorth)), clipNorth);
+                        result.storage.emplace_back( LInf_normalize(cross_product(cur->north_, clipNorth)), clipNorth);
                       }
                     } else if( !is_negative(curDot) ) { // cur is "ON" the clipping plane
                       ++nbKept;
                       if ( is_negative(nextDot) ) // next is "OUT"
-                        result.emplace_back(cur->vertex_, clipNorth);
+                        result.storage.emplace_back(cur->vertex_, clipNorth);
                       else
-                        result.push_back(*cur);
+                        result.storage.push_back(*cur);
                     } else { // cur is "OUT"
                       if ( is_positive(nextDot) ) { // next is "IN"
-                        result.emplace_back( LInf_normalize(cross_product(clipNorth, cur->north_)), cur->north_);
+                        result.storage.emplace_back( LInf_normalize(cross_product(clipNorth, cur->north_)), cur->north_);
                       }
                     }
                     curDot = nextDot;
                     ++cur;
                   }
-                  if( (result.size() < 3/*too small*/) || ((nbKept == n)/*no change*/) ) {
-                    result.clear();
+                  if( (result.storage.size() < 3/*too small*/) || ((nbKept == n)/*no change*/) ) {
+                    result.storage.clear();
                   }
                   break;
                 }
     }
   }
+
+  void clear()
+  {
+    storage.clear();
+  }
+
+  bool empty() const
+  {
+    return storage.empty();
+  }
+
+  void swap(SphericalPolygon& other)
+  {
+    storage.swap(other.storage);
+  }
+
 };
 
 template<typename K>

--- a/Convex_hull_3/include/CGAL/Convex_hull_hierarchy_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_hierarchy_3.h
@@ -189,7 +189,7 @@ struct Convex_hull_hierarchy_3{
     Dir_GT gt;
     GTC converter;
 
-    auto csp = gt.compare_foo_bar_3_object();
+    auto csp = gt.compare_projection_along_direction_3_object();
 
     VPM vpm = get_const_property_map(vertex_point, hierarchy_sm[0]);
 
@@ -206,7 +206,7 @@ struct Convex_hull_hierarchy_3{
       for(auto vh=++(vertices(sm).begin()); vh!=vertices(sm).end(); ++vh){
         vertex_descriptor v = *vh;
         auto p = converter(get(vpm, get(to_base_maps[level], v)));
-        if(csp(dir, p_max, p)==SMALLER){
+        if(csp(p_max, p, dir)==SMALLER){
           p_max=p;
           argmax=v;
         }
@@ -232,7 +232,7 @@ struct Convex_hull_hierarchy_3{
         is_local_max=true;
         for(vertex_descriptor v: vertices_around_target(argmax ,csm)){
           auto p = converter(get(vpm, get(cbase, v)));
-          if(csp(dir, p_max, p)==SMALLER){
+          if(csp(p_max, p, dir)==SMALLER){
             p_max = p;
             argmax = v;
             is_local_max = false; // repeat with the new vertex

--- a/Convex_hull_3/include/CGAL/Convex_hull_hierarchy_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_hierarchy_3.h
@@ -205,7 +205,7 @@ struct Convex_hull_hierarchy_3{
       //If maxlevel is small, we simply go through all its vertices
       for(auto vh=++(vertices(sm).begin()); vh!=vertices(sm).end(); ++vh){
         vertex_descriptor v = *vh;
-        auto p = converter(get(vpm, get(to_base_maps[level], v)));
+        const auto& p = converter(get(vpm, get(to_base_maps[level], v)));
         if(csp(p_max, p, dir)==SMALLER){
           p_max=p;
           argmax=v;
@@ -231,7 +231,7 @@ struct Convex_hull_hierarchy_3{
       do{
         is_local_max=true;
         for(vertex_descriptor v: vertices_around_target(argmax ,csm)){
-          auto p = converter(get(vpm, get(cbase, v)));
+          const auto& p = converter(get(vpm, get(cbase, v)));
           if(csp(p_max, p, dir)==SMALLER){
             p_max = p;
             argmax = v;

--- a/Convex_hull_3/include/CGAL/Convex_hull_hierarchy_3.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_hierarchy_3.h
@@ -189,11 +189,9 @@ struct Convex_hull_hierarchy_3{
     Dir_GT gt;
     GTC converter;
 
-    auto vector_3 = gt.construct_vector_3_object();
-    auto csp = gt.compare_scalar_product_3_object();
+    auto csp = gt.compare_foo_bar_3_object();
 
     VPM vpm = get_const_property_map(vertex_point, hierarchy_sm[0]);
-    const typename Dir_GT::Vector_3 &vdir = dir.vector();
 
     size_t level=maxlevel();
 
@@ -202,14 +200,14 @@ struct Convex_hull_hierarchy_3{
       return CGAL::extreme_vertex_3(sm, dir);
 
     vertex_descriptor argmax = *vertices(sm).begin();
-    Vector_3 vec_max = vector_3(ORIGIN, converter(get(vpm, get(to_base_maps[level], argmax))));
+    auto p_max = converter(get(vpm, get(to_base_maps[level], argmax)));
     if(vertices(sm).size() <= MAXSIZE_FOR_NAIVE_SEARCH){
       //If maxlevel is small, we simply go through all its vertices
       for(auto vh=++(vertices(sm).begin()); vh!=vertices(sm).end(); ++vh){
         vertex_descriptor v = *vh;
-        Vector_3 vec = vector_3(ORIGIN, converter(get(vpm, get(to_base_maps[level], v))));
-        if(csp(vec_max, vdir, vec, vdir)==SMALLER){
-          vec_max=vec;
+        auto p = converter(get(vpm, get(to_base_maps[level], v)));
+        if(csp(dir, p_max, p)==SMALLER){
+          p_max=p;
           argmax=v;
         }
       }
@@ -233,9 +231,9 @@ struct Convex_hull_hierarchy_3{
       do{
         is_local_max=true;
         for(vertex_descriptor v: vertices_around_target(argmax ,csm)){
-          Vector_3 vec = vector_3(ORIGIN, converter(get(vpm, get(cbase, v))));
-          if(csp(vec_max, vdir, vec, vdir)==SMALLER){
-            vec_max = vec;
+          auto p = converter(get(vpm, get(cbase, v)));
+          if(csp(dir, p_max, p)==SMALLER){
+            p_max = p;
             argmax = v;
             is_local_max = false; // repeat with the new vertex
             break;

--- a/Convex_hull_3/include/CGAL/extreme_point_3.h
+++ b/Convex_hull_3/include/CGAL/extreme_point_3.h
@@ -110,7 +110,7 @@ extreme_point_3(const PointRange& r, const Direction &dir, const NamedParameters
   typename PointRange::const_iterator argmax=r.begin();
   auto p_max = converter(get(point_map, *argmax));
   for(typename PointRange::const_iterator it=++r.begin(); it!=r.end(); ++it){
-    auto p = converter(get(point_map, *it));
+    const auto& p = converter(get(point_map, *it));
     if(csp(p_max, p, dir)==SMALLER){
       p_max=p;
       argmax=it;
@@ -205,7 +205,7 @@ extreme_vertex_3(const Graph& g, const Direction &dir, const NamedParameters &np
   do{
     is_local_max=true;
     for(auto v: vertices_around_target(argmax, g)){
-      auto p = converter(get(point_map, v));
+      const auto& p = converter(get(point_map, v));
       if(csp(p_max, p, dir)==SMALLER){
         p_max = p;
         argmax = v;

--- a/Convex_hull_3/include/CGAL/extreme_point_3.h
+++ b/Convex_hull_3/include/CGAL/extreme_point_3.h
@@ -96,7 +96,6 @@ extreme_point_3(const PointRange& r, const Direction &dir, const NamedParameters
       Default_GT
     > ::type;
   GT gt = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
-  using Vector_3 = typename GT::Vector_3;
 
   using Default_geom_traits_converter = Cartesian_converter<Point_GT, GT>;
   using GTC=typename internal_np::Lookup_named_param_def <
@@ -106,15 +105,14 @@ extreme_point_3(const PointRange& r, const Direction &dir, const NamedParameters
     > ::type;
   GTC converter = choose_parameter<GTC>(get_parameter(np, internal_np::geom_traits_converter));
 
-  auto vector_3 = gt.construct_vector_3_object();
-  auto csp = gt.compare_scalar_product_3_object();
+  auto csp = gt.compare_foo_bar_3_object();
 
   typename PointRange::const_iterator argmax=r.begin();
-  Vector_3 vec_max = vector_3(ORIGIN, converter(get(point_map, *argmax)));
+  auto p_max = converter(get(point_map, *argmax));
   for(typename PointRange::const_iterator it=++r.begin(); it!=r.end(); ++it){
-    Vector_3 vec = vector_3(ORIGIN, converter(get(point_map, *it)));
-    if(csp(vec_max, dir.vector(), vec, dir.vector())==SMALLER){
-      vec_max=vec;
+    auto p = converter(get(point_map, *it));
+    if(csp(dir, p_max, p)==SMALLER){
+      p_max=p;
       argmax=it;
     }
   }
@@ -185,7 +183,6 @@ extreme_vertex_3(const Graph& g, const Direction &dir, const NamedParameters &np
       Default_GT
     > ::type;
   GT gt = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
-  using Vector_3 = typename GT::Vector_3;
 
   using Default_geom_traits_converter = Cartesian_converter<GraphGT, GT>;
   using GTC=typename internal_np::Lookup_named_param_def <
@@ -195,8 +192,7 @@ extreme_vertex_3(const Graph& g, const Direction &dir, const NamedParameters &np
     > ::type;
   GTC converter = choose_parameter<GTC>(get_parameter(np, internal_np::geom_traits_converter));
 
-  auto vector_3 = gt.construct_vector_3_object();
-  auto csp = gt.compare_scalar_product_3_object();
+  auto csp = gt.compare_foo_bar_3_object();
 
   // If the number of vertices is small, simply test all vertices
   if(vertices(g).size()<20)
@@ -204,14 +200,14 @@ extreme_vertex_3(const Graph& g, const Direction &dir, const NamedParameters &np
 
   // Walks on the mesh to find a local maximum
   vertex_descriptor argmax = *vertices(g).begin();
-  Vector_3 vec_max = vector_3(ORIGIN, converter(get(point_map,argmax)));
+  auto p_max = converter(get(point_map,argmax));
   bool is_local_max;
   do{
     is_local_max=true;
     for(auto v: vertices_around_target(argmax, g)){
-      Vector_3 vec = vector_3(ORIGIN, converter(get(point_map, v)));
-      if(csp(vec_max, dir.vector(), vec, dir.vector())==SMALLER){
-        vec_max = vec;
+      auto p = converter(get(point_map, v));
+      if(csp(dir, p_max, p)==SMALLER){
+        p_max = p;
         argmax = v;
         is_local_max=false; // repeat with the new vertex
         break;

--- a/Convex_hull_3/include/CGAL/extreme_point_3.h
+++ b/Convex_hull_3/include/CGAL/extreme_point_3.h
@@ -105,13 +105,13 @@ extreme_point_3(const PointRange& r, const Direction &dir, const NamedParameters
     > ::type;
   GTC converter = choose_parameter<GTC>(get_parameter(np, internal_np::geom_traits_converter));
 
-  auto csp = gt.compare_foo_bar_3_object();
+  auto csp = gt.compare_projection_along_direction_3_object();
 
   typename PointRange::const_iterator argmax=r.begin();
   auto p_max = converter(get(point_map, *argmax));
   for(typename PointRange::const_iterator it=++r.begin(); it!=r.end(); ++it){
     auto p = converter(get(point_map, *it));
-    if(csp(dir, p_max, p)==SMALLER){
+    if(csp(p_max, p, dir)==SMALLER){
       p_max=p;
       argmax=it;
     }
@@ -192,7 +192,7 @@ extreme_vertex_3(const Graph& g, const Direction &dir, const NamedParameters &np
     > ::type;
   GTC converter = choose_parameter<GTC>(get_parameter(np, internal_np::geom_traits_converter));
 
-  auto csp = gt.compare_foo_bar_3_object();
+  auto csp = gt.compare_projection_along_direction_3_object();
 
   // If the number of vertices is small, simply test all vertices
   if(vertices(g).size()<20)
@@ -206,7 +206,7 @@ extreme_vertex_3(const Graph& g, const Direction &dir, const NamedParameters &np
     is_local_max=true;
     for(auto v: vertices_around_target(argmax, g)){
       auto p = converter(get(point_map, v));
-      if(csp(dir, p_max, p)==SMALLER){
+      if(csp(p_max, p, dir)==SMALLER){
         p_max = p;
         argmax = v;
         is_local_max=false; // repeat with the new vertex

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -4,6 +4,13 @@
 
 Release date: July 2026
 
+### [2D and 3D Linear Geometry Kernel](https://doc.cgal.org/6.2/Manual/packages.html#PkgKernel23)
+
+- Added a new concept, `CompareProjectionAlongDirection_3`,
+     to the 3D Kernel concepts to compare the order of projected points on a line. Corresponding functors
+     in the model (`Compare_projection_along_direction_3`) and free function (`compare_projection_along_direction()`)
+     have also been added.
+
 ### [Generalized Barycentric Coordinates 3](https://doc.cgal.org/6.2/Manual/packages.html#PkgBarycentricCoordinates3) (new package)
 -   This package provides functions to compute various types of generalized barycentric coordinates
     (Wachspress, mean value, discrete harmonic and tetrahedron coordinates) for points located inside closed convex

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -865,9 +865,8 @@ const CGAL::Point_3<Kernel>& t);
 /// \ingroup kernel_global_function
 
 /*!
-returns, given the line `l` passing through the origin and of direction `dir`,
-`CGAL::SMALLER`, `CGAL::EQUAL`, or `CGAL::LARGER` if the projection of `p` on `l`
-precedes, coincides, or follows that of `q` in the direction pointed by `dir`.
+returns `CGAL::SMALLER`, `CGAL::EQUAL`, or `CGAL::LARGER` if the projection of `p` onto
+a line with direction `dir` precedes, coincides, or follows that of `q` in the direction pointed by `dir`.
 
 \sa `compare_distance_to_point_grp`
 \sa `compare_signed_distance_to_line_grp`

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -862,45 +862,28 @@ const CGAL::Point_3<Kernel>& t);
 
 /// @}
 
-/// \defgroup compare_scalar_product_grp CGAL::compare_scalar_product()
 /// \ingroup kernel_global_function
-/// \sa `compare_distance_to_point_grp`
-/// \sa `compare_signed_distance_to_line_grp`
-/// \sa `compare_signed_distance_to_plane_grp`
-/// \sa `has_larger_distance_to_point_grp`
-/// \sa `has_larger_signed_distance_to_line_grp`
-/// \sa `has_larger_signed_distance_to_plane_grp`
-/// \sa `has_smaller_distance_to_point_grp`
-/// \sa `has_smaller_signed_distance_to_line_grp`
-/// \sa `has_smaller_signed_distance_to_plane_grp`
-/// @{
 
 /*!
-returns `CGAL::LARGER`
-iff the scalar product of `u` and
-`v` is larger than the scalar product `sp`, `CGAL::SMALLER`, iff it is smaller,
-and `CGAL::EQUAL` iff both are equal.
+returns `CGAL::LARGER` iff the scalar product of `p-ORIGIN` and `dir.vector()`
+is larger than the scalar product of `q-dir` and `dir.vector()`,
+`CGAL::SMALLER`, iff it is smaller, and `CGAL::EQUAL` iff both are equal.
+
+\sa `compare_distance_to_point_grp`
+\sa `compare_signed_distance_to_line_grp`
+\sa `compare_signed_distance_to_plane_grp`
+\sa `has_larger_distance_to_point_grp`
+\sa `has_larger_signed_distance_to_line_grp`
+\sa `has_larger_signed_distance_to_plane_grp`
+\sa `has_smaller_distance_to_point_grp`
+\sa `has_smaller_signed_distance_to_line_grp`
+\sa `has_smaller_signed_distance_to_plane_grp`
 */
 template <typename Kernel>
 Comparison_result
-compare_scalar_product(const CGAL::Vector_3<Kernel> &u,
-                       const CGAL::Vector_3<Kernel> &v,
-                       const CGAL::FT<Kernel> &sp);
-
-/*!
-returns `CGAL::LARGER`
-iff the scalar product of `u` and
-`v` is larger than the scalar product of `w` and `x`, `CGAL::SMALLER`, iff it is smaller,
-and `CGAL::EQUAL` iff both are equal.
-*/
-template <typename Kernel>
-Comparison_result
-compare_scalar_product(const CGAL::Vector_3<Kernel> &u,
-                       const CGAL::Vector_3<Kernel> &v,
-                       const CGAL::Vector_3<Kernel> &w,
-                       const CGAL::Vector_3<Kernel> &x);
-
-/// @}
+compare_foo_bar(const CGAL::Direction_3<Kernel> &dir,
+                const CGAL::Point_3<Kernel> &p,
+                const CGAL::Point_3<Kernel> &q);
 
 
 /// \defgroup compare_slopes_grp CGAL::compare_slope()

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -865,9 +865,10 @@ const CGAL::Point_3<Kernel>& t);
 /// \ingroup kernel_global_function
 
 /*!
-returns `CGAL::LARGER` iff the scalar product of `p-ORIGIN` and `dir.vector()`
-is larger than the scalar product of `q-dir` and `dir.vector()`,
-`CGAL::SMALLER`, iff it is smaller, and `CGAL::EQUAL` iff both are equal.
+returns, given the line `l` passing through the origin and of direction `dir`,
+`CGAL::SMALLER`, `CGAL::LARGER`, and `CGAL::EQUAL` if when comparing the distances to the origin of
+the projections onto `l`,  the point `p` is closer, farther, and equal to `q`,
+respectively.
 
 \sa `compare_distance_to_point_grp`
 \sa `compare_signed_distance_to_line_grp`
@@ -881,9 +882,9 @@ is larger than the scalar product of `q-dir` and `dir.vector()`,
 */
 template <typename Kernel>
 Comparison_result
-compare_foo_bar(const CGAL::Direction_3<Kernel> &dir,
-                const CGAL::Point_3<Kernel> &p,
-                const CGAL::Point_3<Kernel> &q);
+compare_projection_along_direction_3(const CGAL::Point_3<Kernel> &p,
+                                     const CGAL::Point_3<Kernel> &q,
+                                     const CGAL::Direction_3<Kernel> &dir);
 
 
 /// \defgroup compare_slopes_grp CGAL::compare_slope()

--- a/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
+++ b/Kernel_23/doc/Kernel_23/CGAL/Kernel/global_functions.h
@@ -866,9 +866,8 @@ const CGAL::Point_3<Kernel>& t);
 
 /*!
 returns, given the line `l` passing through the origin and of direction `dir`,
-`CGAL::SMALLER`, `CGAL::LARGER`, and `CGAL::EQUAL` if when comparing the distances to the origin of
-the projections onto `l`,  the point `p` is closer, farther, and equal to `q`,
-respectively.
+`CGAL::SMALLER`, `CGAL::EQUAL`, or `CGAL::LARGER` if the projection of `p` on `l`
+precedes, coincides, or follows that of `q` in the direction pointed by `dir`.
 
 \sa `compare_distance_to_point_grp`
 \sa `compare_signed_distance_to_line_grp`

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -9029,9 +9029,8 @@ public:
 
   /*!
     returns, given the line `l` passing through the origin and of direction `dir`,
-    `CGAL::SMALLER`, `CGAL::LARGER`, and `CGAL::EQUAL` if when comparing the distances to the origin of
-    the projections onto `l`,  the point `p` is closer, farther, and equal to `q`,
-    respectively.
+    `CGAL::SMALLER`, `CGAL::EQUAL`, or `CGAL::LARGER` if the projection of `p` on
+    `l` precedes, coincides, or follows that of `q` in the direction pointed by `dir`.
   */
   Comparison_result operator()(const Kernel::Point_3 &p,
                                const Kernel::Point_3 &q,

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -9028,9 +9028,8 @@ public:
   /// @{
 
   /*!
-    returns, given the line `l` passing through the origin and of direction `dir`,
-    `CGAL::SMALLER`, `CGAL::EQUAL`, or `CGAL::LARGER` if the projection of `p` on
-    `l` precedes, coincides, or follows that of `q` in the direction pointed by `dir`.
+    returns `CGAL::SMALLER`, `CGAL::EQUAL`, or `CGAL::LARGER` if the projection of `p` onto
+    a line with direction `dir` precedes, coincides, or follows that of `q` in the direction pointed by `dir`.
   */
   Comparison_result operator()(const Kernel::Point_3 &p,
                                const Kernel::Point_3 &q,

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -9017,10 +9017,10 @@ public:
 
   \cgalRefines{AdaptableTernaryFunction}
 
-  \sa `CGAL::compare_foo_bar()`
+  \sa `CGAL::compare_projection_along_direction()`
 
 */
-class CompareFooBar_3 {
+class CompareProjectionAlongDirection_3 {
 public:
 
   /// \name Operations
@@ -9028,13 +9028,14 @@ public:
   /// @{
 
   /*!
-    returns `CGAL::LARGER` iff the scalar product of `p-ORIGIN` and `dir.vector()`
-    is larger than the scalar product of `q-dir` and `dir.vector()`,
-    `CGAL::SMALLER`, iff it is smaller, and `CGAL::EQUAL` iff both are equal.
+    returns, given the line `l` passing through the origin and of direction `dir`,
+    `CGAL::SMALLER`, `CGAL::LARGER`, and `CGAL::EQUAL` if when comparing the distances to the origin of
+    the projections onto `l`,  the point `p` is closer, farther, and equal to `q`,
+    respectively.
   */
-  Comparison_result operator()(const Kernel::Direction_3 &dir,
-                               const Kernel::Point_3 &p,
-                               const Kernel::Point_3 &q);
+  Comparison_result operator()(const Kernel::Point_3 &p,
+                               const Kernel::Point_3 &q,
+                               const Kernel::Direction_3 &dir);
 
   /// @}
 

--- a/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/FunctionObjectConcepts.h
@@ -9017,10 +9017,10 @@ public:
 
   \cgalRefines{AdaptableTernaryFunction}
 
-  \sa `compare_scalar_product_grp`
+  \sa `CGAL::compare_foo_bar()`
 
 */
-class CompareScalarProduct_3 {
+class CompareFooBar_3 {
 public:
 
   /// \name Operations
@@ -9028,23 +9028,13 @@ public:
   /// @{
 
   /*!
-  returns `CGAL::LARGER` iff the scalar product of `u` and `v` is larger than the scalar product `sp`,
-  `CGAL::SMALLER`, iff it is smaller,
-  and `CGAL::EQUAL` iff both are equal.
-*/
-  Comparison_result operator()(const Kernel::Vector_3 &u,
-                               const Kernel::Vector_3 &v,
-                               const Kernel::FT &sp);
-
-  /*!
-    returns `CGAL::LARGER` iff the scalar product of `u` and `v` is larger than the scalar product of `w` and `x`,
-    `CGAL::SMALLER`, iff it is smaller,
-    and `CGAL::EQUAL` iff both are equal.
+    returns `CGAL::LARGER` iff the scalar product of `p-ORIGIN` and `dir.vector()`
+    is larger than the scalar product of `q-dir` and `dir.vector()`,
+    `CGAL::SMALLER`, iff it is smaller, and `CGAL::EQUAL` iff both are equal.
   */
-  Comparison_result operator()(const Kernel::Vector_3 &u,
-                               const Kernel::Vector_3 &v,
-                               const Kernel::Vector_3 &w,
-                               const Kernel::Vector_3 &x);
+  Comparison_result operator()(const Kernel::Direction_3 &dir,
+                               const Kernel::Point_3 &p,
+                               const Kernel::Point_3 &q);
 
   /// @}
 

--- a/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
@@ -1466,9 +1466,9 @@ public:
   typedef unspecified_type Less_signed_distance_to_plane_3;
 
   /*!
-    a model of `Kernel::CompareScalarProduct_3`
+    a model of `Kernel::CompareFooBar_3`
   */
-  typedef unspecified_type Compare_scalar_product_3;
+  typedef unspecified_type Compare_foo_bar_3;
 
   /*!
     a model of `Kernel::LessDistanceToPoint_3`

--- a/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
+++ b/Kernel_23/doc/Kernel_23/Concepts/Kernel.h
@@ -1465,10 +1465,11 @@ public:
   */
   typedef unspecified_type Less_signed_distance_to_plane_3;
 
+
   /*!
-    a model of `Kernel::CompareFooBar_3`
+    a model of `Kernel::CompareProjectionAlongDirection_3`
   */
-  typedef unspecified_type Compare_foo_bar_3;
+  typedef unspecified_type Compare_projection_along_direction_3;
 
   /*!
     a model of `Kernel::LessDistanceToPoint_3`

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -159,7 +159,7 @@
 - \link compare_lexicographically_linear_grp `CGAL::compare_lexicographically()` \endlink
 - \link compare_signed_distance_to_line_grp `CGAL::compare_signed_distance_to_line()` \endlink
 - \link compare_signed_distance_to_plane_grp `CGAL::compare_signed_distance_to_plane()` \endlink
-- \link compare_scalar_product_grp `CGAL::compare_scalar_product()` \endlink
+- `CGAL::compare_foo_bar()`
 - \link compare_slopes_grp `CGAL::compare_slopes()` \endlink
 - `CGAL::compare_angle()`
 - \link compare_dihedral_angle_grp `CGAL::compare_dihedral_angle()` \endlink

--- a/Kernel_23/doc/Kernel_23/PackageDescription.txt
+++ b/Kernel_23/doc/Kernel_23/PackageDescription.txt
@@ -159,7 +159,7 @@
 - \link compare_lexicographically_linear_grp `CGAL::compare_lexicographically()` \endlink
 - \link compare_signed_distance_to_line_grp `CGAL::compare_signed_distance_to_line()` \endlink
 - \link compare_signed_distance_to_plane_grp `CGAL::compare_signed_distance_to_plane()` \endlink
-- `CGAL::compare_foo_bar()`
+- `CGAL::compare_projection_along_direction()`
 - \link compare_slopes_grp `CGAL::compare_slopes()` \endlink
 - `CGAL::compare_angle()`
 - \link compare_dihedral_angle_grp `CGAL::compare_dihedral_angle()` \endlink

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -188,16 +188,16 @@ namespace CommonKernelFunctors {
   };
 
   template <typename K>
-  class Compare_foo_bar_3
+  class Compare_projection_along_direction_3
   {
     typedef typename K::Comparison_result  Comparison_result;
     typedef typename K::Point_3           Point_3;
     typedef typename K::Direction_3           Direction_3;
   public:
     Comparison_result
-    operator()(const Direction_3& dir,
-               const Point_3& p,
-               const Point_3& q) const
+    operator()(const Point_3& p,
+               const Point_3& q,
+               const Direction_3& dir) const
     {
       typename K::Compute_scalar_product_3 scalar_product = K().compute_scalar_product_3_object();
       typename K::Construct_vector_3 construct_vector = K().construct_vector_3_object();

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -188,25 +188,21 @@ namespace CommonKernelFunctors {
   };
 
   template <typename K>
-  class Compare_scalar_product_3
+  class Compare_foo_bar_3
   {
     typedef typename K::Comparison_result  Comparison_result;
-    typedef typename K::Vector_3           Vector_3;
-    typedef typename K::FT                 FT;
+    typedef typename K::Point_3           Point_3;
+    typedef typename K::Direction_3           Direction_3;
   public:
     Comparison_result
-    operator()(const Vector_3& u, const Vector_3& v, const FT& sp) const
+    operator()(const Direction_3& dir,
+               const Point_3& p,
+               const Point_3& q) const
     {
       typename K::Compute_scalar_product_3 scalar_product = K().compute_scalar_product_3_object();
-      return CGAL::compare(scalar_product(u,v), sp);
-    }
-
-    Comparison_result
-    operator()(const Vector_3& u, const Vector_3& v,
-               const Vector_3& w, const Vector_3& x) const
-    {
-      typename K::Compute_scalar_product_3 scalar_product = K().compute_scalar_product_3_object();
-      return CGAL::compare(scalar_product(u,v), scalar_product(w,x));
+      typename K::Construct_vector_3 construct_vector = K().construct_vector_3_object();
+      return CGAL::compare(scalar_product(construct_vector(ORIGIN, p), construct_vector(dir)),
+                           scalar_product(construct_vector(ORIGIN, q), construct_vector(dir)));
     }
   };
 

--- a/Kernel_23/include/CGAL/Kernel/function_objects.h
+++ b/Kernel_23/include/CGAL/Kernel/function_objects.h
@@ -201,8 +201,7 @@ namespace CommonKernelFunctors {
     {
       typename K::Compute_scalar_product_3 scalar_product = K().compute_scalar_product_3_object();
       typename K::Construct_vector_3 construct_vector = K().construct_vector_3_object();
-      return CGAL::compare(scalar_product(construct_vector(ORIGIN, p), construct_vector(dir)),
-                           scalar_product(construct_vector(ORIGIN, q), construct_vector(dir)));
+      return CGAL::sign(scalar_product(construct_vector(q, p), construct_vector(dir)));
     }
   };
 

--- a/Kernel_23/include/CGAL/Kernel/global_functions_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_3.h
@@ -475,22 +475,11 @@ compare_lexicographically(const Point_3<K> &p,
 template < class K >
 inline
 typename K::Comparison_result
-compare_scalar_product(const Vector_3<K> &a,
-                       const Vector_3<K> &b,
-                       const typename K::FT &sp)
+compare_foo_bar(const Direction_3<K> &dir,
+                const Point_3<K> &p,
+                const Point_3<K> &q)
 {
-  return internal::compare_scalar_product(a, b, sp, K());
-}
-
-template < class K >
-inline
-typename K::Comparison_result
-compare_scalar_product(const Vector_3<K> &a,
-                       const Vector_3<K> &b,
-                       const Vector_3<K> &c,
-                       const Vector_3<K> &d)
-{
-  return internal::compare_scalar_product(a, b, c, d, K());
+  return internal::compare_foo_bar(dir, p, q, K());
 }
 
 template < class K >

--- a/Kernel_23/include/CGAL/Kernel/global_functions_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_3.h
@@ -475,11 +475,11 @@ compare_lexicographically(const Point_3<K> &p,
 template < class K >
 inline
 typename K::Comparison_result
-compare_foo_bar(const Direction_3<K> &dir,
-                const Point_3<K> &p,
-                const Point_3<K> &q)
+compare_projection_along_direction(const Point_3<K> &p,
+                                   const Point_3<K> &q,
+                                   const Direction_3<K> &dir)
 {
-  return internal::compare_foo_bar(dir, p, q, K());
+  return internal::compare_projection_along_direction(p, q, dir, K());
 }
 
 template < class K >

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
@@ -553,12 +553,12 @@ compare_lexicographically_xyz(const typename K::Point_3 &p,
 template < class K >
 inline
 typename K::Comparison_result
-compare_foo_bar(const typename K::Direction_3 &dir,
-                const typename K::Point_3 &p,
-                const typename K::Point_3 &q,
-                const K &k)
+compare_projection_along_direction(const typename K::Point_3 &p,
+                                   const typename K::Point_3 &q,
+                                   const typename K::Direction_3 &dir,
+                                   const K &k)
 {
-  return k.compare_foo_bar_3_object()(dir, p, q);
+  return k.compare_projection_along_direction_3_object()(p, q, dir);
 }
 
 

--- a/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
+++ b/Kernel_23/include/CGAL/Kernel/global_functions_internal_3.h
@@ -553,24 +553,12 @@ compare_lexicographically_xyz(const typename K::Point_3 &p,
 template < class K >
 inline
 typename K::Comparison_result
-compare_scalar_product(const typename K::Vector_3 &a,
-                       const typename K::Vector_3 &b,
-                       const typename K::FT &sp,
-                       const K &k)
+compare_foo_bar(const typename K::Direction_3 &dir,
+                const typename K::Point_3 &p,
+                const typename K::Point_3 &q,
+                const K &k)
 {
-  return k.compare_scalar_product_3_object()(a, b, sp);
-}
-
-template < class K >
-inline
-typename K::Comparison_result
-compare_scalar_product(const typename K::Vector_3 &a,
-                       const typename K::Vector_3 &b,
-                       const typename K::Vector_3 &c,
-                       const typename K::Vector_3 &d,
-                       const K &k)
-{
-  return k.compare_scalar_product_3_object()(a, b, c, d);
+  return k.compare_foo_bar_3_object()(dir, p, q);
 }
 
 

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -114,8 +114,8 @@ CGAL_Kernel_pred(Compare_power_distance_3,
                  compare_power_distance_3_object)
 CGAL_Kernel_pred(Compare_signed_distance_to_line_2,
                  compare_signed_distance_to_line_2_object)
-CGAL_Kernel_pred(Compare_scalar_product_3,
-                 compare_scalar_product_3_object)
+CGAL_Kernel_pred(Compare_foo_bar_3,
+                 compare_foo_bar_3_object)
 CGAL_Kernel_pred(Compare_slope_2,
                  compare_slope_2_object)
 CGAL_Kernel_pred(Compare_slope_3,

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -112,10 +112,10 @@ CGAL_Kernel_pred(Compare_power_distance_2,
                  compare_power_distance_2_object)
 CGAL_Kernel_pred(Compare_power_distance_3,
                  compare_power_distance_3_object)
-CGAL_Kernel_pred(Compare_signed_distance_to_line_2,
-                 compare_signed_distance_to_line_2_object)
 CGAL_Kernel_pred(Compare_projection_along_direction_3,
                  compare_projection_along_direction_3_object)
+CGAL_Kernel_pred(Compare_signed_distance_to_line_2,
+                 compare_signed_distance_to_line_2_object)
 CGAL_Kernel_pred(Compare_slope_2,
                  compare_slope_2_object)
 CGAL_Kernel_pred(Compare_slope_3,

--- a/Kernel_23/include/CGAL/Kernel/interface_macros.h
+++ b/Kernel_23/include/CGAL/Kernel/interface_macros.h
@@ -114,8 +114,8 @@ CGAL_Kernel_pred(Compare_power_distance_3,
                  compare_power_distance_3_object)
 CGAL_Kernel_pred(Compare_signed_distance_to_line_2,
                  compare_signed_distance_to_line_2_object)
-CGAL_Kernel_pred(Compare_foo_bar_3,
-                 compare_foo_bar_3_object)
+CGAL_Kernel_pred(Compare_projection_along_direction_3,
+                 compare_projection_along_direction_3_object)
 CGAL_Kernel_pred(Compare_slope_2,
                  compare_slope_2_object)
 CGAL_Kernel_pred(Compare_slope_3,

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
@@ -659,10 +659,10 @@ test_new_3(const R& rep)
   tmp34ab = CGAL::compare_distance(p1, p2, p3, p4);
   tmp34ab = CGAL::compare_distance(p1, p2, p3);
 
-typename R::Compare_foo_bar_3 compare_sp
-        = rep.compare_foo_bar_3_object();
-  tmp34ab = compare_sp(d5,p1,p2);
-  tmp34ab = CGAL::compare_foo_bar(d5,p1,p2);
+typename R::Compare_projection_along_direction_3 compare_sp
+        = rep.compare_projection_along_direction_3_object();
+  tmp34ab = compare_sp(p1,p2, d5);
+  tmp34ab = CGAL::compare_projection_along_direction(p1,p2,d5);
 
   typename R::Compare_power_distance_3 compare_power_dist
         = rep.compare_power_distance_3_object();

--- a/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
+++ b/Kernel_23/test/Kernel_23/include/CGAL/_test_new_3.h
@@ -659,15 +659,10 @@ test_new_3(const R& rep)
   tmp34ab = CGAL::compare_distance(p1, p2, p3, p4);
   tmp34ab = CGAL::compare_distance(p1, p2, p3);
 
-typename R::Compare_scalar_product_3 compare_sp
-        = rep.compare_scalar_product_3_object();
-  tmp34ab = compare_sp(v3,v4,FT(1));
-  tmp34ab = compare_sp(v3,v4,v3,v4);
-  tmp34ab = compare_sp(v3,v4,v5,v3+v4);
-
-  tmp34ab = CGAL::compare_scalar_product(v3,v4,v3,v4);
-  tmp34ab = CGAL::compare_scalar_product(v3,v4,FT(1));
-  tmp34ab = CGAL::compare_scalar_product(v3,v4,v5,v3+v4);
+typename R::Compare_foo_bar_3 compare_sp
+        = rep.compare_foo_bar_3_object();
+  tmp34ab = compare_sp(d5,p1,p2);
+  tmp34ab = CGAL::compare_foo_bar(d5,p1,p2);
 
   typename R::Compare_power_distance_3 compare_power_dist
         = rep.compare_power_distance_3_object();


### PR DESCRIPTION
Follow up of #6557 

- do not inherit from std::vector
- the function introduced in the kernel does not really makes sense as the real usage is not based on vector but 2 points and 1 direction.

