### PR TITLE
Documentation: fix CGAL_DOC_VERSION to include pre-release suffixes

### DIFF
--- a/Documentation/doc/CMakeLists.txt
+++ b/Documentation/doc/CMakeLists.txt
@@ -350,7 +350,12 @@ if(NOT CGAL_CREATED_VERSION_NUM)
   if(CGAL_BRANCH_BUILD)
     include(${CGAL_ROOT}/CGALConfigVersion.cmake)
 
-    if(CGAL_BUGFIX_VERSION AND CGAL_BUGFIX_VERSION GREATER 0)
+    # Prefer the public release version (e.g. "6.0-beta1") which includes
+    # pre-release suffixes; fall back to computing from components when it
+    # is not available (issue #8322).
+    if(CGAL_VERSION_PUBLIC_RELEASE_VERSION)
+      set(CGAL_CREATED_VERSION_NUM "${CGAL_VERSION_PUBLIC_RELEASE_VERSION}")
+    elseif(CGAL_BUGFIX_VERSION AND CGAL_BUGFIX_VERSION GREATER 0)
       set(CGAL_CREATED_VERSION_NUM
           "${CGAL_MAJOR_VERSION}.${CGAL_MINOR_VERSION}.${CGAL_BUGFIX_VERSION}")
     else()
@@ -366,8 +371,9 @@ if(NOT CGAL_CREATED_VERSION_NUM)
       #read version.h and get the line with CGAL_VERSION
       file(STRINGS "${CGAL_ROOT}/include/CGAL/version.h" CGAL_VERSION_LINE
            REGEX "CGAL_VERSION ")
-      #extract release id
-      string(REGEX MATCH "[0-9]+\\.[0-9]+\\.?[0-9]*" CGAL_CREATED_VERSION_NUM
+      #extract release id, including any pre-release suffix like -beta1, -dev,
+      #or multi-segment ids such as -Ic-33
+      string(REGEX MATCH "[0-9]+\\.[0-9]+(\\.[0-9]+)?(-[a-zA-Z0-9]+)*" CGAL_CREATED_VERSION_NUM
                    "${CGAL_VERSION_LINE}")
     endif()
   endif()


### PR DESCRIPTION
## Description

## Summary of Changes

In beta releases (e.g. `v6.0-beta1`), the documentation links to example tarballs point to non-existent URLs like `.../v6.0/CGAL-6.0-examples.tar.xz` instead of `.../v6.0-beta1/CGAL-6.0-beta1-examples.tar.xz` because `CGAL_DOC_VERSION` strips the pre-release suffix.

### Fix (branch build path)
Use `CGAL_VERSION_PUBLIC_RELEASE_VERSION` (set in `CGALConfigVersion.cmake`) which already contains the full version string including any `-beta1` or `-dev` suffix. Falls back to the existing major.minor.bugfix logic when that variable is not available.

### Fix (tarball build path)
Extend the regex that extracts the version from `version.h` to also capture pre-release suffixes matching `(-[a-zA-Z0-9]+)?`.

## Release Management

* Affected package(s): Documentation
* Issue(s) solved (if any): fix #8322
* License and copyright ownership: already covered by existing headers