### PR TITLE
Check vertex patches during collapse only if both vertices are not dim 3 

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
@@ -1228,11 +1228,17 @@ auto can_be_collapsed(const typename C3T3::Edge& e,
 
   if(!boundary && !in_cx)
   {
-    auto patch_v0 = surface_patch_index(e.first->vertex(e.second), c3t3);
-    auto patch_v1 = surface_patch_index(e.first->vertex(e.third), c3t3);
+    const auto v0 = e.first->vertex(e.second);
+    const auto v1 = e.first->vertex(e.third);
 
-    if(patch_v0 != std::nullopt && patch_v1 != std::nullopt && patch_v0 != patch_v1)
-      return Collapsible{false, boundary};
+    if(v0->in_dimension() != 3 && v1->in_dimension() != 3)
+    {
+      const auto patch_v0 = surface_patch_index(v0, c3t3);
+      const auto patch_v1 = surface_patch_index(v1, c3t3);
+
+      if(patch_v0 != std::nullopt && patch_v1 != std::nullopt && patch_v0 != patch_v1)
+        return Collapsible{false, boundary};
+    }
   }
 
 //   if(!is_internal(e, c3t3, cell_selector))

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -811,7 +811,7 @@ surface_patch_index(const typename C3t3::Vertex_handle v,
                     const C3t3& c3t3)
 {
   typedef typename C3t3::Facet Facet;
-  std::vector<Facet> facets;
+  boost::container::small_vector<Facet, 64> facets;
   c3t3.triangulation().incident_facets(v, std::back_inserter(facets));
 
   for(const Facet& f : facets)


### PR DESCRIPTION
## Summary of Changes
PR #9531 introduced a check to make sure that no collapse occur that merge vertices belonging to different surface patches. This introduced a regression in performance because surface_patch_index was called for every internal edge of the mesh. The surface_patch_index was allocating on the heap the retrieved incident to the vertex facets. 

- replaced std::vector with boost::small_vector to avoid heap allocation in the common case
- query a vertex's patch only when both endpoints are non-interior

The `surface_patch_index()` searches for an incident facet which is in complex and returns its patch index. During c3t3 construction every vertex of a complex facet is set to dimension 2 ([link](https://github.com/IasonManolas/cgal/blob/4e9aa4e024ee85bfa168e9f60768350772901477/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h#L392)). Thus a dimension 3 vertex cant have an incident facet in the complex and thus surface_patch_index returns nullopt and we cant have different patches.

## Release Management
- Affected package(s): Tetrahedral_remeshing
- License and copyright ownership: unchanged


