### PR TITLE
CGAL: Fix name collision, and change output mode

### DIFF
--- a/CGAL_Core/include/CGAL/CORE/BigFloatRep.h
+++ b/CGAL_Core/include/CGAL/CORE/BigFloatRep.h
@@ -172,10 +172,10 @@ struct BigFloatRep::DecimalOutput {
 
 // constants used by BigFloatRep
 //        NOTES:  CHUNK_BIT is the number of bits in each Chunk
-//        Since LONG_BIT = 32 or 64, then CHUNK_BIT = 14 or 30.
+//        Since CORE_LONG_BIT = 32 or 64, then CHUNK_BIT = 14 or 30.
 //        We have:  0 <= err < 4 * 2^{CHUNK_BIT}
 
-const long CHUNK_BIT = (long)(LONG_BIT / 2 - 2);         //  chunks
+const long CHUNK_BIT = (long)(CORE_LONG_BIT / 2 - 2);         //  chunks
 const long HALF_CHUNK_BIT = (CHUNK_BIT + 1) / 2;
 const long DBL_MAX_CHUNK = (DBL_MAX_EXP - 1) / CHUNK_BIT + 1;
 const double lgTenM = 3.321928094887362;

--- a/CGAL_Core/include/CGAL/CORE/CoreAux.h
+++ b/CGAL_Core/include/CGAL/CORE/CoreAux.h
@@ -31,8 +31,8 @@
 
 namespace CORE {
 
-#ifndef LONG_BIT // such as in Linux
-  #define LONG_BIT (sizeof(long) * 8)
+#ifndef CORE_LONG_BIT // such as in Linux
+  #define CORE_LONG_BIT (sizeof(long) * 8)
 #endif
 
 /// CORE_EPS is unit roundoff for IEEE standard double, i.e., 2^{-53}.

--- a/CGAL_Core/include/CGAL/CORE/CoreAux_impl.h
+++ b/CGAL_Core/include/CGAL/CORE/CoreAux_impl.h
@@ -53,7 +53,7 @@ CGAL_INLINE_FUNCTION
 int flrLg(long x) {
   if (x == LONG_MIN) {
     // special treatment as -LONG_MIN would be not representable as "long"
-    return LONG_BIT - 1;
+    return CORE_LONG_BIT - 1;
   } else {
     //  1 <= |x| <= LONG_MAX
     if (x < 0)
@@ -89,11 +89,11 @@ int flrLg(unsigned long x) {
 CGAL_INLINE_FUNCTION
 int clLg(long x) {
   if (x == LONG_MIN)
-    return LONG_BIT - 1;
+    return CORE_LONG_BIT - 1;
   if (x < 0)
     x = -x;                 // use absolute value
   if (x > (LONG_MAX >> 1))         // the leading data bit is 1
-    return (LONG_BIT - 1);        // exclude the sign bit
+    return (CORE_LONG_BIT - 1);        // exclude the sign bit
   if (x >= 2)
     return flrLg((unsigned long)((x << 1) - 1));
   // SINCE ceilLog_2(x) = floorLog_2(2x-1) for x>=2
@@ -109,7 +109,7 @@ int clLg(long x) {
 CGAL_INLINE_FUNCTION
 int clLg(unsigned long x) {
   if (x > (ULONG_MAX >> 1))        // the leading bit is 1
-    return LONG_BIT;
+    return CORE_LONG_BIT;
   if (x >= 2)
     return flrLg((x << 1) - 1);
   // SINCE ceilLog_2(x) = floorLog_2(2x-1) for x>=2.

--- a/CGAL_Core/include/CGAL/CORE/Real.h
+++ b/CGAL_Core/include/CGAL/CORE/Real.h
@@ -309,7 +309,7 @@ struct _real_mul {
   }
   // specialized for two long values
   static Real eval(long a, long b) {
-    if (flrLg(a) + flrLg(b) >= static_cast<int>(LONG_BIT-2))
+    if (flrLg(a) + flrLg(b) >= static_cast<int>(CORE_LONG_BIT-2))
       return BigInt(BigInt(a)*BigInt(b));
     else
       return a*b;

--- a/Kernel_23/test/Kernel_23/Exact_predicates_exact_constructions_kernel.cpp
+++ b/Kernel_23/test/Kernel_23/Exact_predicates_exact_constructions_kernel.cpp
@@ -74,6 +74,10 @@ int main()
   test<CGAL::Exact_predicates_exact_constructions_kernel>();
 
 #if defined(CGAL_USE_CORE) || defined(CGAL_USE_LEDA)
+
+#if defined(CGAL_USE_LEDA)
+  leda_real::set_output_mode(leda_real::IO_to_double);
+#endif
   test<CGAL::Exact_predicates_exact_constructions_kernel_with_sqrt>();
   test<CGAL::Exact_predicates_exact_constructions_kernel_with_kth_root>();
   test<CGAL::Exact_predicates_exact_constructions_kernel_with_root_of>();


### PR DESCRIPTION

## Summary of Changes

Change a preprocessor macro in Core, as it collided with Leda.
In the testsuite `Exact_predicates_exact_constructions.cpp`  set the output mode for `leda::real` so that it writes doubles and not intervals. 

## Release Management

* Affected package(s):  Kernel_23
* License and copyright ownership:  unchanged 

