### PR TITLE
STL_Extension: document Concurrent_tag::is_parallel

### DIFF
--- a/STL_Extension/doc/STL_Extension/CGAL/tags.h
+++ b/STL_Extension/doc/STL_Extension/CGAL/tags.h
@@ -72,14 +72,34 @@ struct Null_functor {
 Tag used to disable concurrency.
 For example, it may be used by a user to request the sequential version of an algorithm.
 */
-struct Sequential_tag {};
+struct Sequential_tag {
+
+/// \name Constants
+/// @{
+/*!
+`false`. Indicates that this tag represents sequential execution.
+*/
+static constexpr bool is_parallel;
+/// @}
+
+};
 
 /*!
 \ingroup PkgSTLExtensionUtilities
 Tag used to enable concurrency.
 For example, it may be used by a user to request the parallel version of an algorithm.
 */
-struct Parallel_tag {};
+struct Parallel_tag {
+
+/// \name Constants
+/// @{
+/*!
+`true`. Indicates that this tag represents parallel execution.
+*/
+static constexpr bool is_parallel;
+/// @}
+
+};
 
 /*!
 \ingroup PkgSTLExtensionUtilities


### PR DESCRIPTION
## Summary of Changes

Add documentation for the `is_parallel` static member of `Sequential_tag` and `Parallel_tag` in the Doxygen doc stub. The member was added to the source in PR #9274 but was missing from the documentation.

## Release Management

* Affected package(s): `STL_Extension`
* Issue(s) solved (if any): fix #9371
* Feature/Small Feature (if any): None
* Link to compiled documentation (obligatory for small feature) [N/A](https://www.cgal.org)
* License and copyright ownership: No change