### PR TITLE
Intersection_3:  Simplify code of do_intersect for (Segment/Triangle) (Ray/Triangle)

### DIFF
--- a/Intersections_3/include/CGAL/Intersections_3/internal/Ray_3_Triangle_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Ray_3_Triangle_3_do_intersect.h
@@ -147,9 +147,6 @@ do_intersect_coplanar(const typename K::Triangle_3& t,
   case NEGATIVE:
     switch ( pqb ) {
     case POSITIVE:
-      if (pqc == POSITIVE)         // a is isolated on the negative side
-        return visitor.result(coplanar_orientation(*b,*a,p) != POSITIVE);
-      // b is isolated on the positive side
       return visitor.result(coplanar_orientation(*b,*a,p) != POSITIVE);
 
     case NEGATIVE:
@@ -160,11 +157,7 @@ do_intersect_coplanar(const typename K::Triangle_3& t,
       // c is isolated on the positive side
       return visitor.result(coplanar_orientation(*c,*b,p) != POSITIVE);
     case COLLINEAR:
-      if (pqc == NEGATIVE) // b is isolated on the positive side
-        return visitor.result(coplanar_orientation(*b,*a,p) != POSITIVE);
-      // a is isolated on the negative side
       return visitor.result(coplanar_orientation(*b,*a,p) != POSITIVE);
-
     default: // should not happen.
       CGAL_kernel_assertion(false);
       return visitor.result(false);
@@ -173,16 +166,12 @@ do_intersect_coplanar(const typename K::Triangle_3& t,
   case COLLINEAR:
     switch ( pqb ) {
     case POSITIVE:
-      if (pqc == POSITIVE) // a is isolated on the negative side
-        return visitor.result(coplanar_orientation(*b,*a,p) != POSITIVE);
-      // b is isolated on the positive side
       return visitor.result(coplanar_orientation(*b,*a,p) != POSITIVE);
     case NEGATIVE:
       if (pqc == NEGATIVE) // a is isolated on the positive side
         return visitor.result(coplanar_orientation(*a,*c,p) != POSITIVE);
       // b is isolated on the negative side
       return visitor.result(coplanar_orientation(*c,*b,p) != POSITIVE);
-
     case COLLINEAR:
       if (pqc == POSITIVE) // c is isolated on the positive side
         return visitor.result(coplanar_orientation(*c,*b,p) != POSITIVE);

--- a/Intersections_3/include/CGAL/Intersections_3/internal/Segment_3_Triangle_3_do_intersect.h
+++ b/Intersections_3/include/CGAL/Intersections_3/internal/Segment_3_Triangle_3_do_intersect.h
@@ -199,48 +199,31 @@ do_intersect(const typename K::Triangle_3& t,
 
   switch ( abcp ) {
   case POSITIVE:
-    switch ( abcq ) {
-    case POSITIVE:
+    if( abcq == POSITIVE ){
       // the segment lies in the positive open halfspaces defined by the
       // triangle's supporting plane
       return false;
-    case NEGATIVE:
-      // p sees the triangle in counterclockwise order
-      return orientation(p,q,a,b) != POSITIVE
-          && orientation(p,q,b,c) != POSITIVE
-          && orientation(p,q,c,a) != POSITIVE;
-    case COPLANAR:
-      // q belongs to the triangle's supporting plane
-      // p sees the triangle in counterclockwise order
-      return orientation(p,q,a,b) != POSITIVE
-          && orientation(p,q,b,c) != POSITIVE
-          && orientation(p,q,c,a) != POSITIVE;
-    default: // should not happen.
-      CGAL_kernel_assertion(false);
-      return false;
     }
+    // NEGATIVE: p sees the triangle in counterclockwise order
+    // COPLANAR: q belongs to the triangle's supporting plane
+    //           and p sees the triangle in counterclockwise order
+    return orientation(p,q,a,b) != POSITIVE
+        && orientation(p,q,b,c) != POSITIVE
+        && orientation(p,q,c,a) != POSITIVE;
+
   case NEGATIVE:
-    switch ( abcq ) {
-    case POSITIVE:
-      // q sees the triangle in counterclockwise order
-      return orientation(q,p,a,b) != POSITIVE
-          && orientation(q,p,b,c) != POSITIVE
-          && orientation(q,p,c,a) != POSITIVE;
-    case NEGATIVE:
+    if( abcq == NEGATIVE ){
       // the segment lies in the negative open halfspaces defined by the
       // triangle's supporting plane
       return false;
-    case COPLANAR:
-      // q belongs to the triangle's supporting plane
-      // p sees the triangle in clockwise order
-      return orientation(q,p,a,b) != POSITIVE
-          && orientation(q,p,b,c) != POSITIVE
-          && orientation(q,p,c,a) != POSITIVE;
-
-    default: // should not happen.
-      CGAL_kernel_assertion(false);
-      return false;
     }
+    // POSITIVE: q sees the triangle in counterclockwise order
+    // COPLANAR: q belongs to the triangle's supporting plane
+    //           and p sees the triangle in clockwise order
+    return orientation(q,p,a,b) != POSITIVE
+        && orientation(q,p,b,c) != POSITIVE
+        && orientation(q,p,c,a) != POSITIVE;
+
   case COPLANAR: // p belongs to the triangle's supporting plane
     switch ( abcq ) {
     case POSITIVE:


### PR DESCRIPTION
## Summary of Changes

In `do_intersect(Segment/Triangle)` replace  `switch` with three cases whereof two have identical code by an `if` 

In `do_intersect(Ray/Triangle)` no need for an if, because we do the same in case it is false.

## Release Management

* Affected package(s): Intersection_3
* License and copyright ownership:  unchanged

