### PR TITLE
PMP - fix compilation of `PMP::triangulate_faces(2 parameters)`

### DIFF
--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -448,9 +448,9 @@ bool triangulate_faces(const FaceRange& face_range,
 * @see `triangulate_face()`
 * @see `triangulate_polygons()`
 */
-template <typename PolygonMesh, typename NamedParameters = parameters::Default_named_parameters>
+template <typename PolygonMesh, typename CGAL_NP_TEMPLATE_PARAMETERS>
 bool triangulate_faces(PolygonMesh& pmesh,
-                       const NamedParameters& np = parameters::default_values())
+                       const CGAL_NP_CLASS& np = parameters::default_values())
 {
   return triangulate_faces(faces(pmesh), pmesh, np);
 }

--- a/PMP_Remeshing/test/PMP_Remeshing/triangulate_faces_test.cpp
+++ b/PMP_Remeshing/test/PMP_Remeshing/triangulate_faces_test.cpp
@@ -90,6 +90,7 @@ test_triangulate_face_range(const std::string& filename)
 
   typedef typename K::Point_3                    Point;
   typedef CGAL::Surface_mesh<Point>          Surface_mesh;
+  typedef typename boost::graph_traits<Surface_mesh>::face_descriptor face_descriptor;
 
   Surface_mesh mesh;
   std::ifstream input(filename);
@@ -114,6 +115,10 @@ test_triangulate_face_range(const std::string& filename)
   }
 
   assert(CGAL::is_triangle_mesh(mesh));
+
+  // For compilation
+  std::vector<face_descriptor> face_range(faces(mesh).begin(), faces(mesh).end());
+  CGAL::Polygon_mesh_processing::triangulate_faces(face_range, mesh);
 
   // For compilation
   CGAL::Polygon_mesh_processing::triangulate_faces(faces(mesh), mesh,


### PR DESCRIPTION
## Summary of Changes

Neither msvc not clang could find which version with 2 parameters was the right one when compiling `PMP::triangulate_faces(face_range, pmesh)`
Now they do

## Release Management

* Affected package(s): PMP_remesh
* License and copyright ownership: unchanged

