### PR TITLE
Mesh_3: Changed doc of value outside in create_labeled_image_mesh_domain

### DIFF
--- a/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
+++ b/Mesh_3/include/CGAL/Labeled_mesh_domain_3.h
@@ -631,8 +631,7 @@ public:
    *   \cgalParamNEnd
    *   \cgalParamNBegin{value_outside}
    *     \cgalParamDescription{the value attached to voxels
-   *                           outside of the domain to be meshed. It should be lower than
-   *                           `iso_value`.}
+   *                           outside of the domain to be meshed.}
    *     \cgalParamDefault{0}
    *   \cgalParamNEnd
    *


### PR DESCRIPTION

## Summary of Changes

Removed the `iso_value` in the doc of the parameter `value_outside` for the method `create_labeled_image_mesh_domain` .

## Release Management

* Affected package(s): Mesh_3
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: unchanged

