### PR TITLE
Update Orthogonal_cut_plane_traits to works with refine_convex_with_p…

### DIFF
--- a/PMP_Boolean_operations/examples/PMP_Boolean_operations/CMakeLists.txt
+++ b/PMP_Boolean_operations/examples/PMP_Boolean_operations/CMakeLists.txt
@@ -23,6 +23,7 @@ create_single_source_cgal_program("triangle_mesh_autorefinement.cpp")
 create_single_source_cgal_program("snap_polygon_soup.cpp")
 create_single_source_cgal_program("mesh_slicer_example.cpp")
 create_single_source_cgal_program("mesh_kernel_example.cpp")
+create_single_source_cgal_program("mesh_orthogonal_clip_example.cpp")
 
 find_package(Eigen3 QUIET)
 include(CGAL_Eigen3_support)

--- a/PMP_Boolean_operations/examples/PMP_Boolean_operations/mesh_orthogonal_clip_example.cpp
+++ b/PMP_Boolean_operations/examples/PMP_Boolean_operations/mesh_orthogonal_clip_example.cpp
@@ -1,0 +1,40 @@
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+
+#include <CGAL/Polygon_mesh_processing/clip.h>
+
+#include <CGAL/Real_timer.h>
+
+using K = CGAL::Exact_predicates_inexact_constructions_kernel;
+using Mesh = CGAL::Surface_mesh<K::Point_3>;
+
+namespace PMP = CGAL::Polygon_mesh_processing;
+
+int main(int argc, char** argv)
+{
+  const std::string fname = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/blobby.off");
+  const std::string oname = (argc > 2) ? argv[2] : "clipped.off";
+
+  Mesh m;
+  if (!CGAL::IO::read_polygon_mesh(fname, m) || is_empty(m))
+  {
+    std::cerr << "ERROR: cannot read " << fname << "\n";
+    return EXIT_FAILURE;
+  }
+
+  CGAL::Real_timer timer;
+  timer.start();
+
+  PMP::Orthogonal_cut_plane_traits<K> cut_traits;
+  PMP::Orthogonal_cut_plane_traits<K>::Plane_3 pl(0, 0);
+  PMP::clip(m, pl, CGAL::parameters::geom_traits(cut_traits));
+
+  timer.stop();
+
+  std::cout << "Clip computation of " << fname << " done in " << timer.time() << std::endl;
+  std::cout << "Output containing " << vertices(m).size() << " vertices wrote in " << oname << std::endl;
+
+  CGAL::IO::write_polygon_mesh("kernel.off", m, CGAL::parameters::stream_precision(17));
+
+  return EXIT_SUCCESS;
+}

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
@@ -56,9 +56,6 @@ find_crossing_edge(PolygonMesh& pm,
   using GT = typename GetGeomTraits<PolygonMesh, NamedParameters>::type;
   GT traits = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
 
-  using FT = typename GT::FT;
-  using Plane_3 = typename GT::Plane_3;
-  using Point_3 = typename GT::Point_3;
   using Direction_3 = typename GT::Direction_3;
 
   auto vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/clip_convex.h
@@ -59,44 +59,37 @@ find_crossing_edge(PolygonMesh& pm,
   using FT = typename GT::FT;
   using Plane_3 = typename GT::Plane_3;
   using Point_3 = typename GT::Point_3;
+  using Direction_3 = typename GT::Direction_3;
 
   auto vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                               get_property_map(vertex_point, pm));
 
   auto oriented_side = traits.oriented_side_3_object();
   auto normal = traits.construct_orthogonal_vector_3_object();
-  auto vector = traits.construct_vector_3_object();
-  auto point_on = traits.construct_point_on_3_object();
-  auto dot = traits.compute_scalar_product_3_object();
-  auto sq = [&](const Plane_3& pl, const Point_3& p){
-    return dot(vector(point_on(pl), p), normal(pl));
-  };
+  auto direction = traits.construct_direction_3_object();
+  auto cpad = traits.compare_projection_along_direction_3_object();
+  Direction_3 dir = direction(normal(plane));
 
   // ____________________ Find a crossing edge _____________________
 
   vertex_descriptor start = choose_parameter(get_parameter(np, internal_np::starting_vertex_descriptor), *vertices(pm).begin());
   vertex_descriptor src = start;
-  FT sp_src = sq(plane, get(vpm, src));
-  Sign direction_to_zero = sign(sp_src);
-
   vertex_descriptor trg;
-  FT sp_trg;
+  Orientation direction_to_zero = oriented_side(plane, get(vpm, src));
 
   bool is_crossing_edge=false;
   if(direction_to_zero!=EQUAL){
     do{
       bool is_local_max=true;
       for(auto v: vertices_around_target(src ,pm)){
-        sp_trg = sq(plane, get(vpm, v));
         // Check if v in the direction to the plane
-        if(compare(sp_src, sp_trg)==direction_to_zero){
-          if(sign(sp_trg)!=direction_to_zero){
+        if(cpad(get(vpm, src), get(vpm, v), dir) == direction_to_zero){
+          if(oriented_side(plane, get(vpm, v))!= direction_to_zero){
             // Fund a crossing edge
             trg = v;
             is_crossing_edge=true;
           } else {
             // Continue from v
-            sp_src = sp_trg;
             src = v;
           }
           is_local_max=false; // repeat with the new vertex
@@ -113,17 +106,15 @@ find_crossing_edge(PolygonMesh& pm,
   } else {
     // src on the plane
     trg=src;
-    sp_trg = sp_src;
   }
 
-  if(sign(sp_trg)==EQUAL && direction_to_zero!=POSITIVE){
+  if(oriented_side(plane, get(vpm, trg))==EQUAL && direction_to_zero!=POSITIVE){
     // Search a vertex around trg coming from positive side
     bool no_positive_side = true;
     for(auto v: vertices_around_target(trg ,pm)){
       Oriented_side side_v = oriented_side(plane, get(vpm, v));
       if(side_v==ON_POSITIVE_SIDE){
         src = v;
-        sp_src = sq(plane, get(vpm, src));
         no_positive_side = false;
         break;
       }

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/refine_with_plane.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/refine_with_plane.h
@@ -82,6 +82,7 @@ struct Orthogonal_cut_plane_traits
   using FT = typename Kernel::FT;
   using Plane_3 = std::pair<int, FT>;
   using Point_3 = typename Kernel::Point_3;
+  using Vector_3 = typename Kernel::Vector_3;
 
   struct Does_not_support_CDT2{};
 
@@ -123,20 +124,46 @@ struct Orthogonal_cut_plane_traits
     }
   };
 
-  Oriented_side_3 oriented_side_3_object() const
+  struct Construct_point_on_3
   {
-    return Oriented_side_3();
-  }
+    Point_3 operator()(const Plane_3 &plane)
+    {
+      switch(plane.first){
+        case 0:
+          return Point_3(plane.second,0,0);
+        case 1:
+          return Point_3(0,plane.second,0);
+        default:
+          return Point_3(0,0,plane.second);
+      }
+    }
+  };
 
-  Construct_plane_line_intersection_point_3 construct_plane_line_intersection_point_3_object() const
+  struct Construct_orthogonal_vector_3
   {
-    return Construct_plane_line_intersection_point_3();
-  }
+    Vector_3 operator()(const Plane_3 &plane)
+    {
+      switch(plane.first){
+        case 0:
+          return Vector_3(1,0,0);
+        case 1:
+          return Vector_3(0,1,0);
+        default:
+          return Vector_3(0,0,1);
+      }
+    }
+  };
 
-  Compute_squared_distance_3 compute_squared_distance_3_object() const
-  {
-    return Compute_squared_distance_3();
-  }
+  using Construct_vector_3 = typename Kernel::Construct_vector_3;
+  using Compute_scalar_product_3 = typename Kernel::Compute_scalar_product_3;
+
+  Oriented_side_3 oriented_side_3_object() const { return Oriented_side_3(); }
+  Construct_plane_line_intersection_point_3 construct_plane_line_intersection_point_3_object() const { return Construct_plane_line_intersection_point_3(); }
+  Compute_squared_distance_3 compute_squared_distance_3_object() const { return Compute_squared_distance_3(); }
+  Construct_orthogonal_vector_3 construct_orthogonal_vector_3_object() const { return Construct_orthogonal_vector_3(); }
+  Construct_point_on_3 construct_point_on_3_object() const { return Construct_point_on_3(); }
+  Construct_vector_3 construct_vector_3_object() const { return Construct_vector_3(); }
+  Compute_scalar_product_3 compute_scalar_product_3_object() const { return Compute_scalar_product_3(); }
 
 #ifndef CGAL_PLANE_CLIP_DO_NOT_USE_BOX_INTERSECTION_D
 // for does self-intersect

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/refine_with_plane.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/refine_with_plane.h
@@ -126,21 +126,6 @@ struct Orthogonal_cut_plane_traits
     }
   };
 
-  struct Construct_point_on_3
-  {
-    Point_3 operator()(const Plane_3 &plane)
-    {
-      switch(plane.first){
-        case 0:
-          return Point_3(plane.second,0,0);
-        case 1:
-          return Point_3(0,plane.second,0);
-        default:
-          return Point_3(0,0,plane.second);
-      }
-    }
-  };
-
   struct Construct_orthogonal_vector_3
   {
     Vector_3 operator()(const Plane_3 &plane){ return plane.first; }
@@ -163,7 +148,6 @@ struct Orthogonal_cut_plane_traits
   Compute_squared_distance_3 compute_squared_distance_3_object() const { return Compute_squared_distance_3(); }
   Construct_orthogonal_vector_3 construct_orthogonal_vector_3_object() const { return Construct_orthogonal_vector_3(); }
   Construct_direction_3 construct_direction_3_object() const { return Construct_direction_3(); }
-  Construct_point_on_3 construct_point_on_3_object() const { return Construct_point_on_3(); }
   Compare_projection_along_direction_3 compare_projection_along_direction_3_object() const { return Compare_projection_along_direction_3(); }
 
 #ifndef CGAL_PLANE_CLIP_DO_NOT_USE_BOX_INTERSECTION_D

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/refine_with_plane.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/refine_with_plane.h
@@ -82,7 +82,9 @@ struct Orthogonal_cut_plane_traits
   using FT = typename Kernel::FT;
   using Plane_3 = std::pair<int, FT>;
   using Point_3 = typename Kernel::Point_3;
-  using Vector_3 = typename Kernel::Vector_3;
+  using Vector_3 = int;
+  using Direction_3 = int;
+  using Comparison_result =typename Kernel::Comparison_result;
 
   struct Does_not_support_CDT2{};
 
@@ -141,29 +143,28 @@ struct Orthogonal_cut_plane_traits
 
   struct Construct_orthogonal_vector_3
   {
-    Vector_3 operator()(const Plane_3 &plane)
-    {
-      switch(plane.first){
-        case 0:
-          return Vector_3(1,0,0);
-        case 1:
-          return Vector_3(0,1,0);
-        default:
-          return Vector_3(0,0,1);
-      }
-    }
+    Vector_3 operator()(const Plane_3 &plane){ return plane.first; }
   };
 
-  using Construct_vector_3 = typename Kernel::Construct_vector_3;
-  using Compute_scalar_product_3 = typename Kernel::Compute_scalar_product_3;
+  struct Construct_direction_3
+  {
+    Direction_3 operator()(const Vector_3 &vec){ return vec; }
+  };
+
+  struct Compare_projection_along_direction_3
+  {
+    Comparison_result operator()(const Point_3 &p, const Point_3 &q, const Direction_3 &dir){
+      return compare(p[dir], q[dir]);
+    }
+  };
 
   Oriented_side_3 oriented_side_3_object() const { return Oriented_side_3(); }
   Construct_plane_line_intersection_point_3 construct_plane_line_intersection_point_3_object() const { return Construct_plane_line_intersection_point_3(); }
   Compute_squared_distance_3 compute_squared_distance_3_object() const { return Compute_squared_distance_3(); }
   Construct_orthogonal_vector_3 construct_orthogonal_vector_3_object() const { return Construct_orthogonal_vector_3(); }
+  Construct_direction_3 construct_direction_3_object() const { return Construct_direction_3(); }
   Construct_point_on_3 construct_point_on_3_object() const { return Construct_point_on_3(); }
-  Construct_vector_3 construct_vector_3_object() const { return Construct_vector_3(); }
-  Compute_scalar_product_3 compute_scalar_product_3_object() const { return Compute_scalar_product_3(); }
+  Compare_projection_along_direction_3 compare_projection_along_direction_3_object() const { return Compare_projection_along_direction_3(); }
 
 #ifndef CGAL_PLANE_CLIP_DO_NOT_USE_BOX_INTERSECTION_D
 // for does self-intersect

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Three_point_cut_plane_traits.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/internal/Three_point_cut_plane_traits.h
@@ -28,6 +28,7 @@ struct Three_point_cut_plane_traits
   using FT = typename Kernel::FT;
   using Point_3 = typename Kernel::Point_3;
   using Vector_3 = typename Kernel::Vector_3;
+  using Direction_3 = typename Kernel::Direction_3;
 
   struct Plane_3: public std::array<typename Kernel::Point_3, 3>{
     using Base = std::array<typename Kernel::Point_3, 3>;
@@ -80,9 +81,13 @@ struct Three_point_cut_plane_traits
 
   using Compute_scalar_product_3 = typename Kernel::Compute_scalar_product_3;
   using Construct_vector_3 = typename Kernel::Construct_vector_3;
+  using Construct_direction_3 = typename Kernel::Construct_direction_3;
+  using Compare_projection_along_direction_3 = typename Kernel::Compare_projection_along_direction_3;
 
   Compute_scalar_product_3 compute_scalar_product_3_object(){ return Kernel().compute_scalar_product_3_object(); }
   Construct_vector_3 construct_vector_3_object(){ return Kernel().construct_vector_3_object(); }
+  Construct_direction_3 construct_direction_3_object(){ return Kernel().construct_direction_3_object(); }
+  Compare_projection_along_direction_3 compare_projection_along_direction_3_object(){ return Kernel().compare_projection_along_direction_3_object(); }
 
 #ifndef CGAL_PLANE_CLIP_DO_NOT_USE_BOX_INTERSECTION_D
 // for does self-intersect


### PR DESCRIPTION
## Summary of Changes
Orthogonal_cut_plane_traits does not contain some functors required by refine_convex_with_planes, we add these functors.
No API Changed

## Release Management

* Affected package(s): PMP_bool_ops
* Issue(s) solved (if any):
* Feature/Small Feature (if any): 
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: GF

