### PR TITLE
PMP: fix copy/paste error

### DIFF
--- a/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
+++ b/Polygon_mesh_processing/include/CGAL/Polygon_mesh_processing/repair.h
@@ -163,7 +163,7 @@ std::size_t remove_connected_components_of_negligible_size(TriangleMesh& tmesh,
 
   typedef typename GetGeomTraits<TriangleMesh, NamedParameters>::type              GT;
   typedef typename GT::FT                                                          FT;
-  const GT traits = choose_parameter<GT>(get_parameter(np, internal_np::vertex_point));
+  const GT traits = choose_parameter<GT>(get_parameter(np, internal_np::geom_traits));
 
   typedef typename GetVertexPointMap<TriangleMesh, NamedParameters>::const_type    VPM;
   typedef typename boost::property_traits<VPM>::value_type                         Point_3;


### PR DESCRIPTION
Replaces #9537 for 6.1.x