### PR TITLE
SMDS_3 - introduce `to_triangulation_3_complex()`

### DIFF
--- a/SMDS_3/include/CGAL/to_triangulation_3_complex.h
+++ b/SMDS_3/include/CGAL/to_triangulation_3_complex.h
@@ -18,7 +18,8 @@
 #include <CGAL/Mesh_complex_3_in_triangulation_3.h>
 #include <CGAL/Triangulation_3.h>
 
-namespace CGAL {
+namespace CGAL
+{
 
 /*!
  * \ingroup PkgSMDS3Functions
@@ -26,34 +27,35 @@ namespace CGAL {
  * to a `Mesh_complex_3_in_triangulation_3` with a `Triangulation_3` as
  * underlying triangulation.
  *
- * @tparam Tr is the underlying triangulation of the input `Mesh_complex_3_in_triangulation_3`
+ * @tparam C3t3 model of `MeshComplex_3InTriangulation_3`
  * @tparam CornerIndex is the type of the corner indices
  * @tparam CurveIndex is the type of the curve indices
  * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
  *
  * @todo
  */
-template <typename Tr,
-          typename CornerIndex,
-          typename CurveIndex,
+template <typename C3t3,
           typename NamedParameters = parameters::Default_named_parameters>
 CGAL::Mesh_complex_3_in_triangulation_3<
-  CGAL::Triangulation_3<typename Tr::Geom_traits,
-                        typename Tr::Triangulation_data_structure>>
+  CGAL::Triangulation_3<typename C3t3::Triangulation::Geom_traits,
+                        typename C3t3::Triangulation::Triangulation_data_structure>>
 to_triangulation_3_complex(
-  CGAL::Mesh_complex_3_in_triangulation_3<Tr, CornerIndex, CurveIndex> c3t3,
+  C3t3 c3t3,
   const NamedParameters& np = parameters::default_values())
 {
-  using GT = typename Tr::Geom_traits;
-  using TDS = typename Tr::Triangulation_data_structure;
+  using GT = typename C3t3::Triangulation::Geom_traits;
+  using TDS = typename C3t3::Triangulation::Triangulation_data_structure;
+  using Corner_index = typename C3t3::Corner_index;
+  using Curve_index = typename C3t3::Curve_index;
+
   using T3 = CGAL::Triangulation_3<GT, TDS>;
-  using C3t3 = CGAL::Mesh_complex_3_in_triangulation_3<T3, CornerIndex, CurveIndex>;
+  using C3t3_new = CGAL::Mesh_complex_3_in_triangulation_3<T3, Corner_index, Curve_index>;
 
   T3 tr;
   tr.swap(c3t3.triangulation());
-  C3t3 c3t3_new;
+  C3t3_new c3t3_new;
   c3t3_new.triangulation().swap(tr);
-  
+
   // todo : port metadata from input c3t3 to the new one
 
   return c3t3_new;

--- a/SMDS_3/include/CGAL/to_triangulation_3_complex.h
+++ b/SMDS_3/include/CGAL/to_triangulation_3_complex.h
@@ -1,0 +1,64 @@
+// Copyright (c) 2026 GeometryFactory (France).
+// All rights reserved.
+//
+// This file is part of CGAL (www.cgal.org).
+//
+// $URL$
+// $Id$
+// SPDX-License-Identifier: GPL-3.0-or-later OR LicenseRef-Commercial
+//
+//
+// Author(s)     : Jane Tournois
+
+#ifndef CGAL_TO_TRIANGULATION_3_COMPLEX_H
+#define CGAL_TO_TRIANGULATION_3_COMPLEX_H
+
+#include <CGAL/license/SMDS_3.h>
+
+#include <CGAL/Mesh_complex_3_in_triangulation_3.h>
+#include <CGAL/Triangulation_3.h>
+
+namespace CGAL {
+
+/*!
+ * \ingroup PkgSMDS3Functions
+ * converts a `Mesh_complex_3_in_triangulation_3`
+ * to a `Mesh_complex_3_in_triangulation_3` with a `Triangulation_3` as
+ * underlying triangulation.
+ *
+ * @tparam Tr is the underlying triangulation of the input `Mesh_complex_3_in_triangulation_3`
+ * @tparam CornerIndex is the type of the corner indices
+ * @tparam CurveIndex is the type of the curve indices
+ * @tparam NamedParameters a sequence of \ref bgl_namedparameters "Named Parameters"
+ *
+ * @todo
+ */
+template <typename Tr,
+          typename CornerIndex,
+          typename CurveIndex,
+          typename NamedParameters = parameters::Default_named_parameters>
+CGAL::Mesh_complex_3_in_triangulation_3<
+  CGAL::Triangulation_3<typename Tr::Geom_traits,
+                        typename Tr::Triangulation_data_structure>>
+to_triangulation_3_complex(
+  CGAL::Mesh_complex_3_in_triangulation_3<Tr, CornerIndex, CurveIndex> c3t3,
+  const NamedParameters& np = parameters::default_values())
+{
+  using GT = typename Tr::Geom_traits;
+  using TDS = typename Tr::Triangulation_data_structure;
+  using T3 = CGAL::Triangulation_3<GT, TDS>;
+  using C3t3 = CGAL::Mesh_complex_3_in_triangulation_3<T3, CornerIndex, CurveIndex>;
+
+  T3 tr;
+  tr.swap(c3t3.triangulation());
+  C3t3 c3t3_new;
+  c3t3_new.triangulation().swap(tr);
+  
+  // todo : port metadata from input c3t3 to the new one
+
+  return c3t3_new;
+}
+
+} // end namespace CGAL
+
+#endif // CGAL_TO_TRIANGULATION_3_COMPLEX_H

--- a/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/mesh_and_remesh_c3t3.cpp
+++ b/Tetrahedral_remeshing/examples/Tetrahedral_remeshing/mesh_and_remesh_c3t3.cpp
@@ -8,6 +8,7 @@
 #include <CGAL/make_mesh_3.h>
 #include <CGAL/property_map.h>
 
+#include <CGAL/to_triangulation_3_complex.h>
 #include <CGAL/tetrahedral_remeshing.h>
 
 #include <CGAL/IO/File_medit.h>
@@ -72,7 +73,7 @@ int main(int argc, char* argv[])
     cell_radius_edge_ratio = 3, cell_size = 0.05);
 
   // Mesh generation
-  C3t3 c3t3 = CGAL::make_mesh_3<C3t3>(domain, criteria);
+  C3t3 c3t3_mesh_3 = CGAL::make_mesh_3<C3t3>(domain, criteria);
 
   // Property map of constraints
   Constraints_set constraints;
@@ -81,7 +82,7 @@ int main(int argc, char* argv[])
   Corners_set corners;
   Corners_pmap corners_pmap(corners);
 
-  Triangulation_3 tr = CGAL::convert_to_triangulation_3(std::move(c3t3),
+  auto c3t3 = CGAL::to_triangulation_3_complex(std::move(c3t3_mesh_3),
                       edge_is_constrained_map(constraints_pmap).
                       vertex_is_constrained_map(corners_pmap));
 
@@ -93,13 +94,13 @@ int main(int argc, char* argv[])
   //  Then the triangulation is copied and duplicated, and c3t3 remains as is.
 
   const double target_edge_length = 0.1;//coarsen the mesh
-  CGAL::tetrahedral_isotropic_remeshing(tr, target_edge_length,
+  CGAL::tetrahedral_isotropic_remeshing(c3t3, target_edge_length,
    number_of_iterations(5)
    .smooth_constrained_edges(true)
    .edge_is_constrained_map(constraints_pmap));
 
   std::ofstream out("out_remeshed.mesh");
-  CGAL::IO::write_MEDIT(out, tr);
+  CGAL::IO::write_MEDIT(out, c3t3);
   out.close();
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
## Summary of Changes

introduce 
```
C3T3<Triangulation_3> triangulation_3_to_complex(C3T3<Delaunay_T3>)
```
 to "drop" the Delaunay/Regular aspect of the underlying triangulation (generated by Mesh_3) and have no more guarantees/requirements than the ones of `Triangulation_3`.

For example : after Mesh_3, the underlying triangulation is Regular, and remeshing would break the regular-ness of the triangulation.

## Release Management

* Affected package(s): SMDS_3, Tetrahedral_remeshing
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

