### PR TITLE
Basic_viewer: clip-plane cap for Triangulation_3 and Nef_3

### DIFF
--- a/Basic_viewer/include/CGAL/Graphics_scene.h
+++ b/Basic_viewer/include/CGAL/Graphics_scene.h
@@ -18,7 +18,9 @@
 #include <iostream>
 #include <algorithm>
 #include <array>
+#include <functional>
 #include <map>
+#include <unordered_map>
 #include <queue>
 #include <string>
 #include <tuple>
@@ -509,8 +511,20 @@ protected:
 
   // Clip-plane cap: geometric face de-duplication during volume building. The key
   // is the sorted face vertex positions, so both sides of a shared wall match.
+  // Hashed so the build stays linear on meshes with many faces.
   using Face_key = std::vector<std::array<double, 3>>;
-  std::map<Face_key, unsigned int> m_face_dedup;
+  struct Face_key_hash
+  {
+    std::size_t operator()(const Face_key &k) const
+    {
+      std::size_t h=k.size();
+      for (const std::array<double, 3> &p : k)
+        for (double c : p)
+        { h^=std::hash<double>()(c)+0x9e3779b97f4a7c15ULL+(h<<6)+(h>>2); }
+      return h;
+    }
+  };
+  std::unordered_map<Face_key, unsigned int, Face_key_hash> m_face_dedup;
   bool m_building_volume = false;
 
   // Color of the volume currently being built, inherited by its uncolored faces.

--- a/Nef_3/include/CGAL/draw_nef_3.h
+++ b/Nef_3/include/CGAL/draw_nef_3.h
@@ -134,10 +134,8 @@ public:
     if(se==0)
     { return; } //return if not-shalfedge
 
-    if(gs_options.colored_face(nef, f))
-    { graphics_scene.face_begin(gs_options.face_color(nef, f)); }
-    else
-    { graphics_scene.face_begin(); }
+    // The facet inherits the color of its volume (set in compute_elements).
+    graphics_scene.face_begin();
 
     SHalfedge_around_facet_const_circulator hc_start(se);
     SHalfedge_around_facet_const_circulator hc_end(hc_start);
@@ -226,9 +224,17 @@ void compute_elements(const Nef_Polyhedron &nef,
   Nef_Visitor<Nef_Polyhedron, GSOptions> V(nef, graphics_scene, gs_options);
   CGAL_forall_volumes(c, nef)
   {
+    // Only cap solid volumes; skip the outer volume and any empty cavities.
+    if (!c->mark()) { continue; }
+
+    // One group per solid volume, colored so each caps in its own color. A facet
+    // bounds a single solid volume, so it falls in that volume's group.
+    CGAL::Random random((unsigned int)(std::size_t)(&(*c)));
+    graphics_scene.volume_begin(get_random_color(random));
     Shell_entry_const_iterator it;
     CGAL_forall_shells_of(it, c)
     { nef.visit_shell_objects(SFace_const_handle(it), V); }
+    graphics_scene.volume_end();
   }
 
   graphics_scene.reverse_all_normals();
@@ -261,20 +267,7 @@ void add_to_graphics_scene(const CGAL_NEF3_TYPE &anef,
                   typename CGAL_NEF3_TYPE::Halffacet_const_handle /*fh*/>
       gs_options;
 
-  gs_options.colored_face=[](const CGAL_NEF3_TYPE&,
-                             typename CGAL_NEF3_TYPE::Halffacet_const_handle) -> bool
-  { return true; };
-
-  gs_options.face_color=[](const CGAL_NEF3_TYPE&,
-                           typename CGAL_NEF3_TYPE::Halffacet_const_handle fh) -> CGAL::IO::Color
-  {
-    if (fh==nullptr) // use to get the mono color
-    { return CGAL::IO::Color(100, 125, 200); }
-
-    CGAL::Random random((unsigned int)(std::size_t)(&(*fh)));
-    return get_random_color(random);
-  };
-
+  // Faces are colored per volume in compute_elements; no per-face color needed.
   add_to_graphics_scene(anef, graphics_scene, gs_options);
 }
 

--- a/Triangulation_3/include/CGAL/draw_triangulation_3.h
+++ b/Triangulation_3/include/CGAL/draw_triangulation_3.h
@@ -25,26 +25,15 @@ namespace CGAL {
 namespace draw_function_for_t3
 {
 
-template <class T3, class GSOptions>
-void compute_face(typename T3::Finite_facets_iterator fh,
-                  CGAL::Graphics_scene& graphics_scene,
-                  const GSOptions& gs_options, const T3 *t3)
+// Facet i of cell ch (opposite vertex i); its color comes from the cell.
+template <class T3>
+void compute_cell_facet(typename T3::Cell_handle ch, int i,
+                        CGAL::Graphics_scene& graphics_scene)
 {
-  if(!gs_options.draw_face(*t3, fh))
-  { return; }
-
-  if(gs_options.colored_face(*t3, fh))
-  { graphics_scene.face_begin(gs_options.face_color(*t3, fh)); }
-  else
-  { graphics_scene.face_begin(); }
-
-  graphics_scene.add_point_in_face(fh->first->vertex((fh->second + 1) % 4)->
-                                   point());
-  graphics_scene.add_point_in_face(fh->first->vertex((fh->second + 2) % 4)->
-                                   point());
-  graphics_scene.add_point_in_face(fh->first->vertex((fh->second + 3) % 4)->
-                                   point());
-
+  graphics_scene.face_begin();
+  graphics_scene.add_point_in_face(ch->vertex((i + 1) % 4)->point());
+  graphics_scene.add_point_in_face(ch->vertex((i + 2) % 4)->point());
+  graphics_scene.add_point_in_face(ch->vertex((i + 3) % 4)->point());
   graphics_scene.face_end();
 }
 
@@ -92,9 +81,17 @@ void compute_elements(const T3* t3,
 {
   if (gs_options.are_faces_enabled())
   {
-    for (typename T3::Finite_facets_iterator it=t3->finite_facets_begin();
-         it!=t3->finite_facets_end(); ++it)
-    { compute_face(it, graphics_scene, gs_options, t3); }
+    // One volume per finite cell (so each caps in its own color). Each cell adds
+    // its four facets; the scene de-duplicates the ones shared by two cells.
+    for (typename T3::Finite_cells_iterator it=t3->finite_cells_begin();
+         it!=t3->finite_cells_end(); ++it)
+    {
+      CGAL::Random random((unsigned int)(std::size_t)(&*it));
+      graphics_scene.volume_begin(get_random_color(random));
+      for (int i=0; i<4; ++i)
+      { compute_cell_facet<T3>(it, i, graphics_scene); }
+      graphics_scene.volume_end();
+    }
   }
 
   if (gs_options.are_edges_enabled())
@@ -129,27 +126,12 @@ template <class Gt, class Tds, class Lock_data_structure>
 void add_to_graphics_scene(const CGAL_T3_TYPE& at3,
                            CGAL::Graphics_scene& graphics_scene)
 {
+  // Faces are colored per cell in compute_elements; no per-face color needed.
   CGAL::Graphics_scene_options<CGAL_T3_TYPE,
                        typename CGAL_T3_TYPE::Vertex_handle,
                        typename CGAL_T3_TYPE::Finite_edges_iterator,
                        typename CGAL_T3_TYPE::Finite_facets_iterator>
     gs_options;
-
-  gs_options.colored_face =
-    [](const CGAL_T3_TYPE &, const typename CGAL_T3_TYPE::Finite_facets_iterator) -> bool
-    { return true; };
-
-  gs_options.face_color =
-    [](const CGAL_T3_TYPE &at3, const typename CGAL_T3_TYPE::Finite_facets_iterator fh) -> CGAL::IO::Color
-    {
-      if (fh==at3.finite_facets_end())         // use to get the mono color
-        return CGAL::IO::Color(100, 125, 200); // R G B between 0-255
-
-      CGAL::Random random((unsigned int)((std::size_t)(&*(fh->first)) +
-                                         (std::size_t)(fh->second)));
-
-      return get_random_color(random);
-    };
 
   add_to_graphics_scene(at3, graphics_scene, gs_options);
 }


### PR DESCRIPTION
## Description

Follow-up to #9566, which added the per-volume clip-plane cap to the Basic_viewer and the Linear_cell_complex drawer. This extends the same per-volume cap to the two remaining volumetric viewers.

Triangulation_3: one volume group per finite cell, colored per cell. Each cell adds its four facets and the scene de-duplicates the facets shared by two cells, so a shared facet is stored once and both cells reference it for the cap.

Nef_3: one volume group per solid volume. The outer volume and any empty cavities are skipped with the volume mark, so only solid material is capped. Each facet inherits its volume color.

Graphics_scene: the face de-duplication key is now hashed (unordered_map), so the scene build stays linear on meshes with many faces instead of paying the ordered-map log factor.

Testing. Headless grouping checks: Triangulation_3 facet reference counts match (internal facets shared by two cells have reference 2, hull facets 1); Nef_3 volume counts are correct on a single cube, two disjoint cubes, and a hollow cube (the cavity is not capped), with all boundary edges and vertices preserved. Per-cell and per-volume caps were confirmed visually for both viewers.
