### PR TITLE
Basic_viewer: clip-plane capping

### DIFF
--- a/Basic_viewer/include/CGAL/Basic_shaders.h
+++ b/Basic_viewer/include/CGAL/Basic_shaders.h
@@ -396,9 +396,11 @@ const char FRAGMENT_SOURCE_CLIPPING_PLANE[]=R"DELIM(
 
 out mediump vec4 out_color;
 
+uniform mediump vec4 u_Color;
+
 void main(void)
 {
-  out_color = vec4(0.0, 0.0, 0.0, 1.0);
+  out_color = u_Color;
 }
 )DELIM";
 

--- a/Basic_viewer/include/CGAL/Buffer_for_vao.h
+++ b/Basic_viewer/include/CGAL/Buffer_for_vao.h
@@ -487,6 +487,20 @@ public:
     m_face_started=false;
   }
 
+  /// The points accumulated for the face currently being built (before
+  /// triangulation). Used to de-duplicate a face before it is committed.
+  const std::vector<Local_point>& get_points_of_current_face() const
+  { return m_points_of_face; }
+
+  /// Discards the face currently being built without committing its geometry.
+  void cancel_face()
+  {
+    m_face_started=false;
+    m_points_of_face.clear();
+    m_vertex_normals_for_face.clear();
+    m_indices_of_points_of_face.clear();
+  }
+
   /// adds `kp` coordinates to `buffer`
   template<typename KPoint>
   static void add_point_in_buffer(const KPoint& kp, std::vector<BufferType>& buffer)

--- a/Basic_viewer/include/CGAL/Graphics_scene.h
+++ b/Basic_viewer/include/CGAL/Graphics_scene.h
@@ -297,6 +297,9 @@ public:
         m_buffer_for_faces.get_points_of_current_face();
       if (pts.size()>=3)
       {
+        // Volume bounding box (shared walls included), for the cap plane test.
+        for (const Local_point &p : pts) { m_volume_bboxes.back()+=p.bbox(); }
+
         Face_key key=canonical_face_key(pts);
         auto found=m_face_dedup.find(key);
         if (found!=m_face_dedup.end())
@@ -327,6 +330,7 @@ public:
   {
     m_volume_faces.emplace_back();
     m_volume_colors.push_back(acolor);
+    m_volume_bboxes.emplace_back();
     m_current_volume_color=acolor;
     m_current_volume_has_color=true;
     m_building_volume=true;
@@ -336,6 +340,7 @@ public:
   {
     m_volume_faces.emplace_back();
     m_volume_colors.push_back(m_default_color_face);
+    m_volume_bboxes.emplace_back();
     m_current_volume_has_color=false;
     m_building_volume=true;
   }
@@ -355,6 +360,9 @@ public:
 
   const std::vector<CGAL::IO::Color> &get_volume_colors() const
   { return m_volume_colors; }
+
+  const std::vector<CGAL::Bbox_3> &get_volume_bboxes() const
+  { return m_volume_bboxes; }
 
   template <typename KPoint>
   void add_text(const KPoint &kp, const std::string &txt)
@@ -420,6 +428,7 @@ public:
     m_faces.clear();
     m_volume_faces.clear();
     m_volume_colors.clear();
+    m_volume_bboxes.clear();
     m_current_face_start=0;
     m_face_dedup.clear();
     m_building_volume=false;
@@ -495,6 +504,7 @@ protected:
   std::vector<std::pair<unsigned int, unsigned int>> m_faces;
   std::vector<std::vector<unsigned int>> m_volume_faces;
   std::vector<CGAL::IO::Color> m_volume_colors;
+  std::vector<CGAL::Bbox_3> m_volume_bboxes;
   unsigned int m_current_face_start = 0;
 
   // Clip-plane cap: geometric face de-duplication during volume building. The key

--- a/Basic_viewer/include/CGAL/Graphics_scene.h
+++ b/Basic_viewer/include/CGAL/Graphics_scene.h
@@ -74,6 +74,8 @@ public:
                            &m_bounding_box, &arrays[COLOR_LINES]),
         m_buffer_for_faces(&arrays[POS_FACES], nullptr, &m_bounding_box, &arrays[COLOR_FACES],
                            &arrays[FLAT_NORMAL_FACES], &arrays[SMOOTH_NORMAL_FACES]),
+        // Clip-plane cap buffer: positions only, no bbox (shares the faces).
+        m_buffer_for_cap_faces(&arrays[POS_CAP_FACES]),
         m_default_color_face(60, 60, 200),
         m_default_color_point(200, 60, 60),
         m_default_color_segment(0, 0, 0),
@@ -278,6 +280,25 @@ public:
     { m_buffer_for_faces.face_end(); }
   }
 
+  // Clip-plane cap: its own face buffer, one closed boundary per volume.
+  void cap_face_begin()
+  { m_buffer_for_cap_faces.face_begin(); }
+
+  template <typename KPoint>
+  bool add_point_in_cap_face(const KPoint &kp)
+  { return m_buffer_for_cap_faces.add_point_in_face(kp); }
+
+  void cap_face_end()
+  { m_buffer_for_cap_faces.face_end(); }
+
+  // Start a new per-volume cap group (its first vertex index and color).
+  void start_face_group(const CGAL::IO::Color &acolor)
+  { m_face_groups.emplace_back(number_of_elements(POS_CAP_FACES), acolor); }
+
+  const std::vector<std::pair<unsigned int, CGAL::IO::Color>> &
+  get_face_groups() const
+  { return m_face_groups; }
+
   template <typename KPoint>
   void add_text(const KPoint &kp, const std::string &txt)
   {
@@ -338,7 +359,9 @@ public:
     m_buffer_for_rays.clear();
     m_buffer_for_lines.clear();
     m_buffer_for_faces.clear();
+    m_buffer_for_cap_faces.clear();
     m_texts.clear();
+    m_face_groups.clear();
     m_bounding_box=CGAL::Bbox_3();
   }
 
@@ -375,6 +398,7 @@ public:
     POS_RAYS,
     POS_LINES,
     POS_FACES,
+    POS_CAP_FACES, // clip-plane capping: per-volume closed boundary (positions only)
     END_POS,
     BEGIN_COLOR = END_POS,
     COLOR_POINTS = BEGIN_COLOR,
@@ -396,6 +420,7 @@ protected:
   Buffer_for_vao m_buffer_for_rays;
   Buffer_for_vao m_buffer_for_lines;
   Buffer_for_vao m_buffer_for_faces;
+  Buffer_for_vao m_buffer_for_cap_faces; // clip-plane capping (positions only)
 
   CGAL::IO::Color m_default_color_face;
   CGAL::IO::Color m_default_color_point;
@@ -404,6 +429,9 @@ protected:
   CGAL::IO::Color m_default_color_line;
 
   std::vector<std::tuple<Local_point, std::string>> m_texts;
+
+  // Per-volume cap groups: first POS_CAP_FACES vertex and color of each volume.
+  std::vector<std::pair<unsigned int, CGAL::IO::Color>> m_face_groups;
 
   std::vector<BufferType> arrays[LAST_INDEX];
 

--- a/Basic_viewer/include/CGAL/Graphics_scene.h
+++ b/Basic_viewer/include/CGAL/Graphics_scene.h
@@ -74,8 +74,6 @@ public:
                            &m_bounding_box, &arrays[COLOR_LINES]),
         m_buffer_for_faces(&arrays[POS_FACES], nullptr, &m_bounding_box, &arrays[COLOR_FACES],
                            &arrays[FLAT_NORMAL_FACES], &arrays[SMOOTH_NORMAL_FACES]),
-        // Clip-plane cap buffer: positions only, no bbox (shares the faces).
-        m_buffer_for_cap_faces(&arrays[POS_CAP_FACES]),
         m_default_color_face(60, 60, 200),
         m_default_color_point(200, 60, 60),
         m_default_color_segment(0, 0, 0),
@@ -259,7 +257,10 @@ public:
           << std::endl;
     }
     else
-    { m_buffer_for_faces.face_begin(m_default_color_face); }
+    {
+      m_current_face_start = number_of_elements(POS_FACES);
+      m_buffer_for_faces.face_begin(m_default_color_face);
+    }
   }
 
   void face_begin(const CGAL::IO::Color &acolor)
@@ -271,33 +272,51 @@ public:
           << std::endl;
     }
     else
-    { m_buffer_for_faces.face_begin(acolor); }
+    {
+      m_current_face_start = number_of_elements(POS_FACES);
+      m_buffer_for_faces.face_begin(acolor);
+    }
   }
 
   void face_end()
   {
     if (m_buffer_for_faces.is_a_face_started())
-    { m_buffer_for_faces.face_end(); }
+    {
+      m_buffer_for_faces.face_end();
+      // Record this face's vertex range in POS_FACES, for the clip-plane cap.
+      m_faces.emplace_back(m_current_face_start,
+                           number_of_elements(POS_FACES) - m_current_face_start);
+    }
   }
 
-  // Clip-plane cap: its own face buffer, one closed boundary per volume.
-  void cap_face_begin()
-  { m_buffer_for_cap_faces.face_begin(); }
+  // Clip-plane cap: per-volume face grouping over the single face buffer. A
+  // shared wall is referenced by both volumes, so no geometry is duplicated.
+  void volume_begin(const CGAL::IO::Color &acolor)
+  {
+    m_volume_faces.emplace_back();
+    m_volume_colors.push_back(acolor);
+  }
 
-  template <typename KPoint>
-  bool add_point_in_cap_face(const KPoint &kp)
-  { return m_buffer_for_cap_faces.add_point_in_face(kp); }
+  void volume_end() {}
 
-  void cap_face_end()
-  { m_buffer_for_cap_faces.face_end(); }
+  void add_face_to_current_volume(unsigned int face_index)
+  {
+    if (!m_volume_faces.empty())
+    { m_volume_faces.back().push_back(face_index); }
+  }
 
-  // Start a new per-volume cap group (its first vertex index and color).
-  void start_face_group(const CGAL::IO::Color &acolor)
-  { m_face_groups.emplace_back(number_of_elements(POS_CAP_FACES), acolor); }
+  unsigned int number_of_faces() const
+  { return static_cast<unsigned int>(m_faces.size()); }
 
-  const std::vector<std::pair<unsigned int, CGAL::IO::Color>> &
-  get_face_groups() const
-  { return m_face_groups; }
+  // The (first vertex, vertex count) range of face i in POS_FACES.
+  const std::pair<unsigned int, unsigned int> &face_range(unsigned int i) const
+  { return m_faces[i]; }
+
+  const std::vector<std::vector<unsigned int>> &get_volume_faces() const
+  { return m_volume_faces; }
+
+  const std::vector<CGAL::IO::Color> &get_volume_colors() const
+  { return m_volume_colors; }
 
   template <typename KPoint>
   void add_text(const KPoint &kp, const std::string &txt)
@@ -359,9 +378,11 @@ public:
     m_buffer_for_rays.clear();
     m_buffer_for_lines.clear();
     m_buffer_for_faces.clear();
-    m_buffer_for_cap_faces.clear();
     m_texts.clear();
-    m_face_groups.clear();
+    m_faces.clear();
+    m_volume_faces.clear();
+    m_volume_colors.clear();
+    m_current_face_start=0;
     m_bounding_box=CGAL::Bbox_3();
   }
 
@@ -398,7 +419,6 @@ public:
     POS_RAYS,
     POS_LINES,
     POS_FACES,
-    POS_CAP_FACES, // clip-plane capping: per-volume closed boundary (positions only)
     END_POS,
     BEGIN_COLOR = END_POS,
     COLOR_POINTS = BEGIN_COLOR,
@@ -420,7 +440,6 @@ protected:
   Buffer_for_vao m_buffer_for_rays;
   Buffer_for_vao m_buffer_for_lines;
   Buffer_for_vao m_buffer_for_faces;
-  Buffer_for_vao m_buffer_for_cap_faces; // clip-plane capping (positions only)
 
   CGAL::IO::Color m_default_color_face;
   CGAL::IO::Color m_default_color_point;
@@ -430,8 +449,12 @@ protected:
 
   std::vector<std::tuple<Local_point, std::string>> m_texts;
 
-  // Per-volume cap groups: first POS_CAP_FACES vertex and color of each volume.
-  std::vector<std::pair<unsigned int, CGAL::IO::Color>> m_face_groups;
+  // Clip-plane cap: per-face vertex range in POS_FACES, and per-volume face-index
+  // lists with their colors. A shared wall is one face referenced by two volumes.
+  std::vector<std::pair<unsigned int, unsigned int>> m_faces;
+  std::vector<std::vector<unsigned int>> m_volume_faces;
+  std::vector<CGAL::IO::Color> m_volume_colors;
+  unsigned int m_current_face_start = 0;
 
   std::vector<BufferType> arrays[LAST_INDEX];
 

--- a/Basic_viewer/include/CGAL/Graphics_scene.h
+++ b/Basic_viewer/include/CGAL/Graphics_scene.h
@@ -16,6 +16,8 @@
 // TODO #include <CGAL/license/GraphicsView.h>
 
 #include <iostream>
+#include <algorithm>
+#include <array>
 #include <map>
 #include <queue>
 #include <string>
@@ -259,7 +261,10 @@ public:
     else
     {
       m_current_face_start = number_of_elements(POS_FACES);
-      m_buffer_for_faces.face_begin(m_default_color_face);
+      // A face with no color inherits the color of its volume, if it has one.
+      m_buffer_for_faces.face_begin(
+        (m_building_volume && m_current_volume_has_color)
+        ? m_current_volume_color : m_default_color_face);
     }
   }
 
@@ -280,30 +285,63 @@ public:
 
   void face_end()
   {
-    if (m_buffer_for_faces.is_a_face_started())
+    if (!m_buffer_for_faces.is_a_face_started())
+    { return; }
+
+    // Inside a volume, de-duplicate faces by geometry: a shared wall added by the
+    // second volume is dropped and the stored one referenced (one copy in the
+    // display, both volumes referencing it for the cap).
+    if (m_building_volume)
     {
-      m_buffer_for_faces.face_end();
-      // Record this face's vertex range in POS_FACES, for the clip-plane cap.
-      m_faces.emplace_back(m_current_face_start,
-                           number_of_elements(POS_FACES) - m_current_face_start);
+      const std::vector<Local_point> &pts=
+        m_buffer_for_faces.get_points_of_current_face();
+      if (pts.size()>=3)
+      {
+        Face_key key=canonical_face_key(pts);
+        auto found=m_face_dedup.find(key);
+        if (found!=m_face_dedup.end())
+        { // Shared wall already stored: drop this copy, reference the existing.
+          m_buffer_for_faces.cancel_face();
+          m_volume_faces.back().push_back(found->second);
+          return;
+        }
+        m_buffer_for_faces.face_end();
+        const unsigned int idx=static_cast<unsigned int>(m_faces.size());
+        m_faces.emplace_back(m_current_face_start,
+                             number_of_elements(POS_FACES)-m_current_face_start);
+        m_face_dedup.emplace(std::move(key), idx);
+        m_volume_faces.back().push_back(idx);
+        return;
+      }
     }
+
+    m_buffer_for_faces.face_end();
+    // Record this face's vertex range in POS_FACES, for the clip-plane cap.
+    m_faces.emplace_back(m_current_face_start,
+                         number_of_elements(POS_FACES) - m_current_face_start);
   }
 
-  // Clip-plane cap: per-volume face grouping over the single face buffer. A
-  // shared wall is referenced by both volumes, so no geometry is duplicated.
+  // Clip-plane cap: a volume groups the faces added until volume_end, de-duplicated
+  // by geometry (see face_end). Its color is inherited by its uncolored faces.
   void volume_begin(const CGAL::IO::Color &acolor)
   {
     m_volume_faces.emplace_back();
     m_volume_colors.push_back(acolor);
+    m_current_volume_color=acolor;
+    m_current_volume_has_color=true;
+    m_building_volume=true;
   }
 
-  void volume_end() {}
-
-  void add_face_to_current_volume(unsigned int face_index)
+  void volume_begin()
   {
-    if (!m_volume_faces.empty())
-    { m_volume_faces.back().push_back(face_index); }
+    m_volume_faces.emplace_back();
+    m_volume_colors.push_back(m_default_color_face);
+    m_current_volume_has_color=false;
+    m_building_volume=true;
   }
+
+  void volume_end()
+  { m_building_volume=false; }
 
   unsigned int number_of_faces() const
   { return static_cast<unsigned int>(m_faces.size()); }
@@ -383,6 +421,9 @@ public:
     m_volume_faces.clear();
     m_volume_colors.clear();
     m_current_face_start=0;
+    m_face_dedup.clear();
+    m_building_volume=false;
+    m_current_volume_has_color=false;
     m_bounding_box=CGAL::Bbox_3();
   }
 
@@ -455,6 +496,29 @@ protected:
   std::vector<std::vector<unsigned int>> m_volume_faces;
   std::vector<CGAL::IO::Color> m_volume_colors;
   unsigned int m_current_face_start = 0;
+
+  // Clip-plane cap: geometric face de-duplication during volume building. The key
+  // is the sorted face vertex positions, so both sides of a shared wall match.
+  using Face_key = std::vector<std::array<double, 3>>;
+  std::map<Face_key, unsigned int> m_face_dedup;
+  bool m_building_volume = false;
+
+  // Color of the volume currently being built, inherited by its uncolored faces.
+  CGAL::IO::Color m_current_volume_color;
+  bool m_current_volume_has_color = false;
+
+  static Face_key canonical_face_key(const std::vector<Local_point> &pts)
+  {
+    Face_key key;
+    key.reserve(pts.size());
+    for (const Local_point &p : pts)
+    {
+      key.push_back({{CGAL::to_double(p.x()), CGAL::to_double(p.y()),
+                      CGAL::to_double(p.z())}});
+    }
+    std::sort(key.begin(), key.end());
+    return key;
+  }
 
   std::vector<BufferType> arrays[LAST_INDEX];
 

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -21,6 +21,8 @@
 #include <iostream>
 #include <tuple>
 #include <string>
+#include <algorithm>
+#include <cmath>
 #include <CGAL/Graphics_scene.h>
 
 #ifdef __GNUC__
@@ -857,9 +859,13 @@ public:
 
           // Bound each volume's stencil clear to its screen rectangle.
           QMatrix4x4 capMvp;
-          { double m[16]; camera()->getModelViewProjectionMatrix(m);
-            for (int i=0; i<16; ++i) { capMvp.data()[i]=float(m[i]); } }
-          GLint capVp[4]; glGetIntegerv(GL_VIEWPORT, capVp);
+          {
+            double m[16];
+            camera()->getModelViewProjectionMatrix(m);
+            for (int i=0; i<16; ++i) { capMvp.data()[i]=float(m[i]); }
+          }
+          GLint capVp[4];
+          glGetIntegerv(GL_VIEWPORT, capVp);
           if (num_volumes != 0) { glEnable(GL_SCISSOR_TEST); }
 
           for (std::size_t v = 0, nfill = (num_volumes == 0 ? 1 : num_volumes); v < nfill; ++v)
@@ -1461,26 +1467,27 @@ protected:
     const double xs[2]={b.xmin(), b.xmax()};
     const double ys[2]={b.ymin(), b.ymax()};
     const double zs[2]={b.zmin(), b.zmax()};
-    float minx=1e30f, miny=1e30f, maxx=-1e30f, maxy=-1e30f;
+    float px[8], py[8];
     for (int c=0; c<8; ++c)
     {
-      QVector4D p=mvp*QVector4D(float(xs[c&1]), float(ys[(c>>1)&1]),
-                                float(zs[(c>>2)&1]), 1.0f);
+      const QVector4D p=mvp*QVector4D(float(xs[c&1]), float(ys[(c>>1)&1]),
+                                      float(zs[(c>>2)&1]), 1.0f);
       if (p.w()<=0.0f) { return false; }
-      const float px=((p.x()/p.w())*0.5f+0.5f)*vp[2]+vp[0];
-      const float py=((p.y()/p.w())*0.5f+0.5f)*vp[3]+vp[1];
-      if (px<minx) minx=px;  if (px>maxx) maxx=px;
-      if (py<miny) miny=py;  if (py>maxy) maxy=py;
+      px[c]=((p.x()/p.w())*0.5f+0.5f)*vp[2]+vp[0];
+      py[c]=((p.y()/p.w())*0.5f+0.5f)*vp[3]+vp[1];
     }
-    int x0=int(minx); if (float(x0)>minx) --x0;   // floor
-    int y0=int(miny); if (float(y0)>miny) --y0;
-    int x1=int(maxx); if (float(x1)<maxx) ++x1;   // ceil
-    int y1=int(maxy); if (float(y1)<maxy) ++y1;
-    if (x0<vp[0])       { x0=vp[0]; }
-    if (y0<vp[1])       { y0=vp[1]; }
-    if (x1>vp[0]+vp[2]) { x1=vp[0]+vp[2]; }
-    if (y1>vp[1]+vp[3]) { y1=vp[1]+vp[3]; }
-    sx=x0; sy=y0;
+    const auto xr=std::minmax_element(px, px+8);
+    const auto yr=std::minmax_element(py, py+8);
+    int x0=int(std::floor(*xr.first));
+    int y0=int(std::floor(*yr.first));
+    int x1=int(std::ceil(*xr.second));
+    int y1=int(std::ceil(*yr.second));
+    x0=(std::max)(x0, vp[0]);
+    y0=(std::max)(y0, vp[1]);
+    x1=(std::min)(x1, vp[0]+vp[2]);
+    y1=(std::min)(y1, vp[1]+vp[3]);
+    sx=x0;
+    sy=y0;
     sw=(x1>x0)?GLsizei(x1-x0):0;
     sh=(y1>y0)?GLsizei(y1-y0):0;
     return true;

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -835,47 +835,39 @@ public:
         // 1. draw solid HALF
         renderer(DRAW_SOLID_HALF);
 
-        // Clip-plane cap: fill each clipped volume's cross-section in its color.
-        // Draw the volume's cap faces into the stencil (even-odd), then a quad
-        // on the plane where the stencil is odd.
-        if (m_proto_cap)
+        // Clip-plane cap: for each closed volume, fill its faces into the stencil
+        // (even-odd), then a quad where the stencil is odd, in the volume color.
+        // Faces are referenced in the single buffer, so a shared wall serves both
+        // volumes with no duplicated geometry. No volumes: one grey group.
         {
-          const std::vector<std::pair<unsigned int, CGAL::IO::Color>> &groups =
-            m_scene.get_face_groups();
-          const std::size_t ng = groups.size();
-          // No groups (e.g. a surface mesh): cap the whole display buffer as one
-          // grey group. Otherwise cap each per-volume group from the cap buffer.
-          const int cap_vao = (ng == 0) ? VAO_FACES : VAO_CAP_FACES;
-          const GLsizei total = static_cast<GLsizei>(m_scene.number_of_elements(
-            (ng == 0) ? GS::POS_FACES : GS::POS_CAP_FACES));
+          const std::vector<std::vector<unsigned int>> &volumes =
+            m_scene.get_volume_faces();
+          const std::vector<CGAL::IO::Color> &vcolors =
+            m_scene.get_volume_colors();
+          const std::size_t nvol = volumes.size();
+
+          // Compute which volumes/surfaces are closed once, on the first clip.
+          if (!m_cap_closed_valid)
+          { compute_cap_closed(); m_cap_closed_valid = true; }
 
           glEnable(GL_STENCIL_TEST);
           glDisable(GL_CULL_FACE);
 
-          for (std::size_t g = 0, ncap = (ng == 0 ? 1 : ng); g < ncap; ++g)
+          for (std::size_t v = 0, nfill = (nvol == 0 ? 1 : nvol); v < nfill; ++v)
           {
-            GLint start;
-            GLsizei count;
+            // Boundary guard: an open volume/surface has no meaningful cap.
+            if (v < m_cap_closed.size() && m_cap_closed[v] == 0) { continue; }
             QVector4D capcol;
-            if (ng == 0)
-            {
-              start = 0;
-              count = total;
-              capcol = QVector4D(0.6f, 0.6f, 0.6f, 1.0f);
-            }
+            if (nvol == 0)
+            { capcol = QVector4D(0.6f, 0.6f, 0.6f, 1.0f); }
             else
             {
-              start = static_cast<GLint>(groups[g].first);
-              const unsigned int end = (g + 1 < ng)
-                ? groups[g + 1].first : static_cast<unsigned int>(total);
-              count = static_cast<GLsizei>(end - groups[g].first);
-              const CGAL::IO::Color &c = groups[g].second;
+              const CGAL::IO::Color &c = vcolors[v];
               capcol = QVector4D(c.red() / 255.0f, c.green() / 255.0f,
                                  c.blue() / 255.0f, 1.0f);
             }
-            if (count <= 0) { continue; }
 
-            // 1. stencil fill (even-odd) from this volume's faces
+            // 1. even-odd stencil fill from this volume's faces
             glClear(GL_STENCIL_BUFFER_BIT);
             glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
             glDepthMask(GL_FALSE);
@@ -894,9 +886,23 @@ public:
               clipping_plane_rendering_transparency);
             rendering_program_face.setUniformValue("u_ClipPlane", clipPlane);
             rendering_program_face.setUniformValue("u_PointPlane", plane_point);
-            vao[cap_vao].bind();
-            glDrawArrays(GL_TRIANGLES, start, count);
-            vao[cap_vao].release();
+            vao[VAO_FACES].bind();
+            if (nvol == 0)
+            {
+              glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(
+                m_scene.number_of_elements(GS::POS_FACES)));
+            }
+            else
+            {
+              for (unsigned int fi : volumes[v])
+              {
+                const std::pair<unsigned int, unsigned int> &r =
+                  m_scene.face_range(fi);
+                glDrawArrays(GL_TRIANGLES, static_cast<GLint>(r.first),
+                             static_cast<GLsizei>(r.second));
+              }
+            }
+            vao[VAO_FACES].release();
             rendering_program_face.release();
 
             // 2. cap quad where the stencil is odd, in the volume color
@@ -1409,6 +1415,63 @@ protected:
     }
   }
 
+  // Clip-plane cap: a group is cappable only if it is closed (every edge used by
+  // two triangles); an open surface is skipped. Vertices matched by position.
+  void compute_cap_closed()
+  {
+    m_cap_closed.clear();
+    const std::vector<BufferType> &pos=m_scene.get_array_of_index(GS::POS_FACES);
+    const std::vector<std::vector<unsigned int>> &volumes=
+      m_scene.get_volume_faces();
+    const std::size_t nvol=volumes.size();
+    const std::size_t ngroup=(nvol==0 ? 1 : nvol);
+    m_cap_closed.assign(ngroup, 1);
+
+    for (std::size_t g=0; g<ngroup; ++g)
+    {
+      std::map<std::tuple<float, float, float>, unsigned int> vid;
+      std::map<std::pair<unsigned int, unsigned int>, int> ecount;
+
+      auto id_of=[&](unsigned int vtx) -> unsigned int {
+        std::tuple<float, float, float> key(pos[3*vtx], pos[3*vtx+1],
+                                            pos[3*vtx+2]);
+        auto it=vid.find(key);
+        if (it!=vid.end()) { return it->second; }
+        unsigned int id=static_cast<unsigned int>(vid.size());
+        vid.emplace(key, id);
+        return id;
+      };
+      auto add_triangle=[&](unsigned int v0) {
+        const unsigned int i0=id_of(v0), i1=id_of(v0+1), i2=id_of(v0+2);
+        unsigned int e[3][2]={{i0, i1}, {i1, i2}, {i2, i0}};
+        for (int k=0; k<3; ++k)
+        {
+          unsigned int a=e[k][0], b=e[k][1];
+          if (a>b) { std::swap(a, b); }
+          ++ecount[std::make_pair(a, b)];
+        }
+      };
+
+      if (nvol==0)
+      {
+        const unsigned int nv=m_scene.number_of_elements(GS::POS_FACES);
+        for (unsigned int v=0; v+2<nv; v+=3) { add_triangle(v); }
+      }
+      else
+      {
+        for (unsigned int fi : volumes[g])
+        {
+          const std::pair<unsigned int, unsigned int> &r=m_scene.face_range(fi);
+          for (unsigned int v=r.first; v+2<r.first+r.second; v+=3)
+          { add_triangle(v); }
+        }
+      }
+
+      for (const auto &e : ecount)
+      { if (e.second!=2) { m_cap_closed[g]=0; break; } }
+    }
+  }
+
   void initialize_buffers()
   {
     set_camera_mode();
@@ -1525,20 +1588,6 @@ protected:
     rendering_program_face.enableAttributeArray("a_Color");
     rendering_program_face.setAttributeBuffer("a_Color",GL_FLOAT,0,3);
 
-    // 5b) cap faces: positions only, reused by the face program for the stencil
-    // pass (a_Normal/a_Color are unused there).
-    vao[VAO_CAP_FACES].bind();
-    positions = m_scene.get_array_of_index(GS::POS_CAP_FACES);
-
-    ++bufn;
-    CGAL_assertion(bufn<NB_GL_BUFFERS);
-    buffers[bufn].bind();
-    buffers[bufn].allocate(positions.data(), static_cast<int>(positions.size()*sizeof(float)));
-    rendering_program_face.enableAttributeArray("a_Pos");
-    rendering_program_face.setAttributeBuffer("a_Pos",GL_FLOAT,0,3);
-    buffers[bufn].release();
-    vao[VAO_CAP_FACES].release();
-
     // 6) clipping plane shader
     if (isOpenGL_3_2())
     {
@@ -1560,6 +1609,7 @@ protected:
       rendering_program_clipping_plane.release();
     }
 
+    m_cap_closed_valid = false; // clip-plane cap: recompute closedness lazily
     m_are_buffers_initialized = true;
   }
 
@@ -1977,12 +2027,6 @@ protected:
         displayMessage(QString("Draw vertices=%1.").arg(m_draw_vertices?"true":"false"));
         update();
       }
-      else if ((e->key()==::Qt::Key_K) && (modifiers==::Qt::NoButton)) // PROTOTYPE
-      {
-        m_proto_cap=!m_proto_cap;
-        displayMessage(QString("Clip-plane cap=%1.").arg(m_proto_cap?"true":"false"));
-        update();
-      }
       else if ((e->key()==::Qt::Key_W) && (modifiers==::Qt::NoButton))
       {
         m_draw_faces=!m_draw_faces;
@@ -2263,7 +2307,6 @@ protected:
     VAO_RAYS,
     VAO_LINES,
     VAO_FACES,
-    VAO_CAP_FACES,
     VAO_CLIPPING_PLANE,
     NB_VAO_BUFFERS
   };
@@ -2283,8 +2326,9 @@ protected:
   // variables for clipping plane
   bool clipping_plane_rendering = true; // will be toggled when alt+c is pressed, which is used for indicating whether or not to render the clipping plane ;
   float clipping_plane_rendering_transparency = 0.5f; // to what extent the transparent part should be rendered;
-  std::size_t m_clip_grid_vertex_count = 0; // PROTOTYPE: grid vertices before the cap quad in m_array_for_clipping_plane
-  bool m_proto_cap = true; // PROTOTYPE: toggle the clip-plane cap (K)
+  std::size_t m_clip_grid_vertex_count = 0; // clip-plane cap: grid vertices before the cap quad in m_array_for_clipping_plane
+  std::vector<char> m_cap_closed; // clip-plane cap: per group, 1 if closed (cappable)
+  bool m_cap_closed_valid = false; // clip-plane cap: is m_cap_closed up to date
 
 };
 

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -788,9 +788,10 @@ public:
         if (!clipping_plane_rendering) return;
         // render clipping plane here
         rendering_program_clipping_plane.bind();
+        rendering_program_clipping_plane.setUniformValue("u_Color", QVector4D(0.0f, 0.0f, 0.0f, 1.0f));
         vao[VAO_CLIPPING_PLANE].bind();
         glLineWidth(0.1f);
-        glDrawArrays(GL_LINES, 0, static_cast<GLsizei>((m_array_for_clipping_plane.size()/3)));
+        glDrawArrays(GL_LINES, 0, static_cast<GLsizei>(m_clip_grid_vertex_count));
         glLineWidth(1.0f);
         vao[VAO_CLIPPING_PLANE].release();
         rendering_program_clipping_plane.release();
@@ -833,6 +834,89 @@ public:
       {
         // 1. draw solid HALF
         renderer(DRAW_SOLID_HALF);
+
+        // Clip-plane cap: fill each clipped volume's cross-section in its color.
+        // Draw the volume's cap faces into the stencil (even-odd), then a quad
+        // on the plane where the stencil is odd.
+        if (m_proto_cap)
+        {
+          const std::vector<std::pair<unsigned int, CGAL::IO::Color>> &groups =
+            m_scene.get_face_groups();
+          const std::size_t ng = groups.size();
+          // No groups (e.g. a surface mesh): cap the whole display buffer as one
+          // grey group. Otherwise cap each per-volume group from the cap buffer.
+          const int cap_vao = (ng == 0) ? VAO_FACES : VAO_CAP_FACES;
+          const GLsizei total = static_cast<GLsizei>(m_scene.number_of_elements(
+            (ng == 0) ? GS::POS_FACES : GS::POS_CAP_FACES));
+
+          glEnable(GL_STENCIL_TEST);
+          glDisable(GL_CULL_FACE);
+
+          for (std::size_t g = 0, ncap = (ng == 0 ? 1 : ng); g < ncap; ++g)
+          {
+            GLint start;
+            GLsizei count;
+            QVector4D capcol;
+            if (ng == 0)
+            {
+              start = 0;
+              count = total;
+              capcol = QVector4D(0.6f, 0.6f, 0.6f, 1.0f);
+            }
+            else
+            {
+              start = static_cast<GLint>(groups[g].first);
+              const unsigned int end = (g + 1 < ng)
+                ? groups[g + 1].first : static_cast<unsigned int>(total);
+              count = static_cast<GLsizei>(end - groups[g].first);
+              const CGAL::IO::Color &c = groups[g].second;
+              capcol = QVector4D(c.red() / 255.0f, c.green() / 255.0f,
+                                 c.blue() / 255.0f, 1.0f);
+            }
+            if (count <= 0) { continue; }
+
+            // 1. stencil fill (even-odd) from this volume's faces
+            glClear(GL_STENCIL_BUFFER_BIT);
+            glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_FALSE);
+            glDepthMask(GL_FALSE);
+            glDisable(GL_DEPTH_TEST);
+            glStencilFunc(GL_ALWAYS, 0, 0xFF);
+            glStencilOp(GL_KEEP, GL_KEEP, GL_INVERT);
+
+            rendering_program_face.bind();
+            rendering_program_face.setUniformValue("u_UseDefaultColor",
+                                                   static_cast<GLint>(1));
+            rendering_program_face.setUniformValue("u_DefaultColor",
+                                                   QVector3D(0.0, 0.0, 0.0));
+            rendering_program_face.setUniformValue("u_RenderingMode",
+              static_cast<float>(DRAW_SOLID_HALF));
+            rendering_program_face.setUniformValue("u_RenderingTransparency",
+              clipping_plane_rendering_transparency);
+            rendering_program_face.setUniformValue("u_ClipPlane", clipPlane);
+            rendering_program_face.setUniformValue("u_PointPlane", plane_point);
+            vao[cap_vao].bind();
+            glDrawArrays(GL_TRIANGLES, start, count);
+            vao[cap_vao].release();
+            rendering_program_face.release();
+
+            // 2. cap quad where the stencil is odd, in the volume color
+            glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE);
+            glDepthMask(GL_TRUE);
+            glEnable(GL_DEPTH_TEST);
+            glStencilFunc(GL_NOTEQUAL, 0, 0xFF);
+            glStencilOp(GL_KEEP, GL_KEEP, GL_KEEP);
+
+            rendering_program_clipping_plane.bind();
+            rendering_program_clipping_plane.setUniformValue("u_Color", capcol);
+            vao[VAO_CLIPPING_PLANE].bind();
+            glDrawArrays(GL_TRIANGLES,
+                         static_cast<GLint>(m_clip_grid_vertex_count), 6);
+            vao[VAO_CLIPPING_PLANE].release();
+            rendering_program_clipping_plane.release();
+          }
+
+          glDisable(GL_STENCIL_TEST);
+        }
 
         // 2. render clipping plane here
         renderer_clipping_plane(clipping_plane_rendering);
@@ -1441,6 +1525,20 @@ protected:
     rendering_program_face.enableAttributeArray("a_Color");
     rendering_program_face.setAttributeBuffer("a_Color",GL_FLOAT,0,3);
 
+    // 5b) cap faces: positions only, reused by the face program for the stencil
+    // pass (a_Normal/a_Color are unused there).
+    vao[VAO_CAP_FACES].bind();
+    positions = m_scene.get_array_of_index(GS::POS_CAP_FACES);
+
+    ++bufn;
+    CGAL_assertion(bufn<NB_GL_BUFFERS);
+    buffers[bufn].bind();
+    buffers[bufn].allocate(positions.data(), static_cast<int>(positions.size()*sizeof(float)));
+    rendering_program_face.enableAttributeArray("a_Pos");
+    rendering_program_face.setAttributeBuffer("a_Pos",GL_FLOAT,0,3);
+    buffers[bufn].release();
+    vao[VAO_CAP_FACES].release();
+
     // 6) clipping plane shader
     if (isOpenGL_3_2())
     {
@@ -1754,6 +1852,14 @@ protected:
     array.push_back(0.f);
     array.push_back(0.f);
     array.push_back(1.f);
+
+    // Clip-plane cap: a filled quad on the plane, same extent as the grid (the
+    // grid line draw uses only the vertices before it).
+    m_clip_grid_vertex_count = array.size()/3;
+    const float s = float(size);
+    const float quad[18] = { -s,-s,0.f,  s,-s,0.f,  s,s,0.f,
+                             -s,-s,0.f,  s,s,0.f,  -s,s,0.f };
+    for (float f : quad) array.push_back(f);
   }
 
   virtual void mouseDoubleClickEvent(QMouseEvent *e)
@@ -1869,6 +1975,12 @@ protected:
       {
         m_draw_vertices=!m_draw_vertices;
         displayMessage(QString("Draw vertices=%1.").arg(m_draw_vertices?"true":"false"));
+        update();
+      }
+      else if ((e->key()==::Qt::Key_K) && (modifiers==::Qt::NoButton)) // PROTOTYPE
+      {
+        m_proto_cap=!m_proto_cap;
+        displayMessage(QString("Clip-plane cap=%1.").arg(m_proto_cap?"true":"false"));
         update();
       }
       else if ((e->key()==::Qt::Key_W) && (modifiers==::Qt::NoButton))
@@ -2151,6 +2263,7 @@ protected:
     VAO_RAYS,
     VAO_LINES,
     VAO_FACES,
+    VAO_CAP_FACES,
     VAO_CLIPPING_PLANE,
     NB_VAO_BUFFERS
   };
@@ -2170,6 +2283,8 @@ protected:
   // variables for clipping plane
   bool clipping_plane_rendering = true; // will be toggled when alt+c is pressed, which is used for indicating whether or not to render the clipping plane ;
   float clipping_plane_rendering_transparency = 0.5f; // to what extent the transparent part should be rendered;
+  std::size_t m_clip_grid_vertex_count = 0; // PROTOTYPE: grid vertices before the cap quad in m_array_for_clipping_plane
+  bool m_proto_cap = true; // PROTOTYPE: toggle the clip-plane cap (K)
 
 };
 

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -844,7 +844,9 @@ public:
             m_scene.get_volume_faces();
           const std::vector<CGAL::IO::Color> &vcolors =
             m_scene.get_volume_colors();
-          const std::size_t nvol = volumes.size();
+          const std::vector<CGAL::Bbox_3> &vbboxes =
+            m_scene.get_volume_bboxes();
+          const std::size_t num_volumes = volumes.size();
 
           // Compute which volumes/surfaces are closed once, on the first clip.
           if (!m_cap_closed_valid)
@@ -853,12 +855,33 @@ public:
           glEnable(GL_STENCIL_TEST);
           glDisable(GL_CULL_FACE);
 
-          for (std::size_t v = 0, nfill = (nvol == 0 ? 1 : nvol); v < nfill; ++v)
+          // Bound each volume's stencil clear to its screen rectangle.
+          QMatrix4x4 capMvp;
+          { double m[16]; camera()->getModelViewProjectionMatrix(m);
+            for (int i=0; i<16; ++i) { capMvp.data()[i]=float(m[i]); } }
+          GLint capVp[4]; glGetIntegerv(GL_VIEWPORT, capVp);
+          if (num_volumes != 0) { glEnable(GL_SCISSOR_TEST); }
+
+          for (std::size_t v = 0, nfill = (num_volumes == 0 ? 1 : num_volumes); v < nfill; ++v)
           {
             // Boundary guard: an open volume/surface has no meaningful cap.
             if (v < m_cap_closed.size() && m_cap_closed[v] == 0) { continue; }
+            // Skip a volume the plane does not cross (nothing to cap).
+            if (num_volumes != 0 && v < vbboxes.size() &&
+                !plane_crosses_bbox(vbboxes[v], clipPlane, plane_point))
+            { continue; }
+            if (num_volumes != 0 && v < vbboxes.size())
+            {
+              GLint sx, sy; GLsizei sw, sh;
+              if (bbox_scissor(vbboxes[v], capMvp, capVp, sx, sy, sw, sh))
+              {
+                if (sw==0 || sh==0) { continue; } // off-screen
+                glScissor(sx, sy, sw, sh);
+              }
+              else { glScissor(capVp[0], capVp[1], capVp[2], capVp[3]); }
+            }
             QVector4D capcol;
-            if (nvol == 0)
+            if (num_volumes == 0)
             { capcol = QVector4D(0.6f, 0.6f, 0.6f, 1.0f); }
             else
             {
@@ -887,7 +910,7 @@ public:
             rendering_program_face.setUniformValue("u_ClipPlane", clipPlane);
             rendering_program_face.setUniformValue("u_PointPlane", plane_point);
             vao[VAO_FACES].bind();
-            if (nvol == 0)
+            if (num_volumes == 0)
             {
               glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(
                 m_scene.number_of_elements(GS::POS_FACES)));
@@ -921,6 +944,7 @@ public:
             rendering_program_clipping_plane.release();
           }
 
+          if (num_volumes != 0) { glDisable(GL_SCISSOR_TEST); }
           glDisable(GL_STENCIL_TEST);
         }
 
@@ -1415,6 +1439,53 @@ protected:
     }
   }
 
+  // Clip-plane cap: true if the plane (normal, point) crosses the box.
+  static bool plane_crosses_bbox(const CGAL::Bbox_3 &b,
+                                 const QVector4D &normal, const QVector4D &point)
+  {
+    const double nx=normal.x(), ny=normal.y(), nz=normal.z();
+    const double d=nx*point.x()+ny*point.y()+nz*point.z();
+    double lo=0.0, hi=0.0;
+    if (nx>=0){ lo+=nx*b.xmin(); hi+=nx*b.xmax(); } else { lo+=nx*b.xmax(); hi+=nx*b.xmin(); }
+    if (ny>=0){ lo+=ny*b.ymin(); hi+=ny*b.ymax(); } else { lo+=ny*b.ymax(); hi+=ny*b.ymin(); }
+    if (nz>=0){ lo+=nz*b.zmin(); hi+=nz*b.zmax(); } else { lo+=nz*b.zmax(); hi+=nz*b.zmin(); }
+    return (lo-d)<=0.0 && (hi-d)>=0.0;
+  }
+
+  // Clip-plane cap: framebuffer-pixel rectangle of a world box under mvp/viewport.
+  // Returns false if a corner is behind the camera (caller clears the full screen).
+  static bool bbox_scissor(const CGAL::Bbox_3 &b, const QMatrix4x4 &mvp,
+                           const GLint vp[4],
+                           GLint &sx, GLint &sy, GLsizei &sw, GLsizei &sh)
+  {
+    const double xs[2]={b.xmin(), b.xmax()};
+    const double ys[2]={b.ymin(), b.ymax()};
+    const double zs[2]={b.zmin(), b.zmax()};
+    float minx=1e30f, miny=1e30f, maxx=-1e30f, maxy=-1e30f;
+    for (int c=0; c<8; ++c)
+    {
+      QVector4D p=mvp*QVector4D(float(xs[c&1]), float(ys[(c>>1)&1]),
+                                float(zs[(c>>2)&1]), 1.0f);
+      if (p.w()<=0.0f) { return false; }
+      const float px=((p.x()/p.w())*0.5f+0.5f)*vp[2]+vp[0];
+      const float py=((p.y()/p.w())*0.5f+0.5f)*vp[3]+vp[1];
+      if (px<minx) minx=px;  if (px>maxx) maxx=px;
+      if (py<miny) miny=py;  if (py>maxy) maxy=py;
+    }
+    int x0=int(minx); if (float(x0)>minx) --x0;   // floor
+    int y0=int(miny); if (float(y0)>miny) --y0;
+    int x1=int(maxx); if (float(x1)<maxx) ++x1;   // ceil
+    int y1=int(maxy); if (float(y1)<maxy) ++y1;
+    if (x0<vp[0])       { x0=vp[0]; }
+    if (y0<vp[1])       { y0=vp[1]; }
+    if (x1>vp[0]+vp[2]) { x1=vp[0]+vp[2]; }
+    if (y1>vp[1]+vp[3]) { y1=vp[1]+vp[3]; }
+    sx=x0; sy=y0;
+    sw=(x1>x0)?GLsizei(x1-x0):0;
+    sh=(y1>y0)?GLsizei(y1-y0):0;
+    return true;
+  }
+
   // Clip-plane cap: a group is cappable only if it is closed (every edge used by
   // two triangles); an open surface is skipped. Vertices matched by position.
   void compute_cap_closed()
@@ -1423,22 +1494,22 @@ protected:
     const std::vector<BufferType> &pos=m_scene.get_array_of_index(GS::POS_FACES);
     const std::vector<std::vector<unsigned int>> &volumes=
       m_scene.get_volume_faces();
-    const std::size_t nvol=volumes.size();
-    const std::size_t ngroup=(nvol==0 ? 1 : nvol);
-    m_cap_closed.assign(ngroup, 1);
+    const std::size_t num_volumes=volumes.size();
+    const std::size_t num_groups=(num_volumes==0 ? 1 : num_volumes);
+    m_cap_closed.assign(num_groups, 1);
 
-    for (std::size_t g=0; g<ngroup; ++g)
+    for (std::size_t g=0; g<num_groups; ++g)
     {
-      std::map<std::tuple<float, float, float>, unsigned int> vid;
-      std::map<std::pair<unsigned int, unsigned int>, int> ecount;
+      std::map<std::tuple<float, float, float>, unsigned int> vertex_id_map;
+      std::map<std::pair<unsigned int, unsigned int>, int> edge_count_map;
 
       auto id_of=[&](unsigned int vtx) -> unsigned int {
         std::tuple<float, float, float> key(pos[3*vtx], pos[3*vtx+1],
                                             pos[3*vtx+2]);
-        auto it=vid.find(key);
-        if (it!=vid.end()) { return it->second; }
-        unsigned int id=static_cast<unsigned int>(vid.size());
-        vid.emplace(key, id);
+        auto it=vertex_id_map.find(key);
+        if (it!=vertex_id_map.end()) { return it->second; }
+        unsigned int id=static_cast<unsigned int>(vertex_id_map.size());
+        vertex_id_map.emplace(key, id);
         return id;
       };
       auto add_triangle=[&](unsigned int v0) {
@@ -1448,11 +1519,11 @@ protected:
         {
           unsigned int a=e[k][0], b=e[k][1];
           if (a>b) { std::swap(a, b); }
-          ++ecount[std::make_pair(a, b)];
+          ++edge_count_map[std::make_pair(a, b)];
         }
       };
 
-      if (nvol==0)
+      if (num_volumes==0)
       {
         const unsigned int nv=m_scene.number_of_elements(GS::POS_FACES);
         for (unsigned int v=0; v+2<nv; v+=3) { add_triangle(v); }
@@ -1467,7 +1538,7 @@ protected:
         }
       }
 
-      for (const auto &e : ecount)
+      for (const auto &e : edge_count_map)
       { if (e.second!=2) { m_cap_closed[g]=0; break; } }
     }
   }

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -1478,18 +1478,18 @@ protected:
     }
     const auto xr=std::minmax_element(px, px+8);
     const auto yr=std::minmax_element(py, py+8);
-    int x0=int(std::floor(*xr.first));
-    int y0=int(std::floor(*yr.first));
-    int x1=int(std::ceil(*xr.second));
-    int y1=int(std::ceil(*yr.second));
-    x0=(std::max)(x0, vp[0]);
-    y0=(std::max)(y0, vp[1]);
-    x1=(std::min)(x1, vp[0]+vp[2]);
-    y1=(std::min)(y1, vp[1]+vp[3]);
+    // Clamp to the viewport in float space so the int cast stays in range (a
+    // corner near the camera can project to a coordinate larger than int).
+    const float lox=float(vp[0]), hix=float(vp[0]+vp[2]);
+    const float loy=float(vp[1]), hiy=float(vp[1]+vp[3]);
+    const int x0=int(std::clamp(std::floor(*xr.first),  lox, hix));
+    const int y0=int(std::clamp(std::floor(*yr.first),  loy, hiy));
+    const int x1=int(std::clamp(std::ceil (*xr.second), lox, hix));
+    const int y1=int(std::clamp(std::ceil (*yr.second), loy, hiy));
     sx=x0;
     sy=y0;
-    sw=(x1>x0)?GLsizei(x1-x0):0;
-    sh=(y1>y0)?GLsizei(y1-y0):0;
+    sw=GLsizei(x1-x0);
+    sh=GLsizei(y1-y0);
     return true;
   }
 

--- a/GraphicsView/include/CGAL/Qt/init_ogl_context.h
+++ b/GraphicsView/include/CGAL/Qt/init_ogl_context.h
@@ -43,6 +43,9 @@ inline void init_ogl_context(int major, int minor) {
   // anti-aliased by the framebuffer instead of by per-pixel blending in the
   // shader. This keeps thin edges fully solid instead of fading to the background.
   fmt.setSamples(4);
+  // Stencil buffer for clip-plane capping (filling the cut cross-section of a
+  // clipped solid). Requested here so it is available on the default framebuffer.
+  fmt.setStencilBufferSize(8);
   QSurfaceFormat::setDefaultFormat(fmt);
 
   //for windows

--- a/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
+++ b/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
@@ -20,6 +20,8 @@
 #include <CGAL/Linear_cell_complex_operations.h>
 #include <CGAL/Random.h>
 
+#include <unordered_map>
+
 namespace CGAL {
 
 namespace draw_function_for_lcc
@@ -171,12 +173,22 @@ void compute_elements(const LCC& lcc,
 
   lcc.orient(oriented_mark);
 
+  // Clip-plane cap: dart -> its face index (both sides of a shared wall map to
+  // the same index, so it is referenced once per volume).
+  std::unordered_map<std::size_t, unsigned int> dart_face;
+
   for(typename LCC::Dart_range::const_iterator it=lcc.darts().begin(),
         itend=lcc.darts().end(); it!=itend; ++it)
   {
     if (!lcc.is_marked(it, markvolumes) &&
         gso.draw_volume(lcc, it))
     {
+      // Clip-plane cap: open a volume group in its color.
+      if (gso.colored_volume(lcc, it))
+      { graphics_scene.volume_begin(gso.volume_color(lcc, it)); }
+      else
+      { graphics_scene.volume_begin(graphics_scene.get_default_color_face()); }
+
       for(typename LCC::template Dart_of_cell_basic_range<3>::const_iterator
             itv=lcc.template darts_of_cell_basic<3>(it, markvolumes).begin(),
             itvend=lcc.template darts_of_cell_basic<3>(it, markvolumes).end();
@@ -187,16 +199,21 @@ void compute_elements(const LCC& lcc,
             lcc.is_marked(itv, oriented_mark) &&
             gso.draw_face(lcc, itv))
         {
-          if ((!gso.volume_wireframe(lcc, itv) ||
-               Test_opposite_draw_lcc<LCC>::run(lcc, gso, itv)) &&
-              !gso.face_wireframe(lcc, itv))
+          const bool face_drawn=(!gso.volume_wireframe(lcc, itv) ||
+                                 Test_opposite_draw_lcc<LCC>::run(lcc, gso, itv)) &&
+                                !gso.face_wireframe(lcc, itv);
+          const unsigned int fidx=graphics_scene.number_of_faces();
+          if (face_drawn)
           { compute_face(lcc, itv, it, graphics_scene, gso); }
+          const bool face_added=(graphics_scene.number_of_faces()>fidx);
           for(typename LCC::template Dart_of_cell_basic_range<2>::const_iterator
                 itf=lcc.template darts_of_cell_basic<2>(itv, markfaces).begin(),
                 itfend=lcc.template darts_of_cell_basic<2>(itv, markfaces).end();
               itf!=itfend; ++itf)
           {
             lcc.mark(itf, markfaces);
+            if (face_added)
+            { dart_face[lcc.darts().index(itf)]=fidx; }
             if (!lcc.is_marked(itf, markedges) &&
                 gso.draw_edge(lcc, itf))
             {
@@ -218,6 +235,17 @@ void compute_elements(const LCC& lcc,
           }
         }
       }
+
+      // Clip-plane cap: reference this volume's faces (own and shared) by index.
+      for(auto fit=lcc.template one_dart_per_incident_cell<2,3>(it).begin(),
+               fitend=lcc.template one_dart_per_incident_cell<2,3>(it).end();
+          fit!=fitend; ++fit)
+      {
+        auto found=dart_face.find(lcc.darts().index(fit));
+        if (found!=dart_face.end())
+        { graphics_scene.add_face_to_current_volume(found->second); }
+      }
+      graphics_scene.volume_end();
     }
   }
 
@@ -236,56 +264,6 @@ void compute_elements(const LCC& lcc,
   lcc.free_mark(markedges);
   lcc.free_mark(markvertices);
   lcc.free_mark(oriented_mark);
-}
-
-// Fill one closed face (the side of dh) into the cap buffer (cf. compute_face).
-template <class LCC>
-void compute_cap_face(const LCC& lcc,
-                      typename LCC::Dart_const_handle dh,
-                      CGAL::Graphics_scene& graphics_scene)
-{
-  typename LCC::Dart_const_handle cur=dh;
-  do
-  {
-    if (!lcc.is_next_exist(cur)) { return; } // open face => not filled
-    cur=lcc.next(cur);
-  }
-  while (cur!=dh);
-
-  graphics_scene.cap_face_begin();
-  cur=dh;
-  do
-  {
-    graphics_scene.add_point_in_cap_face(lcc.point(cur));
-    cur=lcc.next(cur);
-  }
-  while (cur!=dh);
-  graphics_scene.cap_face_end();
-}
-
-// Cap geometry: one closed boundary per volume, grouped and colored by volume.
-// One dart per face of the volume keeps shared walls (not de-duplicated as in
-// the display), so each volume stays closed for the parity fill.
-template <class LCC, class GSOptions>
-void compute_cap_elements(const LCC& lcc,
-                          CGAL::Graphics_scene& graphics_scene,
-                          const GSOptions& gso)
-{
-  for (auto vit=lcc.template one_dart_per_cell<3>().begin(),
-            vend=lcc.template one_dart_per_cell<3>().end(); vit!=vend; ++vit)
-  {
-    if (!gso.draw_volume(lcc, vit)) { continue; }
-
-    if (gso.colored_volume(lcc, vit))
-    { graphics_scene.start_face_group(gso.volume_color(lcc, vit)); }
-    else
-    { graphics_scene.start_face_group(graphics_scene.get_default_color_face()); }
-
-    for (auto fit=lcc.template one_dart_per_incident_cell<2,3>(vit).begin(),
-              fend=lcc.template one_dart_per_incident_cell<2,3>(vit).end();
-         fit!=fend; ++fit)
-    { compute_cap_face(lcc, fit, graphics_scene); }
-  }
 }
 
 } // namespace draw_function_for_lcc
@@ -307,8 +285,6 @@ void add_to_graphics_scene(const CGAL_LCC_TYPE& alcc,
 {
   draw_function_for_lcc::compute_elements(static_cast<const Refs&>(alcc),
                                           graphics_scene, gso);
-  draw_function_for_lcc::compute_cap_elements(static_cast<const Refs&>(alcc),
-                                              graphics_scene, gso);
 }
 
 // add_to_graphics_scene: to add a LCC in the given graphic buffer, without a

--- a/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
+++ b/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
@@ -238,6 +238,56 @@ void compute_elements(const LCC& lcc,
   lcc.free_mark(oriented_mark);
 }
 
+// Fill one closed face (the side of dh) into the cap buffer (cf. compute_face).
+template <class LCC>
+void compute_cap_face(const LCC& lcc,
+                      typename LCC::Dart_const_handle dh,
+                      CGAL::Graphics_scene& graphics_scene)
+{
+  typename LCC::Dart_const_handle cur=dh;
+  do
+  {
+    if (!lcc.is_next_exist(cur)) { return; } // open face => not filled
+    cur=lcc.next(cur);
+  }
+  while (cur!=dh);
+
+  graphics_scene.cap_face_begin();
+  cur=dh;
+  do
+  {
+    graphics_scene.add_point_in_cap_face(lcc.point(cur));
+    cur=lcc.next(cur);
+  }
+  while (cur!=dh);
+  graphics_scene.cap_face_end();
+}
+
+// Cap geometry: one closed boundary per volume, grouped and colored by volume.
+// One dart per face of the volume keeps shared walls (not de-duplicated as in
+// the display), so each volume stays closed for the parity fill.
+template <class LCC, class GSOptions>
+void compute_cap_elements(const LCC& lcc,
+                          CGAL::Graphics_scene& graphics_scene,
+                          const GSOptions& gso)
+{
+  for (auto vit=lcc.template one_dart_per_cell<3>().begin(),
+            vend=lcc.template one_dart_per_cell<3>().end(); vit!=vend; ++vit)
+  {
+    if (!gso.draw_volume(lcc, vit)) { continue; }
+
+    if (gso.colored_volume(lcc, vit))
+    { graphics_scene.start_face_group(gso.volume_color(lcc, vit)); }
+    else
+    { graphics_scene.start_face_group(graphics_scene.get_default_color_face()); }
+
+    for (auto fit=lcc.template one_dart_per_incident_cell<2,3>(vit).begin(),
+              fend=lcc.template one_dart_per_incident_cell<2,3>(vit).end();
+         fit!=fend; ++fit)
+    { compute_cap_face(lcc, fit, graphics_scene); }
+  }
+}
+
 } // namespace draw_function_for_lcc
 
 #define CGAL_LCC_TYPE                                                          \
@@ -257,6 +307,8 @@ void add_to_graphics_scene(const CGAL_LCC_TYPE& alcc,
 {
   draw_function_for_lcc::compute_elements(static_cast<const Refs&>(alcc),
                                           graphics_scene, gso);
+  draw_function_for_lcc::compute_cap_elements(static_cast<const Refs&>(alcc),
+                                              graphics_scene, gso);
 }
 
 // add_to_graphics_scene: to add a LCC in the given graphic buffer, without a

--- a/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
+++ b/Linear_cell_complex/include/CGAL/draw_linear_cell_complex.h
@@ -20,8 +20,6 @@
 #include <CGAL/Linear_cell_complex_operations.h>
 #include <CGAL/Random.h>
 
-#include <unordered_map>
-
 namespace CGAL {
 
 namespace draw_function_for_lcc
@@ -62,7 +60,6 @@ struct LCC_geom_utils<LCC, Local_kernel, 2>
 template <class LCC, class GSOptionsLCC>
 void compute_face(const LCC& lcc,
                   typename LCC::Dart_const_handle dh,
-                  typename LCC::Dart_const_handle voldh,
                   CGAL::Graphics_scene& graphics_scene,
                   const GSOptionsLCC& gso)
 {
@@ -79,9 +76,8 @@ void compute_face(const LCC& lcc,
   }
   while (cur!=dh);
 
-  if (gso.colored_volume(lcc, voldh))
-  { graphics_scene.face_begin(gso.volume_color(lcc, voldh)); }
-  else if (gso.colored_face(lcc, dh))
+  // An explicit face color wins; otherwise the face inherits its volume color.
+  if (gso.colored_face(lcc, dh))
   { graphics_scene.face_begin(gso.face_color(lcc, dh)); }
   else
   { graphics_scene.face_begin(); }
@@ -173,22 +169,33 @@ void compute_elements(const LCC& lcc,
 
   lcc.orient(oriented_mark);
 
-  // Clip-plane cap: dart -> its face index (both sides of a shared wall map to
-  // the same index, so it is referenced once per volume).
-  std::unordered_map<std::size_t, unsigned int> dart_face;
-
   for(typename LCC::Dart_range::const_iterator it=lcc.darts().begin(),
         itend=lcc.darts().end(); it!=itend; ++it)
   {
     if (!lcc.is_marked(it, markvolumes) &&
         gso.draw_volume(lcc, it))
     {
-      // Clip-plane cap: open a volume group in its color.
+      // Clip-plane cap: open a volume group; its incident faces are added below
+      // and de-duplicated by the scene, so a shared wall is stored once (no map).
       if (gso.colored_volume(lcc, it))
       { graphics_scene.volume_begin(gso.volume_color(lcc, it)); }
       else
-      { graphics_scene.volume_begin(graphics_scene.get_default_color_face()); }
+      { graphics_scene.volume_begin(); }
 
+      // Faces of this volume (one dart per incident face, on the volume's side).
+      for(auto fit=lcc.template one_dart_per_incident_cell<2,3>(it).begin(),
+               fitend=lcc.template one_dart_per_incident_cell<2,3>(it).end();
+          fit!=fitend; ++fit)
+      {
+        if ((!gso.volume_wireframe(lcc, fit) ||
+             Test_opposite_draw_lcc<LCC>::run(lcc, gso, fit)) &&
+            !gso.face_wireframe(lcc, fit))
+        { compute_face(lcc, fit, graphics_scene, gso); }
+      }
+
+      graphics_scene.volume_end();
+
+      // Edges and vertices of this volume (each drawn once).
       for(typename LCC::template Dart_of_cell_basic_range<3>::const_iterator
             itv=lcc.template darts_of_cell_basic<3>(it, markvolumes).begin(),
             itvend=lcc.template darts_of_cell_basic<3>(it, markvolumes).end();
@@ -199,21 +206,12 @@ void compute_elements(const LCC& lcc,
             lcc.is_marked(itv, oriented_mark) &&
             gso.draw_face(lcc, itv))
         {
-          const bool face_drawn=(!gso.volume_wireframe(lcc, itv) ||
-                                 Test_opposite_draw_lcc<LCC>::run(lcc, gso, itv)) &&
-                                !gso.face_wireframe(lcc, itv);
-          const unsigned int fidx=graphics_scene.number_of_faces();
-          if (face_drawn)
-          { compute_face(lcc, itv, it, graphics_scene, gso); }
-          const bool face_added=(graphics_scene.number_of_faces()>fidx);
           for(typename LCC::template Dart_of_cell_basic_range<2>::const_iterator
                 itf=lcc.template darts_of_cell_basic<2>(itv, markfaces).begin(),
                 itfend=lcc.template darts_of_cell_basic<2>(itv, markfaces).end();
               itf!=itfend; ++itf)
           {
             lcc.mark(itf, markfaces);
-            if (face_added)
-            { dart_face[lcc.darts().index(itf)]=fidx; }
             if (!lcc.is_marked(itf, markedges) &&
                 gso.draw_edge(lcc, itf))
             {
@@ -235,17 +233,6 @@ void compute_elements(const LCC& lcc,
           }
         }
       }
-
-      // Clip-plane cap: reference this volume's faces (own and shared) by index.
-      for(auto fit=lcc.template one_dart_per_incident_cell<2,3>(it).begin(),
-               fitend=lcc.template one_dart_per_incident_cell<2,3>(it).end();
-          fit!=fitend; ++fit)
-      {
-        auto found=dart_face.find(lcc.darts().index(fit));
-        if (found!=dart_face.end())
-        { graphics_scene.add_face_to_current_volume(found->second); }
-      }
-      graphics_scene.volume_end();
     }
   }
 


### PR DESCRIPTION
### Summary

Fills the flat cross-section where the clipping plane cuts a solid, so a clipped closed solid reads as a real slice instead of a hollow shell. For a volumetric input (a Linear_cell_complex) each volume's cross-section is filled in that volume's own color, so the inner volumes stay distinct at the cut.

Updated per the mailing thread. The cap now follows Guillaume's suggestion to keep it out of the drawing functions and factorize the grouping in the Basic_viewer through `Graphics_scene`, and Guillaume's open-surface question is handled by a closed-input guard. Ready for review.

### How it works

- **Stencil parity fill.** The clipped solid is drawn once into the stencil buffer with an even-odd (parity) rule, so an odd number of surface crossings marks the interior. Parity is winding-independent, so it handles an LCC's inconsistent face orientation. A quad on the clip plane is then filled where the stencil is odd.
- **Per-fragment clip is enough.** The existing shader discard gives a clean cap edge and multisampling anti-aliases it, so no `gl_ClipDistance` path is needed.
- **Per-volume grouping in `Graphics_scene`, over the single face buffer.** `Graphics_scene` gains `volume_begin`/`volume_end` and, per volume, a list of face indices into the single (de-duplicated) face buffer. A shared wall is one face referenced by both neighboring volumes, so each volume is still closed for the parity fill while no geometry is duplicated and the display buffer stays de-duplicated. The separate cap buffer (`POS_CAP_FACES`) from the first version is gone.
- **The LCC drawer only groups.** It calls `volume_begin`/`volume_end` around each volume and assigns that volume's faces by index, using a small dart-to-face-index map so a shared wall resolves to the same face for both neighbors. The viewer's cap pass draws each volume's referenced faces into the stencil, then a quad in the volume color.
- **Closed-input guard.** Parity is only defined for a closed surface, so an open group has no meaningful cap. The viewer detects closedness from the face buffer alone (an edge used by a single triangle means open), matching vertices by position, and skips the cap for an open group. This is computed once, lazily, on the first clip, and cached, so a mesh that is never clipped pays nothing.
- **Surface-mesh fallback.** A non-volumetric input has no per-volume groups and falls back to filling the whole face buffer as one cap in a neutral grey (still subject to the closed guard).
- The stencil buffer is requested in `init_ogl_context`.
- Only the two solid clip modes are capped (solid-half-only, solid-half-wireframe). The transparent-half mode is left uncapped so the ghost stays visible.

### Changes from the first version (per review)

- **Placement.** Guillaume asked to keep the cap out of the many drawing functions and factorize it in the Basic_viewer. Done: the grouping now lives in `Graphics_scene` (`volume_begin`/`volume_end`) and the per-volume cap pass is in the viewer; the LCC drawer only tags faces to volumes.
- **No duplicated geometry.** The first version used a separate, non-de-duplicated cap buffer. Now a shared wall is a single face referenced by both volumes.
- **Open surfaces.** Added the closed-input guard for Guillaume's boundary question.
- **Always-on.** The prototype `K` toggle is removed; the cap is always on in the two solid clip modes.
- **Lazy.** The closed check is computed on the first clip and cached, not eagerly on every draw.

### Open questions for review

- **Other volumetric drawers.** The grouping is emitted by the LCC drawer. `Combinatorial_map` and `Generalized_map` could tag volumes the same way; happy to add that here or in a follow-up.
- **Cap color.** The cap is the volume's own color, drawn flat so it stays distinct from the real lit faces. Keep it, or make it configurable?

### Performance

The only per-mesh cost is the closed check, which runs over every face once on the first clip and is then cached. On the refined_elephant model (~89k faces) it is about 100 ms, one time. It uses ordered maps; if a much larger mesh ever makes that first-clip pause visible, the vertex and edge lookups can move to hashed maps. The stencil fill itself is one pass per volume per frame, fine for tens of volumes; a very large multi-volume complex would want the passes batched.

### Testing

Tested on a single hexahedron, rows of sewn hexahedra sharing internal walls (2, 6, and 40 volumes), disjoint hexahedra, a flat open sheet (correctly skipped by the guard), and closed surface meshes including the dense refined_elephant (~89k faces) across all three clip modes. Each volume's cross-section fills in its own color with no alternation across shared walls, the surface mesh caps grey, an open surface is left uncapped, and the transparent-half mode stays uncapped. Before/after screenshots are on the CGAL wiki.
