### PR TITLE
Three read-only substitutions for repeated star/point-location queries

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/collapse_short_edges.h
@@ -19,6 +19,7 @@
 #include <boost/bimap/set_of.hpp>
 #include <boost/bimap/multiset_of.hpp>
 #include <boost/container/small_vector.hpp>
+#include <boost/container/flat_set.hpp>
 #include <boost/functional/hash.hpp>
 
 #include <vector>
@@ -727,7 +728,10 @@ bool are_edge_lengths_valid(const typename C3t3::Edge& edge,
   else
     CGAL_assertion(false);
 
-  std::unordered_map<Vertex_handle, FT> edges_sqlength_after_collapse;
+  boost::container::flat_set<Vertex_handle,
+    std::less<Vertex_handle>,
+    boost::container::small_vector<Vertex_handle, 64> > examined;
+
   for (const Edge& ei : inc_edges)
   {
     if (is_outside(ei, c3t3, cell_selector))
@@ -739,15 +743,12 @@ bool are_edge_lengths_valid(const typename C3t3::Edge& edge,
     if (vh == v0 || vh == v1)
       continue;
 
-    FT sqlen = FT(0);
-    if (edges_sqlength_after_collapse.find(vh) == edges_sqlength_after_collapse.end())
-    {
-      sqlen = CGAL::squared_distance(point(new_pos), point(vh->point()));
-      edges_sqlength_after_collapse[vh] = sqlen;
-    }
-    else
-      sqlen = edges_sqlength_after_collapse[vh];
+    // a vertex adjacent to both extremities is met once per star, and the test
+    // below reads nothing but `vh` : running it again cannot change its outcome
+    if (!examined.insert(vh).second)
+      continue;
 
+    const FT sqlen = CGAL::squared_distance(point(new_pos), point(vh->point()));
     const FT sizing_at_vh = sizing_at_vertex(vh, sizing, c3t3, cell_selector);
     const FT sqhigh
         = CGAL::square(FT(4) / FT(3)) * (std::max)(CGAL::square(sizing_at_vh),

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -31,6 +31,7 @@
 #include <boost/container/flat_set.hpp>
 #include <boost/container/small_vector.hpp>
 #include <boost/bimap.hpp>
+#include <boost/iterator/function_output_iterator.hpp>
 
 #include <optional>
 
@@ -811,15 +812,18 @@ surface_patch_index(const typename C3t3::Vertex_handle v,
                     const C3t3& c3t3)
 {
   typedef typename C3t3::Facet Facet;
-  boost::container::small_vector<Facet, 64> facets;
-  c3t3.triangulation().incident_facets(v, std::back_inserter(facets));
+  std::optional<typename C3t3::Surface_patch_index> patch;
 
-  for(const Facet& f : facets)
-  {
-    if (c3t3.is_in_complex(f))
-      return c3t3.surface_patch_index(f);
-  }
-  return std::nullopt;
+  // the star is examined through an output iterator rather than collected :
+  // only the first facet of the complex is of interest
+  c3t3.triangulation().incident_facets(v,
+    boost::make_function_output_iterator([&](const Facet& f)
+    {
+      if (patch == std::nullopt && c3t3.is_in_complex(f))
+        patch = c3t3.surface_patch_index(f);
+    }));
+
+  return patch;
 }
 
 template<typename C3t3>

--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/tetrahedral_remeshing_helpers.h
@@ -1586,9 +1586,16 @@ auto midpoint_with_info(const typename C3t3::Edge& e,
   const int midpoint_dim = boundary_edge
     ? (std::max)(u->in_dimension(), v->in_dimension())
     : 3;
+  // the midpoint lies on `e`, and all the cells incident to an edge that is not
+  // on a boundary share one subdomain : locating the midpoint would return one
+  // of them, so `e.first` already carries the answer
+  CGAL_expensive_assertion(boundary_edge
+    || subdomain_index_at_point_3(midpoint_pt, e.first, c3t3.triangulation())
+         == e.first->subdomain_index());
+
   const Index midpoint_index = boundary_edge
     ? max_dimension_index(c3t3.triangulation().vertices(e))
-    : subdomain_index_at_point_3(midpoint_pt, e.first, c3t3.triangulation());
+    : Index(e.first->subdomain_index());
 
   return Midpoint_with_info{midpoint_pt, midpoint_dim, midpoint_index};
 }


### PR DESCRIPTION
## Summary

Three independent optimizations, grouped together because each is a small, self-contained
substitution of a cheaper read for a query that a nearby invariant already answers:

- **Read the subdomain of an edge midpoint off the edge.** `midpoint_with_info()` located a
  non-boundary edge's midpoint with `subdomain_index_at_point_3()`, a full point-location query,
  purely to learn its subdomain. Every cell incident to a non-boundary edge shares one subdomain,
  since `is_boundary()` is exactly the test that rules out a facet of the complex or a subdomain
  change around the edge. The midpoint lies on the edge, so a locate can only return one of those
  incident cells, and `e.first` already is one. Reading `e.first->subdomain_index()` gives the
  same answer without the query. The locate is kept as a `CGAL_expensive_assertion`.
- **Look for the surface patch without collecting the star.** `surface_patch_index()` collected a
  vertex's entire incident-facet star into a `small_vector`, then scanned it for the first facet
  belonging to the complex. Streaming through a function output iterator instead removes the
  collection and stops at the first match, same as the scan already did.
- **Examine each neighbour once when validating lengths.** `are_edge_lengths_valid()` visits the
  incident edges of both endpoints of a collapsed edge, so a vertex adjacent to both is visited
  twice; the squared length was recomputed and re-queried from the sizing field on the repeat
  even though the loop's own test reads nothing but the vertex handle. Tracking already-examined
  vertices in a `flat_set` and skipping repeats removes the redundant sizing-field query.

## Testing

**Verdict equivalence.** All three changes are read-only substitutions or streaming equivalents
over predicates already determined by the triangulation's invariants; none change which edge,
vertex, or collapse is selected, or in what order. Full test suite (all executables in
`test/Tetrahedral_remeshing`) passes.

**Byte-identical output**, against plain `cgal/main`:

| mesh | tets | byte-identical |
|---|---|---|
| bear | ~40K | YES |
| bunny00 | ~225K | YES |
| 101556.mesh (Thingi10K) | 3,521,237 | YES |

**Performance.** `perf stat -e instructions`, Linux, Release, sequential, against plain
`cgal/main`.

| mesh | iterations | `cgal/main` instr | this MR | Δ instr |
|---|---|---|---|---|
| bear | 10 | 67.04 G | 58.35 G | -12.97% |
| bunny00 | 10 | 148.80 G | 130.91 G | -12.02% |
| 101556.mesh | 3 | 2441.29 G | 2263.33 G | -7.29% |

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged