### PR TITLE
Fix incorrect template declaration of lower_hull_points_2()/upper_hull_points_2() in Convex_hull_2 docs

### DIFF
--- a/Convex_hull_2/doc/Convex_hull_2/CGAL/convex_hull_2.h
+++ b/Convex_hull_2/doc/Convex_hull_2/CGAL/convex_hull_2.h
@@ -96,9 +96,6 @@ rightmost point are equal) the extreme point is reported.
 \pre The source range [`first`,`beyond`) does not contain
 `result`.
 
-The default traits class `Default_traits` is the kernel in which the
-value type of `InputIterator` is defined.
-
 The different treatment by `upper_hull_points_2()` of the case that
 all points are equal ensures that concatenation of lower and upper hull
 points gives the sequence of extreme points.
@@ -130,13 +127,26 @@ This function uses Andrew's variant of Graham's scan algorithm
 \cgalCite{a-aeach-79}, \cgalCite{m-mdscg-84}. The algorithm has worst-case running time
 of \cgalBigO{n \log n} for \f$ n\f$ input points.
 
+*/
+template <class InputIterator, class OutputIterator, class Traits>
+OutputIterator
+lower_hull_points_2(InputIterator first, InputIterator beyond,
+                    OutputIterator result,
+                    const Traits& ch_traits);
 
+/*!
+\ingroup PkgConvexHull2Subsequence
+
+generates the counterclockwise sequence of extreme points on the
+lower hull of a given set of input points, using as traits class
+the kernel in which the point type is defined.
+
+The kernel is deduced using `std::iterator_traits` and `CGAL::Kernel_traits`.
 */
 template <class InputIterator, class OutputIterator>
 OutputIterator
 lower_hull_points_2(InputIterator first, InputIterator beyond,
-                    OutputIterator result,
-                    const Traits& ch_traits = Default_traits );
+                    OutputIterator result);
 
 } /* namespace CGAL */
 
@@ -159,9 +169,6 @@ If there is only one extreme point (<I>i.e.</I>, the leftmost and
 rightmost point are equal), the extreme point is not reported.
 \pre The source range [`first`,`beyond`) does not contain
 `result`.
-
-The default traits class `Default_traits` is the kernel in which the
-value type of `InputIterator` is defined.
 
 The different treatment by `lower_hull_points_2()` of the case that
 all points are equal ensures that concatenation of lower and upper hull
@@ -195,9 +202,23 @@ variant of Graham's scan algorithm \cgalCite{a-aeach-79}, \cgalCite{m-mdscg-84}.
 has worst-case running time of \cgalBigO{n \log n} for \f$ n\f$ input points.
 
 */
-template <class InputIterator, class OutputIterator>
+template <class InputIterator, class OutputIterator, class Traits>
 OutputIterator
 upper_hull_points_2(InputIterator first, InputIterator beyond,
                     OutputIterator result,
-                    const Traits& ch_traits = Default_traits);
+                    const Traits& ch_traits);
+
+/*!
+\ingroup PkgConvexHull2Subsequence
+
+generates the counterclockwise sequence of extreme points on the
+upper hull of a given set of input points, using as traits class
+the kernel in which the point type is defined.
+
+The kernel is deduced using `std::iterator_traits` and `CGAL::Kernel_traits`.
+*/
+template <class InputIterator, class OutputIterator>
+OutputIterator
+upper_hull_points_2(InputIterator first, InputIterator beyond,
+                    OutputIterator result);
 } /* namespace CGAL */


### PR DESCRIPTION
## Summary
Fixes an inconsistency in the documentation of `CGAL::lower_hull_points_2()` and `CGAL::upper_hull_points_2()` in the `Convex_hull_2` package. This is a documentation-only change with no impact on compiled code or the public API.

## Problem
In `Convex_hull_2/doc/Convex_hull_2/CGAL/convex_hull_2.h`, both functions were declared with a template parameter list that did not match the symbols used in the declaration body:

```cpp
template <class InputIterator, class OutputIterator>
OutputIterator
lower_hull_points_2(InputIterator first, InputIterator beyond,
                    OutputIterator result,
                    const Traits& ch_traits = Default_traits );
```

Two problems here:
1. `Traits` is used as a type in `const Traits& ch_traits`, but `Traits`  is **not declared** in the template parameter list (`class Traits`  is missing).
2. `= Default_traits` is given as a default value, but `Default_traits`  is **not defined anywhere** in the codebase.

The same issue was present for `upper_hull_points_2()`.

## Root cause
Comparing against the real implementation in `Convex_hull_2/include/CGAL/convex_hull_2.h`, these functions actually have **two separate overloads**:

```cpp
// Overload 1: explicit traits class
template <class InputIterator, class OutputIterator, class Traits>
OutputIterator
lower_hull_points_2(InputIterator first, InputIterator last,
                    OutputIterator result, const Traits& ch_traits);

// Overload 2: traits deduced from the point's kernel
template <class ForwardIterator, class OutputIterator>
OutputIterator
lower_hull_points_2(ForwardIterator first, ForwardIterator last,
                    OutputIterator result);
```

The documentation had incorrectly merged these two distinct overloads into a single, malformed declaration instead of documenting them separately — unlike `convex_hull_2()` earlier in the same file, which correctly documents both overloads independently.

## Fix
Split the doc declaration of `lower_hull_points_2()` and `upper_hull_points_2()` into two properly-templated declarations each, mirroring the existing correct pattern used for `convex_hull_2()`:
- One overload takes an explicit `Traits` parameter (`template <class InputIterator, class OutputIterator, class Traits>`).
- One overload omits it and documents that the traits/kernel is deduced  via `std::iterator_traits` and `CGAL::Kernel_traits` (`template <class InputIterator, class OutputIterator>`).

## Verification
- Confirmed by cross-referencin   `Convex_hull_2/include/CGAL/convex_hull_2.h` (actual implementation   against the doc stub — the two-overload structure matches exactly.
- `grep -n "Default_traits\|class Traits"` on the modified file no  shows `class Traits` only inside correctly-formed template paramete   lists, and no remaining reference to the undefined `Default_traits`.
- This is a doc-only file consumed by Doxygen; it does not affect compilation of the library or examples.

## Type of change
- [x] Documentation fix
- [ ] Bug fix (code)
- [ ] New feature

Fixes #9574