### PR TITLE
Rework mesh simplification lab plugin

### DIFF
--- a/Lab/demo/Lab/Plugins/Surface_mesh/CMakeLists.txt
+++ b/Lab/demo/Lab/Plugins/Surface_mesh/CMakeLists.txt
@@ -20,6 +20,11 @@ if(NOT CGAL_DISABLE_GMP)
         PROPERTIES RESOURCE_LOCK Selection_test_resources)
     endif()
 
+    qt6_wrap_ui( mesh_simplificationUI_FILES  Mesh_simplification_dialog.ui)
+    cgal_lab_plugin(mesh_simplification_plugin Mesh_simplification_plugin ${mesh_simplificationUI_FILES})
+    target_link_libraries(
+      mesh_simplification_plugin PRIVATE scene_surface_mesh_item scene_selection_item
+                                         CGAL::Eigen3_support)
   else()
     message(STATUS "NOTICE: Eigen 3.1 (or greater) was not found. The Parameterization plugin will not be available.")
   endif()
@@ -34,10 +39,6 @@ if(NOT CGAL_DISABLE_GMP)
       "compilation of  mesh_segmentation_plugin"
       PROPERTIES RESOURCE_LOCK Selection_test_resources)
   endif()
-
-  qt6_wrap_ui( mesh_simplificationUI_FILES  Mesh_simplification_dialog.ui)
-  cgal_lab_plugin(mesh_simplification_plugin Mesh_simplification_plugin ${mesh_simplificationUI_FILES})
-  target_link_libraries(mesh_simplification_plugin PRIVATE scene_surface_mesh_item scene_selection_item)
 
   qt6_wrap_ui(shortestPathUI_FILES Shortest_path_widget.ui)
   cgal_lab_plugin(shortest_path_plugin Shortest_path_plugin

--- a/Lab/demo/Lab/Plugins/Surface_mesh/Mesh_simplification_dialog.ui
+++ b/Lab/demo/Lab/Plugins/Surface_mesh/Mesh_simplification_dialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>311</width>
-    <height>171</height>
+    <width>632</width>
+    <height>305</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -15,136 +15,147 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Stop simplification as soon as:</string>
-     </property>
-    </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
      <item>
-      <widget class="QCheckBox" name="m_use_nb_edges">
-       <property name="text">
-        <string>Number of edges =</string>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <item>
+        <widget class="QLabel" name="label_Strategy">
+         <property name="text">
+          <string>Cost &amp; Placement</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
      <item>
-      <widget class="QSpinBox" name="m_nb_edges">
-       <property name="minimum">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <number>400000000</number>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <item>
+        <widget class="QRadioButton" name="radio_GH">
+         <property name="text">
+          <string>Garland-Heckbert</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="radio_LT">
+         <property name="text">
+          <string>Lindstrom-Turk</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QRadioButton" name="radio_EL">
+         <property name="text">
+          <string>Edge Length / Midpoint</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
-      <spacer name="horizontalSpacer_2">
+      <spacer name="verticalSpacer">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
-         <height>20</height>
+         <width>20</width>
+         <height>40</height>
         </size>
        </property>
       </spacer>
      </item>
      <item>
-      <widget class="QComboBox" name="m_combinatorial">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
        <item>
-        <property name="text">
-         <string>AND</string>
-        </property>
+        <widget class="QLabel" name="label_Stop">
+         <property name="text">
+          <string>Stop Criterion</string>
+         </property>
+        </widget>
        </item>
-       <item>
-        <property name="text">
-         <string>OR</string>
-        </property>
-       </item>
-      </widget>
+      </layout>
      </item>
      <item>
-      <spacer name="horizontalSpacer">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QRadioButton" name="radio_EdgeLength">
+           <property name="text">
+            <string>Edge Length</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="radio_EdgeCount">
+           <property name="text">
+            <string>Edge Count</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QRadioButton" name="radio_FacetCount">
+           <property name="text">
+            <string>Facet Count</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QDoubleSpinBox" name="spin_EdgeLength"/>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="spin_EdgeCount"/>
+         </item>
+         <item>
+          <widget class="QSpinBox" name="spin_FacetCount"/>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <spacer name="verticalSpacer_2">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
-         <height>20</height>
+         <width>20</width>
+         <height>40</height>
         </size>
        </property>
       </spacer>
      </item>
-    </layout>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
-      <widget class="QCheckBox" name="m_use_edge_length">
-       <property name="enabled">
-        <bool>true</bool>
-       </property>
-       <property name="text">
-        <string>Minimum edge length =</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="DoubleEdit" name="m_edge_length">
-       <property name="text">
-        <string>0.000</string>
-       </property>
-      </widget>
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QCheckBox" name="useBoundedPlacement">
+         <property name="text">
+          <string>Bound Placement</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
      </item>
     </layout>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>DoubleEdit</class>
-   <extends>QLineEdit</extends>
-   <header>CGAL_double_edit.h</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections>
   <connection>

--- a/Lab/demo/Lab/Plugins/Surface_mesh/Mesh_simplification_dialog.ui
+++ b/Lab/demo/Lab/Plugins/Surface_mesh/Mesh_simplification_dialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Stop Predicate</string>
+   <string>Surface Mesh Simplification</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>

--- a/Lab/demo/Lab/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
@@ -4,11 +4,19 @@
 #include "Scene_polyhedron_selection_item.h"
 
 #include <CGAL/Surface_mesh_simplification/edge_collapse.h>
+
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Edge_count_stop_predicate.h>
+#include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Face_count_stop_predicate.h>
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Edge_length_stop_predicate.h>
+
+#include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Midpoint_placement.h>
+#include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Edge_length_cost.h>
+
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Constrained_placement.h>
+#include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/LindstromTurk_cost.h>
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/LindstromTurk_placement.h>
-#include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_placement.h>
+#include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_policies.h>
+#include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_filter.h>
 
 #include <CGAL/Three/CGAL_Lab_plugin_interface.h>
 
@@ -17,51 +25,18 @@
 #include <QInputDialog>
 #include <QElapsedTimer>
 #include <QAction>
+
 #include <QMessageBox>
+#include <QButtonGroup>
+
+#include <optional>
+#include <type_traits>
 
 typedef Scene_surface_mesh_item Scene_facegraph_item;
 typedef Scene_facegraph_item::Face_graph FaceGraph;
+typedef EPICK::FT FT;
 
 namespace SMS = ::CGAL::Surface_mesh_simplification;
-
-class Custom_stop_predicate
-{
-  bool m_and;
-  SMS::Edge_count_stop_predicate<FaceGraph> m_count_stop;
-  SMS::Edge_length_stop_predicate<double> m_length_stop;
-
-public:
-  Custom_stop_predicate(const bool use_and,
-                        const std::size_t nb_edges,
-                        const double edge_length)
-    : m_and (use_and),
-      m_count_stop (nb_edges),
-      m_length_stop (edge_length)
-  {
-    std::cerr << "Simplifying until:" << std::endl
-              << " * Number of edges = " << nb_edges << std::endl
-              << (use_and ? " AND " : " OR ") << std::endl
-              << " * Minimum edge length = " << edge_length << std::endl;
-  }
-
-  template <typename Profile>
-  bool operator()(const double& current_cost,
-                  const Profile& edge_profile,
-                  const std::size_t initial_count,
-                  const std::size_t current_count) const
-  {
-    if (m_and)
-    {
-      return (m_count_stop(current_cost, edge_profile, initial_count, current_count) &&
-              m_length_stop(current_cost, edge_profile, initial_count, current_count));
-    }
-    else
-    {
-      return (m_count_stop(current_cost, edge_profile, initial_count, current_count) ||
-              m_length_stop(current_cost, edge_profile, initial_count, current_count));
-    }
-  }
-};
 
 using namespace CGAL::Three;
 
@@ -87,11 +62,13 @@ public:
     QAction *actionSimplify = new QAction("Simplification", mw);
     actionSimplify->setProperty("subMenuName",
                                 "Triangulated Surface Mesh Simplification");
-    connect(actionSimplify, SIGNAL(triggered()), this, SLOT(on_actionSimplify_triggered()));
+    connect(actionSimplify, SIGNAL(triggered()),
+            this, SLOT(on_actionSimplify_triggered()));
     _actions <<actionSimplify;
   }
 
-  bool applicable(QAction*) const {
+  bool applicable(QAction*) const
+  {
     return qobject_cast<Scene_facegraph_item*>(scene->item(scene->mainSelectionIndex())) ||
            qobject_cast<Scene_polyhedron_selection_item*>(scene->item(scene->mainSelectionIndex()));
   }
@@ -134,17 +111,72 @@ void CGAL_Lab_mesh_simplification_plugin::on_actionSimplify_triggered()
     connect(ui.buttonBox, SIGNAL(rejected()),
             &dialog, SLOT(reject()));
 
+    // Set up button groups for exclusive selection
+    QButtonGroup *strategyGroup = new QButtonGroup(&dialog);
+    strategyGroup->addButton(ui.radio_GH);
+    strategyGroup->addButton(ui.radio_LT);
+    strategyGroup->addButton(ui.radio_EL);
+    ui.radio_GH->setChecked(true);
+
+    QButtonGroup *stopGroup = new QButtonGroup(&dialog);
+    stopGroup->addButton(ui.radio_EdgeLength);
+    stopGroup->addButton(ui.radio_EdgeCount);
+    stopGroup->addButton(ui.radio_FacetCount);
+    ui.radio_EdgeCount->setChecked(true);
+
+    ui.useBoundedPlacement->setChecked(true);
+
     Scene_interface::Bbox bbox = poly_item != nullptr ? poly_item->bbox()
                                                       : (selection_item != nullptr ? selection_item->bbox()
                                                                                    : scene->bbox());
 
-    double diago_length = CGAL::sqrt((bbox.xmax() - bbox.xmin())*(bbox.xmax() - bbox.xmin()) +
-                                     (bbox.ymax() - bbox.ymin())*(bbox.ymax() - bbox.ymin()) +
-                                     (bbox.zmax() - bbox.zmin())*(bbox.zmax() - bbox.zmin()));
+    double diag_length = CGAL::sqrt((bbox.xmax() - bbox.xmin())*(bbox.xmax() - bbox.xmin()) +
+                                    (bbox.ymax() - bbox.ymin())*(bbox.ymax() - bbox.ymin()) +
+                                    (bbox.zmax() - bbox.zmin())*(bbox.zmax() - bbox.zmin()));
 
-    ui.m_nb_edges->setValue((int)(num_halfedges(pmesh) / 4));
-    ui.m_nb_edges->setMaximum((int)(num_halfedges(pmesh)));
-    ui.m_edge_length->setValue(diago_length * 0.05);
+    ui.spin_EdgeCount->setMinimum(0);
+    ui.spin_EdgeCount->setMaximum(static_cast<int>(num_edges(pmesh)));
+    ui.spin_EdgeCount->setValue(static_cast<int>(num_edges(pmesh)/2));
+    ui.spin_FacetCount->setMinimum(0);
+    ui.spin_FacetCount->setMaximum(static_cast<int>(num_faces(pmesh)));
+    ui.spin_FacetCount->setValue(static_cast<int>(num_faces(pmesh)/2));
+    ui.spin_EdgeLength->setValue(diag_length * 0.05);
+
+    ui.spin_EdgeLength->setEnabled(ui.radio_EdgeLength->isChecked());
+    ui.spin_EdgeCount->setEnabled(ui.radio_EdgeCount->isChecked());
+    ui.spin_FacetCount->setEnabled(ui.radio_FacetCount->isChecked());
+    connect(ui.radio_EdgeLength, &QRadioButton::toggled,
+            ui.spin_EdgeLength, &QWidget::setEnabled);
+    connect(ui.radio_EdgeCount, &QRadioButton::toggled,
+            ui.spin_EdgeCount, &QWidget::setEnabled);
+    connect(ui.radio_FacetCount, &QRadioButton::toggled,
+            ui.spin_FacetCount, &QWidget::setEnabled);
+
+    // Disable Edge Length stop for GH and LT strategies
+    ui.radio_EdgeLength->setEnabled(false); // GH is default
+    connect(ui.radio_GH, &QRadioButton::toggled,
+            [&ui](bool checked) {
+              ui.radio_EdgeLength->setEnabled(!checked);
+              if (checked &&  ui.radio_EdgeLength->isChecked()) {
+                  ui.radio_EdgeCount->setChecked(true);
+              }
+            });
+    connect(ui.radio_LT, &QRadioButton::toggled,
+            [&ui](bool checked) {
+              ui.radio_EdgeLength->setEnabled(!checked);
+              if (checked && ui.radio_EdgeLength->isChecked()) {
+                  ui.radio_EdgeCount->setChecked(true);
+              }
+            });
+    connect(ui.radio_EL, &QRadioButton::toggled,
+            [&ui](bool checked) {
+              ui.radio_EdgeLength->setEnabled(checked);
+              if (checked && !ui.radio_EdgeLength->isChecked() &&
+                             !ui.radio_EdgeCount->isChecked() &&
+                             !ui.radio_FacetCount->isChecked()) {
+                  ui.radio_EdgeLength->setChecked(true);
+              }
+            });
 
     // check user cancellation
     if(dialog.exec() == QDialog::Rejected)
@@ -158,28 +190,95 @@ void CGAL_Lab_mesh_simplification_plugin::on_actionSimplify_triggered()
     QApplication::setOverrideCursor(Qt::WaitCursor);
     QApplication::processEvents();
 
-    Custom_stop_predicate stop(
-      (ui.m_combinatorial->currentIndex() == 0) && !(ui.m_use_nb_edges->isChecked()) && !(ui.m_use_edge_length->isChecked()),
-      (ui.m_use_nb_edges->isChecked() ? ui.m_nb_edges->value() : 0),
-      (ui.m_use_edge_length->isChecked() ? ui.m_edge_length->value() : (std::numeric_limits<double>::max)()));
-
-    if(selection_item)
+    auto call_edge_collapse = [&](const auto& stop, const auto& cost, const auto& base_placement)
     {
-      SMS::Constrained_placement<SMS::Bounded_normal_change_placement<SMS::LindstromTurk_placement<FaceGraph> >,
-        Scene_polyhedron_selection_item::Is_constrained_map<
-          Scene_polyhedron_selection_item::Selection_set_edge> > placement(selection_item->constrained_edges_pmap());
+      using Base_placement = std::decay_t<decltype(base_placement)>;
 
-      SMS::edge_collapse(pmesh, stop,
-                         CGAL::parameters::edge_is_constrained_map(selection_item->constrained_edges_pmap())
-                                          .get_placement(placement));
+      if(selection_item)
+      {
+        SMS::Constrained_placement<
+          Base_placement,
+          Scene_polyhedron_selection_item::Is_constrained_map<
+            Scene_polyhedron_selection_item::Selection_set_edge> > placement(selection_item->constrained_edges_pmap(), base_placement);
+
+        if(ui.useBoundedPlacement->isChecked())
+        {
+          SMS::Bounded_normal_change_filter<> filter;
+          SMS::edge_collapse(pmesh, stop,
+                            CGAL::parameters::edge_is_constrained_map(selection_item->constrained_edges_pmap())
+                                             .get_cost(cost)
+                                             .filter(filter)
+                                             .get_placement(placement));
+        }
+        else
+        {
+          SMS::edge_collapse(pmesh, stop,
+                            CGAL::parameters::edge_is_constrained_map(selection_item->constrained_edges_pmap())
+                                             .get_cost(cost)
+                                             .get_placement(placement));
+        }
+      }
+      else
+      {
+        if(ui.useBoundedPlacement->isChecked())
+        {
+          SMS::Bounded_normal_change_filter<> filter;
+          SMS::edge_collapse(pmesh, stop,
+                            CGAL::parameters::vertex_index_map(get(boost::vertex_index, pmesh))
+                                             .get_cost(cost)
+                                             .filter(filter)
+                                             .get_placement(base_placement));
+        }
+        else
+        {
+          SMS::edge_collapse(pmesh, stop,
+                            CGAL::parameters::vertex_index_map(get(boost::vertex_index, pmesh))
+                                             .get_cost(cost)
+                                             .get_placement(base_placement));
+        }
+      }
+    };
+
+    if (ui.radio_LT->isChecked())
+    {
+      if (ui.radio_EdgeCount->isChecked())
+        call_edge_collapse(SMS::Edge_count_stop_predicate<FaceGraph>(ui.spin_EdgeCount->value()),
+                           SMS::LindstromTurk_cost<FaceGraph>(),
+                           SMS::LindstromTurk_placement<FaceGraph>());
+      else
+        call_edge_collapse(SMS::Face_count_stop_predicate<FaceGraph>(ui.spin_FacetCount->value()),
+                           SMS::LindstromTurk_cost<FaceGraph>(),
+                           SMS::LindstromTurk_placement<FaceGraph>());
+    }
+    else if (ui.radio_GH->isChecked())
+    {
+      SMS::GarlandHeckbert_policies<FaceGraph, EPICK> policies(pmesh);
+      if (ui.radio_EdgeCount->isChecked())
+        call_edge_collapse(SMS::Edge_count_stop_predicate<FaceGraph>(ui.spin_EdgeCount->value()),
+                           policies, policies);
+      else
+        call_edge_collapse(SMS::Face_count_stop_predicate<FaceGraph>(ui.spin_FacetCount->value()),
+                           policies, policies);
+    }
+    else if (ui.radio_EL->isChecked())
+    {
+      if (ui.radio_EdgeLength->isChecked())
+        call_edge_collapse(SMS::Edge_length_stop_predicate<FT>(ui.spin_EdgeLength->value()),
+                           SMS::Edge_length_cost<FaceGraph>(),
+                           SMS::Midpoint_placement<FaceGraph>());
+      else if (ui.radio_EdgeCount->isChecked())
+        call_edge_collapse(SMS::Edge_count_stop_predicate<FaceGraph>(ui.spin_EdgeCount->value()),
+                           SMS::Edge_length_cost<FaceGraph>(),
+                           SMS::Midpoint_placement<FaceGraph>());
+      else
+        call_edge_collapse(SMS::Face_count_stop_predicate<FaceGraph>(ui.spin_FacetCount->value()),
+                           SMS::Edge_length_cost<FaceGraph>(),
+                           SMS::Midpoint_placement<FaceGraph>());
     }
     else
     {
-      SMS::Bounded_normal_change_placement<SMS::LindstromTurk_placement<FaceGraph> > placement;
-
-      SMS::edge_collapse(pmesh, stop,
-                         CGAL::parameters::vertex_index_map(get(boost::vertex_index, pmesh))
-                                          .get_placement(placement));
+      std::cerr << "Unknown simplification strategy selected." << std::endl;
+      return;
     }
 
     std::cout << "ok (" << time.elapsed() << " ms, " << num_halfedges(pmesh) / 2 << " edges)" << std::endl;

--- a/Lab/demo/Lab/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Surface_mesh/Mesh_simplification_plugin.cpp
@@ -1,14 +1,7 @@
-#include <CGAL/Three/CGAL_Lab_plugin_interface.h>
+#include "ui_Mesh_simplification_dialog.h"
 
 #include "Scene_surface_mesh_item.h"
 #include "Scene_polyhedron_selection_item.h"
-
-#include <QApplication>
-#include <QMainWindow>
-#include <QInputDialog>
-#include <QElapsedTimer>
-#include <QAction>
-#include <QMessageBox>
 
 #include <CGAL/Surface_mesh_simplification/edge_collapse.h>
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Edge_count_stop_predicate.h>
@@ -17,21 +10,33 @@
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/LindstromTurk_placement.h>
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_placement.h>
 
-#include "ui_Mesh_simplification_dialog.h"
+#include <CGAL/Three/CGAL_Lab_plugin_interface.h>
+
+#include <QApplication>
+#include <QMainWindow>
+#include <QInputDialog>
+#include <QElapsedTimer>
+#include <QAction>
+#include <QMessageBox>
 
 typedef Scene_surface_mesh_item Scene_facegraph_item;
 typedef Scene_facegraph_item::Face_graph FaceGraph;
 
+namespace SMS = ::CGAL::Surface_mesh_simplification;
+
 class Custom_stop_predicate
 {
   bool m_and;
-  CGAL::Surface_mesh_simplification::Edge_count_stop_predicate<FaceGraph> m_count_stop;
-  CGAL::Surface_mesh_simplification::Edge_length_stop_predicate<double> m_length_stop;
+  SMS::Edge_count_stop_predicate<FaceGraph> m_count_stop;
+  SMS::Edge_length_stop_predicate<double> m_length_stop;
 
 public:
-
-  Custom_stop_predicate (bool use_and, std::size_t nb_edges, double edge_length)
-    : m_and (use_and), m_count_stop (nb_edges), m_length_stop (edge_length)
+  Custom_stop_predicate(const bool use_and,
+                        const std::size_t nb_edges,
+                        const double edge_length)
+    : m_and (use_and),
+      m_count_stop (nb_edges),
+      m_length_stop (edge_length)
   {
     std::cerr << "Simplifying until:" << std::endl
               << " * Number of edges = " << nb_edges << std::endl
@@ -40,31 +45,35 @@ public:
   }
 
   template <typename Profile>
-  bool operator() (const double& current_cost, const Profile& edge_profile,
-                   std::size_t initial_count, std::size_t current_count) const
+  bool operator()(const double& current_cost,
+                  const Profile& edge_profile,
+                  const std::size_t initial_count,
+                  const std::size_t current_count) const
   {
     if (m_and)
-      return (m_count_stop(current_cost, edge_profile, initial_count, current_count)
-              && m_length_stop(current_cost, edge_profile, initial_count, current_count));
+    {
+      return (m_count_stop(current_cost, edge_profile, initial_count, current_count) &&
+              m_length_stop(current_cost, edge_profile, initial_count, current_count));
+    }
     else
-      return (m_count_stop(current_cost, edge_profile, initial_count, current_count)
-              || m_length_stop(current_cost, edge_profile, initial_count, current_count));
+    {
+      return (m_count_stop(current_cost, edge_profile, initial_count, current_count) ||
+              m_length_stop(current_cost, edge_profile, initial_count, current_count));
+    }
   }
-
 };
 
-
 using namespace CGAL::Three;
-class CGAL_Lab_mesh_simplification_plugin :
-  public QObject,
-  public CGAL_Lab_plugin_interface
+
+class CGAL_Lab_mesh_simplification_plugin
+  : public QObject,
+    public CGAL_Lab_plugin_interface
 {
   Q_OBJECT
   Q_INTERFACES(CGAL::Three::CGAL_Lab_plugin_interface)
   Q_PLUGIN_METADATA(IID "com.geometryfactory.CGALLab.PluginInterface/1.0")
 
 public:
-
   QList<QAction*> actions() const {
     return _actions;
   }
@@ -73,34 +82,32 @@ public:
             Scene_interface* scene_interface,
             Messages_interface*)
   {
-      mw = mainWindow;
-      scene = scene_interface;
-     QAction *actionSimplify = new QAction("Simplification", mw);
-      actionSimplify->setProperty("subMenuName",
-                                  "Triangulated Surface Mesh Simplification");
-      connect(actionSimplify, SIGNAL(triggered()), this, SLOT(on_actionSimplify_triggered()));
-      _actions <<actionSimplify;
+    mw = mainWindow;
+    scene = scene_interface;
+    QAction *actionSimplify = new QAction("Simplification", mw);
+    actionSimplify->setProperty("subMenuName",
+                                "Triangulated Surface Mesh Simplification");
+    connect(actionSimplify, SIGNAL(triggered()), this, SLOT(on_actionSimplify_triggered()));
+    _actions <<actionSimplify;
+  }
 
-  }
   bool applicable(QAction*) const {
-    return qobject_cast<Scene_facegraph_item*>(scene->item(scene->mainSelectionIndex()))
-      || qobject_cast<Scene_polyhedron_selection_item*>(scene->item(scene->mainSelectionIndex()));
+    return qobject_cast<Scene_facegraph_item*>(scene->item(scene->mainSelectionIndex())) ||
+           qobject_cast<Scene_polyhedron_selection_item*>(scene->item(scene->mainSelectionIndex()));
   }
+
 public Q_SLOTS:
   void on_actionSimplify_triggered();
+
 private :
   Scene_interface *scene;
   QMainWindow *mw;
   QList<QAction*> _actions;
-
 }; // end CGAL_Lab_mesh_simplification_plugin
 
 void CGAL_Lab_mesh_simplification_plugin::on_actionSimplify_triggered()
 {
   const CGAL::Three::Scene_interface::Item_id index = scene->mainSelectionIndex();
-
-  Scene_facegraph_item* poly_item =
-    qobject_cast<Scene_facegraph_item*>(scene->item(index));
 
   Scene_polyhedron_selection_item* selection_item =
     qobject_cast<Scene_polyhedron_selection_item*>(scene->item(index));
@@ -109,11 +116,14 @@ void CGAL_Lab_mesh_simplification_plugin::on_actionSimplify_triggered()
     QMessageBox::warning(mw, "Empty Edges", "There are no selected edges. Aborting.");
     return;
   }
+
+  Scene_facegraph_item* poly_item =
+    qobject_cast<Scene_facegraph_item*>(scene->item(index));
+
   if (poly_item || selection_item)
   {
-    FaceGraph& pmesh = (poly_item != nullptr)
-      ? *poly_item->polyhedron()
-      : *selection_item->polyhedron();
+    FaceGraph& pmesh = (poly_item != nullptr) ? *poly_item->polyhedron()
+                                              : *selection_item->polyhedron();
 
     // get option
     QDialog dialog(mw);
@@ -125,16 +135,16 @@ void CGAL_Lab_mesh_simplification_plugin::on_actionSimplify_triggered()
             &dialog, SLOT(reject()));
 
     Scene_interface::Bbox bbox = poly_item != nullptr ? poly_item->bbox()
-      : (selection_item != nullptr ? selection_item->bbox()
-        : scene->bbox());
+                                                      : (selection_item != nullptr ? selection_item->bbox()
+                                                                                   : scene->bbox());
 
-    double diago_length = CGAL::sqrt((bbox.xmax()-bbox.xmin())*(bbox.xmax()-bbox.xmin())
-                                     + (bbox.ymax()-bbox.ymin())*(bbox.ymax()-bbox.ymin()) +
-                                     (bbox.zmax()-bbox.zmin())*(bbox.zmax()-bbox.zmin()));
+    double diago_length = CGAL::sqrt((bbox.xmax() - bbox.xmin())*(bbox.xmax() - bbox.xmin()) +
+                                     (bbox.ymax() - bbox.ymin())*(bbox.ymax() - bbox.ymin()) +
+                                     (bbox.zmax() - bbox.zmin())*(bbox.zmax() - bbox.zmin()));
 
-    ui.m_nb_edges->setValue ((int)(num_halfedges(pmesh) / 4));
-    ui.m_nb_edges->setMaximum ((int)(num_halfedges(pmesh)));
-    ui.m_edge_length->setValue (diago_length * 0.05);
+    ui.m_nb_edges->setValue((int)(num_halfedges(pmesh) / 4));
+    ui.m_nb_edges->setMaximum((int)(num_halfedges(pmesh)));
+    ui.m_edge_length->setValue(diago_length * 0.05);
 
     // check user cancellation
     if(dialog.exec() == QDialog::Rejected)
@@ -144,46 +154,35 @@ void CGAL_Lab_mesh_simplification_plugin::on_actionSimplify_triggered()
     QElapsedTimer time;
     time.start();
     std::cout << "Simplify...";
+
     QApplication::setOverrideCursor(Qt::WaitCursor);
     QApplication::processEvents();
-    Custom_stop_predicate stop ((ui.m_combinatorial->currentIndex() == 0)
-                                && !(ui.m_use_nb_edges->isChecked())
-                                && !(ui.m_use_edge_length->isChecked()),
-                                (ui.m_use_nb_edges->isChecked()
-                                 ? ui.m_nb_edges->value()
-                                 : 0),
-                                (ui.m_use_edge_length->isChecked()
-                                 ? ui.m_edge_length->value()
-                                 : (std::numeric_limits<double>::max)()));
 
-    if (selection_item)
-      {
-        CGAL::Surface_mesh_simplification::Constrained_placement
-          <CGAL::Surface_mesh_simplification::Bounded_normal_change_placement
-           <CGAL::Surface_mesh_simplification::LindstromTurk_placement
-            <FaceGraph> >,
-           Scene_polyhedron_selection_item::Is_constrained_map
-           <Scene_polyhedron_selection_item::Selection_set_edge> >
-          placement (selection_item->constrained_edges_pmap());
+    Custom_stop_predicate stop(
+      (ui.m_combinatorial->currentIndex() == 0) && !(ui.m_use_nb_edges->isChecked()) && !(ui.m_use_edge_length->isChecked()),
+      (ui.m_use_nb_edges->isChecked() ? ui.m_nb_edges->value() : 0),
+      (ui.m_use_edge_length->isChecked() ? ui.m_edge_length->value() : (std::numeric_limits<double>::max)()));
 
-        CGAL::Surface_mesh_simplification::edge_collapse
-          (pmesh, stop,
-           CGAL::parameters::edge_is_constrained_map(selection_item->constrained_edges_pmap())
-           .get_placement(placement));
-      }
+    if(selection_item)
+    {
+      SMS::Constrained_placement<SMS::Bounded_normal_change_placement<SMS::LindstromTurk_placement<FaceGraph> >,
+        Scene_polyhedron_selection_item::Is_constrained_map<
+          Scene_polyhedron_selection_item::Selection_set_edge> > placement(selection_item->constrained_edges_pmap());
+
+      SMS::edge_collapse(pmesh, stop,
+                         CGAL::parameters::edge_is_constrained_map(selection_item->constrained_edges_pmap())
+                                          .get_placement(placement));
+    }
     else
-      {
-        CGAL::Surface_mesh_simplification::Bounded_normal_change_placement
-          <CGAL::Surface_mesh_simplification::LindstromTurk_placement
-           <FaceGraph> > placement;
+    {
+      SMS::Bounded_normal_change_placement<SMS::LindstromTurk_placement<FaceGraph> > placement;
 
-        CGAL::Surface_mesh_simplification::edge_collapse
-          (pmesh, stop,
-           CGAL::parameters::vertex_index_map(get(boost::vertex_index, pmesh)).get_placement(placement));
-      }
+      SMS::edge_collapse(pmesh, stop,
+                         CGAL::parameters::vertex_index_map(get(boost::vertex_index, pmesh))
+                                          .get_placement(placement));
+    }
 
-    std::cout << "ok (" << time.elapsed() << " ms, "
-      << num_halfedges(pmesh) / 2 << " edges)" << std::endl;
+    std::cout << "ok (" << time.elapsed() << " ms, " << num_halfedges(pmesh) / 2 << " edges)" << std::endl;
 
     // update scene
     if (poly_item != nullptr)
@@ -192,12 +191,12 @@ void CGAL_Lab_mesh_simplification_plugin::on_actionSimplify_triggered()
       poly_item->polyhedron()->collect_garbage();
     }
     else
-      {
+    {
       selection_item->polyhedron_item()->polyhedron()->collect_garbage();
       selection_item->poly_item_changed();
       selection_item->changed_with_poly_item();
       selection_item->invalidateOpenGLBuffers();
-      }
+    }
 
     scene->itemChanged(index);
     QApplication::restoreOverrideCursor();

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_placement.h
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_placement.h
@@ -8,7 +8,6 @@ namespace Surface_mesh_simplification {
 \deprecated This class is deprecated since \cgal 5.3 and the use of
 `Bounded_normal_change_filter` should be preferred.
 
-
 The class `Bounded_normal_change_placement` is a model for the `GetPlacement` concept
 which serves as a filter for another placement. It rejects the placement if any
 triangle in the profile changes the normal by more than 90 degree.

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_plane_and_line_policies.h
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_plane_and_line_policies.h
@@ -15,7 +15,7 @@ Compared to the "classic" plane strategy, this strategy improves the speed and t
 \note Both the cost and the placement policies must be used together as they internally use
 and share information associating quadrics to vertices.
 Note however, that they may still be wrapped with behavior-modifying classes
-such as `Constrained_placement` or `Bounded_normal_change_placement`.
+such as `Constrained_placement` or `Bounded_normal_change_filter`.
 
 \tparam TriangleMesh is the type of surface mesh being simplified, and must be a model
                      of the `MutableFaceGraph` and `HalfedgeListGraph` concepts.

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_plane_policies.h
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_plane_policies.h
@@ -13,7 +13,7 @@ as described in their seminal paper \cgalCite{gh-ssqem-97}.
 Both the cost and the placement policies must be used together as they internally use
 and share information associating quadrics to vertices.
 Note however, that they may still be wrapped with behavior modifying classes
-such as `Constrained_placement` or `Bounded_normal_change_placement`.
+such as `Constrained_placement` or `Bounded_normal_change_filter`.
 
 \tparam TriangleMesh is the type of surface mesh being simplified, and must be a model
                      of the `MutableFaceGraph` and `HalfedgeListGraph` concepts.

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_probabilistic_plane_policies.h
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_probabilistic_plane_policies.h
@@ -14,7 +14,7 @@ for speed and quality of the result (Section \ref SurfaceMeshSimplificationGarla
 Both the cost and the placement policies must be used together as they internally use
 and share information associating quadrics to vertices.
 Note however, that they may still be wrapped with behavior modifying classes
-such as `Constrained_placement` or `Bounded_normal_change_placement`.
+such as `Constrained_placement` or `Bounded_normal_change_filter`.
 
 \tparam TriangleMesh is the type of surface mesh being simplified, and must be a model
                      of the `MutableFaceGraph` and `HalfedgeListGraph` concepts.

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_probabilistic_triangle_policies.h
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_probabilistic_triangle_policies.h
@@ -14,7 +14,7 @@ for speed and quality of the result (Section \ref SurfaceMeshSimplificationGarla
 Both the cost and the placement policies must be used together as they internally use
 and share information associating quadrics to vertices.
 Note however, that they may still be wrapped with behavior modifying classes
-such as `Constrained_placement` or `Bounded_normal_change_placement`.
+such as `Constrained_placement` or `Bounded_normal_change_filter`.
 
 \tparam TriangleMesh is the type of surface mesh being simplified, and must be a model
                      of the `MutableFaceGraph` and `HalfedgeListGraph` concepts.

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_triangle_policies.h
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_triangle_policies.h
@@ -12,7 +12,7 @@ as in `GarlandHeckbert_plane_policies`.
 Both the cost and the placement policies must be used together as they internally use
 and share information associating quadrics to vertices.
 Note however, that they may still be wrapped with behavior modifying classes
-such as `Constrained_placement` or `Bounded_normal_change_placement`.
+such as `Constrained_placement` or `Bounded_normal_change_filter`.
 
 \tparam TriangleMesh is the type of surface mesh being simplified, and must be a model
                      of the `MutableFaceGraph` and `HalfedgeListGraph` concepts.

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/Concepts/GetPlacement.h
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/Concepts/GetPlacement.h
@@ -18,7 +18,7 @@ or can be intentionally returned to prevent the edge from being collapsed.
 \cgalHasModels{CGAL::Surface_mesh_simplification::Midpoint_placement<TriangleMesh>}
 \cgalHasModels{CGAL::Surface_mesh_simplification::LindstromTurk_placement<TriangleMesh>}
 \cgalHasModels{CGAL::Surface_mesh_simplification::GarlandHeckbert_policies<TriangleMesh, GeomTraits>}
-\cgalHasModels{CGAL::Surface_mesh_simplification::Bounded_normal_change_placement<Placement>}
+\cgalHasModels{CGAL::Surface_mesh_simplification::Bounded_normal_change_filter<Placement>}
 \cgalHasModels{CGAL::Surface_mesh_simplification::Constrained_placement<Placement>}
 \cgalHasModelsEnd
 */

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/PackageDescription.txt
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/PackageDescription.txt
@@ -54,7 +54,7 @@
 
 \cgalCRPSection{Policy Enhancements}
 - `CGAL::Surface_mesh_simplification::Constrained_placement<Placement, TriangleMesh>`
-- `CGAL::Surface_mesh_simplification::Bounded_normal_change_placement<Placement>`
+- `CGAL::Surface_mesh_simplification::Bounded_normal_change_placement<Placement>` (deprecated)
 - `CGAL::Surface_mesh_simplification::Bounded_normal_change_filter<Filter>`
 - `CGAL::Surface_mesh_simplification::Polyhedral_envelope_filter<Filter>`
 

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/Surface_mesh_simplification.txt
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/Surface_mesh_simplification.txt
@@ -420,7 +420,7 @@ both the cost and the placement policies, which must be used together as they sh
 The state-of-the-art strategy of combining plane and line-based quadric error metrics is implemented with the class
 `Surface_mesh_simplification::GarlandHeckbert_policies`.
 Although both policies must be used together, it is still possible to wrap either policy
-using behavior modifiers such as `Surface_mesh_simplification::Bounded_normal_change_placement`.
+using behavior modifiers such as `Surface_mesh_simplification::Bounded_normal_change_filter`.
 
 \cgalExample{Surface_mesh_simplification/edge_collapse_garland_heckbert.cpp}
 

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_placement.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_placement.h
@@ -28,7 +28,13 @@ template<class GetPlacement>
 class Bounded_normal_change_placement
 {
 public:
-  Bounded_normal_change_placement(const GetPlacement& get_placement = GetPlacement())
+  template <typename GP = GetPlacement,
+            std::enable_if_t<std::is_default_constructible_v<GP>, int> = 0>
+  Bounded_normal_change_placement()
+    : m_get_placement()
+  {}
+
+  Bounded_normal_change_placement(const GetPlacement& get_placement)
     : m_get_placement(get_placement)
   {}
 

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_placement.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_placement.h
@@ -13,6 +13,10 @@
 
 #include <CGAL/license/Surface_mesh_simplification.h>
 
+#define CGAL_DEPRECATED_HEADER "<CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_placement.h>"
+#define CGAL_REPLACEMENT_HEADER "<CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_filter.h>"
+#include <CGAL/Installation/internal/deprecation_warning.h>
+
 #include <CGAL/property_map.h>
 
 #include <optional>

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Constrained_placement.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Constrained_placement.h
@@ -24,8 +24,15 @@ class Constrained_placement
   : public BasePlacement
 {
 public:
-  Constrained_placement(const EdgeIsConstrainedMap map = EdgeIsConstrainedMap(),
-                        const BasePlacement& base = BasePlacement())
+  template <typename BP = BasePlacement,
+            typename std::enable_if_t<std::is_default_constructible_v<BP>, int> = 0>
+  Constrained_placement(const EdgeIsConstrainedMap map = EdgeIsConstrainedMap())
+    : BasePlacement(),
+      m_ecm(map)
+  {}
+
+  Constrained_placement(const EdgeIsConstrainedMap map,
+                        const BasePlacement& base)
     : BasePlacement(base),
       m_ecm(map)
   {}

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_plane_and_line_policies.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_plane_and_line_policies.h
@@ -96,6 +96,8 @@ public:
   typedef typename GeomTraits::FT                                              FT;
 
 public:
+  GarlandHeckbert_plane_and_line_policies() = delete;
+
   template<typename NP = parameters::Default_named_parameters>
   GarlandHeckbert_plane_and_line_policies(TriangleMesh& tmesh, const NP& np = parameters::default_values()):
     Base(tmesh,

--- a/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
+++ b/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/internal/Edge_collapse.h
@@ -1133,6 +1133,8 @@ is_collapse_geometrically_valid(const Profile& profile, Placement_type k0)
     }
   }
 
+  CGAL_SMS_TRACE(3,"collapse validity: " << res);
+
   return res;
 }
 

--- a/Surface_mesh_simplification/test/Surface_mesh_simplification/edge_collapse_garland_heckbert_variations.cpp
+++ b/Surface_mesh_simplification/test/Surface_mesh_simplification/edge_collapse_garland_heckbert_variations.cpp
@@ -3,7 +3,7 @@
 
 #include <CGAL/Surface_mesh_simplification/edge_collapse.h>
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Edge_count_ratio_stop_predicate.h>
-#include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_placement.h>
+#include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/Bounded_normal_change_filter.h>
 #include <CGAL/Surface_mesh_simplification/Policies/Edge_collapse/GarlandHeckbert_policies.h>
 
 #include <CGAL/Polygon_mesh_processing/measure.h>
@@ -96,18 +96,18 @@ Surface_mesh edge_collapse(Surface_mesh& mesh,
 {
   typedef typename Policy::Get_cost Cost;
   typedef typename Policy::Get_placement Placement;
-  typedef SMS::Bounded_normal_change_placement<Placement> Bounded_placement;
 
   std::cout << "Edge collapse mesh of " << num_edges(mesh) << " edges. Policy: " << typeid(Policy).name() << std::endl;
 
   const Cost& cost = p.get_cost();
   const Placement& unbounded_placement = p.get_placement();
-  Bounded_placement bounded_placement(unbounded_placement);
   SMS::Edge_count_ratio_stop_predicate<Surface_mesh> stop(ratio);
+  SMS::Bounded_normal_change_filter<> filter;
 
   std::chrono::time_point<std::chrono::steady_clock> start_time = std::chrono::steady_clock::now();
 
   SMS::edge_collapse(mesh, stop, CGAL::parameters::get_cost(cost)
+                                                  .filter(filter)
                                                   .get_placement(unbounded_placement));
 
   std::chrono::time_point<std::chrono::steady_clock> end_time = std::chrono::steady_clock::now();


### PR DESCRIPTION
## Summary of Changes

- Old UI was misleading because the edge length stop criterion is not an appropriate choice for Lindstrom Turk since the edges are not sorted according to edge length
- Add other strategies (GH, edge length) 
- Use the correct bounded placement
- Fix not deprecating something announcement as deprecated

OLD:
<img width="320" height="224" alt="image" src="https://github.com/user-attachments/assets/fe4e0d80-8d05-4f92-bfee-1b9be50b88b9" />

NEW:
<img width="642" height="353" alt="image" src="https://github.com/user-attachments/assets/70945567-18a2-49eb-8c90-f43347541b4a" />


## Release Management

* Affected package(s): `Lab`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

