### PR TITLE
Kernel_23: Simplify Has_on_unbounded_side_3

### DIFF
--- a/Filtered_kernel/include/CGAL/Filtered_kernel/internal/Static_filters/Has_on_unbounded_side_3.h
+++ b/Filtered_kernel/include/CGAL/Filtered_kernel/internal/Static_filters/Has_on_unbounded_side_3.h
@@ -57,180 +57,30 @@ public:
       fit_in_double(get_approx(c).z(), scz) &&
       fit_in_double(s.squared_radius(), ssr))
     {
-      CGAL_BRANCH_PROFILER_BRANCH_1(tmp);
-      bool center_inside = true;
+      bool center_inside =  ! ( (scx < bxmin) || (scx > bxmax) || (scy < bymin) || (scy > bymax)|| (scz < bzmin) || (scz > bzmax) );
+      if(center_inside){
+        return false;
+      }
 
+      //  AF: What does this guard against ?
       if ((ssr < 1.11261183279326254436e-293) || (ssr > 2.80889552322236673473e+306)) {
         CGAL_BRANCH_PROFILER_BRANCH_2(tmp);
         return Base::operator()(s, b);
       }
-      double distance = 0;
-      double max1 = 0;
-      double double_tmp_result = 0;
+
+      // When the center is outside, the closest point has the following coordinates
+      double px = std::clamp(scx, bxmin, bxmax); // equivalent to:  std::min(std::max(scx,bxmin),bxmax);
+      double py = std::clamp(scy, bymin, bymax);
+      double pz = std::clamp(scz, bzmin, bzmax);
+
+      // AF:  We now need an error bound on the folling expression
+      double sqdist = CGAL::square(px-scx) + CGAL::square(py-scy) + CGAL::square(pz-scz);
       double eps = 0;
-      if (scx < bxmin)
-      {
-        double bxmin_scx = bxmin - scx;
-        max1 = bxmin_scx;
-
-        center_inside = false;
-
-        distance = square(bxmin_scx);
-        double_tmp_result = (distance - ssr);
-
-        if ((max1 < 3.33558365626356687717e-147) || (max1 > 1.67597599124282407923e+153)) {
-          CGAL_BRANCH_PROFILER_BRANCH_2(tmp);
-          return Base::operator()(s, b);
-        }
-
-        eps = 1.99986535548615598560e-15 * (std::max)(ssr, square(max1));
-
-        if (double_tmp_result > eps) {
-          return true;
-        }
-      }
-      else if (scx > bxmax)
-      {
-        double scx_bxmax = scx - bxmax;
-        max1 = scx_bxmax;
-
-        center_inside = false;
-
-        distance = square(scx_bxmax);
-        double_tmp_result = (distance - ssr);
-
-        if ((max1 < 3.33558365626356687717e-147) || (max1 > 1.67597599124282407923e+153)) {
-          CGAL_BRANCH_PROFILER_BRANCH_2(tmp);
-          return Base::operator()(s, b);
-        }
-
-        eps = 1.99986535548615598560e-15 * (std::max)(ssr, square(max1));
-
-        if (double_tmp_result > eps) {
-          return true;
-        }
-      }
-      else
-      {
-        double scx_bxmin = scx - bxmin;
-        double bxmax_scx = bxmax - scx;
-        max1 = (std::min)(scx_bxmin, bxmax_scx);
-
-        distance = square(max1);
-        double_tmp_result = (distance - ssr);
-
-        if ((max1 < 3.33558365626356687717e-147) || (max1 > 1.67597599124282407923e+153)) {
-          CGAL_BRANCH_PROFILER_BRANCH_2(tmp);
-          return Base::operator()(s, b);
-        }
+      double delta = sqdist - ssr;
+      if(delta > eps || delta < -eps){
+        return ssr < sqdist;
       }
 
-
-      if (scy < bymin)
-      {
-        double bymin_scy = bymin - scy;
-        if (max1 < bymin_scy) {
-          max1 = bymin_scy;
-        }
-
-        center_inside = false;
-
-        distance += square(bymin_scy);
-      }
-      else if (scy > bymax)
-      {
-        double scy_bymax = scy - bymax;
-        if (max1 < scy_bymax) {
-          max1 = scy_bymax;
-        }
-
-        center_inside = false;
-
-        distance += square(scy_bymax);
-      }
-      else {
-        double scy_bymin = scy - bymin;
-        double bymax_scy = bymax - scy;
-        double d = (std::min)(scy_bymin, bymax_scy);
-        if (max1 < d) {
-          max1 = d;
-        }
-
-        distance += square(d);
-      }
-
-      double_tmp_result = (distance - ssr);
-
-      if ((max1 < 3.33558365626356687717e-147) || (max1 > 1.67597599124282407923e+153)) {
-        CGAL_BRANCH_PROFILER_BRANCH_2(tmp);
-        return Base::operator()(s, b);
-      }
-
-      eps = 1.99986535548615598560e-15 * (std::max)(ssr, square(max1));
-
-      if (!center_inside && double_tmp_result > eps) {
-        return true;
-      }
-
-
-      if (scz < bzmin)
-      {
-        double bzmin_scz = bzmin - scz;
-        if (max1 < bzmin_scz) {
-          max1 = bzmin_scz;
-        }
-
-        center_inside = false;
-
-        distance += square(bzmin_scz);
-      }
-      else if (scz > bzmax)
-      {
-        double scz_bzmax = scz - bzmax;
-        if (max1 < scz_bzmax) {
-          max1 = scz_bzmax;
-        }
-
-        center_inside = false;
-
-        distance += square(scz_bzmax);
-      }
-      else
-      {
-        double scz_bzmin = scz - bzmin;
-        double bzmax_scz = bzmax - scz;
-        double d = (std::min)(scz_bzmin, bzmax_scz);
-
-        if (max1 < d) {
-          max1 = d;
-        }
-
-        distance += square(d);
-      }
-
-      if (center_inside)
-        return false;
-
-      double_tmp_result = (distance - ssr);
-      if ((max1 < 3.33558365626356687717e-147) || (max1 > 1.67597599124282407923e+153)) {
-        CGAL_BRANCH_PROFILER_BRANCH_2(tmp);
-        return Base::operator()(s, b);
-      }
-
-      eps = 1.99986535548615598560e-15 * (std::max)(ssr, square(max1));
-
-      if (double_tmp_result > eps) {
-        return true;
-      }
-      else if (double_tmp_result <= -eps) {
-        return false;
-      }
-      else {
-        CGAL_BRANCH_PROFILER_BRANCH_2(tmp);
-        return Base::operator()(s, b);
-      }
-
-      CGAL_BRANCH_PROFILER_BRANCH_2(tmp);
     }
     return Base::operator()(s, b);
   }


### PR DESCRIPTION
## Summary of Changes

I tried to simplify the code in `Has_unbounded_side_3`    for `Sphere_3/Iso_cuboid_3`.   I hope it is correct.
What is missing is the epsilon for the potential error in the static filter. @sloriot can you help here.

We might add in the [documentation](https://cgal.geometryfactory.com/CGAL/doc/main/Kernel_23/classKernel_1_1HasOnUnboundedSide__3.html) that we also support `Iso_cuboid_3/Sphere_3`.  In fact that is just symmetric for two volumes.

## Release Management

* Affected package(s):  Kernel_23
* Issue(s) solved (if any): fix #9493
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:   unchanged

