### PR TITLE
Lab: Fix About

### DIFF
--- a/Lab/demo/Lab/resources/about.html
+++ b/Lab/demo/Lab/resources/about.html
@@ -3,7 +3,7 @@
     <h2>CGAL Lab</h2>
     <p>Copyright &copy;2008-2026
       <a href="https://www.geometryfactory.com/">GeometryFactory</a>
-      and <a href="https://www-sop.inria.fr/">INRIA Centre at Université Côte d'Azur<a/></p>
+      and <a href="https://www.inria.fr/en/inria-centre-universite-cote-azur">INRIA Centre at Université Côte d'Azur<a/></p>
     <p>This application illustrates the data structures
       of <a href="https://www.cgal.org/">CGAL</a>, and operations and
       algorithms that can be applied to.</p>

--- a/Lab/demo/Lab/resources/about.html
+++ b/Lab/demo/Lab/resources/about.html
@@ -1,9 +1,9 @@
 <html>
   <body>
     <h2>CGAL Lab</h2>
-    <p>Copyright &copy;2008-2009
+    <p>Copyright &copy;2008-2026
       <a href="https://www.geometryfactory.com/">GeometryFactory</a>
-      and <a href="https://www-sop.inria.fr/">INRIA Sophia Antipolis - Mediterranee<a/></p>
+      and <a href="https://www-sop.inria.fr/">INRIA Centre at Université Côte d'Azur<a/></p>
     <p>This application illustrates the data structures
       of <a href="https://www.cgal.org/">CGAL</a>, and operations and
       algorithms that can be applied to.</p>

--- a/Lab/demo/Lab/resources/about.html
+++ b/Lab/demo/Lab/resources/about.html
@@ -3,7 +3,7 @@
     <h2>CGAL Lab</h2>
     <p>Copyright &copy;2008-2026
       <a href="https://www.geometryfactory.com/">GeometryFactory</a>
-      and <a href="https://www.inria.fr/en/inria-centre-universite-cote-azur">INRIA Centre at Université Côte d'Azur<a/></p>
+      and <a href="https://www.inria.fr/en/inria-centre-universite-cote-azur">Inria Centre at Université Côte d'Azur<a/></p>
     <p>This application illustrates the data structures
       of <a href="https://www.cgal.org/">CGAL</a>, and operations and
       algorithms that can be applied to.</p>


### PR DESCRIPTION
## Summary of Changes

Fixes in the About box.

<img width="497" height="195" alt="image" src="https://github.com/user-attachments/assets/6fd564ff-0041-4bba-9f37-e0b974191088" />

As CGAL Lab lives in the directory Lab/demo/Lab` we will not change the  "About the demo...".

## Release Management

* Affected package(s):  Lab

