### PR TITLE
Fix camera rotation continuing during path playback

### DIFF
--- a/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
+++ b/GraphicsView/include/CGAL/Qt/qglviewer_impl.h
@@ -2076,6 +2076,9 @@ void CGAL::QGLViewer::keyPressEvent(QKeyEvent *e) {
     static QElapsedTimer doublePress;
 
     if (modifiers == playPathKeyboardModifiers()) {
+      if(camera()->frame()->isSpinning()){
+        camera()->frame()->stopSpinning();
+      }
       qint64 elapsed = doublePress.restart();
       if ((elapsed < 250) && (index == previousPathId_))
         camera()->resetPath(index);


### PR DESCRIPTION
## Summary of Changes
This PR fixes an issue where the camera continues to rotate while a camera path is being played.

Previously, if the user was interacting with the Basic_Viewer (e.g., rotating the camera) and then started path playback, the ongoing rotation was not stopped. As a result, the animation was corrupted, producing incorrect and unintuitive camera motion.

This PR fixes this problem by stopping the camera before starting the playback.

## Release Management

* Affected package(s): GraphicsView, Basic_Viewer

