### PR TITLE
Fix copy-paste errors in compile_shaders() error messages and comments

### DIFF
--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -986,7 +986,7 @@ protected:
       if (!rendering_program_sphere.addShader(geometry_shader_sphere))
       { std::cerr << "Adding geometry shader for sphere FAILED" << std::endl;}
       if (!rendering_program_sphere.addShader(fragment_shader_sphere))
-      { std::cerr << "Adding fragment shader for clipping plane FAILED" << std::endl; }
+      { std::cerr << "Adding fragment shader for sphere FAILED" << std::endl; }
       if (!rendering_program_sphere.link())
       { std::cerr << "Linking Program for sphere FAILED" << std::endl; }
     }
@@ -994,7 +994,6 @@ protected:
     // Cylinder shader
     if (isOpenGL_4_3())
     {
-      // clipping plane shader
       source_ = VERTEX_SOURCE_SHAPE;
 
       QOpenGLShader *vertex_shader_cylinder = new QOpenGLShader(QOpenGLShader::Vertex);
@@ -1019,7 +1018,7 @@ protected:
       if (!rendering_program_cylinder.addShader(geometry_shader_cylinder))
       { std::cerr << "Adding geometry shader for cylinder FAILED" << std::endl;}
       if (!rendering_program_cylinder.addShader(fragment_shader_cylinder))
-      { std::cerr << "Adding fragment shader for clipping plane FAILED" << std::endl; }
+      { std::cerr << "Adding fragment shader for cylinder FAILED" << std::endl; }
       if (!rendering_program_cylinder.link())
       { std::cerr << "Linking Program for cylinder FAILED" << std::endl; }
     }
@@ -1051,12 +1050,12 @@ protected:
       if (!rendering_program_normal.addShader(geometry_shader_normal))
       { std::cerr << "Adding geometry shader for normal FAILED" << std::endl;}
       if (!rendering_program_normal.addShader(fragment_shader_normal))
-      { std::cerr << "Adding fragment shader for clipping plane FAILED" << std::endl; }
+      { std::cerr << "Adding fragment shader for normal FAILED" << std::endl; }
       if (!rendering_program_normal.link())
       { std::cerr << "Linking Program for normal FAILED" << std::endl; }
     }
 
-    // Normal shader
+    // Triangle shader
     if (isOpenGL_4_3())
     {
       source_ = VERTEX_SOURCE_TRIANGLE;
@@ -1083,7 +1082,7 @@ protected:
       if (!rendering_program_triangle.addShader(geometry_shader_triangle))
       { std::cerr << "Adding geometry shader for triangle FAILED" << std::endl;}
       if (!rendering_program_triangle.addShader(fragment_shader_triangle))
-      { std::cerr << "Adding fragment shader for clipping plane FAILED" << std::endl; }
+      { std::cerr << "Adding fragment shader for triangle FAILED" << std::endl; }
       if (!rendering_program_triangle.link())
       { std::cerr << "Linking Program for triangle FAILED" << std::endl; }
     }


### PR DESCRIPTION
## Summary of Changes

Fix 6 copy-paste errors in `Basic_viewer/include/CGAL/Qt/Basic_viewer.h` `compile_shaders()` that were carried over from the clipping plane shader section when the sphere, cylinder, normal, and triangle shader blocks were added:

**4 incorrect error messages** — the fragment shader `std::cerr` messages for sphere (line 989), cylinder (line 1022), normal (line 1054), and triangle (line 1086) all incorrectly said `"Adding fragment shader for clipping plane FAILED"` instead of naming the actual shader. Fixed each to reference the correct shader name.

**1 stale comment** — line 997 had `// clipping plane shader` at the start of the Cylinder shader block. Removed it.

**1 wrong section comment** — line 1059 had `// Normal shader` as the section header for the Triangle shader block. Changed to `// Triangle shader`.

## Release Management

* Affected package(s): `Basic_viewer`
* Issue(s) solved (if any): fix #9392
* Feature/Small Feature (if any): N/A
* License and copyright ownership: N/A