### PR TITLE
Basic_viewer: color faces by value (distance, cell size, and a drawer value)

### DIFF
--- a/BGL/include/CGAL/draw_face_graph.h
+++ b/BGL/include/CGAL/draw_face_graph.h
@@ -82,7 +82,7 @@ void compute_elements(const FG &fg,
         }
         while (hd != first_hd);
         // Colour by value: attach the face's scalar value before committing it.
-        if (gs_options.valued_face(fg, fh))
+        if (gs_options.is_face_valued(fg, fh))
         { graphics_scene.set_face_value(gs_options.face_value(fg, fh)); }
         graphics_scene.face_end();
       }

--- a/BGL/include/CGAL/draw_face_graph.h
+++ b/BGL/include/CGAL/draw_face_graph.h
@@ -60,7 +60,7 @@ void compute_elements(const FG &fg,
 
   if (gs_options.are_faces_enabled())
   {
-    // Colour by value: name the value once, for the legend.
+    // Color by value: name the value once, for the legend.
     if (!gs_options.face_value_name.empty())
     { graphics_scene.set_value_name(gs_options.face_value_name); }
     for (auto fh : faces(fg))
@@ -81,7 +81,7 @@ void compute_elements(const FG &fg,
           hd = next(hd, fg);
         }
         while (hd != first_hd);
-        // Colour by value: attach the face's scalar value before committing it.
+        // Color by value: attach the face's scalar value before committing it.
         if (gs_options.is_face_valued(fg, fh))
         { graphics_scene.set_face_value(gs_options.face_value(fg, fh)); }
         graphics_scene.face_end();

--- a/BGL/include/CGAL/draw_face_graph.h
+++ b/BGL/include/CGAL/draw_face_graph.h
@@ -60,6 +60,9 @@ void compute_elements(const FG &fg,
 
   if (gs_options.are_faces_enabled())
   {
+    // Colour by value: name the value once, for the legend.
+    if (!gs_options.face_value_name.empty())
+    { graphics_scene.set_value_name(gs_options.face_value_name); }
     for (auto fh : faces(fg))
     {
       if (fh != boost::graph_traits<FG>::null_face() && // face exists
@@ -78,6 +81,9 @@ void compute_elements(const FG &fg,
           hd = next(hd, fg);
         }
         while (hd != first_hd);
+        // Colour by value: attach the face's scalar value before committing it.
+        if (gs_options.valued_face(fg, fh))
+        { graphics_scene.set_face_value(gs_options.face_value(fg, fh)); }
         graphics_scene.face_end();
       }
     }

--- a/Basic_viewer/doc/Basic_viewer/Concepts/GraphicsSceneOptions.h
+++ b/Basic_viewer/doc/Basic_viewer/Concepts/GraphicsSceneOptions.h
@@ -75,6 +75,18 @@ public:
   /// `nullptr` by default.
   std::function<CGAL::IO::Color(const DS &, face_descriptor)> face_color;
 
+  /// `std::function` that returns `true` if the given face carries a scalar value to
+  /// colour it by, `false` otherwise. `false` by default.
+  std::function<bool(const DS &, face_descriptor)> valued_face;
+
+  /// `std::function` that returns the scalar value of the given face. Used only when
+  /// `valued_face()` returns `true`. The viewer normalises the values over their range
+  /// and maps them to a color palette.
+  std::function<float(const DS &, face_descriptor)> face_value;
+
+  /// name of the value, shown in the viewer's color legend (for example "aspect ratio").
+  std::string face_value_name;
+
   /// ignores all vertices when `b` is `true`; otherwise ignores only vertices for which `ignore_vertex()` returns `true`.
   void ignore_all_vertices(bool b);
 

--- a/Basic_viewer/doc/Basic_viewer/Concepts/GraphicsSceneOptions.h
+++ b/Basic_viewer/doc/Basic_viewer/Concepts/GraphicsSceneOptions.h
@@ -77,10 +77,10 @@ public:
 
   /// `std::function` that returns `true` if the given face carries a scalar value to
   /// colour it by, `false` otherwise. `false` by default.
-  std::function<bool(const DS &, face_descriptor)> valued_face;
+  std::function<bool(const DS &, face_descriptor)> is_face_valued;
 
   /// `std::function` that returns the scalar value of the given face. Used only when
-  /// `valued_face()` returns `true`. The viewer normalises the values over their range
+  /// `is_face_valued()` returns `true`. The viewer normalises the values over their range
   /// and maps them to a color palette.
   std::function<float(const DS &, face_descriptor)> face_value;
 

--- a/Basic_viewer/doc/Basic_viewer/Concepts/GraphicsSceneOptions.h
+++ b/Basic_viewer/doc/Basic_viewer/Concepts/GraphicsSceneOptions.h
@@ -75,8 +75,7 @@ public:
   /// `nullptr` by default.
   std::function<CGAL::IO::Color(const DS &, face_descriptor)> face_color;
 
-  /// `std::function` that returns `true` if the given face carries a scalar value to
-  /// colour it by, `false` otherwise. `false` by default.
+  /// `std::function` that returns `true` when call for faces having an associated a scalar value, and `false` otherwise. `false` by default.
   std::function<bool(const DS &, face_descriptor)> is_face_valued;
 
   /// `std::function` that returns the scalar value of the given face. Used only when

--- a/Basic_viewer/doc/Basic_viewer/Concepts/GraphicsSceneOptions.h
+++ b/Basic_viewer/doc/Basic_viewer/Concepts/GraphicsSceneOptions.h
@@ -80,7 +80,7 @@ public:
   std::function<bool(const DS &, face_descriptor)> is_face_valued;
 
   /// `std::function` that returns the scalar value of the given face. Used only when
-  /// `is_face_valued()` returns `true`. The viewer normalises the values over their range
+  /// `is_face_valued()` returns `true`. The viewer normalizes the values over their range
   /// and maps them to a color palette.
   std::function<float(const DS &, face_descriptor)> face_value;
 

--- a/Basic_viewer/doc/Basic_viewer/Concepts/GraphicsSceneOptions.h
+++ b/Basic_viewer/doc/Basic_viewer/Concepts/GraphicsSceneOptions.h
@@ -78,7 +78,7 @@ public:
   /// `std::function` that returns `true` when call for faces having an associated a scalar value, and `false` otherwise. `false` by default.
   std::function<bool(const DS &, face_descriptor)> is_face_valued;
 
-  /// `std::function` that returns the scalar value of the given face. Used only when
+  /// `std::function` that returns the associated scalar value of a face. Called only if
   /// `is_face_valued()` returns `true`. The viewer normalizes the values over their range
   /// and maps them to a color palette.
   std::function<float(const DS &, face_descriptor)> face_value;

--- a/Basic_viewer/include/CGAL/Basic_shaders.h
+++ b/Basic_viewer/include/CGAL/Basic_shaders.h
@@ -81,6 +81,10 @@ uniform mediump float u_RenderingTransparency;
 uniform mediump float u_ColorMapMode;
 uniform mediump float u_ValueMin;
 uniform mediump float u_ValueMax;
+// Per cell: use the cell centre instead of the fragment position, so a whole cell
+// takes one flat colour and neighbouring cells do not melt together.
+uniform int           u_ColorPerCell;
+uniform highp   vec3  u_CellCentroid;
 
 vec3 colour_palette(float t, float mode)
 {
@@ -105,7 +109,8 @@ void main(void)
   vec3 base = fColor.rgb;
   if (u_ColorMapMode > 0.5)
   {
-    float value = dot(ls_fP.xyz-u_PointPlane.xyz, normalize(u_ClipPlane.xyz));
+    vec3 p = (u_ColorPerCell != 0) ? u_CellCentroid : ls_fP.xyz;
+    float value = dot(p-u_PointPlane.xyz, normalize(u_ClipPlane.xyz));
     float t = clamp((value-u_ValueMin)/max(u_ValueMax-u_ValueMin, 1e-6), 0.0, 1.0);
     base = colour_palette(t, u_ColorMapMode);
   }

--- a/Basic_viewer/include/CGAL/Basic_shaders.h
+++ b/Basic_viewer/include/CGAL/Basic_shaders.h
@@ -81,10 +81,10 @@ uniform mediump float u_RenderingTransparency;
 uniform mediump float u_ColorMapMode;
 uniform mediump float u_ValueMin;
 uniform mediump float u_ValueMax;
-// Per cell: use the cell centre instead of the fragment position, so a whole cell
-// takes one flat colour and neighbouring cells do not melt together.
+// Per cell: the viewer gives one value for the whole cell (its centre distance or
+// its size), so a whole cell takes one flat colour and neighbouring cells do not melt.
 uniform int           u_ColorPerCell;
-uniform highp   vec3  u_CellCentroid;
+uniform highp   float u_CellValue;
 
 vec3 colour_palette(float t, float mode)
 {
@@ -109,8 +109,8 @@ void main(void)
   vec3 base = fColor.rgb;
   if (u_ColorMapMode > 0.5)
   {
-    vec3 p = (u_ColorPerCell != 0) ? u_CellCentroid : ls_fP.xyz;
-    float value = dot(p-u_PointPlane.xyz, normalize(u_ClipPlane.xyz));
+    float value = (u_ColorPerCell != 0) ? u_CellValue
+                : dot(ls_fP.xyz-u_PointPlane.xyz, normalize(u_ClipPlane.xyz));
     float t = clamp((value-u_ValueMin)/max(u_ValueMax-u_ValueMin, 1e-6), 0.0, 1.0);
     base = colour_palette(t, u_ColorMapMode);
   }

--- a/Basic_viewer/include/CGAL/Basic_shaders.h
+++ b/Basic_viewer/include/CGAL/Basic_shaders.h
@@ -75,18 +75,18 @@ uniform highp   vec4  u_PointPlane;
 uniform mediump float u_RenderingMode;
 uniform mediump float u_RenderingTransparency;
 
-// Colour by value: 0 keeps the vertex colour, otherwise a palette index. The
+// Color by value: 0 keeps the vertex color, otherwise a palette index. The
 // value shown is the signed distance from the fragment to the clipping plane,
 // normalised to [u_ValueMin, u_ValueMax].
 uniform mediump float u_ColorMapMode;
 uniform mediump float u_ValueMin;
 uniform mediump float u_ValueMax;
 // Per cell: the viewer gives one value for the whole cell (its centre distance or
-// its size), so a whole cell takes one flat colour and neighbouring cells do not melt.
+// its size), so a whole cell takes one flat color and neighbouring cells do not melt.
 uniform int           u_ColorPerCell;
 uniform highp   float u_CellValue;
 
-vec3 colour_palette(float t, float mode)
+vec3 color_palette(float t, float mode)
 {
   if (mode < 1.5)
   { return clamp(vec3(t*3.0, t*3.0-1.0, t*3.0-2.0), 0.0, 1.0); } // heat
@@ -116,14 +116,14 @@ void main(void)
   L = normalize(L);
   V = normalize(V);
 
-  // Base colour is the vertex colour, or a palette applied to the value.
+  // Base color is the vertex color, or a palette applied to the value.
   vec3 base = fColor.rgb;
   if (u_ColorMapMode > 0.5)
   {
     float value = (u_ColorPerCell != 0) ? u_CellValue
                 : dot(ls_fP.xyz-u_PointPlane.xyz, normalize(u_ClipPlane.xyz));
     float t = clamp((value-u_ValueMin)/max(u_ValueMax-u_ValueMin, 1e-6), 0.0, 1.0);
-    base = colour_palette(t, u_ColorMapMode);
+    base = color_palette(t, u_ColorMapMode);
   }
 
   highp vec3 R = reflect(-L, a_Normal);

--- a/Basic_viewer/include/CGAL/Basic_shaders.h
+++ b/Basic_viewer/include/CGAL/Basic_shaders.h
@@ -75,6 +75,23 @@ uniform highp   vec4  u_PointPlane;
 uniform mediump float u_RenderingMode;
 uniform mediump float u_RenderingTransparency;
 
+// Colour by value: 0 keeps the vertex colour, otherwise a palette index. The
+// value shown is the signed distance from the fragment to the clipping plane,
+// normalised to [u_ValueMin, u_ValueMax].
+uniform mediump float u_ColorMapMode;
+uniform mediump float u_ValueMin;
+uniform mediump float u_ValueMax;
+
+vec3 colour_palette(float t, float mode)
+{
+  if (mode < 1.5)
+  { return clamp(vec3(t*3.0, t*3.0-1.0, t*3.0-2.0), 0.0, 1.0); } // heat
+  if (mode < 2.5)
+  { return clamp(vec3(1.5-abs(4.0*t-3.0), 1.5-abs(4.0*t-2.0), 1.5-abs(4.0*t-1.0)),
+                 0.0, 1.0); } // jet
+  return vec3(t); // grey ramp
+}
+
 void main(void)
 {
   highp vec3 L = u_LightPos.xyz - vs_fP.xyz;
@@ -84,9 +101,18 @@ void main(void)
   L = normalize(L);
   V = normalize(V);
 
+  // Base colour is the vertex colour, or a palette applied to the value.
+  vec3 base = fColor.rgb;
+  if (u_ColorMapMode > 0.5)
+  {
+    float value = dot(ls_fP.xyz-u_PointPlane.xyz, normalize(u_ClipPlane.xyz));
+    float t = clamp((value-u_ValueMin)/max(u_ValueMax-u_ValueMin, 1e-6), 0.0, 1.0);
+    base = colour_palette(t, u_ColorMapMode);
+  }
+
   highp vec3 R = reflect(-L, a_Normal);
-  highp vec4 diffuse = vec4(max(dot(a_Normal,L), 0.0) * u_LightDiff.rgb * fColor.rgb, 1.0);
-  highp vec4 ambient = vec4(u_LightAmb.rgb * fColor.rgb, 1.0);
+  highp vec4 diffuse = vec4(max(dot(a_Normal,L), 0.0) * u_LightDiff.rgb * base, 1.0);
+  highp vec4 ambient = vec4(u_LightAmb.rgb * base, 1.0);
   highp vec4 specular = pow(max(dot(R,V), 0.0), u_SpecPower) * u_LightSpec;
 
   // onPlane == 1: inside clipping plane, should be solid;

--- a/Basic_viewer/include/CGAL/Basic_shaders.h
+++ b/Basic_viewer/include/CGAL/Basic_shaders.h
@@ -93,7 +93,18 @@ vec3 colour_palette(float t, float mode)
   if (mode < 2.5)
   { return clamp(vec3(1.5-abs(4.0*t-3.0), 1.5-abs(4.0*t-2.0), 1.5-abs(4.0*t-1.0)),
                  0.0, 1.0); } // jet
-  return vec3(t); // grey ramp
+  if (mode < 3.5)
+  { return vec3(t); } // grey ramp
+  // viridis, a perceptually uniform map (polynomial fit by Matt Zucker). The same
+  // coefficients are mirrored in the viewer's legend so the bar matches the faces.
+  const vec3 c0=vec3(0.2777273272234177, 0.005407344544966578, 0.3340998053353061);
+  const vec3 c1=vec3(0.1050930431085774, 1.404613529898575, 1.384590162594685);
+  const vec3 c2=vec3(-0.3308618287255563, 0.214847559468213, 0.09509516302823659);
+  const vec3 c3=vec3(-4.634230498983486, -5.799100973351585, -19.33244095627987);
+  const vec3 c4=vec3(6.228269936347081, 14.17993336680509, 56.69055260068105);
+  const vec3 c5=vec3(4.776384997670288, -13.74514537774601, -65.35303263337234);
+  const vec3 c6=vec3(-5.435455855934631, 4.645852612178535, 26.3124352495832);
+  return clamp(c0+t*(c1+t*(c2+t*(c3+t*(c4+t*(c5+t*c6))))), 0.0, 1.0);
 }
 
 void main(void)

--- a/Basic_viewer/include/CGAL/Graphics_scene.h
+++ b/Basic_viewer/include/CGAL/Graphics_scene.h
@@ -252,11 +252,11 @@ public:
     return m_buffer_for_faces.is_a_face_started();
   }
 
-  /// sets the scalar value of the face currently being built. The viewer can colour
+  /// sets the scalar value of the face currently being built. The viewer can color
   /// the faces by these values, normalised over their range and mapped to a palette.
   void set_face_value(float v) { m_current_face_value=v; m_has_face_values=true; }
 
-  /// sets the name of the value, shown in the viewer's colour legend.
+  /// sets the name of the value, shown in the viewer's color legend.
   void set_value_name(const std::string &n) { m_value_name=n; }
 
   void face_begin()
@@ -335,7 +335,7 @@ public:
     record_current_face_value();
   }
 
-  // Colour by value: store the value of the face just committed, parallel to
+  // Color by value: store the value of the face just committed, parallel to
   // m_faces, and keep the min and max for the palette range.
   void record_current_face_value()
   {
@@ -390,7 +390,7 @@ public:
   const std::vector<CGAL::Bbox_3> &get_volume_bboxes() const
   { return m_volume_bboxes; }
 
-  // Colour by value: the per-face values set by the drawer, whether any were set,
+  // Color by value: the per-face values set by the drawer, whether any were set,
   // the legend name, and the value range.
   const std::vector<float> &get_face_values() const { return m_face_values; }
   bool has_face_values() const { return m_has_face_values; }
@@ -541,8 +541,8 @@ protected:
   std::vector<CGAL::Bbox_3> m_volume_bboxes;
   unsigned int m_current_face_start = 0;
 
-  // Colour by value: an optional scalar per face, set by the drawer, that the viewer
-  // maps to a palette (like the colour, but any float). Each value is parallel to
+  // Color by value: an optional scalar per face, set by the drawer, that the viewer
+  // maps to a palette (like the color, but any float). Each value is parallel to
   // m_faces; m_value_name labels the legend.
   std::vector<float> m_face_values;
   float m_current_face_value = 0.f;

--- a/Basic_viewer/include/CGAL/Graphics_scene.h
+++ b/Basic_viewer/include/CGAL/Graphics_scene.h
@@ -252,9 +252,11 @@ public:
     return m_buffer_for_faces.is_a_face_started();
   }
 
-  // Colour by value: set the scalar value of the face about to be built, and the
-  // legend name for the value. The viewer colours the faces by these when asked.
+  /// sets the scalar value of the face currently being built. The viewer can colour
+  /// the faces by these values, normalised over their range and mapped to a palette.
   void set_face_value(float v) { m_current_face_value=v; m_has_face_values=true; }
+
+  /// sets the name of the value, shown in the viewer's colour legend.
   void set_value_name(const std::string &n) { m_value_name=n; }
 
   void face_begin()

--- a/Basic_viewer/include/CGAL/Graphics_scene.h
+++ b/Basic_viewer/include/CGAL/Graphics_scene.h
@@ -252,6 +252,11 @@ public:
     return m_buffer_for_faces.is_a_face_started();
   }
 
+  // Colour by value: set the scalar value of the face about to be built, and the
+  // legend name for the value. The viewer colours the faces by these when asked.
+  void set_face_value(float v) { m_current_face_value=v; m_has_face_values=true; }
+  void set_value_name(const std::string &n) { m_value_name=n; }
+
   void face_begin()
   {
     if (a_face_started())
@@ -314,6 +319,7 @@ public:
         const unsigned int idx=static_cast<unsigned int>(m_faces.size());
         m_faces.emplace_back(m_current_face_start,
                              number_of_elements(POS_FACES)-m_current_face_start);
+        record_current_face_value();
         m_face_dedup.emplace(std::move(key), idx);
         m_volume_faces.back().push_back(idx);
         return;
@@ -324,6 +330,22 @@ public:
     // Record this face's vertex range in POS_FACES, for the clip-plane cap.
     m_faces.emplace_back(m_current_face_start,
                          number_of_elements(POS_FACES) - m_current_face_start);
+    record_current_face_value();
+  }
+
+  // Colour by value: store the value of the face just committed, parallel to
+  // m_faces, and keep the min and max for the palette range.
+  void record_current_face_value()
+  {
+    if (m_has_face_values)
+    {
+      if (m_face_values.empty())
+      { m_face_value_min=m_face_value_max=m_current_face_value; }
+      else
+      { if (m_current_face_value<m_face_value_min) { m_face_value_min=m_current_face_value; }
+        if (m_current_face_value>m_face_value_max) { m_face_value_max=m_current_face_value; } }
+    }
+    m_face_values.push_back(m_current_face_value);
   }
 
   // Clip-plane cap: a volume groups the faces added until volume_end, de-duplicated
@@ -365,6 +387,14 @@ public:
 
   const std::vector<CGAL::Bbox_3> &get_volume_bboxes() const
   { return m_volume_bboxes; }
+
+  // Colour by value: the per-face values set by the drawer, whether any were set,
+  // the legend name, and the value range.
+  const std::vector<float> &get_face_values() const { return m_face_values; }
+  bool has_face_values() const { return m_has_face_values; }
+  const std::string &value_name() const { return m_value_name; }
+  float face_value_min() const { return m_face_value_min; }
+  float face_value_max() const { return m_face_value_max; }
 
   template <typename KPoint>
   void add_text(const KPoint &kp, const std::string &txt)
@@ -508,6 +538,16 @@ protected:
   std::vector<CGAL::IO::Color> m_volume_colors;
   std::vector<CGAL::Bbox_3> m_volume_bboxes;
   unsigned int m_current_face_start = 0;
+
+  // Colour by value: an optional scalar per face, set by the drawer, that the viewer
+  // maps to a palette (like the colour, but any float). Each value is parallel to
+  // m_faces; m_value_name labels the legend.
+  std::vector<float> m_face_values;
+  float m_current_face_value = 0.f;
+  bool m_has_face_values = false;
+  std::string m_value_name;
+  float m_face_value_min = 0.f;
+  float m_face_value_max = 1.f;
 
   // Clip-plane cap: geometric face de-duplication during volume building. The key
   // is the sorted face vertex positions, so both sides of a shared wall match.

--- a/Basic_viewer/include/CGAL/Graphics_scene_options.h
+++ b/Basic_viewer/include/CGAL/Graphics_scene_options.h
@@ -67,10 +67,17 @@ struct Graphics_scene_options<DS, VertexDescriptor, EdgeDescriptor, FaceDescript
 
   std::function<bool(const DS &, face_descriptor)> face_wireframe;
 
-  // Colour by value: valued_face marks a face that carries a scalar value,
-  // face_value returns it, and face_value_name labels the legend.
+  /// `std::function` that returns `true` if the given face carries a scalar value to
+  /// colour it by, `false` otherwise. `false` by default.
   std::function<bool(const DS &, face_descriptor)>  valued_face;
+
+  /// `std::function` that returns the scalar value of the given face. Called only
+  /// when `valued_face()` returns `true`. The viewer normalises the values over their
+  /// range and maps them to a colour palette.
   std::function<float(const DS &, face_descriptor)> face_value;
+
+  /// The name of the value, shown in the viewer's colour legend (for example
+  /// "aspect ratio"). Empty by default.
   std::string face_value_name;
 
   // These functions must be non null if the corresponding colored_XXX function

--- a/Basic_viewer/include/CGAL/Graphics_scene_options.h
+++ b/Basic_viewer/include/CGAL/Graphics_scene_options.h
@@ -53,7 +53,7 @@ struct Graphics_scene_options<DS, VertexDescriptor, EdgeDescriptor, FaceDescript
 
     face_wireframe=[](const DS &, face_descriptor)->bool { return false; };
 
-    valued_face=[](const DS &, face_descriptor)->bool { return false; };
+    is_face_valued=[](const DS &, face_descriptor)->bool { return false; };
   }
 
   // The seven following functions should not be null
@@ -69,10 +69,10 @@ struct Graphics_scene_options<DS, VertexDescriptor, EdgeDescriptor, FaceDescript
 
   /// `std::function` that returns `true` if the given face carries a scalar value to
   /// colour it by, `false` otherwise. `false` by default.
-  std::function<bool(const DS &, face_descriptor)>  valued_face;
+  std::function<bool(const DS &, face_descriptor)>  is_face_valued;
 
   /// `std::function` that returns the scalar value of the given face. Called only
-  /// when `valued_face()` returns `true`. The viewer normalises the values over their
+  /// when `is_face_valued()` returns `true`. The viewer normalises the values over their
   /// range and maps them to a colour palette.
   std::function<float(const DS &, face_descriptor)> face_value;
 

--- a/Basic_viewer/include/CGAL/Graphics_scene_options.h
+++ b/Basic_viewer/include/CGAL/Graphics_scene_options.h
@@ -52,6 +52,8 @@ struct Graphics_scene_options<DS, VertexDescriptor, EdgeDescriptor, FaceDescript
     colored_face=[](const DS &, face_descriptor)->bool { return false; };
 
     face_wireframe=[](const DS &, face_descriptor)->bool { return false; };
+
+    valued_face=[](const DS &, face_descriptor)->bool { return false; };
   }
 
   // The seven following functions should not be null
@@ -64,6 +66,12 @@ struct Graphics_scene_options<DS, VertexDescriptor, EdgeDescriptor, FaceDescript
   std::function<bool(const DS &, face_descriptor)>   colored_face;
 
   std::function<bool(const DS &, face_descriptor)> face_wireframe;
+
+  // Colour by value: valued_face marks a face that carries a scalar value,
+  // face_value returns it, and face_value_name labels the legend.
+  std::function<bool(const DS &, face_descriptor)>  valued_face;
+  std::function<float(const DS &, face_descriptor)> face_value;
+  std::string face_value_name;
 
   // These functions must be non null if the corresponding colored_XXX function
   // returns true.

--- a/Basic_viewer/include/CGAL/Graphics_scene_options.h
+++ b/Basic_viewer/include/CGAL/Graphics_scene_options.h
@@ -68,15 +68,15 @@ struct Graphics_scene_options<DS, VertexDescriptor, EdgeDescriptor, FaceDescript
   std::function<bool(const DS &, face_descriptor)> face_wireframe;
 
   /// `std::function` that returns `true` if the given face carries a scalar value to
-  /// colour it by, `false` otherwise. `false` by default.
+  /// color it by, `false` otherwise. `false` by default.
   std::function<bool(const DS &, face_descriptor)>  is_face_valued;
 
   /// `std::function` that returns the scalar value of the given face. Called only
   /// when `is_face_valued()` returns `true`. The viewer normalises the values over their
-  /// range and maps them to a colour palette.
+  /// range and maps them to a color palette.
   std::function<float(const DS &, face_descriptor)> face_value;
 
-  /// The name of the value, shown in the viewer's colour legend (for example
+  /// The name of the value, shown in the viewer's color legend (for example
   /// "aspect ratio"). Empty by default.
   std::string face_value_name;
 

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -124,6 +124,7 @@ public:
     setKeyDescription(::Qt::Key_U, "Move camera direction upside down");
     setKeyDescription(::Qt::Key_V, "Toggles vertices display");
     setKeyDescription(::Qt::Key_W, "Toggles faces display");
+    setKeyDescription(::Qt::Key_D, "Cycle colouring faces by value (distance to the plane)");
     setKeyDescription(::Qt::Key_Plus, "Increase size of edges");
     setKeyDescription(::Qt::Key_Minus, "Decrease size of edges");
     setKeyDescription(::Qt::ControlModifier, ::Qt::Key_Plus, "Increase size of vertices");
@@ -733,6 +734,11 @@ public:
         rendering_program_face.setUniformValue("u_RenderingTransparency", clipping_plane_rendering_transparency);
         rendering_program_face.setUniformValue("u_ClipPlane", clipPlane);
         rendering_program_face.setUniformValue("u_PointPlane", plane_point);
+        // Colour by value: the value is the distance to the clipping plane, scaled
+        // by the scene radius each side of it.
+        rendering_program_face.setUniformValue("u_ColorMapMode", static_cast<GLfloat>(m_color_map));
+        rendering_program_face.setUniformValue("u_ValueMin", static_cast<GLfloat>(-sceneRadius()));
+        rendering_program_face.setUniformValue("u_ValueMax", static_cast<GLfloat>(sceneRadius()));
 
         vao[VAO_FACES].bind();
         glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(m_scene.number_of_elements(GS::POS_FACES)));
@@ -2291,6 +2297,21 @@ protected:
         displayMessage(QString("Draw faces=%1.").arg(m_draw_faces?"true":"false"));
         update();
       }
+      else if ((e->key()==::Qt::Key_D) && (modifiers==::Qt::NoButton))
+      {
+        // Colour the faces by a value (here the distance to the clipping plane):
+        // off, then the heat, jet and grey palettes.
+        m_color_map=(m_color_map+1)%4;
+        switch(m_color_map)
+        {
+        case 0: displayMessage(QString("Colour by value = off")); break;
+        case 1: displayMessage(QString("Colour by value = heat (distance to plane)")); break;
+        case 2: displayMessage(QString("Colour by value = jet (distance to plane)")); break;
+        case 3: displayMessage(QString("Colour by value = grey (distance to plane)")); break;
+        default: break;
+        }
+        update();
+      }
       else if ((e->key()==::Qt::Key_Plus) && (!modifiers.testFlag(::Qt::ControlModifier))) // No ctrl
       {
         m_size_edges+=.5;
@@ -2546,6 +2567,7 @@ protected:
   std::vector<std::vector<unsigned int>> m_edge_owners; // whole-volume clip: per edge, owning volumes
   std::vector<std::vector<unsigned int>> m_point_owners; // whole-volume clip: per vertex, owning volumes
   bool m_clip_owners_valid = false; // whole-volume clip: are the owner lists up to date
+  int m_color_map=0; // colour by value: 0 off, 1 heat, 2 jet, 3 grey ramp
   CGAL::qglviewer::ManipulatedFrame* m_frame_plane=nullptr;
 
   // Buffer for clipping plane is not stored in the scene because it is not

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -739,8 +739,9 @@ public:
         // Colour by value: the value is the distance to the clipping plane, scaled
         // by the scene radius each side of it.
         rendering_program_face.setUniformValue("u_ColorMapMode", static_cast<GLfloat>(m_color_map));
-        rendering_program_face.setUniformValue("u_ValueMin", static_cast<GLfloat>(-sceneRadius()));
-        rendering_program_face.setUniformValue("u_ValueMax", static_cast<GLfloat>(sceneRadius()));
+        { double dvmin, dvmax; distance_value_range(clipPlane, plane_point, dvmin, dvmax);
+          rendering_program_face.setUniformValue("u_ValueMin", static_cast<GLfloat>(dvmin));
+          rendering_program_face.setUniformValue("u_ValueMax", static_cast<GLfloat>(dvmax)); }
 
         vao[VAO_FACES].bind();
         const std::vector<std::vector<unsigned int>> &vols=m_scene.get_volume_faces();
@@ -992,8 +993,9 @@ public:
         // Colour by value: the kept volumes follow the same colour map as the other
         // face modes, per fragment or one flat value per cell.
         rendering_program_face.setUniformValue("u_ColorMapMode", static_cast<GLfloat>(m_color_map));
-        rendering_program_face.setUniformValue("u_ValueMin", static_cast<GLfloat>(-sceneRadius()));
-        rendering_program_face.setUniformValue("u_ValueMax", static_cast<GLfloat>(sceneRadius()));
+        { double dvmin, dvmax; distance_value_range(clipPlane, plane_point, dvmin, dvmax);
+          rendering_program_face.setUniformValue("u_ValueMin", static_cast<GLfloat>(dvmin));
+          rendering_program_face.setUniformValue("u_ValueMax", static_cast<GLfloat>(dvmax)); }
         const bool per_cell=(m_color_map!=0 && m_color_value!=0 && num_volumes!=0);
         const bool size_mode=(m_color_value==2);
         if (per_cell && size_mode)
@@ -1162,7 +1164,7 @@ public:
 
     // Colour by value: show the palette and the value range as a small legend.
     if (m_color_map!=0)
-    { draw_color_legend(); }
+    { draw_color_legend(clipPlane, plane_point); }
 
     // Multiply matrix to get in the frame coordinate system.
     // glMultMatrixd(manipulatedFrame()->matrix()); // Linker error
@@ -1850,16 +1852,40 @@ protected:
     return QColor(int(r*255.f), int(g*255.f), int(b*255.f));
   }
 
+  // Colour by value (distance): the actual signed-distance range the geometry spans
+  // along the plane normal, from the scene bounding-box corners, so the palette and
+  // the legend cover the values really present rather than the whole scene radius
+  // (which left the colours bunched in the middle of the ramp).
+  void distance_value_range(const QVector4D &clipPlane, const QVector4D &plane_point,
+                            double &vmin, double &vmax)
+  {
+    const CGAL::Bbox_3 b=m_scene.bounding_box();
+    const QVector3D n=QVector3D(clipPlane).normalized();
+    const QVector3D pt=plane_point.toVector3D();
+    vmin=(std::numeric_limits<double>::max)();
+    vmax=-(std::numeric_limits<double>::max)();
+    for (int c=0; c<8; ++c)
+    {
+      const QVector3D corner(float((c&1) ? b.xmax() : b.xmin()),
+                             float((c&2) ? b.ymax() : b.ymin()),
+                             float((c&4) ? b.zmax() : b.zmin()));
+      const double d=QVector3D::dotProduct(corner-pt, n);
+      if (d<vmin) { vmin=d; }
+      if (d>vmax) { vmax=d; }
+    }
+    if (vmax-vmin<1e-6) { vmax=vmin+1.0; } // guard a degenerate (flat) range
+  }
+
   // Colour by value: draw a small legend, a gradient bar with the value range, so
   // the colours read as numbers. The range and label match the current value.
-  void draw_color_legend()
+  void draw_color_legend(const QVector4D &clipPlane, const QVector4D &plane_point)
   {
     const bool size_mode=(m_color_value==2 && !m_scene.get_volume_faces().empty());
     double vmin, vmax;
     if (size_mode)
     { if (!m_cell_sizes_valid) { compute_cell_sizes(); }
       vmin=m_cell_size_min; vmax=m_cell_size_max; }
-    else { vmin=-sceneRadius(); vmax=sceneRadius(); }
+    else { distance_value_range(clipPlane, plane_point, vmin, vmax); }
 
     const int barW=16, barH=150;
     const int x=width()-barW-70, y=height()-barH-30;

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -125,7 +125,7 @@ public:
     setKeyDescription(::Qt::Key_V, "Toggles vertices display");
     setKeyDescription(::Qt::Key_W, "Toggles faces display");
     setKeyDescription(::Qt::Key_D, "Cycle colouring faces by value (distance to the plane)");
-    setKeyDescription(::Qt::ShiftModifier, ::Qt::Key_D, "Colour by value: per cell (flat) or smooth");
+    setKeyDescription(::Qt::ShiftModifier, ::Qt::Key_D, "Colour by value: distance smooth, distance per cell, size per cell");
     setKeyDescription(::Qt::Key_Plus, "Increase size of edges");
     setKeyDescription(::Qt::Key_Minus, "Decrease size of edges");
     setKeyDescription(::Qt::ControlModifier, ::Qt::Key_Plus, "Increase size of vertices");
@@ -743,18 +743,35 @@ public:
 
         vao[VAO_FACES].bind();
         const std::vector<std::vector<unsigned int>> &vols=m_scene.get_volume_faces();
-        if (m_color_map!=0 && m_color_per_cell && !vols.empty())
+        if (m_color_map!=0 && m_color_value!=0 && !vols.empty())
         {
-          // Colour by value, per cell: one flat colour per volume, taken from its
-          // centre, so neighbouring cells do not melt into one.
+          // Per cell: draw each volume with one flat value, so a whole cell takes
+          // one colour and neighbouring cells do not melt into one. The value is the
+          // centre's distance to the plane, or the cell size.
           rendering_program_face.setUniformValue("u_ColorPerCell", static_cast<GLint>(1));
           const std::vector<CGAL::Bbox_3> &bb=m_scene.get_volume_bboxes();
+          const bool size_mode=(m_color_value==2);
+          if (size_mode)
+          {
+            if (!m_cell_sizes_valid) { compute_cell_sizes(); }
+            rendering_program_face.setUniformValue("u_ValueMin", static_cast<GLfloat>(m_cell_size_min));
+            rendering_program_face.setUniformValue("u_ValueMax", static_cast<GLfloat>(m_cell_size_max));
+          }
+          const QVector3D n=QVector3D(clipPlane).normalized();
+          const QVector3D pt=plane_point.toVector3D();
           for (std::size_t v=0; v<vols.size(); ++v)
           {
-            const CGAL::Bbox_3 &b=bb[v];
-            rendering_program_face.setUniformValue("u_CellCentroid",
-              QVector3D(float((b.xmin()+b.xmax())*0.5), float((b.ymin()+b.ymax())*0.5),
-                        float((b.zmin()+b.zmax())*0.5)));
+            float value;
+            if (size_mode) { value=m_cell_sizes[v]; }
+            else
+            {
+              const CGAL::Bbox_3 &b=bb[v];
+              const QVector3D c(float((b.xmin()+b.xmax())*0.5),
+                                float((b.ymin()+b.ymax())*0.5),
+                                float((b.zmin()+b.zmax())*0.5));
+              value=QVector3D::dotProduct(c-pt, n);
+            }
+            rendering_program_face.setUniformValue("u_CellValue", static_cast<GLfloat>(value));
             for (unsigned int fi : vols[v])
             {
               const std::pair<unsigned int, unsigned int> &r=m_scene.face_range(fi);
@@ -1746,9 +1763,30 @@ protected:
     }
   }
 
+  // Colour by value (size): one size per cell, the bounding-box volume, with the
+  // range over all cells so the palette spans from the smallest to the largest.
+  void compute_cell_sizes()
+  {
+    const std::vector<CGAL::Bbox_3> &bb=m_scene.get_volume_bboxes();
+    m_cell_sizes.resize(bb.size());
+    m_cell_size_min=(std::numeric_limits<float>::max)();
+    m_cell_size_max=0.f;
+    for (std::size_t v=0; v<bb.size(); ++v)
+    {
+      const CGAL::Bbox_3 &b=bb[v];
+      const float s=float((b.xmax()-b.xmin())*(b.ymax()-b.ymin())*(b.zmax()-b.zmin()));
+      m_cell_sizes[v]=s;
+      if (s<m_cell_size_min) { m_cell_size_min=s; }
+      if (s>m_cell_size_max) { m_cell_size_max=s; }
+    }
+    if (bb.empty()) { m_cell_size_min=0.f; m_cell_size_max=1.f; }
+    m_cell_sizes_valid=true;
+  }
+
   void initialize_buffers()
   {
     set_camera_mode();
+    m_cell_sizes_valid=false; // colour by value: the scene may have changed
     rendering_program_p_l.bind();
 
     unsigned int bufn = 0;
@@ -2340,10 +2378,17 @@ protected:
       }
       else if ((e->key()==::Qt::Key_D) && (modifiers==::Qt::ShiftModifier))
       {
-        // Colour by value: one flat colour per cell instead of a smooth gradient,
-        // so neighbouring cells with a close value do not melt together.
-        m_color_per_cell=!m_color_per_cell;
-        displayMessage(QString("Colour by value per cell=%1.").arg(m_color_per_cell?"true":"false"));
+        // Colour by value: pick the value and how it is shown. Distance to the plane
+        // as a smooth gradient, the same distance as one flat colour per cell, then
+        // the cell size as one flat colour per cell.
+        m_color_value=(m_color_value+1)%3;
+        switch(m_color_value)
+        {
+        case 0: displayMessage(QString("Colour by value = distance (smooth)")); break;
+        case 1: displayMessage(QString("Colour by value = distance (per cell)")); break;
+        case 2: displayMessage(QString("Colour by value = size (per cell)")); break;
+        default: break;
+        }
         update();
       }
       else if ((e->key()==::Qt::Key_Plus) && (!modifiers.testFlag(::Qt::ControlModifier))) // No ctrl
@@ -2602,7 +2647,12 @@ protected:
   std::vector<std::vector<unsigned int>> m_point_owners; // whole-volume clip: per vertex, owning volumes
   bool m_clip_owners_valid = false; // whole-volume clip: are the owner lists up to date
   int m_color_map=0; // colour by value: 0 off, 1 heat, 2 jet, 3 grey ramp
-  bool m_color_per_cell=false; // colour by value: one flat colour per cell (Shift+D)
+  int m_color_value=0; // colour by value source (Shift+D): 0 distance smooth,
+                       // 1 distance per cell, 2 size per cell
+  std::vector<float> m_cell_sizes; // colour by value: per-cell size (bbox volume)
+  float m_cell_size_min=0.f; // colour by value: size range for the palette
+  float m_cell_size_max=1.f;
+  bool m_cell_sizes_valid=false; // colour by value: recompute the sizes on scene change
   CGAL::qglviewer::ManipulatedFrame* m_frame_plane=nullptr;
 
   // Buffer for clipping plane is not stored in the scene because it is not

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -1940,7 +1940,7 @@ protected:
     { if (!m_cell_sizes_valid) { compute_cell_sizes(); }
       vmin=m_cell_size_min; vmax=m_cell_size_max; label=QString("size"); }
     else
-    { distance_value_range(clipPlane, plane_point, vmin, vmax); label=QString("distance to plane"); }
+    { distance_value_range(clipPlane, plane_point, vmin, vmax); label=QString("distance to clipping plane"); }
 
     // No range to map (a uniform value, e.g. a flat mesh with a parallel plane):
     // skip the legend rather than show a misleading full gradient. The threshold is
@@ -1957,7 +1957,10 @@ protected:
     }
     painter.setPen(::Qt::black);
     painter.drawRect(x, y, barW, barH);
-    painter.drawText(x-2, y-8, label);
+    // Right-align the label so a long name grows to the left, into empty space,
+    // instead of running off the right edge.
+    painter.drawText(QRect(0, y-22, x+barW+40, 16),
+                     ::Qt::AlignRight | ::Qt::AlignVCenter, label);
     painter.drawText(x+barW+5, y+11, QString::number(vmax, 'g', 3));
     painter.drawText(x+barW+5, y+barH, QString::number(vmin, 'g', 3));
     painter.end();

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -125,8 +125,8 @@ public:
     setKeyDescription(::Qt::Key_U, "Move camera direction upside down");
     setKeyDescription(::Qt::Key_V, "Toggles vertices display");
     setKeyDescription(::Qt::Key_W, "Toggles faces display");
-    setKeyDescription(::Qt::Key_D, "Cycle colouring faces by value (distance to the plane)");
-    setKeyDescription(::Qt::ShiftModifier, ::Qt::Key_D, "Colour by value: distance smooth, distance per cell, size per cell");
+    setKeyDescription(::Qt::Key_D, "Cycle coloring faces by value (distance to the plane)");
+    setKeyDescription(::Qt::ShiftModifier, ::Qt::Key_D, "Color by value: distance smooth, distance per cell, size per cell");
     setKeyDescription(::Qt::Key_Plus, "Increase size of edges");
     setKeyDescription(::Qt::Key_Minus, "Decrease size of edges");
     setKeyDescription(::Qt::ControlModifier, ::Qt::Key_Plus, "Increase size of vertices");
@@ -736,9 +736,9 @@ public:
         rendering_program_face.setUniformValue("u_RenderingTransparency", clipping_plane_rendering_transparency);
         rendering_program_face.setUniformValue("u_ClipPlane", clipPlane);
         rendering_program_face.setUniformValue("u_PointPlane", plane_point);
-        // Colour by value: the value is the distance to the clipping plane, over a scale
+        // Color by value: the value is the distance to the clipping plane, over a scale
         // anchored at the plane (0) and growing into the kept half, so moving the plane
-        // sweeps the colours instead of leaving them unchanged.
+        // sweeps the colors instead of leaving them unchanged.
         rendering_program_face.setUniformValue("u_ColorMapMode", static_cast<GLfloat>(m_color_map));
         { double dvmin, dvmax; distance_value_range(clipPlane, plane_point, dvmin, dvmax);
           rendering_program_face.setUniformValue("u_ValueMin", static_cast<GLfloat>(dvmin));
@@ -766,7 +766,7 @@ public:
         else if (m_color_map!=0 && (m_color_value==1 || m_color_value==2) && !vols.empty())
         {
           // Per cell: draw each volume with one flat value, so a whole cell takes
-          // one colour and neighbouring cells do not melt into one. The value is the
+          // one color and neighbouring cells do not melt into one. The value is the
           // centre's distance to the plane, or the cell size.
           rendering_program_face.setUniformValue("u_ColorPerCell", static_cast<GLint>(1));
           const std::vector<CGAL::Bbox_3> &bb=m_scene.get_volume_bboxes();
@@ -912,7 +912,7 @@ public:
             if (num_volumes == 0)
             { capcol = QVector4D(0.6f, 0.6f, 0.6f, 1.0f); }
             else if (m_color_map!=0)
-            { // Colour by value: cap follows the palette, like the volume's faces.
+            { // Color by value: cap follows the palette, like the volume's faces.
               const QColor cc=volume_value_color(v, clipPlane, plane_point);
               capcol = QVector4D(float(cc.redF()), float(cc.greenF()),
                                  float(cc.blueF()), 1.0f);
@@ -1014,7 +1014,7 @@ public:
           clipping_plane_rendering_transparency);
         rendering_program_face.setUniformValue("u_ClipPlane", clipPlane);
         rendering_program_face.setUniformValue("u_PointPlane", plane_point);
-        // Colour by value: the kept volumes follow the same colour map as the other
+        // Color by value: the kept volumes follow the same color map as the other
         // face modes, per fragment or one flat value per cell.
         rendering_program_face.setUniformValue("u_ColorMapMode", static_cast<GLfloat>(m_color_map));
         { double dvmin, dvmax; distance_value_range(clipPlane, plane_point, dvmin, dvmax);
@@ -1036,7 +1036,7 @@ public:
         if (num_volumes == 0)
         {
           // No volumes (a surface mesh, for example): there is nothing to clip whole,
-          // so colour all faces by value, including the drawer's per-face value.
+          // so color all faces by value, including the drawer's per-face value.
           if (m_color_map!=0 && m_color_value==3 && m_scene.has_face_values())
           {
             rendering_program_face.setUniformValue("u_ColorPerCell", static_cast<GLint>(1));
@@ -1206,7 +1206,7 @@ public:
       glEnable(GL_LIGHTING);
     }
 
-    // Colour by value: show the palette and the value range as a small legend.
+    // Color by value: show the palette and the value range as a small legend.
     if (m_color_map!=0)
     { draw_color_legend(clipPlane, plane_point); }
 
@@ -1845,7 +1845,7 @@ protected:
     }
   }
 
-  // Colour by value (size): one size per cell, the bounding-box volume, with the
+  // Color by value (size): one size per cell, the bounding-box volume, with the
   // range over all cells so the palette spans from the smallest to the largest.
   void compute_cell_sizes()
   {
@@ -1865,8 +1865,8 @@ protected:
     m_cell_sizes_valid=true;
   }
 
-  // Colour by value: the palette as a QColor, matching colour_palette() in the
-  // shader, so the legend bar shows the same colours as the faces.
+  // Color by value: the palette as a QColor, matching color_palette() in the
+  // shader, so the legend bar shows the same colors as the faces.
   QColor legend_palette_color(float t) const
   {
     auto cl=[](float x){ return x<0.f ? 0.f : (x>1.f ? 1.f : x); };
@@ -1877,7 +1877,7 @@ protected:
                               b=cl(1.5f-std::abs(4.f*t-1.f)); }
     else if (m_color_map<4) { r=g=b=cl(t); } // grey ramp
     else
-    { // viridis, the same coefficients as colour_palette() in Basic_shaders.h
+    { // viridis, the same coefficients as color_palette() in Basic_shaders.h
       static const float C[7][3]={
         { 0.277727f,  0.005407f,  0.334100f},
         { 0.105093f,  1.404614f,  1.384590f},
@@ -1896,21 +1896,21 @@ protected:
     return QColor(int(r*255.f), int(g*255.f), int(b*255.f));
   }
 
-  // Colour by value (distance): the actual signed-distance range the geometry spans
+  // Color by value (distance): the actual signed-distance range the geometry spans
   // along the plane normal, from the scene bounding-box corners, so the palette and
   // the legend cover the values really present rather than the whole scene radius
-  // (which left the colours bunched in the middle of the ramp).
+  // (which left the colors bunched in the middle of the ramp).
   void distance_value_range(const QVector4D &clipPlane, const QVector4D &plane_point,
                             double &vmin, double &vmax)
   {
-    // Colour by distance to the clipping plane, anchored at the plane: 0 at the plane
+    // Color by distance to the clipping plane, anchored at the plane: 0 at the plane
     // (one end of the palette), growing into the kept (solid) half up to its farthest
     // point. The kept half is dot(pos-pt, n) > 0 (see onPlane in the shader). We do not
     // use the symmetric bounding-box span, which would (a) shift with the plane so both
-    // range ends moved with the distances and the colours never changed when the plane
+    // range ends moved with the distances and the colors never changed when the plane
     // was only translated (they did on rotation), and (b) advertise in the legend the
-    // colours of the clipped-away half, which no visible face shows. Anchored at the
-    // plane the colours sweep as the plane is moved (the farthest distance changes), and
+    // colors of the clipped-away half, which no visible face shows. Anchored at the
+    // plane the colors sweep as the plane is moved (the farthest distance changes), and
     // the legend matches the visible faces.
     const CGAL::Bbox_3 b=m_scene.bounding_box();
     const QVector3D n=QVector3D(clipPlane).normalized();
@@ -1928,7 +1928,7 @@ protected:
     vmax=dmax;
   }
 
-  // Colour by value: the palette colour for a volume's clip-plane cap. The cap faces
+  // Color by value: the palette color for a volume's clip-plane cap. The cap faces
   // carry no value of their own, so the cap takes the value the volume shows: its
   // size, its centre distance, or the mean of its per-face values.
   QColor volume_value_color(std::size_t v, const QVector4D &clipPlane,
@@ -1957,8 +1957,8 @@ protected:
     return legend_palette_color(float(t));
   }
 
-  // Colour by value: draw a small legend, a gradient bar with the value range, so
-  // the colours read as numbers. The range and label match the current value.
+  // Color by value: draw a small legend, a gradient bar with the value range, so
+  // the colors read as numbers. The range and label match the current value.
   void draw_color_legend(const QVector4D &clipPlane, const QVector4D &plane_point)
   {
     double vmin, vmax;
@@ -1999,7 +1999,7 @@ protected:
   void initialize_buffers()
   {
     set_camera_mode();
-    m_cell_sizes_valid=false; // colour by value: the scene may have changed
+    m_cell_sizes_valid=false; // color by value: the scene may have changed
     rendering_program_p_l.bind();
 
     unsigned int bufn = 0;
@@ -2576,23 +2576,23 @@ protected:
       }
       else if ((e->key()==::Qt::Key_D) && (modifiers==::Qt::NoButton))
       {
-        // Colour the faces by a value (here the distance to the clipping plane):
+        // Color the faces by a value (here the distance to the clipping plane):
         // off, then the heat, jet and grey palettes.
         m_color_map=(m_color_map+1)%5;
         switch(m_color_map)
         {
-        case 0: displayMessage(QString("Colour by value = off")); break;
-        case 1: displayMessage(QString("Colour by value = heat")); break;
-        case 2: displayMessage(QString("Colour by value = jet")); break;
-        case 3: displayMessage(QString("Colour by value = grey")); break;
-        case 4: displayMessage(QString("Colour by value = viridis")); break;
+        case 0: displayMessage(QString("Color by value = off")); break;
+        case 1: displayMessage(QString("Color by value = heat")); break;
+        case 2: displayMessage(QString("Color by value = jet")); break;
+        case 3: displayMessage(QString("Color by value = grey")); break;
+        case 4: displayMessage(QString("Color by value = viridis")); break;
         default: break;
         }
         update();
       }
       else if ((e->key()==::Qt::Key_D) && (modifiers==::Qt::ShiftModifier))
       {
-        // Colour by value: pick the value and how it is shown. Skip the modes that
+        // Color by value: pick the value and how it is shown. Skip the modes that
         // do not apply to the current scene: the per-cell and size modes need
         // volumes, and the user value needs values set by the drawer. This keeps the
         // message, the faces and the legend in agreement.
@@ -2606,10 +2606,10 @@ protected:
         }
         switch(m_color_value)
         {
-        case 0: displayMessage(QString("Colour by value = distance (smooth)")); break;
-        case 1: displayMessage(QString("Colour by value = distance (per cell)")); break;
-        case 2: displayMessage(QString("Colour by value = size (per cell)")); break;
-        case 3: displayMessage(QString("Colour by value = %1 (per face)").arg(m_scene.value_name().c_str())); break;
+        case 0: displayMessage(QString("Color by value = distance (smooth)")); break;
+        case 1: displayMessage(QString("Color by value = distance (per cell)")); break;
+        case 2: displayMessage(QString("Color by value = size (per cell)")); break;
+        case 3: displayMessage(QString("Color by value = %1 (per face)").arg(m_scene.value_name().c_str())); break;
         default: break;
         }
         update();
@@ -2869,13 +2869,13 @@ protected:
   std::vector<std::vector<unsigned int>> m_edge_owners; // whole-volume clip: per edge, owning volumes
   std::vector<std::vector<unsigned int>> m_point_owners; // whole-volume clip: per vertex, owning volumes
   bool m_clip_owners_valid = false; // whole-volume clip: are the owner lists up to date
-  int m_color_map=0; // colour by value: 0 off, 1 heat, 2 jet, 3 grey ramp
-  int m_color_value=0; // colour by value source (Shift+D): 0 distance smooth,
+  int m_color_map=0; // color by value: 0 off, 1 heat, 2 jet, 3 grey ramp
+  int m_color_value=0; // color by value source (Shift+D): 0 distance smooth,
                        // 1 distance per cell, 2 size per cell
-  std::vector<float> m_cell_sizes; // colour by value: per-cell size (bbox volume)
-  float m_cell_size_min=0.f; // colour by value: size range for the palette
+  std::vector<float> m_cell_sizes; // color by value: per-cell size (bbox volume)
+  float m_cell_size_min=0.f; // color by value: size range for the palette
   float m_cell_size_max=1.f;
-  bool m_cell_sizes_valid=false; // colour by value: recompute the sizes on scene change
+  bool m_cell_sizes_valid=false; // color by value: recompute the sizes on scene change
   CGAL::qglviewer::ManipulatedFrame* m_frame_plane=nullptr;
 
   // Buffer for clipping plane is not stored in the scene because it is not

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -988,6 +988,22 @@ public:
           clipping_plane_rendering_transparency);
         rendering_program_face.setUniformValue("u_ClipPlane", clipPlane);
         rendering_program_face.setUniformValue("u_PointPlane", plane_point);
+        // Colour by value: the kept volumes follow the same colour map as the other
+        // face modes, per fragment or one flat value per cell.
+        rendering_program_face.setUniformValue("u_ColorMapMode", static_cast<GLfloat>(m_color_map));
+        rendering_program_face.setUniformValue("u_ValueMin", static_cast<GLfloat>(-sceneRadius()));
+        rendering_program_face.setUniformValue("u_ValueMax", static_cast<GLfloat>(sceneRadius()));
+        const bool per_cell=(m_color_map!=0 && m_color_value!=0 && num_volumes!=0);
+        const bool size_mode=(m_color_value==2);
+        if (per_cell && size_mode)
+        {
+          if (!m_cell_sizes_valid) { compute_cell_sizes(); }
+          rendering_program_face.setUniformValue("u_ValueMin", static_cast<GLfloat>(m_cell_size_min));
+          rendering_program_face.setUniformValue("u_ValueMax", static_cast<GLfloat>(m_cell_size_max));
+        }
+        rendering_program_face.setUniformValue("u_ColorPerCell", static_cast<GLint>(per_cell?1:0));
+        const QVector3D n=QVector3D(clipPlane).normalized();
+        const QVector3D pt=plane_point.toVector3D();
 
         vao[VAO_FACES].bind();
         if (num_volumes == 0)
@@ -997,9 +1013,24 @@ public:
         }
         else
         {
+          const std::vector<CGAL::Bbox_3> &bb = m_scene.get_volume_bboxes();
           for (std::size_t v = 0; v < num_volumes; ++v)
           {
             if (!m_volumes_kept[v]) { continue; }
+            if (per_cell)
+            {
+              float value;
+              if (size_mode) { value=m_cell_sizes[v]; }
+              else
+              {
+                const CGAL::Bbox_3 &b=bb[v];
+                const QVector3D c(float((b.xmin()+b.xmax())*0.5),
+                                  float((b.ymin()+b.ymax())*0.5),
+                                  float((b.zmin()+b.zmax())*0.5));
+                value=QVector3D::dotProduct(c-pt, n);
+              }
+              rendering_program_face.setUniformValue("u_CellValue", static_cast<GLfloat>(value));
+            }
             for (unsigned int fi : volumes[v])
             {
               const std::pair<unsigned int, unsigned int> &r = m_scene.face_range(fi);

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -910,6 +910,12 @@ public:
             QVector4D capcol;
             if (num_volumes == 0)
             { capcol = QVector4D(0.6f, 0.6f, 0.6f, 1.0f); }
+            else if (m_color_map!=0)
+            { // Colour by value: cap follows the palette, like the volume's faces.
+              const QColor cc=volume_value_color(v, clipPlane, plane_point);
+              capcol = QVector4D(float(cc.redF()), float(cc.greenF()),
+                                 float(cc.blueF()), 1.0f);
+            }
             else
             {
               const CGAL::IO::Color &c = vcolors[v];
@@ -1892,6 +1898,35 @@ protected:
     }
   }
 
+  // Colour by value: the palette colour for a volume's clip-plane cap. The cap faces
+  // carry no value of their own, so the cap takes the value the volume shows: its
+  // size, its centre distance, or the mean of its per-face values.
+  QColor volume_value_color(std::size_t v, const QVector4D &clipPlane,
+                            const QVector4D &plane_point)
+  {
+    const std::vector<std::vector<unsigned int>> &vols=m_scene.get_volume_faces();
+    double vmin, vmax, value;
+    if (m_color_value==3 && m_scene.has_face_values())
+    { vmin=m_scene.face_value_min(); vmax=m_scene.face_value_max();
+      const std::vector<float> &fv=m_scene.get_face_values();
+      double sum=0.0; std::size_t n=0;
+      for (unsigned int fi : vols[v]) { if (fi<fv.size()) { sum+=fv[fi]; ++n; } }
+      value=(n>0) ? sum/double(n) : vmin; }
+    else if (m_color_value==2)
+    { if (!m_cell_sizes_valid) { compute_cell_sizes(); }
+      vmin=m_cell_size_min; vmax=m_cell_size_max; value=m_cell_sizes[v]; }
+    else
+    { distance_value_range(clipPlane, plane_point, vmin, vmax);
+      const CGAL::Bbox_3 &b=m_scene.get_volume_bboxes()[v];
+      const QVector3D c(float((b.xmin()+b.xmax())*0.5), float((b.ymin()+b.ymax())*0.5),
+                        float((b.zmin()+b.zmax())*0.5));
+      value=QVector3D::dotProduct(c-plane_point.toVector3D(),
+                                  QVector3D(clipPlane).normalized()); }
+    double t=(vmax-vmin>1e-12) ? (value-vmin)/(vmax-vmin) : 0.0;
+    t=(t<0.0) ? 0.0 : (t>1.0 ? 1.0 : t);
+    return legend_palette_color(float(t));
+  }
+
   // Colour by value: draw a small legend, a gradient bar with the value range, so
   // the colours read as numbers. The range and label match the current value.
   void draw_color_legend(const QVector4D &clipPlane, const QVector4D &plane_point)
@@ -1905,7 +1940,7 @@ protected:
     { if (!m_cell_sizes_valid) { compute_cell_sizes(); }
       vmin=m_cell_size_min; vmax=m_cell_size_max; label=QString("size"); }
     else
-    { distance_value_range(clipPlane, plane_point, vmin, vmax); label=QString("distance"); }
+    { distance_value_range(clipPlane, plane_point, vmin, vmax); label=QString("distance to plane"); }
 
     // No range to map (a uniform value, e.g. a flat mesh with a parallel plane):
     // skip the legend rather than show a misleading full gradient. The threshold is

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -1829,7 +1829,24 @@ protected:
     else if (m_color_map<3) { r=cl(1.5f-std::abs(4.f*t-3.f)); // jet
                               g=cl(1.5f-std::abs(4.f*t-2.f));
                               b=cl(1.5f-std::abs(4.f*t-1.f)); }
-    else { r=g=b=cl(t); } // grey ramp
+    else if (m_color_map<4) { r=g=b=cl(t); } // grey ramp
+    else
+    { // viridis, the same coefficients as colour_palette() in Basic_shaders.h
+      static const float C[7][3]={
+        { 0.277727f,  0.005407f,  0.334100f},
+        { 0.105093f,  1.404614f,  1.384590f},
+        {-0.330862f,  0.214848f,  0.095095f},
+        {-4.634230f, -5.799101f, -19.332441f},
+        { 6.228270f, 14.179933f,  56.690553f},
+        { 4.776385f,-13.745145f, -65.353033f},
+        {-5.435456f,  4.645853f,  26.312435f}};
+      float rgb[3];
+      for (int k=0; k<3; ++k)
+      { float v=C[6][k];
+        for (int j=5; j>=0; --j) { v=C[j][k]+t*v; }
+        rgb[k]=cl(v); }
+      r=rgb[0]; g=rgb[1]; b=rgb[2];
+    }
     return QColor(int(r*255.f), int(g*255.f), int(b*255.f));
   }
 
@@ -2442,13 +2459,14 @@ protected:
       {
         // Colour the faces by a value (here the distance to the clipping plane):
         // off, then the heat, jet and grey palettes.
-        m_color_map=(m_color_map+1)%4;
+        m_color_map=(m_color_map+1)%5;
         switch(m_color_map)
         {
         case 0: displayMessage(QString("Colour by value = off")); break;
-        case 1: displayMessage(QString("Colour by value = heat (distance to plane)")); break;
-        case 2: displayMessage(QString("Colour by value = jet (distance to plane)")); break;
-        case 3: displayMessage(QString("Colour by value = grey (distance to plane)")); break;
+        case 1: displayMessage(QString("Colour by value = heat")); break;
+        case 2: displayMessage(QString("Colour by value = jet")); break;
+        case 3: displayMessage(QString("Colour by value = grey")); break;
+        case 4: displayMessage(QString("Colour by value = viridis")); break;
         default: break;
         }
         update();

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -1034,8 +1034,28 @@ public:
         vao[VAO_FACES].bind();
         if (num_volumes == 0)
         {
-          glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(
-            m_scene.number_of_elements(GS::POS_FACES)));
+          // No volumes (a surface mesh, for example): there is nothing to clip whole,
+          // so colour all faces by value, including the drawer's per-face value.
+          if (m_color_map!=0 && m_color_value==3 && m_scene.has_face_values())
+          {
+            rendering_program_face.setUniformValue("u_ColorPerCell", static_cast<GLint>(1));
+            rendering_program_face.setUniformValue("u_ValueMin", static_cast<GLfloat>(m_scene.face_value_min()));
+            rendering_program_face.setUniformValue("u_ValueMax", static_cast<GLfloat>(m_scene.face_value_max()));
+            const std::vector<float> &fvals=m_scene.get_face_values();
+            const unsigned int nf=m_scene.number_of_faces();
+            for (unsigned int f=0; f<nf && f<fvals.size(); ++f)
+            {
+              rendering_program_face.setUniformValue("u_CellValue", static_cast<GLfloat>(fvals[f]));
+              const std::pair<unsigned int, unsigned int> &r=m_scene.face_range(f);
+              glDrawArrays(GL_TRIANGLES, static_cast<GLint>(r.first),
+                           static_cast<GLsizei>(r.second));
+            }
+          }
+          else
+          {
+            glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(
+              m_scene.number_of_elements(GS::POS_FACES)));
+          }
         }
         else
         {

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -745,7 +745,24 @@ public:
 
         vao[VAO_FACES].bind();
         const std::vector<std::vector<unsigned int>> &vols=m_scene.get_volume_faces();
-        if (m_color_map!=0 && m_color_value!=0 && !vols.empty())
+        if (m_color_map!=0 && m_color_value==3 && m_scene.has_face_values())
+        {
+          // User value: one flat value per face, provided by the drawer (for example
+          // the aspect ratio of the face), mapped to the palette.
+          rendering_program_face.setUniformValue("u_ColorPerCell", static_cast<GLint>(1));
+          rendering_program_face.setUniformValue("u_ValueMin", static_cast<GLfloat>(m_scene.face_value_min()));
+          rendering_program_face.setUniformValue("u_ValueMax", static_cast<GLfloat>(m_scene.face_value_max()));
+          const std::vector<float> &fvals=m_scene.get_face_values();
+          const unsigned int nf=m_scene.number_of_faces();
+          for (unsigned int f=0; f<nf && f<fvals.size(); ++f)
+          {
+            rendering_program_face.setUniformValue("u_CellValue", static_cast<GLfloat>(fvals[f]));
+            const std::pair<unsigned int, unsigned int> &r=m_scene.face_range(f);
+            glDrawArrays(GL_TRIANGLES, static_cast<GLint>(r.first),
+                         static_cast<GLsizei>(r.second));
+          }
+        }
+        else if (m_color_map!=0 && (m_color_value==1 || m_color_value==2) && !vols.empty())
         {
           // Per cell: draw each volume with one flat value, so a whole cell takes
           // one colour and neighbouring cells do not melt into one. The value is the
@@ -1873,19 +1890,27 @@ protected:
       if (d<vmin) { vmin=d; }
       if (d>vmax) { vmax=d; }
     }
-    if (vmax-vmin<1e-6) { vmax=vmin+1.0; } // guard a degenerate (flat) range
   }
 
   // Colour by value: draw a small legend, a gradient bar with the value range, so
   // the colours read as numbers. The range and label match the current value.
   void draw_color_legend(const QVector4D &clipPlane, const QVector4D &plane_point)
   {
-    const bool size_mode=(m_color_value==2 && !m_scene.get_volume_faces().empty());
     double vmin, vmax;
-    if (size_mode)
+    QString label;
+    if (m_color_value==3 && m_scene.has_face_values())
+    { vmin=m_scene.face_value_min(); vmax=m_scene.face_value_max();
+      label=QString(m_scene.value_name().c_str()); }
+    else if (m_color_value==2 && !m_scene.get_volume_faces().empty())
     { if (!m_cell_sizes_valid) { compute_cell_sizes(); }
-      vmin=m_cell_size_min; vmax=m_cell_size_max; }
-    else { distance_value_range(clipPlane, plane_point, vmin, vmax); }
+      vmin=m_cell_size_min; vmax=m_cell_size_max; label=QString("size"); }
+    else
+    { distance_value_range(clipPlane, plane_point, vmin, vmax); label=QString("distance"); }
+
+    // No range to map (a uniform value, e.g. a flat mesh with a parallel plane):
+    // skip the legend rather than show a misleading full gradient. The threshold is
+    // relative to the value magnitude, so it holds at any scale.
+    if (vmax-vmin<=1e-6*(std::fabs(vmin)+std::fabs(vmax))) { return; }
 
     const int barW=16, barH=150;
     const int x=width()-barW-70, y=height()-barH-30;
@@ -1897,7 +1922,7 @@ protected:
     }
     painter.setPen(::Qt::black);
     painter.drawRect(x, y, barW, barH);
-    painter.drawText(x-2, y-8, QString(size_mode ? "size" : "distance"));
+    painter.drawText(x-2, y-8, label);
     painter.drawText(x+barW+5, y+11, QString::number(vmax, 'g', 3));
     painter.drawText(x+barW+5, y+barH, QString::number(vmin, 'g', 3));
     painter.end();
@@ -2499,15 +2524,24 @@ protected:
       }
       else if ((e->key()==::Qt::Key_D) && (modifiers==::Qt::ShiftModifier))
       {
-        // Colour by value: pick the value and how it is shown. Distance to the plane
-        // as a smooth gradient, the same distance as one flat colour per cell, then
-        // the cell size as one flat colour per cell.
-        m_color_value=(m_color_value+1)%3;
+        // Colour by value: pick the value and how it is shown. Skip the modes that
+        // do not apply to the current scene: the per-cell and size modes need
+        // volumes, and the user value needs values set by the drawer. This keeps the
+        // message, the faces and the legend in agreement.
+        const bool has_vols=!m_scene.get_volume_faces().empty();
+        const bool has_vals=m_scene.has_face_values();
+        for (int step=1; step<=4; ++step)
+        {
+          const int m=(m_color_value+step)%4;
+          if (m==0 || ((m==1 || m==2) && has_vols) || (m==3 && has_vals))
+          { m_color_value=m; break; }
+        }
         switch(m_color_value)
         {
         case 0: displayMessage(QString("Colour by value = distance (smooth)")); break;
         case 1: displayMessage(QString("Colour by value = distance (per cell)")); break;
         case 2: displayMessage(QString("Colour by value = size (per cell)")); break;
+        case 3: displayMessage(QString("Colour by value = %1 (per face)").arg(m_scene.value_name().c_str())); break;
         default: break;
         }
         update();

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -34,6 +34,7 @@
 
 #include <QApplication>
 #include <QKeyEvent>
+#include <QPainter>
 
 #include <CGAL/Qt/qglviewer.h>
 #include <CGAL/Qt/manipulatedFrame.h>
@@ -1159,6 +1160,10 @@ public:
       glEnable(GL_LIGHTING);
     }
 
+    // Colour by value: show the palette and the value range as a small legend.
+    if (m_color_map!=0)
+    { draw_color_legend(); }
+
     // Multiply matrix to get in the frame coordinate system.
     // glMultMatrixd(manipulatedFrame()->matrix()); // Linker error
     // Scale down the drawings
@@ -1812,6 +1817,47 @@ protected:
     }
     if (bb.empty()) { m_cell_size_min=0.f; m_cell_size_max=1.f; }
     m_cell_sizes_valid=true;
+  }
+
+  // Colour by value: the palette as a QColor, matching colour_palette() in the
+  // shader, so the legend bar shows the same colours as the faces.
+  QColor legend_palette_color(float t) const
+  {
+    auto cl=[](float x){ return x<0.f ? 0.f : (x>1.f ? 1.f : x); };
+    float r, g, b;
+    if (m_color_map<2) { r=cl(t*3.f); g=cl(t*3.f-1.f); b=cl(t*3.f-2.f); } // heat
+    else if (m_color_map<3) { r=cl(1.5f-std::abs(4.f*t-3.f)); // jet
+                              g=cl(1.5f-std::abs(4.f*t-2.f));
+                              b=cl(1.5f-std::abs(4.f*t-1.f)); }
+    else { r=g=b=cl(t); } // grey ramp
+    return QColor(int(r*255.f), int(g*255.f), int(b*255.f));
+  }
+
+  // Colour by value: draw a small legend, a gradient bar with the value range, so
+  // the colours read as numbers. The range and label match the current value.
+  void draw_color_legend()
+  {
+    const bool size_mode=(m_color_value==2 && !m_scene.get_volume_faces().empty());
+    double vmin, vmax;
+    if (size_mode)
+    { if (!m_cell_sizes_valid) { compute_cell_sizes(); }
+      vmin=m_cell_size_min; vmax=m_cell_size_max; }
+    else { vmin=-sceneRadius(); vmax=sceneRadius(); }
+
+    const int barW=16, barH=150;
+    const int x=width()-barW-70, y=height()-barH-30;
+    QPainter painter(this);
+    for (int i=0; i<barH; ++i)
+    {
+      const float t=1.f-float(i)/float(barH-1); // top of the bar is the max value
+      painter.fillRect(x, y+i, barW, 1, legend_palette_color(t));
+    }
+    painter.setPen(::Qt::black);
+    painter.drawRect(x, y, barW, barH);
+    painter.drawText(x-2, y-8, QString(size_mode ? "size" : "distance"));
+    painter.drawText(x+barW+5, y+11, QString::number(vmax, 'g', 3));
+    painter.drawText(x+barW+5, y+barH, QString::number(vmin, 'g', 3));
+    painter.end();
   }
 
   void initialize_buffers()

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -736,8 +736,9 @@ public:
         rendering_program_face.setUniformValue("u_RenderingTransparency", clipping_plane_rendering_transparency);
         rendering_program_face.setUniformValue("u_ClipPlane", clipPlane);
         rendering_program_face.setUniformValue("u_PointPlane", plane_point);
-        // Colour by value: the value is the distance to the clipping plane, scaled
-        // by the scene radius each side of it.
+        // Colour by value: the value is the distance to the clipping plane, over a scale
+        // anchored at the plane (0) and growing into the kept half, so moving the plane
+        // sweeps the colours instead of leaving them unchanged.
         rendering_program_face.setUniformValue("u_ColorMapMode", static_cast<GLfloat>(m_color_map));
         { double dvmin, dvmax; distance_value_range(clipPlane, plane_point, dvmin, dvmax);
           rendering_program_face.setUniformValue("u_ValueMin", static_cast<GLfloat>(dvmin));
@@ -1902,20 +1903,29 @@ protected:
   void distance_value_range(const QVector4D &clipPlane, const QVector4D &plane_point,
                             double &vmin, double &vmax)
   {
+    // Colour by distance to the clipping plane, anchored at the plane: 0 at the plane
+    // (one end of the palette), growing into the kept (solid) half up to its farthest
+    // point. The kept half is dot(pos-pt, n) > 0 (see onPlane in the shader). We do not
+    // use the symmetric bounding-box span, which would (a) shift with the plane so both
+    // range ends moved with the distances and the colours never changed when the plane
+    // was only translated (they did on rotation), and (b) advertise in the legend the
+    // colours of the clipped-away half, which no visible face shows. Anchored at the
+    // plane the colours sweep as the plane is moved (the farthest distance changes), and
+    // the legend matches the visible faces.
     const CGAL::Bbox_3 b=m_scene.bounding_box();
     const QVector3D n=QVector3D(clipPlane).normalized();
     const QVector3D pt=plane_point.toVector3D();
-    vmin=(std::numeric_limits<double>::max)();
-    vmax=-(std::numeric_limits<double>::max)();
+    double dmax=0.0;
     for (int c=0; c<8; ++c)
     {
       const QVector3D corner(float((c&1) ? b.xmax() : b.xmin()),
                              float((c&2) ? b.ymax() : b.ymin()),
                              float((c&4) ? b.zmax() : b.zmin()));
       const double d=QVector3D::dotProduct(corner-pt, n);
-      if (d<vmin) { vmin=d; }
-      if (d>vmax) { vmax=d; }
+      if (d>dmax) { dmax=d; }
     }
+    vmin=0.0;
+    vmax=dmax;
   }
 
   // Colour by value: the palette colour for a volume's clip-plane cap. The cap faces

--- a/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
+++ b/Basic_viewer/include/CGAL/Qt/Basic_viewer.h
@@ -125,6 +125,7 @@ public:
     setKeyDescription(::Qt::Key_V, "Toggles vertices display");
     setKeyDescription(::Qt::Key_W, "Toggles faces display");
     setKeyDescription(::Qt::Key_D, "Cycle colouring faces by value (distance to the plane)");
+    setKeyDescription(::Qt::ShiftModifier, ::Qt::Key_D, "Colour by value: per cell (flat) or smooth");
     setKeyDescription(::Qt::Key_Plus, "Increase size of edges");
     setKeyDescription(::Qt::Key_Minus, "Decrease size of edges");
     setKeyDescription(::Qt::ControlModifier, ::Qt::Key_Plus, "Increase size of vertices");
@@ -741,7 +742,32 @@ public:
         rendering_program_face.setUniformValue("u_ValueMax", static_cast<GLfloat>(sceneRadius()));
 
         vao[VAO_FACES].bind();
-        glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(m_scene.number_of_elements(GS::POS_FACES)));
+        const std::vector<std::vector<unsigned int>> &vols=m_scene.get_volume_faces();
+        if (m_color_map!=0 && m_color_per_cell && !vols.empty())
+        {
+          // Colour by value, per cell: one flat colour per volume, taken from its
+          // centre, so neighbouring cells do not melt into one.
+          rendering_program_face.setUniformValue("u_ColorPerCell", static_cast<GLint>(1));
+          const std::vector<CGAL::Bbox_3> &bb=m_scene.get_volume_bboxes();
+          for (std::size_t v=0; v<vols.size(); ++v)
+          {
+            const CGAL::Bbox_3 &b=bb[v];
+            rendering_program_face.setUniformValue("u_CellCentroid",
+              QVector3D(float((b.xmin()+b.xmax())*0.5), float((b.ymin()+b.ymax())*0.5),
+                        float((b.zmin()+b.zmax())*0.5)));
+            for (unsigned int fi : vols[v])
+            {
+              const std::pair<unsigned int, unsigned int> &r=m_scene.face_range(fi);
+              glDrawArrays(GL_TRIANGLES, static_cast<GLint>(r.first),
+                           static_cast<GLsizei>(r.second));
+            }
+          }
+        }
+        else
+        {
+          rendering_program_face.setUniformValue("u_ColorPerCell", static_cast<GLint>(0));
+          glDrawArrays(GL_TRIANGLES, 0, static_cast<GLsizei>(m_scene.number_of_elements(GS::POS_FACES)));
+        }
         glDisable(GL_POLYGON_OFFSET_FILL);
       };
 
@@ -2312,6 +2338,14 @@ protected:
         }
         update();
       }
+      else if ((e->key()==::Qt::Key_D) && (modifiers==::Qt::ShiftModifier))
+      {
+        // Colour by value: one flat colour per cell instead of a smooth gradient,
+        // so neighbouring cells with a close value do not melt together.
+        m_color_per_cell=!m_color_per_cell;
+        displayMessage(QString("Colour by value per cell=%1.").arg(m_color_per_cell?"true":"false"));
+        update();
+      }
       else if ((e->key()==::Qt::Key_Plus) && (!modifiers.testFlag(::Qt::ControlModifier))) // No ctrl
       {
         m_size_edges+=.5;
@@ -2568,6 +2602,7 @@ protected:
   std::vector<std::vector<unsigned int>> m_point_owners; // whole-volume clip: per vertex, owning volumes
   bool m_clip_owners_valid = false; // whole-volume clip: are the owner lists up to date
   int m_color_map=0; // colour by value: 0 off, 1 heat, 2 jet, 3 grey ramp
+  bool m_color_per_cell=false; // colour by value: one flat colour per cell (Shift+D)
   CGAL::qglviewer::ManipulatedFrame* m_frame_plane=nullptr;
 
   // Buffer for clipping plane is not stored in the scene because it is not

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -36,7 +36,7 @@ Release date: December 2026
 
 ### [Basic Viewer](https://doc.cgal.org/6.3/Manual/packages.html#PkgBasicViewer)
 
-- Added the possibility to colour the faces by a value mapped to a colour palette: the
+- Added the possibility to color the faces by a value mapped to a color palette: the
   distance to the clipping plane, the cell size, or a scalar value provided by the drawer.
   A drawer can attach a value to each face through the new `Graphics_scene_options` functions
   `is_face_valued` and `face_value` (with `face_value_name` for the legend). As an example, the

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -34,6 +34,13 @@ Release date: December 2026
   handle cases when some identical faces are shared between the input meshes. This leads to a significant speed up
   in those cases.
 
+### [Basic Viewer](https://doc.cgal.org/6.3/Manual/packages.html#PkgBasicViewer)
+
+- Added the possibility to colour the faces by a value mapped to a colour palette: the
+  distance to the clipping plane, the cell size, or a scalar value provided by the drawer.
+  A drawer can attach a value to each face through the new `Graphics_scene_options` functions
+  `valued_face` and `face_value` (with `face_value_name` for the legend). As an example, the
+  surface mesh drawer exposes the aspect ratio of each face.
 
 ## [Release 6.2](https://github.com/CGAL/cgal/releases/tag/v6.2)
 

--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -39,7 +39,7 @@ Release date: December 2026
 - Added the possibility to colour the faces by a value mapped to a colour palette: the
   distance to the clipping plane, the cell size, or a scalar value provided by the drawer.
   A drawer can attach a value to each face through the new `Graphics_scene_options` functions
-  `valued_face` and `face_value` (with `face_value_name` for the legend). As an example, the
+  `is_face_valued` and `face_value` (with `face_value_name` for the legend). As an example, the
   surface mesh drawer exposes the aspect ratio of each face.
 
 ## [Release 6.2](https://github.com/CGAL/cgal/releases/tag/v6.2)

--- a/Surface_mesh/include/CGAL/draw_surface_mesh.h
+++ b/Surface_mesh/include/CGAL/draw_surface_mesh.h
@@ -145,8 +145,8 @@ struct Graphics_scene_options_surface_mesh
     else
     { this->colored_face=[](const SM &, face_descriptor)->bool { return false; }; }
 
-    // Colour by value: expose the aspect ratio (longest edge / shortest edge) of
-    // each face, so the viewer can colour the mesh by it (Shift+D).
+    // Color by value: expose the aspect ratio (longest edge / shortest edge) of
+    // each face, so the viewer can color the mesh by it (Shift+D).
     this->face_value_name="aspect ratio";
     this->is_face_valued=[](const SM &, face_descriptor)->bool { return true; };
     this->face_value=[](const SM &sm, face_descriptor f)->float

--- a/Surface_mesh/include/CGAL/draw_surface_mesh.h
+++ b/Surface_mesh/include/CGAL/draw_surface_mesh.h
@@ -148,7 +148,7 @@ struct Graphics_scene_options_surface_mesh
     // Colour by value: expose the aspect ratio (longest edge / shortest edge) of
     // each face, so the viewer can colour the mesh by it (Shift+D).
     this->face_value_name="aspect ratio";
-    this->valued_face=[](const SM &, face_descriptor)->bool { return true; };
+    this->is_face_valued=[](const SM &, face_descriptor)->bool { return true; };
     this->face_value=[](const SM &sm, face_descriptor f)->float
     {
       double l2min=(std::numeric_limits<double>::max)(), l2max=0.0;

--- a/Surface_mesh/include/CGAL/draw_surface_mesh.h
+++ b/Surface_mesh/include/CGAL/draw_surface_mesh.h
@@ -144,6 +144,26 @@ struct Graphics_scene_options_surface_mesh
     }
     else
     { this->colored_face=[](const SM &, face_descriptor)->bool { return false; }; }
+
+    // Colour by value: expose the aspect ratio (longest edge / shortest edge) of
+    // each face, so the viewer can colour the mesh by it (Shift+D).
+    this->face_value_name="aspect ratio";
+    this->valued_face=[](const SM &, face_descriptor)->bool { return true; };
+    this->face_value=[](const SM &sm, face_descriptor f)->float
+    {
+      double l2min=(std::numeric_limits<double>::max)(), l2max=0.0;
+      auto h=halfedge(f, sm); const auto first=h;
+      do
+      {
+        const auto vec=sm.point(target(h, sm))-sm.point(source(h, sm));
+        const double l2=CGAL::to_double(vec.squared_length());
+        if (l2<l2min) { l2min=l2; }
+        if (l2>l2max) { l2max=l2; }
+        h=next(h, sm);
+      }
+      while (h!=first);
+      return (l2min>0.0) ? static_cast<float>(std::sqrt(l2max/l2min)) : 1.f;
+    };
   }
 
 private:


### PR DESCRIPTION
## Small feature 

Wiki page [here](https://cgalwiki.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Colour_faces_by_value_in_the_Basic_Viewer)

This PR adds a small feature to the public API: a drawer can attach a scalar value to each face, which the Basic_viewer maps to a colour palette, mirroring the existing colour path.

New API:
- `Graphics_scene_options`: `valued_face` (does this face have a value), `face_value` (the value), `face_value_name` (the legend label).
- `Graphics_scene`: `set_face_value(float)`, `set_value_name(const std::string&)`.

Purpose: mesh-quality visualisation. The viewer cannot compute a quality measure itself (it only has the boundary triangles); each drawer can. The surface mesh drawer uses this to expose the aspect ratio of each face.

Scope: small and additive. It mirrors `colored_face` / `face_color`, defaults to off (no value), and changes no existing behaviour.

## Description 

This adds an automatic colouring of the faces by a value, mapped to a colour from a palette, discussed with the mentors as a follow-up to the clipping work.

Palette (D key). D turns the colouring on and cycles the palette: off, then a heat, a jet, a grey ramp and viridis (a perceptually uniform map). The palette is evaluated in the face shader, so there is no texture.

Value (Shift+D key). Shift+D picks the value, skipping the ones that do not apply to the scene:
- distance to the plane, as a smooth per-fragment gradient;
- the same distance, one flat colour per cell (needs volumes);
- the cell size, one flat colour per cell (needs volumes);
- a value provided by the drawer, one flat colour per face (see below).

Distance is computed live in the shader from the clipping plane the user places with Ctrl+C. Distance and size are normalised over the range actually present in the scene, so the whole palette is used.

A value from the drawer. Following Guillaume's suggestion, the viewer does not have to compute geometric values itself. A drawer can attach a scalar value to each face, the same way it attaches a colour: the graphics-scene options gain valued_face / face_value / face_value_name, the scene stores the value next to the colour, and the viewer maps it to the palette. As the example, the surface mesh viewer exposes the aspect ratio (longest edge / shortest edge) of each face. This is the general mechanism for mesh-quality colouring (aspect ratio, Jacobian, and so on), with each drawer computing what its mesh allows.

Legend. A small legend is drawn when the colouring is on: a gradient bar in the current palette with the value range, labelled by the drawer's name (or distance / size). It uses the same range and palette as the faces, so the two match, and it is hidden when the value has no range (a uniform field).

The Basic_viewer part is contained in Basic_shaders.h and Basic_viewer.h. The value mechanism also touches Graphics_scene.h, Graphics_scene_options.h, the face-graph drawer (BGL/draw_face_graph.h), and the surface mesh drawer.

Testing: verified on grids of hexahedra (Linear_cell_complex) and on triangle meshes (Surface_mesh). The values and palettes behave as described, the per-cell and per-face modes read as flat blocks, the colours span the full palette with the legend matching the values present (including as the clipping plane is moved and rotated), the drawer-provided aspect ratio colours the surface mesh with a named legend, and the colouring holds in every clipping mode.

## Note on next step (Guillaume's suggestion)

The value mechanism generalises the built-in size and enables mesh-quality colouring per data structure. The surface mesh aspect ratio is the first example; values on volumes (set_volume_val) and other measures are natural follow-ups.