### PR TITLE
Clear variable before filling it

### DIFF
--- a/Installation/lib/cmake/CGAL/CGALConfig.cmake
+++ b/Installation/lib/cmake/CGAL/CGALConfig.cmake
@@ -30,6 +30,7 @@ if(BRANCH_BUILD)
   set(CGAL_MODULES_DIR ${CGAL_ROOT}/Installation/cmake/modules)
   file(GLOB packages_dirs ${CGAL_ROOT}/*)
 #  message("packages_dirs: ${packages_dirs}")
+  set(CGAL_INCLUDE_DIRS)
   foreach(package_dir ${packages_dirs})
     set(inc_dir ${package_dir}/include)
     if(IS_DIRECTORY ${inc_dir}


### PR DESCRIPTION
Avoid duplicated entries in `CGAL_INCLUDE_DIRS`

Issue observed after [this](https://github.com/CGAL/cgal/blob/main/Installation/CMakeLists.txt#L832) `find_package` call.