### PR TITLE
PMP: Corefinement polish documentation

### DIFF
--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/autorefinement.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/autorefinement.h
@@ -1745,10 +1745,10 @@ bool autorefine_triangle_soup(PointRange& soup_points,
 
 /**
  * \ingroup PMP_corefinement_grp
- * refines a triangle mesh so that no triangles intersects in their interior.
+ * refines a triangle mesh so that no pair of triangles intersects in their interior.
  *
  * Note that this function is only provided as a shortcut for calling `autorefine_triangle_soup()`
- * with a mesh. For any advance usage the aforementioned function should be called directly.
+ * with a mesh. For any advanced usage the aforementioned function should be called directly.
  *
  * @tparam TriangleMesh a model of `HalfedgeListGraph`, `FaceListGraph`, and `MutableFaceGraph`
  * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"


### PR DESCRIPTION
## Summary of Changes

Taken the importance of autorefinement the documentation should be improved.

### Todo 

- [x] typos
- [ ] Add example in the User Manual.
- [ ] Add an illustration
- [ ] @LeoValque told me that the comment of the function is not correct. He mentioned a partial overlap of two triangle edges.

## Release Management

* Affected package(s): PMP_Boolean
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:  unchanged

