### PR TITLE
Mesh_3 global optimizers: fix a possibility to hide points

### DIFF
--- a/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
+++ b/Mesh_3/include/CGAL/Mesh_3/C3T3_helpers.h
@@ -28,6 +28,7 @@
 #include <CGAL/Mesh_3/Triangulation_helpers.h>
 #include <CGAL/Time_stamper.h>
 #include <CGAL/tuple.h>
+#include <CGAL/unordered_flat_map.h>
 #include <CGAL/iterator.h>
 #include <CGAL/array.h>
 #include <CGAL/Handle_hash_function.h>
@@ -3018,7 +3019,9 @@ move_point(const Vertex_handle& old_vertex,
 
     Vertex_handle new_vertex = move_point_topo_change(old_vertex, new_position, outdated_cells_set);
 
-    moving_vertices.insert(new_vertex);
+    if(new_vertex != Vertex_handle{}) {
+      moving_vertices.insert(new_vertex);
+    }
     return new_vertex;
   }
 }
@@ -3104,7 +3107,9 @@ move_point(const Vertex_handle& old_vertex,
 
     lock_moving_vertices();
     moving_vertices.erase(old_vertex);
-    moving_vertices.insert(new_vertex);
+    if(new_vertex != Vertex_handle{}) {
+      moving_vertices.insert(new_vertex);
+    }
     unlock_moving_vertices();
 
     // Don't "unlock_all_elements" here, the caller may need it to do it himself
@@ -3148,6 +3153,23 @@ move_point_topo_change(const Vertex_handle& old_vertex,
 
   if (could_lock_zone && *could_lock_zone == false)
     return Vertex_handle();
+
+  CGAL::unordered_flat_set<Vertex_handle> insertion_conflict_vertices;
+  std::for_each(insertion_conflict_cells.begin(), insertion_conflict_cells.end(),
+                [&](const Cell_handle& c) {
+                  for(auto v: tr_.vertices(c)) {
+                    insertion_conflict_vertices.insert(v);
+                  }
+                });
+  std::for_each(insertion_conflict_boundary.begin(), insertion_conflict_boundary.end(),
+                [&](const Facet& f) {
+                  for(auto v: tr_.vertices(f)) {
+                    insertion_conflict_vertices.erase(v);
+                  }
+                });
+  if(!insertion_conflict_vertices.empty()) {
+    return Vertex_handle{};
+  }
 
   lock_outdated_cells();
   for(typename Cell_set::iterator it = insertion_conflict_cells.begin();

--- a/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
+++ b/Mesh_3/include/CGAL/Mesh_3/Mesh_global_optimizer.h
@@ -547,7 +547,9 @@ private:
           }
 
           // Restore size in meshing_info data
-          new_v->set_meshing_info(size);
+          if(new_v != Vertex_handle{}) {
+            new_v->set_meshing_info(size);
+          }
         }
         else // Move point
         {
@@ -993,7 +995,9 @@ update_mesh(const Moves_vector& moves,
         Vertex_handle new_v = helper_.move_point(v, move, outdated_cells, moving_vertices);
 
         // Restore size in meshing_info data
-        new_v->set_meshing_info(size);
+        if(new_v != Vertex_handle{}) {
+          new_v->set_meshing_info(size);
+        }
       }
       else // Move point
       {


### PR DESCRIPTION
## Summary of Changes

During the LLoyd or ODT optimization, this patch prevents points from being hidden.

## Release Management

* Affected package(s): Mesh_3
* Issue(s) solved (if any): 
* License and copyright ownership: no changes

