### PR TITLE
Mesh_3 - fix doc after speedup PR

### DIFF
--- a/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
+++ b/Mesh_3/doc/Mesh_3/Concepts/MeshDomainWithFeatures_3.h
@@ -102,8 +102,8 @@ of `p` and `q` on the curve.
 FT curve_segment_length(const Point_3& p, const Point_3& q,
                         const Curve_index& curve_index,
                         CGAL::Orientation orientation) const;
-/*!
 
+/*!
 Returns `CGAL::POSITIVE` if the signed geodesic distance from
 `p` to `q` on the way through `r` along loop with index `ci`
 is positive, `CGAL::NEGATIVE` if the distance is negative.
@@ -122,10 +122,17 @@ CGAL::Sign distance_sign(const Point_3& p, const Point_3& q,
                          const Curve_index& ci) const;
 
 /*!
-Returns the length of curve with index
+Returns the length of the input curve with index
 `curve_index`
 */
 FT curve_length(const Curve_index& curve_index) const;
+
+/**
+ * Returns the signed geodesic distance between points `pa` and `pb` on the curve
+ * with index `curve_index`.
+ */
+FT signed_geodesic_distance(const Point_3& pa, const Point_3& pb, const Curve_index& curve_index) const;
+
 /*!
 Returns `true` if the portion of the curve of index `index`,
 between the points `c1` and `c2`, is covered by the spheres of

--- a/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_3/Protect_edges_sizing_field.h
+++ b/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_3/Protect_edges_sizing_field.h
@@ -1883,6 +1883,8 @@ void
 Protect_edges_sizing_field<C3T3, MD, Sf>::
 insert_balls_on_edges()
 {
+  Vertex_handle locate_hint_vh{};
+
   // Get features
   using Feature_tuple = typename MD::Get_curves_output_type;
   std::vector<Feature_tuple> input_features;
@@ -1930,7 +1932,7 @@ insert_balls_on_edges()
                                   CGAL::square(p_size),
                                   1 /*dim*/,
                                   p_index,
-                                  Vertex_handle(),
+                                  locate_hint_vh,
                                   curve_index,
                                   CGAL::Emptyset_iterator()).first;
 
@@ -1941,6 +1943,7 @@ insert_balls_on_edges()
         // the variable 'vp'.
         vq = vp;
       }
+      locate_hint_vh = vp;
 
       // Insert balls and set treated
 //      if(do_balls_intersect(vp, vq))

--- a/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_3/Protect_edges_sizing_field.h
+++ b/Periodic_3_mesh_3/include/CGAL/Periodic_3_mesh_3/Protect_edges_sizing_field.h
@@ -1590,7 +1590,7 @@ std::pair<typename Protect_edges_sizing_field<C3T3, MD, Sf>::Vertex_handle,
           ErasedVeOutIt>
 Protect_edges_sizing_field<C3T3, MD, Sf>::
 smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
-                   Vertex_handle prev, const Curve_index_container& curve_indices,
+                   Vertex_handle locate_hint_vh, const Curve_index_container& curve_indices,
                    ErasedVeOutIt out)
 {
 #if CGAL_MESH_3_PROTECTION_DEBUG & 1
@@ -1615,7 +1615,7 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
   // Check that new point will not be inside a power sphere
   typename Tr::Locate_type lt;
   int li, lj;
-  Cell_handle ch = tr().locate(wp0, lt, li, lj, prev);
+  Cell_handle ch = tr().locate(wp0, lt, li, lj, locate_hint_vh);
 
 #if CGAL_MESH_3_PROTECTION_DEBUG & 2
   std::cerr << "locate returns: " << &*ch << " lt: " << lt << " lilj: " << li << " " << lj << std::endl;
@@ -1669,7 +1669,7 @@ smart_insert_point(const Bare_point& p, Weight w, int dim, const Index& index,
 #if CGAL_MESH_3_PROTECTION_DEBUG & 1
       std::cerr << "Moved dummy point, calling smart_insert() again" << std::endl;
 #endif
-      return smart_insert_point(p, w, dim, index, prev, curve_indices, out);
+      return smart_insert_point(p, w, dim, index, locate_hint_vh, curve_indices, out);
     }
     else
     {
@@ -2118,16 +2118,22 @@ insert_balls(const Vertex_handle& vp,
 #endif
       const Bare_point new_point =
         domain_.construct_point_on_curve(vpp, curve_index, d_signF * d / 2);
-      const int dim = 1; // new_point is on edge
+      const int dim_1 = 1; // new_point is on edge
       const Index index = domain_.index_from_curve_index(curve_index);
-      const FT point_weight = CGAL::square(size_(new_point, dim, index));
+      const FT point_weight = CGAL::square(size_(new_point, dim_1, index));
 
 #if CGAL_MESH_3_PROTECTION_DEBUG & 1
       std::cerr << "  middle point: " << new_point << std::endl;
       std::cerr << "  new weight: " << point_weight << std::endl;
 #endif
       std::pair<Vertex_handle, ErasedVeOutIt> pair =
-        smart_insert_point(new_point, point_weight, dim, index, Vertex_handle(), curve_index, out);
+        smart_insert_point(new_point,
+                           point_weight,
+                           dim_1,
+                           index,
+                           vp,
+                           curve_index,
+                           out);
       Vertex_handle new_vertex = pair.first;
 
       out = pair.second;


### PR DESCRIPTION
## Summary of Changes

Since the merge of PR #9274 (speedup protecting balls placement), the concept `MeshDomainWithFeatures_3` has become incomplete.
It's fixed.

For now the doc sticks to the case where `api_version == API_version::v1`

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): fix #9405
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: unchanged

