### PR TITLE
Lab: Suppress warning

### DIFF
--- a/GraphicsView/include/CGAL/Qt/frame.h
+++ b/GraphicsView/include/CGAL/Qt/frame.h
@@ -12,6 +12,11 @@
 #ifndef QGLVIEWER_FRAME_H
 #define QGLVIEWER_FRAME_H
 
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 16
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wsfinae-incomplete"
+#endif
+
 #include <QObject>
 #include <QString>
 #include <CGAL/export/Qt.h>
@@ -443,5 +448,9 @@ private:
 #ifdef CGAL_HEADER_ONLY
 //#include <CGAL/Qt/qglviewer_impl_list.h>
 #endif // CGAL_HEADER_ONLY
+
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 16
+#  pragma GCC diagnostic pop
+#endif
 
 #endif // QGLVIEWER_FRAME_H

--- a/GraphicsView/include/CGAL/Qt/keyFrameInterpolator.h
+++ b/GraphicsView/include/CGAL/Qt/keyFrameInterpolator.h
@@ -12,6 +12,11 @@
 #ifndef QGLVIEWER_KEY_FRAME_INTERPOLATOR_H
 #define QGLVIEWER_KEY_FRAME_INTERPOLATOR_H
 
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 16
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wsfinae-incomplete"
+#endif
+
 #include <QObject>
 #include <QTimer>
 #include <CGAL/export/Qt.h>
@@ -352,5 +357,9 @@ private:
 };
 
 }} // namespace CGAL::qglviewer
+
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 16
+#  pragma GCC diagnostic pop
+#endif
 
 #endif // QGLVIEWER_KEY_FRAME_INTERPOLATOR_H

--- a/GraphicsView/include/CGAL/Qt/manipulatedCameraFrame.h
+++ b/GraphicsView/include/CGAL/Qt/manipulatedCameraFrame.h
@@ -12,6 +12,12 @@
 
 #ifndef QGLVIEWER_MANIPULATED_CAMERA_FRAME_H
 #define QGLVIEWER_MANIPULATED_CAMERA_FRAME_H
+
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 16
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wsfinae-incomplete"
+#endif
+
 #include <QTimer>
 
 #include <CGAL/export/Qt.h>
@@ -234,7 +240,12 @@ private:
 
 }} // namespace CGAL::qglviewer
 
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 16
+#  pragma GCC diagnostic pop
+#endif
+
 #ifdef CGAL_HEADER_ONLY
 //#include <CGAL/Qt/qglviewer_impl_list.h>
 #endif // CGAL_HEADER_ONLY
+
 #endif // QGLVIEWER_MANIPULATED_CAMERA_FRAME_H

--- a/Installation/include/CGAL/config.h
+++ b/Installation/include/CGAL/config.h
@@ -315,9 +315,6 @@ using std::max;
 #ifndef __has_cpp_attribute
   #define __has_cpp_attribute(x) 0  // Compatibility with non-supporting compilers.
 #endif
-#ifndef __has_warning
-  #define __has_warning(x) 0  // Compatibility with non-clang compilers.
-#endif
 
 #if __has_include(<version>)
 #  include <version>

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -32,6 +32,11 @@ class QOpenGLFramebufferObject;
 class TextRenderer;
 class TextListItem;
 
+#ifdef __GNUC__
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wsfinae-incomplete"
+#endif
+
 //! \file Viewer_interface.h
 #include <CGAL/Three/Viewer_config.h> // for VIEWER_EXPORT
 namespace CGAL{
@@ -293,4 +298,8 @@ public:
 }; // end class Viewer_interface
 }
 }
+#ifdef __GNUC__
+#  pragma GCC diagnostic pop
+#endif
+
 #endif // VIEWER_INTERFACE_H

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -32,11 +32,6 @@ class QOpenGLFramebufferObject;
 class TextRenderer;
 class TextListItem;
 
-#if defined(__has_warning) && __has_warning("-Wsfinae-incomplete")
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wsfinae-incomplete"
-#endif
-
 //! \file Viewer_interface.h
 #include <CGAL/Three/Viewer_config.h> // for VIEWER_EXPORT
 namespace CGAL{
@@ -298,9 +293,5 @@ public:
 }; // end class Viewer_interface
 }
 }
-
-#if defined(__has_warning) && __has_warning("-Wsfinae-incomplete")
-#  pragma GCC diagnostic pop
-#endif
 
 #endif // VIEWER_INTERFACE_H

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -32,7 +32,7 @@ class QOpenGLFramebufferObject;
 class TextRenderer;
 class TextListItem;
 
-#ifdef __GNUC__
+#if defined(__has_warning) && __has_warning("-Wsfinae-incomplete")
 #  pragma GCC diagnostic push
 #  pragma GCC diagnostic ignored "-Wsfinae-incomplete"
 #endif
@@ -298,7 +298,8 @@ public:
 }; // end class Viewer_interface
 }
 }
-#ifdef __GNUC__
+
+#if defined(__has_warning) && __has_warning("-Wsfinae-incomplete")
 #  pragma GCC diagnostic pop
 #endif
 

--- a/Three/include/CGAL/Three/Viewer_interface.h
+++ b/Three/include/CGAL/Three/Viewer_interface.h
@@ -15,6 +15,11 @@
 
 #include <CGAL/license/Three.h>
 
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 16
+#  pragma GCC diagnostic push
+#  pragma GCC diagnostic ignored "-Wsfinae-incomplete"
+#endif
+
 #include <QMap>
 #include <CGAL/Qt/qglviewer.h>
 #include <QWidget>
@@ -293,5 +298,9 @@ public:
 }; // end class Viewer_interface
 }
 }
+
+#if defined(__GNUC__) && !defined(__clang__) && __GNUC__ >= 16
+#  pragma GCC diagnostic pop
+#endif
 
 #endif // VIEWER_INTERFACE_H


### PR DESCRIPTION
## Summary of Changes

Suppress [warning](https://cgal.geometryfactory.com/CGAL/testsuite/CGAL-6.2-Ic-134/Lab_Demo/TestReport_lrineau_Ubuntu-latest-GCC6-CXX1z.gz) issued by gcc.
```
include/CGAL/Three/Viewer_interface.h:42:21: warning: defining ‘CGAL::Three::Viewer_interface’, which previously failed to be complete in a SFINAE context [-Wsfinae-incomplete=]
   42 | class VIEWER_EXPORT Viewer_interface : public CGAL::QGLViewer{
      |                     ^~~~~~~~~~~~~~~~
```

## Release Management

* Affected package(s): Lab
* License and copyright ownership:  unchanged

