### PR TITLE
Fix PMP negligible component geom traits lookup

### DIFF
--- a/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/PMP_Mesh_repair/include/CGAL/Polygon_mesh_processing/repair.h
@@ -9,7 +9,8 @@
 //
 //
 // Author(s)     : Sebastien Loriot,
-//                 Mael Rouxel-Labbé
+//                 Mael Rouxel-Labbé,
+//                 Utkarsh Khajuria <utkarshkhajuria55@gmail.com>
 
 #ifndef CGAL_POLYGON_MESH_PROCESSING_REPAIR_H
 #define CGAL_POLYGON_MESH_PROCESSING_REPAIR_H
@@ -163,7 +164,7 @@ std::size_t remove_connected_components_of_negligible_size(TriangleMesh& tmesh,
 
   typedef typename GetGeomTraits<TriangleMesh, NamedParameters>::type              GT;
   typedef typename GT::FT                                                          FT;
-  const GT traits = choose_parameter<GT>(get_parameter(np, internal_np::vertex_point));
+  const GT traits = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
 
   typedef typename GetVertexPointMap<TriangleMesh, NamedParameters>::const_type    VPM;
   typedef typename boost::property_traits<VPM>::value_type                         Point_3;

--- a/PMP_Mesh_repair/test/PMP_Mesh_repair/test_pmp_repair_degeneracies.cpp
+++ b/PMP_Mesh_repair/test/PMP_Mesh_repair/test_pmp_repair_degeneracies.cpp
@@ -262,6 +262,17 @@ void remove_negligible_connected_components(const std::string filename)
   PMP::remove_connected_components_of_negligible_size(mesh, CP::area_threshold(1e15));
   assert(is_empty(mesh));
 
+  // Explicit vertex point map and geom traits
+  std::cout << "---------\nexplicit vertex point map and geom traits..." << std::endl;
+  Mesh mesh_with_explicit_np = mesh_cpy;
+  auto vpm = get(CGAL::vertex_point, mesh_with_explicit_np);
+  const std::size_t nb_explicit_np = PMP::remove_connected_components_of_negligible_size(
+                                      mesh_with_explicit_np,
+                                      CP::vertex_point_map(vpm)
+                                         .geom_traits(K()));
+  assert(nb_explicit_np == 3);
+  assert(PMP::internal::number_of_connected_components(mesh_with_explicit_np) == 1);
+
   // Could also have used default parameters, which does the job by itself
   std::cout << "---------\ndefault values..." << std::endl;
 


### PR DESCRIPTION
Fixes the named-parameter lookup for `remove_connected_components_of_negligible_size()` when both an explicit vertex point map and explicit geometry traits are provided.

The function was selecting the geometry traits from `internal_np::vertex_point` instead of `internal_np::geom_traits`. This caused the explicit `geom_traits(...)` named parameter to be ignored/misread in that code path.

This patch:

* changes the lookup to `internal_np::geom_traits`
* adds a regression test using both `vertex_point_map(...)` and `geom_traits(...)`

Local validation:

```bash
cmake -S ~/trees/cgal/PMP_Mesh_repair/test/PMP_Mesh_repair \
      -B ~/build/cgal/pmp_negligible_geom_traits_pr_release \
      -DCMAKE_BUILD_TYPE=Release \
      -DCGAL_DIR=~/build/cgal/dev_debug

cmake --build ~/build/cgal/pmp_negligible_geom_traits_pr_release \
      --target test_pmp_repair_degeneracies --parallel 4

cd ~/build/cgal/pmp_negligible_geom_traits_pr_release
./test_pmp_repair_degeneracies
```

Result:

```text
run_rc=0
```
