### PR TITLE
Tetrahedral remeshing - make each step optional

### DIFF
--- a/STL_Extension/include/CGAL/STL_Extension/internal/parameters_interface.h
+++ b/STL_Extension/include/CGAL/STL_Extension/internal/parameters_interface.h
@@ -294,6 +294,7 @@ CGAL_add_named_parameter(cell_selector_t, cell_selector, cell_is_selected_map)
 CGAL_add_named_parameter(facet_is_constrained_t, facet_is_constrained, facet_is_constrained_map)
 CGAL_add_named_parameter(smooth_constrained_edges_t, smooth_constrained_edges, smooth_constrained_edges)
 CGAL_add_named_parameter(nb_flip_smooth_iterations_t, nb_flip_smooth_iterations, nb_flip_smooth_iterations)
+CGAL_add_named_parameter(nb_smoothing_iterations_t, nb_smoothing_iterations, nb_smoothing_iterations)
 
 // List of named parameters used in Alpha_wrap_23
 CGAL_add_named_parameter(do_enforce_manifoldness_t, do_enforce_manifoldness, do_enforce_manifoldness)

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -59,7 +59,14 @@ public:
   void after_flip(CellHandle /* c */) {}
 };
 
-
+struct Remeshing_steps
+{
+  bool do_split = true;
+  bool do_collapse = true;
+  bool do_flip = true;
+  std::size_t nb_smoothing_iterations = 1;
+  std::size_t nb_flip_smooth_iterations = 3;
+};
 
 template<typename Triangulation
          , typename SizingFunction
@@ -597,7 +604,7 @@ public:
   }
 
   void remesh(const std::size_t& max_it,
-              const std::size_t& nb_extra_iterations)
+              const Remeshing_steps& steps)
   {
     std::size_t it_nb = 0;
     while (it_nb < max_it)
@@ -608,11 +615,20 @@ public:
 #endif
       if (!resolution_reached())
       {
-        split();
-        collapse();
+        if(steps.do_split)
+          split();
+        if(steps.do_collapse)
+          collapse();
       }
-      flip();
-      smooth();
+      if(steps.do_flip)
+        flip();
+
+      std::size_t it_smoothing = 0;
+      while (it_smoothing < steps.nb_smoothing_iterations)
+      {
+        smooth();
+        ++it_smoothing;
+      }
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
       std::cout << "# Iteration " << it_nb << " done : "
@@ -634,7 +650,7 @@ public:
     }
 
     m_vertex_smoother.start_flip_smooth_steps(m_c3t3);
-    while (it_nb < max_it + nb_extra_iterations)
+    while (it_nb < max_it + steps.nb_flip_smooth_iterations)
     {
       ++it_nb;
 

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -654,8 +654,10 @@ public:
     {
       ++it_nb;
 
-      flip();
-      smooth();
+      if(steps.do_flip)
+        flip();
+      if(steps.nb_smoothing_iterations > 0)
+        smooth();
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
       std::cout << "# Iteration " << it_nb << " (flip and smooth only) done : "

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_adaptive_remeshing_impl.h
@@ -68,6 +68,20 @@ struct Remeshing_steps
   std::size_t nb_flip_smooth_iterations = 3;
 };
 
+template<typename NamedParameters>
+Remeshing_steps get_remeshing_steps(const NamedParameters& np)
+{
+  using parameters::choose_parameter;
+  using parameters::get_parameter;
+
+  return Remeshing_steps{
+    choose_parameter(get_parameter(np, internal_np::do_split), true),
+    choose_parameter(get_parameter(np, internal_np::do_collapse), true),
+    choose_parameter(get_parameter(np, internal_np::do_flip), true),
+    static_cast<std::size_t>(choose_parameter(get_parameter(np, internal_np::nb_smoothing_iterations), 1)),
+    static_cast<std::size_t>(choose_parameter(get_parameter(np, internal_np::nb_flip_smooth_iterations), 3))};
+}
+
 template<typename Triangulation
          , typename SizingFunction
          , typename VertexIsConstrainedMap

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -221,9 +221,12 @@ void tetrahedral_isotropic_remeshing(
   // Advanced and non documented parameters
   auto visitor = choose_parameter<typename Remesher_types::Default_Visitor>(get_parameter(np, internal_np::visitor));
 
-  auto nb_extra_iterations
-    = choose_parameter(get_parameter(np, internal_np::nb_flip_smooth_iterations),
-        std::size_t{3});
+  Tetrahedral_remeshing::internal::Remeshing_steps steps{
+      choose_parameter(get_parameter(np, internal_np::do_split), true),
+      choose_parameter(get_parameter(np, internal_np::do_collapse), true),
+      choose_parameter(get_parameter(np, internal_np::do_flip), true),
+      choose_parameter(get_parameter(np, internal_np::nb_smoothing_iterations), std::size_t{1}),
+      choose_parameter(get_parameter(np, internal_np::nb_flip_smooth_iterations), std::size_t{3})};
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
   std::cout << "Tetrahedral remeshing ("
@@ -255,7 +258,7 @@ void tetrahedral_isotropic_remeshing(
   nb_extra_iterations = 0;
 #endif
 
-  remesher.remesh(max_it, nb_extra_iterations);
+  remesher.remesh(max_it, steps);
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
   const double angle_bound = 5.0;
@@ -475,9 +478,12 @@ void tetrahedral_isotropic_remeshing(
   auto visitor
     = choose_parameter<typename Remesher_types::Default_Visitor>(get_parameter(np, internal_np::visitor));
 
-  auto nb_extra_iterations
-    = choose_parameter(get_parameter(np, internal_np::nb_flip_smooth_iterations),
-        std::size_t{3});
+  Tetrahedral_remeshing::internal::Remeshing_steps steps{
+      choose_parameter(get_parameter(np, internal_np::do_split), true),
+      choose_parameter(get_parameter(np, internal_np::do_collapse), true),
+      choose_parameter(get_parameter(np, internal_np::do_flip), true),
+      choose_parameter(get_parameter(np, internal_np::nb_smoothing_iterations), std::size_t{1}),
+      choose_parameter(get_parameter(np, internal_np::nb_flip_smooth_iterations), std::size_t{3})};
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
   std::cout << "Tetrahedral remeshing ("
@@ -508,7 +514,7 @@ void tetrahedral_isotropic_remeshing(
   nb_extra_iterations = 0;
 #endif
 
-  remesher.remesh(max_it, nb_extra_iterations);
+  remesher.remesh(max_it, steps);
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_DEBUG
   const double angle_bound = 5.0;

--- a/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
+++ b/Tetrahedral_remeshing/include/CGAL/tetrahedral_remeshing.h
@@ -221,12 +221,8 @@ void tetrahedral_isotropic_remeshing(
   // Advanced and non documented parameters
   auto visitor = choose_parameter<typename Remesher_types::Default_Visitor>(get_parameter(np, internal_np::visitor));
 
-  Tetrahedral_remeshing::internal::Remeshing_steps steps{
-      choose_parameter(get_parameter(np, internal_np::do_split), true),
-      choose_parameter(get_parameter(np, internal_np::do_collapse), true),
-      choose_parameter(get_parameter(np, internal_np::do_flip), true),
-      choose_parameter(get_parameter(np, internal_np::nb_smoothing_iterations), std::size_t{1}),
-      choose_parameter(get_parameter(np, internal_np::nb_flip_smooth_iterations), std::size_t{3})};
+  Tetrahedral_remeshing::internal::Remeshing_steps steps
+    = Tetrahedral_remeshing::internal::get_remeshing_steps(np);
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
   std::cout << "Tetrahedral remeshing ("
@@ -478,12 +474,8 @@ void tetrahedral_isotropic_remeshing(
   auto visitor
     = choose_parameter<typename Remesher_types::Default_Visitor>(get_parameter(np, internal_np::visitor));
 
-  Tetrahedral_remeshing::internal::Remeshing_steps steps{
-      choose_parameter(get_parameter(np, internal_np::do_split), true),
-      choose_parameter(get_parameter(np, internal_np::do_collapse), true),
-      choose_parameter(get_parameter(np, internal_np::do_flip), true),
-      choose_parameter(get_parameter(np, internal_np::nb_smoothing_iterations), std::size_t{1}),
-      choose_parameter(get_parameter(np, internal_np::nb_flip_smooth_iterations), std::size_t{3})};
+  Tetrahedral_remeshing::internal::Remeshing_steps steps
+    = Tetrahedral_remeshing::internal::get_remeshing_steps(np);
 
 #ifdef CGAL_TETRAHEDRAL_REMESHING_VERBOSE
   std::cout << "Tetrahedral remeshing ("


### PR DESCRIPTION
## Summary of Changes

This PR adds named parameters to make different remeshing steps optional
New named parameters :

- `do_split`
- `do_collapse`
- `do_flip`
- `nb_smoothing_operations`

note `nb_flip_smooth_operations` was already there

Do you @sloriot @MaelRL think they should be documented, maybe in an "Advanced NP" section?

## Release Management

* Affected package(s): Tetrahedral_remeshing
* Feature/Small Feature (if any):
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership: unchanged

