### PR TITLE
CGAL Lab: fix a bug with dialogs popping behind the window

### DIFF
--- a/Lab/demo/Lab/Plugins/Classification/Classification_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Classification/Classification_plugin.cpp
@@ -502,7 +502,7 @@ public Q_SLOTS:
     if (points_item->point_set()->has_property_map<int> ("shape"))
     {
       QMessageBox::StandardButton reply
-        = QMessageBox::question(nullptr, "Point Set Classification",
+        = QMessageBox::question(CGAL::Three::Three::mainWindow(), "Point Set Classification",
                                 "This point set is divided in clusters. Do you want to classify clusters instead of points?",
                                 QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
 
@@ -1049,7 +1049,7 @@ public Q_SLOTS:
     if (classif->number_of_labels() != 0)
     {
       QMessageBox::StandardButton reply
-        = QMessageBox::question(nullptr, "Classification",
+        = QMessageBox::question(CGAL::Three::Three::mainWindow(), "Classification",
                                 "Current labels will be discarded. Continue?",
                                 QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
 
@@ -1076,7 +1076,7 @@ public Q_SLOTS:
     if (classif->number_of_labels() != 0)
     {
       QMessageBox::StandardButton reply
-        = QMessageBox::question(nullptr, "Classification",
+        = QMessageBox::question(CGAL::Three::Three::mainWindow(), "Classification",
                                 "Current labels will be discarded. Continue?",
                                 QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
 
@@ -1104,7 +1104,7 @@ public Q_SLOTS:
     if (classif->number_of_labels() != 0)
     {
       QMessageBox::StandardButton reply
-        = QMessageBox::question(nullptr, "Classification",
+        = QMessageBox::question(CGAL::Three::Three::mainWindow(), "Classification",
                                 "Current labels will be discarded. Continue?",
                                 QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
 
@@ -1145,7 +1145,7 @@ public Q_SLOTS:
     if (classif->number_of_labels() != 0)
     {
       QMessageBox::StandardButton reply
-        = QMessageBox::question(nullptr, "Classification",
+        = QMessageBox::question(CGAL::Three::Three::mainWindow(), "Classification",
                                 "Current labels will be discarded. Continue?",
                                 QMessageBox::Yes|QMessageBox::No, QMessageBox::Yes);
 

--- a/Lab/demo/Lab/Plugins/IO/OFF_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/IO/OFF_io_plugin.cpp
@@ -183,7 +183,7 @@ CGAL_Lab_off_plugin::load_off(QFileInfo fileinfo) {
     item->setNbIsolatedvertices(isolated_v);
     //needs two restore, it's not a typo
     QApplication::restoreOverrideCursor();
-    QMessageBox::warning((QWidget*)nullptr,
+    QMessageBox::warning(CGAL::Three::Three::mainWindow(),
                          tr("Isolated vertices"),
                          tr("%1 isolated vertices found")
                          .arg(item->getNbIsolatedvertices()));
@@ -196,7 +196,7 @@ CGAL_Lab_off_plugin::load_off(QFileInfo fileinfo) {
   {
 
     QApplication::restoreOverrideCursor();
-    QMessageBox::warning((QWidget*)nullptr,
+    QMessageBox::warning(CGAL::Three::Three::mainWindow(),
                          tr("Non Manifold Vertices"),
                          tr("Non-manifold vertices have been found"));
   }

--- a/Lab/demo/Lab/Plugins/IO/VTK_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/IO/VTK_io_plugin.cpp
@@ -225,7 +225,7 @@ public:
       {
         if(!CGAL::is_triangle_mesh(*poly_item->polyhedron()))
         {
-          QMessageBox::warning(0, "Error",
+          QMessageBox::warning(CGAL::Three::Three::mainWindow(), "Error",
                                "Cannot save a mesh in vtu format if "
                                "it is not pure triangle.");
           return false;

--- a/Lab/demo/Lab/Plugins/Mesh_3/C3t3_io_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Mesh_3/C3t3_io_plugin.cpp
@@ -150,7 +150,7 @@ CGAL_Lab_c3t3_binary_io_plugin::load(
       }
       else if(item->c3t3().triangulation().number_of_finite_cells() == 0)
       {
-        QMessageBox::warning((QWidget*)NULL, tr("C3t3_io_plugin"),
+        QMessageBox::warning(CGAL::Three::Three::mainWindow(), tr("C3t3_io_plugin"),
                                        tr("No finite cell provided.\n"
                                           "Nothing to display."),
                                         QMessageBox::Ok);

--- a/Lab/demo/Lab/Plugins/Mesh_3/Tetrahedra_filtering_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Mesh_3/Tetrahedra_filtering_plugin.cpp
@@ -162,7 +162,7 @@ public Q_SLOTS:
       QString message = tr("The filtering is only available for items with less than %1 subdomains, and this one has %2")
                             .arg(max_number_of_item)
                             .arg(c3t3_item->subdomain_indices().size());
-      QMessageBox::warning(nullptr, "Warning", message);
+      QMessageBox::warning(CGAL::Three::Three::mainWindow(), "Warning", message);
       return;
     }
     int counter = 0;

--- a/Lab/demo/Lab/Plugins/PMP/Surface_intersection_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/PMP/Surface_intersection_plugin.cpp
@@ -141,7 +141,7 @@ void CGAL_Lab_intersection_plugin::intersectionSurfaces()
       }
       catch(const CGAL::Polygon_mesh_processing::Corefinement::Self_intersection_exception&)
       {
-        QMessageBox::warning((QWidget*)nullptr,
+        QMessageBox::warning(CGAL::Three::Three::mainWindow(),
           tr("Self-intersections Found"),
           tr("Some self-intersections were found amongst intersecting facets"));
         delete new_item;

--- a/Lab/demo/Lab/Plugins/Point_set/Point_set_average_spacing_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Point_set/Point_set_average_spacing_plugin.cpp
@@ -4,6 +4,7 @@
 #include "Scene_points_with_normal_item.h"
 #include <CGAL/Three/CGAL_Lab_plugin_helper.h>
 #include <CGAL/Three/CGAL_Lab_plugin_interface.h>
+#include <CGAL/Three/Three.h>
 
 #include <CGAL/compute_average_spacing.h>
 #include <CGAL/Real_timer.h>
@@ -129,7 +130,7 @@ void CGAL_Lab_point_set_average_spacing_plugin::on_actionAverageSpacing_triggere
               << std::endl;
     QApplication::restoreOverrideCursor();
 
-    QMessageBox::information(nullptr,
+    QMessageBox::information(CGAL::Three::Three::mainWindow(),
                              tr("Average Spacing"),
                              tr("Average Spacing = %1 = %2 * point set radius")
                              .arg(average_spacing)

--- a/Lab/demo/Lab/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Point_set/Point_set_normal_estimation_plugin.cpp
@@ -1,5 +1,6 @@
 #include "config.h"
 #include "Scene_points_with_normal_item.h"
+#include <CGAL/Three/Three.h>
 #include <CGAL/Three/CGAL_Lab_plugin_helper.h>
 #include <CGAL/Three/CGAL_Lab_plugin_interface.h>
 
@@ -391,7 +392,7 @@ void CGAL_Lab_point_set_normal_estimation_plugin::on_actionNormalOrientation_tri
       // Warns user
       if (nb_unoriented_normals > 0)
       {
-        QMessageBox::information(nullptr,
+        QMessageBox::information(CGAL::Three::Three::mainWindow(),
                                  tr("Points with an unoriented normal"),
                                  tr("%1 point(s) with an unoriented normal are selected.\nPlease orient them or remove them before running Poisson reconstruction.")
                                  .arg(nb_unoriented_normals));

--- a/Lab/demo/Lab/Plugins/Point_set/Point_set_shape_detection_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Point_set/Point_set_shape_detection_plugin.cpp
@@ -3,6 +3,7 @@
 #include "Scene_polygon_soup_item.h"
 #include "Scene_surface_mesh_item.h"
 #include <CGAL/Three/Scene_group_item.h>
+#include <CGAL/Three/Three.h>
 
 #include <CGAL/Three/CGAL_Lab_plugin_helper.h>
 #include <CGAL/Three/CGAL_Lab_plugin_interface.h>
@@ -1076,7 +1077,7 @@ void CGAL_Lab_point_set_shape_detection_plugin::on_actionEstimateParameters_trig
 
       if (points->nb_selected_points() == 0)
         {
-          QMessageBox::information(nullptr,
+          QMessageBox::information(CGAL::Three::Three::mainWindow(),
                                    tr("Warning"),
                                    tr("Selection is empty.\nTo estimate parameters, please select a planar section."));
           return;
@@ -1137,7 +1138,7 @@ void CGAL_Lab_point_set_shape_detection_plugin::on_actionEstimateParameters_trig
       QApplication::restoreOverrideCursor();
 
 
-      QMessageBox::information(nullptr,
+      QMessageBox::information(CGAL::Three::Three::mainWindow(),
                                tr("Estimated Parameters"),
                                tr("Epsilon = [%1 ; %2 ; %3 ; %4 ; %5]\nNormal Tolerance = [%6 ; %7 ; %8 ; %9 ; %10]\nMinimum Number of Points = %11\nConnectivity Epsilon = [%12 ; %13 ; %14 ; %15 ; %16]")
                                .arg(std::sqrt(epsilon.front()))

--- a/Lab/demo/Lab/Plugins/Point_set/Point_set_simplification_plugin.cpp
+++ b/Lab/demo/Lab/Plugins/Point_set/Point_set_simplification_plugin.cpp
@@ -2,6 +2,7 @@
 #include "Scene_points_with_normal_item.h"
 #include <CGAL/Three/CGAL_Lab_plugin_helper.h>
 #include <CGAL/Three/CGAL_Lab_plugin_interface.h>
+#include <CGAL/Three/Three.h>
 
 #include <CGAL/grid_simplify_point_set.h>
 #include <CGAL/random_simplify_point_set.h>
@@ -267,7 +268,7 @@ void CGAL_Lab_point_set_simplification_plugin::on_actionSimplify_triggered()
     // Warns user
     if (nb_points_to_remove > 0)
     {
-      QMessageBox::information(nullptr,
+      QMessageBox::information(CGAL::Three::Three::mainWindow(),
                                tr("Points selected for removal"),
                                tr("%1 point(s) are selected for removal.\nYou may delete or reset the selection using the item context menu.")
                                .arg(nb_points_to_remove));

--- a/STL_Extension/include/CGAL/Triangulation_simplex_base_with_time_stamp.h
+++ b/STL_Extension/include/CGAL/Triangulation_simplex_base_with_time_stamp.h
@@ -43,6 +43,10 @@ public:
     typedef typename BaseWithTSBase::template Rebind_TDS<TDS>::Other Base2;
     typedef Triangulation_simplex_base_with_time_stamp<Base2> Other;
   };
+
+  static std::string io_signature() {
+    return Get_io_signature<BaseWithTSBase>()();
+  }
 };
 
 } // namespace CGAL

--- a/STL_Extension/include/CGAL/Triangulation_simplex_base_with_time_stamp.h
+++ b/STL_Extension/include/CGAL/Triangulation_simplex_base_with_time_stamp.h
@@ -11,10 +11,12 @@
 #define CGAL_SIMPLEX_BASE_WITH_TIME_STAMP_H
 
 #include <CGAL/tags.h> // for Tag_true
-#include <cstdint>     // for std::size_t
-#include <utility>     // for std::forward
+#include <cstddef>     // for std::size_t
+#include <string>
 
 namespace CGAL {
+
+template <class T> struct Get_io_signature;
 
 /// @brief A base class with a time stamp.
 ///

--- a/Scripts/developer_scripts/cgal_check_dependencies.sh
+++ b/Scripts/developer_scripts/cgal_check_dependencies.sh
@@ -37,10 +37,10 @@ done
 
 cmake -DCGAL_ENABLE_CHECK_HEADERS=TRUE -DDOXYGEN_EXECUTABLE="$DOX_PATH" -DCGAL_COPY_DEPENDENCIES=TRUE -DCMAKE_CXX_FLAGS="-std=c++1y" ..
 if [ -n "$DO_CHECK_HEADERS" ]; then
-    make -j"$(nproc --all)" -k check_headers
-    make -j"$(nproc --all)" -k check_headers_linked_twice
+    cmake --build . -j"$(nproc --all)" --target check_headers -v -- -k
+    cmake --build . -j"$(nproc --all)" --target check_headers_linked_twice -v -- -k
 fi
-make -j"$(nproc --all)" -k packages_dependencies
+cmake --build . -j"$(nproc --all)" --target packages_dependencies -v -- -k
 echo " Checks finished"
 for pkg_path in "$CGAL_ROOT"/*
 do
@@ -65,7 +65,8 @@ rm -r dep_check_build
 if [ -n "$TOTAL_RES" ]; then
   # shellcheck disable=SC2059
   printf "$TOTAL_RES"
-  echo " You can run cmake with options CGAL_ENABLE_CHECK_HEADERS and CGAL_COPY_DEPENDENCIES ON, make the target packages_dependencies and commit the new dependencies files,"
+  echo " You can run cmake with options \`CGAL_ENABLE_CHECK_HEADERS\` and \`CGAL_COPY_DEPENDENCIES\` set to \`ON\`"
+  echo " then build the target \`packages_dependencies\` and commit the new dependencies files,"
   echo " or simply manually edit the problematic files."
   exit 1
 else


### PR DESCRIPTION
## Summary of Changes

- CGAL Lab: fix a bug with dialogs popping behind the window. This was because the `parent()` of the dialog was set to `nullptr` or `0`.
- add minors unrelated changes. 

## Release Management

* Affected package(s): Lab
* License and copyright ownership: no change


