### PR TITLE
Fix inline assembly for arm-neon-android

### DIFF
--- a/Installation/include/CGAL/gdb_autoload.h
+++ b/Installation/include/CGAL/gdb_autoload.h
@@ -25,7 +25,7 @@
 
 // Use inline assembly to embed the .debug_gdb_scripts section
 __asm__(
-    ".pushsection \".debug_gdb_scripts\", \"MS\",@progbits,1\n"
+    ".pushsection \".debug_gdb_scripts\", \"MS\",%progbits,1\n"
     ".byte 4\n"
     ".ascii \"gdb.inlined-script.CGAL\\n\"\n"
     ".ascii \"import gdb\\n\"\n"


### PR DESCRIPTION
## Summary of Changes

Backport of vcpkg update https://github.com/microsoft/vcpkg/pull/53776, as the change in https://github.com/CGAL/cgal/commit/eb2257df4da4c52c75fe384e803d9a6376057b8a doesn't compile with arm-neon-android, when building openmvs 2.3.0:
```
<inline asm>:1:41: error: expected '%<type>' or "<type>"
    1 | .pushsection ".debug_gdb_scripts", "MS",@progbits,1
      |                                         ^
<inline asm>:8:12: error: .popsection without corresponding .pushsection
    8 | .popsection
      |            ^
```

## Release Management


