### PR TITLE
Spelling correction

### DIFF
--- a/Basic_viewer/include/CGAL/Basic_shaders.h
+++ b/Basic_viewer/include/CGAL/Basic_shaders.h
@@ -145,7 +145,7 @@ void main(void)
   if (u_IsOrthographic)
   {
     // In orthographic projection clip-space w is always 1; using u_PointSize
-    // as the divisor cancelled out the user's setting (pointSize = 1 always).
+    // as the divisor canceled out the user's setting (pointSize = 1 always).
     // Use 1.0 so gl_PointSize = u_PointSize, a direct screen-pixel diameter.
     distance = 1.0;
   }

--- a/Tetrahedral_remeshing/doc/Tetrahedral_remeshing/Tetrahedral_remeshing.txt
+++ b/Tetrahedral_remeshing/doc/Tetrahedral_remeshing/Tetrahedral_remeshing.txt
@@ -133,7 +133,7 @@ are ignored by the remeshing algorithm.
 Optional BGL named parameters offer more precise
 control on the remeshing process.
 
-The default behaviour is to remesh only the cells with a non-zero `Subdomain_index`.
+The default behavior is to remesh only the cells with a non-zero `Subdomain_index`.
 The use of the named parameter `cell_is_selected_map` enables to change this behavior,
 and select the cells to remesh with a custom selection criterion.
 


### PR DESCRIPTION
Spelling correction
- in running text `behavior` is used
- in function names, unfortunately, `behaviour` is used in function names

