### PR TITLE
Remove 9 no-op uniquely_add_flags() calls from CGAL_SetupFlags.cmake

### DIFF
--- a/Installation/cmake/modules/CGAL_SetupFlags.cmake
+++ b/Installation/cmake/modules/CGAL_SetupFlags.cmake
@@ -31,18 +31,9 @@ endif()
 
 typed_cache_set( BOOL ${CGAL_DONT_OVERRIDE_CMAKE_FLAGS_DESCRIPTION} CGAL_DONT_OVERRIDE_CMAKE_FLAGS TRUE )
 
-uniquely_add_flags( CMAKE_CXX_FLAGS                   ${CGAL_CXX_FLAGS}                   )
-uniquely_add_flags( CMAKE_CXX_FLAGS_RELEASE           ${CGAL_CXX_FLAGS_RELEASE}           )
-uniquely_add_flags( CMAKE_CXX_FLAGS_DEBUG             ${CGAL_CXX_FLAGS_DEBUG}             )
-uniquely_add_flags( CMAKE_MODULE_LINKER_FLAGS         ${CGAL_MODULE_LINKER_FLAGS}         )
-uniquely_add_flags( CMAKE_MODULE_LINKER_FLAGS_RELEASE ${CGAL_MODULE_LINKER_FLAGS_RELEASE} )
-uniquely_add_flags( CMAKE_MODULE_LINKER_FLAGS_DEBUG   ${CGAL_MODULE_LINKER_FLAGS_DEBUG}   )
-uniquely_add_flags( CMAKE_SHARED_LINKER_FLAGS         ${CGAL_SHARED_LINKER_FLAGS}         )
-uniquely_add_flags( CMAKE_SHARED_LINKER_FLAGS_RELEASE ${CGAL_SHARED_LINKER_FLAGS_RELEASE} )
-uniquely_add_flags( CMAKE_SHARED_LINKER_FLAGS_DEBUG   ${CGAL_SHARED_LINKER_FLAGS_DEBUG}   )
-uniquely_add_flags( CMAKE_EXE_LINKER_FLAGS            ${CGAL_EXE_LINKER_FLAGS}            )
-uniquely_add_flags( CMAKE_EXE_LINKER_FLAGS_RELEASE    ${CGAL_EXE_LINKER_FLAGS_RELEASE}    )
-uniquely_add_flags( CMAKE_EXE_LINKER_FLAGS_DEBUG      ${CGAL_EXE_LINKER_FLAGS_DEBUG}      )
+uniquely_add_flags( CMAKE_CXX_FLAGS           ${CGAL_CXX_FLAGS}           )
+uniquely_add_flags( CMAKE_SHARED_LINKER_FLAGS ${CGAL_SHARED_LINKER_FLAGS} )
+uniquely_add_flags( CMAKE_EXE_LINKER_FLAGS    ${CGAL_EXE_LINKER_FLAGS}    )
 
 # Set a default build type if none is given
 if ( NOT CMAKE_BUILD_TYPE )


### PR DESCRIPTION
## Summary of Changes

`CGAL_SetupFlags.cmake` contained 12 `uniquely_add_flags()` calls that propagate `CGAL_*` flag variables into `CMAKE_*` variables. 9 of these reference source variables that are **never set anywhere** in the codebase:

- `CGAL_CXX_FLAGS_RELEASE`, `CGAL_CXX_FLAGS_DEBUG`
- `CGAL_MODULE_LINKER_FLAGS`, `CGAL_MODULE_LINKER_FLAGS_RELEASE`, `CGAL_MODULE_LINKER_FLAGS_DEBUG`
- `CGAL_SHARED_LINKER_FLAGS_RELEASE`, `CGAL_SHARED_LINKER_FLAGS_DEBUG`
- `CGAL_EXE_LINKER_FLAGS_RELEASE`, `CGAL_EXE_LINKER_FLAGS_DEBUG`

The `uniquely_add_flags()` macro (defined in `CGAL_Macros.cmake`) has a guard `if("${ARGC}" GREATER "1")` — when the source variable is empty/unset, the macro is a complete no-op (ARGC evaluates to 1, body is skipped).

Note: The `_INIT` variants (e.g., `CGAL_CXX_FLAGS_RELEASE_INIT`) in `CGALConfig_binary.cmake.in` and `CGALConfig_install.cmake.in` are different variables consumed by the `CGAL_CONFIG_LOADED` block above, not by these calls.

**3 calls are retained** because their source variables ARE actively populated:
- `CGAL_CXX_FLAGS` — set by `Installation/CMakeLists.txt` (MSVC, GCC, Intel, SunPro flags)
- `CGAL_SHARED_LINKER_FLAGS` — set for SunPro compiler
- `CGAL_EXE_LINKER_FLAGS` — set for SunPro compiler

## Release Management

* Affected package(s): Installation
* Issue(s) solved (if any): partially addresses #4815
* Feature/Small Feature (if any): N/A
* License and copyright ownership: N/A (dead code removal, no new code)