### PR TITLE
Lab: Do not repair in an IO plugin

### DIFF
--- a/Lab/demo/Lab/Scene_surface_mesh_item.cpp
+++ b/Lab/demo/Lab/Scene_surface_mesh_item.cpp
@@ -1564,22 +1564,6 @@ Scene_surface_mesh_item::load_obj(std::istream& in)
 {
   typedef SMesh::Point Point;
   bool failed = !CGAL::IO::read_OBJ(in, *(d->smesh_), CGAL::parameters::verbose(true));
-  if(failed)
-  {
-    in.clear();
-    in.seekg(0);
-    std::vector<Point> points;
-    std::vector<std::vector<std::size_t> > faces;
-    failed = !CGAL::IO::read_OBJ(in, points, faces);
-    if(!failed)
-    {
-      CGAL::Polygon_mesh_processing::repair_polygon_soup(points, faces);
-      CGAL::Polygon_mesh_processing::orient_polygon_soup(points, faces);
-
-      clear(*(d->smesh_));
-      CGAL::Polygon_mesh_processing::polygon_soup_to_polygon_mesh(points, faces, *(d->smesh_));
-    }
-  }
 
   if((!failed) && !isEmpty())
   {

--- a/Lab/demo/Lab/Scene_surface_mesh_item.cpp
+++ b/Lab/demo/Lab/Scene_surface_mesh_item.cpp
@@ -28,10 +28,6 @@
 #include <CGAL/Polygon_mesh_processing/connected_components.h>
 #include <CGAL/Polygon_mesh_processing/compute_normal.h>
 #include <CGAL/Polygon_mesh_processing/self_intersections.h>
-#include <CGAL/Polygon_mesh_processing/shape_predicates.h>
-#include <CGAL/Polygon_mesh_processing/orient_polygon_soup.h>
-#include <CGAL/Polygon_mesh_processing/polygon_soup_to_polygon_mesh.h>
-#include <CGAL/Polygon_mesh_processing/repair_polygon_soup.h>
 #include "triangulate_primitive.h"
 
 #include <CGAL/IO/OBJ.h>
@@ -1562,7 +1558,6 @@ Scene_surface_mesh_item::save(std::ostream& out) const
 bool
 Scene_surface_mesh_item::load_obj(std::istream& in)
 {
-  typedef SMesh::Point Point;
   bool failed = !CGAL::IO::read_OBJ(in, *(d->smesh_), CGAL::parameters::verbose(true));
 
   if((!failed) && !isEmpty())


### PR DESCRIPTION
## Summary of Changes

When reading an `*.obj` file that is not a 2-manifold the IO plugin must not try to repair but just create a polygon soup item.

## Release Management

* Affected package(s): Lab
* License and copyright ownership:  unchanged

