### PR TITLE
Add missing Point_d alias to Fuzzy_sphere

### DIFF
--- a/Spatial_searching/include/CGAL/Fuzzy_sphere.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_sphere.h
@@ -134,6 +134,7 @@ class Fuzzy_sphere:
   typedef internal::Fuzzy_sphere_impl<SearchTraits,typename SearchTraits::Point_d> Base;
   typedef typename Base::FT FT;
 public:
+  typedef typename SearchTraits::Point_d Point_d;
   // constructors
   Fuzzy_sphere(const SearchTraits& traits_=SearchTraits()):Base(traits_){}
   Fuzzy_sphere(const typename SearchTraits::Point_d& center, FT radius, FT epsilon=FT(0),const SearchTraits& traits_=SearchTraits()) :
@@ -149,6 +150,7 @@ class Fuzzy_sphere< Search_traits_adapter<K,PM,Base_traits> >
   typedef internal::Fuzzy_sphere_impl<SearchTraits,typename Base_traits::Point_d> Base;
   typedef typename Base_traits::FT FT;
 public:
+  typedef typename SearchTraits::Point_d Point_d;
   // constructors
   Fuzzy_sphere(const SearchTraits& traits_=SearchTraits()):Base(traits_){}
 


### PR DESCRIPTION
## Summary of Changes

This pull request adds the missing `Point_d` alias to `Fuzzy_sphere`.

The documentation states that `Point_d` should be defined, and `Fuzzy_iso_box` already exposes this alias. This change makes the API consistent by adding `Point_d` to both the primary template and the `Search_traits_adapter` specialization of `Fuzzy_sphere`.

## Release Management

* Affected package(s): Spatial_searching
* Issue(s) solved (if any): fix #9535
* Feature/Small Feature (if any): N/A
* Link to compiled documentation (obligatory for small feature): N/A
* License and copyright ownership: The changes are contributed under the same license as CGAL.
