### PR TITLE
Fix Epeck_d spatial searching compilation

### DIFF
--- a/NewKernel_d/include/CGAL/iterator_from_indices.h
+++ b/NewKernel_d/include/CGAL/iterator_from_indices.h
@@ -29,7 +29,7 @@ template <class Container_, class Value_, class Ref_=
         >
 class Iterator_from_indices
 : public boost::iterator_facade<Iterator_from_indices<Container_,Value_,Ref_,Coord_access>,
-        Value_, std::bidirectional_iterator_tag, Ref_>
+        Value_, std::random_access_iterator_tag, Ref_>
 {
         friend class boost::iterator_core_access;
         //FIXME: use int to save space
@@ -53,6 +53,9 @@ class Iterator_from_indices
                 return ca(*cont,index);
         }
         public:
+        Ref_ operator[](std::ptrdiff_t n) const {
+                return ca(*cont,index+n);
+        }
         Iterator_from_indices(){}
         Iterator_from_indices(Container_& cont_,std::size_t n)
                 : cont(&cont_), index(n) {}

--- a/Spatial_searching/include/CGAL/Fuzzy_iso_box.h
+++ b/Spatial_searching/include/CGAL/Fuzzy_iso_box.h
@@ -18,6 +18,7 @@
 
 
 #include <algorithm>
+#include <iterator>
 
 #include <CGAL/Kd_tree_rectangle.h>
 #include <CGAL/Search_traits_adapter.h>
@@ -72,7 +73,7 @@ namespace CGAL {
       Construct_cartesian_const_iterator_d construct_it=traits.construct_cartesian_const_iterator_d_object();
       Cartesian_const_iterator_d begin = construct_it(p),
         end = construct_it(p,1);
-      dim = static_cast<unsigned int>(end - begin);
+      dim = static_cast<unsigned int>(std::distance(begin, end));
 
       Iso_box_d box = Construct_iso_box_d()(p,q);
       Construct_min_vertex_d construct_min_vertex_d;

--- a/Spatial_searching/test/Spatial_searching/CMakeLists.txt
+++ b/Spatial_searching/test/Spatial_searching/CMakeLists.txt
@@ -11,6 +11,19 @@ file(
   GLOB cppfiles
   RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_SOURCE_DIR}/*.cpp)
+
+list(REMOVE_ITEM cppfiles "issue_9534.cpp")
+
 foreach(cppfile ${cppfiles})
   create_single_source_cgal_program("${cppfile}")
 endforeach()
+
+find_package(Eigen3 QUIET)
+include(CGAL_Eigen3_support)
+
+if(TARGET CGAL::Eigen3_support)
+  create_single_source_cgal_program("issue_9534.cpp")
+  target_link_libraries(issue_9534 PRIVATE CGAL::Eigen3_support)
+else()
+  message(STATUS "NOTICE: The test 'issue_9534' requires Eigen3 and will not be compiled.")
+endif()

--- a/Spatial_searching/test/Spatial_searching/issue_9534.cpp
+++ b/Spatial_searching/test/Spatial_searching/issue_9534.cpp
@@ -1,0 +1,74 @@
+#include <CGAL/Dimension.h>
+#include <CGAL/Epeck_d.h>
+#include <CGAL/Fuzzy_iso_box.h>
+#include <CGAL/Fuzzy_sphere.h>
+#include <CGAL/Kd_tree.h>
+#include <CGAL/Search_traits_d.h>
+
+#include <array>
+#include <iterator>
+#include <vector>
+
+template<class Kernel>
+int test()
+{
+  using Traits = CGAL::Search_traits_d<Kernel>;
+  using Point = typename Traits::Point_d;
+  using FT = typename Kernel::FT;
+  using Tree = CGAL::Kd_tree<Traits>;
+  using Fuzzy_iso_box = CGAL::Fuzzy_iso_box<Traits>;
+  using Fuzzy_sphere = CGAL::Fuzzy_sphere<Traits>;
+
+  const std::array<FT, 2> c0 = {FT(0), FT(0)};
+  const std::array<FT, 2> c1 = {FT(1), FT(1)};
+  const std::array<FT, 2> c2 = {FT(2), FT(2)};
+
+  const Point p0(2, c0.begin(), c0.end());
+  const Point p1(2, c1.begin(), c1.end());
+  const Point p2(2, c2.begin(), c2.end());
+
+  Tree tree;
+  tree.insert(p0);
+  tree.insert(p1);
+  tree.insert(p2);
+
+  const Fuzzy_iso_box box(p0, p2);
+  std::vector<Point> result;
+  tree.search(std::back_inserter(result), box);
+
+  if (result.empty())
+    return 1;
+
+  result.clear();
+
+  const Fuzzy_sphere sphere(p1, FT(2));
+  tree.search(std::back_inserter(result), sphere);
+
+  if (result.empty())
+    return 2;
+
+  tree.remove(p1);
+
+  if (tree.size() != 2)
+    return 3;
+
+  return 0;
+}
+
+int main()
+{
+  using Static_kernel = CGAL::Epeck_d<CGAL::Dimension_tag<2> >;
+  using Dynamic_kernel = CGAL::Epeck_d<CGAL::Dynamic_dimension_tag>;
+
+  int result = test<Static_kernel>();
+
+  if (result != 0)
+    return result;
+
+  result = test<Dynamic_kernel>();
+
+  if (result != 0)
+    return 10 + result;
+
+  return 0;
+}


### PR DESCRIPTION
## Summary

Fixes Spatial Searching compilation failures when using `Epeck_d`.

`Iterator_from_indices` already implements the operations required by a
random-access iterator through `increment()`, `decrement()`, `advance()`,
and `distance_to()`, but advertised only bidirectional traversal.

This change:

- advertises random-access traversal;
- adds an explicit `operator[]` returning the iterator reference type,
  avoiding the inherited Boost proxy result;
- adds a regression test for static and dynamic `Epeck_d`;
- covers `Fuzzy_iso_box`, `Fuzzy_sphere`, Kd-tree insertion, search,
  removal, and size verification.

The regression test is enabled when Eigen support is available.

Fixes #9534.

## Validation

Validated from a clean worktree based on `public/main` commit
`10968626f93fca92bd0b2b934c2899819e732bb1`.

- Confirmed the regression fails on the unchanged baseline with the
  expected iterator/random-access compilation errors.
- Built all 17 Spatial Searching test targets in Release.
- Built all 17 Spatial Searching test targets in Debug.
- Built all 4 NewKernel_d test targets in Release and Debug.
- Ran the new regression in Release and Debug.
- Ran assertion-enabled `Epick_d`, `Epick_d_eigen`, `test_bbox_d`,
  `remove`, and `Splitters` tests.
- Ran the `tri2` Debug test with 1,000 points.
