### PR TITLE
Periodic_2_triangulation_2: add manual toggle for 1-sheet conversion (Fix #8244)  

### DIFF
--- a/Periodic_2_triangulation_2/include/CGAL/Periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/Periodic_2_triangulation_2.h
@@ -948,6 +948,13 @@ public:
     return (_cover[0] == 1) && (_cover[1] == 1);
   }
 
+
+  /// Disables automatic conversion to 1-sheet covering
+  void disable_auto_convert() { _auto_convert_enabled = false; }
+
+  /// Enables automatic conversion to 1-sheet covering
+  void enable_auto_convert() { _auto_convert_enabled = true; }
+
   /// [Undoc] Combines two offsets, where the first offset is defined by the
   /// virtual vertex and the second by the face.
   Offset combine_offsets(const Offset& o_c, const Offset& o_t) const
@@ -1165,7 +1172,7 @@ protected:
   {
     // Fall back to 1-cover if the criterion that the longest edge is shorter
     // than sqrt(0.166) is fulfilled.
-    if (_too_long_edge_counter == 0 && !is_1_cover())
+    if (_auto_convert_enabled && _too_long_edge_counter == 0 && !is_1_cover())
       {
         CGAL_expensive_assertion( is_valid() );
         this->convert_to_1_sheeted_covering();
@@ -1513,6 +1520,9 @@ protected:
   Too_long_edges_map _too_long_edges;
   /// Number of edges that are too long
   size_t _too_long_edge_counter;
+
+  /// Toggle to allow or prevent automatic conversion to 1-sheet covering
+  bool _auto_convert_enabled = true;
 
 private:
   /// map of offsets for periodic copies of vertices

--- a/Periodic_2_triangulation_2/include/CGAL/Periodic_2_triangulation_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/Periodic_2_triangulation_2.h
@@ -1686,6 +1686,7 @@ void Periodic_2_triangulation_2<Gt, Tds>::copy_triangulation(
   _domain = tr._domain;
   _edge_length_threshold = tr._edge_length_threshold;
   _too_long_edge_counter = tr._too_long_edge_counter;
+  _auto_convert_enabled = tr._auto_convert_enabled;
   if (tr.is_1_cover())
     {
       _tds = tr.tds();
@@ -1713,6 +1714,8 @@ void Periodic_2_triangulation_2<Gt, Tds>::swap(Periodic_2_triangulation_2 &tr)
   std::swap(tr._edge_length_threshold, _edge_length_threshold);
   std::swap(tr._too_long_edges, _too_long_edges);
   std::swap(tr._too_long_edge_counter, _too_long_edge_counter);
+
+  std::swap(tr._auto_convert_enabled, _auto_convert_enabled);
 
   std::swap(tr._virtual_vertices, _virtual_vertices);
   std::swap(tr._virtual_vertices_reverse, _virtual_vertices_reverse);

--- a/Periodic_2_triangulation_2/include/CGAL/Periodic_2_triangulation_hierarchy_2.h
+++ b/Periodic_2_triangulation_2/include/CGAL/Periodic_2_triangulation_hierarchy_2.h
@@ -83,7 +83,10 @@ public:
   {
     hierarchy[0] = this;
     for(int i = 1; i < m_maxlevel; ++i)
+    {
       hierarchy[i] = new PTr_Base(domain, traits);
+      hierarchy[i]->disable_auto_convert();
+    }
     insert(first, last);
   }
 
@@ -191,7 +194,10 @@ Periodic_2_triangulation_hierarchy_2(const Iso_rectangle& domain, const Geom_tra
   level_mult_cover = 0;
   hierarchy[0] = this;
   for(int i = 1; i < m_maxlevel; ++i)
+  {
     hierarchy[i] = new PTr_Base(domain, traits);
+    hierarchy[i]->disable_auto_convert();
+  }
 }
 
 
@@ -204,7 +210,10 @@ Periodic_2_triangulation_hierarchy_2(const Periodic_2_triangulation_hierarchy_2<
   // create an empty triangulation to be able to delete it !
   hierarchy[0] = this;
   for(int i = 1; i < m_maxlevel; ++i)
+  {
     hierarchy[i] = new PTr_Base(tr.domain(), tr.geom_traits());
+    hierarchy[i]->disable_auto_convert();
+  }
   copy_triangulation(tr);
 }
 
@@ -619,7 +628,7 @@ Periodic_2_triangulation_hierarchy_2<PTr>::
 random_level()
 {
   if ( level_mult_cover < m_maxlevel
-       && hierarchy[level_mult_cover]->number_of_sheets() == make_array(1, 1) )
+       && hierarchy[0]->number_of_sheets() == make_array(1, 1) )
     ++level_mult_cover;
 
   boost::geometric_distribution<> proba(1.0 / m_ratio);


### PR DESCRIPTION
## Summary of Changes

1.  Added a bool flag  _auto_convert_enabled  to control automatic conversion to a 1‑sheeted covering.
2. Added public methods disable_auto_convert() and enable_auto_convert() to toggle this flag.
3. Modified try_to_convert_to_one_cover() to check _auto_convert_enabled before performing the conversion.
4. Updated the copy constructor to copy _auto_convert_enabled.

## Release Management

* Affected package(s): Periodic_2_triangulation_2
* Issue(s) solved (if any): fix #8244
* Feature/Small Feature (if any):  N/A (Bug fix)
* Link to compiled documentation : N/A
* License and copyright ownership: I authored these changes and contribute them under the standard CGAL license terms.

