### PR TITLE
Spelling corrections

### DIFF
--- a/Generator/doc/Generator/CGAL/point_generators_3.h
+++ b/Generator/doc/Generator/CGAL/point_generators_3.h
@@ -849,7 +849,7 @@ namespace CGAL {
 /*!
 
 The class `Random_points_in_triangle_soup_3` is an input iterator creating points uniformly distributed inside a soup of triangles.
-The triangle range must be valid and unchanged while the generator is used. Triangle are triple of indices referring to position of points
+The triangle range must be valid and unchanged while the generator is used. Triangles are triplets of indices referring to position of points
 in the input point range.
 
 \tparam PointRange a model of the concepts `RandomAccessContainer` with value type begin a point from a \cgal kernel

--- a/Generator/doc/Generator/CGAL/point_generators_3.h
+++ b/Generator/doc/Generator/CGAL/point_generators_3.h
@@ -849,7 +849,7 @@ namespace CGAL {
 /*!
 
 The class `Random_points_in_triangle_soup_3` is an input iterator creating points uniformly distributed inside a soup of triangles.
-The triangle range must be valid and unchanged while the generator is used. Triangle are triple of indices refering to position of points
+The triangle range must be valid and unchanged while the generator is used. Triangle are triple of indices referring to position of points
 in the input point range.
 
 \tparam PointRange a model of the concepts `RandomAccessContainer` with value type begin a point from a \cgal kernel

--- a/Orthtree/include/CGAL/Orthtree.h
+++ b/Orthtree/include/CGAL/Orthtree.h
@@ -796,7 +796,7 @@ public:
 
     `bool operator()(Traits::Sphere_d, Traits::Bbox_d)`
 
-    `Kernel::HasOnUnboundedSide_2` and `Kernel::HasOnUnboundedSide_3` are compatible concepts for dimenions 2 and 3.
+    `Kernel::HasOnUnboundedSide_2` and `Kernel::HasOnUnboundedSide_3` are compatible concepts for dimensions 2 and 3.
 
     \tparam OutputIterator a model of `OutputIterator` that accepts `Node_index` types
 


### PR DESCRIPTION
Spelling corrections

Note: the sentence "Triangle are triple of indices referring to position of points in the input point range." in Generator/doc/Generator/CGAL/point_generators_3.h should probably be reformulated (maybe " Traingles are triplets of indices....")

