### PR TITLE
Various improvements for tet soup to triangulations

### DIFF
--- a/SMDS_3/doc/SMDS_3/PackageDescription.txt
+++ b/SMDS_3/doc/SMDS_3/PackageDescription.txt
@@ -63,6 +63,7 @@
 \cgalCRPSection{Function Templates}
 
 - `CGAL::facets_in_complex_3_to_triangle_mesh()`
+- `CGAL::is_tetrahedron_soup_a_triangulation()`
 - `CGAL::tetrahedron_soup_to_triangulation_3()`
 
 \cgalCRPSection{Input/Output Functions}

--- a/SMDS_3/include/CGAL/SMDS_3/internal/SMDS_3_helper.h
+++ b/SMDS_3/include/CGAL/SMDS_3/internal/SMDS_3_helper.h
@@ -29,6 +29,8 @@ namespace internal {
   {
     typedef typename Triangulation::Vertex_handle        Vertex_handle;
     typedef typename Triangulation::Cell_handle          Cell_handle;
+    CGAL_postcondition(tr.is_valid());
+
     typedef typename Triangulation::Geom_traits::Point_3 Point_3;
     typename Triangulation::Geom_traits::Construct_point_3 cp
       = tr.geom_traits().construct_point_3_object();
@@ -37,6 +39,10 @@ namespace internal {
 
     std::vector<Cell_handle> infcells;
     tr.incident_cells(tr.infinite_vertex(), std::back_inserter(infcells));
+
+    std::vector<Vertex_handle> bvertices;
+    tr.adjacent_vertices(tr.infinite_vertex(), std::back_inserter(bvertices));
+
     for (Cell_handle c : infcells)
     {
       const Cell_handle neigh = c->neighbor(c->index(tr.infinite_vertex()));
@@ -48,7 +54,7 @@ namespace internal {
       const CGAL::Orientation o = orientation(
           pfacet[0], pfacet[1], pfacet[2], cp(neigh->vertex(i)->point()));
 
-      for (Vertex_handle v : tr.finite_vertex_handles())
+      for (Vertex_handle v : bvertices)
       {
         if (c->has_vertex(v))
           continue;

--- a/SMDS_3/include/CGAL/SMDS_3/tet_soup_to_c3t3.h
+++ b/SMDS_3/include/CGAL/SMDS_3/tet_soup_to_c3t3.h
@@ -439,7 +439,9 @@ bool build_triangulation_impl(Tr& tr,
     vh->set_dimension(-1);
 
   if(verbose)
+  {
     std::cout << "build vertices done (" << tr.tds().number_of_vertices() << " vertices)" << std::endl;
+  }
 
   if (!finite_cells.empty())
   {
@@ -471,6 +473,11 @@ bool build_triangulation_impl(Tr& tr,
     {
       if (vit->cell() == Cell_handle())
         tr.tds().delete_vertex(vit);
+    }
+
+    if(verbose)
+    {
+      std::cout << "vertices after purge: " << tr.tds().number_of_vertices() << std::endl;
     }
 
     tr.tds().set_dimension(3);

--- a/SMDS_3/include/CGAL/SMDS_3/tet_soup_to_c3t3.h
+++ b/SMDS_3/include/CGAL/SMDS_3/tet_soup_to_c3t3.h
@@ -466,6 +466,13 @@ bool build_triangulation_impl(Tr& tr,
       std::cout << "build infinite cells done (" << tr.tds().cells().size() << " cells)" << std::endl;
     }
 
+    // purge vertices which have no incident cell (unused points in the initial range)
+    for (auto vit = tr.finite_vertices_begin(), end = tr.finite_vertices_end(); vit != end; ++vit)
+    {
+      if (vit->cell() == Cell_handle())
+        tr.tds().delete_vertex(vit);
+    }
+
     tr.tds().set_dimension(3);
 
     if (!CGAL::SMDS_3::assign_neighbors<Tr>(tr, incident_cells_map, allow_non_manifold))

--- a/SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h
+++ b/SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h
@@ -316,7 +316,7 @@ namespace CGAL {
   *
   * @returns the 3D triangulation built from \p tets
   *
-  * @post the output triangulation must be a triangulation of the convex hull of `tets`
+  * @pre the tetrahedron soup must form a partition of the convex hull of `tets`
   *
   * @sa @ref SMDS_3/tetrahedron_soup_to_c3t3_example.cpp
   *
@@ -431,7 +431,7 @@ namespace CGAL {
   * @returns the 3D triangulation built from parameters
   *
   * @pre `points` contains each point only once
-  * @post the output triangulation must be a triangulation of the convex hull of `points`
+  * @pre the tetrahedron soup must form a partition of the convex hull of `tets`
   * @post `is_valid()` returns `true` for the returned triangulation
   *
   * @sa \link Polygon_mesh_processing::polygon_soup_to_polygon_mesh() `CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh()` \endlink

--- a/SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h
+++ b/SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h
@@ -24,6 +24,7 @@
 #include <CGAL/SMDS_3/internal/SMDS_3_helper.h>
 #include <CGAL/Named_function_parameters.h>
 #include <CGAL/boost/graph/named_params_helper.h>
+#include <CGAL/unordered_flat_map.h>
 
 #include <boost/unordered_map.hpp>
 #include <boost/container/flat_set.hpp>
@@ -68,69 +69,69 @@ namespace CGAL {
 
     const bool verbose = choose_parameter(get_parameter(np, internal_np::verbose), false);
 
-    if(std::begin(tets) == std::end(tets))
+    if (std::begin(tets) == std::end(tets))
       return true;
 
     // check that no tetrahedron has twice the same vertex
     // and build mapping of facets to incident cells
     V_ID max_id = 0;
 
-    typedef std::array<V_ID, 3> Facet_vvv;
+    typedef std::array<V_ID, 3> F_ID;
     typedef std::vector<std::size_t> Incident_tet_indices;
-    typedef boost::unordered_map<Facet_vvv, Incident_tet_indices> Incident_cells_map;
+    typedef boost::unordered_map<F_ID, Incident_tet_indices> Incident_cells_map;
     Incident_cells_map incident_cells_map;
 
-    for(std::size_t tet_idx = 0; tet_idx < tets.size(); ++tet_idx)
+    for (std::size_t tet_idx = 0; tet_idx < tets.size(); ++tet_idx)
     {
       const Tetrahedron& tet = tets[tet_idx];
 
-      if(tet.size() != 4) {
-        if (verbose) {
+      if (tet.size() != 4)
+      {
+        if (verbose)
           std::cerr << "Tetrahedron #" << tet_idx << " has " << tet.size() << " vertices" << std::endl;
-        }
         return false;
       }
 
       boost::container::flat_set<V_ID> tet_vertices;
       std::vector<V_ID> tet_vertices_vec;
 
-      for(V_ID id : tet)
+      for (V_ID id : tet)
       {
-        if(max_id < id)
+        if (max_id < id)
           max_id = id;
 
-        if(!tet_vertices.insert(id).second) {
-          if (verbose) {
+        if (!tet_vertices.insert(id).second)
+        {
+          if (verbose)
             std::cerr << "Tetrahedron #" << tet_idx << " has duplicate vertex " << id << std::endl;
-          }
           return false; // vertex met twice in the same tetrahedron
         }
 
         tet_vertices_vec.push_back(id);
       }
 
-      for(int i=0; i<4; ++i)
+      for (int i=0; i<4; ++i)
       {
-        Facet_vvv facet;
+        F_ID facet;
         int idx = 0;
-        for(int j = 0; j < 4; ++j)
+        for (int j=0; j<4; ++j)
         {
-          if(i != j)
+          if (i != j)
             facet[idx++] = tet_vertices_vec[j];
         }
 
         // Sort the facet vertices to create a canonical ordering
-        if(facet[1] < facet[0]) std::swap(facet[0], facet[1]);
-        if(facet[2] < facet[1]) std::swap(facet[1], facet[2]);
-        if(facet[1] < facet[0]) std::swap(facet[0], facet[1]);
+        if (facet[1] < facet[0]) std::swap(facet[0], facet[1]);
+        if (facet[2] < facet[1]) std::swap(facet[1], facet[2]);
+        if (facet[1] < facet[0]) std::swap(facet[0], facet[1]);
 
         incident_cells_map[facet].push_back(tet_idx);
 
         // check that each facet has at most two incident cells
-        if(incident_cells_map[facet].size() > 2) {
-          if (verbose) {
+        if (incident_cells_map[facet].size() > 2)
+        {
+          if (verbose)
             std::cerr << "Facet with > 2 incident cells" << std::endl;
-          }
           return false;
         }
       }
@@ -140,10 +141,10 @@ namespace CGAL {
     // Build adjacency graph: two tetrahedra are adjacent if they share a facet
     std::vector<std::vector<std::size_t> > tet_adjacency(tets.size());
 
-    for(const auto& facet_and_incident : incident_cells_map)
+    for (const auto& facet_and_incident : incident_cells_map)
     {
       const Incident_tet_indices& incident = facet_and_incident.second;
-      if(incident.size() == 2)
+      if (incident.size() == 2)
       {
         std::size_t tet1 = incident[0];
         std::size_t tet2 = incident[1];
@@ -153,7 +154,7 @@ namespace CGAL {
     }
 
     // Check connectivity via BFS
-    if(tets.size() > 0)
+    if (tets.size() > 0)
     {
       std::vector<bool> visited(tets.size(), false);
       std::queue<std::size_t> q;
@@ -161,27 +162,26 @@ namespace CGAL {
       visited[0] = true;
       std::size_t component_size = 1;
 
-      while(!q.empty())
+      while (!q.empty())
       {
         std::size_t current = q.front();
         q.pop();
 
-        for(std::size_t neighbor : tet_adjacency[current])
+        for (std::size_t neighbor : tet_adjacency[current])
         {
-          if(!visited[neighbor])
+          if (!visited[neighbor])
           {
             visited[neighbor] = true;
             q.push(neighbor);
-            component_size++;
+            ++component_size;
           }
         }
       }
 
-      if(component_size != tets.size())
+      if (component_size != tets.size())
       {
-        if (verbose) {
+        if (verbose)
           std::cerr << component_size << " volume connected components" << std::endl;
-        }
         return false;
       }
     }
@@ -195,21 +195,20 @@ namespace CGAL {
     Vertex_to_tets_map vertex_to_tets;
     Edge_to_tets_map edge_to_tets;
 
-    // Build vertex-to-tetrahedra and edge-to-tetrahedra maps
-    for(std::size_t tet_idx=0; tet_idx<tets.size(); ++tet_idx)
+    for (std::size_t tet_idx = 0; tet_idx < tets.size(); ++tet_idx)
     {
       const Tetrahedron& tet = tets[tet_idx];
 
-      for(V_ID v : tet)
+      for (V_ID v : tet)
         vertex_to_tets[v].push_back(tet_idx);
 
-      for(int i=0; i<4; ++i)
+      for (int i = 0; i < 4; ++i)
       {
-        for(int j=i+1; j<4; ++j)
+        for (int j = i+1; j < 4; ++j)
         {
           V_ID v1 = tet[i];
           V_ID v2 = tet[j];
-          if(v1 > v2)
+          if (v1 > v2)
             std::swap(v1, v2);
           edge_to_tets[std::make_pair(v1, v2)].push_back(tet_idx);
         }
@@ -217,7 +216,7 @@ namespace CGAL {
     }
 
     // Check that around each vertex, tetrahedra form a single connected component
-    for(const auto& v_and_tets : vertex_to_tets)
+    for (const auto& v_and_tets : vertex_to_tets)
     {
       const std::vector<std::size_t>& inc_tets = v_and_tets.second;
       CGAL_assertion(inc_tets.size() != 0);
@@ -229,15 +228,15 @@ namespace CGAL {
       local_q.push(seed);
       remaining.erase(seed);
 
-      while(!local_q.empty())
+      while (!local_q.empty())
       {
         std::size_t current = local_q.front();
         local_q.pop();
 
-        for(std::size_t neighbor : tet_adjacency[current])
+        for (std::size_t neighbor : tet_adjacency[current])
         {
           auto it = remaining.find(neighbor);
-          if(it != remaining.end())
+          if (it != remaining.end())
           {
             local_q.push(neighbor);
             remaining.erase(it);
@@ -245,20 +244,19 @@ namespace CGAL {
         }
       }
 
-      if(!remaining.empty())
+      if (!remaining.empty())
       {
-        if (verbose) {
-          std::cerr << "more than one CC around vertex" << std::endl;
-        }
+        if (verbose)
+          std::cerr << "More than one CC around vertex" << std::endl;
         return false;
       }
     }
 
     // Check that around each edge, tetrahedra form a single connected component
-    for(const auto& e_and_tets : edge_to_tets)
+    for (const auto& e_and_tets : edge_to_tets)
     {
       const std::vector<std::size_t>& inc_tets = e_and_tets.second;
-      if(inc_tets.size() == 0)
+      if (inc_tets.size() == 0)
         continue;
 
       std::set<std::size_t> remaining(inc_tets.begin(), inc_tets.end());
@@ -268,15 +266,15 @@ namespace CGAL {
       local_q.push(seed);
       remaining.erase(seed);
 
-      while(!local_q.empty())
+      while (!local_q.empty())
       {
         std::size_t current = local_q.front();
         local_q.pop();
 
-        for(std::size_t neighbor : tet_adjacency[current])
+        for (std::size_t neighbor : tet_adjacency[current])
         {
           auto it = remaining.find(neighbor);
-          if(it != remaining.end())
+          if (it != remaining.end())
           {
             local_q.push(neighbor);
             remaining.erase(it);
@@ -284,18 +282,16 @@ namespace CGAL {
         }
       }
 
-      if(!remaining.empty())
+      if (!remaining.empty())
       {
-        if (verbose) {
-          std::cerr << "more than one CC around edge" << std::endl;
-        }
+        if (verbose)
+          std::cerr << "More than one CC around edge" << std::endl;
         return false;
       }
     }
 
-    if (verbose) {
+    if (verbose)
       std::cout << "Tetrahedron soup is a valid triangulation" << std::endl;
-    }
 
     return true;
   }
@@ -476,19 +472,24 @@ namespace CGAL {
     Subdomains_ref_type subdomains = choose_parameter(
           get_parameter_reference(np, internal_np::subdomain_indices),
           subdomain_indices);
-    const bool non_manifold = choose_parameter(
+    const bool allow_non_manifold = choose_parameter(
           get_parameter(np, internal_np::allow_non_manifold),
           false);
+    const bool verbose = choose_parameter(get_parameter(np, internal_np::verbose), false);
 
-    CGAL::SMDS_3::build_triangulation_with_subdomains_range(tr, points, tets, subdomains, facets,
-      /*verbose = */false, /*replace_domain_0 = */false, non_manifold);
+    CGAL_precondition_code(if (!allow_non_manifold))
+    CGAL_precondition(is_tetrahedron_soup_a_triangulation(tets, CGAL::parameters::verbose(verbose)));
 
-    CGAL_assertion(CGAL::SMDS_3::internal::is_convex(tr));
+    SMDS_3::build_triangulation_with_subdomains_range(tr, points, tets, subdomains, facets,
+      verbose, /*replace_domain_0 = */false, allow_non_manifold);
+
+    CGAL_postcondition_code(if (!allow_non_manifold))
+    CGAL_postcondition(CGAL::SMDS_3::internal::is_convex(tr));
 
     return tr;
   }
 
-} //namespace CGAL
+} // namespace CGAL
 
 
 #endif // CGAL_SMDS_3_TETRAHEDRON_SOUP_TO_C3T3_H

--- a/SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h
+++ b/SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h
@@ -51,9 +51,19 @@ namespace CGAL {
   * @tparam TetrahedronRange a model of the concept `RandomAccessContainer`
   * whose `value_type` is a model of the concept `RandomAccessContainer`
   * whose `value_type` is `std::size_t`.
+  * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
   *
   * @param tets each element in the range describes a tetrahedron
   * using the indices of the vertices.
+  * @param np an optional sequence of \ref bgl_namedparameters "Named Parameters" among the ones listed below
+  *
+  * \cgalNamedParamsBegin
+  *   \cgalParamNBegin{verbose}
+  *     \cgalParamDescription{if `true`, the function prints messages about the checks it performs}
+  *     \cgalParamType{Boolean}
+  *     \cgalParamDefault{`false`}
+  *   \cgalParamNEnd
+  * \cgalNamedParamsEnd
   */
   template <typename TetrahedronRange,
             typename NamedParameters = parameters::Default_named_parameters>

--- a/SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h
+++ b/SMDS_3/include/CGAL/tetrahedron_soup_to_triangulation_3.h
@@ -25,11 +25,280 @@
 #include <CGAL/Named_function_parameters.h>
 #include <CGAL/boost/graph/named_params_helper.h>
 
-#include <vector>
-#include <array>
 #include <boost/unordered_map.hpp>
+#include <boost/container/flat_set.hpp>
+
+#include <array>
+#include <queue>
+#include <set>
+#include <vector>
 
 namespace CGAL {
+
+  /**
+  * \ingroup PkgSMDS3Functions
+  *
+  * \brief returns `true` if the soup of tetrahedra defines a valid triangulation
+  * that can be handled by `tetrahedron_soup_to_triangulation_3()`.
+  *
+  * It checks that each facet has at most two incident cells,
+  * no tetrahedron has twice the same vertex,
+  * and the tetrahedron soup describes a manifold volume.
+  * This function does not require a range of points as an argument
+  * since the check is purely topological.
+  *
+  * @tparam TetrahedronRange a model of the concept `RandomAccessContainer`
+  * whose `value_type` is a model of the concept `RandomAccessContainer`
+  * whose `value_type` is `std::size_t`.
+  *
+  * @param tets each element in the range describes a tetrahedron
+  * using the indices of the vertices.
+  */
+  template <typename TetrahedronRange,
+            typename NamedParameters = parameters::Default_named_parameters>
+  bool is_tetrahedron_soup_a_triangulation(const TetrahedronRange& tets,
+                                           const NamedParameters& np = parameters::default_values())
+  {
+    using parameters::choose_parameter;
+    using parameters::is_default_parameter;
+    using parameters::get_parameter;
+
+    typedef typename boost::range_value<TetrahedronRange>::type           Tetrahedron;
+    typedef typename boost::range_value<Tetrahedron>::type                V_ID;
+
+    const bool verbose = choose_parameter(get_parameter(np, internal_np::verbose), false);
+
+    if(std::begin(tets) == std::end(tets))
+      return true;
+
+    // check that no tetrahedron has twice the same vertex
+    // and build mapping of facets to incident cells
+    V_ID max_id = 0;
+
+    typedef std::array<V_ID, 3> Facet_vvv;
+    typedef std::vector<std::size_t> Incident_tet_indices;
+    typedef boost::unordered_map<Facet_vvv, Incident_tet_indices> Incident_cells_map;
+    Incident_cells_map incident_cells_map;
+
+    for(std::size_t tet_idx = 0; tet_idx < tets.size(); ++tet_idx)
+    {
+      const Tetrahedron& tet = tets[tet_idx];
+
+      if(tet.size() != 4) {
+        if (verbose) {
+          std::cerr << "Tetrahedron #" << tet_idx << " has " << tet.size() << " vertices" << std::endl;
+        }
+        return false;
+      }
+
+      boost::container::flat_set<V_ID> tet_vertices;
+      std::vector<V_ID> tet_vertices_vec;
+
+      for(V_ID id : tet)
+      {
+        if(max_id < id)
+          max_id = id;
+
+        if(!tet_vertices.insert(id).second) {
+          if (verbose) {
+            std::cerr << "Tetrahedron #" << tet_idx << " has duplicate vertex " << id << std::endl;
+          }
+          return false; // vertex met twice in the same tetrahedron
+        }
+
+        tet_vertices_vec.push_back(id);
+      }
+
+      for(int i=0; i<4; ++i)
+      {
+        Facet_vvv facet;
+        int idx = 0;
+        for(int j = 0; j < 4; ++j)
+        {
+          if(i != j)
+            facet[idx++] = tet_vertices_vec[j];
+        }
+
+        // Sort the facet vertices to create a canonical ordering
+        if(facet[1] < facet[0]) std::swap(facet[0], facet[1]);
+        if(facet[2] < facet[1]) std::swap(facet[1], facet[2]);
+        if(facet[1] < facet[0]) std::swap(facet[0], facet[1]);
+
+        incident_cells_map[facet].push_back(tet_idx);
+
+        // check that each facet has at most two incident cells
+        if(incident_cells_map[facet].size() > 2) {
+          if (verbose) {
+            std::cerr << "Facet with > 2 incident cells" << std::endl;
+          }
+          return false;
+        }
+      }
+    }
+
+    // check that there is only a single connected component of tetrahedra
+    // Build adjacency graph: two tetrahedra are adjacent if they share a facet
+    std::vector<std::vector<std::size_t> > tet_adjacency(tets.size());
+
+    for(const auto& facet_and_incident : incident_cells_map)
+    {
+      const Incident_tet_indices& incident = facet_and_incident.second;
+      if(incident.size() == 2)
+      {
+        std::size_t tet1 = incident[0];
+        std::size_t tet2 = incident[1];
+        tet_adjacency[tet1].push_back(tet2);
+        tet_adjacency[tet2].push_back(tet1);
+      }
+    }
+
+    // Check connectivity via BFS
+    if(tets.size() > 0)
+    {
+      std::vector<bool> visited(tets.size(), false);
+      std::queue<std::size_t> q;
+      q.push(0);
+      visited[0] = true;
+      std::size_t component_size = 1;
+
+      while(!q.empty())
+      {
+        std::size_t current = q.front();
+        q.pop();
+
+        for(std::size_t neighbor : tet_adjacency[current])
+        {
+          if(!visited[neighbor])
+          {
+            visited[neighbor] = true;
+            q.push(neighbor);
+            component_size++;
+          }
+        }
+      }
+
+      if(component_size != tets.size())
+      {
+        if (verbose) {
+          std::cerr << component_size << " volume connected components" << std::endl;
+        }
+        return false;
+      }
+    }
+
+    // check that there is only a single volume connected component of tetrahedra around each vertex
+    // and around each edge
+    typedef std::pair<V_ID, V_ID> E_ID;
+    typedef std::map<V_ID, std::vector<std::size_t> > Vertex_to_tets_map;
+    typedef std::map<E_ID, std::vector<std::size_t> > Edge_to_tets_map;
+
+    Vertex_to_tets_map vertex_to_tets;
+    Edge_to_tets_map edge_to_tets;
+
+    // Build vertex-to-tetrahedra and edge-to-tetrahedra maps
+    for(std::size_t tet_idx=0; tet_idx<tets.size(); ++tet_idx)
+    {
+      const Tetrahedron& tet = tets[tet_idx];
+
+      for(V_ID v : tet)
+        vertex_to_tets[v].push_back(tet_idx);
+
+      for(int i=0; i<4; ++i)
+      {
+        for(int j=i+1; j<4; ++j)
+        {
+          V_ID v1 = tet[i];
+          V_ID v2 = tet[j];
+          if(v1 > v2)
+            std::swap(v1, v2);
+          edge_to_tets[std::make_pair(v1, v2)].push_back(tet_idx);
+        }
+      }
+    }
+
+    // Check that around each vertex, tetrahedra form a single connected component
+    for(const auto& v_and_tets : vertex_to_tets)
+    {
+      const std::vector<std::size_t>& inc_tets = v_and_tets.second;
+      CGAL_assertion(inc_tets.size() != 0);
+
+      std::set<std::size_t> remaining(inc_tets.begin(), inc_tets.end());
+      std::queue<std::size_t> local_q;
+
+      std::size_t seed = *remaining.begin();
+      local_q.push(seed);
+      remaining.erase(seed);
+
+      while(!local_q.empty())
+      {
+        std::size_t current = local_q.front();
+        local_q.pop();
+
+        for(std::size_t neighbor : tet_adjacency[current])
+        {
+          auto it = remaining.find(neighbor);
+          if(it != remaining.end())
+          {
+            local_q.push(neighbor);
+            remaining.erase(it);
+          }
+        }
+      }
+
+      if(!remaining.empty())
+      {
+        if (verbose) {
+          std::cerr << "more than one CC around vertex" << std::endl;
+        }
+        return false;
+      }
+    }
+
+    // Check that around each edge, tetrahedra form a single connected component
+    for(const auto& e_and_tets : edge_to_tets)
+    {
+      const std::vector<std::size_t>& inc_tets = e_and_tets.second;
+      if(inc_tets.size() == 0)
+        continue;
+
+      std::set<std::size_t> remaining(inc_tets.begin(), inc_tets.end());
+      std::queue<std::size_t> local_q;
+
+      std::size_t seed = *remaining.begin();
+      local_q.push(seed);
+      remaining.erase(seed);
+
+      while(!local_q.empty())
+      {
+        std::size_t current = local_q.front();
+        local_q.pop();
+
+        for(std::size_t neighbor : tet_adjacency[current])
+        {
+          auto it = remaining.find(neighbor);
+          if(it != remaining.end())
+          {
+            local_q.push(neighbor);
+            remaining.erase(it);
+          }
+        }
+      }
+
+      if(!remaining.empty())
+      {
+        if (verbose) {
+          std::cerr << "more than one CC around edge" << std::endl;
+        }
+        return false;
+      }
+    }
+
+    if (verbose) {
+      std::cout << "Tetrahedron soup is a valid triangulation" << std::endl;
+    }
+
+    return true;
+  }
 
   /** \ingroup PkgSMDS3Functions
   * builds a 3D triangulation from a soup of tetrahedra.

--- a/SMDS_3/test/SMDS_3/test_tet_soup_to_c3t3.cpp
+++ b/SMDS_3/test/SMDS_3/test_tet_soup_to_c3t3.cpp
@@ -27,7 +27,7 @@ int main(int , char* [])
 {
   std::cout << "Random seed " << CGAL::get_default_random().get_seed() << std::endl;
 
-  const int nbv = 100;
+  const int nbv = 10000;
 
   //a triangulation
   DT3 delaunay;
@@ -47,6 +47,10 @@ int main(int , char* [])
     Vertex_handle v = delaunay.insert(points[i]);
     v2i[v] = i++;
   }
+
+  // add some useless points
+  points.push_back(Point_3(10, 10, 10));
+  points.push_back(Point_3(20, 20, 20));
 
   tetrahedra.reserve(delaunay.number_of_finite_cells());
   tets_by_indices.reserve(delaunay.number_of_finite_cells());
@@ -91,7 +95,7 @@ int main(int , char* [])
   //build triangulation from indices and subdomains
   Remeshing_triangulation tr3
     = CGAL::tetrahedron_soup_to_triangulation_3<Remeshing_triangulation>(
-        points, tets_by_indices, CGAL::parameters::subdomain_indices(std::cref(subdomains)));
+        points, tets_by_indices, CGAL::parameters::subdomain_indices(std::cref(subdomains)).verbose(true));
   assert(tr3.is_valid());
 
   //build triangulation from indices, subdomains and surface facets
@@ -99,7 +103,8 @@ int main(int , char* [])
     = CGAL::tetrahedron_soup_to_triangulation_3<Remeshing_triangulation>(
         points, tets_by_indices,
         CGAL::parameters::subdomain_indices(std::cref(subdomains))
-                         .surface_facets(std::cref(border_facets)));
+                         .surface_facets(std::cref(border_facets))
+                         .verbose(true));
   assert(tr4.is_valid());
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary of Changes

- add a function `is_tet_soup_a_triangulation()`, similar to `PMP::is_polygon_soup_a_polygon_mesh()`
- Faster `is_convex` check
- Handle the case where the point range has not been filtered to only contain points that are involved in the tetrahedron range and would create isolated vertices

## Release Management

* Affected package(s): `SMDS_3`
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): TBD
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: no changes

