### PR TITLE
Lazy: replace std::call_once with lock-free atomic once in Lazy_rep::…

### DIFF
--- a/Filtered_kernel/include/CGAL/Lazy.h
+++ b/Filtered_kernel/include/CGAL/Lazy.h
@@ -51,6 +51,77 @@
 
 namespace CGAL {
 
+namespace internal {
+
+// Lock-free replacement for std::call_once in Lazy_rep::exact().
+//
+// libstdc++ has a futex fast path for std::call_once on Linux only; on
+// every other platform (notably mingw-w64) it falls back to the generic
+// implementation, which acquires a GLOBAL mutex and broadcasts a GLOBAL
+// condition variable (one kernel wake syscall) for every once_flag that
+// completes.  Lazy_rep evaluates each DAG node through call_once exactly
+// once, and an exact-kernel workload creates millions of nodes, so on
+// those platforms every first exactification pays a syscall and all
+// threads serialize on one process-wide lock: profiling a Boolean-set
+// workload on Windows/mingw-w64 showed ~1/3 of all samples inside
+// SetEvent stacks in a single-threaded run, and negative scaling at any
+// thread count (2 threads = 2x slower, 32 threads = 5.7x slower than 1).
+//
+// States: 0 = not run, 1 = running, 2 = done, 3 = running with waiters.
+// The fast path is a single acquire load; the completing thread issues a
+// wake only when a waiter actually announced itself, so the uncontended
+// case never touches the kernel.  An exception returns the flag to 0,
+// matching std::call_once semantics.
+//
+// C++20 atomic wait/notify is used when available (it parks contended
+// waiters in the kernel); in C++17 mode the rare contended wait
+// degrades to a yield loop, which is still strictly better than the
+// global-mutex path this replaces.
+inline void lazy_once_wait(std::atomic<unsigned char>& flag)
+{
+#if defined(__cpp_lib_atomic_wait)
+  flag.wait(3, std::memory_order_acquire);
+#else
+  while (flag.load(std::memory_order_acquire) == 3)
+    std::this_thread::yield();
+#endif
+}
+
+inline void lazy_once_wake(std::atomic<unsigned char>& flag)
+{
+#if defined(__cpp_lib_atomic_wait)
+  flag.notify_all();
+#else
+  (void)flag;
+#endif
+}
+
+template <class F>
+inline void lazy_call_once(std::atomic<unsigned char>& flag, F&& f)
+{
+  unsigned char s = flag.load(std::memory_order_acquire);
+  while (s != 2) {
+    if (s == 0 && flag.compare_exchange_weak(s, 1, std::memory_order_acquire)) {
+      try {
+        f();
+      } catch (...) {
+        if (flag.exchange(0, std::memory_order_release) == 3) lazy_once_wake(flag);
+        throw;
+      }
+      if (flag.exchange(2, std::memory_order_release) == 3) lazy_once_wake(flag);
+      return;
+    }
+    if (s == 1 && !flag.compare_exchange_weak(s, 3, std::memory_order_acquire))
+      continue;
+    if (s == 1 || s == 3) {
+      lazy_once_wait(flag);
+      s = flag.load(std::memory_order_acquire);
+    }
+  }
+}
+
+} // namespace internal
+
 template <typename D>
 class Bbox_d;
 
@@ -321,7 +392,7 @@ public:
 
   AT_wrap<AT> at_orig{};
   mutable std::atomic<AT_wrap<AT>*> ptr_ { &at_orig };
-  mutable std::once_flag once;
+  mutable std::atomic<unsigned char> once{0}; // see internal::lazy_call_once above
 
   Lazy_rep () {}
 
@@ -352,7 +423,7 @@ public:
   {
     // The test is unnecessary, only use it if benchmark says so, or in order to avoid calling Lazy_exact_Ex_Cst::update_exact() (which used to contain an assertion)
     //if (is_lazy())
-    std::call_once(once, [this](){this->update_exact();});
+    internal::lazy_call_once(once, [this](){this->update_exact();});
     return exact_unsafe(); // call_once already synchronized memory
   }
 
@@ -435,7 +506,7 @@ public:
   mutable AT at;
   mutable std::atomic<ET*> ptr_ { nullptr };
 #ifdef CGAL_HAS_THREADS
-  mutable std::once_flag once;
+  mutable std::atomic<unsigned char> once{0}; // see internal::lazy_call_once above
 #endif
 
   Lazy_rep () {}
@@ -477,7 +548,7 @@ public:
 #ifdef CGAL_HAS_THREADS
     // The test is unnecessary, only use it if benchmark says so, or in order to avoid calling Lazy_exact_Ex_Cst::update_exact() (which used to contain an assertion)
     //if (is_lazy())
-    std::call_once(once, [this](){this->update_exact();});
+    internal::lazy_call_once(once, [this](){this->update_exact();});
 #else
     if (is_lazy())
       this->update_exact();
@@ -547,7 +618,7 @@ public:
 
   mutable std::atomic<double> x, y; // -inf, +sup
   mutable std::atomic<ET*> ptr_ { nullptr };
-  mutable std::once_flag once;
+  mutable std::atomic<unsigned char> once{0}; // see internal::lazy_call_once above
 
   Lazy_rep (AT a = AT())
       : x(-a.inf()), y(a.sup()) {}
@@ -586,7 +657,7 @@ public:
   {
     // The test is unnecessary, only use it if benchmark says so, or in order to avoid calling Lazy_exact_Ex_Cst::update_exact() (which used to contain an assertion)
     //if (is_lazy())
-    std::call_once(once, [this](){this->update_exact();});
+    internal::lazy_call_once(once, [this](){this->update_exact();});
     return exact_unsafe(); // call_once already synchronized memory
   }
 


### PR DESCRIPTION
# `std::call_once` in `Lazy_rep::exact()` serializes all exact-kernel work on futex-less platforms (mingw-w64)

The accompanying patch is `cgal-lazy-call-once.patch` (against v6.2,
`Filtered_kernel/include/CGAL/Lazy.h`). 

## Summary

`Lazy_rep::exact()` guards lazy exactification with `std::call_once`
(Lazy.h, three sites). In libstdc++, `std::call_once` has a fast futex
path **on Linux only**; every other platform — notably Windows with
mingw-w64 — uses the generic fallback, which for *every completing
`once_flag`* acquires one **process-global mutex** and broadcasts one
**process-global condition variable** (a kernel wake syscall via
winpthreads `SetEvent`).

A lazy DAG node's flag completes exactly once, but an exact-kernel
workload (EPECK, `General_polygon_set_2` over circle-segment traits)
creates **millions of nodes**, so each of them pays a syscall, and —
much worse — every thread doing exactification serializes on that single
process-wide lock.

## Observed impact (Windows 11, mingw-w64 UCRT64, GCC 16.2, CGAL 6.2, 32 HW threads)

PCB pocketing workload (repeated `join`/`difference`/offset over arc
polygons), ETW trace with symbolized stacks:

* single-threaded run: ~1/3 of all CPU samples are in stacks ending in
  `SetEvent`, called from `Lazy_exact_*::update_exact` /
  `Real_embeddable_traits::Sgn` / `Sqrt_extension::compare`;
* thread scaling is **negative at any width**: 1 thread 2.29 s,
  2 threads — 2× slower, 32 threads — 5.7× slower than one; a 1.5 GB
  context-switch storm in the 8-thread trace (threads fighting for the
  global `once` mutex);
* on a real board the same computation took 187 s versus ~14 s on a
  comparable Linux box — entirely attributable to this effect.

With `std::call_once` replaced by a per-flag atomic once (patch below):

* single-threaded time halves (4.7 s → 2.4 s on our benchmark);
* parallel scaling becomes positive again (8 threads: 1.21 s);
* end-to-end: the 187 s board computation dropped to 8.0 s;
* results are bit-identical (the guard's semantics are unchanged).

## Fix

Replace the `std::once_flag` member with
`std::atomic<unsigned char>` (states: 0 not run / 1 running / 2 done /
3 running-with-waiters) and a small `internal::lazy_call_once`:

* fast path — one acquire load (same as the futex fast path on Linux);
* the winner runs `update_exact()` and wakes waiters **only if a waiter
  actually announced itself**, so the uncontended case never enters the
  kernel;
* an exception resets the flag to 0, matching `std::call_once`;
* contended waiting uses C++20 `atomic::wait/notify` when available
  (`__cpp_lib_atomic_wait`), with a yield loop as the C++17 fallback.

A related note already exists in Lazy.h ("The test is unnecessary, only
use it if benchmark says so" above `exact()`, and the long comment in
`Lazy_rep` discussing a CAS-based alternative) — this patch is
essentially that alternative, motivated by measurements.

The patch also shrinks `Lazy_rep` by `sizeof(std::once_flag) - 1` bytes
per node, which is a small win on all platforms including Linux.

## Reproducing

Any EPECK-heavy Boolean-set workload on mingw-w64 shows it; the quickest
check is a profiler: stacks of a single-threaded run are full of
`SetEvent` under `update_exact`. On Linux the futex path hides the
problem (a syscall only on actual contention), though the global
condvar broadcast still exists in the generic path for all other
futex-less targets.
