### PR TITLE
Tetrahedral remeshing: Give up on a flip as soon as its angles stop improving

### DIFF
--- a/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/flip_edges.h
+++ b/Tetrahedral_remeshing/include/CGAL/Tetrahedral_remeshing/internal/flip_edges.h
@@ -499,6 +499,15 @@ void find_best_flip_to_improve_dh(C3t3& c3t3,
           keep = false;
           break;
         }
+
+        // the worst angle of the flip only ever grows from here, so once it has
+        // reached the one the edge already has, this vertex cannot be kept -
+        // unless the cells are inverted, where it is kept whatever it measures
+        if (is_sliver_well_oriented && !(max_flip_cos_dh < curr_max_cos_dh))
+        {
+          keep = false;
+          break;
+        }
       }
     }
     facets.clear();
@@ -679,6 +688,15 @@ void find_best_flip_to_improve_dh(C3t3& c3t3,
         }
 
         if (max_flip_cos_dh.is_one())//it will not get worse than 1.
+        {
+          keep = false;
+          break;
+        }
+
+        // the worst angle of the flip only ever grows from here, so once it has
+        // reached the one the edge already has, this vertex cannot be kept -
+        // unless the cells are inverted, where it is kept whatever it measures
+        if (is_sliver_well_oriented && !(max_flip_cos_dh < curr_max_cosdh))
         {
           keep = false;
           break;


### PR DESCRIPTION
## Summary

`find_best_flip_to_improve_dh()` searches, for each candidate flip vertex, over the cells the
flip would produce, tracking the worst dihedral-angle cosine seen so far. A vertex is only kept
if that worst angle is better than the edge's current worst angle. The search does not stop once
a candidate can no longer win: it keeps scanning the remaining cells and comparing angles that
can only make its worst-case value grow, never shrink.

Once the re running worst angle for a candidate vertexaches the edge's current worst angle, that
vertex is already disqualified (worse case can only stay the same or grow from there), so the
loop can stop scanning it right there instead of finishing the remaining cells. The same pattern
appears twice: once for each of the two symmetric flip-direction loops in this function.

The well-oriented/inverted-cells exception is preserved: for a candidate whose cells are inverted
(not well-oriented), the running worst angle is not a valid signal to reject on, so the early exit
only fires when `is_sliver_well_oriented` is true.

## Testing

**Verdict equivalence.** The early exit stops scanning a vertex only after it is already
guaranteed to be rejected by the existing "is this vertex worth keeping" test, so it changes when
the loop stops, not what any candidate's outcome is. Full test suite (all executables in
`test/Tetrahedral_remeshing`) passes.

**Byte-identical output**, against plain `cgal/main`:

| mesh | tets | byte-identical |
|---|---|---|
| bear | ~40K | YES |
| bunny00 | ~225K | YES |
| 101556.mesh (Thingi10K) | 3,521,237 | YES |

**Performance.** `perf stat -e instructions`, Linux, Release, sequential, against plain
`cgal/main`.

| mesh | iterations | `cgal/main` instr | this PR | Δ instr |
|---|---|---|---|---|
| bear | 10 | 67.04 G | 63.35 G | -5.52% |
| bunny00 | 10 | 148.80 G | 139.60 G | -6.19% |
| 101556.mesh | 3 | 2441.29 G | 2368.41 G | -2.99% |

## Release Management

* Affected package(s): Tetrahedral_remeshing
* License and copyright ownership: unchanged
