### PR TITLE
Nef_S2: fix error conditions in SM_io_parser::read_vertex

### DIFF
--- a/Nef_S2/include/CGAL/Nef_S2/SM_io_parser.h
+++ b/Nef_S2/include/CGAL/Nef_S2/SM_io_parser.h
@@ -203,7 +203,7 @@ bool SM_io_parser<Decorator_>::read_vertex(SVertex_handle v)
        !(in >> p) ||
        !check_sep("}") ) return false;
 
-  if(f<0 || (iso && f > fn) || (!iso && f > en))
+  if(f<0 || (iso && static_cast<unsigned>(f) >= fn) || (!iso && static_cast<unsigned>(f) >= en))
   {
     in.setstate(std::ios_base::badbit);
     return false;


### PR DESCRIPTION
## Summary of Changes

Fix an error condition in `SM_io_parser::read_vertex`.

## Release Management

* Affected package(s): Nef_s2
* License and copyright ownership: unchanged
