### PR TITLE
Polygon algorithms: honor iterator requirements

### DIFF
--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
@@ -40,8 +40,8 @@ namespace Polygon_2 {
 // in the range are collinear segments, up to a given tolerance.
 //
 // \tparam K must be a model of `Kernel`
-// \tparam InputForwardIterator must be a model of `ForwardIterator`
-//                              with value type `K::Point_2`
+// \tparam InputBidirectionalIterator must be a model of `BidirectionalIterator`
+//                                    with value type `K::Point_2`
 // \tparam OutputForwardIterator must be a model of `OutputIterator`
 //                               with value type `K::Point_2`
 //
@@ -53,9 +53,9 @@ namespace Polygon_2 {
 //
 // \pre The range `(first, beyond)` is composed of at least three points.
 // \pre Not all points in the range `(first, beyond)` are (almost) collinear.
-template<typename K, typename InputForwardIterator, typename OutputForwardIterator>
-OutputForwardIterator filter_collinear_points(InputForwardIterator first,
-                                              InputForwardIterator beyond,
+template<typename K, typename InputBidirectionalIterator, typename OutputForwardIterator>
+OutputForwardIterator filter_collinear_points(InputBidirectionalIterator first,
+                                              InputBidirectionalIterator beyond,
                                               OutputForwardIterator out,
                                               const typename K::FT tolerance =
                                                 std::numeric_limits<typename K::FT>::epsilon())
@@ -65,9 +65,9 @@ OutputForwardIterator filter_collinear_points(InputForwardIterator first,
   typedef typename K::FT                              FT;
   typedef typename K::Point_2                         Point;
 
-  InputForwardIterator last = std::prev(beyond);
+  InputBidirectionalIterator last = std::prev(beyond);
 
-  InputForwardIterator vit = first, vit_next = vit, vit_next_2 = vit, vend = vit;
+  InputBidirectionalIterator vit = first, vit_next = vit, vit_next_2 = vit, vend = vit;
   ++vit_next;
   ++(++vit_next_2);
 
@@ -318,11 +318,11 @@ std::cout << "polygon not locally convex!" << std::endl;
 //      Traits::Compare_y_2 compare_y_2_object()
 //      Traits::Orientation_2 and orientation_2_object()
 
-template <class ForwardIterator, class Point, class Traits>
-Oriented_side oriented_side_2(ForwardIterator first,
-                                        ForwardIterator last,
-                                        const Point& point,
-                                        const Traits& traits)
+template <class BidirIterator, class Point, class Traits>
+Oriented_side oriented_side_2(BidirIterator first,
+                              BidirIterator last,
+                              const Point& point,
+                              const Traits& traits)
 {
   Orientation o = orientation_2(first, last, traits);
   CGAL_assertion(o != COLLINEAR);
@@ -508,17 +508,17 @@ namespace internal {
 // This exists because the "is_simple_2" precondition in the orientation_2() function is in fact
 // stronger than necessary: it also works for strictly simple polygons, which matters for
 // SLS2 and AW2, as the polygons might have non-manifoldness.
-template <class ForwardIterator, class Traits>
-Orientation orientation_2_no_precondition(ForwardIterator first,
-                                          ForwardIterator last,
+template <class BidirIterator, class Traits>
+Orientation orientation_2_no_precondition(BidirIterator first,
+                                          BidirIterator last,
                                           const Traits& traits)
 {
-  ForwardIterator i = left_vertex_2(first, last, traits);
+  BidirIterator i = left_vertex_2(first, last, traits);
 
-  ForwardIterator prev = (i == first) ? last : i;
+  BidirIterator prev = (i == first) ? last : i;
   --prev;
 
-  ForwardIterator next = i;
+  BidirIterator next = i;
   ++next;
   if (next == last)
     next = first;
@@ -534,9 +534,9 @@ Orientation orientation_2_no_precondition(ForwardIterator first,
 } // namespace internal
 } // namespace Polygon
 
-template <class ForwardIterator, class Traits>
-Orientation orientation_2(ForwardIterator first,
-                          ForwardIterator last,
+template <class BidirIterator, class Traits>
+Orientation orientation_2(BidirIterator first,
+                          BidirIterator last,
                           const Traits& traits)
 {
   CGAL_precondition(is_simple_2(first, last, traits));

--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
@@ -333,9 +333,9 @@ std::cout << "polygon not locally convex!" << std::endl;
 //      Traits::Compare_y_2 compare_y_2_object()
 //      Traits::Orientation_2 and orientation_2_object()
 
-template <class BidirIterator, class Point, class Traits>
-Oriented_side oriented_side_2(BidirIterator first,
-                              BidirIterator last,
+template <class ForwardIterator, class Point, class Traits>
+Oriented_side oriented_side_2(ForwardIterator first,
+                              ForwardIterator last,
                               const Point& point,
                               const Traits& traits)
 {
@@ -523,39 +523,55 @@ namespace internal {
 // This exists because the "is_simple_2" precondition in the orientation_2() function is in fact
 // stronger than necessary: it also works for strictly simple polygons, which matters for
 // SLS2 and AW2, as the polygons might have non-manifoldness.
-template <class BidirIterator, class Traits>
-Orientation orientation_2_no_precondition(BidirIterator first,
-                                          BidirIterator last,
+template <class ForwardIterator, class Traits>
+Orientation orientation_2_no_precondition(ForwardIterator first,
+                                          ForwardIterator beyond,
                                           const Traits& traits)
 {
-  BidirIterator i = left_vertex_2(first, last, traits);
+  typedef typename Traits::Point_2 Point;
 
-  BidirIterator prev = (i == first) ? last : i;
-  --prev;
+  CGAL_precondition(first != beyond); // Ensure range is not empty
 
-  BidirIterator next = i;
-  ++next;
-  if (next == last)
-    next = first;
+  // The code below is a custom left_vertex_2 that keeps track of the predecessor of the leftmost vertex
+  CGAL::internal::Polygon_2::Compare_vertices<Traits> less(traits.less_xy_2_object());
 
-  // if the range [first,last) contains fewer than three points, then some
+  ForwardIterator min_it = first, min_prev = first;
+
+  ForwardIterator prev = first, curr = std::next(first);
+  while (curr != beyond) {
+    if (less(*curr, *min_it)) {
+      min_it = curr;
+      min_prev = prev;
+    }
+    prev = curr;
+    ++curr;
+  }
+
+  // If the left vertex is the first, its predecessor in a polygon is the last element,
+  // and 'prev' points to the last element in the range.
+  if (min_it == first)
+    min_prev = prev;
+
+  ForwardIterator min_next = std::next(min_it);
+  if (min_next == beyond)
+    min_next = first;
+
+  // if the range [first,beyond) contains fewer than three points, then some
   // of the points (prev,i,next) will coincide
 
-  // return the orientation of the triple (prev,i,next)
-  typedef typename Traits::Point_2 Point;
-  return traits.orientation_2_object()(Point(*prev), Point(*i), Point(*next));
+  return traits.orientation_2_object()(Point(*min_prev), Point(*min_it), Point(*min_next));
 }
 
 } // namespace internal
 } // namespace Polygon
 
-template <class BidirIterator, class Traits>
-Orientation orientation_2(BidirIterator first,
-                          BidirIterator last,
+template <class ForwardIterator, class Traits>
+Orientation orientation_2(ForwardIterator first,
+                          ForwardIterator beyond,
                           const Traits& traits)
 {
-  CGAL_precondition(is_simple_2(first, last, traits));
-  return Polygon::internal::orientation_2_no_precondition(first, last, traits);
+  CGAL_precondition(is_simple_2(first, beyond, traits));
+  return Polygon::internal::orientation_2_no_precondition(first, beyond, traits);
 }
 
 } //namespace CGAL

--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
@@ -40,8 +40,8 @@ namespace Polygon_2 {
 // in the range are collinear segments, up to a given tolerance.
 //
 // \tparam K must be a model of `Kernel`
-// \tparam InputBidirectionalIterator must be a model of `BidirectionalIterator`
-//                                    with value type `K::Point_2`
+// \tparam InputForwardIterator must be a model of `BidirectionalIterator`
+//                              with value type `K::Point_2`
 // \tparam OutputForwardIterator must be a model of `OutputIterator`
 //                               with value type `K::Point_2`
 //
@@ -53,9 +53,9 @@ namespace Polygon_2 {
 //
 // \pre The range `(first, beyond)` is composed of at least three points.
 // \pre Not all points in the range `(first, beyond)` are (almost) collinear.
-template<typename K, typename ForwardIterator, typename OutputForwardIterator>
-OutputForwardIterator filter_collinear_points(ForwardIterator first,
-                                              ForwardIterator beyond,
+template<typename K, typename InputForwardIterator, typename OutputForwardIterator>
+OutputForwardIterator filter_collinear_points(InputForwardIterator first,
+                                              InputForwardIterator beyond,
                                               OutputForwardIterator out,
                                               const typename K::FT tolerance =
                                                 std::numeric_limits<typename K::FT>::epsilon())
@@ -66,13 +66,13 @@ OutputForwardIterator filter_collinear_points(ForwardIterator first,
   CGAL_precondition(std::distance(first, beyond) >= 3);
 
   // Helper to safely advance and wrap around in a purely forward manner
-  auto wrapped_advance = [&](ForwardIterator it) {
+  auto wrapped_advance = [&](InputForwardIterator it) {
     ++it;
     return (it == beyond) ? first : it;
   };
 
   // Helper for collinearity logic
-  auto is_collinear = [&](ForwardIterator i1, ForwardIterator i2, ForwardIterator i3) {
+  auto is_collinear = [&](InputForwardIterator i1, InputForwardIterator i2, InputForwardIterator i3) {
     const Point& p1 = *i1;
     const Point& p2 = *i2;
     const Point& p3 = *i3;
@@ -82,9 +82,9 @@ OutputForwardIterator filter_collinear_points(ForwardIterator first,
   };
 
   // find a corner
-  ForwardIterator v0 = first;
-  ForwardIterator v1 = std::next(first);
-  ForwardIterator v2 = std::next(v1);
+  InputForwardIterator v0 = first;
+  InputForwardIterator v1 = std::next(first);
+  InputForwardIterator v2 = std::next(v1);
 
   bool all_collinear = false;
 
@@ -104,9 +104,9 @@ OutputForwardIterator filter_collinear_points(ForwardIterator first,
   if (all_collinear)
     return out;
 
-  ForwardIterator anchor = v1;
-  ForwardIterator p = v2;
-  ForwardIterator q = wrapped_advance(v2);
+  InputForwardIterator anchor = v1;
+  InputForwardIterator p = v2;
+  InputForwardIterator q = wrapped_advance(v2);
 
   *out++ = *anchor;
 

--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
@@ -53,61 +53,76 @@ namespace Polygon_2 {
 //
 // \pre The range `(first, beyond)` is composed of at least three points.
 // \pre Not all points in the range `(first, beyond)` are (almost) collinear.
-template<typename K, typename InputBidirectionalIterator, typename OutputForwardIterator>
-OutputForwardIterator filter_collinear_points(InputBidirectionalIterator first,
-                                              InputBidirectionalIterator beyond,
+template<typename K, typename ForwardIterator, typename OutputForwardIterator>
+OutputForwardIterator filter_collinear_points(ForwardIterator first,
+                                              ForwardIterator beyond,
                                               OutputForwardIterator out,
                                               const typename K::FT tolerance =
                                                 std::numeric_limits<typename K::FT>::epsilon())
 {
+  typedef typename K::FT      FT;
+  typedef typename K::Point_2 Point;
+
   CGAL_precondition(std::distance(first, beyond) >= 3);
 
-  typedef typename K::FT                              FT;
-  typedef typename K::Point_2                         Point;
+  // Helper to safely advance and wrap around in a purely forward manner
+  auto wrapped_advance = [&](ForwardIterator it) {
+    ++it;
+    return (it == beyond) ? first : it;
+  };
 
-  InputBidirectionalIterator last = std::prev(beyond);
+  // Helper for collinearity logic
+  auto is_collinear = [&](ForwardIterator i1, ForwardIterator i2, ForwardIterator i3) {
+    const Point& p1 = *i1;
+    const Point& p2 = *i2;
+    const Point& p3 = *i3;
+    const FT det = CGAL::determinant(p1.x() - p3.x(), p1.y() - p3.y(),
+                                     p2.x() - p3.x(), p2.y() - p3.y());
+    return CGAL::abs(det) <= tolerance;
+  };
 
-  InputBidirectionalIterator vit = first, vit_next = vit, vit_next_2 = vit, vend = vit;
-  ++vit_next;
-  ++(++vit_next_2);
+  // find a corner
+  ForwardIterator v0 = first;
+  ForwardIterator v1 = std::next(first);
+  ForwardIterator v2 = std::next(v1);
 
-  bool stop = false;
+  bool all_collinear = false;
 
-  do
-  {
-    CGAL_assertion(vit != vit_next);
-    CGAL_assertion(vit_next != vit_next_2);
-    CGAL_assertion(vit != vit_next_2);
+  while (is_collinear(v0, v1, v2)) {
+    v0 = v1;
+    v1 = v2;
+    v2 = wrapped_advance(v2);
 
-    const Point& o = *vit;
-    const Point& p = *vit_next;
-    const Point& q = *vit_next_2;
-
-    // Stop when 'p' is the starting point. It does not matter whether we are
-    // in a collinear case or not.
-    stop = (vit_next == vend);
-
-    const FT det = CGAL::determinant(o.x() - q.x(), o.y() - q.y(),
-                                     p.x() - q.x(), p.y() - q.y());
-
-    if(CGAL::abs(det) <= tolerance)
-    {
-      // Only move 'p' and 'q' to ignore consecutive collinear points
-      vit_next = (vit_next == last) ? first : ++vit_next;
-      vit_next_2 = (vit_next_2 == last) ? first : ++vit_next_2;
-    }
-    else
-    {
-      // 'vit = vit_next' and not '++vit' because we don't necessarily have *(next(vit) == p)
-      // and collinear points between 'o' and 'p' are ignored
-      vit = vit_next;
-      vit_next = (vit_next == last) ? first : ++vit_next;
-      vit_next_2 = (vit_next_2 == last) ? first : ++vit_next_2;
-
-      *out++ = p;
+    if (v0 == first) {
+      all_collinear = true;
+      break; // We made a full circle and found no corners.
     }
   }
-  while(!stop);
+
+  // If the polygon is entirely degenerate (e.g. all points lie on one line),
+  // there are no 2D corners to output. We safely return empty.
+  if (all_collinear)
+    return out;
+
+  ForwardIterator anchor = v1;
+  ForwardIterator p = v2;
+  ForwardIterator q = wrapped_advance(v2);
+
+  *out++ = *anchor;
+
+  while (p != v1) {
+    if (is_collinear(anchor, p, q)) {
+      // 'p' forms a flat line between 'anchor' and 'q'. Skip 'p'.
+      p = q;
+      q = wrapped_advance(q);
+    } else {
+      // 'p' creates a turn, becomes the next anchor
+      *out++ = *p;
+      anchor = p;
+      p = q;
+      q = wrapped_advance(q);
+    }
+  }
 
   return out;
 }

--- a/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
+++ b/Polygon/include/CGAL/Polygon_2/Polygon_2_algorithms_impl.h
@@ -178,8 +178,8 @@ public:
 
 template <class ForwardIterator, class PolygonTraits>
 ForwardIterator left_vertex_2(ForwardIterator first,
-                                   ForwardIterator last,
-                                   const PolygonTraits&traits)
+                              ForwardIterator last,
+                              const PolygonTraits& traits)
 {
     CGAL_precondition(first != last);
     internal::Polygon_2::Compare_vertices<PolygonTraits>
@@ -194,8 +194,8 @@ ForwardIterator left_vertex_2(ForwardIterator first,
 
 template <class ForwardIterator, class PolygonTraits>
 ForwardIterator right_vertex_2(ForwardIterator first,
-                                    ForwardIterator last,
-                                    const PolygonTraits &traits)
+                               ForwardIterator last,
+                               const PolygonTraits &traits)
 {
     CGAL_precondition(first != last);
     internal::Polygon_2::Compare_vertices<PolygonTraits>
@@ -210,8 +210,8 @@ ForwardIterator right_vertex_2(ForwardIterator first,
 
 template <class ForwardIterator, class PolygonTraits>
 ForwardIterator top_vertex_2(ForwardIterator first,
-                                  ForwardIterator last,
-                                  const PolygonTraits&traits)
+                             ForwardIterator last,
+                             const PolygonTraits& traits)
 {
     CGAL_precondition(first != last);
     return std::max_element(first, last, traits.less_yx_2_object());
@@ -224,8 +224,8 @@ ForwardIterator top_vertex_2(ForwardIterator first,
 
 template <class ForwardIterator, class PolygonTraits>
 ForwardIterator bottom_vertex_2(ForwardIterator first,
-                                     ForwardIterator last,
-                                     const PolygonTraits&traits)
+                                ForwardIterator last,
+                                const PolygonTraits& traits)
 {
     CGAL_precondition(first != last);
     return std::min_element(first, last, traits.less_yx_2_object());
@@ -247,8 +247,8 @@ ForwardIterator bottom_vertex_2(ForwardIterator first,
 
 template <class ForwardIterator, class Traits>
 bool is_convex_2(ForwardIterator first,
-                      ForwardIterator last,
-                      const Traits& traits)
+                 ForwardIterator last,
+                 const Traits& traits)
 {
   ForwardIterator previous = first;
   if (previous == last) return true;
@@ -409,9 +409,9 @@ int which_side_in_slab(Point const &point, Point const &low, Point const &high,
 
 template <class ForwardIterator, class Point, class PolygonTraits>
 Bounded_side bounded_side_2(ForwardIterator first,
-                                      ForwardIterator last,
-                                      const Point& point,
-                                      const PolygonTraits& traits)
+                            ForwardIterator last,
+                            const Point& point,
+                            const PolygonTraits& traits)
 {
 
   ForwardIterator current = first;

--- a/Polygon/include/CGAL/Polygon_2_algorithms.h
+++ b/Polygon/include/CGAL/Polygon_2_algorithms.h
@@ -257,16 +257,16 @@ bool is_simple_2(ForwardIterator first,
 ///   - `compare_x_2_object()`
 ///   - `compare_y_2_object()`
 ///   - `orientation_2_object()`
-/// \tparam BidirectionalIterator must have `PolygonTraits::Point_2` as value type.
+/// \tparam ForwardIterator must have `PolygonTraits::Point_2` as value type.
 ///
 /// \sa `PolygonTraits_2`
 /// \sa `CGAL::bounded_side_2()`
 /// \sa `CGAL::is_simple_2()`
 /// \sa `CGAL::Polygon_2`
 /// \sa `Oriented_side`
-template <class BidirectionalIterator, class Point, class Traits>
-Oriented_side oriented_side_2(BidirectionalIterator first,
-                              BidirectionalIterator last,
+template <class ForwardIterator, class Point, class Traits>
+Oriented_side oriented_side_2(ForwardIterator first,
+                              ForwardIterator last,
                               const Point& point,
                               const Traits& traits);
 
@@ -316,15 +316,15 @@ Bounded_side bounded_side_2(ForwardIterator first,
 ///   - `Less_xy_2`
 ///   - `less_xy_2_object()`
 ///   - `orientation_2_object()`
-/// \tparam BidirectionalIterator must have `Traits::Point_2` as value type.
+/// \tparam ForwardIterator must have `Traits::Point_2` as value type.
 ///
 /// \sa `PolygonTraits_2`
 /// \sa `CGAL::is_simple_2()`
 /// \sa `CGAL::Polygon_2`
 /// \sa `CGAL::Orientation`
-template <class BidirectionalIterator, class Traits>
-Orientation orientation_2(BidirectionalIterator first,
-                          BidirectionalIterator last,
+template <class ForwardIterator, class Traits>
+Orientation orientation_2(ForwardIterator first,
+                          ForwardIterator last,
                           const Traits& traits);
 
 /// @}

--- a/Polygon/include/CGAL/Polygon_2_algorithms.h
+++ b/Polygon/include/CGAL/Polygon_2_algorithms.h
@@ -261,16 +261,16 @@ bool is_simple_2(ForwardIterator first,
 ///   - `compare_x_2_object()`
 ///   - `compare_y_2_object()`
 ///   - `orientation_2_object()`
-/// \tparam ForwardIterator must have `PolygonTraits::Point_2` as value type.
+/// \tparam BidirectionalIterator must have `PolygonTraits::Point_2` as value type.
 ///
 /// \sa `PolygonTraits_2`
 /// \sa `CGAL::bounded_side_2()`
 /// \sa `CGAL::is_simple_2()`
 /// \sa `CGAL::Polygon_2`
 /// \sa `Oriented_side`
-template <class ForwardIterator, class Point, class Traits>
-Oriented_side oriented_side_2(ForwardIterator first,
-                              ForwardIterator last,
+template <class BidirectionalIterator, class Point, class Traits>
+Oriented_side oriented_side_2(BidirectionalIterator first,
+                              BidirectionalIterator last,
                               const Point& point,
                               const Traits& traits);
 
@@ -322,17 +322,15 @@ Bounded_side bounded_side_2(ForwardIterator first,
 ///   - `Less_xy_2`
 ///   - `less_xy_2_object()`
 ///   - `orientation_2_object()`
-/// \tparam ForwardIterator must have`Traits::Point_2` as value type.
-///
-///
+/// \tparam BidirectionalIterator must have `Traits::Point_2` as value type.
 ///
 /// \sa `PolygonTraits_2`
 /// \sa `CGAL::is_simple_2()`
 /// \sa `CGAL::Polygon_2`
 /// \sa `CGAL::Orientation`
-template <class ForwardIterator, class Traits>
-Orientation orientation_2(ForwardIterator first,
-                          ForwardIterator last,
+template <class BidirectionalIterator, class Traits>
+Orientation orientation_2(BidirectionalIterator first,
+                          BidirectionalIterator last,
                           const Traits& traits);
 
 /// @}

--- a/Polygon/include/CGAL/Polygon_2_algorithms.h
+++ b/Polygon/include/CGAL/Polygon_2_algorithms.h
@@ -61,8 +61,7 @@ ForwardIterator left_vertex_2(ForwardIterator first,
 /// `[first,last)`. In case of a tie, the point
 /// with the largest `y`-coordinate is taken.
 ///
-/// \tparam Traits is a model of the concept
-///           `PolygonTraits_2`.
+/// \tparam Traits is a model of the concept `PolygonTraits_2`.
 ///           In fact, only the members `Less_xy_2` and
 ///           `less_xy_2_object()` are used.
 /// \tparam ForwardIterator must have`Traits::Point_2` as value type.
@@ -81,8 +80,7 @@ ForwardIterator right_vertex_2(ForwardIterator first,
 /// `[first,last)`. In case of a tie, the point
 /// with the largest `x`-coordinate is taken.
 ///
-/// \tparam Traits is a model of the concept
-///           `PolygonTraits_2`.
+/// \tparam Traits is a model of the concept `PolygonTraits_2`.
 ///           Only the members `Less_yx_2` and
 ///           `less_yx_2_object()` are used.
 /// \tparam ForwardIterator must have `Traits::Point_2` as value type.
@@ -100,8 +98,7 @@ ForwardIterator top_vertex_2(ForwardIterator first,
 /// `[first,last)`. In case of a tie, the point
 /// with the smallest `x`-coordinate is taken.
 ///
-/// \tparam Traits is a model of the concept
-///           `PolygonTraits_2`.
+/// \tparam Traits is a model of the concept `PolygonTraits_2`.
 ///           Only the members `Less_yx_2` and
 ///           `less_yx_2_object()` are used.
 /// \tparam ForwardIterator must have `Traits::Point_2` as value type.
@@ -123,8 +120,7 @@ ForwardIterator bottom_vertex_2(ForwardIterator first,
 /// The functionality is also available by the `polygon_area_2()` function, which
 /// returns the area instead of taking it as a parameter.
 ///
-/// \tparam Traits is a model of the concept
-///           `PolygonTraits_2`.
+/// \tparam Traits is a model of the concept `PolygonTraits_2`.
 ///           Only the following members of this traits class are used:
 ///   - `Compute_area_2` : Computes the signed area of the
 ///             oriented triangle defined by 3 `Point_2` passed as arguments.
@@ -250,8 +246,8 @@ bool is_simple_2(ForwardIterator first,
 // instead of Point, but this is not allowed by g++ 2.7.2.
 ///
 /// Computes on which side of a polygon a point lies.
-/// \tparam Traits is a model of the concept
-///           `PolygonTraits_2`.
+///
+/// \tparam Traits is a model of the concept `PolygonTraits_2`.
 ///           Only the following members of this traits class are used:
 ///   - `Less_xy_2`
 ///   - `Compare_x_2`
@@ -284,8 +280,7 @@ Oriented_side oriented_side_2(BidirectionalIterator first,
 /// According to the definition points in the bounded region are inside the polygon.
 ///
 ///
-/// \tparam Traits is a model of the concept
-///           `PolygonTraits_2`.
+/// \tparam Traits is a model of the concept `PolygonTraits_2`.
 ///           Only the following members of this traits class are used:
 ///   - `Compare_x_2`
 ///   - `Compare_y_2`
@@ -316,8 +311,7 @@ Bounded_side bounded_side_2(ForwardIterator first,
 /// Computes if a polygon is clockwise or counterclockwise oriented.
 /// \pre \link CGAL::is_simple_2 `is_simple_2`\endlink(`first`, `last`, `traits`)
 ///
-/// \tparam Traits is a model of the concept
-///           `PolygonTraits_2`.
+/// \tparam Traits is a model of the concept `PolygonTraits_2`.
 ///           Only the following members of this traits class are used:
 ///   - `Less_xy_2`
 ///   - `less_xy_2_object()`

--- a/Polygon/test/Polygon/AlgorithmTest.cpp
+++ b/Polygon/test/Polygon/AlgorithmTest.cpp
@@ -9,6 +9,70 @@
 using std::cout;
 using std::endl;
 
+// Custom forward and bidirectional iterators to test the algorithms requirements
+template <class T>
+class Forward_iterator
+{
+public:
+  typedef std::forward_iterator_tag iterator_category;
+  typedef T value_type;
+  typedef std::ptrdiff_t difference_type;
+  typedef T* pointer;
+  typedef T& reference;
+
+  Forward_iterator() : ptr_(nullptr) {}
+  explicit Forward_iterator(T* ptr) : ptr_(ptr) {}
+
+  reference operator*() const { return *ptr_; }
+  pointer operator->() const { return ptr_; }
+
+  Forward_iterator& operator++() { ++ptr_; return *this; }
+  Forward_iterator operator++(int) { Forward_iterator tmp(*this); ++ptr_; return tmp; }
+
+  friend bool operator==(const Forward_iterator& a, const Forward_iterator& b) { return a.ptr_ == b.ptr_; }
+  friend bool operator!=(const Forward_iterator& a, const Forward_iterator& b) { return a.ptr_ != b.ptr_; }
+
+private:
+  T* ptr_;
+};
+
+// free function constructor
+template <class T>
+Forward_iterator<T> make_forward_iterator(T* ptr) { return Forward_iterator<T>(ptr); }
+
+template <class T>
+class Bidirectional_iterator
+{
+public:
+  typedef std::bidirectional_iterator_tag iterator_category;
+  typedef T value_type;
+  typedef std::ptrdiff_t difference_type;
+  typedef T* pointer;
+  typedef T& reference;
+
+  Bidirectional_iterator() : ptr_(nullptr) {}
+  explicit Bidirectional_iterator(T* ptr) : ptr_(ptr) {}
+
+  reference operator*() const { return *ptr_; }
+  pointer operator->() const { return ptr_; }
+
+  Bidirectional_iterator& operator++() { ++ptr_; return *this; }
+  Bidirectional_iterator operator++(int) { Bidirectional_iterator tmp(*this); ++ptr_; return tmp; }
+  Bidirectional_iterator& operator--() { --ptr_; return *this; }
+  Bidirectional_iterator operator--(int) { Bidirectional_iterator tmp(*this); --ptr_; return tmp; }
+
+  friend bool operator==(const Bidirectional_iterator& a, const Bidirectional_iterator& b) { return a.ptr_ == b.ptr_; }
+  friend bool operator!=(const Bidirectional_iterator& a, const Bidirectional_iterator& b)
+  { return a.ptr_ != b.ptr_; }
+
+private:
+  T* ptr_;
+};
+
+// free function constructor
+template <class T>
+Bidirectional_iterator<T> make_bidirectional_iterator(T* ptr) { return Bidirectional_iterator<T>(ptr); }
+
 //------------------------------------------------------------------------------//
 //      test the almost-collinear point filtering function (undocumented)
 //------------------------------------------------------------------------------//
@@ -38,7 +102,8 @@ void test_collinear_point_filtering(const R&, const char* FileName)
   std::size_t final_size;
 
   // check for 3 points
-  CGAL::internal::Polygon_2::filter_collinear_points<R>(polygon.begin(), polygon.begin() + 3,
+  CGAL::internal::Polygon_2::filter_collinear_points<R>(make_bidirectional_iterator(&polygon[0]),
+                                                        make_bidirectional_iterator(&polygon[0] + 3),
                                                         std::back_inserter(simplified_polygon),
                                                         0 /*tolerance*/);
   final_size = simplified_polygon.size();
@@ -47,7 +112,8 @@ void test_collinear_point_filtering(const R&, const char* FileName)
 
   // generic tests
   simplified_polygon.clear();
-  CGAL::internal::Polygon_2::filter_collinear_points<R>(polygon.begin(), polygon.end(),
+  CGAL::internal::Polygon_2::filter_collinear_points<R>(make_bidirectional_iterator(&polygon[0]),
+                                                        make_bidirectional_iterator(&polygon[0] + polygon.size()),
                                                         std::back_inserter(simplified_polygon),
                                                         0 /*tolerance*/);
   final_size = simplified_polygon.size();
@@ -56,7 +122,8 @@ void test_collinear_point_filtering(const R&, const char* FileName)
 
     // --
   simplified_polygon.clear();
-  CGAL::internal::Polygon_2::filter_collinear_points<R>(polygon.begin(), polygon.end(),
+  CGAL::internal::Polygon_2::filter_collinear_points<R>(make_bidirectional_iterator(&polygon[0]),
+                                                        make_bidirectional_iterator(&polygon[0] + polygon.size()),
                                                         std::back_inserter(simplified_polygon),
                                                         1e-10);
   final_size = simplified_polygon.size();
@@ -74,8 +141,6 @@ void test_collinear_point_filtering(const R&, const char* FileName)
 template <class R, class Point>
 void test_polygon(const R&, const Point&, const char* FileName)
 {
-  typedef typename std::vector<Point>::iterator iterator;
-
   // read a point and a polygon from the file 'FileName'
   std::ifstream from(FileName);
   if (!from) {
@@ -96,33 +161,34 @@ void test_polygon(const R&, const Point&, const char* FileName)
     // show the point and the polygon
     cout << "point: " << point << endl;
     cout << "polygon:" << endl;
-    std::copy(polygon.begin(), polygon.end(),
-        std::ostream_iterator<Point>(cout, "\n"));
+    std::copy(polygon.begin(), polygon.end(), std::ostream_iterator<Point>(cout, "\n"));
     cout << endl;
 
-    iterator left =
-        CGAL::left_vertex_2(polygon.begin(), polygon.end());
-    iterator right =
-        CGAL::right_vertex_2(polygon.begin(), polygon.end());
-    iterator top =
-        CGAL::top_vertex_2(polygon.begin(), polygon.end());
-    iterator bottom =
-        CGAL::bottom_vertex_2(polygon.begin(), polygon.end());
-    bool simple =
-        CGAL::is_simple_2(polygon.begin(), polygon.end());
-    bool convex =
-        CGAL::is_convex_2(polygon.begin(), polygon.end());
-    CGAL::Bbox_2 bbox =
-        CGAL::bbox_2(polygon.begin(), polygon.end(), R());
+    auto left = CGAL::left_vertex_2(make_forward_iterator(&polygon[0]),
+                                    make_forward_iterator(&polygon[0]+polygon.size()));
+    auto right = CGAL::right_vertex_2(make_forward_iterator(&polygon[0]),
+                                      make_forward_iterator(&polygon[0]+polygon.size()));
+    auto top = CGAL::top_vertex_2(make_forward_iterator(&polygon[0]),
+                                  make_forward_iterator(&polygon[0]+polygon.size()));
+    auto bottom = CGAL::bottom_vertex_2(make_forward_iterator(&polygon[0]),
+                                        make_forward_iterator(&polygon[0]+polygon.size()));
+    bool simple = CGAL::is_simple_2(make_forward_iterator(&polygon[0]),
+                                    make_forward_iterator(&polygon[0]+polygon.size()));
+    bool convex = CGAL::is_convex_2(make_forward_iterator(&polygon[0]),
+                                    make_forward_iterator(&polygon[0]+polygon.size()));
+    CGAL::Bbox_2 bbox = CGAL::bbox_2(make_forward_iterator(&polygon[0]),
+                                     make_forward_iterator(&polygon[0]+polygon.size()), R());
     typename R::FT area = 0, area2;
-    CGAL::area_2(polygon.begin(), polygon.end(), area, R());
-    area2 = CGAL::polygon_area_2(polygon.begin(), polygon.end(), R());
-    CGAL::Bounded_side bside =
-         CGAL::bounded_side_2(polygon.begin(), polygon.end(), point);
-    CGAL::Oriented_side oside =
-        CGAL::oriented_side_2(polygon.begin(), polygon.end(), point);
-    CGAL::Orientation orientation =
-        CGAL::orientation_2(polygon.begin(), polygon.end());
+    CGAL::area_2(make_forward_iterator(&polygon[0]),
+                 make_forward_iterator(&polygon[0]+polygon.size()), area, R());
+    area2 = CGAL::polygon_area_2(make_forward_iterator(&polygon[0]),
+                                 make_forward_iterator(&polygon[0]+polygon.size()), R());
+    CGAL::Bounded_side bside = CGAL::bounded_side_2(make_forward_iterator(&polygon[0]),
+                                                    make_forward_iterator(&polygon[0]+polygon.size()), point);
+    CGAL::Oriented_side oside = CGAL::oriented_side_2(make_bidirectional_iterator(&polygon[0]),
+                                                      make_bidirectional_iterator(&polygon[0]+polygon.size()), point);
+    CGAL::Orientation orientation = CGAL::orientation_2(make_bidirectional_iterator(&polygon[0]),
+                                                        make_bidirectional_iterator(&polygon[0]+polygon.size()));
 
     cout << "left   = " << *left << endl;
     cout << "right  = " << *right << endl;

--- a/Polygon/test/Polygon/AlgorithmTest.cpp
+++ b/Polygon/test/Polygon/AlgorithmTest.cpp
@@ -102,8 +102,8 @@ void test_collinear_point_filtering(const R&, const char* FileName)
   std::size_t final_size;
 
   // check for 3 points
-  CGAL::internal::Polygon_2::filter_collinear_points<R>(make_bidirectional_iterator(&polygon[0]),
-                                                        make_bidirectional_iterator(&polygon[0] + 3),
+  CGAL::internal::Polygon_2::filter_collinear_points<R>(make_forward_iterator(&polygon[0]),
+                                                        make_forward_iterator(&polygon[0] + 3),
                                                         std::back_inserter(simplified_polygon),
                                                         0 /*tolerance*/);
   final_size = simplified_polygon.size();
@@ -112,8 +112,8 @@ void test_collinear_point_filtering(const R&, const char* FileName)
 
   // generic tests
   simplified_polygon.clear();
-  CGAL::internal::Polygon_2::filter_collinear_points<R>(make_bidirectional_iterator(&polygon[0]),
-                                                        make_bidirectional_iterator(&polygon[0] + polygon.size()),
+  CGAL::internal::Polygon_2::filter_collinear_points<R>(make_forward_iterator(&polygon[0]),
+                                                        make_forward_iterator(&polygon[0] + polygon.size()),
                                                         std::back_inserter(simplified_polygon),
                                                         0 /*tolerance*/);
   final_size = simplified_polygon.size();
@@ -122,8 +122,8 @@ void test_collinear_point_filtering(const R&, const char* FileName)
 
     // --
   simplified_polygon.clear();
-  CGAL::internal::Polygon_2::filter_collinear_points<R>(make_bidirectional_iterator(&polygon[0]),
-                                                        make_bidirectional_iterator(&polygon[0] + polygon.size()),
+  CGAL::internal::Polygon_2::filter_collinear_points<R>(make_forward_iterator(&polygon[0]),
+                                                        make_forward_iterator(&polygon[0] + polygon.size()),
                                                         std::back_inserter(simplified_polygon),
                                                         1e-10);
   final_size = simplified_polygon.size();
@@ -185,10 +185,10 @@ void test_polygon(const R&, const Point&, const char* FileName)
                                  make_forward_iterator(&polygon[0]+polygon.size()), R());
     CGAL::Bounded_side bside = CGAL::bounded_side_2(make_forward_iterator(&polygon[0]),
                                                     make_forward_iterator(&polygon[0]+polygon.size()), point);
-    CGAL::Oriented_side oside = CGAL::oriented_side_2(make_bidirectional_iterator(&polygon[0]),
-                                                      make_bidirectional_iterator(&polygon[0]+polygon.size()), point);
-    CGAL::Orientation orientation = CGAL::orientation_2(make_bidirectional_iterator(&polygon[0]),
-                                                        make_bidirectional_iterator(&polygon[0]+polygon.size()));
+    CGAL::Oriented_side oside = CGAL::oriented_side_2(make_forward_iterator(&polygon[0]),
+                                                      make_forward_iterator(&polygon[0]+polygon.size()), point);
+    CGAL::Orientation orientation = CGAL::orientation_2(make_forward_iterator(&polygon[0]),
+                                                        make_forward_iterator(&polygon[0]+polygon.size()));
 
     cout << "left   = " << *left << endl;
     cout << "right  = " << *right << endl;


### PR DESCRIPTION
## Summary of Changes

For polygons, some functions (`CGAL::orientation_2`, `CGAL::oriented_side_2`, etc.) advertised Forward Iterator but actually required bidirectional iterators.

This PR updates the code such that forward iterators can be used (and test it). The internal function that can clean collinearity occurrences within a polygon is rewritten because some assertions were overly zealous.

## Release Management

* Affected package(s): `Polygon`
* Issue(s) solved (if any): fix #9468
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

