### PR TITLE
Nef_3: Fix ID_support_handler logic error

### DIFF
--- a/Nef_3/include/CGAL/Nef_3/ID_support_handler.h
+++ b/Nef_3/include/CGAL/Nef_3/ID_support_handler.h
@@ -273,7 +273,7 @@ class ID_support_handler<SNC_indexed_items, Decorator> {
     index2 = get_hash(se2->twin()->get_index());
     if(index1 < index2) {
       se->twin()->set_index(index1);
-      set_hash(se1->twin()->get_index(), index1);
+      set_hash(se2->twin()->get_index(), index1);
     } else {
       se->twin()->set_index(index2);
       set_hash(se1->twin()->get_index(), index2);
@@ -305,12 +305,10 @@ class ID_support_handler<SNC_indexed_items, Decorator> {
     int index2 = get_hash(sl2->get_index());
     if(index1 < index2) {
       se->set_index(index1);
-      set_hash(se1->get_index(), index1);
       set_hash(sl2->get_index(), index1);
     } else {
       se->set_index(index2);
       set_hash(se1->get_index(), index2);
-      set_hash(sl2->get_index(), index2);
     }
 
     index1 = get_hash(se1->twin()->get_index());

--- a/Nef_3/test/Nef_3/test_id_support.cpp
+++ b/Nef_3/test/Nef_3/test_id_support.cpp
@@ -1,0 +1,95 @@
+#include <CGAL/Exact_predicates_exact_constructions_kernel.h>
+#include <CGAL/Nef_3/SNC_indexed_items.h>
+#include <CGAL/Nef_3/SNC_structure.h>
+#include <CGAL/Nef_3/SNC_decorator.h>
+#include <CGAL/Nef_3/ID_support_handler.h>
+#include <cassert>
+
+typedef CGAL::Exact_predicates_exact_constructions_kernel K;
+typedef CGAL::SNC_indexed_items Items;
+typedef CGAL::SNC_structure<K, Items, bool> SNC_structure;
+typedef CGAL::SNC_decorator<SNC_structure> SNC_decorator;
+typedef CGAL::SM_decorator<SNC_structure::Sphere_map> SM_decorator;
+typedef CGAL::ID_support_handler<Items, SNC_decorator> ID_support_handler;
+
+typedef SNC_structure::Vertex_handle Vertex_handle;
+typedef SNC_structure::SHalfedge_handle SHalfedge_handle;
+typedef SNC_structure::SHalfloop_handle SHalfloop_handle;
+typedef SNC_structure::Sphere_circle Sphere_circle;
+
+void run_test_case(int fw_id1, int bw_id1, int fw_id2, int bw_id2, bool test_loop) {
+    ID_support_handler handler;
+
+    handler.initialize_hash(fw_id1);
+    handler.initialize_hash(bw_id1);
+    handler.initialize_hash(fw_id2);
+    handler.initialize_hash(bw_id2);
+
+    SNC_structure snc;
+    Vertex_handle v = snc.new_vertex();
+    SM_decorator SD(&*v);
+
+    SHalfedge_handle se = SD.new_shalfedge_pair();
+    se->circle() = Sphere_circle(1,0,0);
+    se->twin()->circle() = se->circle().opposite();
+
+    SHalfedge_handle se1 = SD.new_shalfedge_pair();
+    se1->set_forward_index(fw_id1);
+    se1->set_backward_index(bw_id1);
+    se1->twin()->set_forward_index(bw_id1);
+    se1->twin()->set_backward_index(fw_id1);
+    se1->circle() = se->circle();
+    se1->twin()->circle() = se->circle().opposite();
+
+    if (test_loop) {
+
+        SHalfloop_handle sl2 = SD.new_shalfloop_pair();
+        sl2->circle() = se->circle();
+        sl2->twin()->circle() = se->circle().opposite();
+        sl2->set_index(fw_id2);
+        sl2->twin()->set_index(bw_id2);
+
+        handler.handle_support(se, se1, sl2);
+
+        // fw_id1 is merged with fw_id2
+        assert(handler.get_hash(fw_id1) == handler.get_hash(fw_id2));
+
+        // bw_id1 is merged with bw_id2
+        assert(handler.get_hash(bw_id1) == handler.get_hash(bw_id2));
+    } else {
+
+        SHalfedge_handle se2 = SD.new_shalfedge_pair();
+        se2->set_forward_index(fw_id2);
+        se2->set_backward_index(bw_id2);
+        se2->twin()->set_forward_index(bw_id2);
+        se2->twin()->set_backward_index(fw_id2);
+        se2->circle() = se->circle();
+        se2->twin()->circle() = se->circle().opposite();
+
+        handler.handle_support(se, se1, se2);
+
+        // fw_id1 is merged with fw_id2
+        assert(handler.get_hash(fw_id1) == handler.get_hash(fw_id2));
+
+        // bw_id1 is merged with bw_id2
+        assert(handler.get_hash(bw_id1) == handler.get_hash(bw_id2));
+    }
+}
+
+int main() {
+    const int id1 = 10;
+    const int id2 = 11;
+
+    const int id3 = 20;
+    const int id4 = 21;
+
+    // edge-edge
+    run_test_case(id1, id2, id3, id4, false);
+    run_test_case(id3, id4, id1, id2, false);
+
+    // edge-loop
+    run_test_case(id1, id2, id3, id4, true);
+    run_test_case(id3, id4, id1, id2, true);
+
+    return 0;
+}


### PR DESCRIPTION
## Summary of Changes

This fixes a logical error in ID_support_handler (probably caused by a typo) 

First I should explain that in this code:
https://github.com/CGAL/cgal/blob/2e165ee808b9bcd2c0981c73a203084172b2b852/Nef_3/include/CGAL/Nef_3/ID_support_handler.h#L304-L314

The assignment of se1's hashed index to se1's hashed index (line 308) is a no-op `H[x₁] ← H[x₁]`
likewise the assignment of sl2's hashed index to sl2's hashed index (line 313) is a no-op. These no-op's don't really matter but for the sake of correctness I've removed them. The real problem is with this code:

https://github.com/CGAL/cgal/blob/2e165ee808b9bcd2c0981c73a203084172b2b852/Nef_3/include/CGAL/Nef_3/ID_support_handler.h#L276

The intention here isn't a no-op the intention is for it to merge the indexes using the union find.
`set_hash(se2->twin()->get_index(), index1);`

I have created a failing test that passes when the fix is applied. However in a more general sense this bug doesn't create a topological, or geometric flaw, because in the correct logic is applied in another pass:

https://github.com/CGAL/cgal/blob/2e165ee808b9bcd2c0981c73a203084172b2b852/Nef_3/include/CGAL/Nef_3/SNC_SM_overlayer.h#L320-L334 

In certain cases cycling the svertices means visiting the same halfedges via each local sphere but with the indexes reversed (`index2 < index1`) so it falls into the branch of code where the logic is correct. 

## Release Management

* Affected package(s): Nef_3
* Issue(s) solved (if any): fix bug
* License and copyright ownership: CGAL

