### PR TITLE
Hash_map: Implemented a flat_map backend using unordered_flat_map

### DIFF
--- a/Hash_map/include/CGAL/Hash_map/internal/flat_map.h
+++ b/Hash_map/include/CGAL/Hash_map/internal/flat_map.h
@@ -1,0 +1,113 @@
+// Copyright (c) 2026 GeometryFactory Sarl (France)
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org)
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: LGPL-3.0-or-later OR LicenseRef-Commercial
+//
+//
+// Author(s)     : Andreas Fabri, Giles Bathgate
+
+#ifndef CGAL_INTERNAL_FLAT_MAP_H
+#define CGAL_INTERNAL_FLAT_MAP_H
+
+#include <CGAL/config.h>
+#include <CGAL/memory.h>
+#include <CGAL/unordered_flat_map.h>
+
+#include <cstddef>
+#include <memory>
+#include <utility>
+
+namespace CGAL {
+namespace internal {
+
+/**
+ * @brief A Unique_hash_map backend that wraps CGAL::unordered_flat_map.
+ */
+template <typename Value, typename Allocator = CGAL_ALLOCATOR(Value)>
+class flat_map {
+
+    struct identity_hash {
+        std::size_t operator()(std::size_t x) const noexcept { return x; }
+    };
+
+public:
+    typedef std::size_t Key;
+    typedef std::pair<const Key, Value> Entry;
+    typedef typename std::allocator_traits<Allocator>::template rebind_alloc<Entry> Entry_allocator;
+    typedef CGAL::unordered_flat_map<Key, Value, identity_hash, std::equal_to<Key>, Entry_allocator> Map;
+    typedef const Entry* Item;
+    typedef flat_map<Value, Allocator> Self;
+
+    static constexpr std::size_t default_size = 8;
+
+    flat_map(std::size_t reserve = default_size,
+             const Value& default_val = Value(),
+             const Allocator& allocator = Allocator())
+        : map_(reserve, identity_hash(), std::equal_to<Key>(), allocator),
+          default_value_(default_val) {
+    }
+
+    flat_map(const Self& other)
+        : map_(other.map_),
+          default_value_(other.default_value_) {
+    }
+
+    Self& operator=(const Self& other) {
+        if (this != &other) {
+            map_ = other.map_;
+            default_value_ = other.default_value_;
+        }
+        return *this;
+    }
+
+    flat_map(Self&& other) noexcept
+        : map_(std::move(other.map_)),
+          default_value_(std::move(other.default_value_)) {
+    }
+
+    Self& operator=(Self&& other) noexcept {
+        if (this != &other) {
+            map_ = std::move(other.map_);
+            default_value_ = std::move(other.default_value_);
+        }
+        return *this;
+    }
+
+    Value& xdef() { return default_value_; }
+    const Value& cxdef() const { return default_value_; }
+
+    Key index(Item it) const { return it->first; }
+    const Value& inf(Item it) const { return it->second; }
+
+    void reserve(std::size_t count) { map_.reserve(count); }
+    void clear() { map_.clear(); }
+
+    Value& access(Key key) {
+        auto it = map_.find(key);
+        if (it != map_.end()) return it->second;
+        return map_.emplace(key, default_value_).first->second;
+    }
+
+    Item lookup(Key key) const {
+        auto it = map_.find(key);
+        if (it != map_.end()) return &*it;
+        return nullptr;
+    }
+
+    void statistics() const {
+        std::cout << "flat_map: size=" << map_.size() << "\n";
+    }
+
+private:
+    Map map_;
+    Value default_value_;
+};
+
+} // namespace internal
+} // namespace CGAL
+
+#endif // CGAL_INTERNAL_FLAT_MAP_H

--- a/Hash_map/include/CGAL/Hash_map/internal/unordered_flat_map_adaptor.h
+++ b/Hash_map/include/CGAL/Hash_map/internal/unordered_flat_map_adaptor.h
@@ -28,7 +28,7 @@ namespace internal {
  * @brief A Unique_hash_map backend that wraps CGAL::unordered_flat_map.
  */
 template <typename Value, typename Allocator = CGAL_ALLOCATOR(Value)>
-class flat_map {
+class unordered_flat_map_adaptor {
 
     struct identity_hash {
         std::size_t operator()(std::size_t x) const noexcept { return x; }
@@ -40,18 +40,18 @@ public:
     typedef typename std::allocator_traits<Allocator>::template rebind_alloc<Entry> Entry_allocator;
     typedef CGAL::unordered_flat_map<Key, Value, identity_hash, std::equal_to<Key>, Entry_allocator> Map;
     typedef const Entry* Item;
-    typedef flat_map<Value, Allocator> Self;
+    typedef unordered_flat_map_adaptor<Value, Allocator> Self;
 
     static constexpr std::size_t default_size = 8;
 
-    flat_map(std::size_t reserve = default_size,
+    unordered_flat_map_adaptor(std::size_t reserve = default_size,
              const Value& default_val = Value(),
              const Allocator& allocator = Allocator())
         : map_(reserve, identity_hash(), std::equal_to<Key>(), allocator),
           default_value_(default_val) {
     }
 
-    flat_map(const Self& other)
+    unordered_flat_map_adaptor(const Self& other)
         : map_(other.map_),
           default_value_(other.default_value_) {
     }
@@ -64,7 +64,7 @@ public:
         return *this;
     }
 
-    flat_map(Self&& other) noexcept
+    unordered_flat_map_adaptor(Self&& other) noexcept
         : map_(std::move(other.map_)),
           default_value_(std::move(other.default_value_)) {
     }

--- a/Hash_map/include/CGAL/Hash_map/internal/unordered_flat_map_adaptor.h
+++ b/Hash_map/include/CGAL/Hash_map/internal/unordered_flat_map_adaptor.h
@@ -87,9 +87,8 @@ public:
     void clear() { map_.clear(); }
 
     Value& access(Key key) {
-        auto it = map_.find(key);
-        if (it != map_.end()) return it->second;
-        return map_.emplace(key, default_value_).first->second;
+        auto [it, inserted] = map_.try_emplace(key, default_value_);
+        return it->second;
     }
 
     Item lookup(Key key) const {

--- a/Hash_map/include/CGAL/Unique_hash_map.h
+++ b/Hash_map/include/CGAL/Unique_hash_map.h
@@ -23,7 +23,7 @@
 #include <CGAL/config.h>
 #include <CGAL/memory.h>
 #include <CGAL/Handle_hash_function.h>
-#include <CGAL/Hash_map/internal/flat_map.h>
+#include <CGAL/Hash_map/internal/unordered_flat_map_adaptor.h>
 #include <CGAL/Hash_map/internal/chained_map.h>
 
 #include <cstddef>
@@ -49,7 +49,7 @@ public:
 
 private:
 #ifndef CGAL_USE_CHAINED_MAP
-    typedef internal::flat_map<Data, Allocator>    Map;
+    typedef internal::unordered_flat_map_adaptor<Data, Allocator> Map;
 #else
     typedef internal::chained_map<Data, Allocator>   Map;
 #endif

--- a/Hash_map/include/CGAL/Unique_hash_map.h
+++ b/Hash_map/include/CGAL/Unique_hash_map.h
@@ -23,7 +23,9 @@
 #include <CGAL/config.h>
 #include <CGAL/memory.h>
 #include <CGAL/Handle_hash_function.h>
+#include <CGAL/Hash_map/internal/flat_map.h>
 #include <CGAL/Hash_map/internal/chained_map.h>
+
 #include <cstddef>
 
 namespace CGAL {
@@ -46,7 +48,11 @@ public:
     typedef Unique_hash_map<Key,Data,Hash_function,Allocator> Self;
 
 private:
+#ifndef CGAL_USE_CHAINED_MAP
+    typedef internal::flat_map<Data, Allocator>    Map;
+#else
     typedef internal::chained_map<Data, Allocator>   Map;
+#endif
     typedef typename Map::Item                       Item;
 
 private:


### PR DESCRIPTION
## Summary of Changes

* Added unorderd_flat_map_adaptor.h based on CGAL::unordered_flat_map 
* Patched Unique_hash_map.h to use this map as its default backend.
* Original chained_map can be re-enabled via CGAL_USE_CHAINED_MAP define.


The map when using boost::unordered_flat_map uses cache friendly memory layout. The `mulx` mixing uses [Fibonacci hashing](https://github.com/boostorg/unordered/blob/669918498c3ca6eee91bd4ce29153186d300e005/include/boost/unordered/detail/mulx.hpp#L111), leading to a ~6-7% performance boost in the [Nef_3_benchmark.](https://github.com/afabri/Nef_3_benchmark/actions/runs/24610769638/job/71964645882)


## Release Management

* Affected package(s): Hash_map, Nef_3...
* Issue(s) solved (if any): performance
* License and copyright ownership: CGAL, (I added Adreas Fabri and Myself as authors in the new file. Can be changed on request.)

