### PR TITLE
Triangulation_3: Store subdeterminant for in_sphere predicate

### DIFF
--- a/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
+++ b/Cartesian_kernel/include/CGAL/Cartesian/function_objects.h
@@ -27,6 +27,8 @@
 #include <CGAL/Distance_3/Point_3_Point_3.h>
 #include <CGAL/Distance_3/internal/squared_distance_utils_3.h>
 
+#include <array>
+
 namespace CGAL {
 
 namespace CartesianKernelFunctors {
@@ -4379,6 +4381,18 @@ namespace CartesianKernelFunctors {
                                        r.x(), r.y(), r.z(),
                                        s.x(), s.y(), s.z(),
                                        test.x(), test.y(), test.z());
+    }
+  Oriented_side
+    operator()( const Point_3& p, const Point_3& q, const Point_3& r,
+                const Point_3& s, const Point_3& test,
+                const std::array<double,4>& det) const
+    {
+      return side_of_oriented_sphereC3(p.x(), p.y(), p.z(),
+                                       q.x(), q.y(), q.z(),
+                                       r.x(), r.y(), r.z(),
+                                       s.x(), s.y(), s.z(),
+                                       test.x(), test.y(), test.z(),
+                                       det);
     }
   };
 

--- a/Cartesian_kernel/include/CGAL/predicates/kernel_ftC3.h
+++ b/Cartesian_kernel/include/CGAL/predicates/kernel_ftC3.h
@@ -369,6 +369,19 @@ side_of_oriented_sphereC3(const FT &px, const FT &py, const FT &pz,
   // Note that the determinant above is det(P,R,Q,S) (Q and R are swapped)!
 }
 
+inline
+Oriented_side
+side_of_oriented_sphereC3(double px, double py, double pz,
+                          double tx, double ty, double tz,
+                          const array<double,4>& det)
+{
+  double ptx = tx - px;
+  double pty = ty - py;
+  double ptz = tz - pz;
+  return sign(ptx * det[0] - pty * det[1] + ptz * det[2] - (ptx*ptx + pty*pty + ptz*ptz) * det[3]);
+}
+
+
 template <class FT >
 CGAL_KERNEL_MEDIUM_INLINE
 typename Same_uncertainty_nt<Bounded_side, FT>::type

--- a/Cartesian_kernel/include/CGAL/predicates/kernel_ftC3.h
+++ b/Cartesian_kernel/include/CGAL/predicates/kernel_ftC3.h
@@ -21,6 +21,7 @@
 #include <CGAL/predicates/sign_of_determinant.h>
 #include <CGAL/predicates/kernel_ftC2.h>
 #include <CGAL/constructions/kernel_ftC3.h>
+#include <array>
 
 namespace CGAL {
 
@@ -373,7 +374,7 @@ inline
 Oriented_side
 side_of_oriented_sphereC3(double px, double py, double pz,
                           double tx, double ty, double tz,
-                          const array<double,4>& det)
+                          const std::array<double,4>& det)
 {
   double ptx = tx - px;
   double pty = ty - py;

--- a/Filtered_kernel/include/CGAL/Filtered_kernel/internal/Static_filters/Side_of_oriented_sphere_3.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/internal/Static_filters/Side_of_oriented_sphere_3.h
@@ -131,7 +131,6 @@ public:
                                          qtx,qty,qtz,qt2,
                                          stx,sty,stz,st2);
 
-
           // Protect against underflow in the computation of eps.
           if (maxx < 1e-58) /* sqrt^5(min_double/eps) */ {
             if (maxx == 0)
@@ -179,18 +178,14 @@ public:
           double qtx = qx - tx;
           double qty = qy - ty;
           double qtz = qz - tz;
-          double qt2 = CGAL_NTS square(qtx) + CGAL_NTS square(qty)
-                     + CGAL_NTS square(qtz);
+
           double rtx = rx - tx;
           double rty = ry - ty;
           double rtz = rz - tz;
-         double rt2 = CGAL_NTS square(rtx) + CGAL_NTS square(rty)
-                     + CGAL_NTS square(rtz);
+
           double stx = sx - tx;
           double sty = sy - ty;
           double stz = sz - tz;
-          double st2 = CGAL_NTS square(stx) + CGAL_NTS square(sty)
-                     + CGAL_NTS square(stz);
 
           // Compute the semi-static bound.
           double maxx = CGAL::abs(ptx);

--- a/Filtered_kernel/include/CGAL/Filtered_kernel/internal/Static_filters/Side_of_oriented_sphere_3.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/internal/Static_filters/Side_of_oriented_sphere_3.h
@@ -131,6 +131,7 @@ public:
                                          qtx,qty,qtz,qt2,
                                          stx,sty,stz,st2);
 
+
           // Protect against underflow in the computation of eps.
           if (maxx < 1e-58) /* sqrt^5(min_double/eps) */ {
             if (maxx == 0)
@@ -147,6 +148,127 @@ public:
       }
       return Base::operator()(p, q, r, s, t);
   }
+
+
+
+  Oriented_side
+  operator()(const Point_3 &p, const Point_3 &q, const Point_3 &r,
+             const Point_3 &s, const Point_3 &t, const std::array<double,4>& subdet) const
+  {
+      CGAL_BRANCH_PROFILER_3("semi-static failures/attempts/calls to   : Side_of_oriented_sphere_3", tmp);
+
+      double px, py, pz, qx, qy, qz, rx, ry, rz, sx, sy, sz, tx, ty, tz;
+
+      if (fit_in_double(p.x(), px) && fit_in_double(p.y(), py) &&
+          fit_in_double(p.z(), pz) &&
+          fit_in_double(q.x(), qx) && fit_in_double(q.y(), qy) &&
+          fit_in_double(q.z(), qz) &&
+          fit_in_double(r.x(), rx) && fit_in_double(r.y(), ry) &&
+          fit_in_double(r.z(), rz) &&
+          fit_in_double(s.x(), sx) && fit_in_double(s.y(), sy) &&
+          fit_in_double(s.z(), sz) &&
+          fit_in_double(t.x(), tx) && fit_in_double(t.y(), ty) &&
+          fit_in_double(t.z(), tz))
+      {
+          CGAL_BRANCH_PROFILER_BRANCH_1(tmp);
+
+          double ptx = px - tx;
+          double pty = py - ty;
+          double ptz = pz - tz;
+          double pt2 = CGAL_NTS square(ptx) + CGAL_NTS square(pty)
+                     + CGAL_NTS square(ptz);
+          double qtx = qx - tx;
+          double qty = qy - ty;
+          double qtz = qz - tz;
+          double qt2 = CGAL_NTS square(qtx) + CGAL_NTS square(qty)
+                     + CGAL_NTS square(qtz);
+          double rtx = rx - tx;
+          double rty = ry - ty;
+          double rtz = rz - tz;
+         double rt2 = CGAL_NTS square(rtx) + CGAL_NTS square(rty)
+                     + CGAL_NTS square(rtz);
+          double stx = sx - tx;
+          double sty = sy - ty;
+          double stz = sz - tz;
+          double st2 = CGAL_NTS square(stx) + CGAL_NTS square(sty)
+                     + CGAL_NTS square(stz);
+
+          // Compute the semi-static bound.
+          double maxx = CGAL::abs(ptx);
+          double maxy = CGAL::abs(pty);
+          double maxz = CGAL::abs(ptz);
+
+          double aqtx = CGAL::abs(qtx);
+          double artx = CGAL::abs(rtx);
+          double astx = CGAL::abs(stx);
+
+          double aqty = CGAL::abs(qty);
+          double arty = CGAL::abs(rty);
+          double asty = CGAL::abs(sty);
+
+          double aqtz = CGAL::abs(qtz);
+          double artz = CGAL::abs(rtz);
+          double astz = CGAL::abs(stz);
+
+#ifdef CGAL_USE_SSE2_MAX
+          CGAL::Max<double> mmax;
+          maxx = mmax(maxx, aqtx, artx, astx);
+          maxy = mmax(maxy, aqty, arty, asty);
+          maxz = mmax(maxz, aqtz, artz, astz);
+#else
+          if (maxx < aqtx) maxx = aqtx;
+          if (maxx < artx) maxx = artx;
+          if (maxx < astx) maxx = astx;
+
+          if (maxy < aqty) maxy = aqty;
+          if (maxy < arty) maxy = arty;
+          if (maxy < asty) maxy = asty;
+
+          if (maxz < aqtz) maxz = aqtz;
+          if (maxz < artz) maxz = artz;
+          if (maxz < astz) maxz = astz;
+#endif
+
+          double eps = 1.2466136531027298e-13 * maxx * maxy * maxz;
+
+#ifdef CGAL_USE_SSE2_MAX
+          /*
+          CGAL::Min<double> mmin;
+          double tmp = mmin(maxx, maxy, maxz);
+          maxz = mmax(maxx, maxy, maxz);
+          maxx = tmp;
+          */
+          sse2minmax(maxx,maxy,maxz);
+          // maxy can contain ANY element
+
+#else
+          // Sort maxx < maxy < maxz.
+          if (maxx > maxz)
+              std::swap(maxx, maxz);
+          if (maxy > maxz)
+              std::swap(maxy, maxz);
+          else if (maxy < maxx)
+              std::swap(maxx, maxy);
+#endif
+          double det =  - ptx * subdet[0] + pty * subdet[1] - ptz * subdet[2] -+ (ptx*ptx + pty*pty + ptz*ptz) * subdet[3];
+
+          // Protect against underflow in the computation of eps.
+          if (maxx < 1e-58) /* sqrt^5(min_double/eps) */ {
+            if (maxx == 0)
+              return ON_ORIENTED_BOUNDARY;
+          }
+          // Protect against overflow in the computation of det.
+          else if (maxz < 1e61) /* sqrt^5(max_double/4 [hadamard]) */ {
+            eps *= (maxz * maxz);
+            if (det > eps)  return ON_POSITIVE_SIDE;
+            if (det < -eps) return ON_NEGATIVE_SIDE;
+          }
+
+          CGAL_BRANCH_PROFILER_BRANCH_2(tmp);
+      }
+      return Base::operator()(p, q, r, s, t);
+  }
+
 
   // Computes the epsilon for Side_of_oriented_sphere_3.
   static double compute_epsilon()

--- a/Filtered_kernel/include/CGAL/Filtered_kernel/internal/Static_filters/Side_of_oriented_sphere_3.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/internal/Static_filters/Side_of_oriented_sphere_3.h
@@ -249,7 +249,7 @@ public:
           else if (maxy < maxx)
               std::swap(maxx, maxy);
 #endif
-          double det =  - ptx * subdet[0] + pty * subdet[1] - ptz * subdet[2] -+ (ptx*ptx + pty*pty + ptz*ptz) * subdet[3];
+          double det =  - ptx * subdet[0] + pty * subdet[1] - ptz * subdet[2] -pt2 * subdet[3];
 
           // Protect against underflow in the computation of eps.
           if (maxx < 1e-58) /* sqrt^5(min_double/eps) */ {

--- a/Filtered_kernel/include/CGAL/Filtered_kernel/internal/Static_filters/Side_of_oriented_sphere_3.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/internal/Static_filters/Side_of_oriented_sphere_3.h
@@ -156,7 +156,6 @@ public:
              const Point_3 &s, const Point_3 &t, const std::array<double,4>& subdet) const
   {
       CGAL_BRANCH_PROFILER_3("semi-static failures/attempts/calls to   : Side_of_oriented_sphere_3", tmp);
-
       double px, py, pz, qx, qy, qz, rx, ry, rz, sx, sy, sz, tx, ty, tz;
 
       if (fit_in_double(p.x(), px) && fit_in_double(p.y(), py) &&

--- a/Kernel_23/include/CGAL/determinant.h
+++ b/Kernel_23/include/CGAL/determinant.h
@@ -420,12 +420,11 @@ inline void subdeterminants(
   double ca2 = cax*cax + cay*cay + caz*caz;
   double da2 = dax*dax + day*day + daz*daz;
 
-  det[0] = determinant(bay, baz, ba2,
-                       cay, caz, ca2,
-                       day, daz, da2);
-  det[1] = determinant(bax, baz, ba2,
-                       cax, caz, ca2,
-                       dax, daz, da2);
+  double bc = baz*ca2 - caz*ba2;
+  double bd = baz*da2 - daz*ba2;
+  double cd = caz*da2 - daz*ca2;
+  det[0] = bay*cd - cay*bd + day*bc;
+  det[1] = bax*cd - cax*bd + dax*bc;
 
   double sd0 = bax*cay - bay*cax;
   double sd1 = bax*day - bay*dax;

--- a/Kernel_23/include/CGAL/determinant.h
+++ b/Kernel_23/include/CGAL/determinant.h
@@ -20,6 +20,8 @@
 
 #include <CGAL/kernel_config.h>
 
+#include <array>
+
 namespace CGAL {
 
 template <class RT>

--- a/Kernel_23/include/CGAL/determinant.h
+++ b/Kernel_23/include/CGAL/determinant.h
@@ -426,12 +426,12 @@ inline void subdeterminants(
   det[1] = determinant(bax, baz, ba2,
                        cax, caz, ca2,
                        dax, daz, da2);
-  det[2] = determinant(bax, bay, ba2,
-                       cax, cay, ca2,
-                       dax, day, da2);
-  det[3] = determinant(bax, bay, baz,
-                       cax, cay, caz,
-                       dax, day, daz);
+
+  double sd0 = bax*cay - bay*cax;
+  double sd1 = bax*day - bay*dax;
+  double sd2 = cax*day - cay*dax;
+  det[2] = ba2 * sd2 - ca2 * sd1 + da2 * sd0;
+  det[3] = baz * sd2 - caz * sd1 + daz * sd0;
 }
 
 } //namespace CGAL

--- a/Kernel_23/include/CGAL/determinant.h
+++ b/Kernel_23/include/CGAL/determinant.h
@@ -399,6 +399,40 @@ determinant(
   return m0123456;
 }
 
+inline void subdeterminants(
+ double ax,  double ay,  double az,
+ double bx,  double by,  double bz,
+ double cx,  double cy,  double cz,
+ double dx,  double dy,  double dz,
+ std::array<double,4>& det)
+{
+  double bax = bx-ax;
+  double bay = by-ay;
+  double baz = bz-az;
+  double cax = cx-ax;
+  double cay = cy-ay;
+  double caz = cz-az;
+  double dax = dx-ax;
+  double day = dy-ay;
+  double daz = dz-az;
+
+  double ba2 = bax*bax + bay*bay + baz*baz;
+  double ca2 = cax*cax + cay*cay + caz*caz;
+  double da2 = dax*dax + day*day + daz*daz;
+
+  det[0] = determinant(bay, baz, ba2,
+                       cay, caz, ca2,
+                       day, daz, da2);
+  det[1] = determinant(bax, baz, ba2,
+                       cax, caz, ca2,
+                       dax, daz, da2);
+  det[2] = determinant(bax, bay, ba2,
+                       cax, cay, ca2,
+                       dax, day, da2);
+  det[3] = determinant(bax, bay, baz,
+                       cax, cay, caz,
+                       dax, day, daz);
+}
 
 } //namespace CGAL
 

--- a/TDS_3/include/CGAL/Triangulation_data_structure_3.h
+++ b/TDS_3/include/CGAL/Triangulation_data_structure_3.h
@@ -664,11 +664,11 @@ public:
       f.first->set_neighbor(f.second, nc);
 
       vertex_pair_facet_map.set({u, v}, {local_facet_index,
-                                         static_cast<unsigned char>(nc->index(w))});
+                                         static_cast<unsigned char>(2)});
       vertex_pair_facet_map.set({v, w}, {local_facet_index,
-                                         static_cast<unsigned char>(nc->index(u))});
+                                         static_cast<unsigned char>(1)});
       vertex_pair_facet_map.set({w, u}, {local_facet_index,
-                                         static_cast<unsigned char>(nc->index(v))});
+                                         static_cast<unsigned char>(0)});
     }
 
     for(auto it = vertex_pair_facet_map.begin(); it != vertex_pair_facet_map.end(); ++it){

--- a/Triangulation_3/benchmark/Triangulation_3/CMakeLists.txt
+++ b/Triangulation_3/benchmark/Triangulation_3/CMakeLists.txt
@@ -15,6 +15,7 @@ create_single_source_cgal_program("ocean.cpp")
 create_single_source_cgal_program("incident_edges.cpp")
 create_single_source_cgal_program("simple_2.cpp")
 create_single_source_cgal_program("simple.cpp")
+create_single_source_cgal_program("DT_storing_subdeterminant.cpp")
 create_single_source_cgal_program("Triangulation_benchmark_3.cpp")
 create_single_source_cgal_program("segment_traverser_benchmark.cpp" )
 

--- a/Triangulation_3/benchmark/Triangulation_3/DT_storing_subdeterminant.cpp
+++ b/Triangulation_3/benchmark/Triangulation_3/DT_storing_subdeterminant.cpp
@@ -1,0 +1,46 @@
+// #define CGAL_DELAUNAY_3_USE_SUBDETERMINANTS 1
+
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/Delaunay_triangulation_3.h>
+#include <CGAL/Triangulation_cell_base_with_info_3.h>
+#include <CGAL/Timer.h>
+#include <vector>
+#include <array>
+#include <iostream>
+#include <string>
+#include <fstream>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel         K;
+typedef CGAL::Triangulation_vertex_base_3<K>                        Vb;
+typedef CGAL::Triangulation_cell_base_with_info_3<std::array<double,4>, K>    Cbb;
+typedef CGAL::Delaunay_triangulation_cell_base_3<K>            Cb;
+typedef CGAL::Triangulation_data_structure_3<Vb, Cb>                Tds;
+typedef CGAL::Delaunay_triangulation_3<K, Tds>                      Delaunay;
+typedef Delaunay::Point                                             Point;
+typedef CGAL::Timer                                                 Timer;
+
+int main(int argc, char* argv[])
+{
+  const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("points_3/ocean_r.xyz");
+  std::ifstream in(filename.c_str());
+  std::vector<Point> points;
+  Point p;
+
+  while(in >> p ){
+    points.push_back(p);
+  }
+
+  std::cout << points.size() << " points read\n";
+
+  Timer timer;
+  timer.start();
+  {
+    Delaunay dt;
+    dt.insert(points.begin(), points.end());
+  }
+  std::cerr << timer.time() << " sec" << std::endl;
+  std::cout << "done" << std::endl;
+  return 0;
+}
+

--- a/Triangulation_3/benchmark/Triangulation_3/DT_storing_subdeterminant.cpp
+++ b/Triangulation_3/benchmark/Triangulation_3/DT_storing_subdeterminant.cpp
@@ -1,5 +1,5 @@
-// #define CGAL_DELAUNAY_3_USE_SUBDETERMINANTS 1
-
+#define CGAL_DELAUNAY_3_USE_SUBDETERMINANTS 1
+// #define CGAL_PROFILE
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
 #include <CGAL/Delaunay_triangulation_3.h>
@@ -13,8 +13,12 @@
 
 typedef CGAL::Exact_predicates_inexact_constructions_kernel         K;
 typedef CGAL::Triangulation_vertex_base_3<K>                        Vb;
+#ifdef CGAL_DELAUNAY_3_USE_SUBDETERMINANTS
 typedef CGAL::Triangulation_cell_base_with_info_3<std::array<double,4>, K>    Cbb;
-typedef CGAL::Delaunay_triangulation_cell_base_3<K>            Cb;
+typedef CGAL::Delaunay_triangulation_cell_base_3<K,Cbb>             Cb;
+#else
+typedef CGAL::Delaunay_triangulation_cell_base_3<K>                 Cb;
+#endif
 typedef CGAL::Triangulation_data_structure_3<Vb, Cb>                Tds;
 typedef CGAL::Delaunay_triangulation_3<K, Tds>                      Delaunay;
 typedef Delaunay::Point                                             Point;
@@ -27,7 +31,7 @@ int main(int argc, char* argv[])
   std::vector<Point> points;
   Point p;
 
-  while(in >> p ){
+  while(in >> p){
     points.push_back(p);
   }
 

--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -1130,6 +1130,7 @@ insert(const Point& p, Locate_type lt, Cell_handle c, int li, int lj, bool *coul
 
 #ifdef CGAL_DELAUNAY_3_USE_SUBDETERMINANTS
      std::vector<Cell_handle> cells;
+     cells.reserve(64);
      this->incident_cells(v, std::back_inserter(cells));
       for(Cell_handle ch : cells)
       {
@@ -1155,6 +1156,7 @@ insert(const Point& p, Locate_type lt, Cell_handle c, int li, int lj, bool *coul
 #ifdef CGAL_DELAUNAY_3_USE_SUBDETERMINANTS
      if(dimension() == 3){
      std::vector<Cell_handle> cells;
+     cells.reserve(64);
      this->incident_cells(v, std::back_inserter(cells));
       for(Cell_handle ch : cells)
       {

--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -184,6 +184,10 @@ protected:
                                         const Point& p2, const Point& p3,
                                         const Point& t, bool perturb = false) const;
 
+  Oriented_side side_of_oriented_sphere(const Point& p0, const Point& p1,
+                                        const Point& p2, const Point& p3,
+                                        const Point& t, const std::array<double,4>& det, bool perturb = false) const;
+
   Bounded_side coplanar_side_of_bounded_circle(const Point& p, const Point& q,
                                                const Point& r, const Point& s, bool perturb = false) const;
 
@@ -734,10 +738,28 @@ private:
   side_of_sphere(Vertex_handle v0, Vertex_handle v1,
                  Vertex_handle v2, Vertex_handle v3,
                  const Point& p, bool perturb) const;
+
+  Bounded_side
+  side_of_sphere(Vertex_handle v0, Vertex_handle v1,
+                 Vertex_handle v2, Vertex_handle v3,
+                 const Point& p, const std::array<double,4>& det, bool perturb) const;
+
 public:
   // Queries
   Bounded_side side_of_sphere(Cell_handle c, const Point& p, bool perturb = false) const
   {
+#ifdef CGAL_DELAUNAY_3_USE_SUBDETERMINANTS
+    if(! is_infinite(c)){
+
+    Bounded_side bs = side_of_sphere(c->vertex(0), c->vertex(1),
+                                     c->vertex(2), c->vertex(3), p, c->info(), perturb);
+
+    CGAL_assertion_code(Bounded_side check = side_of_sphere(c->vertex(0), c->vertex(1),
+                                                            c->vertex(2), c->vertex(3), p, perturb));
+    CGAL_assertion(bs == check);
+    return bs;
+    }
+#endif
     return side_of_sphere(c->vertex(0), c->vertex(1),
                           c->vertex(2), c->vertex(3), p, perturb);
   }
@@ -1105,13 +1127,51 @@ insert(const Point& p, Locate_type lt, Cell_handle c, int li, int lj, bool *coul
       Conflict_tester_3 tester(p, this);
       Vertex_handle v = insert_in_conflict(p, lt, c, li, lj,
                                            tester, hidden_point_visitor, could_lock_zone);
+
+#ifdef CGAL_DELAUNAY_3_USE_SUBDETERMINANTS
+     std::vector<Cell_handle> cells;
+     this->incident_cells(v, std::back_inserter(cells));
+      for(Cell_handle ch : cells)
+      {
+        if(! is_infinite(ch)){
+           const Point& p0 = ch->vertex(0)->point();
+           const Point& p1 = ch->vertex(1)->point();
+           const Point& p2 = ch->vertex(2)->point();
+           const Point& p3 = ch->vertex(3)->point();
+           subdeterminants(p0.x(), p0.y(), p0.z(),
+                           p1.x(), p1.y(), p1.z(),
+                           p2.x(), p2.y(), p2.z(),
+                           p3.x(), p3.y(), p3.z(), ch->info());
+        }
+      }
+#endif
       return v;
     }// dim 3
     case 2:
     {
       Conflict_tester_2 tester(p, this);
-      return insert_in_conflict(p, lt, c, li, lj,
-                                tester, hidden_point_visitor, could_lock_zone);
+       Vertex_handle v = insert_in_conflict(p, lt, c, li, lj,
+                                            tester, hidden_point_visitor, could_lock_zone);
+#ifdef CGAL_DELAUNAY_3_USE_SUBDETERMINANTS
+     if(dimension() == 3){
+     std::vector<Cell_handle> cells;
+     this->incident_cells(v, std::back_inserter(cells));
+      for(Cell_handle ch : cells)
+      {
+        if(! is_infinite(ch)){
+           const Point& p0 = ch->vertex(0)->point();
+           const Point& p1 = ch->vertex(1)->point();
+           const Point& p2 = ch->vertex(2)->point();
+           const Point& p3 = ch->vertex(3)->point();
+           subdeterminants(p0.x(), p0.y(), p0.z(),
+                           p1.x(), p1.y(), p1.z(),
+                           p2.x(), p2.y(), p2.z(),
+                           p3.x(), p3.y(), p3.z(), ch->info());
+        }
+      }
+     }
+#endif
+      return v;
     }//dim 2
     default :
       // dimension <= 1
@@ -1419,6 +1479,49 @@ side_of_oriented_sphere(const Point& p0, const Point& p1, const Point& p2,
 }
 
 template < class Gt, class Tds, class Lds >
+Oriented_side
+Delaunay_triangulation_3<Gt,Tds,Default,Lds>::
+side_of_oriented_sphere(const Point& p0, const Point& p1, const Point& p2,
+                        const Point& p3, const Point& p, const std::array<double,4>& det, bool perturb) const
+{
+  CGAL_precondition(orientation(p0, p1, p2, p3) == POSITIVE);
+
+  Oriented_side os =
+      geom_traits().side_of_oriented_sphere_3_object()(p0, p1, p2, p3, p, det);
+
+  if(os != ON_ORIENTED_BOUNDARY || !perturb)
+    return os;
+
+  // We are now in a degenerate case => we do a symbolic perturbation.
+
+  // We sort the points lexicographically.
+  const Point * points[5] = {&p0, &p1, &p2, &p3, &p};
+  std::sort(points, points + 5, typename Tr_Base::Perturbation_order(this));
+
+  // We successively look whether the leading monomial, then 2nd monomial
+  // of the determinant has non null coefficient.
+  // 2 iterations are enough (cf paper)
+  for(int i=4; i>2; --i)
+  {
+    if(points[i] == &p)
+      return ON_NEGATIVE_SIDE; // since p0 p1 p2 p3 are non coplanar
+    // and positively oriented
+    Orientation o;
+    if(points[i] == &p3 && (o = orientation(p0,p1,p2,p)) != COPLANAR)
+      return o;
+    if(points[i] == &p2 && (o = orientation(p0,p1,p,p3)) != COPLANAR)
+      return o;
+    if(points[i] == &p1 && (o = orientation(p0,p,p2,p3)) != COPLANAR)
+      return o;
+    if(points[i] == &p0 && (o = orientation(p,p1,p2,p3)) != COPLANAR)
+      return o;
+  }
+
+  CGAL_assertion(false);
+  return ON_NEGATIVE_SIDE;
+}
+
+template < class Gt, class Tds, class Lds >
 Bounded_side
 Delaunay_triangulation_3<Gt,Tds,Default,Lds>::
 coplanar_side_of_bounded_circle(const Point& p0, const Point& p1,
@@ -1516,6 +1619,58 @@ side_of_sphere(Vertex_handle v0, Vertex_handle v1,
 
   return (Bounded_side) side_of_oriented_sphere(v0->point(), v1->point(), v2->point(), v3->point(), p, perturb);
 }
+
+template < class Gt, class Tds, class Lds >
+Bounded_side
+Delaunay_triangulation_3<Gt,Tds,Default,Lds>::
+side_of_sphere(Vertex_handle v0, Vertex_handle v1,
+               Vertex_handle v2, Vertex_handle v3,
+               const Point& p,
+               const std::array<double, 4>& det,
+               bool perturb) const
+{
+  CGAL_precondition(dimension() == 3);
+
+  if(is_infinite(v0))
+  {
+    Orientation o = orientation(v2->point(), v1->point(), v3->point(), p);
+    if(o != COPLANAR)
+      return Bounded_side(o);
+
+    return coplanar_side_of_bounded_circle(v2->point(), v1->point(), v3->point(), p, perturb);
+  }
+
+  if(is_infinite(v1))
+  {
+    Orientation o = orientation(v2->point(), v3->point(), v0->point(), p);
+    if(o != COPLANAR)
+      return Bounded_side(o);
+
+    return coplanar_side_of_bounded_circle(v2->point(), v3->point(), v0->point(), p, perturb);
+  }
+
+  if(is_infinite(v2))
+  {
+    Orientation o = orientation(v1->point(), v0->point(), v3->point(), p);
+    if(o != COPLANAR)
+      return Bounded_side(o);
+
+    return coplanar_side_of_bounded_circle(v1->point(), v0->point(), v3->point(), p, perturb);
+  }
+
+  if(is_infinite(v3))
+  {
+    Orientation o = orientation(v0->point(), v1->point(), v2->point(), p);
+    if(o != COPLANAR)
+      return Bounded_side(o);
+
+    return coplanar_side_of_bounded_circle(v0->point(), v1->point(), v2->point(), p, perturb);
+  }
+
+  return (Bounded_side) side_of_oriented_sphere(v0->point(), v1->point(), v2->point(), v3->point(), p, det, perturb);
+}
+
+
 
 template < class Gt, class Tds, class Lds >
 Bounded_side

--- a/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Delaunay_triangulation_3.h
@@ -1127,25 +1127,6 @@ insert(const Point& p, Locate_type lt, Cell_handle c, int li, int lj, bool *coul
       Conflict_tester_3 tester(p, this);
       Vertex_handle v = insert_in_conflict(p, lt, c, li, lj,
                                            tester, hidden_point_visitor, could_lock_zone);
-
-#ifdef CGAL_DELAUNAY_3_USE_SUBDETERMINANTS
-     std::vector<Cell_handle> cells;
-     cells.reserve(64);
-     this->incident_cells(v, std::back_inserter(cells));
-      for(Cell_handle ch : cells)
-      {
-        if(! is_infinite(ch)){
-           const Point& p0 = ch->vertex(0)->point();
-           const Point& p1 = ch->vertex(1)->point();
-           const Point& p2 = ch->vertex(2)->point();
-           const Point& p3 = ch->vertex(3)->point();
-           subdeterminants(p0.x(), p0.y(), p0.z(),
-                           p1.x(), p1.y(), p1.z(),
-                           p2.x(), p2.y(), p2.z(),
-                           p3.x(), p3.y(), p3.z(), ch->info());
-        }
-      }
-#endif
       return v;
     }// dim 3
     case 2:

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -4017,6 +4017,12 @@ insert_in_conflict(const Point& p,
       // as they will be deleted during the insertion.
       hider.process_cells_in_conflict(cells.begin(), cells.end());
 
+#ifdef CGAL_DELAUNAY_3_USE_SUBDETERMINANTS
+      std::vector<Facet> facets_outside(facets.size());
+      for(int i = 0;  i < facets.size(); ++i){
+        facets_outside[i]= mirror_facet(facets[i]);
+      }
+#endif
       Vertex_handle v =
         tds().is_small_hole(facets.size()) ?
         _insert_in_small_hole(p, cells, facets) :
@@ -4026,6 +4032,26 @@ insert_in_conflict(const Point& p,
 
       // Store the hidden points in their new cells.
       hider.reinsert_vertices(v);
+
+#ifdef CGAL_DELAUNAY_3_USE_SUBDETERMINANTS
+      for(auto f : facets_outside)
+      {
+        Facet mf = mirror_facet(f);
+        Cell_handle ch = mf.first;
+        CGAL_assertion(v == ch->vertex(mf.second));
+        if(! is_infinite(ch)){
+           const Point& p0 = ch->vertex(0)->point();
+           const Point& p1 = ch->vertex(1)->point();
+           const Point& p2 = ch->vertex(2)->point();
+           const Point& p3 = ch->vertex(3)->point();
+           subdeterminants(p0.x(), p0.y(), p0.z(),
+                           p1.x(), p1.y(), p1.z(),
+                           p2.x(), p2.y(), p2.z(),
+                           p3.x(), p3.y(), p3.z(), ch->info());
+        }
+      }
+#endif
+
       return v;
     }
     case 2:

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -4034,6 +4034,17 @@ insert_in_conflict(const Point& p,
       hider.reinsert_vertices(v);
 
 #ifdef CGAL_DELAUNAY_3_USE_SUBDETERMINANTS
+
+      struct Sum {
+        int sum = 0;
+        ~Sum()
+        {
+          std::cout <<  "sum of degrees = "<< sum << std::endl;
+        }
+      };
+      static Sum sum;
+
+      sum.sum += facets_outside.size();
       for(auto f : facets_outside)
       {
         Facet mf = mirror_facet(f);

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -4034,19 +4034,9 @@ insert_in_conflict(const Point& p,
       hider.reinsert_vertices(v);
 
 #ifdef CGAL_DELAUNAY_3_USE_SUBDETERMINANTS
-
-      struct Sum {
-        int sum = 0;
-        ~Sum()
-        {
-          std::cout <<  "sum of degrees = "<< sum << std::endl;
-        }
-      };
-      static Sum sum;
-
-      sum.sum += facets_outside.size();
       for(auto f : facets_outside)
       {
+        CGAL_PROFILER("update of subdeterminants")
         Facet mf = mirror_facet(f);
         Cell_handle ch = mf.first;
         CGAL_assertion(v == ch->vertex(mf.second));

--- a/Triangulation_3/include/CGAL/Triangulation_3.h
+++ b/Triangulation_3/include/CGAL/Triangulation_3.h
@@ -4037,9 +4037,7 @@ insert_in_conflict(const Point& p,
       for(auto f : facets_outside)
       {
         CGAL_PROFILER("update of subdeterminants")
-        Facet mf = mirror_facet(f);
-        Cell_handle ch = mf.first;
-        CGAL_assertion(v == ch->vertex(mf.second));
+        Cell_handle ch = f.first->neighbor(f.second);
         if(! is_infinite(ch)){
            const Point& p0 = ch->vertex(0)->point();
            const Point& p1 = ch->vertex(1)->point();


### PR DESCRIPTION
## Summary of Changes

Following [[Marot &al] ](https://arxiv.org/pdf/1805.08831) we store four sub determinants in each cell to accelerate the _in sphere_ test needed for the Delaunay property.   

This is only a draft pull request as currently I store the four sub determinants as `info()` and the code is in an `#ifdef` macro. We should  test  at compile time for the presence of a member function `sub_determinants()` to conditionally activate code.    

### Todo

- [ ] Nicer design than `#ifdef`
- [ ] We probably need another epsilon for the static filter.
- [ ] Benchmarking
- [ ] See if we can do something better for infinite cells
- [ ] Documentation

## Release Management

* Affected package(s): Triangulation_3
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:  unchanged

