### PR TITLE
a degenerate surface mesh does self-intersect

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/self_intersections.h
@@ -96,6 +96,11 @@ struct Triangle_mesh_and_triangle_soup_wrapper
   {
     return is_triangle_mesh(tm);
   }
+
+  static constexpr bool allow_identical_face()
+  {
+    return false;
+  }
 };
 
 template <class PointRange, class TriangleRange>
@@ -174,6 +179,11 @@ struct Triangle_mesh_and_triangle_soup_wrapper<
         return false;
     return true;
   }
+
+  static constexpr bool allow_identical_face()
+  {
+    return true;
+  }
 };
 
 template<typename Output_iterator>
@@ -227,7 +237,7 @@ bool do_faces_intersect(typename Triangle_mesh_and_triangle_soup_wrapper<TM>::fa
   std::array<vertex_descriptor, 4> verts;
   if (Wrapper::faces_have_a_shared_edge(fh, fg, verts, tmesh))
   {
-    if (verts[2]==verts[3]) return false; // only for a soup of triangles
+    if (Wrapper::allow_identical_face() && verts[2]==verts[3]) return false; // only for a soup of triangles
 
     // there is an intersection if the four points are coplanar and the triangles overlap
     if(CGAL::coplanar(get(vpmap, verts[0]),

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/self_intersection_surface_mesh_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/self_intersection_surface_mesh_test.cpp
@@ -208,5 +208,20 @@ int main(int argc, char** argv)
   std::cout << "Test with maximum_number (EPECK):" << std::endl;
   r += test_limited_self_intersections<EPECK>(filename);
 
+  // test degenerate surface mesh
+  {
+    CGAL::Surface_mesh<EPICK::Point_3> mesh;
+
+    auto v0 = mesh.add_vertex(EPICK::Point_3(0.0, 0.0, 0.0));
+    auto v1 = mesh.add_vertex(EPICK::Point_3(1.0, 0.0, 0.0));
+    auto v2 = mesh.add_vertex(EPICK::Point_3(0.0, 1.0, 0.0));
+
+    mesh.add_face(v0, v1, v2);
+    mesh.add_face(v0, v2, v1);
+
+    assert(CGAL::Polygon_mesh_processing::does_self_intersect(mesh));
+  }
+
+
   return r;
 }

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/self_intersection_triangle_soup_test.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/self_intersection_triangle_soup_test.cpp
@@ -230,6 +230,13 @@ int main(int argc, char** argv)
     std::vector< std::array<std::size_t, 3> > triangles={{0,1,2},{0,1,3},{0,1,4},{0,1,5}};
     assert(PMP::does_triangle_soup_self_intersect(points, triangles));
   }
+  {
+    // 4 identical triangles: no self-intersection
+    typedef EPICK::Point_3 Point_3;
+    std::vector<EPICK::Point_3> points = {Point_3(0,0,0), Point_3(1,0,0), Point_3(0,1,0)};
+    std::vector< std::array<std::size_t, 3> > triangles={{0,1,2},{0,2,1},{0,1,2},{0,2,1}};
+    assert(!PMP::does_triangle_soup_self_intersect(points, triangles));
+  }
 
   return r;
 }


### PR DESCRIPTION
fix bug introduced while adding support for triangle soups

Fixes #9486
