### PR TITLE
Ipelet doc cleaning

### DIFF
--- a/CGAL_ipelets/demo/CGAL_ipelets/CMakeLists.txt
+++ b/CGAL_ipelets/demo/CGAL_ipelets/CMakeLists.txt
@@ -92,23 +92,20 @@ if(IPE_FOUND AND IPE_VERSION)
                                                  ${IPE_LIBRARIES})
     if(IPELET_INSTALL_DIR)
       install(TARGETS CGAL_${IPELET} DESTINATION ${IPELET_INSTALL_DIR})
-      install(FILES ./lua/libCGAL_${IPELET}.lua DESTINATION ${IPELET_INSTALL_DIR}) #only for ipe 7
+      install(FILES ./lua/libCGAL_${IPELET}.lua DESTINATION ${IPELET_INSTALL_DIR})
     endif ()
     cgal_add_compilation_test(CGAL_${IPELET})
   endforeach(IPELET)
   target_link_libraries(CGAL_cone_spanners PRIVATE CGAL::CGAL CGAL::CGAL_Core
                                                    CGAL::Eigen3_support)
+
   #example in doc not installed
   add_library(simple_triangulation MODULE simple_triangulation.cpp)
+  target_include_directories(simple_triangulation BEFORE PRIVATE ${IPE_INCLUDE_DIR})
   add_to_cached_list(CGAL_EXECUTABLE_TARGETS simple_triangulation)
   target_link_libraries(simple_triangulation CGAL::CGAL CGAL::Eigen3_support
                         ${IPE_LIBRARIES})
-  target_include_directories(simple_triangulation BEFORE PRIVATE ${IPE_INCLUDE_DIR})
-  if (WITH_IPE_7)
-      target_compile_definitions(simple_triangulation PRIVATE CGAL_USE_IPE_7)
-    endif()
   cgal_add_compilation_test(simple_triangulation)
-
 else()
   message("NOTICE: This project requires the Ipe include files and library, and will not be compiled.")
 endif()

--- a/CGAL_ipelets/doc/CGAL_ipelets/CGAL_ipelets.txt
+++ b/CGAL_ipelets/doc/CGAL_ipelets/CGAL_ipelets.txt
@@ -47,8 +47,45 @@ interface the \cgal 2D Delaunay triangulation with Ipe.
 
 \cgalExample{CGAL_ipelets/simple_triangulation.cpp}
 
+The ipelet should be compiled and placed in a directory where Ipe can find it.
+These directories are listed in the "Show Configuration" entry of the "Help" menu of Ipe.
+Along with the compiled ipelet, a LUA file must be created to load the ipelet in Ipe.
+Below is an example of the LUA file that can be associated to the previous C++ ipelet.
+
+\code
+----------------------------------------------------------------------
+-- Simple Triangulation ipelet description
+----------------------------------------------------------------------
+
+label = "Simple triangulation"
+
+about = [[
+This ipelet is an example of ipelet from the CGAL documentation. See www.cgal.org.
+]]
+
+-- this variable will store the C++ ipelet when it has been loaded
+ipelet = false
+
+function run(model, num)
+  if not ipelet then ipelet = assert(ipe.Ipelet(dllname)) end
+  model:runIpelet(methods[num].label, ipelet, num)
+end
+
+methods = {
+  { label="Simple Triangulation" },
+  { label="Help" },
+}
+
+----------------------------------------------------------------------
+\endcode
+
+Once both the compiled ipelet and the LUA file are in place, the ipelet can be called
+from the "Ipelets" menu of Ipe.
+
 \image html example.png
 \image latex example.png
+
+For more advanced information, we refer to the <a href="https://ipe.otfried.org/ipelib/ipelets.html">documentation of Ipe</a>.
 
 \section CGAL_ipeletsInstallation Installation of the Demo Ipelets
 


### PR DESCRIPTION
## Summary of Changes

The user manual shows how to write a dummy ipelet but only display the .cpp and not the mandatory .lua, which can be confusing.

Also it's useful to indicate where both can be placed.

Clean some cmakelists along the way.

## Release Management

* Affected package(s): `CGAL_Ipelets`
* Issue(s) solved (if any): fix #8561
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

