### PR TITLE
Tet remeshing - fix check before collapse

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
@@ -1215,21 +1215,28 @@ auto can_be_collapsed(const typename C3T3::Edge& e,
     bool on_boundary;
   };
 
-  const bool boundary = c3t3.is_in_complex(e)
-                     || is_boundary(c3t3, e, cell_selector);
+  const bool in_cx = c3t3.is_in_complex(e);
+  if(in_cx && protect_boundaries)
+    return Collapsible{false, true /*boundary*/};
 
-  if (protect_boundaries)
+  const bool boundary = is_boundary(c3t3, e, cell_selector);
+  if(boundary && protect_boundaries)
+    return Collapsible{false, boundary};
+
+  if(!is_selected(e, c3t3.triangulation(), cell_selector))
+    return Collapsible{false, boundary};
+
+  if(!boundary && !in_cx)
   {
-    if (boundary)
+    auto patch_v0 = surface_patch_index(e.first->vertex(e.second), c3t3);
+    auto patch_v1 = surface_patch_index(e.first->vertex(e.third), c3t3);
+
+    if(patch_v0 != std::nullopt && patch_v1 != std::nullopt && patch_v0 != patch_v1)
       return Collapsible{false, boundary};
+  }
 
-    return Collapsible{ is_internal(e, c3t3, cell_selector), boundary};
-  }
-  else
-  {
-    return Collapsible{ is_selected(e, c3t3.triangulation(), cell_selector),
-                        boundary };
-  }
+//   if(!is_internal(e, c3t3, cell_selector))
+  return Collapsible {true, boundary};
 }
 
 template<typename C3T3,

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -810,7 +810,6 @@ std::optional<typename C3t3::Surface_patch_index>
 surface_patch_index(const typename C3t3::Vertex_handle v,
                     const C3t3& c3t3)
 {
-  typedef typename C3t3::Surface_patch_index Surface_patch_index;
   typedef typename C3t3::Facet Facet;
   std::vector<Facet> facets;
   c3t3.triangulation().incident_facets(v, std::back_inserter(facets));

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -806,8 +806,9 @@ bool is_boundary_vertex(const typename C3t3::Vertex_handle& v,
 }
 
 template<typename C3t3>
-typename C3t3::Surface_patch_index surface_patch_index(const typename C3t3::Vertex_handle v,
-    const C3t3& c3t3)
+std::optional<typename C3t3::Surface_patch_index>
+surface_patch_index(const typename C3t3::Vertex_handle v,
+                    const C3t3& c3t3)
 {
   typedef typename C3t3::Surface_patch_index Surface_patch_index;
   typedef typename C3t3::Facet Facet;
@@ -819,7 +820,7 @@ typename C3t3::Surface_patch_index surface_patch_index(const typename C3t3::Vert
     if (c3t3.is_in_complex(f))
       return c3t3.surface_patch_index(f);
   }
-  return Surface_patch_index();
+  return std::nullopt;
 }
 
 template<typename C3t3>
@@ -833,7 +834,7 @@ void set_index(typename C3t3::Vertex_handle v, const C3t3& c3t3)
   case 2:
     CGAL_expensive_assertion(surface_patch_index(v, c3t3)
                   != typename C3t3::Surface_patch_index());
-    v->set_index(surface_patch_index(v, c3t3));
+    v->set_index(surface_patch_index(v, c3t3).value());
     break;
   case 1:
     v->set_index(typename C3t3::Curve_index(1));


### PR DESCRIPTION
## Summary of Changes

the check of collapse feasibility was broken, not dealing properly with end vertices lying on different surface patches

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged

