### PR TITLE
Stop playing path on a mouse press

### DIFF
--- a/GraphicsView/include/CGAL/Qt/camera.h
+++ b/GraphicsView/include/CGAL/Qt/camera.h
@@ -216,7 +216,7 @@ public:
   Default value is 0.005, which is appropriate for most applications. In case
   you need a high dynamic ZBuffer precision, you can increase this value (~0.1).
   A lower value will prevent clipping of very close objects at the expense of a
-  worst Z precision.
+  worse Z precision.
 
   Only meaningful when Camera type is Camera::PERSPECTIVE. */
   qreal zNearCoefficient() const { return zNearCoef_; }
@@ -364,6 +364,7 @@ public:
   This ManipulatedCameraFrame defines its position() and orientation() and can
   translate mouse events into Camera displacement. Set using setFrame(). */
   ManipulatedCameraFrame *frame() const { return frame_; }
+  void stopAllPaths();
 public Q_SLOTS:
   void setFrame(ManipulatedCameraFrame *const mcf);
   //@}

--- a/GraphicsView/include/CGAL/Qt/camera_impl.h
+++ b/GraphicsView/include/CGAL/Qt/camera_impl.h
@@ -1914,7 +1914,7 @@ CGAL_INLINE_FUNCTION
 void Camera::stopAllPaths(){
     for(auto [key,value]: kfi_.asKeyValueRange()){
           if(value->interpolationIsStarted()){
-              value->resetInterpolation();
+              value->stopInterpolation();
           }
       }
 }

--- a/GraphicsView/include/CGAL/Qt/camera_impl.h
+++ b/GraphicsView/include/CGAL/Qt/camera_impl.h
@@ -1910,6 +1910,14 @@ KeyFrameInterpolator *Camera::keyFrameInterpolator(unsigned int i) const {
   else
     return nullptr;
 }
+CGAL_INLINE_FUNCTION
+void Camera::stopAllPaths(){
+    for(auto [key,value]: kfi_.asKeyValueRange()){
+          if(value->interpolationIsStarted()){
+              value->resetInterpolation();
+          }
+      }
+}
 
 /*! Sets the KeyFrameInterpolator that defines the Camera path of index \p i.
 

--- a/GraphicsView/include/CGAL/Qt/manipulatedFrame_impl.h
+++ b/GraphicsView/include/CGAL/Qt/manipulatedFrame_impl.h
@@ -264,6 +264,8 @@ void ManipulatedFrame::mousePressEvent(QMouseEvent *const event,
   // not inserted in mouseBinding_
   // if (action_ == NO_MOUSE_ACTION)
   // event->ignore();
+  camera->stopAllPaths();
+
 
   prevPos_ = pressPos_ = event->pos();
 }


### PR DESCRIPTION

## Summary of Changes

Previously, left-clicking to orbit the camera while a path was playing would directly modify the camera transform, corrupting the ongoing interpolation. Stopping the path playback on a mouse press assumes the user intentionally wants to interrupt it.

## Release Management

* Affected package(s): Basic_Viewer, GraphicsView


