### PR TITLE
Avoid collision with minor macro (bis)

### DIFF
--- a/Surface_mesh_simplification/include/CGAL/internal/robust_cross_product.h
+++ b/Surface_mesh_simplification/include/CGAL/internal/robust_cross_product.h
@@ -76,7 +76,7 @@ typename GeomTraits::Vector_3 similar_coordinates_cross_product(const typename G
   const FT& vy = v.y();
   const FT& vz = v.z();
 
-  auto minor_val = [](const FT& ui, const FT& vi, const FT& uj, const FT& vj)
+  auto compute_minor = [](const FT& ui, const FT& vi, const FT& uj, const FT& vj)
   {
     // The main idea is that we expect ai and bi (and aj and bj) to have roughly the same magnitude
     // since this function is used to compute the cross product of two vectors that are defined
@@ -87,9 +87,9 @@ typename GeomTraits::Vector_3 similar_coordinates_cross_product(const typename G
   };
 
   // ay*
-  FT x = minor_val(uy, vy, uz, vz);
-  FT y = minor_val(uz, vz, ux, vx);
-  FT z = minor_val(ux, vx, uy, vy);
+  FT x = compute_minor(uy, vy, uz, vz);
+  FT y = compute_minor(uz, vz, ux, vx);
+  FT z = compute_minor(ux, vx, uy, vy);
 
   return Vector(x, y, z);
 }

--- a/Surface_mesh_simplification/include/CGAL/internal/robust_cross_product.h
+++ b/Surface_mesh_simplification/include/CGAL/internal/robust_cross_product.h
@@ -76,7 +76,7 @@ typename GeomTraits::Vector_3 similar_coordinates_cross_product(const typename G
   const FT& vy = v.y();
   const FT& vz = v.z();
 
-  auto minor = [](const FT& ui, const FT& vi, const FT& uj, const FT& vj)
+  auto minor_val = [](const FT& ui, const FT& vi, const FT& uj, const FT& vj)
   {
     // The main idea is that we expect ai and bi (and aj and bj) to have roughly the same magnitude
     // since this function is used to compute the cross product of two vectors that are defined
@@ -87,9 +87,9 @@ typename GeomTraits::Vector_3 similar_coordinates_cross_product(const typename G
   };
 
   // ay*
-  FT x = minor(uy, vy, uz, vz);
-  FT y = minor(uz, vz, ux, vx);
-  FT z = minor(ux, vx, uy, vy);
+  FT x = minor_val(uy, vy, uz, vz);
+  FT y = minor_val(uz, vz, ux, vx);
+  FT z = minor_val(ux, vx, uy, vy);
 
   return Vector(x, y, z);
 }


### PR DESCRIPTION
## Summary of Changes

minor is already used in `sys/types.h`
```
In file included from SFCGAL3/src/algorithm/surfaceSimplification.cpp:30:
In file included from CGAL-6.2/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/edge_collapse.h:22:
In file included from CGAL-6.2/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/LindstromTurk.h:16:
In file included from CGAL-6.2/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/LindstromTurk_cost.h:17:
In file included from CGAL-6.2/Surface_mesh_simplification/include/CGAL/Surface_mesh_simplification/Policies/Edge_collapse/internal/Lindstrom_Turk_core.h:20:
In file included from CGAL-6.2/Surface_mesh_simplification/include/CGAL/Cartesian/MatrixC33.h:16:
CGAL-6.2/Surface_mesh_simplification/include/CGAL/internal/robust_cross_product.h:90:20: error: too many arguments provided to function-like macro invocation
   90 |   FT x = minor(uy, vy, uz, vz);
      |                    ^
/usr/include/sys/types.h:337:9: note: macro 'minor' defined here
  337 | #define minor(d)        __minor(d)
      |         ^
```


[OpenBSD](https://github.com/openbsd/src/blob/master/sys/sys/types.h#L216)
[FreeBSD](https://github.com/freebsd/freebsd-src/blob/main/sys/sys/types.h#L337)

Reported by [SFCGAL CI](https://github.com/SFCGAL/SFCGAL/actions/runs/27346692030/job/80797174200#step:3:241)
Reproduced locally (FreeBSD)

cc @ptitjano @landryb

## Release Management

* Affected package(s): Surface_mesh_simplification
* Issue(s) solved (if any): -
* Feature/Small Feature (if any): -
* License and copyright ownership: no change

