### PR TITLE
Fix Index_matcher in vertex_cycle_to_nef_3

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/vertex_cycle_to_nef_3.h
+++ b/Nef_3/include/CGAL/Nef_3/vertex_cycle_to_nef_3.h
@@ -65,7 +65,7 @@ class Compare_face {
 template<typename Items,
   typename Edge, typename CompareEdges> class Index_matcher {
  public:
-  Index_matcher() {}
+  Index_matcher(bool /*withTwin*/) {}
   template<typename Handle>
   void set_index(Handle /*h*/, Edge /*e*/) {}
 };

--- a/Nef_3/test/Nef_3/test_nef_3_vertex_cycle.cpp
+++ b/Nef_3/test/Nef_3/test_nef_3_vertex_cycle.cpp
@@ -1,0 +1,28 @@
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Nef_polyhedron_3.h>
+#include <CGAL/Nef_3/SNC_items.h>
+#include <vector>
+#include <cassert>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel K;
+typedef CGAL::Nef_polyhedron_3<K, CGAL::SNC_items> Nef_polyhedron;
+typedef K::Point_3 Point_3;
+typedef K::Vector_3 Vector_3;
+
+int main()
+{
+  std::vector<Point_3> cycle;
+  cycle.push_back(Point_3(0,0,0));
+  cycle.push_back(Point_3(1,0,0));
+  cycle.push_back(Point_3(1,1,0));
+  cycle.push_back(Point_3(0,1,0));
+
+  Vector_3 normal(0,0,1);
+
+  Nef_polyhedron nef(cycle.begin(), cycle.end(), normal);
+
+  assert(nef.number_of_vertices() == 4);
+  assert(nef.number_of_halfedges() == 10);
+
+  return 0;
+}


### PR DESCRIPTION
## Summary of Changes

This is a fix for the Index_matcher template that doesn't specialize on SNC_indexed_items. The code was introduced in commit 208eaac1f6964f39deef7a6e470db6f01b85bf32 but dosen't have a constructor that takes a boolean parameter.

As such the following code dosen't compile

```c++
#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
#include <CGAL/Nef_polyhedron_3.h>
#include <CGAL/Nef_3/SNC_items.h>
#include <vector>

typedef CGAL::Exact_predicates_exact_constructions_kernel K;
typedef CGAL::Nef_polyhedron_3<K, CGAL::SNC_items> Nef_polyhedron;
typedef typename K::Point_3 Point_3;

int main(int argc, char* argv[])
{
  std::vector<Point_3> v;
  Nef_polyhedron nef(v.begin(), v.end());
  return 0;
}
```

The above code does compile with this change applied.

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): Allow compilation of Nef_3 with SNC_items template. 
* License and copyright ownership: CGAL

