### PR TITLE
Add error message in gmp.h if including it while CGAL_DISABLE_GMP is defined

### DIFF
--- a/Installation/CMakeLists.txt
+++ b/Installation/CMakeLists.txt
@@ -442,16 +442,11 @@ if(CGAL_DISABLE_GMP)
   unset(WITH_CGAL_Core CACHE)
   unset(CGAL_USE_GMP)
   unset(CGAL_USE_GMP CACHE)
-  # Nasty trick to make sure <gmp.h> is not used when CGAL_DISABLE_GMP is TRUE
-  file(WRITE "${CGAL_BINARY_DIR}/include/gmp.h"
-       "#error GMP is disabled by the CMake option CGAL_DISABLE_GMP")
 else()
   list(APPEND CGAL_ESSENTIAL_3RD_PARTY_LIBRARIES GMP MPFR)
 
   # When CMake is run several times, to avoid duplicates
   list(REMOVE_DUPLICATES CGAL_ESSENTIAL_3RD_PARTY_LIBRARIES)
-
-  file(REMOVE "${CGAL_BINARY_DIR}/include/gmp.h")
 endif()
 hide_variable(CGAL_ESSENTIAL_3RD_PARTY_LIBRARIES)
 

--- a/Number_types/include/CGAL/gmp.h
+++ b/Number_types/include/CGAL/gmp.h
@@ -11,6 +11,10 @@
 #ifndef CGAL_GMP_H
 #define CGAL_GMP_H 1
 
+#ifdef CGAL_DISABLE_GMP
+#error GMP is disabled by the CMake option CGAL_DISABLE_GMP
+#endif
+
 #include <CGAL/config.h>
 #include <CGAL/disable_warnings.h>
 #if defined(BOOST_MSVC)


### PR DESCRIPTION
This behavior was only available when "installing" CGAL