### PR TITLE
CMake: auto-enable CGAL_DEV_MODE when building from CGAL source tree

### DIFF
--- a/Installation/lib/cmake/CGAL/CGALConfig.cmake
+++ b/Installation/lib/cmake/CGAL/CGALConfig.cmake
@@ -19,6 +19,29 @@ endfunction()
 
 set(CGAL_FOUND FALSE)
 cgal_detect_branch_build(BRANCH_BUILD)
+# Fix for issue #9441:
+# When building CGAL from its own source tree (branch build),
+# CGAL_DEV_MODE should default to ON so developers automatically
+# get internal warnings and proper include path behavior.
+# Users can override with -DCGAL_DEV_MODE=OFF.
+if(BRANCH_BUILD)
+  set(_cgal_dev_mode_default ON)
+elseif(DEFINED ENV{CGAL_DEV_MODE})
+  set(_cgal_dev_mode_default "$ENV{CGAL_DEV_MODE}")
+else()
+  set(_cgal_dev_mode_default OFF)
+endif()
+
+option(CGAL_DEV_MODE
+  "Enable CGAL developer mode (auto-ON when building from CGAL source tree)"
+  "${_cgal_dev_mode_default}")
+
+if(CGAL_DEV_MODE AND _cgal_dev_mode_default)
+  message(WARNING
+    "CGAL_DEV_MODE is ON because you are building from the CGAL source "
+    "tree. To disable it, pass -DCGAL_DEV_MODE=OFF to CMake or unset "
+    "the CGAL_DEV_MODE environment variable.")
+endif()
 if(BRANCH_BUILD)
   set(CGAL_ROOT ${CGAL_CONFIG_DIR})
   get_filename_component(CGAL_ROOT "${CGAL_ROOT}" DIRECTORY)


### PR DESCRIPTION
Fixes #9441.

## Problem
`CGAL_DEV_MODE` had no `option()` declaration in `CGALConfig.cmake`.
Developers building from the CGAL source tree had to manually set
`CGAL_DEV_MODE=ON` in their shell profile — easy to miss for new contributors.

## Fix
- After `cgal_detect_branch_build()`, compute `_cgal_dev_mode_default`:
  - `ON` if `BRANCH_BUILD` is true
  - `$ENV{CGAL_DEV_MODE}` if the env var is set
  - `OFF` otherwise (external/installed CGAL users unaffected)
- Declare `option(CGAL_DEV_MODE ...)` with that default
- Emit `message(WARNING)` when auto-enabled so developers know
  it's active and can disable it with `-DCGAL_DEV_MODE=OFF`

## Testing
- Configure from CGAL root → WARNING shown, `CGAL_DEV_MODE=ON` ✓
- Configure with `-DCGAL_DEV_MODE=OFF` → no warning, flag OFF ✓  
- External project using installed CGAL → flag OFF by default ✓