### PR TITLE
Tetrahedral Remeshing: Doc fixes

### DIFF
--- a/Tetrahedral_remeshing/doc/Tetrahedral_remeshing/dependencies
+++ b/Tetrahedral_remeshing/doc/Tetrahedral_remeshing/dependencies
@@ -9,3 +9,5 @@ BGL
 Mesh_3
 TDS_3
 SMDS_3
+Surface_mesh
+Polyhedron

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -85,7 +85,7 @@ namespace CGAL
 * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
 *
 * @param tr the triangulation to be remeshed, of type `Triangulation_3<Traits, TDS, SLDS>`.
-*           `Remeshing_triangulation` is a helper class that satisfies all the requirements
+*           `CGAL::Tetrahedral_remeshing::Remeshing_triangulation_3` is a helper class that satisfies all the requirements
 *           of its template parameters.
 * @param sizing the target edge length. This parameter provides a
 *          mesh density target for the remeshing algorithm.


### PR DESCRIPTION
## Summary of Changes

Added namespace and suffix for the class `Remeshing_triangulation_3` .

### Todo

- [ ] The function name and the file name are not the same.
- [ ] The helper class should be mentioned in the examples.

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership:  unchanged

