### PR TITLE
Avoid accidental reference to a temporary

### DIFF
--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polygon_mesh.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polygon_mesh.h
@@ -105,7 +105,7 @@ triangulate_hole_polygon_mesh(PolygonMesh& pmesh,
             const Kernel& k,
             const bool use_cdt,
             const bool skip_cubic_algorithm,
-            Visitor& visitor,
+            const Visitor& visitor,
             const typename Kernel::FT max_squared_distance)
 {
 #ifdef CGAL_HOLE_FILLING_DO_NOT_USE_CDT2

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/internal/Hole_filling/Triangulate_hole_polyline.h
@@ -787,7 +787,7 @@ public:
                     const Polyline_3& Q,
                     Tracer& tracer,
                     const WeightCalculator& WC,
-                    Visitor& visitor) const
+                    const Visitor& visitor) const
   {
     CGAL_assertion(P.front() == P.back());
     CGAL_assertion(Q.empty() || (Q.front() == Q.back()));
@@ -877,7 +877,7 @@ private:
                       Edge_DT e,
                       const Triangulation_DT& tr,
                       const WeightCalculator& WC,
-                      Visitor& visitor,
+                      const Visitor& visitor,
                       const bool produce_incomplete) const
   {
     /**********************************************************************
@@ -1005,7 +1005,7 @@ private:
                                     const Polyline_3& Q,
                                     Tracer& tracer,
                                     const WeightCalculator& WC,
-                                    Visitor& visitor) const
+                                    const Visitor& visitor) const
   {
     typedef std::pair<int, int> Range;
     typedef std::back_insert_iterator<std::vector<Range> > Output_hole_iterator;
@@ -1119,7 +1119,7 @@ private:
                                  const Polyline_3& Q,
                                  Tracer& tracer,
                                  const WeightCalculator& WC,
-                                 Visitor& visitor) const
+                                 const Visitor& visitor) const
   {
     int n = static_cast<int>(edge_exist.size());
     LookupTable<Weight> W(n, Weight::DEFAULT()); // do not forget that these default values are not changed for [i, i+1]
@@ -1175,7 +1175,7 @@ public:
                     const Polyline_3& Q,
                     Tracer& tracer,
                     const WeightCalculator& WC,
-                    Visitor& visitor) const
+                    const Visitor& visitor) const
   {
     CGAL_assertion(P.front() == P.back());
     CGAL_assertion(Q.empty() || (Q.front() == Q.back()));
@@ -1205,7 +1205,7 @@ public:
   void triangulate_all(const Polyline_3& P,
                        const Polyline_3& Q,
                        const WeightCalculator& WC,
-                       Visitor& visitor,
+                       const Visitor& visitor,
                        std::pair<int, int> range,
                        LookupTable<Weight>& W,
                        LookupTable<int>& lambda) const
@@ -1336,7 +1336,7 @@ template <
 bool
 triangulate_hole_polyline_with_cdt(const PointRange& points,
                                    Tracer& tracer,
-                                   Visitor& visitor,
+                                   const Visitor& visitor,
                                    const Validity_checker& is_valid,
                                    const Traits& traits,
                                    const typename Traits::FT max_squared_distance)
@@ -1543,7 +1543,7 @@ triangulate_hole_polyline(const PointRange1& points,
                           const PointRange2& third_points,
                           Tracer& tracer,
                           const WeightCalculator& WC,
-                          Visitor& visitor,
+                          const Visitor& visitor,
                           bool use_delaunay_triangulation,
                           bool skip_cubic_algorithm,
                           const Kernel&)

--- a/STL_Extension/include/CGAL/Named_function_parameters.h
+++ b/STL_Extension/include/CGAL/Named_function_parameters.h
@@ -306,6 +306,12 @@ const T& choose_parameter(const T& t, const D&)
   return t;
 }
 
+template <typename T, typename D>
+T choose_parameter(T&& t, const D&)
+{
+  return t;
+}
+
 // single parameter so that we can avoid a default construction
 template <typename D>
 D choose_parameter(const internal_np::Param_not_found&)

--- a/STL_Extension/include/CGAL/Named_function_parameters.h
+++ b/STL_Extension/include/CGAL/Named_function_parameters.h
@@ -277,19 +277,19 @@ get_parameter_reference(const Named_function_parameters<T, Tag, Base>& np, Query
 
 // Two parameters, non-trivial default value
 template <typename D>
-D& choose_parameter(const internal_np::Param_not_found&, D& d)
+D& choose_parameter(internal_np::Param_not_found, D& d)
 {
   return d;
 }
 
 template <typename D>
-const D& choose_parameter(const internal_np::Param_not_found&, const D& d)
+const D& choose_parameter(internal_np::Param_not_found, const D& d)
 {
   return d;
 }
 
 template <typename D>
-D choose_parameter(const internal_np::Param_not_found&, D&& d)
+D choose_parameter(internal_np::Param_not_found, D&& d)
 {
   return std::forward<D>(d);
 }
@@ -314,7 +314,7 @@ T choose_parameter(T&& t, const D&)
 
 // single parameter so that we can avoid a default construction
 template <typename D>
-D choose_parameter(const internal_np::Param_not_found&)
+D choose_parameter(internal_np::Param_not_found)
 {
   return D();
 }
@@ -532,7 +532,7 @@ struct Boost_parameter_compatibility_wrapper<Tag, true, false>
 
 // Version with three parameters for dynamic property maps
 template <typename D, typename Dynamic_tag, typename PolygonMesh>
-D choose_parameter(const internal_np::Param_not_found&, Dynamic_tag tag, PolygonMesh& pm)
+D choose_parameter(internal_np::Param_not_found, Dynamic_tag tag, PolygonMesh& pm)
 {
   return get(tag, pm);
 }


### PR DESCRIPTION
If the parameter is a temporary, return a copy to avoid dangling reference.