### PR TITLE
Add edge_is_marked in corefinement based functions

### DIFF
--- a/Installation/CHANGES.md
+++ b/Installation/CHANGES.md
@@ -40,9 +40,16 @@ Release date: December 2026
 
 ### [Boolean Operations On Meshes](https://doc.cgal.org/6.3/Manual/packages.html#PkgPMPBooleanOperations)
 
+### Polygon Mesh Processing - Boolean Operations
+- **Breaking change** Added to the corefinement based functions a new named parameter `edge_is_marked_map()` that will specifically collect new intersection edges.
+    Previously, `edge_is_constrained_map()` was storing both input constrained edges (updated when split) as well as new intersection edges.
+    The previous behavior can be reproduced, by passing the property map to both named parameters.
+- Added a new named parameter `edge_is_constrained_map()` to the `clip()` functions in order to preserve constrained edges when clipping a triangle mesh.
 - The corefinement based operations (including Boolean operations) has been optimized to better
   handle cases when some identical faces are shared between the input meshes. This leads to a significant speed up
   in those cases.
+
+
 
 
 ## [Release 6.2](https://github.com/CGAL/cgal/releases/tag/v6.2)

--- a/PMP_Boolean_operations/examples/PMP_Boolean_operations/corefinement_difference_remeshed.cpp
+++ b/PMP_Boolean_operations/examples/PMP_Boolean_operations/corefinement_difference_remeshed.cpp
@@ -49,8 +49,8 @@ int main(int argc, char* argv[])
   }
 
   // create a property on edges to indicate whether they are constrained
-  Mesh::Property_map<edge_descriptor,bool> is_constrained_map =
-    mesh1.add_property_map<edge_descriptor,bool>("e:is_constrained", false).first;
+  Mesh::Property_map<edge_descriptor,bool> is_marked_map =
+    mesh1.add_property_map<edge_descriptor,bool>("e:is_marked", false).first;
 
   // update mesh1 to contain the mesh bounding the difference
   // of the two input volumes.
@@ -60,7 +60,7 @@ int main(int argc, char* argv[])
                                          mesh1,
                                          params::default_values(), // default parameters for mesh1
                                          params::default_values(), // default parameters for mesh2
-                                         params::edge_is_constrained_map(is_constrained_map));
+                                         params::edge_is_marked_map(is_marked_map));
 
   if (valid_difference)
   {
@@ -77,7 +77,7 @@ int main(int argc, char* argv[])
   std::vector<face_descriptor> selected_faces;
   std::vector<bool> is_selected(num_faces(mesh1), false);
   for (edge_descriptor e : edges(mesh1))
-    if (is_constrained_map[e])
+    if (is_marked_map[e])
     {
       // insert all faces incident to the target vertex
       for (halfedge_descriptor h : halfedges_around_target(halfedge(e,mesh1),mesh1))
@@ -103,7 +103,7 @@ int main(int argc, char* argv[])
 
   // remesh the region around the intersection polylines
   PMP::isotropic_remeshing(selected_faces, 0.02, mesh1,
-                           params::edge_is_constrained_map(is_constrained_map));
+                           params::edge_is_constrained_map(is_marked_map));
 
   CGAL::IO::write_polygon_mesh("difference_remeshed.off", mesh1, CGAL::parameters::stream_precision(17));
 

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/clip.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/clip.h
@@ -1342,7 +1342,7 @@ void split(TriangleMesh& tm,
   const bool do_not_modify_splitter = choose_parameter(get_parameter(np_s, internal_np::do_not_modify), false);
 
   PMP::corefine(tm, splitter,
-                CGAL::parameters::vertex_point_map(vpm_tm).edge_is_constrained_map(ecm).visitor(uv),
+                CGAL::parameters::vertex_point_map(vpm_tm).edge_is_marked_map(ecm).visitor(uv),
                 CGAL::parameters::vertex_point_map(vpm_s).do_not_modify(do_not_modify_splitter));
 
   //split mesh along marked edges

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/clip.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/clip.h
@@ -713,7 +713,7 @@ generic_clip_impl(
   typedef Corefinement::No_mark<TriangleMesh> NoMap;
   typedef Corefinement::Edge_properties_for_input<TriangleMesh, User_cst_map, NoMap, Edge_mark_map, NoMap> Edge_properties_in;
 
-  Edge_mark_map edge_mark_map  = get(CGAL::dynamic_edge_property_t<bool>(), tm1);
+  Edge_mark_map edge_mark_map  = get(CGAL::dynamic_edge_property_t<bool>(), tm1, false);
 
   // Face index point maps
   typedef typename CGAL::GetInitializedFaceIndexMap<TriangleMesh, NamedParameters1>::type FaceIndexMap1;
@@ -838,6 +838,13 @@ struct Visitor_wrapper_for_triangulate_face
   *                     will be set after refining `tm` with the intersection with `clipper`}
   *   \cgalParamNEnd
   *
+  *   \cgalParamNBegin{edge_is_constrained_map}
+  *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm`}
+  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor` as key type and `bool` as value type.
+  *                    If an edge marked as constrained in `tm` is split during clipping, the remaining part after the clip will be marked as constrained.}
+  *     \cgalParamDefault{a constant property map returning `false` for any edge}
+  *   \cgalParamNEnd
+  *
   *   \cgalParamNBegin{visitor}
   *     \cgalParamDescription{a visitor used to track the creation of new faces}
   *     \cgalParamType{a class model of `PMPCorefinementVisitor`}
@@ -943,6 +950,13 @@ clip(TriangleMesh& tm,
   *     \cgalParamDefault{`boost::get(CGAL::vertex_point, pm)`}
   *   \cgalParamNEnd
   *
+  *   \cgalParamNBegin{edge_is_constrained_map}
+  *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm`}
+  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor` as key type and `bool` as value type.
+  *                    If an edge marked as constrained in `tm` is split during clipping, the remaining part after the clip will be marked as constrained.}
+  *     \cgalParamDefault{a constant property map returning `false` for any edge}
+  *   \cgalParamNEnd
+  *
   *   \cgalParamNBegin{visitor}
   *     \cgalParamDescription{a visitor used to track the creation of new faces, edges, and faces.
   *                           Note that as there are no mesh associated with `plane`,
@@ -1032,6 +1046,7 @@ bool clip(PolygonMesh& pm,
     return true;
   }
 
+  using edge_descriptor = typename boost::graph_traits<PolygonMesh>::edge_descriptor;
   using halfedge_descriptor = typename boost::graph_traits<PolygonMesh>::halfedge_descriptor;
 
   using GT = typename GetGeomTraits<PolygonMesh, NamedParameters>::type;
@@ -1064,14 +1079,19 @@ bool clip(PolygonMesh& pm,
   bool triangulate = !choose_parameter(get_parameter(np, internal_np::do_not_triangulate_faces), false);
   constexpr bool traits_supports_cdt2 = !internal::Has_member_Does_not_support_CDT2<GT>::value;
   auto vos = get(dynamic_vertex_property_t<Oriented_side>(), pm);
-  auto ecm = get(dynamic_edge_property_t<bool>(), pm, false);
+
+  using Default_ecm = Static_boolean_property_map<edge_descriptor, false>;
+  auto ecm = choose_parameter<Default_ecm>(get_parameter(np, internal_np::edge_is_constrained));
+  auto edge_is_marked_map = get(dynamic_edge_property_t<bool>(), pm, false);
+
   auto construct_orthogonal_vector = traits.construct_orthogonal_vector_3_object();
 
   if (traits_supports_cdt2 && triangulate && !is_triangle_mesh(pm))
     triangulate = false;
 
   refine_with_plane(pm, plane, parameters::vertex_oriented_side_map(vos)
-                                          .edge_is_marked_map(ecm)
+                                          .edge_is_marked_map(edge_is_marked_map)
+                                          .edge_is_constrained_map(ecm)
                                           .vertex_point_map(vpm)
                                           .geom_traits(traits)
                                           .do_not_triangulate_faces(!triangulate)
@@ -1092,7 +1112,7 @@ bool clip(PolygonMesh& pm,
 
   auto fcc = get(dynamic_face_property_t<std::size_t>(), pm);
 
-  std::size_t nbcc = connected_components(pm, fcc, CGAL::parameters::edge_is_constrained_map(ecm));
+  std::size_t nbcc = connected_components(pm, fcc, CGAL::parameters::edge_is_constrained_map(edge_is_marked_map));
 
   std::vector<bool> classified(nbcc, false);
   std::vector<std::size_t> ccs_to_remove;
@@ -1164,6 +1184,13 @@ bool clip(PolygonMesh& pm,
   *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<PolygonMesh>::%vertex_descriptor`
   *                    as key type and `%Point_3` as value type}
   *     \cgalParamDefault{`boost::get(CGAL::vertex_point, tm)`}
+  *   \cgalParamNEnd
+  *
+  *   \cgalParamNBegin{edge_is_constrained_map}
+  *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm`}
+  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor` as key type and `bool` as value type.
+  *                    If an edge marked as constrained in `tm` is split during clipping, the remaining part after the clip will be marked as constrained.}
+  *     \cgalParamDefault{a constant property map returning `false` for any edge}
   *   \cgalParamNEnd
   *
   *   \cgalParamNBegin{visitor}
@@ -1239,8 +1266,7 @@ bool clip(TriangleMesh& tm,
 
   make_hexahedron(iso_cuboid[0], iso_cuboid[1], iso_cuboid[2], iso_cuboid[3],
                   iso_cuboid[4], iso_cuboid[5], iso_cuboid[6], iso_cuboid[7],
-                  clipper);
-  triangulate_faces(clipper);
+                  clipper, parameters::do_not_triangulate_faces(false));
 
   const bool do_not_modify = choose_parameter(get_parameter(np, internal_np::allow_self_intersections), false);
   return clip(tm, clipper, np, params::do_not_modify(do_not_modify));

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/clip.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/clip.h
@@ -706,17 +706,14 @@ generic_clip_impl(
     internal_np::edge_is_constrained_t,
     NamedParameters1,
     Corefinement::No_mark<TriangleMesh>//default
-  > ::type User_ecm1;
+  > ::type User_cst_map;
 
   // User and internal edge is-constrained map
-  typedef typename boost::template property_map<TriangleMesh, CGAL::dynamic_edge_property_t<bool> >::type Algo_ecm1;
-  typedef Corefinement::No_mark<TriangleMesh> Ecm2;
-  typedef OR_property_map<Algo_ecm1, User_ecm1> Ecm1;
-  typedef Corefinement::Ecm_bind<TriangleMesh, Ecm1, Ecm2> Ecm_in;
+  typedef typename boost::template property_map<TriangleMesh, CGAL::dynamic_edge_property_t<bool> >::type Edge_mark_map;
+  typedef Corefinement::No_mark<TriangleMesh> NoMap;
+  typedef Corefinement::Edge_properties_for_input<TriangleMesh, User_cst_map, NoMap, Edge_mark_map, NoMap> Edge_properties_in;
 
-  Algo_ecm1 algo_ecm1  = get(CGAL::dynamic_edge_property_t<bool>(), tm1);
-  Ecm1 ecm1 = Ecm1(algo_ecm1, choose_parameter<User_ecm1>(get_parameter(np1, internal_np::edge_is_constrained)));
-  Ecm2 ecm2;
+  Edge_mark_map edge_mark_map  = get(CGAL::dynamic_edge_property_t<bool>(), tm1);
 
   // Face index point maps
   typedef typename CGAL::GetInitializedFaceIndexMap<TriangleMesh, NamedParameters1>::type FaceIndexMap1;
@@ -737,17 +734,19 @@ generic_clip_impl(
   // surface intersection algorithm call
   typedef Corefinement::Generic_clip_output_builder<TriangleMesh,
                                                     Vpm, Vpm2,
-                                                    Algo_ecm1,
+                                                    Edge_mark_map,
                                                     FaceIndexMap1,
                                                     Default> Ob;
 
   typedef Corefinement::Surface_intersection_visitor_for_corefinement<
-    TriangleMesh, Vpm, Vpm2, Ob, Ecm_in, User_visitor> Algo_visitor;
-  Ecm_in ecm_in(tm1,tm2,ecm1,ecm2);
-  Ob ob(tm1, tm2, vpm1, vpm2, algo_ecm1, fid_map1, use_compact_clipper);
+    TriangleMesh, Vpm, Vpm2, Ob, Edge_properties_in, User_visitor> Algo_visitor;
+  Edge_properties_in edge_properties_in(tm1,tm2,
+                                        choose_parameter<NoMap>(get_parameter(np1, internal_np::edge_is_constrained)),
+                                        NoMap(),edge_mark_map, NoMap());
+  Ob ob(tm1, tm2, vpm1, vpm2, edge_mark_map, fid_map1, use_compact_clipper);
 
   Corefinement::Intersection_of_triangle_meshes<TriangleMesh, Vpm, Vpm2, Algo_visitor >
-    functor(tm1, tm2, vpm1, vpm2, Algo_visitor(uv,ob,ecm_in,&tm2), &tm2);
+    functor(tm1, tm2, vpm1, vpm2, Algo_visitor(uv,ob,edge_properties_in,&tm2), &tm2);
   functor(CGAL::Emptyset_iterator(), false, true);
 }
 

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/corefinement.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/corefinement.h
@@ -191,8 +191,8 @@ enum Boolean_operation_type {UNION = 0, INTERSECTION=1,
   *
   *   \cgalParamNBegin{edge_is_constrained_map}
   *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm1` (`tm2`)}
-  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
-  *                    as key type and `bool` as value type}
+  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`as key type and `bool` as value type.
+  *                    If an edge marked as constrained in `tm1` (tm2`) is split during corefinement, the resulting sub-edges will be marked as constrained.}
   *     \cgalParamDefault{a constant property map returning `false` for any edge}
   *   \cgalParamNEnd
   *
@@ -246,8 +246,8 @@ enum Boolean_operation_type {UNION = 0, INTERSECTION=1,
   *
   *   \cgalParamNBegin{edge_is_constrained_map}
   *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm_out`.
-  *                           An edge of `tm_out` is constrained if it is on the intersection of `tm1` and `tm2`,
-  *                           or if the edge corresponds to a constrained edge in `tm1` or `tm2`.}
+  *                           An edge of `tm_out` is constrained if the edge corresponds to a constrained edge in `tm1` or `tm2`.
+  *                           If an edge marked as constrained in `tm1` (tm2`) is split during corefinement, the resulting sub-edges will be marked as constrained.}
   *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
   *                    as key type and `bool` as value type}
   *   \cgalParamNEnd
@@ -529,8 +529,8 @@ corefine_and_compute_boolean_operations(
   *
   *   \cgalParamNBegin{edge_is_constrained_map}
   *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm1` (`tm2`)}
-  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
-  *                    as key type and `bool` as value type}
+  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`as key type and `bool` as value type
+  *                    If an edge marked as constrained in `tm1` (tm2`) is split during corefinement, the resulting sub-edges will be marked as constrained.
   *     \cgalParamDefault{a constant property map returning `false` for any edge}
   *   \cgalParamNEnd
   *
@@ -583,8 +583,7 @@ corefine_and_compute_boolean_operations(
   *
   *   \cgalParamNBegin{edge_is_constrained_map}
   *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm_out`.
-  *                           An edge of `tm_out` is constrained if it is on the intersection of `tm1` and `tm2`,
-  *                           or if the edge corresponds to a constrained edge in `tm1` or `tm2`.}
+  *                           An edge of `tm_out` is constrained if the edge corresponds to a (part of a) constrained edge in `tm1` or `tm2`.}
   *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
   *                    as key type and `bool` as value type}
   *   \cgalParamNEnd
@@ -724,9 +723,8 @@ corefine_and_compute_difference(      TriangleMesh& tm1,
  *
  *   \cgalParamNBegin{edge_is_constrained_map}
  *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm1` (`tm2`)}
- *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
- *                    as key type and `bool` as value type. If an edge marked as constrained is split by this function,
- *                    the resulting edges will also be marked as constrained.}
+ *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor` as key type and `bool` as value type.
+ *                    If an edge marked as constrained in is split during corefinement, the resulting sub-edges will be marked as constrained.}
  *     \cgalParamDefault{a constant property map returning `false` for any edge}
  *   \cgalParamNEnd
  *

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/corefinement.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/corefinement.h
@@ -141,16 +141,6 @@ enum Boolean_operation_type {UNION = 0, INTERSECTION=1,
 #endif
 }
 
-
-#define CGAL_COREF_SET_OUTPUT_EDGE_MARK_MAP(I) \
-  typedef typename internal_np::Lookup_named_param_def < \
-    internal_np::edge_is_constrained_t, \
-    NPOut##I, \
-    Corefinement::No_mark<TriangleMesh> \
-  > ::type Ecm_out_##I; \
-    Ecm_out_##I ecm_out_##I = \
-      parameters::choose_parameter<Ecm_out_##I>(parameters::get_parameter(std::get<I>(nps_out), internal_np::edge_is_constrained));
-
 /**
   * \ingroup PMP_boolop_grp
   *
@@ -296,7 +286,10 @@ corefine_and_compute_boolean_operations(
                    NPOut1,
                    NPOut2,
                    NPOut3>& nps_out
-                    = std::tuple<NPOut0,NPOut1,NPOut2,NPOut3>())
+                    = std::tuple<NPOut0,NPOut1,NPOut2,NPOut3>(parameters::default_values(),
+                                                              parameters::default_values(),
+                                                              parameters::default_values(),
+                                                              parameters::default_values()))
 {
   using parameters::choose_parameter;
   using parameters::get_parameter;
@@ -435,14 +428,7 @@ corefine_and_compute_boolean_operations(
   typedef typename Corefinement::Get_Ecm_bind<TriangleMesh, NPIn1, NPIn2>::type Ecm_in;
 
   //for output meshes
-  CGAL_COREF_SET_OUTPUT_EDGE_MARK_MAP(0)
-  CGAL_COREF_SET_OUTPUT_EDGE_MARK_MAP(1)
-  CGAL_COREF_SET_OUTPUT_EDGE_MARK_MAP(2)
-  CGAL_COREF_SET_OUTPUT_EDGE_MARK_MAP(3)
-
-  // In the current version all types must be the same so an array would be fine
-  typedef std::tuple<Ecm_out_0, Ecm_out_1, Ecm_out_2, Ecm_out_3>
-                                                            Edge_mark_map_tuple;
+  typedef typename Corefinement::Get_Ecm_out_bind<TriangleMesh, std::tuple<NPOut0, NPOut1, NPOut2,NPOut3>>::type Ecm_out;
 
   // Face index point maps
   typedef typename CGAL::GetInitializedFaceIndexMap<TriangleMesh, NPIn1>::type FaceIndexMap1;
@@ -469,14 +455,14 @@ corefine_and_compute_boolean_operations(
                                                   FaceIndexMap2,
                                                   Default,
                                                   Ecm_in,
-                                                  Edge_mark_map_tuple,
+                                                  Ecm_out,
                                                   User_visitor> Ob;
 
   typedef Corefinement::Surface_intersection_visitor_for_corefinement<
             TriangleMesh, VPM1, VPM2, Ob, Ecm_in, User_visitor> Algo_visitor;
 
   Ecm_in ecm_in(tm1,tm2,np1,np2);
-  Edge_mark_map_tuple ecms_out(ecm_out_0, ecm_out_1, ecm_out_2, ecm_out_3);
+  Ecm_out ecms_out(nps_out);
   Ob ob(tm1, tm2, vpm1, vpm2, fid_map1, fid_map2, ecm_in, vpm_out_tuple, ecms_out, uv, output);
 
   // special case used for clipping open meshes

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/corefinement.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/corefinement.h
@@ -201,9 +201,17 @@ enum Boolean_operation_type {UNION = 0, INTERSECTION=1,
   *
   *   \cgalParamNBegin{edge_is_constrained_map}
   *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm1` (`tm2`)}
-  *     \cgalParamType{a class model of `ReadablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
+  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
   *                    as key type and `bool` as value type}
   *     \cgalParamDefault{a constant property map returning `false` for any edge}
+  *   \cgalParamNEnd
+  *
+  *   \cgalParamNBegin{edge_is_marked_map}
+  *     \cgalParamDescription{a property map filled by this function with `true` for all intersection edges of faces
+  *                           of `tm1` and `tm1`, and `false` for all other edges.}
+  *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
+  *                    as key type and `bool` as value type}
+  *     \cgalParamDefault{unused}
   *   \cgalParamNEnd
   *
   *   \cgalParamNBegin{face_index_map}
@@ -253,6 +261,15 @@ enum Boolean_operation_type {UNION = 0, INTERSECTION=1,
   *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
   *                    as key type and `bool` as value type}
   *   \cgalParamNEnd
+  *
+  *   \cgalParamNBegin{edge_is_marked_map}
+  *     \cgalParamDescription{a property map filled by this function with `true` for all intersection edges of faces
+  *                           of `tm1` and `tm1`, and `false` for all other edges.}
+  *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
+  *                    as key type and `bool` as value type}
+  *     \cgalParamDefault{unused}
+  *   \cgalParamNEnd
+  *
   * \cgalNamedParamsEnd
   *
   * @return an array filled as follows: for each operation computed, the position in the array
@@ -413,24 +430,9 @@ corefine_and_compute_boolean_operations(
       return CGAL::make_array(true, true, true, true);
     }
 
-// Edge is-constrained maps
+// Edge property maps
   //for input meshes
-  typedef typename internal_np::Lookup_named_param_def <
-    internal_np::edge_is_constrained_t,
-    NPIn1,
-    Corefinement::No_mark<TriangleMesh>//default
-  > ::type Ecm1;
-
-  typedef typename internal_np::Lookup_named_param_def <
-    internal_np::edge_is_constrained_t,
-    NPIn2,
-    Corefinement::No_mark<TriangleMesh>//default
-  > ::type Ecm2;
-
-  Ecm1 ecm1 = choose_parameter<Ecm1>(get_parameter(np1, internal_np::edge_is_constrained));
-  Ecm2 ecm2 = choose_parameter<Ecm2>(get_parameter(np2, internal_np::edge_is_constrained));
-
-  typedef Corefinement::Ecm_bind<TriangleMesh, Ecm1, Ecm2> Ecm_in;
+  typedef typename Corefinement::Get_Ecm_bind<TriangleMesh, NPIn1, NPIn2>::type Ecm_in;
 
   //for output meshes
   CGAL_COREF_SET_OUTPUT_EDGE_MARK_MAP(0)
@@ -473,7 +475,7 @@ corefine_and_compute_boolean_operations(
   typedef Corefinement::Surface_intersection_visitor_for_corefinement<
             TriangleMesh, VPM1, VPM2, Ob, Ecm_in, User_visitor> Algo_visitor;
 
-  Ecm_in ecm_in(tm1,tm2,ecm1,ecm2);
+  Ecm_in ecm_in(tm1,tm2,np1,np2);
   Edge_mark_map_tuple ecms_out(ecm_out_0, ecm_out_1, ecm_out_2, ecm_out_3);
   Ob ob(tm1, tm2, vpm1, vpm2, fid_map1, fid_map2, ecm_in, vpm_out_tuple, ecms_out, uv, output);
 
@@ -541,9 +543,17 @@ corefine_and_compute_boolean_operations(
   *
   *   \cgalParamNBegin{edge_is_constrained_map}
   *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm1` (`tm2`)}
-  *     \cgalParamType{a class model of `ReadablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
+  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
   *                    as key type and `bool` as value type}
   *     \cgalParamDefault{a constant property map returning `false` for any edge}
+  *   \cgalParamNEnd
+  *
+  *   \cgalParamNBegin{edge_is_marked_map}
+  *     \cgalParamDescription{a property map filled by this function with `true` for all intersection edges of faces
+  *                           of `tm1` and `tm1`, and `false` for all other edges.}
+  *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
+  *                    as key type and `bool` as value type}
+  *     \cgalParamDefault{unused}
   *   \cgalParamNEnd
   *
   *   \cgalParamNBegin{face_index_map}
@@ -592,6 +602,15 @@ corefine_and_compute_boolean_operations(
   *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
   *                    as key type and `bool` as value type}
   *   \cgalParamNEnd
+  *
+  *   \cgalParamNBegin{edge_is_marked_map}
+  *     \cgalParamDescription{a property map filled by this function with `true` for all intersection edges of faces
+  *                           of `tm1` and `tm1`, and `false` for all other edges.}
+  *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
+  *                    as key type and `bool` as value type}
+  *     \cgalParamDefault{unused}
+  *   \cgalParamNEnd
+  *
   * \cgalNamedParamsEnd
   *
   * @return `true` if the output surface mesh is manifold and is put into `tm_out`.
@@ -719,9 +738,18 @@ corefine_and_compute_difference(      TriangleMesh& tm1,
  *
  *   \cgalParamNBegin{edge_is_constrained_map}
  *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm1` (`tm2`)}
- *     \cgalParamType{a class model of `ReadablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
- *                    as key type and `bool` as value type}
+ *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
+ *                    as key type and `bool` as value type. If an edge marked as constrained is split by this function,
+ *                    the resulting edges will also be marked as constrained.}
  *     \cgalParamDefault{a constant property map returning `false` for any edge}
+ *   \cgalParamNEnd
+ *
+ *   \cgalParamNBegin{edge_is_marked_map}
+ *     \cgalParamDescription{a property map filled by this function with `true` for all intersection edges of faces
+ *                           of `tm1` and `tm1`, and `false` for all other edges.}
+ *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
+ *                    as key type and `bool` as value type}
+ *     \cgalParamDefault{unused}
  *   \cgalParamNEnd
  *
  *   \cgalParamNBegin{visitor}
@@ -791,28 +819,15 @@ corefine(      TriangleMesh& tm1,
   VPM2 vpm2 = choose_parameter(get_parameter(np2, internal_np::vertex_point),
                                get_property_map(boost::vertex_point, tm2));
 
-// Edge is-constrained maps
-  typedef typename internal_np::Lookup_named_param_def <
-    internal_np::edge_is_constrained_t,
-    NamedParameters1,
-    Corefinement::No_mark<TriangleMesh>//default
-  > ::type Ecm1;
+// Edge property maps
+  typedef typename Corefinement::Get_Ecm_bind<TriangleMesh, NamedParameters1, NamedParameters2>::type Ecm;
+  Ecm ecm(tm1,tm2,np1, np2);
 
-  typedef typename internal_np::Lookup_named_param_def <
-    internal_np::edge_is_constrained_t,
-    NamedParameters2,
-    Corefinement::No_mark<TriangleMesh>//default
-  > ::type Ecm2;
-
-  Ecm1 ecm1 = choose_parameter<Ecm1>(get_parameter(np1, internal_np::edge_is_constrained));
-  Ecm2 ecm2 = choose_parameter<Ecm2>(get_parameter(np2, internal_np::edge_is_constrained));
-
-  typedef Corefinement::Ecm_bind<TriangleMesh, Ecm1, Ecm2> Ecm;
-
+// TODO: double check that what we get with shared faces PR (actually coref should have them but bool op are unchecking them)
   if (&tm1==&tm2)
   {
-    Corefinement::mark_all_edges(tm1, ecm1);
-    Corefinement::mark_all_edges(tm2, ecm2);
+    ecm.set_on_intersection(tm1, edges(tm1));
+    ecm.set_on_intersection(tm2, edges(tm2));
     return;
   }
 
@@ -834,7 +849,6 @@ corefine(      TriangleMesh& tm1,
   TriangleMesh, VPM1, VPM2, Ob, Ecm, User_visitor, false, handle_non_manifold_features> Algo_visitor;
 
   Ob ob;
-  Ecm ecm(tm1,tm2,ecm1,ecm2);
   Corefinement::Intersection_of_triangle_meshes<TriangleMesh, VPM1, VPM2, Algo_visitor>
     functor(tm1, tm2, vpm1, vpm2, Algo_visitor(uv,ob,ecm,const_mesh_ptr), const_mesh_ptr);
 

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/corefinement.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/corefinement.h
@@ -425,10 +425,10 @@ corefine_and_compute_boolean_operations(
 
 // Edge property maps
   //for input meshes
-  typedef typename Corefinement::Get_Ecm_bind<TriangleMesh, NPIn1, NPIn2>::type Ecm_in;
+  typedef typename Corefinement::Get_Edge_properties_for_input<TriangleMesh, NPIn1, NPIn2>::type Edge_properties_in;
 
   //for output meshes
-  typedef typename Corefinement::Get_Ecm_out_bind<TriangleMesh, std::tuple<NPOut0, NPOut1, NPOut2,NPOut3>>::type Ecm_out;
+  typedef typename Corefinement::Get_edge_properties_for_output<TriangleMesh, std::tuple<NPOut0, NPOut1, NPOut2,NPOut3>>::type Edge_properties_out;
 
   // Face index point maps
   typedef typename CGAL::GetInitializedFaceIndexMap<TriangleMesh, NPIn1>::type FaceIndexMap1;
@@ -454,16 +454,16 @@ corefine_and_compute_boolean_operations(
                                                   FaceIndexMap1,
                                                   FaceIndexMap2,
                                                   Default,
-                                                  Ecm_in,
-                                                  Ecm_out,
+                                                  Edge_properties_in,
+                                                  Edge_properties_out,
                                                   User_visitor> Ob;
 
   typedef Corefinement::Surface_intersection_visitor_for_corefinement<
-            TriangleMesh, VPM1, VPM2, Ob, Ecm_in, User_visitor> Algo_visitor;
+            TriangleMesh, VPM1, VPM2, Ob, Edge_properties_in, User_visitor> Algo_visitor;
 
-  Ecm_in ecm_in(tm1,tm2,np1,np2);
-  Ecm_out ecms_out(nps_out);
-  Ob ob(tm1, tm2, vpm1, vpm2, fid_map1, fid_map2, ecm_in, vpm_out_tuple, ecms_out, uv, output);
+  Edge_properties_in em_in(tm1,tm2,np1,np2);
+  Edge_properties_out em_out(nps_out);
+  Ob ob(tm1, tm2, vpm1, vpm2, fid_map1, fid_map2, em_in, vpm_out_tuple, em_out, uv, output);
 
   // special case used for clipping open meshes
   if (choose_parameter(get_parameter(np1, internal_np::use_bool_op_to_clip_surface), false))
@@ -478,7 +478,7 @@ corefine_and_compute_boolean_operations(
   }
 
   Corefinement::Intersection_of_triangle_meshes<TriangleMesh, VPM1, VPM2, Algo_visitor >
-    functor(tm1, tm2, vpm1, vpm2, Algo_visitor(uv,ob,ecm_in));
+    functor(tm1, tm2, vpm1, vpm2, Algo_visitor(uv,ob,em_in));
   functor(CGAL::Emptyset_iterator(), throw_on_self_intersection, true);
 
 
@@ -806,14 +806,14 @@ corefine(      TriangleMesh& tm1,
                                get_property_map(boost::vertex_point, tm2));
 
 // Edge property maps
-  typedef typename Corefinement::Get_Ecm_bind<TriangleMesh, NamedParameters1, NamedParameters2>::type Ecm;
-  Ecm ecm(tm1,tm2,np1, np2);
+  typedef typename Corefinement::Get_Edge_properties_for_input<TriangleMesh, NamedParameters1, NamedParameters2>::type Edge_properties;
+  Edge_properties em(tm1,tm2,np1, np2);
 
 // TODO: double check that what we get with shared faces PR (actually coref should have them but bool op are unchecking them)
   if (&tm1==&tm2)
   {
-    ecm.set_on_intersection(tm1, edges(tm1));
-    ecm.set_on_intersection(tm2, edges(tm2));
+    em.set_on_intersection(tm1, edges(tm1));
+    em.set_on_intersection(tm2, edges(tm2));
     return;
   }
 
@@ -832,11 +832,11 @@ corefine(      TriangleMesh& tm1,
 // surface intersection algorithm call
   typedef Corefinement::No_extra_output_from_corefinement<TriangleMesh> Ob;
   typedef Corefinement::Surface_intersection_visitor_for_corefinement<
-  TriangleMesh, VPM1, VPM2, Ob, Ecm, User_visitor, false, handle_non_manifold_features> Algo_visitor;
+  TriangleMesh, VPM1, VPM2, Ob, Edge_properties, User_visitor, false, handle_non_manifold_features> Algo_visitor;
 
   Ob ob;
   Corefinement::Intersection_of_triangle_meshes<TriangleMesh, VPM1, VPM2, Algo_visitor>
-    functor(tm1, tm2, vpm1, vpm2, Algo_visitor(uv,ob,ecm,const_mesh_ptr), const_mesh_ptr);
+    functor(tm1, tm2, vpm1, vpm2, Algo_visitor(uv,ob,em,const_mesh_ptr), const_mesh_ptr);
 
   // Fill non-manifold feature maps if provided
   functor.set_non_manifold_feature_map_1(parameters::get_parameter(np1, internal_np::non_manifold_feature_map));
@@ -914,8 +914,8 @@ autorefine(      TriangleMesh& tm,
     internal_np::edge_is_constrained_t,
     NamedParameters,
     Corefinement::No_mark<TriangleMesh>//default
-  > ::type Ecm;
-  Ecm ecm = choose_parameter<Ecm>(get_parameter(np, internal_np::edge_is_constrained));
+  > ::type Edge_properties;
+  Edge_properties em = choose_parameter<Edge_properties>(get_parameter(np, internal_np::edge_is_constrained));
 
 // User visitor
   typedef typename internal_np::Lookup_named_param_def <
@@ -929,11 +929,11 @@ autorefine(      TriangleMesh& tm,
 // surface intersection algorithm call
   typedef Corefinement::No_extra_output_from_corefinement<TriangleMesh> Ob;
   typedef Corefinement::Surface_intersection_visitor_for_corefinement<
-    TriangleMesh, VPM, VPM, Ob, Ecm, User_visitor,true> Algo_visitor;
+    TriangleMesh, VPM, VPM, Ob, Edge_properties, User_visitor,true> Algo_visitor;
   Ob ob;
 
   Corefinement::Intersection_of_triangle_meshes<TriangleMesh, VPM, VPM, Algo_visitor>
-    functor(tm, vpm, Algo_visitor(uv,ob,ecm) );
+    functor(tm, vpm, Algo_visitor(uv,ob,em) );
 
   functor(CGAL::Emptyset_iterator(), true);
 }
@@ -1012,8 +1012,8 @@ autorefine_and_remove_self_intersections(      TriangleMesh& tm,
     internal_np::edge_is_constrained_t,
     NamedParameters,
     Corefinement::No_mark<TriangleMesh>//default
-  > ::type Ecm;
-  Ecm ecm = choose_parameter<Ecm>(get_parameter(np, internal_np::edge_is_constrained));
+  > ::type Edge_properties;
+  Edge_properties em = choose_parameter<Edge_properties>(get_parameter(np, internal_np::edge_is_constrained));
 
 // User visitor
   typedef typename internal_np::Lookup_named_param_def <
@@ -1027,15 +1027,15 @@ autorefine_and_remove_self_intersections(      TriangleMesh& tm,
   typedef Corefinement::Output_builder_for_autorefinement<TriangleMesh,
                                                           VPM,
                                                           Fid_map,
-                                                          Ecm,
+                                                          Edge_properties,
                                                           Default > Ob;
 
   typedef Corefinement::Surface_intersection_visitor_for_corefinement<
-    TriangleMesh, VPM, VPM, Ob, Ecm, User_visitor,true> Algo_visitor;
-  Ob ob(tm, vpm, fid_map, ecm);
+    TriangleMesh, VPM, VPM, Ob, Edge_properties, User_visitor,true> Algo_visitor;
+  Ob ob(tm, vpm, fid_map, em);
 
   Corefinement::Intersection_of_triangle_meshes<TriangleMesh, VPM, VPM, Algo_visitor>
-    functor(tm, vpm, Algo_visitor(uv,ob,ecm) );
+    functor(tm, vpm, Algo_visitor(uv,ob,em) );
 
   functor(CGAL::Emptyset_iterator(), true);
 

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/corefinement.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/corefinement.h
@@ -191,14 +191,14 @@ enum Boolean_operation_type {UNION = 0, INTERSECTION=1,
   *
   *   \cgalParamNBegin{edge_is_constrained_map}
   *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm1` (`tm2`)}
-  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`as key type and `bool` as value type.
-  *                    If an edge marked as constrained in `tm1` (tm2`) is split during corefinement, the resulting sub-edges will be marked as constrained.}
+  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor` as key type and `bool` as value type.
+  *                    If an edge marked as constrained in `tm1` (`tm2`) is split during corefinement, the resulting sub-edges will be marked as constrained.}
   *     \cgalParamDefault{a constant property map returning `false` for any edge}
   *   \cgalParamNEnd
   *
   *   \cgalParamNBegin{edge_is_marked_map}
   *     \cgalParamDescription{a property map filled by this function with `true` for all intersection edges of faces
-  *                           of `tm1` and `tm1`, and `false` for all other edges.}
+  *                           of `tm1` and `tm2`, and `false` for all other edges.}
   *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
   *                    as key type and `bool` as value type}
   *     \cgalParamDefault{unused}
@@ -247,14 +247,14 @@ enum Boolean_operation_type {UNION = 0, INTERSECTION=1,
   *   \cgalParamNBegin{edge_is_constrained_map}
   *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm_out`.
   *                           An edge of `tm_out` is constrained if the edge corresponds to a constrained edge in `tm1` or `tm2`.
-  *                           If an edge marked as constrained in `tm1` (tm2`) is split during corefinement, the resulting sub-edges will be marked as constrained.}
+  *                           If an edge marked as constrained in `tm1` (`tm2`) is split during corefinement, the resulting sub-edges will be marked as constrained.}
   *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
   *                    as key type and `bool` as value type}
   *   \cgalParamNEnd
   *
   *   \cgalParamNBegin{edge_is_marked_map}
   *     \cgalParamDescription{a property map filled by this function with `true` for all intersection edges of faces
-  *                           of `tm1` and `tm1`, and `false` for all other edges.}
+  *                           of `tm1` and `tm2`, and `false` for all other edges.}
   *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
   *                    as key type and `bool` as value type}
   *     \cgalParamDefault{unused}
@@ -529,14 +529,14 @@ corefine_and_compute_boolean_operations(
   *
   *   \cgalParamNBegin{edge_is_constrained_map}
   *     \cgalParamDescription{a property map containing the constrained-or-not status of each edge of `tm1` (`tm2`)}
-  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`as key type and `bool` as value type
-  *                    If an edge marked as constrained in `tm1` (tm2`) is split during corefinement, the resulting sub-edges will be marked as constrained.
+  *     \cgalParamType{a class model of `ReadWritePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor` as key type and `bool` as value type
+  *                    If an edge marked as constrained in `tm1` (`tm2`) is split during corefinement, the resulting sub-edges will be marked as constrained.}
   *     \cgalParamDefault{a constant property map returning `false` for any edge}
   *   \cgalParamNEnd
   *
   *   \cgalParamNBegin{edge_is_marked_map}
   *     \cgalParamDescription{a property map filled by this function with `true` for all intersection edges of faces
-  *                           of `tm1` and `tm1`, and `false` for all other edges.}
+  *                           of `tm1` and `tm2`, and `false` for all other edges.}
   *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
   *                    as key type and `bool` as value type}
   *     \cgalParamDefault{unused}
@@ -590,7 +590,7 @@ corefine_and_compute_boolean_operations(
   *
   *   \cgalParamNBegin{edge_is_marked_map}
   *     \cgalParamDescription{a property map filled by this function with `true` for all intersection edges of faces
-  *                           of `tm1` and `tm1`, and `false` for all other edges.}
+  *                           of `tm1` and `tm2`, and `false` for all other edges.}
   *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
   *                    as key type and `bool` as value type}
   *     \cgalParamDefault{unused}
@@ -730,7 +730,7 @@ corefine_and_compute_difference(      TriangleMesh& tm1,
  *
  *   \cgalParamNBegin{edge_is_marked_map}
  *     \cgalParamDescription{a property map filled by this function with `true` for all intersection edges of faces
- *                           of `tm1` and `tm1`, and `false` for all other edges.}
+ *                           of `tm1` and `tm2`, and `false` for all other edges.}
  *     \cgalParamType{a class model of `WritablePropertyMap` with `boost::graph_traits<TriangleMesh>::%edge_descriptor`
  *                    as key type and `bool` as value type}
  *     \cgalParamDefault{unused}

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -463,29 +463,12 @@ template <class TriangleMesh,
           class VpmOutTuple,
           class FaceIdMap1,
           class FaceIdMap2,
-          class Kernel_ = Default,
-          class EdgeMarkMapBind_  = Default,
-          class EdgeMarkMapTuple_ = Default,
-          class UserVisitor_      = Default>
+          class Kernel,
+          class EdgeMarkMapIn,
+          class EdgeMarkMapOut,
+          class UserVisitor>
 class Face_graph_output_builder
 {
-//Default typedefs
-  typedef typename Default::Get<
-    Kernel_,
-    typename Kernel_traits<
-      typename boost::property_traits<VertexPointMap1>::value_type
-    >::Kernel >::type                                                   Kernel;
-
-  typedef typename Default::Get<EdgeMarkMapBind_,
-    Ecm_bind<TriangleMesh, No_mark<TriangleMesh> >
-      >::type                                          EdgeMarkMapBind;
-  typedef typename Default::Get<EdgeMarkMapTuple_,
-    std::tuple< No_mark<TriangleMesh>,
-                  No_mark<TriangleMesh>,
-                  No_mark<TriangleMesh>,
-                  No_mark<TriangleMesh> > >::type     EdgeMarkMapTuple;
-  typedef typename Default::Get<
-    UserVisitor_, Default_visitor<TriangleMesh> >::type  UserVisitor;
   typedef typename Has_extra_functions<UserVisitor>::type VUNDF; //shortcut
   typedef typename Has_handle_non_manifold_output<UserVisitor>::type HSV; //shortcut
 
@@ -521,10 +504,10 @@ class Face_graph_output_builder
   const VertexPointMap2& vpm2;
   FaceIdMap1 fids1;
   FaceIdMap2 fids2;
-  EdgeMarkMapBind& marks_on_input_edges;
+  EdgeMarkMapIn& marks_on_input_edges;
   // property maps of output meshes
   const VpmOutTuple& output_vpms;
-  EdgeMarkMapTuple& out_edge_mark_maps;
+  EdgeMarkMapOut& out_edge_mark_maps;
   UserVisitor& user_visitor;
   // mapping vertex to node id
   Node_id_map vertex_to_node_id1, vertex_to_node_id2;
@@ -671,43 +654,41 @@ class Face_graph_output_builder
   }
 
   template<class EdgeMarkMap>
-  void mark_edges(const EdgeMarkMap& edge_mark_map,
-                  const std::vector<edge_descriptor>& edges)
+  void set_on_intersection(const EdgeMarkMap& edge_mark_map,
+                           const std::vector<edge_descriptor>& edges)
   {
     for(edge_descriptor ed : edges)
       put(edge_mark_map, ed, true);
   }
 
-  void mark_edges(const No_mark<TriangleMesh>&,
-                  const std::vector<edge_descriptor>&)
+  void set_on_intersection(const No_mark<TriangleMesh>&,
+                           const std::vector<edge_descriptor>&)
   {} //nothing to do
 
-  template<class EdgeMarkMapTuple>
-  void mark_edges(const EdgeMarkMapTuple& edge_mark_maps,
-                  const std::vector<edge_descriptor>& edges,
-                  int tuple_id)
+  void set_on_intersection(const EdgeMarkMapOut& edge_mark_maps,
+                           const std::vector<edge_descriptor>& edges,
+                           int tuple_id)
   {
     CGAL_assertion(tuple_id < 4 && tuple_id >= 0);
     switch (tuple_id)
     {
     case 0:
-      mark_edges(std::get<0>(edge_mark_maps),edges);
+      set_on_intersection(std::get<0>(edge_mark_maps),edges);
     break;
     case 1:
-      mark_edges(std::get<1>(edge_mark_maps),edges);
+      set_on_intersection(std::get<1>(edge_mark_maps),edges);
     break;
     case 2:
-      mark_edges(std::get<2>(edge_mark_maps),edges);
+      set_on_intersection(std::get<2>(edge_mark_maps),edges);
     break;
     default:
-      mark_edges(std::get<3>(edge_mark_maps),edges);
+      set_on_intersection(std::get<3>(edge_mark_maps),edges);
     }
   }
 
-  template<class EdgeMarkMapTuple>
-  void mark_edges(const EdgeMarkMapTuple& edge_mark_maps,
-                  const Intersection_edge_map& edge_map,
-                  int tuple_id)
+  void set_on_intersection(const EdgeMarkMapOut& edge_mark_maps,
+                           const Intersection_edge_map& edge_map,
+                           int tuple_id)
   {
     std::vector<edge_descriptor> edges;
     edges.reserve(edge_map.size());
@@ -718,33 +699,33 @@ class Face_graph_output_builder
     switch (tuple_id)
     {
     case 0:
-      mark_edges(std::get<0>(edge_mark_maps),edges);
+      set_on_intersection(std::get<0>(edge_mark_maps),edges);
     break;
     case 1:
-      mark_edges(std::get<1>(edge_mark_maps),edges);
+      set_on_intersection(std::get<1>(edge_mark_maps),edges);
     break;
     case 2:
-      mark_edges(std::get<2>(edge_mark_maps),edges);
+      set_on_intersection(std::get<2>(edge_mark_maps),edges);
     break;
     default:
-      mark_edges(std::get<3>(edge_mark_maps),edges);
+      set_on_intersection(std::get<3>(edge_mark_maps),edges);
     }
   }
 
-  void mark_edges(const std::tuple<No_mark<TriangleMesh>,
-                                     No_mark<TriangleMesh>,
-                                     No_mark<TriangleMesh>,
-                                     No_mark<TriangleMesh> >&,
-                 const std::vector<edge_descriptor>&,
-                 int)
+  void set_on_intersection(std::tuple<No_mark<TriangleMesh>,
+                           No_mark<TriangleMesh>,
+                           No_mark<TriangleMesh>,
+                           No_mark<TriangleMesh> >&,
+                           const std::vector<edge_descriptor>&,
+                           int)
   {} // nothing to do
 
-  void mark_edges(const std::tuple<No_mark<TriangleMesh>,
-                                     No_mark<TriangleMesh>,
-                                     No_mark<TriangleMesh>,
-                                     No_mark<TriangleMesh> >&,
-                 const Intersection_edge_map&,
-                 int)
+  void set_on_intersection(std::tuple<No_mark<TriangleMesh>,
+                           No_mark<TriangleMesh>,
+                           No_mark<TriangleMesh>,
+                           No_mark<TriangleMesh> >&,
+                           const Intersection_edge_map&,
+                           int)
   {} // nothing to do
 
 public:
@@ -755,9 +736,9 @@ public:
                             const VertexPointMap2& vpm2,
                             FaceIdMap1 fids1,
                             FaceIdMap2 fids2,
-                            EdgeMarkMapBind& marks_on_input_edges,
+                            EdgeMarkMapIn& marks_on_input_edges,
                             const VpmOutTuple& output_vpms,
-                            EdgeMarkMapTuple& out_edge_mark_maps,
+                            EdgeMarkMapOut& out_edge_mark_maps,
                             UserVisitor& user_visitor,
                             const std::array<std::optional<TriangleMesh*>, 4 >& requested_output)
     : tm1(tm1), tm2(tm2)
@@ -1062,16 +1043,13 @@ public:
       else
         ++epp_it;
     }
+    // boolop is actually unconstraining edges ...
+    marks_on_input_edges.reset_on_intersection(tm1, inter_edges_to_remove1);
     for(edge_descriptor ed : inter_edges_to_remove1)
-    {
-      put(marks_on_input_edges.ecm1, ed, false);
       intersection_edges1.erase(ed);
-    }
+    marks_on_input_edges.reset_on_intersection(tm2, inter_edges_to_remove2);
     for(edge_descriptor ed : inter_edges_to_remove2)
-    {
-      put(marks_on_input_edges.ecm2, ed, false);
       intersection_edges2.erase(ed);
-    }
 
     user_visitor.detect_patches();
 
@@ -2379,7 +2357,7 @@ public:
         )
       CGAL_COREF_FUNCTION_CALL(operation)
       #undef CGAL_COREF_FUNCTION_CALL_DEF
-      mark_edges(out_edge_mark_maps, shared_edges, operation);
+      set_on_intersection(out_edge_mark_maps, shared_edges, operation);
     }
 
     Edge_map disconnected_patches_edge_to_tm2_edge;
@@ -2388,7 +2366,7 @@ public:
     if ( inplace_operation_tm1!=NONE )
     {
       // mark intersection edges in tm1 (using output constrained edge map)
-      mark_edges(out_edge_mark_maps,
+      set_on_intersection(out_edge_mark_maps,
                  mesh_to_intersection_edges[&tm1],
                  inplace_operation_tm1);
 
@@ -2399,9 +2377,9 @@ public:
         user_visitor.in_place_operations(inplace_operation_tm1, inplace_operation_tm2);
 
         // mark intersection edges in tm2 (using output constrained edge map)
-        mark_edges(out_edge_mark_maps,
-                   mesh_to_intersection_edges[&tm2],
-                   inplace_operation_tm2);
+        set_on_intersection(out_edge_mark_maps,
+                            mesh_to_intersection_edges[&tm2],
+                            inplace_operation_tm2);
 
         // operation in tm1 with removal (and optionally inside-out) delayed
         // First backup the border edges of patches to be used
@@ -2497,7 +2475,7 @@ public:
 
         // transfer marks of edges of patches kept to the output edge mark property
         #define CGAL_COREF_FUNCTION_CALL_DEF(BO_type) \
-          copy_edge_mark<TriangleMesh>( \
+          copy_constraint_status<TriangleMesh>( \
           tm1, marks_on_input_edges.ecm1, \
           std::get<BO_type>(out_edge_mark_maps))
         CGAL_COREF_FUNCTION_CALL(inplace_operation_tm1)
@@ -2688,9 +2666,9 @@ public:
         user_visitor.in_place_operation(inplace_operation_tm2);
 
         // mark intersection edges in tm2 (using output constrained edge map)
-        mark_edges(out_edge_mark_maps,
-                   mesh_to_intersection_edges[&tm2],
-                   inplace_operation_tm2);
+        set_on_intersection(out_edge_mark_maps,
+                            mesh_to_intersection_edges[&tm2],
+                            inplace_operation_tm2);
 
         /// handle the operation updating only tm2
         CGAL_assertion( *requested_output[inplace_operation_tm2] == &tm2 );

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -2352,11 +2352,11 @@ public:
           polylines, \
           intersection_edges1, intersection_edges2, \
           vpm1, vpm2, *std::get<BO_type>(output_vpms), \
-          marks_on_input_edges.ecm1, \
-          marks_on_input_edges.ecm2, \
+          marks_on_input_edges.edge_cst_map1, \
+          marks_on_input_edges.edge_cst_map2, \
           marks_on_input_edges.edge_mark_map1, \
           marks_on_input_edges.edge_mark_map2, \
-          std::get<BO_type>(out_edge_mark_maps.ecm_tuple), \
+          std::get<BO_type>(out_edge_mark_maps.edge_cst_tuple), \
           std::get<BO_type>(out_edge_mark_maps.edge_mark_tuple), \
           shared_edges, \
           user_visitor \
@@ -2441,11 +2441,11 @@ public:
             BO_type == TM2_MINUS_TM1, \
           polylines_in_tm1, \
           vpm1, vpm2, \
-          marks_on_input_edges.ecm1, \
-          marks_on_input_edges.ecm2, \
+          marks_on_input_edges.edge_cst_map1, \
+          marks_on_input_edges.edge_cst_map2, \
           marks_on_input_edges.edge_mark_map1, \
           marks_on_input_edges.edge_mark_map2, \
-          std::get<BO_type>(out_edge_mark_maps.ecm_tuple), \
+          std::get<BO_type>(out_edge_mark_maps.edge_cst_tuple), \
           std::get<BO_type>(out_edge_mark_maps.edge_mark_tuple), \
           disconnected_patches_edge_to_tm2_edge, \
           user_visitor)
@@ -2463,11 +2463,11 @@ public:
                                      BO_type==TM2_MINUS_TM1, \
                                      vpm2, \
                                      vpm1, \
-                                     marks_on_input_edges.ecm2, \
-                                     marks_on_input_edges.ecm1, \
+                                     marks_on_input_edges.edge_cst_map2, \
+                                     marks_on_input_edges.edge_cst_map1, \
                                      marks_on_input_edges.edge_mark_map2, \
                                      marks_on_input_edges.edge_mark_map1, \
-                                     std::get<BO_type>(out_edge_mark_maps.ecm_tuple), \
+                                     std::get<BO_type>(out_edge_mark_maps.edge_cst_tuple), \
                                      std::get<BO_type>(out_edge_mark_maps.edge_mark_tuple), \
                                      disconnected_patches_edge_to_tm2_edge, \
                                      user_visitor)
@@ -2483,12 +2483,12 @@ public:
         remove_disconnected_patches(tm1,
                                     patches_of_tm1,
                                     patches_of_tm1_removed,
-                                    marks_on_input_edges.ecm1,
+                                    marks_on_input_edges.edge_cst_map1,
                                     marks_on_input_edges.edge_mark_map1);
 
         // transfer marks of edges of patches kept to the output edge mark property
         #define CGAL_COREF_FUNCTION_CALL_DEF(BO_type) \
-        copy_constraint_status<TriangleMesh>(tm1, marks_on_input_edges.ecm1, std::get<BO_type>(out_edge_mark_maps.ecm_tuple));  \
+        copy_constraint_status<TriangleMesh>(tm1, marks_on_input_edges.edge_cst_map1, std::get<BO_type>(out_edge_mark_maps.edge_cst_tuple));  \
         copy_constraint_status<TriangleMesh>(tm1, marks_on_input_edges.edge_mark_map1, std::get<BO_type>(out_edge_mark_maps.edge_mark_tuple));
         CGAL_COREF_FUNCTION_CALL(inplace_operation_tm1)
         #undef CGAL_COREF_FUNCTION_CALL_DEF
@@ -2657,11 +2657,11 @@ public:
             BO_type == TM1_MINUS_TM2, \
             vpm1, \
             vpm2, \
-            marks_on_input_edges.ecm1, \
-            marks_on_input_edges.ecm2, \
+            marks_on_input_edges.edge_cst_map1, \
+            marks_on_input_edges.edge_cst_map2, \
             marks_on_input_edges.edge_mark_map1, \
             marks_on_input_edges.edge_mark_map2, \
-            std::get<BO_type>(out_edge_mark_maps.ecm_tuple), \
+            std::get<BO_type>(out_edge_mark_maps.edge_cst_tuple), \
             std::get<BO_type>(out_edge_mark_maps.edge_mark_tuple), \
             polylines, \
             user_visitor \
@@ -2704,11 +2704,11 @@ public:
                                      BO_type==TM2_MINUS_TM1, \
                                      vpm2, \
                                      vpm1, \
-                                     marks_on_input_edges.ecm2, \
-                                     marks_on_input_edges.ecm1, \
+                                     marks_on_input_edges.edge_cst_map2, \
+                                     marks_on_input_edges.edge_cst_map1, \
                                      marks_on_input_edges.edge_mark_map2, \
                                      marks_on_input_edges.edge_mark_map1, \
-                                     std::get<BO_type>(out_edge_mark_maps.ecm_tuple), \
+                                     std::get<BO_type>(out_edge_mark_maps.edge_cst_tuple), \
                                      std::get<BO_type>(out_edge_mark_maps.edge_mark_tuple), \
                                      polylines, \
                                      user_visitor);

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Face_graph_output_builder.h
@@ -661,6 +661,7 @@ class Face_graph_output_builder
       put(edge_mark_map, ed, true);
   }
 
+  constexpr
   void set_on_intersection(const No_mark<TriangleMesh>&,
                            const std::vector<edge_descriptor>&)
   {} //nothing to do
@@ -673,16 +674,16 @@ class Face_graph_output_builder
     switch (tuple_id)
     {
     case 0:
-      set_on_intersection(std::get<0>(edge_mark_maps),edges);
+      set_on_intersection(std::get<0>(edge_mark_maps.edge_mark_tuple),edges);
     break;
     case 1:
-      set_on_intersection(std::get<1>(edge_mark_maps),edges);
+      set_on_intersection(std::get<1>(edge_mark_maps.edge_mark_tuple),edges);
     break;
     case 2:
-      set_on_intersection(std::get<2>(edge_mark_maps),edges);
+      set_on_intersection(std::get<2>(edge_mark_maps.edge_mark_tuple),edges);
     break;
     default:
-      set_on_intersection(std::get<3>(edge_mark_maps),edges);
+      set_on_intersection(std::get<3>(edge_mark_maps.edge_mark_tuple),edges);
     }
   }
 
@@ -699,19 +700,20 @@ class Face_graph_output_builder
     switch (tuple_id)
     {
     case 0:
-      set_on_intersection(std::get<0>(edge_mark_maps),edges);
+      set_on_intersection(std::get<0>(edge_mark_maps.edge_mark_tuple),edges);
     break;
     case 1:
-      set_on_intersection(std::get<1>(edge_mark_maps),edges);
+      set_on_intersection(std::get<1>(edge_mark_maps.edge_mark_tuple),edges);
     break;
     case 2:
-      set_on_intersection(std::get<2>(edge_mark_maps),edges);
+      set_on_intersection(std::get<2>(edge_mark_maps.edge_mark_tuple),edges);
     break;
     default:
-      set_on_intersection(std::get<3>(edge_mark_maps),edges);
+      set_on_intersection(std::get<3>(edge_mark_maps.edge_mark_tuple),edges);
     }
   }
 
+  constexpr
   void set_on_intersection(std::tuple<No_mark<TriangleMesh>,
                            No_mark<TriangleMesh>,
                            No_mark<TriangleMesh>,
@@ -720,6 +722,7 @@ class Face_graph_output_builder
                            int)
   {} // nothing to do
 
+  constexpr
   void set_on_intersection(std::tuple<No_mark<TriangleMesh>,
                            No_mark<TriangleMesh>,
                            No_mark<TriangleMesh>,
@@ -2351,7 +2354,10 @@ public:
           vpm1, vpm2, *std::get<BO_type>(output_vpms), \
           marks_on_input_edges.ecm1, \
           marks_on_input_edges.ecm2, \
-          std::get<BO_type>(out_edge_mark_maps), \
+          marks_on_input_edges.edge_mark_map1, \
+          marks_on_input_edges.edge_mark_map2, \
+          std::get<BO_type>(out_edge_mark_maps.ecm_tuple), \
+          std::get<BO_type>(out_edge_mark_maps.edge_mark_tuple), \
           shared_edges, \
           user_visitor \
         )
@@ -2437,7 +2443,10 @@ public:
           vpm1, vpm2, \
           marks_on_input_edges.ecm1, \
           marks_on_input_edges.ecm2, \
-          std::get<BO_type>(out_edge_mark_maps), \
+          marks_on_input_edges.edge_mark_map1, \
+          marks_on_input_edges.edge_mark_map2, \
+          std::get<BO_type>(out_edge_mark_maps.ecm_tuple), \
+          std::get<BO_type>(out_edge_mark_maps.edge_mark_tuple), \
           disconnected_patches_edge_to_tm2_edge, \
           user_visitor)
         CGAL_COREF_FUNCTION_CALL(inplace_operation_tm1)
@@ -2456,7 +2465,10 @@ public:
                                      vpm1, \
                                      marks_on_input_edges.ecm2, \
                                      marks_on_input_edges.ecm1, \
-                                     std::get<BO_type>(out_edge_mark_maps), \
+                                     marks_on_input_edges.edge_mark_map2, \
+                                     marks_on_input_edges.edge_mark_map1, \
+                                     std::get<BO_type>(out_edge_mark_maps.ecm_tuple), \
+                                     std::get<BO_type>(out_edge_mark_maps.edge_mark_tuple), \
                                      disconnected_patches_edge_to_tm2_edge, \
                                      user_visitor)
         CGAL_COREF_FUNCTION_CALL(inplace_operation_tm2)
@@ -2471,13 +2483,13 @@ public:
         remove_disconnected_patches(tm1,
                                     patches_of_tm1,
                                     patches_of_tm1_removed,
-                                    marks_on_input_edges.ecm1);
+                                    marks_on_input_edges.ecm1,
+                                    marks_on_input_edges.edge_mark_map1);
 
         // transfer marks of edges of patches kept to the output edge mark property
         #define CGAL_COREF_FUNCTION_CALL_DEF(BO_type) \
-          copy_constraint_status<TriangleMesh>( \
-          tm1, marks_on_input_edges.ecm1, \
-          std::get<BO_type>(out_edge_mark_maps))
+        copy_constraint_status<TriangleMesh>(tm1, marks_on_input_edges.ecm1, std::get<BO_type>(out_edge_mark_maps.ecm_tuple));  \
+        copy_constraint_status<TriangleMesh>(tm1, marks_on_input_edges.edge_mark_map1, std::get<BO_type>(out_edge_mark_maps.edge_mark_tuple));
         CGAL_COREF_FUNCTION_CALL(inplace_operation_tm1)
         #undef CGAL_COREF_FUNCTION_CALL_DEF
 
@@ -2647,7 +2659,10 @@ public:
             vpm2, \
             marks_on_input_edges.ecm1, \
             marks_on_input_edges.ecm2, \
-            std::get<BO_type>(out_edge_mark_maps), \
+            marks_on_input_edges.edge_mark_map1, \
+            marks_on_input_edges.edge_mark_map2, \
+            std::get<BO_type>(out_edge_mark_maps.ecm_tuple), \
+            std::get<BO_type>(out_edge_mark_maps.edge_mark_tuple), \
             polylines, \
             user_visitor \
           )
@@ -2691,7 +2706,10 @@ public:
                                      vpm1, \
                                      marks_on_input_edges.ecm2, \
                                      marks_on_input_edges.ecm1, \
-                                     std::get<BO_type>(out_edge_mark_maps), \
+                                     marks_on_input_edges.edge_mark_map2, \
+                                     marks_on_input_edges.edge_mark_map1, \
+                                     std::get<BO_type>(out_edge_mark_maps.ecm_tuple), \
+                                     std::get<BO_type>(out_edge_mark_maps.edge_mark_tuple), \
                                      polylines, \
                                      user_visitor);
         CGAL_COREF_FUNCTION_CALL(inplace_operation_tm2)

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Output_builder_for_autorefinement.h
@@ -1184,7 +1184,7 @@ public:
                             Intersection_edge_map> Patches;
     Patches patches(tm, patch_ids, fids, intersection_edges, nb_patches);
     //remove the extra patch
-    remove_patches(tm, ~patches_to_keep,patches, ecm);
+    remove_patches(tm, ~patches_to_keep,patches, ecm, ecm); // WARNING there should be edge_mark_map but this file will disappear soon
 
     stitch_borders(tm, hedge_pairs_to_stitch, parameters::vertex_point_map(vpm));
   }

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -54,6 +54,14 @@ struct Ecm_bind{
 
   typedef typename boost::graph_traits<G>::edge_descriptor edge_descriptor;
 
+  void call_put_for_all_edges(bool b)
+  {
+    if constexpr (!std::is_same_v<Ecm1, No_mark<G>>)
+      for (edge_descriptor e : edges(g1)) put(ecm1, e, b);
+    if constexpr (!std::is_same_v<Ecm2, No_mark<G>>)
+      for (edge_descriptor e : edges(g2)) put(ecm2, e, b);
+  }
+
   void call_put(G& g, edge_descriptor e, bool b) const
   {
     if ( &g==&g1 )
@@ -84,6 +92,7 @@ struct Ecm_bind<G, No_mark<G>, No_mark<G> >
   bool call_get(G&, edge_descriptor) const {
     return false;
   }
+  void call_put_for_all_edges(bool) {}
 };
 
 template<class G>
@@ -559,6 +568,15 @@ public:
     , const_mesh_ptr(const_mesh_ptr)
   {}
 
+  void inputs_are_two_identical_meshes()
+  {
+    if constexpr (std::is_same_v<OutputBuilder, No_extra_output_from_corefinement<TriangleMesh>>)
+    {
+      marks_on_edges.call_put_for_all_edges(true);
+    }
+    else
+      marks_on_edges.call_put_for_all_edges(false);
+  }
 
   void start_filtering_intersections() const
   {

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -41,59 +41,134 @@ namespace Corefinement{
 // TODO option to ignore internal edges for patches of coplanar faces
 
 //binds two edge constrained pmaps
-template <class G, class Ecm1, class Ecm2=Ecm1>
-struct Ecm_bind{
+template <class G, class Ecm1, class Ecm2, class MarkMap1, class MarkMap2>
+struct Ecm_bind
+{
   G& g1;
-  Ecm1& ecm1;
+  Ecm1 ecm1;
+  MarkMap1 edge_mark_map1;
   G& g2;
-  Ecm2& ecm2;
+  Ecm2 ecm2;
+  MarkMap2 edge_mark_map2;
 
-  Ecm_bind(G& g1, G& g2, Ecm1& ecm1, Ecm2& ecm2)
-  : g1(g1), ecm1(ecm1), g2(g2), ecm2(ecm2)
+  Ecm_bind(G& g1, G& g2,
+           Ecm1 ecm1, Ecm2 ecm2,
+           MarkMap1 edge_mark_map1, MarkMap2 edge_mark_map2)
+  : g1(g1), ecm1(ecm1), edge_mark_map1(edge_mark_map1)
+  , g2(g2), ecm2(ecm2), edge_mark_map2(edge_mark_map2)
+  {}
+
+  template<class NP1, class NP2>
+  Ecm_bind(G& g1, G& g2, const NP1& np1, const NP2& np2)
+    : Ecm_bind(g1, g2,
+               parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(np1, internal_np::edge_is_constrained)),
+               parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(np2, internal_np::edge_is_constrained)),
+               parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(np1, internal_np::edge_is_marked_map)),
+               parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(np2, internal_np::edge_is_marked_map)))
   {}
 
   typedef typename boost::graph_traits<G>::edge_descriptor edge_descriptor;
 
-  void call_put_for_all_edges(bool b)
+  void update_on_intersection_status_for_all_edges(bool b)
   {
-    if constexpr (!std::is_same_v<Ecm1, No_mark<G>>)
-      for (edge_descriptor e : edges(g1)) put(ecm1, e, b);
-    if constexpr (!std::is_same_v<Ecm2, No_mark<G>>)
-      for (edge_descriptor e : edges(g2)) put(ecm2, e, b);
+    if constexpr (!std::is_same_v<MarkMap1, No_mark<G>>)
+      for (edge_descriptor e : edges(g1)) put(edge_mark_map1, e, b);
+    if constexpr (!std::is_same_v<MarkMap2, No_mark<G>>)
+      for (edge_descriptor e : edges(g2)) put(edge_mark_map2, e, b);
   }
 
-  void call_put(G& g, edge_descriptor e, bool b) const
+  bool is_constrained(G&g, edge_descriptor e) const
   {
-    if ( &g==&g1 )
-      put(ecm1,e,b);
-    else
-    {
-      CGAL_assertion( &g==&g2 );
-      put(ecm2,e,b);
-    }
-  }
-
-  bool call_get(G& g, edge_descriptor e) const
-  {
+    if constexpr (std::is_same_v<Ecm1, No_mark<G>> && std::is_same_v<Ecm2, No_mark<G>>) return false;
     if ( &g==&g1 )
       return get(ecm1,e);
     CGAL_assertion( &g==&g2 );
     return get(ecm2,e);
   }
+  void set_constrained(G&g, edge_descriptor e) const
+  {
+    if constexpr (std::is_same_v<Ecm1, No_mark<G>> && std::is_same_v<Ecm2, No_mark<G>>) return;
+    if ( &g==&g1 )
+      put(ecm1,e,true);
+    else
+    {
+      CGAL_assertion( &g==&g2 );
+      put(ecm2,e,true);
+    }
+  }
+  void set_on_intersection(G&g, edge_descriptor e) const
+  {
+    if constexpr (std::is_same_v<MarkMap1, No_mark<G>> && std::is_same_v<MarkMap2, No_mark<G>>) return;
+    if ( &g==&g1 )
+      put(edge_mark_map1,e,true);
+    else
+    {
+      CGAL_assertion( &g==&g2 );
+      put(edge_mark_map2,e,true);
+    }
+  }
+  template<class EdgeRange>
+  void set_on_intersection(G&g, const EdgeRange& edge_range) const
+  {
+    if constexpr (std::is_same_v<MarkMap1, No_mark<G>> && std::is_same_v<MarkMap2, No_mark<G>>) return;
+    if ( &g==&g1 )
+      for (edge_descriptor e : edge_range)
+        put(edge_mark_map1,e,true);
+    else
+    {
+      CGAL_assertion( &g==&g2 );
+      for (edge_descriptor e : edge_range)
+        put(edge_mark_map2,e,true);
+    }
+  }
+
+  template<class EdgeRange>
+  void reset_on_intersection(G&g, const EdgeRange& edge_range) const
+  {
+    if constexpr (std::is_same_v<MarkMap1, No_mark<G>> && std::is_same_v<MarkMap2, No_mark<G>>) return;
+    if ( &g==&g1 )
+      for (edge_descriptor e : edge_range)
+        put(edge_mark_map1,e,false);
+    else
+    {
+      CGAL_assertion( &g==&g2 );
+      for (edge_descriptor e : edge_range)
+        put(edge_mark_map2,e,false);
+    }
+  }
 };
 
 template <class G>
-struct Ecm_bind<G, No_mark<G>, No_mark<G> >
+struct Ecm_bind<G, No_mark<G>, No_mark<G>, No_mark<G>, No_mark<G> >
 {
   No_mark<G> ecm1, ecm2;
-  Ecm_bind(G&, G&, const No_mark<G>&, const No_mark<G>&){}
+  template<class NP1, class NP2>
+  Ecm_bind(G&, G&, const NP1&, const NP2&){}
   typedef typename boost::graph_traits<G>::edge_descriptor edge_descriptor;
-  void call_put(G&, edge_descriptor, bool) const {}
-  bool call_get(G&, edge_descriptor) const {
-    return false;
-  }
-  void call_put_for_all_edges(bool) {}
+  constexpr void set_constrained(G&, edge_descriptor) const {}
+  constexpr void set_on_intersection(G&, edge_descriptor) const {}
+  template<class EdgeRange>
+  constexpr void set_on_intersection(G&, const EdgeRange&) const {}
+  template<class EdgeRange>
+  constexpr void reset_on_intersection(G&, const EdgeRange&) const {}
+  constexpr bool is_constrained(G&, edge_descriptor) const { return false;}
+  constexpr void update_on_intersection_status_for_all_edges(bool) {}
 };
+
+template <class G, class NP1, class NP2>
+struct Get_Ecm_bind
+{
+  typedef No_mark<G> D;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, NP1, D> ::type Ecm1;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, NP2, D> ::type Ecm2;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, NP1, D> ::type Mark_map1;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, NP2, D> ::type Mark_map2;
+  typedef Ecm_bind<G, Ecm1, Ecm2, Mark_map1, Mark_map2> type;
+};
+
+template <class G>
+using Default_ecm_bind = Ecm_bind<G,No_mark<G>,No_mark<G>,No_mark<G>,No_mark<G>>;
+
 
 template<class G>
 struct No_extra_output_from_corefinement
@@ -459,8 +534,7 @@ template< class TriangleMesh,
           bool handle_non_manifold_features = false >
 class Surface_intersection_visitor_for_corefinement{
 //default template parameters
-  typedef typename Default::Get<EdgeMarkMapBind_,
-    Ecm_bind<TriangleMesh, No_mark<TriangleMesh> > >::type      EdgeMarkMapBind;
+  typedef typename Default::Get<EdgeMarkMapBind_, Default_ecm_bind<TriangleMesh>>::type      EdgeMarkMapBind;
   typedef typename Default::Get<OutputBuilder_,
     No_extra_output_from_corefinement<TriangleMesh> >::type       OutputBuilder;
   typedef typename Default::Get<
@@ -531,31 +605,46 @@ private:
   bool input_with_coplanar_faces;
   TriangleMesh* const_mesh_ptr;
 
-  template <class Ecm1, class Ecm2>
-  void call_put(Ecm_bind<TriangleMesh, Ecm1, Ecm2>& ecm,
-                TriangleMesh& tm, edge_descriptor ed, bool v)
+  template <class Ecm1, class Ecm2, class MarkMap1, class MarkMap2>
+  void set_constrained(Ecm_bind<TriangleMesh, Ecm1, Ecm2, MarkMap1, MarkMap2>& ecm,
+                       TriangleMesh& tm, edge_descriptor ed)
   {
-    ecm.call_put(tm, ed, v);
+    ecm.set_constrained(tm, ed);
   }
   template <class Ecm>
-  void call_put(Ecm& ecm,
-                TriangleMesh&, edge_descriptor ed, bool v)
+  void set_constrained(Ecm& ecm,
+                       TriangleMesh&, edge_descriptor ed)
   {
-    put(ecm, ed, v);
+    put(ecm, ed, true);
   }
 
-  template <class Ecm1, class Ecm2>
-  bool call_get(const Ecm_bind<TriangleMesh, Ecm1, Ecm2>& ecm,
+  template <class Ecm1, class Ecm2, class MarkMap1, class MarkMap2>
+  void set_on_intersection(Ecm_bind<TriangleMesh, Ecm1, Ecm2, MarkMap1, MarkMap2>& ecm,
+                           TriangleMesh& tm, edge_descriptor ed)
+  {
+    ecm.set_on_intersection(tm, ed);
+  }
+  template <class Ecm>
+  void set_on_intersection(Ecm& ecm,
+                           TriangleMesh&, edge_descriptor ed)
+  {
+    put(ecm, ed, true);
+  }
+
+  template <class Ecm1, class Ecm2, class MarkMap1, class MarkMap2>
+  bool is_constrained(const Ecm_bind<TriangleMesh, Ecm1, Ecm2, MarkMap1, MarkMap2>& ecm,
                 TriangleMesh& tm, edge_descriptor ed)
   {
-    return ecm.call_get(tm, ed);
+    return ecm.is_constrained(tm, ed);
   }
+/*
   template <class Ecm>
   bool call_get(const Ecm& ecm,
                 TriangleMesh&, edge_descriptor ed)
   {
     return get(ecm, ed);
   }
+*/
 // visitor public functions
 public:
   Surface_intersection_visitor_for_corefinement(
@@ -572,10 +661,10 @@ public:
   {
     if constexpr (std::is_same_v<OutputBuilder, No_extra_output_from_corefinement<TriangleMesh>>)
     {
-      marks_on_edges.call_put_for_all_edges(true);
+      marks_on_edges.update_on_intersection_status_for_all_edges(true);
     }
     else
-      marks_on_edges.call_put_for_all_edges(false);
+      marks_on_edges.update_on_intersection_status_for_all_edges(false);
   }
 
   void start_filtering_intersections() const
@@ -1169,7 +1258,7 @@ public:
       //We need an edge incident to the source vertex of hedge. This is the first opposite edge created.
       bool first=true;
       halfedge_descriptor hedge_incident_to_src=Graph_traits::null_halfedge();
-      bool hedge_is_marked = call_get(marks_on_edges,tm,edge(hedge,tm));
+      bool edge_is_constrained = is_constrained(marks_on_edges,tm,edge(hedge,tm));
       //do split the edges
       CGAL_assertion_code(vertex_descriptor expected_src=source(hedge,tm));
       user_visitor.before_edge_split(hedge, tm);
@@ -1188,8 +1277,8 @@ public:
         }
 
         //update marker tags. If the edge was marked, then the resulting edges in the split must be marked
-        if ( hedge_is_marked )
-          call_put(marks_on_edges,tm,edge(hnew,tm),true);
+        if ( edge_is_constrained )
+          set_constrained(marks_on_edges,tm,edge(hnew,tm));
         user_visitor.new_vertex_added(node_id, target(hnew, tm), tm);
         user_visitor.edge_split(hnew, tm);
 
@@ -1308,7 +1397,7 @@ public:
                 std::tie(h, is_face_border) = halfedge(vi,vn, tm);
                 if (is_face_border)
                 {
-                  call_put(marks_on_edges,tm,edge(h,tm),true);
+                  set_on_intersection(marks_on_edges,tm,edge(h,tm));
                   output_builder.set_edge_per_polyline(tm,std::make_pair(id, id_n),h);
                 }
                 else
@@ -1338,7 +1427,7 @@ public:
           halfedge_descriptor nh = Euler::split_face(a[0].first, a[1].first, tm);
           new_faces.push_back(face(opposite(nh, tm), tm));
 
-          call_put(marks_on_edges,tm,edge(nh,tm),true);
+          set_on_intersection(marks_on_edges,tm,edge(nh,tm));
           output_builder.set_edge_per_polyline(tm,std::make_pair(a[0].second, a[1].second),nh);
         }
 
@@ -1542,7 +1631,7 @@ public:
         //is defined as one of them defines an adjacent face
         //CGAL_assertion(it_poly_hedge!=edge_to_hedge.end());
         if( it_poly_hedge!=edge_to_hedge.end() ){
-          call_put(marks_on_edges,tm,edge(it_poly_hedge->second,tm),true);
+          set_on_intersection(marks_on_edges,tm,edge(it_poly_hedge->second,tm));
           output_builder.set_edge_per_polyline(tm,node_id_pair,it_poly_hedge->second);
         }
         else{
@@ -1552,7 +1641,7 @@ public:
           it_poly_hedge=edge_to_hedge.find(opposite_pair);
           CGAL_assertion( it_poly_hedge!=edge_to_hedge.end() );
 
-          call_put(marks_on_edges,tm,edge(it_poly_hedge->second,tm),true);
+          set_on_intersection(marks_on_edges,tm,edge(it_poly_hedge->second,tm));
           output_builder.set_edge_per_polyline(tm,opposite_pair,it_poly_hedge->second);
         }
       }
@@ -1601,6 +1690,7 @@ public:
     {
       TriangleMesh& tm=*it->first;
       CGAL_assertion(&tm!=const_mesh_ptr);
+      CGAL_assertion(&tm1==&tm || &tm2==&tm);
 
     //   Face_boundaries& face_boundaries=mesh_to_face_boundaries[&tm];
 
@@ -1656,7 +1746,7 @@ public:
               }
               if (did_break) continue;
               std::pair<Node_id,Node_id> edge_pair(node_id,node_id_of_first);
-              call_put(marks_on_edges,tm,edge(hedge,tm),true);
+              set_on_intersection(marks_on_edges,tm,edge(hedge,tm));
               output_builder.set_edge_per_polyline(tm,edge_pair,hedge);
             }
           }

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -677,10 +677,17 @@ private:
   }
 
   template <class CstMap1, class CstMap2, class MarkMap1, class MarkMap2>
-  bool is_constrained(const Edge_properties_for_input<TriangleMesh, CstMap1, CstMap2, MarkMap1, MarkMap2>& em,
+  bool is_constrained(Edge_properties_for_input<TriangleMesh, CstMap1, CstMap2, MarkMap1, MarkMap2>& em,
                 TriangleMesh& tm, edge_descriptor ed)
   {
     return em.is_constrained(tm, ed);
+  }
+
+  template <class Edge_map>
+  bool is_constrained(Edge_map& em,
+                      TriangleMesh&, edge_descriptor ed)
+  {
+    return get(em, ed);
   }
 
 // visitor public functions

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -141,7 +141,7 @@ struct Ecm_bind
 template <class G>
 struct Ecm_bind<G, No_mark<G>, No_mark<G>, No_mark<G>, No_mark<G> >
 {
-  No_mark<G> ecm1, ecm2;
+  No_mark<G> ecm1, ecm2, edge_mark_map1, edge_mark_map2;
   template<class NP1, class NP2>
   Ecm_bind(G&, G&, const NP1&, const NP2&){}
   typedef typename boost::graph_traits<G>::edge_descriptor edge_descriptor;
@@ -165,6 +165,51 @@ struct Get_Ecm_bind
   typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, NP2, D> ::type Mark_map2;
   typedef Ecm_bind<G, Ecm1, Ecm2, Mark_map1, Mark_map2> type;
 };
+
+
+template <class G,
+          class Ecm_0, class Ecm_1, class Ecm_2, class Ecm_3,
+          class MarkMap_0, class MarkMap_1, class MarkMap_2, class MarkMap_3>
+struct Ecm_out_bind
+{
+  std::tuple<Ecm_0, Ecm_1, Ecm_2, Ecm_3> ecm_tuple;
+  std::tuple<MarkMap_0, MarkMap_1, MarkMap_2, MarkMap_3> edge_mark_tuple;
+
+
+  Ecm_out_bind(Ecm_0 ecm0, Ecm_1 ecm1, Ecm_2 ecm2, Ecm_3 ecm3,
+               MarkMap_0 edge_mark_map0, MarkMap_1 edge_mark_map1, MarkMap_2 edge_mark_map2, MarkMap_3 edge_mark_map3)
+  : ecm_tuple(ecm0,ecm1,ecm2,ecm3)
+  , edge_mark_tuple(edge_mark_map0,edge_mark_map1,edge_mark_map2,edge_mark_map3)
+  {}
+
+  template<class NP_tuple>
+  Ecm_out_bind(const NP_tuple nps)
+    : Ecm_out_bind(parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<0>(nps), internal_np::edge_is_constrained)),
+                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<1>(nps), internal_np::edge_is_constrained)),
+                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<2>(nps), internal_np::edge_is_constrained)),
+                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<3>(nps), internal_np::edge_is_constrained)),
+                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<0>(nps), internal_np::edge_is_marked_map)),
+                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<1>(nps), internal_np::edge_is_marked_map)),
+                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<2>(nps), internal_np::edge_is_marked_map)),
+                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<3>(nps), internal_np::edge_is_marked_map)))
+  {}
+};
+
+template <class G, class NP_tuple>
+struct Get_Ecm_out_bind
+{
+  typedef No_mark<G> D;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, std::tuple_element_t<0, NP_tuple>, D> ::type Ecm0;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, std::tuple_element_t<1, NP_tuple>, D> ::type Ecm1;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, std::tuple_element_t<2, NP_tuple>, D> ::type Ecm2;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, std::tuple_element_t<3, NP_tuple>, D> ::type Ecm3;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, std::tuple_element_t<0, NP_tuple>, D> ::type Mark_map0;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, std::tuple_element_t<1, NP_tuple>, D> ::type Mark_map1;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, std::tuple_element_t<2, NP_tuple>, D> ::type Mark_map2;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, std::tuple_element_t<3, NP_tuple>, D> ::type Mark_map3;
+  typedef Ecm_out_bind<G, Ecm0, Ecm1, Ecm2, Ecm3, Mark_map0, Mark_map1, Mark_map2, Mark_map3> type;
+};
+
 
 template <class G>
 using Default_ecm_bind = Ecm_bind<G,No_mark<G>,No_mark<G>,No_mark<G>,No_mark<G>>;

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/Visitor.h
@@ -41,30 +41,30 @@ namespace Corefinement{
 // TODO option to ignore internal edges for patches of coplanar faces
 
 //binds two edge constrained pmaps
-template <class G, class Ecm1, class Ecm2, class MarkMap1, class MarkMap2>
-struct Ecm_bind
+template <class G, class CstMap1, class CstMap2, class MarkMap1, class MarkMap2>
+struct Edge_properties_for_input
 {
   G& g1;
-  Ecm1 ecm1;
+  CstMap1 edge_cst_map1;
   MarkMap1 edge_mark_map1;
   G& g2;
-  Ecm2 ecm2;
+  CstMap2 edge_cst_map2;
   MarkMap2 edge_mark_map2;
 
-  Ecm_bind(G& g1, G& g2,
-           Ecm1 ecm1, Ecm2 ecm2,
-           MarkMap1 edge_mark_map1, MarkMap2 edge_mark_map2)
-  : g1(g1), ecm1(ecm1), edge_mark_map1(edge_mark_map1)
-  , g2(g2), ecm2(ecm2), edge_mark_map2(edge_mark_map2)
+  Edge_properties_for_input(G& g1, G& g2,
+                            CstMap1 edge_cst_map1, CstMap2 edge_cst_map2,
+                            MarkMap1 edge_mark_map1, MarkMap2 edge_mark_map2)
+  : g1(g1), edge_cst_map1(edge_cst_map1), edge_mark_map1(edge_mark_map1)
+  , g2(g2), edge_cst_map2(edge_cst_map2), edge_mark_map2(edge_mark_map2)
   {}
 
   template<class NP1, class NP2>
-  Ecm_bind(G& g1, G& g2, const NP1& np1, const NP2& np2)
-    : Ecm_bind(g1, g2,
-               parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(np1, internal_np::edge_is_constrained)),
-               parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(np2, internal_np::edge_is_constrained)),
-               parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(np1, internal_np::edge_is_marked_map)),
-               parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(np2, internal_np::edge_is_marked_map)))
+  Edge_properties_for_input(G& g1, G& g2, const NP1& np1, const NP2& np2)
+    : Edge_properties_for_input(g1, g2,
+                                parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(np1, internal_np::edge_is_constrained)),
+                                parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(np2, internal_np::edge_is_constrained)),
+                                parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(np1, internal_np::edge_is_marked_map)),
+                                parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(np2, internal_np::edge_is_marked_map)))
   {}
 
   typedef typename boost::graph_traits<G>::edge_descriptor edge_descriptor;
@@ -79,21 +79,21 @@ struct Ecm_bind
 
   bool is_constrained(G&g, edge_descriptor e) const
   {
-    if constexpr (std::is_same_v<Ecm1, No_mark<G>> && std::is_same_v<Ecm2, No_mark<G>>) return false;
+    if constexpr (std::is_same_v<CstMap1, No_mark<G>> && std::is_same_v<CstMap2, No_mark<G>>) return false;
     if ( &g==&g1 )
-      return get(ecm1,e);
+      return get(edge_cst_map1,e);
     CGAL_assertion( &g==&g2 );
-    return get(ecm2,e);
+    return get(edge_cst_map2,e);
   }
   void set_constrained(G&g, edge_descriptor e) const
   {
-    if constexpr (std::is_same_v<Ecm1, No_mark<G>> && std::is_same_v<Ecm2, No_mark<G>>) return;
+    if constexpr (std::is_same_v<CstMap1, No_mark<G>> && std::is_same_v<CstMap2, No_mark<G>>) return;
     if ( &g==&g1 )
-      put(ecm1,e,true);
+      put(edge_cst_map1,e,true);
     else
     {
       CGAL_assertion( &g==&g2 );
-      put(ecm2,e,true);
+      put(edge_cst_map2,e,true);
     }
   }
   void set_on_intersection(G&g, edge_descriptor e) const
@@ -139,11 +139,11 @@ struct Ecm_bind
 };
 
 template <class G>
-struct Ecm_bind<G, No_mark<G>, No_mark<G>, No_mark<G>, No_mark<G> >
+struct Edge_properties_for_input<G, No_mark<G>, No_mark<G>, No_mark<G>, No_mark<G> >
 {
-  No_mark<G> ecm1, ecm2, edge_mark_map1, edge_mark_map2;
+  No_mark<G> edge_cst_map1, edge_cst_map2, edge_mark_map1, edge_mark_map2;
   template<class NP1, class NP2>
-  Ecm_bind(G&, G&, const NP1&, const NP2&){}
+  Edge_properties_for_input(G&, G&, const NP1&, const NP2&){}
   typedef typename boost::graph_traits<G>::edge_descriptor edge_descriptor;
   constexpr void set_constrained(G&, edge_descriptor) const {}
   constexpr void set_on_intersection(G&, edge_descriptor) const {}
@@ -156,63 +156,63 @@ struct Ecm_bind<G, No_mark<G>, No_mark<G>, No_mark<G>, No_mark<G> >
 };
 
 template <class G, class NP1, class NP2>
-struct Get_Ecm_bind
+struct Get_Edge_properties_for_input
 {
   typedef No_mark<G> D;
-  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, NP1, D> ::type Ecm1;
-  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, NP2, D> ::type Ecm2;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, NP1, D> ::type Cst_map1;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, NP2, D> ::type Cst_map2;
   typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, NP1, D> ::type Mark_map1;
   typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, NP2, D> ::type Mark_map2;
-  typedef Ecm_bind<G, Ecm1, Ecm2, Mark_map1, Mark_map2> type;
+  typedef Edge_properties_for_input<G, Cst_map1, Cst_map2, Mark_map1, Mark_map2> type;
 };
 
 
 template <class G,
-          class Ecm_0, class Ecm_1, class Ecm_2, class Ecm_3,
+          class CstMap_0, class CstMap_1, class CstMap_2, class CstMap_3,
           class MarkMap_0, class MarkMap_1, class MarkMap_2, class MarkMap_3>
-struct Ecm_out_bind
+struct Edge_properties_for_output
 {
-  std::tuple<Ecm_0, Ecm_1, Ecm_2, Ecm_3> ecm_tuple;
+  std::tuple<CstMap_0, CstMap_1, CstMap_2, CstMap_3> edge_cst_tuple;
   std::tuple<MarkMap_0, MarkMap_1, MarkMap_2, MarkMap_3> edge_mark_tuple;
 
 
-  Ecm_out_bind(Ecm_0 ecm0, Ecm_1 ecm1, Ecm_2 ecm2, Ecm_3 ecm3,
-               MarkMap_0 edge_mark_map0, MarkMap_1 edge_mark_map1, MarkMap_2 edge_mark_map2, MarkMap_3 edge_mark_map3)
-  : ecm_tuple(ecm0,ecm1,ecm2,ecm3)
+  Edge_properties_for_output(CstMap_0 edge_cst_map0, CstMap_1 edge_cst_map1, CstMap_2 edge_cst_map2, CstMap_3 edge_cst_map3,
+                             MarkMap_0 edge_mark_map0, MarkMap_1 edge_mark_map1, MarkMap_2 edge_mark_map2, MarkMap_3 edge_mark_map3)
+  : edge_cst_tuple(edge_cst_map0,edge_cst_map1,edge_cst_map2,edge_cst_map3)
   , edge_mark_tuple(edge_mark_map0,edge_mark_map1,edge_mark_map2,edge_mark_map3)
   {}
 
   template<class NP_tuple>
-  Ecm_out_bind(const NP_tuple nps)
-    : Ecm_out_bind(parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<0>(nps), internal_np::edge_is_constrained)),
-                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<1>(nps), internal_np::edge_is_constrained)),
-                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<2>(nps), internal_np::edge_is_constrained)),
-                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<3>(nps), internal_np::edge_is_constrained)),
-                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<0>(nps), internal_np::edge_is_marked_map)),
-                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<1>(nps), internal_np::edge_is_marked_map)),
-                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<2>(nps), internal_np::edge_is_marked_map)),
-                   parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<3>(nps), internal_np::edge_is_marked_map)))
+  Edge_properties_for_output(const NP_tuple nps)
+    : Edge_properties_for_output(parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<0>(nps), internal_np::edge_is_constrained)),
+                                 parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<1>(nps), internal_np::edge_is_constrained)),
+                                 parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<2>(nps), internal_np::edge_is_constrained)),
+                                 parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<3>(nps), internal_np::edge_is_constrained)),
+                                 parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<0>(nps), internal_np::edge_is_marked_map)),
+                                 parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<1>(nps), internal_np::edge_is_marked_map)),
+                                 parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<2>(nps), internal_np::edge_is_marked_map)),
+                                 parameters::choose_parameter<No_mark<G>>(parameters::get_parameter(std::get<3>(nps), internal_np::edge_is_marked_map)))
   {}
 };
 
 template <class G, class NP_tuple>
-struct Get_Ecm_out_bind
+struct Get_edge_properties_for_output
 {
   typedef No_mark<G> D;
-  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, std::tuple_element_t<0, NP_tuple>, D> ::type Ecm0;
-  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, std::tuple_element_t<1, NP_tuple>, D> ::type Ecm1;
-  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, std::tuple_element_t<2, NP_tuple>, D> ::type Ecm2;
-  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, std::tuple_element_t<3, NP_tuple>, D> ::type Ecm3;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, std::tuple_element_t<0, NP_tuple>, D> ::type CstMap0;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, std::tuple_element_t<1, NP_tuple>, D> ::type CstMap1;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, std::tuple_element_t<2, NP_tuple>, D> ::type CstMap2;
+  typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_constrained_t, std::tuple_element_t<3, NP_tuple>, D> ::type CstMap3;
   typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, std::tuple_element_t<0, NP_tuple>, D> ::type Mark_map0;
   typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, std::tuple_element_t<1, NP_tuple>, D> ::type Mark_map1;
   typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, std::tuple_element_t<2, NP_tuple>, D> ::type Mark_map2;
   typedef typename internal_np::Lookup_named_param_def<internal_np::edge_is_marked_map_t, std::tuple_element_t<3, NP_tuple>, D> ::type Mark_map3;
-  typedef Ecm_out_bind<G, Ecm0, Ecm1, Ecm2, Ecm3, Mark_map0, Mark_map1, Mark_map2, Mark_map3> type;
+  typedef Edge_properties_for_output<G, CstMap0, CstMap1, CstMap2, CstMap3, Mark_map0, Mark_map1, Mark_map2, Mark_map3> type;
 };
 
 
 template <class G>
-using Default_ecm_bind = Ecm_bind<G,No_mark<G>,No_mark<G>,No_mark<G>,No_mark<G>>;
+using Default_edge_properties_for_input = Edge_properties_for_input<G,No_mark<G>,No_mark<G>,No_mark<G>,No_mark<G>>;
 
 
 template<class G>
@@ -579,7 +579,7 @@ template< class TriangleMesh,
           bool handle_non_manifold_features = false >
 class Surface_intersection_visitor_for_corefinement{
 //default template parameters
-  typedef typename Default::Get<EdgeMarkMapBind_, Default_ecm_bind<TriangleMesh>>::type      EdgeMarkMapBind;
+  typedef typename Default::Get<EdgeMarkMapBind_, Default_edge_properties_for_input<TriangleMesh>>::type      EdgeMarkMapBind;
   typedef typename Default::Get<OutputBuilder_,
     No_extra_output_from_corefinement<TriangleMesh> >::type       OutputBuilder;
   typedef typename Default::Get<
@@ -650,46 +650,39 @@ private:
   bool input_with_coplanar_faces;
   TriangleMesh* const_mesh_ptr;
 
-  template <class Ecm1, class Ecm2, class MarkMap1, class MarkMap2>
-  void set_constrained(Ecm_bind<TriangleMesh, Ecm1, Ecm2, MarkMap1, MarkMap2>& ecm,
+  template <class CstMap1, class CstMap2, class MarkMap1, class MarkMap2>
+  void set_constrained(Edge_properties_for_input<TriangleMesh, CstMap1, CstMap2, MarkMap1, MarkMap2>& edge_properties,
                        TriangleMesh& tm, edge_descriptor ed)
   {
-    ecm.set_constrained(tm, ed);
+    edge_properties.set_constrained(tm, ed);
   }
-  template <class Ecm>
-  void set_constrained(Ecm& ecm,
+  template <class Edge_map>
+  void set_constrained(Edge_map& em,
                        TriangleMesh&, edge_descriptor ed)
   {
-    put(ecm, ed, true);
+    put(em, ed, true);
   }
 
-  template <class Ecm1, class Ecm2, class MarkMap1, class MarkMap2>
-  void set_on_intersection(Ecm_bind<TriangleMesh, Ecm1, Ecm2, MarkMap1, MarkMap2>& ecm,
+  template <class CstMap1, class CstMap2, class MarkMap1, class MarkMap2>
+  void set_on_intersection(Edge_properties_for_input<TriangleMesh, CstMap1, CstMap2, MarkMap1, MarkMap2>& em,
                            TriangleMesh& tm, edge_descriptor ed)
   {
-    ecm.set_on_intersection(tm, ed);
+    em.set_on_intersection(tm, ed);
   }
-  template <class Ecm>
-  void set_on_intersection(Ecm& ecm,
+  template <class Edge_map>
+  void set_on_intersection(Edge_map& em,
                            TriangleMesh&, edge_descriptor ed)
   {
-    put(ecm, ed, true);
+    put(em, ed, true);
   }
 
-  template <class Ecm1, class Ecm2, class MarkMap1, class MarkMap2>
-  bool is_constrained(const Ecm_bind<TriangleMesh, Ecm1, Ecm2, MarkMap1, MarkMap2>& ecm,
+  template <class CstMap1, class CstMap2, class MarkMap1, class MarkMap2>
+  bool is_constrained(const Edge_properties_for_input<TriangleMesh, CstMap1, CstMap2, MarkMap1, MarkMap2>& em,
                 TriangleMesh& tm, edge_descriptor ed)
   {
-    return ecm.is_constrained(tm, ed);
+    return em.is_constrained(tm, ed);
   }
-/*
-  template <class Ecm>
-  bool call_get(const Ecm& ecm,
-                TriangleMesh&, edge_descriptor ed)
-  {
-    return get(ecm, ed);
-  }
-*/
+
 // visitor public functions
 public:
   Surface_intersection_visitor_for_corefinement(

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -34,37 +34,23 @@ template <typename G>
 struct No_mark
 {
   friend
-  bool get(No_mark<G>,
+  constexpr bool get(No_mark<G>,
                   typename boost::graph_traits<G>::edge_descriptor)
   {
     return false;
   }
-  friend void put(No_mark<G>,
-                  typename boost::graph_traits<G>::edge_descriptor, bool)
+  friend
+   void put(No_mark<G>,
+                     typename boost::graph_traits<G>::edge_descriptor, bool)
   {}
 };
 
 template<class G,
-         class EdgeMarkMap>
-void mark_all_edges(G& tm, EdgeMarkMap& edge_mark_map)
-{
-  for(typename boost::graph_traits<G>::edge_descriptor ed :
-                edges(tm))
-  {
-    put(edge_mark_map, ed, true);
-  }
-}
-
-template<class G>
-void mark_all_edges(G&, No_mark<G>&)
-{} //nothing to do
-
-template<class G,
          class EdgeMarkMap,
          class HalfedgeRange>
-void unmark_edges(      G& tm,
-                        EdgeMarkMap& edge_mark_map,
-                  const HalfedgeRange& hedges)
+void unconstrain_edges(G& tm,
+                       EdgeMarkMap& edge_mark_map,
+                       const HalfedgeRange& hedges)
 {
   for(typename boost::graph_traits<G>::halfedge_descriptor hd : hedges)
     put(edge_mark_map, edge(hd, tm), false);
@@ -72,19 +58,19 @@ void unmark_edges(      G& tm,
 
 template <class G,
           class HalfedgeRange>
-void unmark_edges(      G&,
-                        No_mark<G>&,
-                  const HalfedgeRange&)
+void unconstrain_edges(G&,
+                       No_mark<G>&,
+                       const HalfedgeRange&)
 {} //nothing to do
 
 template <class G,
           class edge_descriptor,
           class EdgeMarkMapIn,
           class EdgeMarkMapOut>
-void copy_edge_mark(edge_descriptor ed_in,
-                    edge_descriptor ed_out,
-                    const EdgeMarkMapIn& edge_mark_map_in,
-                          EdgeMarkMapOut& edge_mark_map_out)
+void copy_constraint_status(edge_descriptor ed_in,
+                            edge_descriptor ed_out,
+                            EdgeMarkMapIn edge_mark_map_in,
+                            EdgeMarkMapOut edge_mark_map_out)
 {
   if(get(edge_mark_map_in, ed_in))
     put(edge_mark_map_out, ed_out, true);
@@ -93,35 +79,35 @@ void copy_edge_mark(edge_descriptor ed_in,
 template <class G,
           class edge_descriptor,
           class EdgeMarkMapOut>
-void copy_edge_mark(edge_descriptor,
-                    edge_descriptor,
-                    No_mark<G>,
-                    EdgeMarkMapOut)
+void copy_constraint_status(edge_descriptor,
+                            edge_descriptor,
+                            No_mark<G>,
+                            EdgeMarkMapOut)
 {} // nothing to do
 
 template <class G,
           class edge_descriptor,
           class EdgeMarkMapIn>
-void copy_edge_mark(edge_descriptor,
-                    edge_descriptor,
-                    EdgeMarkMapIn,
-                    No_mark<G>)
+void copy_constraint_status(edge_descriptor,
+                            edge_descriptor,
+                            EdgeMarkMapIn,
+                            No_mark<G>)
 {} // nothing to do
 
 template <class G,
           class edge_descriptor>
-void copy_edge_mark(edge_descriptor,
-                    edge_descriptor,
-                    No_mark<G>,
-                    No_mark<G>)
+void copy_constraint_status(edge_descriptor,
+                            edge_descriptor,
+                            No_mark<G>,
+                            No_mark<G>)
 {} // nothing to do
 
 template <class G,
           class EdgeMarkMapIn,
           class EdgeMarkMapOut>
-void copy_edge_mark(G& g,
-                    const EdgeMarkMapIn & edge_mark_map_in,
-                          EdgeMarkMapOut& edge_mark_map_out)
+void copy_constraint_status(G& g,
+                            EdgeMarkMapIn  edge_mark_map_in,
+                            EdgeMarkMapOut edge_mark_map_out)
 {
   for(typename boost::graph_traits<G>::edge_descriptor ed : edges(g))
     if(get(edge_mark_map_in, ed))
@@ -130,22 +116,22 @@ void copy_edge_mark(G& g,
 
 template <class G,
           class EdgeMarkMapOut>
-void copy_edge_mark(G&,
-                    const No_mark<G> &,
-                          EdgeMarkMapOut&)
+void copy_constraint_status(G&,
+                            No_mark<G>,
+                            EdgeMarkMapOut)
 {} // nothing to do
 
 template <class G,
           class EdgeMarkMapIn>
-void copy_edge_mark(G&,
-                    const EdgeMarkMapIn&,
-                          No_mark<G>&)
+void copy_constraint_status(G&,
+                            EdgeMarkMapIn,
+                            No_mark<G>)
 {} // nothing to do
 
 template <class G>
-void copy_edge_mark(G&,
-                    const No_mark<G>&,
-                          No_mark<G>&)
+void copy_constraint_status(G&,
+                            No_mark<G>,
+                            No_mark<G>)
 {} // nothing to do
 
 
@@ -1149,8 +1135,8 @@ void append_patches_to_triangle_mesh(
       user_visitor.after_edge_copy(h, tm, halfedge(new_edge, output), output);
 
       // copy the mark on input edge to the output edge
-      copy_edge_mark<TriangleMesh>(ed, new_edge,
-                                   edge_mark_map_in, edge_mark_map_out);
+      copy_constraint_status<TriangleMesh>(ed, new_edge,
+                                           edge_mark_map_in, edge_mark_map_out);
 
       halfedge_descriptor new_h = halfedge(new_edge, output);
       tm_to_output_edges[ed] = new_edge;
@@ -1608,7 +1594,7 @@ void compute_inplace_operation_delay_removal_and_insideout(
   const VertexPointMap2& vpm2,
         EdgeMarkMapIn1&,
   const EdgeMarkMapIn2& edge_mark_map2,
-  const EdgeMarkMapOut& edge_mark_map_out1,
+  const EdgeMarkMapOut& edge_mark_map_out,
   EdgeMap& disconnected_patches_edge_to_tm2_edge,
   UserVisitor& user_visitor)
 {
@@ -1658,7 +1644,7 @@ void compute_inplace_operation_delay_removal_and_insideout(
                                           patches_of_tm2,
                                           vpm1,
                                           vpm2,
-                                          edge_mark_map_out1,
+                                          edge_mark_map_out,
                                           edge_mark_map2,
                                           tm2_edge_to_tm1_edge,
                                           user_visitor);
@@ -1668,7 +1654,7 @@ void compute_inplace_operation_delay_removal_and_insideout(
                                            patches_of_tm2,
                                            vpm1,
                                            vpm2,
-                                           edge_mark_map_out1,
+                                           edge_mark_map_out,
                                            edge_mark_map2,
                                            tm2_edge_to_tm1_edge,
                                            user_visitor);
@@ -1710,7 +1696,7 @@ remove_patches(TriangleMesh& tm,
 
     // edges removed must be unmarked to avoid issues when adding new elements
     // that could be marked because they retrieve a previously set property
-    unmark_edges(tm, edge_mark_map, patch.interior_edges);
+    unconstrain_edges(tm, edge_mark_map, patch.interior_edges);
 
     // In case a ccb of the patch is not a cycle (the source and target vertices
     // are border vertices), the first halfedge of that ccb will not have its
@@ -1753,7 +1739,7 @@ template <class TriangleMesh,
           class VertexPointMap2,
           class EdgeMarkMapIn1,
           class EdgeMarkMapIn2,
-          class EdgeMarkMapOut1,
+          class EdgeMarkMapOut,
           class UserVisitor>
 void compute_inplace_operation(
         TriangleMesh& tm1,
@@ -1766,9 +1752,9 @@ void compute_inplace_operation(
   bool reverse_patch_orientation_tm2,
   const VertexPointMap1& vpm1,
   const VertexPointMap2& vpm2,
-        EdgeMarkMapIn1& edge_mark_map_in1,
-  const EdgeMarkMapIn2& edge_mark_map_in2,
-        EdgeMarkMapOut1& edge_mark_map_out1,
+        EdgeMarkMapIn1 edge_mark_map_in1,
+        EdgeMarkMapIn2 edge_mark_map_in2,
+        EdgeMarkMapOut edge_mark_map_out,
   std::unordered_map<
     typename boost::graph_traits<TriangleMesh>::edge_descriptor,
     typename boost::graph_traits<TriangleMesh>::edge_descriptor
@@ -1782,7 +1768,7 @@ void compute_inplace_operation(
   remove_patches(tm1, ~patches_of_tm1_to_keep, patches_of_tm1, edge_mark_map_in1);
 
   // transfer marks of edges of patches kept to the output edge mark property
-  copy_edge_mark<TriangleMesh>(tm1, edge_mark_map_in1, edge_mark_map_out1);
+  copy_constraint_status<TriangleMesh>(tm1, edge_mark_map_in1, edge_mark_map_out);
 
   if (reverse_patch_orientation_tm1){
     Polygon_mesh_processing::
@@ -1800,7 +1786,7 @@ void compute_inplace_operation(
                                           patches_of_tm2,
                                           vpm1,
                                           vpm2,
-                                          edge_mark_map_out1,
+                                          edge_mark_map_out,
                                           edge_mark_map_in2,
                                           tm2_edge_to_tm1_edge,
                                           user_visitor);
@@ -1810,7 +1796,7 @@ void compute_inplace_operation(
                                            patches_of_tm2,
                                            vpm1,
                                            vpm2,
-                                           edge_mark_map_out1,
+                                           edge_mark_map_out,
                                            edge_mark_map_in2,
                                            tm2_edge_to_tm1_edge,
                                            user_visitor);
@@ -1861,7 +1847,7 @@ template <class TriangleMesh,
           class VertexPointMap2,
           class EdgeMarkMapIn1,
           class EdgeMarkMapIn2,
-          class EdgeMarkMapOut1,
+          class EdgeMarkMapOut,
           class UserVisitor>
 void compute_inplace_operation(
         TriangleMesh& tm1,
@@ -1874,9 +1860,9 @@ void compute_inplace_operation(
   bool reverse_patch_orientation_tm2,
   const VertexPointMap1& vpm1,
   const VertexPointMap2& vpm2,
-  const EdgeMarkMapIn1& edge_mark_map_in1,
-  const EdgeMarkMapIn2& edge_mark_map_in2,
-  const EdgeMarkMapOut1& edge_mark_map_out1,
+       EdgeMarkMapIn1 edge_mark_map_in1,
+       EdgeMarkMapIn2 edge_mark_map_in2,
+       EdgeMarkMapOut edge_mark_map_out,
   const IntersectionPolylines& polylines,
         UserVisitor& user_visitor)
 {
@@ -1900,7 +1886,7 @@ void compute_inplace_operation(
                             vpm2,
                             edge_mark_map_in1,
                             edge_mark_map_in2,
-                            edge_mark_map_out1,
+                            edge_mark_map_out,
                             tm2_edge_to_tm1_edge,
                             user_visitor);
 }
@@ -2022,7 +2008,7 @@ void remove_disconnected_patches(
 
     // edges removed must be unmarked to avoid issues when adding new elements
     // that could be marked because they retrieve a previously set property
-    unmark_edges(tm, edge_mark_map, patch.interior_edges);
+    unconstrain_edges(tm, edge_mark_map, patch.interior_edges);
 
     for(halfedge_descriptor h : patch.interior_edges)
       remove_edge(edge(h, tm), tm);

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/face_graph_utils.h
@@ -1079,8 +1079,8 @@ template < bool reverse_patch_orientation,
            class PatchContainer,
            class VertexPointMap,
            class VertexPointMapOut,
-           class EdgeMarkMapOut,
-           class EdgeMarkMapIn ,
+           class EdgeCstMapOut, class EdgeMarkMapOut,
+           class EdgeCstMapIn , class EdgeMarkMapIn ,
            class UserVisitor>
 void append_patches_to_triangle_mesh(
   TriangleMesh& output,
@@ -1088,8 +1088,8 @@ void append_patches_to_triangle_mesh(
   PatchContainer& patches,
   const VertexPointMapOut& vpm_out,
   const VertexPointMap& vpm_tm,
-  EdgeMarkMapOut& edge_mark_map_out,
-  const EdgeMarkMapIn& edge_mark_map_in,
+  EdgeCstMapOut& edge_cst_map_out, EdgeMarkMapOut& edge_mark_map_out,
+  const EdgeCstMapIn& edge_cst_map_in, const EdgeMarkMapIn& edge_mark_map_in,
   std::unordered_map<
     typename boost::graph_traits<TriangleMesh>::edge_descriptor,
     typename boost::graph_traits<TriangleMesh>::edge_descriptor
@@ -1135,8 +1135,8 @@ void append_patches_to_triangle_mesh(
       user_visitor.after_edge_copy(h, tm, halfedge(new_edge, output), output);
 
       // copy the mark on input edge to the output edge
-      copy_constraint_status<TriangleMesh>(ed, new_edge,
-                                           edge_mark_map_in, edge_mark_map_out);
+      copy_constraint_status<TriangleMesh>(ed, new_edge, edge_cst_map_in, edge_cst_map_out);
+      copy_constraint_status<TriangleMesh>(ed, new_edge, edge_mark_map_in, edge_mark_map_out);
 
       halfedge_descriptor new_h = halfedge(new_edge, output);
       tm_to_output_edges[ed] = new_edge;
@@ -1315,9 +1315,9 @@ template < class TriangleMesh,
            class VertexPointMap1,
            class VertexPointMap2,
            class VertexPointMapOut,
-           class EdgeMarkMap1,
-           class EdgeMarkMap2,
-           class EdgeMarkMapOut,
+           class EdgeCstMap1, class EdgeCstMap2,
+           class EdgeMarkMap1, class EdgeMarkMap2,
+           class EdgeCstMapOut, class EdgeMarkMapOut,
            class IntersectionPolylines,
            class PatchContainer1,
            class PatchContainer2,
@@ -1336,9 +1336,9 @@ void fill_new_triangle_mesh(
   const VertexPointMap1& vpm1,
   const VertexPointMap2& vpm2,
   const VertexPointMapOut& vpm_out,
-  const EdgeMarkMap1& edge_mark_map1,
-  const EdgeMarkMap2& edge_mark_map2,
-        EdgeMarkMapOut& edge_mark_map_out,
+  const EdgeCstMap1& edge_cst_map1, const EdgeCstMap2& edge_cst_map2,
+  const EdgeMarkMap1& edge_mark_map1, const EdgeMarkMap2& edge_mark_map2,
+        EdgeCstMapOut& edge_cst_map_out, EdgeMarkMapOut& edge_mark_map_out,
   std::vector< typename boost::graph_traits<TriangleMesh>::edge_descriptor>&
                                                             output_shared_edges,
   UserVisitor& user_visitor)
@@ -1379,7 +1379,9 @@ void fill_new_triangle_mesh(
                                           patches_of_tm1,
                                           vpm_out,
                                           vpm1,
+                                          edge_cst_map_out,
                                           edge_mark_map_out,
+                                          edge_cst_map1,
                                           edge_mark_map1,
                                           tm1_to_output_edges,
                                           user_visitor);
@@ -1389,7 +1391,9 @@ void fill_new_triangle_mesh(
                                            patches_of_tm1,
                                            vpm_out,
                                            vpm1,
+                                           edge_cst_map_out,
                                            edge_mark_map_out,
+                                           edge_cst_map1,
                                            edge_mark_map1,
                                            tm1_to_output_edges,
                                            user_visitor);
@@ -1401,7 +1405,9 @@ void fill_new_triangle_mesh(
                                           patches_of_tm2,
                                           vpm_out,
                                           vpm2,
+                                          edge_cst_map_out,
                                           edge_mark_map_out,
+                                          edge_cst_map2,
                                           edge_mark_map2,
                                           tm2_to_output_edges,
                                           user_visitor);
@@ -1411,7 +1417,9 @@ void fill_new_triangle_mesh(
                                            patches_of_tm2,
                                            vpm_out,
                                            vpm2,
+                                           edge_cst_map_out,
                                            edge_mark_map_out,
+                                           edge_cst_map2,
                                            edge_mark_map2,
                                            tm2_to_output_edges,
                                            user_visitor);
@@ -1577,9 +1585,9 @@ template <class TriangleMesh,
           class EdgeMap,
           class VertexPointMap1,
           class VertexPointMap2,
-          class EdgeMarkMapIn1,
-          class EdgeMarkMapIn2,
-          class EdgeMarkMapOut,
+          class EdgeCstMapIn1, class EdgeCstMapIn2,
+          class EdgeMarkMapIn1, class EdgeMarkMapIn2,
+          class EdgeCstMapOut, class EdgeMarkMapOut,
           class UserVisitor>
 void compute_inplace_operation_delay_removal_and_insideout(
   TriangleMesh& tm1,
@@ -1592,9 +1600,9 @@ void compute_inplace_operation_delay_removal_and_insideout(
   const IntersectionPolylines& polylines,
   const VertexPointMap1& vpm1,
   const VertexPointMap2& vpm2,
-        EdgeMarkMapIn1&,
-  const EdgeMarkMapIn2& edge_mark_map2,
-  const EdgeMarkMapOut& edge_mark_map_out,
+        EdgeCstMapIn1&, const EdgeCstMapIn2& edge_cst_map2,
+        EdgeMarkMapIn1&, const EdgeMarkMapIn2& edge_mark_map2,
+  const EdgeCstMapOut& edge_cst_map_out, const EdgeMarkMapOut& edge_mark_map_out,
   EdgeMap& disconnected_patches_edge_to_tm2_edge,
   UserVisitor& user_visitor)
 {
@@ -1644,7 +1652,9 @@ void compute_inplace_operation_delay_removal_and_insideout(
                                           patches_of_tm2,
                                           vpm1,
                                           vpm2,
+                                          edge_cst_map_out,
                                           edge_mark_map_out,
+                                          edge_cst_map2,
                                           edge_mark_map2,
                                           tm2_edge_to_tm1_edge,
                                           user_visitor);
@@ -1654,7 +1664,9 @@ void compute_inplace_operation_delay_removal_and_insideout(
                                            patches_of_tm2,
                                            vpm1,
                                            vpm2,
+                                           edge_cst_map_out,
                                            edge_mark_map_out,
+                                           edge_cst_map2,
                                            edge_mark_map2,
                                            tm2_edge_to_tm1_edge,
                                            user_visitor);
@@ -1662,11 +1674,13 @@ void compute_inplace_operation_delay_removal_and_insideout(
 
 template <class TriangleMesh,
           class PatchContainer,
+          class EdgeCstMap,
           class EdgeMarkMap>
 void
 remove_patches(TriangleMesh& tm,
                const boost::dynamic_bitset<>& patches_to_remove,
                PatchContainer& patches,
+               const EdgeCstMap& edge_cst_map,
                const EdgeMarkMap& edge_mark_map)
 {
   typedef boost::graph_traits<TriangleMesh> GT;
@@ -1696,6 +1710,7 @@ remove_patches(TriangleMesh& tm,
 
     // edges removed must be unmarked to avoid issues when adding new elements
     // that could be marked because they retrieve a previously set property
+    unconstrain_edges(tm, edge_cst_map, patch.interior_edges);
     unconstrain_edges(tm, edge_mark_map, patch.interior_edges);
 
     // In case a ccb of the patch is not a cycle (the source and target vertices
@@ -1737,9 +1752,9 @@ template <class TriangleMesh,
           class PatchContainer2,
           class VertexPointMap1,
           class VertexPointMap2,
-          class EdgeMarkMapIn1,
-          class EdgeMarkMapIn2,
-          class EdgeMarkMapOut,
+          class EdgeCstMapIn1, class EdgeCstMapIn2,
+          class EdgeMarkMapIn1, class EdgeMarkMapIn2,
+          class EdgeCstMapOut, class EdgeMarkMapOut,
           class UserVisitor>
 void compute_inplace_operation(
         TriangleMesh& tm1,
@@ -1752,9 +1767,9 @@ void compute_inplace_operation(
   bool reverse_patch_orientation_tm2,
   const VertexPointMap1& vpm1,
   const VertexPointMap2& vpm2,
-        EdgeMarkMapIn1 edge_mark_map_in1,
-        EdgeMarkMapIn2 edge_mark_map_in2,
-        EdgeMarkMapOut edge_mark_map_out,
+        EdgeCstMapIn1 edge_cst_map_in1, EdgeCstMapIn2 edge_cst_map_in2,
+        EdgeMarkMapIn1 edge_mark_map_in1, EdgeMarkMapIn2 edge_mark_map_in2,
+        EdgeCstMapOut edge_cst_map_out, EdgeMarkMapOut edge_mark_map_out,
   std::unordered_map<
     typename boost::graph_traits<TriangleMesh>::edge_descriptor,
     typename boost::graph_traits<TriangleMesh>::edge_descriptor
@@ -1765,9 +1780,10 @@ void compute_inplace_operation(
       typename boost::graph_traits<TriangleMesh>::edge_descriptor,
       typename boost::graph_traits<TriangleMesh>::edge_descriptor> EdgeMap;
   //clean up patches not kept
-  remove_patches(tm1, ~patches_of_tm1_to_keep, patches_of_tm1, edge_mark_map_in1);
+  remove_patches(tm1, ~patches_of_tm1_to_keep, patches_of_tm1, edge_cst_map_in1, edge_mark_map_in1);
 
   // transfer marks of edges of patches kept to the output edge mark property
+  copy_constraint_status<TriangleMesh>(tm1, edge_cst_map_in1, edge_cst_map_out);
   copy_constraint_status<TriangleMesh>(tm1, edge_mark_map_in1, edge_mark_map_out);
 
   if (reverse_patch_orientation_tm1){
@@ -1786,7 +1802,9 @@ void compute_inplace_operation(
                                           patches_of_tm2,
                                           vpm1,
                                           vpm2,
+                                          edge_cst_map_out,
                                           edge_mark_map_out,
+                                          edge_cst_map_in2,
                                           edge_mark_map_in2,
                                           tm2_edge_to_tm1_edge,
                                           user_visitor);
@@ -1796,7 +1814,9 @@ void compute_inplace_operation(
                                            patches_of_tm2,
                                            vpm1,
                                            vpm2,
+                                           edge_cst_map_out,
                                            edge_mark_map_out,
+                                           edge_cst_map_in2,
                                            edge_mark_map_in2,
                                            tm2_edge_to_tm1_edge,
                                            user_visitor);
@@ -1845,9 +1865,9 @@ template <class TriangleMesh,
           class IntersectionPolylines,
           class VertexPointMap1,
           class VertexPointMap2,
-          class EdgeMarkMapIn1,
-          class EdgeMarkMapIn2,
-          class EdgeMarkMapOut,
+          class EdgeCstMapIn1, class EdgeCstMapIn2,
+          class EdgeMarkMapIn1, class EdgeMarkMapIn2,
+          class EdgeCstMapOut, class EdgeMarkMapOut,
           class UserVisitor>
 void compute_inplace_operation(
         TriangleMesh& tm1,
@@ -1860,9 +1880,9 @@ void compute_inplace_operation(
   bool reverse_patch_orientation_tm2,
   const VertexPointMap1& vpm1,
   const VertexPointMap2& vpm2,
-       EdgeMarkMapIn1 edge_mark_map_in1,
-       EdgeMarkMapIn2 edge_mark_map_in2,
-       EdgeMarkMapOut edge_mark_map_out,
+       EdgeCstMapIn1 edge_cst_map_in1, EdgeCstMapIn2 edge_cst_map_in2,
+       EdgeMarkMapIn1 edge_mark_map_in1, EdgeMarkMapIn2 edge_mark_map_in2,
+       EdgeCstMapOut edge_cst_map_out, EdgeMarkMapOut edge_mark_map_out,
   const IntersectionPolylines& polylines,
         UserVisitor& user_visitor)
 {
@@ -1884,9 +1904,9 @@ void compute_inplace_operation(
                             reverse_patch_orientation_tm2,
                             vpm1,
                             vpm2,
-                            edge_mark_map_in1,
-                            edge_mark_map_in2,
-                            edge_mark_map_out,
+                            edge_cst_map_in1, edge_cst_map_in2,
+                            edge_mark_map_in1, edge_mark_map_in2,
+                            edge_cst_map_out, edge_mark_map_out,
                             tm2_edge_to_tm1_edge,
                             user_visitor);
 }
@@ -1988,11 +2008,12 @@ void remove_unused_polylines(
     remove_edge(e,tm);
 }
 
-template <class TriangleMesh, class PatchContainer, class EdgeMarkMap>
+template <class TriangleMesh, class PatchContainer, class EdgeCstMap, class EdgeMarkMap>
 void remove_disconnected_patches(
   TriangleMesh& tm,
   PatchContainer& patches,
   const boost::dynamic_bitset<>& patches_to_remove,
+  EdgeCstMap& edge_cst_map,
   EdgeMarkMap& edge_mark_map)
 {
   typedef boost::graph_traits<TriangleMesh> GT;
@@ -2008,6 +2029,7 @@ void remove_disconnected_patches(
 
     // edges removed must be unmarked to avoid issues when adding new elements
     // that could be marked because they retrieve a previously set property
+    unconstrain_edges(tm, edge_cst_map, patch.interior_edges);
     unconstrain_edges(tm, edge_mark_map, patch.interior_edges);
 
     for(halfedge_descriptor h : patch.interior_edges)

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/internal/Corefinement/intersection_impl.h
@@ -96,6 +96,7 @@ struct Default_surface_intersection_visitor{
   void input_have_coplanar_faces(){}
   template<class T>
   void check_no_duplicates(const T&){}
+  void inputs_are_two_identical_meshes(){}
   template<class T,class VPM1,class VPM2>
   void finalize(T&,
                 const TriangleMesh&, const TriangleMesh&,
@@ -1923,6 +1924,7 @@ public:
             *output++=polyline;
           }
         }
+        visitor.inputs_are_two_identical_meshes();
         visitor.finalize(nodes,tm1,tm2,vpm1,vpm2, identical_patches);
 
         return output;

--- a/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/intersection_polylines.h
+++ b/PMP_Boolean_operations/include/CGAL/Polygon_mesh_processing/intersection_polylines.h
@@ -96,6 +96,18 @@ intersection_polylines(const TriangleMesh& tm1,
   VPM2 vpm2 = parameters::choose_parameter(parameters::get_parameter(np2, internal_np::vertex_point),
                                            get_const_property_map(CGAL::vertex_point, tm2));
 
+  if (&tm1==&tm2)
+  {
+    if (throw_on_self_intersection && does_self_intersect(tm1))
+      throw Corefinement::Self_intersection_exception();
+    for (auto e : edges(tm1))
+    {
+      std::vector s = {get(vpm1, source(e, tm1)), get(vpm1, target(e, tm1))};
+      *polyline_output++=s;
+    }
+    return polyline_output;
+  }
+
   Corefinement::Intersection_of_triangle_meshes<TriangleMesh, VPM1, VPM2>
     functor(tm1, tm2, vpm1, vpm2);
 

--- a/PMP_Boolean_operations/test/PMP_Boolean_operations/test_corefinement_and_constraints.cpp
+++ b/PMP_Boolean_operations/test/PMP_Boolean_operations/test_corefinement_and_constraints.cpp
@@ -1,4 +1,5 @@
 #include <CGAL/Polygon_mesh_processing/corefinement.h>
+#include <CGAL/Polygon_mesh_processing/intersection_polylines.h>
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Exact_predicates_inexact_constructions_kernel.h>
 
@@ -190,6 +191,57 @@ void test_bool_op(Triangle_mesh tm1, Triangle_mesh tm2, bool reverse, const char
   test_bool_op_no_copy(tm1, tm2, outname, reverse);
 }
 
+void test_identical_models(const Triangle_mesh& tm1)
+{
+  std::size_t nedges=num_edges(tm1);
+  // first test with corefine
+  Triangle_mesh m1=tm1, m2=tm1;
+  auto ecm1 = m1.add_property_map<Triangle_mesh::Edge_index, bool>("ecm", false).first;
+  auto ecm2 = m2.add_property_map<Triangle_mesh::Edge_index, bool>("ecm", false).first;
+  PMP::corefine(m1, m2, params::edge_is_constrained_map(ecm1), params::edge_is_constrained_map(ecm2));
+  assert( count_constrained_edges(m1, ecm1)==nedges );
+  assert( count_constrained_edges(m2, ecm2)==nedges );
+  Triangle_mesh m3=tm1;
+  auto ecm3 = m3.add_property_map<Triangle_mesh::Edge_index, bool>("ecm", false).first;
+  PMP::corefine(m3, m3, params::edge_is_constrained_map(ecm3), params::edge_is_constrained_map(ecm3));
+  assert( count_constrained_edges(m3, ecm3)==nedges );
+  m3.clear_without_removing_property_maps();
+
+
+  // then corefine_and_compute_boolean_operations
+  PMP::corefine_and_compute_union(m1, m2, m3, params::edge_is_constrained_map(ecm1), params::edge_is_constrained_map(ecm2), params::edge_is_constrained_map(ecm3));
+  assert( count_constrained_edges(m1, ecm1)==0. ); // they are cleared, even if provided by the user
+  assert( count_constrained_edges(m2, ecm2)==0. ); // they are cleared, even if provided by the user
+  assert( count_constrained_edges(m3, ecm3)==0. );
+
+  m3.clear_without_removing_property_maps();
+  CGAL::Bbox_3 bb = PMP::bbox(m1);
+  bb = CGAL::Bbox_3(bb.xmin()+2*(bb.xmax()-bb.xmin()), bb.ymin()+2*(bb.ymax()-bb.ymin()), bb.zmin()+2*(bb.zmax()-bb.zmin()),
+                    bb.xmax()+2*(bb.xmax()-bb.xmax()), bb.ymax()+2*(bb.ymax()-bb.ymin()), bb.zmax()+2*(bb.zmax()-bb.zmin()));
+  CGAL::make_hexahedron(bb, m1, params::do_not_triangulate_faces(false));
+  PMP::corefine_and_compute_union(m1, m2, m3, params::edge_is_constrained_map(ecm1), params::edge_is_constrained_map(ecm2), params::edge_is_constrained_map(ecm3));
+  assert( count_constrained_edges(m1, ecm1)==0. ); // they are cleared, even if provided by the user
+  assert( count_constrained_edges(m2, ecm2)==0. ); // they are cleared, even if provided by the user
+  assert( count_constrained_edges(m3, ecm3)==0. );
+
+  m3=tm1;
+  ecm3 = m3.add_property_map<Triangle_mesh::Edge_index, bool>("ecm", false).first;
+  PMP::corefine_and_compute_union(m3, m3, m3, params::edge_is_constrained_map(ecm3), params::edge_is_constrained_map(ecm3), params::edge_is_constrained_map(ecm3));
+  assert( count_constrained_edges(m3, ecm3)==0. );
+  assert( vertices(m3).size()==vertices(tm1).size() );
+
+  // finally polyline_intersection
+  std::vector<std::vector<K::Point_3>> polylines;
+  PMP::intersection_polylines(tm1, m1, std::back_inserter(polylines));
+  assert(polylines.size()==edges(tm1).size());
+  polylines.clear();
+  PMP::intersection_polylines(tm1, m2, std::back_inserter(polylines));
+  assert(polylines.size()==edges(tm1).size());
+  polylines.clear();
+  PMP::intersection_polylines(tm1, tm1, std::back_inserter(polylines));
+  assert(polylines.size()==edges(tm1).size());
+}
+
 
 int main()
 {
@@ -228,4 +280,6 @@ int main()
   test_bool_op(tm1, tm2, false, "e:cst_out");
   test_bool_op(tm1, tm2, true, "e:cst");
   test_bool_op(tm1, tm2, false, "e:cst");
+  std::cout << "Testing operations on identical meshes\n";
+  test_identical_models(tm1);
 }

--- a/PMP_Boolean_operations/test/PMP_Boolean_operations/test_corefinement_and_constraints.cpp
+++ b/PMP_Boolean_operations/test/PMP_Boolean_operations/test_corefinement_and_constraints.cpp
@@ -74,6 +74,15 @@ void translate(Triangle_mesh& tm,
 //  }
 // }
 
+// void dump_as_polyline(const Triangle_mesh& tm, std::string prop, std::string out)
+// {
+//   auto ecm = tm.property_map<Triangle_mesh::Edge_index,bool>(prop).value();
+//   std::ofstream oout(out);
+//   for(auto e : edges(tm))
+//     if (get(ecm, e))
+//       oout << "2 " << tm.point(source(e, tm)) << " " <<  tm.point(target(e, tm)) << "\n";
+// }
+
 std::size_t
 count_constrained_edges(const Triangle_mesh& tm, const Constrained_edge_map& ecm)
 {
@@ -95,13 +104,23 @@ void test_corefine(Triangle_mesh tm1, Triangle_mesh tm2)
   assert( count_constrained_edges(tm1, ecm1)==307 );
   assert( count_constrained_edges(tm2, ecm2)==307 );
 
+  auto mark_map1=tm1.add_property_map<Triangle_mesh::Edge_index,bool>("e:mark").first;
+  auto mark_map2=tm2.add_property_map<Triangle_mesh::Edge_index,bool>("e:mark").first;
+
   PMP::corefine(tm1,
                 tm2,
-                params::edge_is_constrained_map(ecm1),
-                params::edge_is_constrained_map(ecm2) );
+                params::edge_is_constrained_map(ecm1).edge_is_marked_map(mark_map1),
+                params::edge_is_constrained_map(ecm2).edge_is_marked_map(mark_map2)
+  );
 
-  assert( count_constrained_edges(tm1, ecm1)==658 );
-  assert( count_constrained_edges(tm2, ecm2)==655 );
+  assert( count_constrained_edges(tm1, ecm1)+count_constrained_edges(tm1, mark_map1)==658 );
+  assert( count_constrained_edges(tm2, ecm2)+count_constrained_edges(tm1, mark_map2)==655 );
+
+  assert( count_constrained_edges(tm1, ecm1)==323 );
+  assert( count_constrained_edges(tm2, ecm2)==320 );
+
+  assert( count_constrained_edges(tm1, mark_map1)==335 );
+  assert( count_constrained_edges(tm2, mark_map2)==335 );
 }
 
 void test_union_no_copy(
@@ -114,6 +133,7 @@ void test_union_no_copy(
     tm2.property_map<Triangle_mesh::Edge_index,bool>("e:cst").value();
   Constrained_edge_map ecm_out =
     tm_out.property_map<Triangle_mesh::Edge_index,bool>(outname).value();
+  auto mark_map_out=tm_out.add_property_map<Triangle_mesh::Edge_index,bool>("e:mark").first;
 
   assert( count_constrained_edges(tm1, ecm1)==307 );
   assert( count_constrained_edges(tm2, ecm2)==307 );
@@ -123,11 +143,12 @@ void test_union_no_copy(
                                   tm_out,
                                   params::edge_is_constrained_map(ecm1),
                                   params::edge_is_constrained_map(ecm2),
-                                  params::edge_is_constrained_map(ecm_out) );
+                                  params::edge_is_constrained_map(ecm_out).edge_is_marked_map(mark_map_out) );
 
-  assert( skip_test_1 || count_constrained_edges(tm1, ecm1)==658 );
-  assert( skip_test_2 || count_constrained_edges(tm2, ecm2)==655 );
-  assert( count_constrained_edges(tm_out, ecm_out)==838 );
+  assert( skip_test_1 || count_constrained_edges(tm1, ecm1)==323 );
+  assert( skip_test_2 || count_constrained_edges(tm2, ecm2)==320 );
+  assert( count_constrained_edges(tm_out, ecm_out)==503 );
+  assert( count_constrained_edges(tm_out, mark_map_out)==335 );
 }
 
 void test_union(Triangle_mesh tm1, Triangle_mesh tm2, Triangle_mesh tm_out,
@@ -174,10 +195,10 @@ void test_bool_op_no_copy(
                                                output,
                                                params::edge_is_constrained_map(ecm1),
                                                params::edge_is_constrained_map(ecm2),
-                                               std::make_tuple(params::edge_is_constrained_map(ecm_out_union),
-                                                                       params::edge_is_constrained_map(ecm_out_inter),
-                                                                       params::default_values(),
-                                                                       params::default_values()));
+                                               std::make_tuple(params::edge_is_constrained_map(ecm_out_union).edge_is_marked_map(ecm_out_union),
+                                                               params::edge_is_constrained_map(ecm_out_inter).edge_is_marked_map(ecm_out_inter),
+                                                               params::default_values(),
+                                                               params::default_values()));
 
   // dump_constrained_edges(*(*output[0]), ecm_out_union, "out_cst_union.cgal");
   // dump_constrained_edges(*(*output[1]), ecm_out_inter, "out_cst_inter.cgal");
@@ -198,18 +219,18 @@ void test_identical_models(const Triangle_mesh& tm1)
   Triangle_mesh m1=tm1, m2=tm1;
   auto ecm1 = m1.add_property_map<Triangle_mesh::Edge_index, bool>("ecm", false).first;
   auto ecm2 = m2.add_property_map<Triangle_mesh::Edge_index, bool>("ecm", false).first;
-  PMP::corefine(m1, m2, params::edge_is_constrained_map(ecm1), params::edge_is_constrained_map(ecm2));
+  PMP::corefine(m1, m2, params::edge_is_marked_map(ecm1), params::edge_is_marked_map(ecm2));
   assert( count_constrained_edges(m1, ecm1)==nedges );
   assert( count_constrained_edges(m2, ecm2)==nedges );
   Triangle_mesh m3=tm1;
   auto ecm3 = m3.add_property_map<Triangle_mesh::Edge_index, bool>("ecm", false).first;
-  PMP::corefine(m3, m3, params::edge_is_constrained_map(ecm3), params::edge_is_constrained_map(ecm3));
+  PMP::corefine(m3, m3, params::edge_is_marked_map(ecm3), params::edge_is_marked_map(ecm3));
   assert( count_constrained_edges(m3, ecm3)==nedges );
   m3.clear_without_removing_property_maps();
 
 
   // then corefine_and_compute_boolean_operations
-  PMP::corefine_and_compute_union(m1, m2, m3, params::edge_is_constrained_map(ecm1), params::edge_is_constrained_map(ecm2), params::edge_is_constrained_map(ecm3));
+  PMP::corefine_and_compute_union(m1, m2, m3, params::edge_is_marked_map(ecm1), params::edge_is_marked_map(ecm2), params::edge_is_marked_map(ecm3));
   assert( count_constrained_edges(m1, ecm1)==0. ); // they are cleared, even if provided by the user
   assert( count_constrained_edges(m2, ecm2)==0. ); // they are cleared, even if provided by the user
   assert( count_constrained_edges(m3, ecm3)==0. );
@@ -219,14 +240,14 @@ void test_identical_models(const Triangle_mesh& tm1)
   bb = CGAL::Bbox_3(bb.xmin()+2*(bb.xmax()-bb.xmin()), bb.ymin()+2*(bb.ymax()-bb.ymin()), bb.zmin()+2*(bb.zmax()-bb.zmin()),
                     bb.xmax()+2*(bb.xmax()-bb.xmax()), bb.ymax()+2*(bb.ymax()-bb.ymin()), bb.zmax()+2*(bb.zmax()-bb.zmin()));
   CGAL::make_hexahedron(bb, m1, params::do_not_triangulate_faces(false));
-  PMP::corefine_and_compute_union(m1, m2, m3, params::edge_is_constrained_map(ecm1), params::edge_is_constrained_map(ecm2), params::edge_is_constrained_map(ecm3));
+  PMP::corefine_and_compute_union(m1, m2, m3, params::edge_is_marked_map(ecm1), params::edge_is_marked_map(ecm2), params::edge_is_marked_map(ecm3));
   assert( count_constrained_edges(m1, ecm1)==0. ); // they are cleared, even if provided by the user
   assert( count_constrained_edges(m2, ecm2)==0. ); // they are cleared, even if provided by the user
   assert( count_constrained_edges(m3, ecm3)==0. );
 
   m3=tm1;
   ecm3 = m3.add_property_map<Triangle_mesh::Edge_index, bool>("ecm", false).first;
-  PMP::corefine_and_compute_union(m3, m3, m3, params::edge_is_constrained_map(ecm3), params::edge_is_constrained_map(ecm3), params::edge_is_constrained_map(ecm3));
+  PMP::corefine_and_compute_union(m3, m3, m3, params::edge_is_marked_map(ecm3), params::edge_is_marked_map(ecm3), params::edge_is_marked_map(ecm3));
   assert( count_constrained_edges(m3, ecm3)==0. );
   assert( vertices(m3).size()==vertices(tm1).size() );
 
@@ -242,6 +263,21 @@ void test_identical_models(const Triangle_mesh& tm1)
   assert(polylines.size()==edges(tm1).size());
 }
 
+void test_mark_cst()
+{
+  Triangle_mesh tm1, tm2;
+  read_input(tm1);
+  read_input(tm2);
+  translate(tm2);
+
+  Triangle_mesh tm_out;
+  auto ecm = tm_out.add_property_map<Triangle_mesh::Edge_index, bool>("ecm").first;
+  auto emm = tm_out.add_property_map<Triangle_mesh::Edge_index, bool>("emm").first;
+  PMP::corefine_and_compute_union(tm1, tm2, tm_out, params::default_values(), params::default_values(), params::edge_is_constrained_map(ecm).edge_is_marked_map(emm));
+
+  assert( count_constrained_edges(tm_out, ecm)==0 );
+  assert( count_constrained_edges(tm_out, emm)==335 );
+}
 
 int main()
 {
@@ -282,4 +318,6 @@ int main()
   test_bool_op(tm1, tm2, false, "e:cst");
   std::cout << "Testing operations on identical meshes\n";
   test_identical_models(tm1);
+  std::cout << "Extra tests\n";
+  test_mark_cst();
 }

--- a/PMP_Boolean_operations/test/PMP_Boolean_operations/test_pmp_clip.cpp
+++ b/PMP_Boolean_operations/test/PMP_Boolean_operations/test_pmp_clip.cpp
@@ -1,5 +1,7 @@
 #include <CGAL/Polygon_mesh_processing/clip.h>
 #include <CGAL/Polygon_mesh_processing/transform.h>
+#include <CGAL/Polygon_mesh_processing/detect_features.h>
+#include <CGAL/boost/graph/generators.h>
 
 #include <CGAL/Surface_mesh.h>
 #include <CGAL/Polyhedron_3.h>
@@ -1294,6 +1296,102 @@ void test_clip_and_split_with_plane_visitor()
 
 }
 
+
+
+
+template <class ECM>
+std::size_t
+count_constrained_edges(const Surface_mesh& tm, ECM ecm)
+{
+  std::size_t n=0;
+  for(auto e : tm.edges())
+  {
+    if ( ecm[e] ) ++n;
+  }
+  return n;
+}
+
+/*
+template <class ECM>
+void dump_constrained_edges(const Surface_mesh& tm, ECM ecm, std::string fname)
+{
+  std::ofstream output(fname);
+  for(auto e : tm.edges())
+  {
+    if ( get(ecm, e) )
+      output << "2 " << tm.point( tm.vertex(e, 0) )
+             <<  " " << tm.point( tm.vertex(e, 1) ) << "\n";
+  }
+}
+*/
+
+void test_edge_is_contrained()
+{
+  {
+  Surface_mesh tm;
+  std::ifstream(CGAL::data_file_path("meshes/joint_refined.off")) >> tm;
+
+  auto ecm = tm.add_property_map<Surface_mesh::Edge_index, bool>("ecm", false).first;
+  PMP::detect_sharp_edges(tm, 60, ecm);
+
+  CGAL::Bbox_3 bb(-0.61222702264785767, -0.31298750638961792, -0.16560758650302887,
+                  0.54861283302307129, 0.62676382064819336, 0.68821543455123901);
+
+  Surface_mesh clipper;
+  CGAL::make_hexahedron(K::Iso_cuboid_3(bb), clipper, params::do_not_triangulate_faces(false));
+
+  PMP::clip(tm, clipper, params::edge_is_constrained_map(ecm));
+
+  assert( count_constrained_edges(tm, ecm)==132 );
+  }
+
+  {
+  Surface_mesh tm;
+  std::ifstream(CGAL::data_file_path("meshes/joint_refined.off")) >> tm;
+
+  auto ecm = tm.add_property_map<Surface_mesh::Edge_index, bool>("ecm", false).first;
+  PMP::detect_sharp_edges(tm, 60, ecm);
+
+  CGAL::Bbox_3 bb(-0.61222702264785767, -0.31298750638961792, -0.16560758650302887,
+                  0.54861283302307129, 0.62676382064819336, 0.68821543455123901);
+
+  Surface_mesh clipper;
+  CGAL::make_hexahedron(K::Iso_cuboid_3(bb), clipper, params::do_not_triangulate_faces(false));
+
+  PMP::clip(tm, clipper, params::edge_is_constrained_map(ecm).clip_volume(true));
+
+  assert( count_constrained_edges(tm, ecm)==132 );
+  }
+
+  {
+  Surface_mesh tm;
+  std::ifstream(CGAL::data_file_path("meshes/joint_refined.off")) >> tm;
+
+  auto ecm = tm.add_property_map<Surface_mesh::Edge_index, bool>("ecm", false).first;
+  PMP::detect_sharp_edges(tm, 60, ecm);
+
+  K::Plane_3 plane(-1.63242e-16, -1, -2.22045e-16, -0.242727);
+
+  PMP::clip(tm, plane, params::edge_is_constrained_map(ecm));
+
+  assert( count_constrained_edges(tm, ecm)==146 );
+  }
+
+  {
+  Surface_mesh tm;
+  std::ifstream(CGAL::data_file_path("meshes/joint_refined.off")) >> tm;
+
+  auto ecm = tm.add_property_map<Surface_mesh::Edge_index, bool>("ecm", false).first;
+  PMP::detect_sharp_edges(tm, 60, ecm);
+
+  K::Plane_3 plane(-1.63242e-16, -1, -2.22045e-16, -0.242727);
+
+  PMP::clip(tm, plane, params::edge_is_constrained_map(ecm).clip_volume(true));
+
+  assert( count_constrained_edges(tm, ecm)==146 );
+  }
+}
+
 int main()
 {
   std::cout << "Surface Mesh" << std::endl;
@@ -1324,6 +1422,9 @@ int main()
   std::cout << "Done!" << std::endl;
   std::cout << "running test_clip_and_split_with_plane_visitor\n";
   test_clip_and_split_with_plane_visitor();
+  std::cout << "running test_edge_is_contrained\n";
+  test_edge_is_contrained();
   std::cout << "Done!" << std::endl;
+
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
## Summary of Changes

Make the intersection edges to be reported in `edge_is_marked` and only optionally in `edge_is_constrained`

## Release Management

* Affected package(s): PMP_Boolean_operations
* Issue(s) solved (if any): fix #0000, fix #0000,...
* Feature/Small Feature (if any): [here](https://cgalwiki.geometryfactory.com/CGAL/Members/wiki/Features/Small_Features/Edge_is_marked_in_coref)
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:   unchanged 

