### PR TITLE
Use overloads of choose_parameter to avoid allocating default values

### DIFF
--- a/Alpha_wrap_3/benchmark/Alpha_wrap_3/Quality/distance_utils.h
+++ b/Alpha_wrap_3/benchmark/Alpha_wrap_3/Quality/distance_utils.h
@@ -90,9 +90,6 @@ inline double approximate_distance(const TriangleMesh& tm1,
   using AABB_traits = CGAL::AABB_traits_3<GT, Primitive>;
   using AABB_tree = CGAL::AABB_tree<AABB_traits>;
 
-  using CGAL::parameters::choose_parameter;
-  using CGAL::parameters::get_parameter;
-
   std::vector<Point_3> original_sample_points;
   CGAL::Polygon_mesh_processing::sample_triangle_mesh(tm1, std::back_inserter(original_sample_points),
                                                       CGAL::parameters::all_default());

--- a/BGL/include/CGAL/boost/graph/IO/Generic_facegraph_builder.h
+++ b/BGL/include/CGAL/boost/graph/IO/Generic_facegraph_builder.h
@@ -102,10 +102,10 @@ public:
 
     // Construct the graph
     VPM vpm = choose_parameter(get_parameter(np, internal_np::vertex_point), get_property_map(CGAL::vertex_point, g));
-    VNM vnm = choose_parameter(get_parameter(np, internal_np::vertex_normal_map), VNM());
-    VCM vcm = choose_parameter(get_parameter(np, internal_np::vertex_color_map), VCM());
-    VTM vtm = choose_parameter(get_parameter(np, internal_np::vertex_texture_map), VTM());
-    FCM fcm = choose_parameter(get_parameter(np, internal_np::face_color_map), FCM());
+    VNM vnm = choose_parameter<VNM>(get_parameter(np, internal_np::vertex_normal_map));
+    VCM vcm = choose_parameter<VCM>(get_parameter(np, internal_np::vertex_color_map));
+    VTM vtm = choose_parameter<VTM>(get_parameter(np, internal_np::vertex_texture_map));
+    FCM fcm = choose_parameter<FCM>(get_parameter(np, internal_np::face_color_map));
 
     const bool has_vertex_normals = (is_vnm_requested && !(vertex_normals.empty()));
     const bool has_vertex_colors = (is_vcm_requested && !(vertex_colors.empty()));

--- a/BGL/include/CGAL/boost/graph/IO/OM.h
+++ b/BGL/include/CGAL/boost/graph/IO/OM.h
@@ -234,10 +234,8 @@ bool write_OM(const std::string& fname,
 
   using CGAL::parameters::get_parameter;
   using CGAL::parameters::choose_parameter;
-  auto vfpm = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained),
-                               CGAL::Constant_property_map<vertex_descriptor, bool>(false));
-  auto efpm = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
-                               CGAL::Constant_property_map<edge_descriptor, bool>(false));
+  auto vfpm = choose_parameter<Static_boolean_property_map<vertex_descriptor, false>>(get_parameter(np, internal_np::vertex_is_constrained));
+  auto efpm = choose_parameter<Static_boolean_property_map<edge_descriptor, false>>(get_parameter(np, internal_np::edge_is_constrained));
   auto vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                               get_const_property_map(vertex_point, g));
   std::streamsize precision = choose_parameter(get_parameter(np, internal_np::stream_precision),

--- a/BGL/include/CGAL/boost/graph/IO/PLY.h
+++ b/BGL/include/CGAL/boost/graph/IO/PLY.h
@@ -366,8 +366,8 @@ bool write_PLY(std::ostream& os,
   using parameters::is_default_parameter;
   using parameters::get_parameter;
 
-  VCM vcm = choose_parameter(get_parameter(np, internal_np::vertex_color_map), VCM());
-  FCM fcm = choose_parameter(get_parameter(np, internal_np::face_color_map), FCM());
+  VCM vcm = choose_parameter<VCM>(get_parameter(np, internal_np::vertex_color_map));
+  FCM fcm = choose_parameter<FCM>(get_parameter(np, internal_np::face_color_map));
 
   bool has_vcolor = !is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>::value;
   bool has_fcolor = !is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>::value;

--- a/BGL/include/CGAL/boost/graph/alpha_expansion_graphcut.h
+++ b/BGL/include/CGAL/boost/graph/alpha_expansion_graphcut.h
@@ -525,9 +525,6 @@ double alpha_expansion_graphcut (const InputGraph& input_graph,
                                  VertexLabelMap vertex_label_map,
                                  const NamedParameters& np = parameters::default_values())
 {
-  using parameters::choose_parameter;
-  using parameters::get_parameter;
-
   typedef boost::graph_traits<InputGraph> GT;
   typedef typename GT::edge_descriptor input_edge_descriptor;
   typedef typename GT::vertex_descriptor input_vertex_descriptor;
@@ -686,9 +683,6 @@ double alpha_expansion_graphcut (const InputGraph& input_graph,
       VertexLabelMap vertex_label_map,
       const NamedParameters& np)
   {
-    using parameters::choose_parameter;
-    using parameters::get_parameter;
-
     typedef boost::graph_traits<InputGraph> GT;
     typedef typename GT::edge_descriptor input_edge_descriptor;
     typedef typename GT::vertex_descriptor input_vertex_descriptor;

--- a/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
+++ b/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
@@ -713,7 +713,7 @@ public:
     */
   template <typename PolygonMesh, typename CGAL_NP_TEMPLATE_PARAMETERS>
   Conforming_constrained_Delaunay_triangulation_3(const PolygonMesh& mesh, const CGAL_NP_CLASS& np = parameters::default_values())
-      : cdt_impl(parameters::choose_parameter(parameters::get_parameter(np, internal_np::geom_traits), Traits{}))
+      : cdt_impl(parameters::choose_parameter<Traits>(parameters::get_parameter(np, internal_np::geom_traits)))
   {
     // ----------------------------------
     // cstr... (polygon mesh)
@@ -724,7 +724,7 @@ public:
 
     auto mesh_vp_map = choose_parameter(get_parameter(np, internal_np::vertex_point),
                                         get_const_property_map(vertex_point, mesh));
-    this->debug() = choose_parameter(get_parameter(np, internal_np::debug), CDT_3::Debug_options{});
+    this->debug() = choose_parameter<CDT_3::Debug_options>(get_parameter(np, internal_np::debug));
 
     using graph_traits = boost::graph_traits<PolygonMesh>;
     using vertex_descriptor = typename graph_traits::vertex_descriptor;
@@ -927,7 +927,7 @@ public:
   Conforming_constrained_Delaunay_triangulation_3(const PointRange& points,
                                                   const PolygonRange& polygons,
                                                   const NamedParams& np = parameters::default_values())
-      : cdt_impl(parameters::choose_parameter(parameters::get_parameter(np, internal_np::geom_traits), Traits{}))
+      : cdt_impl(parameters::choose_parameter<Traits>(parameters::get_parameter(np, internal_np::geom_traits)))
   {
     // ----------------------------------
     // cstr... (polygon soup)
@@ -938,8 +938,7 @@ public:
     using PointRange_const_iterator = typename PointRange::const_iterator;
     using PointRange_value_type = typename std::iterator_traits<PointRange_const_iterator>::value_type;
 
-    auto point_map = choose_parameter(get_parameter(np, internal_np::point_map),
-                                                    CGAL::Identity_property_map<PointRange_value_type>{});
+    auto point_map = choose_parameter<CGAL::Identity_property_map<PointRange_value_type>>(get_parameter(np, internal_np::point_map));
 
     constexpr bool has_plc_face_id = !parameters::is_default_parameter<NamedParams, internal_np::plc_face_id_t>::value;
 

--- a/Convex_hull_3/include/CGAL/Convex_hull_3/distance.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/distance.h
@@ -413,13 +413,9 @@ typename internal::GetGeomTraitsFromConvex<Convex_1, NamedParameters_1>::type::F
 separation_distance(const Convex_1& c1, const Convex_2& c2,
                     const NamedParameters_1& np1 = parameters::default_values(),
                     const NamedParameters_2& np2 = parameters::default_values()){
-  using CGAL::parameters::choose_parameter;
-  using CGAL::parameters::get_parameter;
-
   //The function need exact computation to works correctly
   using EPECK=Exact_predicates_exact_constructions_kernel;
   using GT= typename internal::GetGeomTraitsFromConvex<Convex_1, NamedParameters_1>::type;
-  // GT gt = choose_parameter<GT>(get_parameter(np1, internal_np::geom_traits));
   return predicates_impl::Separation_distance_functor<GT, EPECK>()(c1, c2, np1, np2);
 }
 

--- a/Convex_hull_3/include/CGAL/Convex_hull_3/do_intersect.h
+++ b/Convex_hull_3/include/CGAL/Convex_hull_3/do_intersect.h
@@ -352,10 +352,7 @@ template <class Convex_1, class Convex_2,
 bool do_intersect(const Convex_1& ch1, const Convex_2& ch2,
                   const NamedParameters_1& np1 = parameters::default_values(),
                   const NamedParameters_2& np2 = parameters::default_values()){
-  using CGAL::parameters::choose_parameter;
-  using CGAL::parameters::get_parameter;
   using GT= typename internal::GetGeomTraitsFromConvex<Convex_1, NamedParameters_1>::type;
-  // GT gt = choose_parameter<GT>(get_parameter(np1, internal_np::geom_traits));
   return Do_intersect_traits<GT>().do_intersect_object()(ch1, ch2, np1, np2);
 }
 

--- a/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
+++ b/Mesh_2/include/CGAL/lloyd_optimize_mesh_2.h
@@ -157,8 +157,8 @@ lloyd_optimize_mesh_2(CDT& cdt, const CGAL_NP_CLASS& np = parameters::default_va
                                       convergence_ratio,
                                       freeze_bound,
                                       time_limit,
-                                      choose_parameter(get_parameter(np, internal_np::i_seed_begin_iterator), CGAL::Emptyset_iterator()),
-                                      choose_parameter(get_parameter(np, internal_np::i_seed_end_iterator), CGAL::Emptyset_iterator()),
+                                      choose_parameter<CGAL::Emptyset_iterator>(get_parameter(np, internal_np::i_seed_begin_iterator)),
+                                      choose_parameter<CGAL::Emptyset_iterator>(get_parameter(np, internal_np::i_seed_end_iterator)),
                                       mark);
   }
 }

--- a/Mesh_3/include/CGAL/Mesh_3/Labeled_mesh_domain_3_image.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Labeled_mesh_domain_3_image.h
@@ -117,10 +117,10 @@ create_gray_image_mesh_domain(const CGAL::Image_3& image_, const CGAL_NP_CLASS& 
   auto iso_value_ = choose_parameter(get_parameter(np, internal_np::iso_value_param), 0);
   auto value_outside_ = choose_parameter(get_parameter(np, internal_np::voxel_value), 0);
   FT relative_error_bound_ = choose_parameter(get_parameter(np, internal_np::error_bound), FT(1e-3));
-  auto image_values_to_subdomain_indices_ = choose_parameter(get_parameter(np, internal_np::image_subdomain_index), Null_functor());
+  auto image_values_to_subdomain_indices_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::image_subdomain_index));
   CGAL::Random* p_rng_ = choose_parameter(get_parameter(np, internal_np::rng), nullptr);
-  auto null_subdomain_index_ = choose_parameter(get_parameter(np, internal_np::null_subdomain_index_param), Null_functor());
-  auto construct_surface_patch_index_ = choose_parameter(get_parameter(np, internal_np::surface_patch_index), Null_functor());
+  auto null_subdomain_index_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::null_subdomain_index_param));
+  auto construct_surface_patch_index_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::surface_patch_index));
   namespace p = CGAL::parameters;
   return Labeled_mesh_domain_3
             (p::function = create_gray_image_wrapper
@@ -151,10 +151,10 @@ create_labeled_image_mesh_domain(const CGAL::Image_3& image_, const CGAL_NP_CLAS
   auto iso_value_ = choose_parameter(get_parameter(np, internal_np::iso_value_param), 0);
   auto value_outside_ = choose_parameter(get_parameter(np, internal_np::voxel_value), 0);
   FT relative_error_bound_ = choose_parameter(get_parameter(np, internal_np::error_bound), FT(1e-3));
-  auto image_values_to_subdomain_indices_ = choose_parameter(get_parameter(np, internal_np::image_subdomain_index), Null_functor());
+  auto image_values_to_subdomain_indices_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::image_subdomain_index));
   CGAL::Random* p_rng_ = choose_parameter(get_parameter(np, internal_np::rng), nullptr);
-  auto null_subdomain_index_ = choose_parameter(get_parameter(np, internal_np::null_subdomain_index_param), Null_functor());
-  auto construct_surface_patch_index_ = choose_parameter(get_parameter(np, internal_np::surface_patch_index), Null_functor());
+  auto null_subdomain_index_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::null_subdomain_index_param));
+  auto construct_surface_patch_index_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::surface_patch_index));
 
   using Image_ref_type = typename internal_np::Lookup_named_param_def<internal_np::weights_param_t,
                                                                       CGAL_NP_CLASS,
@@ -225,10 +225,10 @@ create_gray_image_mesh_domain(const CGAL_NP_CLASS& np)
   auto iso_value_ = choose_parameter(get_parameter(np, internal_np::iso_value_param), 0);
   auto value_outside_ = choose_parameter(get_parameter(np, internal_np::voxel_value), 0);
   FT relative_error_bound_ = choose_parameter(get_parameter(np, internal_np::error_bound), FT(1e-3));
-  auto image_values_to_subdomain_indices_ = choose_parameter(get_parameter(np, internal_np::image_subdomain_index), Null_functor());
+  auto image_values_to_subdomain_indices_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::image_subdomain_index));
   CGAL::Random* p_rng_ = choose_parameter(get_parameter(np, internal_np::rng), nullptr);
-  auto null_subdomain_index_ = choose_parameter(get_parameter(np, internal_np::null_subdomain_index_param), Null_functor());
-  auto construct_surface_patch_index_ = choose_parameter(get_parameter(np, internal_np::surface_patch_index), Null_functor());
+  auto null_subdomain_index_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::null_subdomain_index_param));
+  auto construct_surface_patch_index_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::surface_patch_index));
   namespace p = CGAL::parameters;
   return Labeled_mesh_domain_3
           (p::function = create_gray_image_wrapper

--- a/Mesh_3/include/CGAL/Mesh_3/Labeled_mesh_domain_3_implicit_function.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Labeled_mesh_domain_3_implicit_function.h
@@ -287,7 +287,7 @@ public:
                 bounding_object,
                 parameters::choose_parameter(parameters::get_parameter(np, internal_np::error_bound), FT(1e-3)),
                 parameters::choose_parameter(parameters::get_parameter(np, internal_np::surface_patch_index), construct_pair_functor()),
-                parameters::choose_parameter(parameters::get_parameter(np, internal_np::null_subdomain_index_param), Null_subdomain_index()),
+                parameters::choose_parameter<Null_subdomain_index>(parameters::get_parameter(np, internal_np::null_subdomain_index_param)),
                 parameters::choose_parameter(parameters::get_parameter(np, internal_np::rng), nullptr))
   {}
 ///@}
@@ -298,7 +298,7 @@ public:
                 parameters::get_parameter(np, internal_np::bounding_object_param),
                 parameters::choose_parameter(parameters::get_parameter(np, internal_np::error_bound), FT(1e-3)),
                 parameters::choose_parameter(parameters::get_parameter(np, internal_np::surface_patch_index), construct_pair_functor()),
-                parameters::choose_parameter(parameters::get_parameter(np, internal_np::null_subdomain_index_param), Null_subdomain_index()),
+                parameters::choose_parameter<Null_subdomain_index>(parameters::get_parameter(np, internal_np::null_subdomain_index_param)),
                 parameters::choose_parameter(parameters::get_parameter(np, internal_np::rng), nullptr))
   {}
 
@@ -385,8 +385,8 @@ public:
     using parameters::choose_parameter;
     FT relative_error_bound_ = choose_parameter(get_parameter(np, internal_np::error_bound), FT(1e-3));
     CGAL::Random* p_rng_ = choose_parameter(get_parameter(np, internal_np::rng), nullptr);
-    auto null_subdomain_index_ = choose_parameter(get_parameter(np, internal_np::null_subdomain_index_param), Null_functor());
-    auto construct_surface_patch_index_ = choose_parameter(get_parameter(np, internal_np::surface_patch_index), Null_functor());
+    auto null_subdomain_index_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::null_subdomain_index_param));
+    auto construct_surface_patch_index_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::surface_patch_index));
     namespace p = CGAL::parameters;
     return Labeled_mesh_domain_3
             (p::function = make_implicit_to_labeling_function_wrapper<BGT>(function),

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/autorefinement.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/autorefinement.h
@@ -1792,11 +1792,7 @@ void
 autorefine(      TriangleMesh& tm,
            const NamedParameters& np = parameters::default_values())
 {
-  using parameters::choose_parameter;
-  using parameters::get_parameter;
-
   typedef typename GetGeomTraits<TriangleMesh, NamedParameters>::type GT;
-  // GT traits = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
 
   std::vector<typename GT::Point_3> soup_points;
   std::vector<std::array<std::size_t, 3> > soup_triangles;

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/refine_mesh_at_isolevel.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/refine_mesh_at_isolevel.h
@@ -92,7 +92,7 @@ void refine_mesh_at_isolevel(PolygonMesh& pm,
   VPM vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                              get_property_map(vertex_point, pm));
 
-  ECM ecm = choose_parameter(get_parameter(np, internal_np::edge_is_constrained), Default_ECM());
+  ECM ecm = choose_parameter<Default_ECM>(get_parameter(np, internal_np::edge_is_constrained));
 
   std::unordered_map<face_descriptor, std::vector<halfedge_descriptor> > faces_to_split;
   std::vector<edge_descriptor> to_split;

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/manifoldness.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/manifoldness.h
@@ -176,8 +176,7 @@ std::size_t make_umbrella_manifold(typename boost::graph_traits<PolygonMesh>::ha
                                                        NamedParameters,
                                                        Static_boolean_property_map<vertex_descriptor, false> // default (no constraint pmap)
                                                        >::type                  VerticesMap;
-  VerticesMap cmap = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained),
-                                      Static_boolean_property_map<vertex_descriptor, false>());
+  VerticesMap cmap = choose_parameter<Static_boolean_property_map<vertex_descriptor, false>>(get_parameter(np, internal_np::vertex_is_constrained));
 
   std::size_t nb_new_vertices = 0;
 
@@ -438,8 +437,7 @@ std::size_t duplicate_non_manifold_vertices(PolygonMesh& pm,
                                                        NamedParameters,
                                                        Emptyset_iterator>::type Output_iterator;
 
-  Output_iterator out = choose_parameter(get_parameter(np, internal_np::output_iterator),
-                                         Emptyset_iterator());
+  Output_iterator out = choose_parameter<Emptyset_iterator>(get_parameter(np, internal_np::output_iterator));
 
   std::vector<halfedge_descriptor> non_manifold_cones;
   non_manifold_vertices(pm, std::back_inserter(non_manifold_cones));

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/repair_degeneracies.h
@@ -709,20 +709,20 @@ bool remove_almost_degenerate_faces(const FaceRange& face_range,
   typedef typename internal_np::Lookup_named_param_def<internal_np::vertex_is_constrained_t,
                                                        NamedParameters,
                                                        Default_VCM>::type       VCM;
-  VCM vcm_np = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained), Default_VCM());
+  VCM vcm_np = choose_parameter<Default_VCM>(get_parameter(np, internal_np::vertex_is_constrained));
 
   typedef Static_boolean_property_map<edge_descriptor, false>                   Default_ECM;
   typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t,
                                                        NamedParameters,
                                                        Default_ECM>::type       ECM;
-  ECM ecm = choose_parameter(get_parameter(np, internal_np::edge_is_constrained), Default_ECM());
+  ECM ecm = choose_parameter<Default_ECM>(get_parameter(np, internal_np::edge_is_constrained));
 
   typedef typename GetVertexPointMap<TriangleMesh, NamedParameters>::const_type VPM;
   VPM vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                              get_const_property_map(vertex_point, tmesh));
 
   typedef typename GetGeomTraits<TriangleMesh, NamedParameters>::type           Traits;
-  Traits gt = choose_parameter(get_parameter(np, internal_np::geom_traits), Traits());
+  Traits gt = choose_parameter<Traits>(get_parameter(np, internal_np::geom_traits));
 
   typedef typename internal_np::Lookup_named_param_def<
             internal_np::filter_t,
@@ -2036,7 +2036,7 @@ bool remove_degenerate_faces(const FaceRange& face_range,
   VertexPointMap vpmap = choose_parameter(get_parameter(np, internal_np::vertex_point),
                                           get_property_map(vertex_point, tmesh));
   typedef typename GetGeomTraits<TM, NamedParameters>::type                         Traits;
-  Traits traits = choose_parameter(get_parameter(np, internal_np::geom_traits), Traits());
+  Traits traits = choose_parameter<Traits>(get_parameter(np, internal_np::geom_traits));
 
   typedef typename boost::property_traits<VertexPointMap>::value_type               Point_3;
   typedef typename boost::property_traits<VertexPointMap>::reference                Point_ref;

--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/stitch_borders.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/stitch_borders.h
@@ -1079,8 +1079,7 @@ std::size_t stitch_boundary_cycle(const typename boost::graph_traits<PolygonMesh
   typedef typename internal_np::Lookup_named_param_def<internal_np::halfedges_keeper_t,
                                                        CGAL_NP_CLASS,
                                                        Default_halfedges_keeper<PolygonMesh> >::type  Halfedge_keeper;
-  const Halfedge_keeper hd_kpr = choose_parameter(get_parameter(np, internal_np::halfedges_keeper),
-                                                  Default_halfedges_keeper<PolygonMesh>());
+  const Halfedge_keeper hd_kpr = choose_parameter<Default_halfedges_keeper<PolygonMesh>>(get_parameter(np, internal_np::halfedges_keeper));
 
   halfedge_descriptor bh = h, bh_mem = bh;
 
@@ -1346,8 +1345,7 @@ std::size_t stitch_borders(const BorderHalfedgeRange& boundary_cycle_representat
   typedef typename internal_np::Lookup_named_param_def<internal_np::halfedges_keeper_t,
                                                        CGAL_NP_CLASS,
                                                        Default_halfedges_keeper<PolygonMesh> >::type  Halfedge_keeper;
-  const Halfedge_keeper hd_kpr = choose_parameter(get_parameter(np, internal_np::halfedges_keeper),
-                                                  Default_halfedges_keeper<PolygonMesh>());
+  const Halfedge_keeper hd_kpr = choose_parameter<Default_halfedges_keeper<PolygonMesh>>(get_parameter(np, internal_np::halfedges_keeper));
 
   bool per_cc = choose_parameter(get_parameter(np, internal_np::apply_per_connected_component), false);
 

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/angle_and_area_smoothing.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/angle_and_area_smoothing.h
@@ -211,8 +211,7 @@ void angle_and_area_smoothing(const FaceRange& faces,
   const bool use_safety_constraints = choose_parameter(get_parameter(np, internal_np::use_safety_constraints), true);
   const bool use_Delaunay_flips = choose_parameter(get_parameter(np, internal_np::use_Delaunay_flips), true);
 
-  VCMap vcmap = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained),
-                                 get(Vertex_property_tag(), tmesh, false));
+  VCMap vcmap = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained), Vertex_property_tag(), tmesh, false);
 
   ECMap ecmap = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
                                  Static_boolean_property_map<edge_descriptor, false>());

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/approximated_centroidal_Voronoi_diagram_remeshing.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/approximated_centroidal_Voronoi_diagram_remeshing.h
@@ -337,7 +337,7 @@ void upsample_subdivision_property(TriangleMesh& tmesh,
 
   using VPM = typename CGAL::GetVertexPointMap<TriangleMesh, NamedParameters>::type;
   VPM vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
-                         get_property_map(CGAL::vertex_point, tmesh));
+                             get_property_map(CGAL::vertex_point, tmesh));
 
   // unordered_set of old vertices
   std::unordered_set<vertex_descriptor> old_vertices;
@@ -1405,9 +1405,8 @@ bool approximated_centroidal_Voronoi_diagram_remeshing(TriangleMesh& tmesh,
   auto ps = internal::acvd_impl(tmesh, static_cast<int>(nb_vertices), np);
   CGAL_assertion(is_polygon_soup_a_polygon_mesh(ps.second));
 
-  auto vpm = parameters::choose_parameter(
-                parameters::get_parameter(np, CGAL::vertex_point),
-                get_property_map(CGAL::vertex_point, tmesh));
+  auto vpm = parameters::choose_parameter(parameters::get_parameter(np, CGAL::vertex_point),
+                                          get_property_map(CGAL::vertex_point, tmesh));
 
   remove_all_elements(tmesh);
   polygon_soup_to_polygon_mesh(ps.first, ps.second, tmesh, parameters::vertex_point_map(vpm));

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/random_perturbation.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/random_perturbation.h
@@ -184,8 +184,7 @@ void random_perturbation(VertexRange vertices
       NamedParameters,
       Static_boolean_property_map<vertex_descriptor, false> // default
     > ::type VCMap;
-  VCMap vcmap = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained),
-                                 Static_boolean_property_map<vertex_descriptor, false>());
+  VCMap vcmap = choose_parameter<Static_boolean_property_map<vertex_descriptor, false>>(get_parameter(np, internal_np::vertex_is_constrained));
 
   unsigned int seed = choose_parameter(get_parameter(np, internal_np::random_seed), -1);
   bool do_project = choose_parameter(get_parameter(np, internal_np::do_project), true);

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/remesh.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/remesh.h
@@ -255,16 +255,14 @@ void isotropic_remeshing(const FaceRange& faces
       NamedParameters,
       Static_boolean_property_map<edge_descriptor, false> // default (no constraint pmap)
     > ::type ECMap;
-  ECMap ecmap = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
-                                 Static_boolean_property_map<edge_descriptor, false>());
+  ECMap ecmap = choose_parameter<Static_boolean_property_map<edge_descriptor, false>>(get_parameter(np, internal_np::edge_is_constrained));
 
   typedef typename internal_np::Lookup_named_param_def <
       internal_np::vertex_is_constrained_t,
       NamedParameters,
       Static_boolean_property_map<vertex_descriptor, false> // default (no constraint pmap)
     > ::type VCMap;
-  VCMap vcmap = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained),
-                                 Static_boolean_property_map<vertex_descriptor, false>());
+  VCMap vcmap = choose_parameter<Static_boolean_property_map<vertex_descriptor, false>>(get_parameter(np, internal_np::vertex_is_constrained));
 
   bool protect = choose_parameter(get_parameter(np, internal_np::protect_constraints), false);
   typedef typename internal_np::Lookup_named_param_def <
@@ -281,8 +279,7 @@ void isotropic_remeshing(const FaceRange& faces
 #endif
     ) ) );
 
-  auto shall_move = choose_parameter(get_parameter(np, internal_np::allow_move_functor),
-                                     internal::Allow_all_moves());
+  auto shall_move = choose_parameter<internal::Allow_all_moves>(get_parameter(np, internal_np::allow_move_functor));
 
 #if !defined(CGAL_NO_PRECONDITIONS)
   if(protect)
@@ -480,8 +477,7 @@ void split_long_edges(const EdgeRange& edges
         NamedParameters,
         Static_boolean_property_map<edge_descriptor, false> // default (no constraint pmap)
       > ::type ECMap;
-  ECMap ecmap = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
-                                 Static_boolean_property_map<edge_descriptor, false>());
+  ECMap ecmap = choose_parameter<Static_boolean_property_map<edge_descriptor, false>>(get_parameter(np, internal_np::edge_is_constrained));
 
   typedef typename internal_np::Lookup_named_param_def <
       internal_np::face_patch_t,

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/smooth_shape.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/smooth_shape.h
@@ -134,8 +134,7 @@ void smooth_shape(const FaceRange& faces,
   GeomTraits gt = choose_parameter<GeomTraits>(get_parameter(np, internal_np::geom_traits));
   VertexPointMap vpmap = choose_parameter(get_parameter(np, internal_np::vertex_point),
                                           get_property_map(CGAL::vertex_point, tmesh));
-  VCMap vcmap = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained),
-                                 Static_boolean_property_map<vertex_descriptor, false>());
+  VCMap vcmap = choose_parameter<Static_boolean_property_map<vertex_descriptor, false>>(get_parameter(np, internal_np::vertex_is_constrained));
   const unsigned int nb_iterations = choose_parameter(get_parameter(np, internal_np::number_of_iterations), 1);
   const bool scale_after_smoothing = choose_parameter(get_parameter(np, internal_np::do_scale), true);
 

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/tangential_relaxation.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/tangential_relaxation.h
@@ -156,16 +156,14 @@ void tangential_relaxation(const VertexRange& vertices,
       CGAL_NP_CLASS,
       Static_boolean_property_map<edge_descriptor, false> // default (no constraint)
     > ::type ECM;
-  ECM ecm = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
-                             Default_ECM());
+  ECM ecm = choose_parameter<Default_ECM>(get_parameter(np, internal_np::edge_is_constrained));
 
   typedef typename internal_np::Lookup_named_param_def <
       internal_np::vertex_is_constrained_t,
       CGAL_NP_CLASS,
       Static_boolean_property_map<vertex_descriptor, false> // default (no constraint)
     > ::type VCM;
-  VCM vcm = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained),
-                             Static_boolean_property_map<vertex_descriptor, false>());
+  VCM vcm = choose_parameter<Static_boolean_property_map<vertex_descriptor, false>>(get_parameter(np, internal_np::vertex_is_constrained));
 
   typedef typename internal_np::Lookup_named_param_def <
       internal_np::sizing_function_t,
@@ -227,8 +225,7 @@ void tangential_relaxation(const VertexRange& vertices,
       CGAL_NP_CLASS,
       internal::Allow_all_moves// default
     > ::type Shall_move;
-  Shall_move shall_move = choose_parameter(get_parameter(np, internal_np::allow_move_functor),
-                                           internal::Allow_all_moves());
+  Shall_move shall_move = choose_parameter<internal::Allow_all_moves>(get_parameter(np, internal_np::allow_move_functor));
 
   for (unsigned int nit = 0; nit < nb_iterations; ++nit)
   {

--- a/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
+++ b/PMP_Remeshing/include/CGAL/Polygon_mesh_processing/triangulate_faces.h
@@ -216,8 +216,7 @@ public:
     Traits traits = choose_parameter<Traits>(get_parameter(np, internal_np::geom_traits));
     VPM vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
                                get_property_map(vertex_point, pmesh));
-    Visitor visitor = choose_parameter<Visitor>(get_parameter(np, internal_np::visitor),
-                                                Triangulate_faces::Default_visitor<PolygonMesh>());
+    Visitor visitor = choose_parameter<Visitor>(get_parameter(np, internal_np::visitor));
 
     typename Traits::Construct_cross_product_vector_3 cross_product =
       traits.construct_cross_product_vector_3_object();

--- a/Point_set_processing_3/include/CGAL/bilateral_smooth_point_set.h
+++ b/Point_set_processing_3/include/CGAL/bilateral_smooth_point_set.h
@@ -283,8 +283,7 @@ bilateral_smooth_point_set(
   typedef typename Kernel::FT FT;
 
   double sharpness_angle = choose_parameter(get_parameter(np, internal_np::sharpness_angle), 30.);
-  const std::function<bool(double)>& callback = choose_parameter(get_parameter(np, internal_np::callback),
-                                                                 std::function<bool(double)>());
+  const std::function<bool(double)>& callback = choose_parameter<std::function<bool(double)>>(get_parameter(np, internal_np::callback));
 
   CGAL_precondition(points.begin() != points.end());
   CGAL_precondition(k > 1);

--- a/Point_set_processing_3/include/CGAL/cluster_point_set.h
+++ b/Point_set_processing_3/include/CGAL/cluster_point_set.h
@@ -155,8 +155,7 @@ std::size_t cluster_point_set (PointRange& points,
   typename Kernel::FT factor = choose_parameter(get_parameter(np, internal_np::attraction_factor),
                                                 typename Kernel::FT(2));
 
-  const std::function<bool(double)>& callback = choose_parameter(get_parameter(np, internal_np::callback),
-                                                               std::function<bool(double)>());
+  const std::function<bool(double)>& callback = choose_parameter<std::function<bool(double)>>(get_parameter(np, internal_np::callback));
 
   double callback_factor = 1.;
   if (!std::is_same<Adjacencies,

--- a/Point_set_processing_3/include/CGAL/compute_average_spacing.h
+++ b/Point_set_processing_3/include/CGAL/compute_average_spacing.h
@@ -166,8 +166,7 @@ compute_average_spacing(
   typedef typename NP_helper::Geom_traits Kernel;
 
   PointMap point_map = NP_helper::get_const_point_map(points, np);
-  const std::function<bool(double)>& callback = choose_parameter(get_parameter(np, internal_np::callback),
-                                                                 std::function<bool(double)>());
+  const std::function<bool(double)>& callback = choose_parameter<std::function<bool(double)>>(get_parameter(np, internal_np::callback));
 
   // types for K nearest neighbors search structure
   typedef typename Kernel::FT FT;

--- a/Point_set_processing_3/include/CGAL/hierarchy_simplify_point_set.h
+++ b/Point_set_processing_3/include/CGAL/hierarchy_simplify_point_set.h
@@ -197,8 +197,7 @@ namespace CGAL {
     PointMap point_map = NP_helper::get_point_map(points, np);
     unsigned int size = choose_parameter(get_parameter(np, internal_np::size), 10);
     double var_max = choose_parameter(get_parameter(np, internal_np::maximum_variation), 1./3.);
-    const std::function<bool(double)>& callback = choose_parameter(get_parameter(np, internal_np::callback),
-                                                                   std::function<bool(double)>());
+    const std::function<bool(double)>& callback = choose_parameter<std::function<bool(double)>>(get_parameter(np, internal_np::callback));
 
     typedef typename std::iterator_traits<typename PointRange::iterator>::value_type Input_type;
 

--- a/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/jet_estimate_normals.h
@@ -206,8 +206,7 @@ jet_estimate_normals(
   unsigned int degree_fitting = choose_parameter(get_parameter(np, internal_np::degree_fitting), 2);
   FT neighbor_radius = choose_parameter(get_parameter(np, internal_np::neighbor_radius), FT(0));
 
-  const std::function<bool(double)>& callback = choose_parameter(get_parameter(np, internal_np::callback),
-                                                               std::function<bool(double)>());
+  const std::function<bool(double)>& callback = choose_parameter<std::function<bool(double)>>(get_parameter(np, internal_np::callback));
 
   // types for K nearest neighbors search structure
   typedef Point_set_processing_3::internal::Neighbor_query<Kernel, PointRange&, PointMap> Neighbor_query;

--- a/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
+++ b/Point_set_processing_3/include/CGAL/jet_smooth_point_set.h
@@ -209,8 +209,7 @@ jet_smooth_point_set(
                                                          typename Kernel::FT(0));
   unsigned int degree_fitting = choose_parameter(get_parameter(np, internal_np::degree_fitting), 2);
   unsigned int degree_monge = choose_parameter(get_parameter(np, internal_np::degree_monge), 2);
-  const std::function<bool(double)>& callback = choose_parameter(get_parameter(np, internal_np::callback),
-                                                               std::function<bool(double)>());
+  const std::function<bool(double)>& callback = choose_parameter<std::function<bool(double)>>(get_parameter(np, internal_np::callback));
 
   // types for K nearest neighbors search structure
   typedef Point_set_processing_3::internal::Neighbor_query<Kernel, PointRange&, PointMap> Neighbor_query;

--- a/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/pca_estimate_normals.h
@@ -173,8 +173,7 @@ pca_estimate_normals(
   PointMap point_map = NP_helper::get_point_map(points, np);
   NormalMap normal_map = NP_helper::get_normal_map(points, np);
   FT neighbor_radius = choose_parameter(get_parameter(np, internal_np::neighbor_radius), FT(0));
-  const std::function<bool(double)>& callback = choose_parameter(get_parameter(np, internal_np::callback),
-                                                                 std::function<bool(double)>());
+  const std::function<bool(double)>& callback = choose_parameter<std::function<bool(double)>>(get_parameter(np, internal_np::callback));
 
   // Input points types
   typedef typename PointRange::iterator iterator;

--- a/Point_set_processing_3/include/CGAL/poisson_eliminate.h
+++ b/Point_set_processing_3/include/CGAL/poisson_eliminate.h
@@ -307,12 +307,12 @@ void poisson_eliminate(const PointRange &points, std::size_t number_of_points, O
   const double beta = 0.65; // not used currently
   const double gamma = 1.5; // not used currently
   // named parameters for weight limiting, currently not used as the performance gain seems small and there is a high risk to get a defective output
-  const bool weight_limiting = parameters::choose_parameter(parameters::get_parameter(np, internal_np::weight_limiting), false);
+  const bool weight_limiting = choose_parameter(get_parameter(np, internal_np::weight_limiting), false);
   // named parameter for progressive
-  const bool progressive = parameters::choose_parameter(parameters::get_parameter(np, internal_np::progressive), false);
+  const bool progressive = choose_parameter(get_parameter(np, internal_np::progressive), false);
   // named parameter for tiling
-  const bool tiling = parameters::choose_parameter(parameters::get_parameter(np, internal_np::tiling), false);
-  const unsigned int dimension = parameters::choose_parameter(parameters::get_parameter(np, internal_np::dimension), 2);
+  const bool tiling = choose_parameter(get_parameter(np, internal_np::tiling), false);
+  const unsigned int dimension = choose_parameter(get_parameter(np, internal_np::dimension), 2);
 
   CGAL_assertion(ambient_dimension >= dimension);
 
@@ -336,10 +336,10 @@ void poisson_eliminate(const PointRange &points, std::size_t number_of_points, O
     domain_size *= CGAL::to_double(upper[i] - lower[i]);
 
   // named parameter for r_max
-  double r_max = CGAL::to_double(parameters::choose_parameter(parameters::get_parameter(np, internal_np::maximum_radius), 2 * poisson_eliminate_impl::get_maximum_radius(dimension, number_of_points, domain_size)));
+  double r_max = CGAL::to_double(choose_parameter(get_parameter(np, internal_np::maximum_radius), 2 * poisson_eliminate_impl::get_maximum_radius(dimension, number_of_points, domain_size)));
   double r_min = CGAL::to_double(weight_limiting ? poisson_eliminate_impl::get_minimum_radius(points.size(), number_of_points, beta, gamma, r_max) : 0);
 
-  auto weight_functor = parameters::choose_parameter(parameters::get_parameter(np, internal_np::weight_function), poisson_eliminate_impl::Weight_functor<Point>(r_min, alpha));
+  auto weight_functor = choose_parameter(get_parameter(np, internal_np::weight_function), poisson_eliminate_impl::Weight_functor<Point>(r_min, alpha));
 
   std::size_t heap_size = points.size();
   std::vector<Point> tiling_points;

--- a/Point_set_processing_3/include/CGAL/remove_outliers.h
+++ b/Point_set_processing_3/include/CGAL/remove_outliers.h
@@ -191,8 +191,7 @@ remove_outliers(
                                                          typename Kernel::FT(0));
   double threshold_percent = choose_parameter(get_parameter(np, internal_np::threshold_percent), 10.);
   double threshold_distance = choose_parameter(get_parameter(np, internal_np::threshold_distance), 0.);
-  const std::function<bool(double)>& callback = choose_parameter(get_parameter(np, internal_np::callback),
-                                                                 std::function<bool(double)>());
+  const std::function<bool(double)>& callback = choose_parameter<std::function<bool(double)>>(get_parameter(np, internal_np::callback));
 
   typedef typename Kernel::FT FT;
 

--- a/Point_set_processing_3/include/CGAL/vcm_estimate_normals.h
+++ b/Point_set_processing_3/include/CGAL/vcm_estimate_normals.h
@@ -265,9 +265,6 @@ compute_vcm (const PointRange& points,
              double convolution_radius,
              const NamedParameters& np = parameters::default_values())
 {
-    using parameters::choose_parameter;
-    using parameters::get_parameter;
-
     // basic geometric types
     typedef Point_set_processing_3_np_helper<PointRange, NamedParameters> NP_helper;
     typedef typename NP_helper::Const_point_map PointMap;
@@ -311,9 +308,6 @@ vcm_estimate_normals_internal (PointRange& points,
                                int nb_neighbors_convolve = -1 ///< number of neighbors used during the convolution.
 )
 {
-    using parameters::choose_parameter;
-    using parameters::get_parameter;
-
     // basic geometric types
     typedef Point_set_processing_3_np_helper<PointRange, NamedParameters> NP_helper;
     typedef typename NP_helper::Point_map PointMap;

--- a/Point_set_processing_3/include/CGAL/wlop_simplify_and_regularize_point_set.h
+++ b/Point_set_processing_3/include/CGAL/wlop_simplify_and_regularize_point_set.h
@@ -449,8 +449,7 @@ wlop_simplify_and_regularize_point_set(
   double radius = choose_parameter(get_parameter(np, internal_np::neighbor_radius), -1);
   unsigned int iter_number = choose_parameter(get_parameter(np, internal_np::number_of_iterations), 35);
   bool require_uniform_sampling = choose_parameter(get_parameter(np, internal_np::require_uniform_sampling), false);
-  const std::function<bool(double)>& callback = choose_parameter(get_parameter(np, internal_np::callback),
-                                                                 std::function<bool(double)>());
+  const std::function<bool(double)>& callback = choose_parameter<std::function<bool(double)>>(get_parameter(np, internal_np::callback));
 
   typedef typename Kernel::Point_3   Point;
   typedef typename Kernel::FT        FT;

--- a/Poisson_surface_reconstruction_3/include/CGAL/Poisson_mesh_domain_3.h
+++ b/Poisson_surface_reconstruction_3/include/CGAL/Poisson_mesh_domain_3.h
@@ -226,8 +226,8 @@ public:
 
     FT relative_error_bound_ = choose_parameter(get_parameter(np, internal_np::error_bound), FT(1e-3));
     CGAL::Random* p_rng_ = choose_parameter(get_parameter(np, internal_np::rng), nullptr);
-    auto null_subdomain_index_ = choose_parameter(get_parameter(np, internal_np::null_subdomain_index_param), Null_functor());
-    auto construct_surface_patch_index_ = choose_parameter(get_parameter(np, internal_np::surface_patch_index), Null_functor());
+    auto null_subdomain_index_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::null_subdomain_index_param));
+    auto construct_surface_patch_index_ = choose_parameter<Null_functor>(get_parameter(np, internal_np::surface_patch_index));
 
     return Poisson_mesh_domain_3(function,
              bounding_object,

--- a/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/CMakeLists.txt
@@ -7,6 +7,9 @@ project(Polygon_mesh_processing_Benchmarks)
 # CGAL and its components
 find_package(CGAL REQUIRED)
 
+
+  create_single_source_cgal_program("compute_normals_benchmark.cpp")
+  
 find_package(Eigen3 QUIET)
 include(CGAL_Eigen3_support)
 
@@ -29,6 +32,7 @@ if (FAST_ENVELOPE_BUILD_DIR)
       set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
   endif()
 
+  
   create_single_source_cgal_program("fastE.cpp")
   target_link_libraries( fastE PRIVATE CGAL::Eigen3_support)
   target_link_libraries( fastE PRIVATE FastEnvelope IndirectPredicates geogram)

--- a/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/CMakeLists.txt
+++ b/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/CMakeLists.txt
@@ -9,7 +9,7 @@ find_package(CGAL REQUIRED)
 
 
   create_single_source_cgal_program("compute_normals_benchmark.cpp")
-  
+
 find_package(Eigen3 QUIET)
 include(CGAL_Eigen3_support)
 
@@ -32,7 +32,7 @@ if (FAST_ENVELOPE_BUILD_DIR)
       set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
   endif()
 
-  
+
   create_single_source_cgal_program("fastE.cpp")
   target_link_libraries( fastE PRIVATE CGAL::Eigen3_support)
   target_link_libraries( fastE PRIVATE FastEnvelope IndirectPredicates geogram)

--- a/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/compute_normals_benchmark.cpp
+++ b/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/compute_normals_benchmark.cpp
@@ -1,0 +1,44 @@
+#include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
+#include <CGAL/Surface_mesh.h>
+
+#include <CGAL/Polygon_mesh_processing/compute_normal.h>
+#include <CGAL/Polygon_mesh_processing/IO/polygon_mesh_io.h>
+#include <CGAL/Timer.h>
+
+#include <iostream>
+#include <string>
+
+typedef CGAL::Exact_predicates_inexact_constructions_kernel K;
+
+typedef K::Point_3                                          Point;
+typedef K::Vector_3                                         Vector;
+
+typedef CGAL::Surface_mesh<Point>                           Mesh;
+typedef boost::graph_traits<Mesh>::vertex_descriptor        vertex_descriptor;
+typedef boost::graph_traits<Mesh>::face_descriptor          face_descriptor;
+
+namespace PMP = CGAL::Polygon_mesh_processing;
+
+int main(int argc, char* argv[])
+{
+  const std::string filename = (argc > 1) ? argv[1] : CGAL::data_file_path("meshes/eight.off");
+
+  Mesh mesh;
+  if(!PMP::IO::read_polygon_mesh(filename, mesh))
+  {
+    std::cerr << "Invalid input." << std::endl;
+    return 1;
+  }
+
+  auto vnormals = mesh.add_property_map<vertex_descriptor, Vector>("v:normal", CGAL::NULL_VECTOR).first;
+  auto fnormals = mesh.add_property_map<face_descriptor, Vector>("f:normal", CGAL::NULL_VECTOR).first;
+
+  CGAL::Timer timer;
+  timer.start();
+  PMP::compute_normals(mesh, vnormals, fnormals);
+  timer.stop();
+  std::cout << "Time: " << timer.time() << " seconds" << std::endl;
+    
+
+  return 0;
+}

--- a/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/compute_normals_benchmark.cpp
+++ b/Polygon_mesh_processing/benchmark/Polygon_mesh_processing/compute_normals_benchmark.cpp
@@ -38,7 +38,7 @@ int main(int argc, char* argv[])
   PMP::compute_normals(mesh, vnormals, fnormals);
   timer.stop();
   std::cout << "Time: " << timer.time() << " seconds" << std::endl;
-    
+
 
   return 0;
 }

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/bbox.h
@@ -75,7 +75,7 @@ CGAL::Bbox_3 bbox(const PolygonMesh& pmesh,
 
   typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
     vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
-                            get_const_property_map(CGAL::vertex_point, pmesh));
+                           get_const_property_map(CGAL::vertex_point, pmesh));
 
   typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type GT;
   GT gt = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
@@ -142,7 +142,7 @@ CGAL::Bbox_3 vertex_bbox(typename boost::graph_traits<PolygonMesh>::vertex_descr
 
   typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
     vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
-                            get_const_property_map(CGAL::vertex_point, pmesh));
+                           get_const_property_map(CGAL::vertex_point, pmesh));
 
   typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type GT;
   GT gt = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
@@ -197,7 +197,7 @@ CGAL::Bbox_3 edge_bbox(typename boost::graph_traits<PolygonMesh>::edge_descripto
 
   typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
     vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
-                            get_const_property_map(CGAL::vertex_point, pmesh));
+                           get_const_property_map(CGAL::vertex_point, pmesh));
 
   typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type GT;
   GT gt = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
@@ -257,7 +257,7 @@ CGAL::Bbox_3 face_bbox(typename boost::graph_traits<PolygonMesh>::face_descripto
 
   typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type
     vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
-                            get_const_property_map(CGAL::vertex_point, pmesh));
+                           get_const_property_map(CGAL::vertex_point, pmesh));
 
   typedef typename GetGeomTraits<PolygonMesh, NamedParameters>::type GT;
   GT gt = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -700,16 +700,9 @@ compute_vertex_normal(typename boost::graph_traits<PolygonMesh>::vertex_descript
   typedef typename GetVertexPointMap<PolygonMesh, NamedParameters>::const_type VPMap;
   VPMap vpmap = choose_parameter(get_parameter(np, internal_np::vertex_point),
                                  get_const_property_map(vertex_point, pmesh));
+  typedef CGAL::dynamic_face_property_t<Vector_3>                             Face_normal_tag;
 
-  typedef std::unordered_map<face_descriptor, Vector_3>                       Face_vector_map;
-  typedef boost::associative_property_map<Face_vector_map>                    Default_map;
-
-  typedef typename internal_np::Lookup_named_param_def<internal_np::face_normal_t,
-                                                       NamedParameters,
-                                                       Default_map>::type     Face_normal_map;
-  Face_vector_map default_fvmap;
-  Face_normal_map face_normals = choose_parameter(get_parameter(np, internal_np::face_normal),
-                                                  Default_map(default_fvmap));
+  auto face_normals = choose_parameter(get_parameter(np, internal_np::face_normal), Face_normal_tag(), pmesh);
   const bool must_compute_face_normals = is_default_parameter<NamedParameters, internal_np::face_normal_t>::value;
 
 #ifdef CGAL_PMP_COMPUTE_NORMAL_DEBUG_PP
@@ -825,8 +818,7 @@ void compute_vertex_normals(const PolygonMesh& pmesh,
   typedef typename internal_np::Lookup_named_param_def<internal_np::face_normal_t,
                                                        NamedParameters,
                                                        Face_normal_dmap>::type   Face_normal_map;
-  Face_normal_map face_normals = choose_parameter(get_parameter(np, internal_np::face_normal),
-                                                  get(Face_normal_tag(), pmesh));
+  Face_normal_map face_normals = choose_parameter(get_parameter(np, internal_np::face_normal), Face_normal_tag(), pmesh);
   const bool must_compute_face_normals = is_default_parameter<NamedParameters, internal_np::face_normal_t>::value;
 
   if(must_compute_face_normals)

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -26,6 +26,8 @@
 
 #include <boost/graph/graph_traits.hpp>
 
+#include <boost/container/small_vector.hpp>
+
 #include <iostream>
 #include <limits>
 #include <utility>

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/compute_normal.h
@@ -274,12 +274,12 @@ bool almost_equal(const typename GT::Vector_3& v1, const typename GT::Vector_3& 
   return traits.compute_scalar_product_3_object()(v1, v2) >= cos_theta;
 }
 
-template <typename PolygonMesh, typename FaceNormalVector, typename K>
+template <typename PolygonMesh, typename Incident_faces, typename FaceNormalVector, typename K>
 bool does_enclose_other_normals(const std::size_t i, const std::size_t j, const std::size_t k,
                                 const typename K::Vector_3& nb,
                                 const typename K::FT sp_bi,
                                 typename boost::graph_traits<PolygonMesh>::face_descriptor &not_enclose_normal,
-                                const std::vector<typename boost::graph_traits<PolygonMesh>::face_descriptor>& incident_faces,
+                                const Incident_faces& incident_faces,
                                 const FaceNormalVector& face_normals,
                                 const K& traits)
 {
@@ -410,8 +410,7 @@ compute_vertex_normal_most_visible_min_circle(typename boost::graph_traits<Polyg
   typename GT::Compute_scalar_product_3 sp_3 = traits.compute_scalar_product_3_object();
   typename GT::Construct_cross_product_vector_3 cp_3 = traits.construct_cross_product_vector_3_object();
 
-  std::vector<face_descriptor> incident_faces;
-  incident_faces.reserve(8);
+  boost::container::small_vector<face_descriptor,8> incident_faces;
   for(face_descriptor f : CGAL::faces_around_target(halfedge(v, pmesh), pmesh))
   {
     // Remove degenerate and redundant faces

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/connected_components.h
@@ -736,8 +736,7 @@ void keep_or_remove_connected_components(PolygonMesh& pmesh
                                                         CGAL_NP_CLASS,
                                                         Static_boolean_property_map<vertex_descriptor, false> // default (not used)
                                                          >::type Vertex_map;
-    Vertex_map is_cst = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained),
-                                         Static_boolean_property_map<vertex_descriptor, false>());
+    Vertex_map is_cst = choose_parameter<Static_boolean_property_map<vertex_descriptor, false>>(get_parameter(np, internal_np::vertex_is_constrained));
     for (vertex_descriptor v : vertices_to_remove)
       if (!get(is_cst, v))
         remove_vertex(v, pmesh);
@@ -1007,7 +1006,7 @@ void split_connected_components_impl(FIMap fim,
   using parameters::is_default_parameter;
 
   Fpm pidmap = choose_parameter(get_parameter(np, internal_np::face_patch),
-                                get(CGAL::dynamic_face_property_t<faces_size_type>(), tm));
+                                CGAL::dynamic_face_property_t<faces_size_type>(), tm);
 
   faces_size_type nb_patches = 0;
   if(is_default_parameter<NamedParameters, internal_np::face_patch_t>::value)
@@ -1114,8 +1113,7 @@ void split_connected_components(const PolygonMesh& pmesh,
   using parameters::choose_parameter;
   using parameters::get_parameter;
 
-  Ecm ecm = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
-                             Default_ecm());
+  Ecm ecm = choose_parameter<Default_ecm>(get_parameter(np, internal_np::edge_is_constrained));
 
   internal::split_connected_components_impl(CGAL::get_initialized_face_index_map(pmesh, np),
                                             CGAL::get_initialized_halfedge_index_map(pmesh, np),

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/distance.h
@@ -2538,8 +2538,7 @@ double bounded_error_Hausdorff_distance(const TriangleMesh1& tm1,
   const bool match_faces2 = choose_parameter(get_parameter(np2, internal_np::match_faces), true);
   const bool match_faces = match_faces1 && match_faces2;
 
-  auto out = choose_parameter(get_parameter(np1, internal_np::output_iterator),
-                              CGAL::Emptyset_iterator());
+  auto out = choose_parameter<CGAL::Emptyset_iterator>(get_parameter(np1, internal_np::output_iterator));
 
   CGAL_precondition(error_bound >= 0.);
 
@@ -2592,10 +2591,8 @@ double bounded_error_symmetric_Hausdorff_distance(const TriangleMesh1& tm1,
   const bool match_faces = match_faces1 && match_faces2;
 
   // TODO: should we return a union of these realizing triangles?
-  auto out1 = choose_parameter(get_parameter(np1, internal_np::output_iterator),
-                               CGAL::Emptyset_iterator());
-  auto out2 = choose_parameter(get_parameter(np2, internal_np::output_iterator),
-                               CGAL::Emptyset_iterator());
+  auto out1 = choose_parameter<CGAL::Emptyset_iterator>(get_parameter(np1, internal_np::output_iterator));
+  auto out2 = choose_parameter<CGAL::Emptyset_iterator>(get_parameter(np2, internal_np::output_iterator));
 
   CGAL_precondition(error_bound >= 0.);
 

--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/interpolated_corrected_curvatures.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/interpolated_corrected_curvatures.h
@@ -625,8 +625,7 @@ void interpolated_corrected_curvatures_one_vertex(
   Vertex_position_map vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
     get_const_property_map(CGAL::vertex_point, pmesh));
 
-  Vertex_normal_map vnm = choose_parameter(get_parameter(np, internal_np::vertex_normal_map),
-    get(Vector_map_tag(), pmesh));
+  Vertex_normal_map vnm = choose_parameter(get_parameter(np, internal_np::vertex_normal_map), Vector_map_tag(), pmesh);
 
   // if the normal map is not provided, compute it
   if (is_default_parameter<NamedParameters, internal_np::vertex_normal_map_t>::value)
@@ -776,8 +775,7 @@ private:
     vpm = choose_parameter(get_parameter(np, internal_np::vertex_point),
       get_const_property_map(CGAL::vertex_point, pmesh));
 
-    vnm = choose_parameter(get_parameter(np, internal_np::vertex_normal_map),
-      get(Vector_map_tag(), pmesh));
+    vnm = choose_parameter(get_parameter(np, internal_np::vertex_normal_map), Vector_map_tag(), pmesh);
 
     // if no normal map is given, compute normals
     if (is_default_parameter<NamedParameters, internal_np::vertex_normal_map_t>::value)
@@ -793,9 +791,9 @@ private:
     is_Gaussian_curvature_selected = !is_default_parameter<NamedParameters, internal_np::vertex_Gaussian_curvature_map_t>::value;
     is_principal_curvatures_and_directions_selected = !is_default_parameter<NamedParameters, internal_np::vertex_principal_curvatures_and_directions_map_t>::value;
 
-    mean_curvature_map = choose_parameter(get_parameter(np, internal_np::vertex_mean_curvature_map), Default_scalar_map());
-    gaussian_curvature_map = choose_parameter(get_parameter(np, internal_np::vertex_Gaussian_curvature_map), Default_scalar_map());
-    principal_curvatures_and_directions_map = choose_parameter(get_parameter(np, internal_np::vertex_principal_curvatures_and_directions_map), Default_principal_map());
+    mean_curvature_map = choose_parameter<Default_scalar_map>(get_parameter(np, internal_np::vertex_mean_curvature_map));
+    gaussian_curvature_map = choose_parameter<Default_scalar_map>(get_parameter(np, internal_np::vertex_Gaussian_curvature_map));
+    principal_curvatures_and_directions_map = choose_parameter<Default_principal_map>(get_parameter(np, internal_np::vertex_principal_curvatures_and_directions_map));
   }
 
   void set_ball_radius(const FT radius) {

--- a/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_np_function.cpp
+++ b/Polygon_mesh_processing/test/Polygon_mesh_processing/test_pmp_np_function.cpp
@@ -63,7 +63,7 @@ void my_function_with_named_parameters(PolygonMesh& mesh, const NamedParameters&
   // check is a parameter has been given by the user
   constexpr bool do_project_is_default = is_default_parameter<NamedParameters, internal_np::do_project_t>::value;
 
-  VCM vcm_np = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained), Default_VCM());
+  VCM vcm_np = choose_parameter<Default_VCM>(get_parameter(np, internal_np::vertex_is_constrained));
 
 
   //demonstrates usage for those values.

--- a/STL_Extension/include/CGAL/Named_function_parameters.h
+++ b/STL_Extension/include/CGAL/Named_function_parameters.h
@@ -319,6 +319,33 @@ const T& choose_parameter(const T& t)
   return t;
 }
 
+// version with a dynamic property tag with initialisation
+template <typename Tag, typename Graph, typename V>
+auto
+choose_parameter(const internal_np::Param_not_found&, Tag tag, Graph& graph, const V& default_value)
+{
+  return get(tag, graph, default_value);
+}
+
+template <typename Tag, typename Graph>
+auto
+choose_parameter(const internal_np::Param_not_found&, Tag tag, Graph& graph)
+{
+  return get(tag, graph);
+}
+
+template <typename T, typename Tag, typename Graph, typename V>
+const T& choose_parameter(const T& t,  Tag, Graph&, const V&)
+{
+  return t;
+}
+
+template <typename T, typename Tag, typename Graph>
+const T& choose_parameter(const T& t, Tag, Graph&)
+{
+  return t;
+}
+
 } // parameters namespace
 
 namespace internal_np {

--- a/Shape_detection/include/CGAL/Polygon_mesh_processing/region_growing.h
+++ b/Shape_detection/include/CGAL/Polygon_mesh_processing/region_growing.h
@@ -236,8 +236,7 @@ region_growing_of_planes_on_faces(const PolygonMesh& mesh,
       NamedParameters,
       Static_boolean_property_map<edge_descriptor, false> // default (no constraint pmap)
     > ::type ECM;
-  ECM ecm = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
-                             Static_boolean_property_map<edge_descriptor, false>());
+  ECM ecm = choose_parameter<Static_boolean_property_map<edge_descriptor, false>>(get_parameter(np, internal_np::edge_is_constrained));
 
   typedef typename internal_np::Lookup_named_param_def <
     internal_np::least_squares_fitting_t,
@@ -415,7 +414,6 @@ detect_corners_of_regions(
 {
   using parameters::choose_parameter;
   using parameters::get_parameter;
-  using parameters::is_default_parameter;
 
   using VPM = typename GetVertexPointMap < PolygonMesh, NamedParameters>::const_type;
   using Traits = typename GetGeomTraits<PolygonMesh, NamedParameters>::type;
@@ -432,14 +430,7 @@ detect_corners_of_regions(
                 Default_ecm
               > ::type;
 
-  Default_ecm dynamic_ecm;
-  if(is_default_parameter<NamedParameters, internal_np::edge_is_constrained_t>::value)
-  {
-    dynamic_ecm = get(CGAL::dynamic_edge_property_t<bool>(), mesh);
-    for (edge_descriptor e : edges(mesh))
-      put(dynamic_ecm, e, false);
-  }
-  Ecm ecm = choose_parameter(get_parameter(np, internal_np::edge_is_constrained), dynamic_ecm);
+  Ecm ecm = choose_parameter(get_parameter(np, internal_np::edge_is_constrained), CGAL::dynamic_edge_property_t<bool>(), mesh, false);
 
   typedef typename internal_np::Lookup_named_param_def <
     internal_np::least_squares_fitting_t,

--- a/Shape_regularization/include/CGAL/Shape_regularization/Contours/Longest_direction_2.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/Contours/Longest_direction_2.h
@@ -101,8 +101,8 @@ namespace Contours {
       const bool is_closed,
       const NamedParameters& np = parameters::default_values()) :
     m_input_range(input_range),
-    m_point_map(parameters::choose_parameter(parameters::get_parameter(
-      np, internal_np::point_map), PointMap())) {
+    m_point_map(parameters::choose_parameter<PointMap>(parameters::get_parameter(
+      np, internal_np::point_map))) {
 
       CGAL_precondition(m_input_range.size() >= 2);
 

--- a/Shape_regularization/include/CGAL/Shape_regularization/Contours/Multiple_directions_2.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/Contours/Multiple_directions_2.h
@@ -126,8 +126,8 @@ namespace Contours {
       const bool is_closed,
       const NamedParameters& np = parameters::default_values()) :
     m_input_range(input_range),
-    m_point_map(parameters::choose_parameter(parameters::get_parameter(
-      np, internal_np::point_map), PointMap())) {
+    m_point_map(parameters::choose_parameter<PointMap>(parameters::get_parameter(
+      np, internal_np::point_map))) {
 
       CGAL_precondition(input_range.size() >= 2);
       m_max_angle_2 = parameters::choose_parameter(

--- a/Shape_regularization/include/CGAL/Shape_regularization/Contours/User_defined_directions_2.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/Contours/User_defined_directions_2.h
@@ -115,8 +115,8 @@ namespace Contours {
       const DirectionRange& direction_range,
       const NamedParameters& np = parameters::default_values()) :
     m_input_range(input_range),
-    m_point_map(parameters::choose_parameter(parameters::get_parameter(
-      np, internal_np::point_map), PointMap())),
+    m_point_map(parameters::choose_parameter<PointMap>(parameters::get_parameter(
+      np, internal_np::point_map))),
     m_max_angle_2(FT(5)) {
 
       CGAL_precondition(input_range.size() >= 2);

--- a/Shape_regularization/include/CGAL/Shape_regularization/QP_regularization.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/QP_regularization.h
@@ -150,8 +150,8 @@ namespace Shape_regularization {
     m_neighbor_query(neighbor_query),
     m_regularization_type(regularization_type),
     m_quadratic_program(quadratic_program),
-    m_traits(parameters::choose_parameter(parameters::get_parameter(
-      np, internal_np::geom_traits), GeomTraits())),
+    m_traits(parameters::choose_parameter<GeomTraits>(parameters::get_parameter(
+      np, internal_np::geom_traits))),
     m_parameters(Parameters()) {
 
       clear();

--- a/Shape_regularization/include/CGAL/Shape_regularization/Segments/Angle_regularization_2.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/Segments/Angle_regularization_2.h
@@ -120,8 +120,8 @@ namespace Segments {
       InputRange& input_range,
       const NamedParameters& np = parameters::default_values()) :
     m_input_range(input_range),
-    m_segment_map(parameters::choose_parameter(parameters::get_parameter(
-      np, internal_np::segment_map), SegmentMap())),
+    m_segment_map(parameters::choose_parameter<SegmentMap>(parameters::get_parameter(
+      np, internal_np::segment_map))),
     m_num_modified_segments(0) {
 
       const FT max_angle = parameters::choose_parameter(

--- a/Shape_regularization/include/CGAL/Shape_regularization/Segments/Delaunay_neighbor_query_2.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/Segments/Delaunay_neighbor_query_2.h
@@ -110,8 +110,8 @@ namespace Segments {
       const InputRange& input_range,
       const NamedParameters& np = parameters::default_values()) :
     m_input_range(input_range),
-    m_segment_map(parameters::choose_parameter(parameters::get_parameter(
-      np, internal_np::segment_map), SegmentMap())) {
+    m_segment_map(parameters::choose_parameter<SegmentMap>(parameters::get_parameter(
+      np, internal_np::segment_map))) {
 
       clear();
       create_unique_group();

--- a/Shape_regularization/include/CGAL/Shape_regularization/Segments/Offset_regularization_2.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/Segments/Offset_regularization_2.h
@@ -124,8 +124,8 @@ namespace Segments {
       InputRange& input_range,
       const NamedParameters& np = parameters::default_values()) :
     m_input_range(input_range),
-    m_segment_map(parameters::choose_parameter(parameters::get_parameter(
-      np, internal_np::segment_map), SegmentMap())),
+    m_segment_map(parameters::choose_parameter<SegmentMap>(parameters::get_parameter(
+      np, internal_np::segment_map))),
     m_num_modified_segments(0) {
 
       const FT max_offset = parameters::choose_parameter(

--- a/Shape_regularization/include/CGAL/Shape_regularization/regularize_contours.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/regularize_contours.h
@@ -126,10 +126,10 @@ namespace Contours {
     using Point_2 = typename PointMap::value_type;
     using GeomTraits = typename CGAL::Kernel_traits<Point_2>::Kernel;
 
-    const PointMap point_map = parameters::choose_parameter(
-      parameters::get_parameter(np, internal_np::point_map), PointMap());
-    const GeomTraits traits = parameters::choose_parameter(
-      parameters::get_parameter(np, internal_np::geom_traits), GeomTraits());
+    const PointMap point_map = parameters::choose_parameter<PointMap>(
+      parameters::get_parameter(np, internal_np::point_map));
+    const GeomTraits traits = parameters::choose_parameter<GeomTraits>(
+      parameters::get_parameter(np, internal_np::geom_traits));
 
     CGAL_precondition(input_range.size() >= 3);
     using Contour_regularizer =
@@ -249,10 +249,10 @@ namespace Contours {
     using Point_2 = typename PointMap::value_type;
     using GeomTraits = typename CGAL::Kernel_traits<Point_2>::Kernel;
 
-    const PointMap point_map = parameters::choose_parameter(
-      parameters::get_parameter(np, internal_np::point_map), PointMap());
-    const GeomTraits traits = parameters::choose_parameter(
-      parameters::get_parameter(np, internal_np::geom_traits), GeomTraits());
+    const PointMap point_map = parameters::choose_parameter<PointMap>(
+      parameters::get_parameter(np, internal_np::point_map));
+    const GeomTraits traits = parameters::choose_parameter<GeomTraits>(
+      parameters::get_parameter(np, internal_np::geom_traits));
 
     CGAL_precondition(input_range.size() >= 2);
     using Contour_regularizer =

--- a/Shape_regularization/include/CGAL/Shape_regularization/regularize_planes.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/regularize_planes.h
@@ -300,7 +300,7 @@ namespace Planes {
                               "Error: no plane index map");
 
     const PlaneIndexMap index_map =
-      choose_parameter(get_parameter(np, internal_np::plane_index_map), PlaneIndexMap());
+      choose_parameter<PlaneIndexMap>(get_parameter(np, internal_np::plane_index_map));
 
     using Kernel = typename Kernel_traits<
       typename boost::property_traits<PointMap>::value_type>::type;
@@ -450,12 +450,12 @@ namespace Planes {
     using PlaneMap = typename CGAL::Point_set_processing_3::
       GetPlaneMap<PlaneRange, NamedParameters>::type;
     const PlaneMap plane_map =
-      choose_parameter(get_parameter(np, internal_np::plane_map), PlaneMap());
+      choose_parameter<PlaneMap>(get_parameter(np, internal_np::plane_map));
 
     using PointMap = typename CGAL::
       GetPointMap<PointRange, NamedParameters>::type;
     const PointMap point_map =
-      choose_parameter(get_parameter(np, internal_np::point_map), PointMap());
+      choose_parameter<PointMap>(get_parameter(np, internal_np::point_map));
 
     regularize_planes(planes, plane_map, points, point_map, np);
   }

--- a/Shape_regularization/include/CGAL/Shape_regularization/regularize_segments.h
+++ b/Shape_regularization/include/CGAL/Shape_regularization/regularize_segments.h
@@ -379,10 +379,10 @@ namespace Segments {
     using Segment_2 = typename SegmentMap::value_type;
     using GeomTraits = typename CGAL::Kernel_traits<Segment_2>::Kernel;
 
-    const SegmentMap segment_map = parameters::choose_parameter(
-      parameters::get_parameter(np, internal_np::segment_map), SegmentMap());
-    const GeomTraits traits = parameters::choose_parameter(
-      parameters::get_parameter(np, internal_np::geom_traits), GeomTraits());
+    const SegmentMap segment_map = parameters::choose_parameter<SegmentMap>(
+      parameters::get_parameter(np, internal_np::segment_map));
+    const GeomTraits traits = parameters::choose_parameter<GeomTraits>(
+      parameters::get_parameter(np, internal_np::geom_traits));
 
     CGAL_precondition(input_range.size() >= 1);
     using Parallel_groups_2 = internal::Parallel_groups_2<
@@ -472,10 +472,10 @@ namespace Segments {
     using Segment_2 = typename SegmentMap::value_type;
     using GeomTraits = typename CGAL::Kernel_traits<Segment_2>::Kernel;
 
-    const SegmentMap segment_map = parameters::choose_parameter(
-      parameters::get_parameter(np, internal_np::segment_map), SegmentMap());
-    const GeomTraits traits = parameters::choose_parameter(
-      parameters::get_parameter(np, internal_np::geom_traits), GeomTraits());
+    const SegmentMap segment_map = parameters::choose_parameter<SegmentMap>(
+      parameters::get_parameter(np, internal_np::segment_map));
+    const GeomTraits traits = parameters::choose_parameter<GeomTraits>(
+      parameters::get_parameter(np, internal_np::geom_traits));
 
     CGAL_precondition(input_range.size() >= 1);
     using Collinear_groups_2 = internal::Collinear_groups_2<
@@ -565,10 +565,10 @@ namespace Segments {
     using Segment_2 = typename SegmentMap::value_type;
     using GeomTraits = typename CGAL::Kernel_traits<Segment_2>::Kernel;
 
-    const SegmentMap segment_map = parameters::choose_parameter(
-      parameters::get_parameter(np, internal_np::segment_map), SegmentMap());
-    const GeomTraits traits = parameters::choose_parameter(
-      parameters::get_parameter(np, internal_np::geom_traits), GeomTraits());
+    const SegmentMap segment_map = parameters::choose_parameter<SegmentMap>(
+      parameters::get_parameter(np, internal_np::segment_map));
+    const GeomTraits traits = parameters::choose_parameter<GeomTraits>(
+      parameters::get_parameter(np, internal_np::geom_traits));
 
     CGAL_precondition(input_range.size() >= 1);
     using Orthogonal_groups_2 = internal::Orthogonal_groups_2<
@@ -657,10 +657,10 @@ namespace Segments {
     using Segment_2 = typename SegmentMap::value_type;
     using GeomTraits = typename CGAL::Kernel_traits<Segment_2>::Kernel;
 
-    const SegmentMap segment_map = parameters::choose_parameter(
-      parameters::get_parameter(np, internal_np::segment_map), SegmentMap());
-    const GeomTraits traits = parameters::choose_parameter(
-      parameters::get_parameter(np, internal_np::geom_traits), GeomTraits());
+    const SegmentMap segment_map = parameters::choose_parameter<SegmentMap>(
+      parameters::get_parameter(np, internal_np::segment_map));
+    const GeomTraits traits = parameters::choose_parameter<GeomTraits>(
+      parameters::get_parameter(np, internal_np::geom_traits));
 
     CGAL_precondition(input_range.size() >= 1);
     using Unique_segments_2 = internal::Unique_segments_2<

--- a/Stream_support/include/CGAL/IO/OFF.h
+++ b/Stream_support/include/CGAL/IO/OFF.h
@@ -192,14 +192,10 @@ bool read_OFF(std::istream& is,
   using parameters::get_parameter;
 
   return internal::read_OFF(is, points, polygons,
-                            choose_parameter(get_parameter(np, internal_np::vertex_normal_output_iterator),
-                                             CGAL::Emptyset_iterator()),
-                            choose_parameter(get_parameter(np, internal_np::vertex_color_output_iterator),
-                                             CGAL::Emptyset_iterator()),
-                            choose_parameter(get_parameter(np, internal_np::vertex_texture_output_iterator),
-                                             CGAL::Emptyset_iterator()),
-                            choose_parameter(get_parameter(np, internal_np::face_color_output_iterator),
-                                             CGAL::Emptyset_iterator()),
+                            choose_parameter<CGAL::Emptyset_iterator>(get_parameter(np, internal_np::vertex_normal_output_iterator)),
+                            choose_parameter<CGAL::Emptyset_iterator>(get_parameter(np, internal_np::vertex_color_output_iterator)),
+                            choose_parameter<CGAL::Emptyset_iterator>(get_parameter(np, internal_np::vertex_texture_output_iterator)),
+                            choose_parameter<CGAL::Emptyset_iterator>(get_parameter(np, internal_np::face_color_output_iterator)),
                             choose_parameter(get_parameter(np, internal_np::verbose), true));
 }
 

--- a/Stream_support/include/CGAL/IO/OFF/read_off_points.h
+++ b/Stream_support/include/CGAL/IO/OFF/read_off_points.h
@@ -50,9 +50,6 @@ bool read_OFF(std::istream& is,
               std::enable_if_t<CGAL::is_iterator<PointOutputIterator>::value>*
               )
 {
-  using parameters::choose_parameter;
-  using parameters::get_parameter;
-
   typedef Point_set_processing_3::Fake_point_range<OutputIteratorValueType> PointRange;
 
   // basic geometric types

--- a/Stream_support/include/CGAL/IO/PLY.h
+++ b/Stream_support/include/CGAL/IO/PLY.h
@@ -327,10 +327,8 @@ bool read_PLY(std::istream& is,
   std::vector<std::pair<float, float> > dummy_pf;
 
   return internal::read_PLY(is, points, polygons, comments, std::back_inserter(dummy_pui),
-                            choose_parameter(get_parameter(np, internal_np::face_color_output_iterator),
-                                             CGAL::Emptyset_iterator()),
-                            choose_parameter(get_parameter(np, internal_np::vertex_color_output_iterator),
-                                             CGAL::Emptyset_iterator()),
+                            choose_parameter<CGAL::Emptyset_iterator>(get_parameter(np, internal_np::face_color_output_iterator)),
+                            choose_parameter<CGAL::Emptyset_iterator>(get_parameter(np, internal_np::vertex_color_output_iterator)),
                             std::back_inserter(dummy_pf),
                             choose_parameter(get_parameter(np, internal_np::verbose), true));
 }

--- a/Stream_support/include/CGAL/IO/XYZ/write_xyz_points.h
+++ b/Stream_support/include/CGAL/IO/XYZ/write_xyz_points.h
@@ -41,9 +41,6 @@ bool write_XYZ_PSP(std::ostream& os,
                    const PointRange& points,
                    const CGAL_NP_CLASS& np = CGAL::parameters::default_values())
 {
-  using CGAL::parameters::choose_parameter;
-  using CGAL::parameters::get_parameter;
-
   // basic geometric types
   typedef Point_set_processing_3_np_helper<PointRange, CGAL_NP_CLASS> NP_helper;
   typedef typename NP_helper::Const_point_map PointMap;

--- a/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
+++ b/Surface_mesh/include/CGAL/Surface_mesh/IO/PLY.h
@@ -743,14 +743,14 @@ void fill_header(std::ostream& os, const Surface_mesh<Point>& sm,
   using parameters::is_default_parameter;
   using parameters::get_parameter;
 
-  VCM vcm = choose_parameter(get_parameter(np, internal_np::vertex_color_map), VCM());
+  VCM vcm = choose_parameter<VCM>(get_parameter(np, internal_np::vertex_color_map));
   bool has_vcolor = !is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_color_map_t>::value;
 
   using FCM = typename internal_np::Lookup_named_param_def<
     internal_np::face_color_map_t,
     CGAL_NP_CLASS,
     typename Surface_mesh<Point>::template Property_map<FIndex, CGAL::IO::Color> >::type;
-  FCM fcm = choose_parameter(get_parameter(np, internal_np::face_color_map), FCM());
+  FCM fcm = choose_parameter<FCM>(get_parameter(np, internal_np::face_color_map));
   bool has_fcolor = !is_default_parameter<CGAL_NP_CLASS, internal_np::face_color_map_t>::value;
 
   std::vector<std::string> prop = sm.template properties<Simplex>();

--- a/Tetrahedral_remeshing/include/CGAL/Adaptive_remeshing_sizing_field.h
+++ b/Tetrahedral_remeshing/include/CGAL/Adaptive_remeshing_sizing_field.h
@@ -353,12 +353,9 @@ create_adaptive_remeshing_sizing_field(const Tr& tr,
   using Edge_vv = std::pair<V, V>;
   using Facet = typename Tr::Facet;
 
-  auto ecmap = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
-    CGAL::Constant_property_map<Edge_vv, bool>(false));
-  auto fcmap = choose_parameter(get_parameter(np, internal_np::facet_is_constrained),
-    CGAL::Constant_property_map<Facet, bool>(false));
-  auto cell_selector = choose_parameter(get_parameter(np, internal_np::cell_selector),
-    CGAL::Tetrahedral_remeshing::internal::All_cells_selected<Tr>());
+  auto ecmap = choose_parameter<Static_boolean_property_map<Edge_vv, false>>(get_parameter(np, internal_np::edge_is_constrained));
+  auto fcmap = choose_parameter<Static_boolean_property_map<Facet, false>>(get_parameter(np, internal_np::facet_is_constrained));
+  auto cell_selector = choose_parameter<CGAL::Tetrahedral_remeshing::internal::All_cells_selected<Tr>>(get_parameter(np, internal_np::cell_selector));
 
   return Adaptive_remeshing_sizing_field<Tr>(tr, ecmap, fcmap, cell_selector);
 }

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -680,7 +680,7 @@ struct Adaptive_remesher_type_generator
   >::type;
 
   using Vertex_handle = typename Tr::Vertex_handle;
-  using Default_VCMap = Constant_property_map<Vertex_handle, bool>;
+  using Default_VCMap = Static_boolean_property_map<Vertex_handle, false>;
   using VCMap = typename internal_np::Lookup_named_param_def<
     internal_np::vertex_is_constrained_t,
     NamedParameters,
@@ -688,7 +688,7 @@ struct Adaptive_remesher_type_generator
   >::type;
 
   using Edge_vv = std::pair<Vertex_handle, Vertex_handle>;
-  using Default_ECMap = Constant_property_map<Edge_vv, bool>;
+  using Default_ECMap = Static_boolean_property_map<Edge_vv, false>;
   using ECMap = typename internal_np::Lookup_named_param_def<
     internal_np::edge_is_constrained_t,
     NamedParameters,
@@ -696,7 +696,7 @@ struct Adaptive_remesher_type_generator
   >::type;
 
   using Facet = typename Tr::Facet;
-  using Default_FCMap = Constant_property_map<Facet, bool>;
+  using Default_FCMap = Static_boolean_property_map<Facet, false>;
   using FCMap = typename internal_np::Lookup_named_param_def<
     internal_np::facet_is_constrained_t,
     NamedParameters,

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -210,21 +210,16 @@ void tetrahedral_isotropic_remeshing(
                        false);
 
   auto cell_select
-    = choose_parameter(get_parameter(np, internal_np::cell_selector),
-                                     typename Remesher_types::Default_Selection_functor());
+    = choose_parameter<typename Remesher_types::Default_Selection_functor>(get_parameter(np, internal_np::cell_selector));
 
-  auto vcmap = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained),
-                                typename Remesher_types::Default_VCMap(false));
+  auto vcmap = choose_parameter<typename Remesher_types::Default_VCMap>(get_parameter(np, internal_np::vertex_is_constrained));
 
-  auto ecmap = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
-                                typename Remesher_types::Default_ECMap(false));
+  auto ecmap = choose_parameter<typename Remesher_types::Default_ECMap>(get_parameter(np, internal_np::edge_is_constrained));
 
-  auto fcmap = choose_parameter(get_parameter(np, internal_np::facet_is_constrained),
-                                typename Remesher_types::Default_FCMap(false));
+  auto fcmap = choose_parameter<typename Remesher_types::Default_FCMap>(get_parameter(np, internal_np::facet_is_constrained));
 
   // Advanced and non documented parameters
-  auto visitor = choose_parameter(get_parameter(np, internal_np::visitor),
-                                  typename Remesher_types::Default_Visitor());
+  auto visitor = choose_parameter<typename Remesher_types::Default_Visitor>(get_parameter(np, internal_np::visitor));
 
   auto nb_extra_iterations
     = choose_parameter(get_parameter(np, internal_np::nb_flip_smooth_iterations),
@@ -373,8 +368,7 @@ convert_to_triangulation_3(
   using ECMap = typename Remesher_types::ECMap;
   if (!std::is_same_v<ECMap, Default_edge_pmap>)
   {
-    ECMap ecmap = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
-                                   Default_edge_pmap(false));
+    ECMap ecmap = choose_parameter<Default_edge_pmap>(get_parameter(np, internal_np::edge_is_constrained));
     for (auto e : c3t3.edges_in_complex())
     {
       const auto evv = CGAL::Tetrahedral_remeshing::make_vertex_pair(e);//ordered pair
@@ -386,8 +380,7 @@ convert_to_triangulation_3(
   using VCMap = typename Remesher_types::VCMap;
   if (!std::is_same_v<VCMap, Default_vertex_pmap>)
   {
-    VCMap vcmap = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained),
-                                   Default_vertex_pmap(false));
+    VCMap vcmap = choose_parameter<Default_vertex_pmap>(get_parameter(np, internal_np::vertex_is_constrained));
     for (auto v : c3t3.vertices_in_complex())
     {
       put(vcmap, v, true);
@@ -470,22 +463,17 @@ void tetrahedral_isotropic_remeshing(
         false);
 
   auto cell_select
-    = choose_parameter(get_parameter(np, internal_np::cell_selector),
-        typename Remesher_types::Default_Selection_functor());
+    = choose_parameter<typename Remesher_types::Default_Selection_functor>(get_parameter(np, internal_np::cell_selector));
 
-  auto vcmap = choose_parameter(get_parameter(np, internal_np::vertex_is_constrained),
-                                typename Remesher_types::Default_VCMap(false));
+  auto vcmap = choose_parameter<typename Remesher_types::Default_VCMap>(get_parameter(np, internal_np::vertex_is_constrained));
 
-  auto ecmap = choose_parameter(get_parameter(np, internal_np::edge_is_constrained),
-                                typename Remesher_types::Default_ECMap(false));
+  auto ecmap = choose_parameter<typename Remesher_types::Default_ECMap>(get_parameter(np, internal_np::edge_is_constrained));
 
-  auto fcmap = choose_parameter(get_parameter(np, internal_np::facet_is_constrained),
-                                typename Remesher_types::Default_FCMap(false));
+  auto fcmap = choose_parameter<typename Remesher_types::Default_FCMap>(get_parameter(np, internal_np::facet_is_constrained));
 
   // Advanced and non documented parameters
   auto visitor
-    = choose_parameter(get_parameter(np, internal_np::visitor),
-        typename Remesher_types::Default_Visitor());
+    = choose_parameter<typename Remesher_types::Default_Visitor>(get_parameter(np, internal_np::visitor));
 
   auto nb_extra_iterations
     = choose_parameter(get_parameter(np, internal_np::nb_flip_smooth_iterations),


### PR DESCRIPTION
Also add a new overload for the case of dynamic properties

Fixes #9516