### PR TITLE
CGALConfig.cmake: resolve symlinks before computing CGAL_CONFIG_DIR (fix #8521)

### DIFF
--- a/Installation/lib/cmake/CGAL/CGALConfig.cmake
+++ b/Installation/lib/cmake/CGAL/CGALConfig.cmake
@@ -7,7 +7,15 @@ set( CGAL_REQUESTED_COMPONENTS ${CGAL_FIND_COMPONENTS} )
 
 set(CGAL_LIBRARIES CGAL)
 
-get_filename_component(CGAL_CONFIG_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
+# Resolve symlinks before extracting the directory so that the subsequent
+# DIRECTORY walk produces a correct CGAL_ROOT (e.g. /lib -> /usr/lib on
+# Arch Linux).  See https://github.com/CGAL/cgal/issues/8521
+if(NOT CMAKE_VERSION VERSION_LESS 3.19)
+  file(REAL_PATH "${CMAKE_CURRENT_LIST_FILE}" _cgal_config_realpath)
+else()
+  get_filename_component(_cgal_config_realpath "${CMAKE_CURRENT_LIST_FILE}" REALPATH)
+endif()
+get_filename_component(CGAL_CONFIG_DIR "${_cgal_config_realpath}" DIRECTORY)
 
 function(cgal_detect_branch_build VAR_NAME)
   if(IS_DIRECTORY ${CGAL_CONFIG_DIR}/../../../../Installation/package_info/Installation/)

--- a/Installation/lib/cmake/CGAL/CGALConfig.cmake
+++ b/Installation/lib/cmake/CGAL/CGALConfig.cmake
@@ -2,6 +2,8 @@
 # This file is the CGALConfig.cmake for a header-only CGAL installation
 #
 
+cmake_minimum_required(VERSION 3.22...3.31)
+
 # For CGAL_CreateSingleSourceCGALProgram.cmake
 set( CGAL_REQUESTED_COMPONENTS ${CGAL_FIND_COMPONENTS} )
 
@@ -10,11 +12,7 @@ set(CGAL_LIBRARIES CGAL)
 # Resolve symlinks before extracting the directory so that the subsequent
 # DIRECTORY walk produces a correct CGAL_ROOT (e.g. /lib -> /usr/lib on
 # Arch Linux).  See https://github.com/CGAL/cgal/issues/8521
-if(NOT CMAKE_VERSION VERSION_LESS 3.19)
-  file(REAL_PATH "${CMAKE_CURRENT_LIST_FILE}" _cgal_config_realpath)
-else()
-  get_filename_component(_cgal_config_realpath "${CMAKE_CURRENT_LIST_FILE}" REALPATH)
-endif()
+file(REAL_PATH "${CMAKE_CURRENT_LIST_FILE}" _cgal_config_realpath)
 get_filename_component(CGAL_CONFIG_DIR "${_cgal_config_realpath}" DIRECTORY)
 
 function(cgal_detect_branch_build VAR_NAME)


### PR DESCRIPTION
## Summary of Changes

On distributions such as Arch Linux and Fedora where `/lib` is a symlink to `/usr/lib`, `CMAKE_CURRENT_LIST_FILE` may resolve to `/lib/cmake/CGAL/CGALConfig.cmake`.  The subsequent chain of `get_filename_component(... DIRECTORY)` calls then walks up through the symlink path, producing `CGAL_ROOT=/` instead of `/usr`, and the existence check for  `include/CGAL/config.h` fails — even though CGAL is properly installed.

**Fix:** resolve the real path of `CMAKE_CURRENT_LIST_FILE` before extracting the directory.  Uses `file(REAL_PATH)` when available (CMake >= 3.19), with a `get_filename_component(... REALPATH)` fallback for CMake 3.15–3.18.

Reproducer (from @lrineau's comment):
```
CGAL_DIR=/lib/cmake/CGAL cmake . -B build
# → CGAL_FOUND=FALSE, even though CGAL is installed
```

## Release Management

* Affected package(s): Installation
* Issue(s) solved (if any): fix #8521
* License and copyright ownership: same as CGAL