### PR TITLE
PMP: fix split_long_edges compilation with Epeck kernel

### DIFF
--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -391,7 +391,7 @@ namespace internal {
 #endif
 
       //collect long edges
-      typedef std::pair<halfedge_descriptor, double> H_and_sql;
+      typedef std::pair<halfedge_descriptor, FT> H_and_sql;
       std::multiset< H_and_sql, std::function<bool(H_and_sql,H_and_sql)> >
         long_edges(
           [](const H_and_sql& p1, const H_and_sql& p2)
@@ -400,9 +400,9 @@ namespace internal {
       for(edge_descriptor e : edge_range)
       {
         const halfedge_descriptor he = halfedge(e, mesh_);
-        std::optional<double> sqlen = sizing.is_too_long(source(he, mesh_), target(he, mesh_), mesh_);
+        std::optional<FT> sqlen = sizing.is_too_long(source(he, mesh_), target(he, mesh_), mesh_);
         if(sqlen != std::nullopt)
-          long_edges.emplace(he, sqlen.value());
+          long_edges.emplace(he, std::move(*sqlen));
       }
 
       //split long edges
@@ -437,14 +437,14 @@ namespace internal {
 
         //check sub-edges
         //if it was more than twice the "long" threshold, insert them
-        std::optional<double> sqlen_new = sizing.is_too_long(source(hnew, mesh_), target(hnew, mesh_), mesh_);
+        std::optional<FT> sqlen_new = sizing.is_too_long(source(hnew, mesh_), target(hnew, mesh_), mesh_);
         if(sqlen_new != std::nullopt)
-          long_edges.emplace(hnew, sqlen_new.value());
+          long_edges.emplace(hnew, std::move(*sqlen_new));
 
         const halfedge_descriptor hnext = next(hnew, mesh_);
         sqlen_new = sizing.is_too_long(source(hnext, mesh_), target(hnext, mesh_), mesh_);
         if (sqlen_new != std::nullopt)
-          long_edges.emplace(hnext, sqlen_new.value());
+          long_edges.emplace(hnext, std::move(*sqlen_new));
 
         //insert new edges to keep triangular faces, and update long_edges
         if (!is_border(hnew, mesh_))

--- a/PMP_Remeshing/test/PMP_Remeshing/remeshing_test_epeck.cpp
+++ b/PMP_Remeshing/test/PMP_Remeshing/remeshing_test_epeck.cpp
@@ -27,5 +27,15 @@ int main(int argc, const char* argv[])
   double target_edge_length = 1.0;
   PMP::isotropic_remeshing(CGAL::faces(mesh), target_edge_length, mesh);
 
+  // Test that split_long_edges also compiles and runs with Epeck (issue #9330)
+  Mesh mesh2;
+  std::ifstream input2(filename);
+  if (!input2 || !(input2 >> mesh2))
+  {
+    std::cerr << "Error: cannot read surface mesh : " << filename << "\n";
+    return 1;
+  }
+  PMP::split_long_edges(CGAL::edges(mesh2), target_edge_length, mesh2);
+
   return 0;
 }


### PR DESCRIPTION
## Summary of Changes

`PMP::split_long_edges()` (the standalone public API overload) fails to compile with `Exact_predicates_exact_constructions_kernel` (Epeck) because `is_too_long()` returns `std::optional<FT>` but the implementation stores these in `std::optional<double>` and
`std::pair<halfedge_descriptor, double>`. With Epeck, `FT` is `Gmpq` which cannot implicitly convert to `double`.

Fixes the 3 affected declarations to use `FT`, consistent with the companion overload used by `isotropic_remeshing()` which already uses `FT` correctly.

Added `split_long_edges()` call to `remeshing_test_epeck.cpp` to prevent regression.

## Release Management

* Affected package(s): PMP_Remeshing
* Issue(s) solved (if any): fix #9330
* License and copyright ownership: already covered by existing headers