### PR TITLE
CDT_3: fix bugs for `main`/6.2.x (includes PR #9426 that targets `6.1.x-branch`)

### DIFF
--- a/Constrained_triangulation_3/include/CGAL/Conforming_Delaunay_triangulation_3.h
+++ b/Constrained_triangulation_3/include/CGAL/Conforming_Delaunay_triangulation_3.h
@@ -817,8 +817,6 @@ protected:
   }
 
   auto constraint_extremities(Constrained_polyline_id c_id) const {
-      CGAL_assertion(std::find(this->constraint_hierarchy.constraints_begin(),
-                               this->constraint_hierarchy.constraints_end(), c_id) != this->constraint_hierarchy.constraints_end());
       CGAL_assertion(this->constraint_hierarchy.vertices_in_constraint_begin(c_id) !=
                      this->constraint_hierarchy.vertices_in_constraint_end(c_id));
       if(debug().constraint_hierarchy()) {

--- a/Constrained_triangulation_3/include/CGAL/Conforming_Delaunay_triangulation_3.h
+++ b/Constrained_triangulation_3/include/CGAL/Conforming_Delaunay_triangulation_3.h
@@ -173,7 +173,7 @@ inline auto& tasks_manager() {
         return instance->timers[task_id].time();
       }
       auto time_ms() const {
-        return instance->timers[task_id].time() / 1000.;
+        return instance->timers[task_id].time() * 1000.;
       }
       ~Scope_guard() {
         instance->timers[task_id].stop();

--- a/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
+++ b/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
@@ -2351,6 +2351,7 @@ private:
   {
     const CDT_2& cdt_2 = face_cdt_2[polygon_contraint_id];
 
+    face_constraint_misses_subfaces_reset(static_cast<std::size_t>(polygon_contraint_id));
     for(const auto fh: cdt_2.all_face_handles())
     {
       if(fh->info().is_outside_the_face) continue;
@@ -4028,6 +4029,9 @@ public:
         the_process_made_progress = false;
       }
     }
+    CGAL_assertion_code(recheck_constrained_Delaunay());
+    CGAL_assertion_msg(face_constraint_misses_subfaces_find_first() == face_constraint_misses_subfaces_npos,
+                       "All faces have been restored, but the triangulation is a CDT. This should not happen.");
   }
 
   void add_bbox_points_if_not_dimension_3() {

--- a/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
+++ b/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
@@ -4168,9 +4168,9 @@ public:
   }
 
   void recheck_for_missing_subfaces() {
-    for(int i = 0, end = face_constraint_misses_subfaces.size(); i < end; ++i) {
+    for(auto i = 0u, end = face_constraint_misses_subfaces.size(); i < end; ++i) {
       if(this->face_data[i].skip_face == false) {
-        search_for_missing_subfaces(i);
+        search_for_missing_subfaces(static_cast<CDT_3_signed_index>(i));
       }
     }
   }

--- a/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
+++ b/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
@@ -4168,9 +4168,9 @@ public:
   }
 
   void recheck_for_missing_subfaces() {
-    for(auto i = 0u, end = face_constraint_misses_subfaces.size(); i < end; ++i) {
+    for(CDT_3_signed_index i = 0, end = static_cast<CDT_3_signed_index>(face_constraint_misses_subfaces.size()); i < end; ++i) {
       if(this->face_data[i].skip_face == false) {
-        search_for_missing_subfaces(static_cast<CDT_3_signed_index>(i));
+        search_for_missing_subfaces(i);
       }
     }
   }

--- a/Lab/demo/Lab/Plugins/PMP/Selection_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/PMP/Selection_plugin.cpp
@@ -1317,7 +1317,13 @@ bool selfIntersect(Mesh* mesh, std::vector<std::pair<typename boost::graph_trait
     (*mesh, std::back_inserter(faces),
     CGAL::parameters::vertex_point_map(get(CGAL::vertex_point, *mesh)));
 
-  std::cout << "ok (" << faces.size() << " triangle pair(s))" << std::endl;
+  std::cout << "self-intersections test: ";
+  if(faces.empty())
+    std::cout << "no self-intersection" << std::endl;
+  else {
+    std::cout << "intersection(s) found, ";
+    std::cout << faces.size() << " triangle pair(s)" << std::endl;
+  }
   return !faces.empty();
 }
 


### PR DESCRIPTION
## Summary of Changes

This PR is for `main` (CGAL 6.2-dev).

It merges PR #9426, and adds a commit (3d7302f18123227cd9bf67ba17e739dbf193acea) that fixes a bug in `CCDT_3::restore_constrained_Delaunay`: during the retrieval of constraint faces, if a new Steiner points was required, then it was possible that some constraints were not correctly handles afterward.

## Release Management

* Affected package(s): CT_3
* License and copyright ownership: no change (CT_3 is owned by GeometryFactory)
