### PR TITLE
BGL: Remove debug output in PLY.h

### DIFF
--- a/BGL/include/CGAL/boost/graph/IO/PLY.h
+++ b/BGL/include/CGAL/boost/graph/IO/PLY.h
@@ -471,8 +471,6 @@ bool write_PLY(std::ostream& os,
       internal::output_properties(os, &fp, make_ply_point_writer (CGAL::Identity_property_map<Target_point>()));
     }
 
-    std::cout << "using generic writer" << std::endl;
-
     if constexpr (!parameters::is_default_parameter<CGAL_NP_CLASS, internal_np::vertex_normal_map_t>::value)
     {
       auto vnm = get_parameter(np, internal_np::vertex_normal_map);


### PR DESCRIPTION
## Summary of Changes

Remove an output that was added while debugging.   As this writes to `std::cout`  this is even a bug in case the function outputs to this `std::ostream`.

## Release Management

* Affected package(s):  BGL
* License and copyright ownership:  unchanged

