### PR TITLE
Installation: avoid -Woverriding-option from /fp:except- on clang-cl and icx

### DIFF
--- a/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
+++ b/Installation/cmake/modules/CGAL_SetupCGALDependencies.cmake
@@ -127,8 +127,16 @@ function(CGAL_setup_CGAL_flags target)
     target_compile_options(${target} INTERFACE
       "-D_SCL_SECURE_NO_DEPRECATE;-D_SCL_SECURE_NO_WARNINGS")
     target_compile_options(${target} INTERFACE
-      $<$<COMPILE_LANGUAGE:CXX>:/fp:strict>
-      $<$<COMPILE_LANGUAGE:CXX>:/fp:except->
+      $<$<COMPILE_LANGUAGE:CXX>:/fp:strict>)
+    if(CMAKE_CXX_COMPILER_ID MATCHES "Clang|IntelLLVM")
+      # clang-cl and icx warn that /fp:except- overrides part of /fp:strict.
+      target_compile_options(${target} INTERFACE
+        "$<$<COMPILE_LANGUAGE:CXX>:SHELL:-Xclang -ffp-exception-behavior=ignore>")
+    else()
+      target_compile_options(${target} INTERFACE
+        $<$<COMPILE_LANGUAGE:CXX>:/fp:except->)
+    endif()
+    target_compile_options(${target} INTERFACE
       $<$<COMPILE_LANGUAGE:CXX>:/bigobj>  # Use /bigobj by default
       )
   elseif(CMAKE_CXX_COMPILER_ID MATCHES "Intel")


### PR DESCRIPTION
## Summary of Changes

clang-cl and icx report `/fp:except-` as overriding part of `/fp:strict` (#9168). Keep `/fp:strict`, which on icx also turns the fast default off, and set the exception mode with `-Xclang` so the driver's override check never sees it. Generated code is identical on clang-cl 22.1.3 and icx 2026.0.0. MSVC still receives the original pair, and the non-MSVC compilers on the supported list never enter this block, so nothing changes for any of them.

## Release Management

* Affected package(s): Installation
* Issue(s) solved (if any): fix #9168
* License and copyright ownership: unchanged
