### PR TITLE
Fix ambiguous = for Emscripten 64-bit

### DIFF
--- a/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
+++ b/Constrained_triangulation_3/include/CGAL/Conforming_constrained_Delaunay_triangulation_3.h
@@ -1334,7 +1334,7 @@ protected:
     const auto face_id = static_cast<std::size_t>(cell->ccdt_3_data().face_constraint_index(facet_index));
     this->face_constraint_misses_subfaces_set(face_id);
     auto fh_2 = cell->ccdt_3_data().face_2(this->face_cdt_2(face_id), facet_index);
-    fh_2->info().facet_3d = {};
+    fh_2->info().facet_3d = decltype(fh_2->info().facet_3d){};
     fh_2->info().missing_subface = true;
     this->set_facet_constrained({cell, facet_index}, -1, {});
   }


### PR DESCRIPTION

## Summary of Changes

Changed `fh_2->info().facet_3d = {};` to `fh_2->info().facet_3d = decltype(fh_2->info().facet_3d){};` in `Conforming_constrained_Delaunay_triangulation_3.h` to fix compilation for emscripten 64-bit


## Release Management

* Affected package(s): `3D Constrained Triangulations`
* Issue(s) solved (if any): fix #9649 
* Feature/Small Feature (if any): Small bug hotfix
* Link to compiled documentation (obligatory for small feature) [*wrong link name to be changed*](httpssss://wrong_URL_to_be_changed/Manual/Pkg)
* License and copyright ownership:

