### PR TITLE
SMS: Document example for parallel simplification

### DIFF
--- a/BGL/doc/BGL/BGL.txt
+++ b/BGL/doc/BGL/BGL.txt
@@ -661,19 +661,19 @@ of the same concept. See `CGAL/boost/graph/graph_traits_inheritance_macros.h` fo
 For algorithms that operate locally, partitioning is often an easy way to parallelize
 the algorithm at little cost.
 The functions `CGAL::METIS::partition_graph()` and `CGAL::METIS::partition_dual_graph()`
-provide wrappers to the graph partitioning library METIS \cgalCite{karypis1998fast},
-allowing to split triangular meshes that are models of the concept `FaceListGraph`
+provide wrappers to the graph partitioning library thirdpartyMETIS ,
+enabling to split triangular meshes that are models of the concept `FaceListGraph`
 into a given number of subdomains.
 
 The following example shows how to read, partition, and write a mesh using
-`partition_dual_graph()`. The class template `CGAL::Face_filtered_graph`
+`CGAL::METIS::partition_dual_graph()`. The class template `CGAL::Face_filtered_graph`
 and the free function `copy_face_graph()` are used to create an independent mesh from one
 of the subdomains of the partition. Note that the copy is optional as writing
 can be done directly using `Face_filtered_graph`.
 
 \cgalExample{BGL_surface_mesh/surface_mesh_partition.cpp}
 
-Using \ref BGLNamedParameters some of the many options of METIS can be customized,
+Using \ref BGLNamedParameters some of the many options of \metis can be customized,
 as shown in \ref BGL_polyhedron_3/polyhedron_partition.cpp "this example".
 
 \section BGLGraphcut Graph Cut

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/Surface_mesh_simplification.txt
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/Surface_mesh_simplification.txt
@@ -426,6 +426,24 @@ using behavior modifiers such as `Surface_mesh_simplification::Bounded_normal_ch
 
 Note that these policies depend on the third party \ref thirdpartyEigen library.
 
+
+\subsection Surface_mesh_simplificationExampleParallel Example Using Parallelism
+
+When using a local stop criterium like only collapsing small edges, a trivial parallelization is possible.
+First the mesh must be partitioned with the help of the \thirdpartyMETIS library.
+Then copies of the patches are generated, simplified independently, the result reassembled,
+and a final pass done sequentially as the boundaries of the patches where not collapsed.
+
+A more elaborate version would also enable the usage of constrained property maps.
+Instead of making copies of patches one might collapse in the input graph.
+This needs taking care of possible race conditons. As the halfedge associated
+to a vertex on the border of two neighboring patches might be modifed at the same time
+by two threads, one would need a mutex or put constraints on all faces incident
+to boundary vertices.
+
+\cgalExample{Surface_mesh_simplification/collapse_small_edges_in_parallel.cpp}
+
+
 \section SimplificationDesign Design and Implementation History
 
 The core of the package, as well as most of the simplification strategies, are the work of Fernando Cacciola,

--- a/Surface_mesh_simplification/doc/Surface_mesh_simplification/examples.txt
+++ b/Surface_mesh_simplification/doc/Surface_mesh_simplification/examples.txt
@@ -11,4 +11,5 @@
 \example Surface_mesh_simplification/edge_collapse_bounded_normal_change.cpp
 \example Surface_mesh_simplification/edge_collapse_visitor_surface_mesh.cpp
 \example Surface_mesh_simplification/edge_collapse_garland_heckbert.cpp
+\example Surface_mesh_simplification/collapse_small_edges_in_parallel.cpp
 */


### PR DESCRIPTION
## Summary of Changes

The package Surface Mesh Simplification comes with an example that used METIS and TBB to partition and simplify a mesh. 
This PR adds it to the User Manual in the examples section.

### Todo

- [ ] add a table with timings

## Release Management

* Affected package(s): Surface_mesh_simplification
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:  unchanged

