### PR TITLE
Fix skipping edge collapse checks

### DIFF
--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/internal/Isotropic_remeshing/remesh_impl.h
@@ -1325,14 +1325,14 @@ private:
         return false;//too many cases to be handled
       if (is_on_patch_border(next(hopp, mesh_)) && is_on_patch_border(prev(hopp, mesh_)))
         return false;//too many cases to be handled
-      else if (is_on_patch_border(next(he, mesh_)))
+      if (is_on_patch_border(next(he, mesh_)))
       {
         //avoid generation of degenerate faces, and self-intersections
         if (source(he, mesh_) ==
           target(next(next_on_patch_border(next(he, mesh_)), mesh_), mesh_))
           return false;
       }
-      else if (is_on_patch_border(prev(hopp, mesh_)))
+      if (is_on_patch_border(prev(hopp, mesh_)))
       {
         //avoid generation of degenerate faces, and self-intersections
         if (target(hopp, mesh_) ==


### PR DESCRIPTION
## Summary of Changes

These tests are about checking if the collapse of an edge with a vertex on a patch border can end collapsing more than its two incident triangles.

The issue is that this configuration can happen on both sides of the edge, and currently if the configuration exists but is not an issue on one side, the check is skipped on the other side, and we end up collapsing something that we should not collapse.

## Release Management

* Affected package(s): `PMP_Remeshing`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

