### PR TITLE
PMP::isotropic_remeshing() - fix debug issue about degenerate faces

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1718,6 +1718,7 @@ private:
           halfedges_around_target(halfedge(v, mesh_), mesh_))
       {
         if(!is_border(h, mesh_) &&
+           is_triangle(h, mesh_) &&
            is_degenerate_triangle_face(face(h, mesh_), mesh_,
                                        parameters::vertex_point_map(vpmap_)
                                                    .geom_traits(gt_)))


### PR DESCRIPTION
## Summary of Changes

After collapse, we check that facets incident to `vkept` are not degenerate, and fix the degeneracy when it's possible.
The facets that are not triangular are skipped for now, hoping that isotropic remeshing does not create new degenerate facets during collapse. If facets are triangular, they are checked and fixed.

This PR solves the issue #9407, and does not change the current behavior of the algorithm when incident facets are triangles,

## Release Management

* Affected package(s): PMP
* Issue(s) solved (if any): fix #9407
* License and copyright ownership: unchanged

