### PR TITLE
Make polyhedron_3_to_lcc() generic for FaceGraph

### DIFF
--- a/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Polyhedron_3_to_lcc.h
+++ b/Linear_cell_complex/doc/Linear_cell_complex/CGAL/Polyhedron_3_to_lcc.h
@@ -2,13 +2,16 @@ namespace CGAL{
 /*!
 \ingroup PkgLinearCellComplexConstructions
 
-Imports `apoly` (a `Polyhedron_3`) into `lcc`, a model of the `LinearCellComplex` concept. Objects are added in `lcc`, existing darts are not modified. Returns a dart created during the import.
+Imports `apoly`into `lcc`. Objects are added in `lcc`, existing darts are not modified. Returns a dart created during the import.
 \pre \link GenericMap::dimension `LCC::dimension`\endlink \f$ \geq\f$ 2 and \link LinearCellComplex::ambient_dimension `LCC::ambient_dimension`\endlink==3.
+
+\tparam LCC a model of `LinearCellComplex`
+\tparam PolygonMesh a model of `FaceGraph`
 
 \sa `CGAL::read_plane_graph_in_lcc<LCC>`
 \sa `CGAL::triangulation_3_to_lcc<LCC,Triangulation>`
 */
-template<class LCC,class Polyhedron>
+template<class LCC,class PolygonMesh>
 typename LCC::Dart_descriptor polyhedron_3_to_lcc(LCC& lcc,
-const Polyhedron &apoly);
+                                                  const PolygonMesh &apoly);
 }

--- a/Linear_cell_complex/doc/Linear_cell_complex/examples.txt
+++ b/Linear_cell_complex/doc/Linear_cell_complex/examples.txt
@@ -7,4 +7,5 @@
 \example Linear_cell_complex/draw_linear_cell_complex.cpp
 \example Linear_cell_complex/linear_cell_complex_3_insert.cpp
 \example Linear_cell_complex/linear_cell_complex_3_vtk_io.cpp
+\example Linear_cell_complex/read_face_graph_in_lcc_3.cpp
 */

--- a/Linear_cell_complex/examples/Linear_cell_complex/CMakeLists.txt
+++ b/Linear_cell_complex/examples/Linear_cell_complex/CMakeLists.txt
@@ -25,6 +25,7 @@ create_single_source_cgal_program(
 create_single_source_cgal_program("linear_cell_complex_3_with_mypoint.cpp")
 create_single_source_cgal_program("linear_cell_complex_4.cpp")
 create_single_source_cgal_program("read_plane_graph_in_lcc_2.cpp")
+create_single_source_cgal_program("read_face_graph_in_lcc_3.cpp")
 create_single_source_cgal_program("voronoi_2.cpp")
 create_single_source_cgal_program("voronoi_3.cpp")
 create_single_source_cgal_program("linear_cell_complex_3_vtk_io.cpp")

--- a/Linear_cell_complex/examples/Linear_cell_complex/read_face_graph_in_lcc_3.cpp
+++ b/Linear_cell_complex/examples/Linear_cell_complex/read_face_graph_in_lcc_3.cpp
@@ -1,0 +1,29 @@
+#include <CGAL/Linear_cell_complex_for_combinatorial_map.h>
+#include <CGAL/Polyhedron_3.h>
+#include <CGAL/Surface_mesh.h>
+#include <CGAL/Polyhedron_3_to_lcc.h>
+#include <CGAL/boost/graph/generators.h>
+
+
+typedef CGAL::Linear_cell_complex_for_combinatorial_map<3> LCC;
+typedef CGAL::Polyhedron_3<LCC::Traits> Polyhedron;
+typedef LCC::Point Point_3;
+typedef CGAL::Surface_mesh<Point_3>  Surface_mesh;
+
+
+int main()
+{
+  Polyhedron polyhedron;
+  Surface_mesh surface_mesh;
+  CGAL::make_tetrahedron(Point_3(0,0,0), Point_3(1,0,0),Point_3(0,1,0),Point_3(0,0,1), polyhedron);
+  CGAL::make_tetrahedron(Point_3(0,0,0), Point_3(1,0,0),Point_3(0,1,0),Point_3(0,0,1), surface_mesh);
+
+
+  LCC lccp, lccs;
+  CGAL::polyhedron_3_to_lcc(lccp, polyhedron);
+  CGAL::polyhedron_3_to_lcc(lccs, surface_mesh);
+
+  std::cout << lccp << std::endl;
+  std::cout << lccs << std::endl;
+  return 0;
+}

--- a/Polyhedron/include/CGAL/Polyhedron_3_to_lcc.h
+++ b/Polyhedron/include/CGAL/Polyhedron_3_to_lcc.h
@@ -36,10 +36,9 @@ namespace CGAL {
   {
     static_assert( LCC::dimension>=2 && LCC::ambient_dimension==3 );
 
-    typedef typename Polyhedron::Halfedge_const_handle  Halfedge_handle;
-    typedef typename Polyhedron::Facet_const_iterator   Facet_iterator;
-    typedef typename Polyhedron::Halfedge_around_facet_const_circulator
-      HF_circulator;
+    typedef typename boost::graph_traits<Polyhedron>::halfedge_descriptor  Halfedge_handle;
+    typedef typename boost::graph_traits<Polyhedron>::face_iterator   Facet_iterator;
+    typedef Halfedge_around_face_circulator<Polyhedron> HF_circulator;
 
     typedef std::map < Halfedge_handle, typename LCC::Dart_descriptor>
       Halfedge_handle_map;
@@ -51,47 +50,49 @@ namespace CGAL {
     typename LCC::Dart_descriptor firstFacet = LCC::null_descriptor, firstAll = LCC::null_descriptor;
 
     // First traversal to build the darts and link them.
-    for (Facet_iterator i = apoly.facets_begin(); i != apoly.facets_end(); ++i)
+    for (Facet_iterator i = faces(apoly).begin(); i != faces(apoly).end(); ++i)
     {
-      HF_circulator j = i->facet_begin();
+      HF_circulator j(halfedge(*i,apoly), apoly), done(j);
       prev = LCC::null_descriptor;
       do
       {
         d = alcc.make_half_edge();
-        TC[j] = d;
+        TC[*j] = d;
 
         if (prev != LCC::null_descriptor) alcc.set_next(prev, d);
         else firstFacet = d;
 
-        if (!j->opposite()->is_border())
+        if (!is_border(opposite(*j, apoly), apoly))
         {
-          it = TC.find(j->opposite());
+          it = TC.find(opposite(*j,apoly));
           if (it != TC.end())
             alcc.template set_opposite<2>(d, it->second);
         }
         prev = d;
       }
-      while (++j != i->facet_begin());
+      while (++j != done);
       alcc.set_next(prev, firstFacet);
       if (firstAll == LCC::null_descriptor) firstAll = firstFacet;
     }
 
     // Second traversal to update the geometry.
     // We run one again through the facets of the HDS.
-    for (Facet_iterator i = apoly.facets_begin(); i != apoly.facets_end(); ++i)
+    auto vpm = get(CGAL::vertex_point, apoly);
+    for (Facet_iterator i = faces(apoly).begin(); i != faces(apoly).end(); ++i)
     {
-      HF_circulator j = i->facet_begin();
+      HF_circulator j(halfedge(*i,apoly), apoly), done(j);
       do
       {
-        d = TC[j]; // Get the dart associated to the Halfedge
+        d = TC[*j]; // Get the dart associated to the Halfedge
         if (alcc.vertex_attribute(d)==LCC::null_descriptor)
         {
           alcc.set_vertex_attribute
-            (d, alcc.create_vertex_attribute(j->opposite()->vertex()->point()));
+            (d, alcc.create_vertex_attribute(get(vpm, target(opposite(*j, apoly), apoly))));
         }
       }
-      while (++j != i->facet_begin());
+      while (++j != done);
     }
+
     return firstAll;
   }
 


### PR DESCRIPTION
## Summary of Changes

While reviewing the hex mesh code I saw that the function reading a polyhedron should be generalized.

### Todo

- [ ] Move part of the header to the LCC package. There are two other functions in there. 

## Release Management

* Affected package(s): LCC
* License and copyright ownership:  unchanged

