### PR TITLE
Add `value` member to Sequential_tag and Parallel_tag

### DIFF
--- a/STL_Extension/include/CGAL/tags.h
+++ b/STL_Extension/include/CGAL/tags.h
@@ -43,8 +43,17 @@ struct Null_functor {
 };
 
 // For concurrency
-struct Sequential_tag { static constexpr bool is_parallel = false; };
-struct Parallel_tag : public Sequential_tag { static constexpr bool is_parallel = true; };
+struct Sequential_tag { 
+  static constexpr bool is_parallel = false;
+  static constexpr bool is_sequential = true;
+  static constexpr bool value = false;
+};
+
+struct Parallel_tag : public Sequential_tag { 
+  static constexpr bool is_parallel = true;
+  static constexpr bool is_sequential = false;
+  static constexpr bool value = true;
+};
 
 #ifdef CGAL_LINKED_WITH_TBB
 typedef CGAL::Parallel_tag Parallel_if_available_tag;


### PR DESCRIPTION
## Summary of Changes

This PR adds a `static constexpr bool value` member to 
`Sequential_tag` and `Parallel_tag`.

Motivation:
Standard C++ boolean traits (such as `std::true_type` and 
`std::false_type`) expose a `value` member. Adding this member 
improves interoperability with generic template code expecting 
`Tag::value`.

Changes:
- Added `value = false` to `Sequential_tag`
- Added `value = true` to `Parallel_tag`
- Preserved existing members (`is_parallel`, `is_sequential`) for backward compatibility

Impact:
- Non-breaking change
- Improves compatibility with STL-style meta-programming

## Release Management

* Affected package(s): STL_Extension
* Feature/Small Feature: Small feature
* License and copyright ownership: No change