### PR TITLE
CGAL/SMDS_3/tet_soup_to_c3t3.h: Skip comments

### DIFF
--- a/SMDS_3/include/CGAL/SMDS_3/tet_soup_to_c3t3.h
+++ b/SMDS_3/include/CGAL/SMDS_3/tet_soup_to_c3t3.h
@@ -602,15 +602,32 @@ bool build_triangulation_from_file(std::istream& is,
   {
     // remove trailing whitespace, in particular a possible '\r' from Windows
     // end-of-line encoding
-    if(!line.empty() && std::isspace(line.back())) {
+    while(!line.empty() && std::isspace(line.back())) {
       line.pop_back();
     }
-    if (line.size() > 0 && line.at(0) == '#' &&
+    if(line.empty())
+      continue;
+
+    // remove whitespaces at the beginning of the line
+    for (std::size_t i=0; i<line.size(); ++i)
+    {
+      if (!std::isspace(line[i]))
+      {
+        if (i!=0)
+          line = line.substr(i);
+        break;
+      }
+    }
+
+    if (line.at(0) == '#' &&
         line.find("CGAL::Mesh_complex_3_in_triangulation_3") != std::string::npos)
     {
       is_CGAL_mesh = true; // with CGAL meshes, domain 0 should be kept
       continue;
     }
+
+    // skip non-CGAL comments
+    if (line.at(0)=='#') continue;
 
     if(line.find("Vertices") != std::string::npos)
     {


### PR DESCRIPTION
if comments are not skipped, `# Vertices`, `# Triangles`, ... would make the reading to fail.